### PR TITLE
Keep legacy and wc-admin version of db update notice in sync

### DIFF
--- a/plugins/woocommerce/changelog/fix-60367
+++ b/plugins/woocommerce/changelog/fix-60367
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure wc-admin db update notification is always in sync with legacy one.

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -24,7 +24,7 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * @since 10.3.0
 	 *
-	 * @param Note $note
+	 * @param Note $note Note to check.
 	 * @return Note
 	 */
 	public static function maybe_update_notice( $note ) {
@@ -33,8 +33,10 @@ class WC_Notes_Run_Db_Update {
 		}
 
 		if ( ! in_array( 'update', \WC_Admin_Notices::get_notices(), true ) ) {
-			// Note is being loaded despite not being necessary.
-			// TODO: remove here.
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$note->save();
+
+			return $note;
 		}
 
 		$needs_db_update = \WC_Install::needs_db_update();

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -68,7 +68,7 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * Retrieves the first notice of this type.
 	 *
-	 * @return int|void Note id or null in case no note was found.
+	 * @return Note Note or null in case no note was found.
 	 */
 	private static function get_current_notice() {
 		try {
@@ -82,29 +82,25 @@ class WC_Notes_Run_Db_Update {
 			return;
 		}
 
-		if ( count( $note_ids ) > 1 ) {
-			// Remove weird duplicates. Leave the first one.
-			$current_notice = array_shift( $note_ids );
-			foreach ( $note_ids as $note_id ) {
-				$note = new Note( $note_id );
-				$data_store->delete( $note );
-			}
-			return $current_notice;
+		$current_note_id = array_shift( $note_ids );
+
+		// Remove weird duplicates. Leave the first one.
+		foreach ( $note_ids as $note_id ) {
+			$note = new Note( $note_id );
+			$data_store->delete( $note );
 		}
 
-		return current( $note_ids );
+		return new Note( $current_note_id );
 	}
 
 	/**
 	 * Set this notice to an actioned one, so that it's no longer displayed.
 	 */
 	public static function set_notice_actioned() {
-		$note_id = self::get_current_notice();
-		if ( ! $note_id ) {
+		$note = self::get_current_notice();
+		if ( ! $note ) {
 			return;
 		}
-
-		$note = new Note( $note_id );
 
 		if ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
@@ -126,7 +122,8 @@ class WC_Notes_Run_Db_Update {
 	 */
 	private static function note_up_to_date( $note, $update_url, $current_actions ) {
 		$actions = $note->get_actions();
-		return count( $current_actions ) === count( array_intersect( wp_list_pluck( $actions, 'name' ), $current_actions ) )
+		return $note->get_id()
+			&& count( $current_actions ) === count( array_intersect( wp_list_pluck( $actions, 'name' ), $current_actions ) )
 			&& in_array( $update_url, wp_list_pluck( $actions, 'query' ), true );
 	}
 
@@ -135,11 +132,12 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * If a $note_id is given, the method updates the note instead of creating a new one.
 	 *
-	 * @param int|Note $note_id Note db record to update.
-	 * @return int Created/Updated note id
+	 * @param null|Note $note Note db record to update. NULL to create a new one.
 	 */
-	private static function update_needed_notice( $note_id = null ) {
-		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
+	private static function update_needed_notice( ?Note $note = null ) {
+		if ( is_null( $note ) ) {
+			$note = new Note();
+		}
 
 		$update_url =
 			add_query_arg(
@@ -199,8 +197,6 @@ class WC_Notes_Run_Db_Update {
 		}
 
 		$note->save();
-
-		return $note->get_id();
 	}
 
 	/**
@@ -208,11 +204,9 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * This is the second out of 3 notices displayed to the user.
 	 *
-	 * @param int|Note $note_id Note id to update.
+	 * @param Note $note Note to update.
 	 */
-	private static function update_in_progress_notice( $note_id ) {
-		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
-
+	private static function update_in_progress_notice( Note $note ) {
 		// Same actions as in includes/admin/views/html-notice-updating.php. This just redirects, performs no action, so without nonce.
 		$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
 		$cron_disabled       = Constants::is_true( 'DISABLE_WP_CRON' );
@@ -231,8 +225,6 @@ class WC_Notes_Run_Db_Update {
 		);
 
 		$note->save();
-
-		return $note->get_id();
 	}
 
 	/**
@@ -240,11 +232,9 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * This is the last notice (3 out of 3 notices) displayed to the user.
 	 *
-	 * @param int|Note $note_id Note id to update.
+	 * @param Note $note Note to update.
 	 */
-	private static function update_done_notice( $note_id ) {
-		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
-
+	private static function update_done_notice( Note $note ) {
 		$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
 			add_query_arg(
 				array(
@@ -268,7 +258,7 @@ class WC_Notes_Run_Db_Update {
 
 		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
 		if ( self::note_up_to_date( $note, $hide_notices_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
-			return $note;
+			return;
 		}
 
 		$note->set_title( __( 'WooCommerce database update done', 'woocommerce' ) );
@@ -284,21 +274,22 @@ class WC_Notes_Run_Db_Update {
 		}
 
 		$note->save();
-
-		return $note->get_id();
 	}
 
 	/**
 	 * Creates the db update note if needed.
 	 *
-	 * @return Note
+	 * @since 10.3.0
 	 */
 	public static function add_notice() {
-		$note_id = self::get_current_notice();
-		$note    = new Note( $note_id ?? '' );
+		$note = self::get_current_notice();
+		if ( ! $note ) {
+			$note = new Note();
+			$note->set_name( self::NOTE_NAME );
+			$note->save();
+		}
 
 		self::maybe_update_notice( $note );
-		return $note;
 	}
 
 	/**
@@ -330,24 +321,27 @@ class WC_Notes_Run_Db_Update {
 				return;
 			} else {
 				// Db update not needed && notice is unactioned -> Thank you note.
-				self::update_done_notice( $note_id );
+				self::update_done_notice( $note );
 				return;
 			}
 		} else {
 			// Db needs update &&.
 			if ( ! $note_id ) {
 				// Db needs update && no notice exists -> create one that shows Nudge to update.
-				$note_id = self::update_needed_notice();
+				self::update_needed_notice();
+				return;
 			}
+
+			$note = new Note( $note_id );
 
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 
 			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				// Db needs update && db update is scheduled -> update note to In progress.
-				self::update_in_progress_notice( $note_id );
+				self::update_in_progress_notice( $note );
 			} else {
 				// Db needs update && db update is not scheduled -> Nudge to run the db update.
-				self::update_needed_notice( $note_id );
+				self::update_needed_notice( $note );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -19,20 +19,41 @@ class WC_Notes_Run_Db_Update {
 	const NOTE_NAME = 'wc-update-db-reminder';
 
 	/**
-	 * Attach hooks.
+	 * Checks whether the note needs an update based on the current db update status.
+	 * Hooked onto the 'woocommerce_get_note_from_db' filter. See {@see \WC_Install}.
+	 *
+	 * @since 10.3.0
+	 *
+	 * @param Note $note
+	 * @return Note
 	 */
-	public function __construct() {
-		// If the old notice gets dismissed, also hide this new one.
-		add_action( 'woocommerce_hide_update_notice', array( __CLASS__, 'set_notice_actioned' ) );
-
-		// Not using Jetpack\Constants here as it can run before 'plugin_loaded' is done.
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX
-			|| defined( 'DOING_CRON' ) && DOING_CRON
-			|| ! is_admin() ) {
-			return;
+	public static function maybe_update_notice( $note ) {
+		if ( ! $note instanceof Note || $note->get_name() !== self::NOTE_NAME ) {
+			return $note;
 		}
 
-		add_action( 'current_screen', array( __CLASS__, 'show_reminder' ) );
+		if ( ! in_array( 'update', \WC_Admin_Notices::get_notices(), true ) ) {
+			// Note is being loaded despite not being necessary.
+			// TODO: remove here.
+		}
+
+		$needs_db_update = \WC_Install::needs_db_update();
+
+		if ( ! $needs_db_update ) {
+			if ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+				self::update_done_notice( $note );
+			}
+		} else {
+			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
+
+			if ( $next_scheduled_date ) {
+				self::update_in_progress_notice( $note );
+			} else {
+				self::update_needed_notice( $note );
+			}
+		}
+
+		return $note;
 	}
 
 	/**
@@ -72,7 +93,6 @@ class WC_Notes_Run_Db_Update {
 	 */
 	public static function set_notice_actioned() {
 		$note_id = self::get_current_notice();
-
 		if ( ! $note_id ) {
 			return;
 		}
@@ -108,15 +128,17 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * If a $note_id is given, the method updates the note instead of creating a new one.
 	 *
-	 * @param integer $note_id Note db record to update.
+	 * @param int|Note $note_id Note db record to update.
 	 * @return int Created/Updated note id
 	 */
 	private static function update_needed_notice( $note_id = null ) {
+		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
+
 		$update_url =
 			add_query_arg(
 				array(
 					'do_update_woocommerce' => 'true',
-					'return_url'            => wc_get_current_admin_url() ? wc_get_current_admin_url() : admin_url( 'admin.php?page=wc-settings' ),
+					'return_url'            => 'wc-admin-referer',
 				),
 				admin_url()
 			);
@@ -140,15 +162,9 @@ class WC_Notes_Run_Db_Update {
 			),
 		);
 
-		if ( $note_id ) {
-			$note = new Note( $note_id );
-		} else {
-			$note = new Note();
-		}
-
 		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
-		if ( self::note_up_to_date( $note, $update_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
-			return $note_id;
+		if ( Note::E_WC_ADMIN_NOTE_UNACTIONED === $note->get_status() && self::note_up_to_date( $note, $update_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
+			return $note;
 		}
 
 		$note->set_title( __( 'WooCommerce database update required', 'woocommerce' ) );
@@ -175,7 +191,9 @@ class WC_Notes_Run_Db_Update {
 			}
 		}
 
-		return $note->save();
+		$note->save();
+
+		return $note->get_id();
 	}
 
 	/**
@@ -183,15 +201,16 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * This is the second out of 3 notices displayed to the user.
 	 *
-	 * @param int $note_id Note id to update.
+	 * @param int|Note $note_id Note id to update.
 	 */
 	private static function update_in_progress_notice( $note_id ) {
+		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
+
 		// Same actions as in includes/admin/views/html-notice-updating.php. This just redirects, performs no action, so without nonce.
 		$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
 		$cron_disabled       = Constants::is_true( 'DISABLE_WP_CRON' );
 		$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress →', 'woocommerce' );
 
-		$note = new Note( $note_id );
 		$note->set_title( __( 'WooCommerce database update in progress', 'woocommerce' ) );
 		$note->set_content( __( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ) );
 
@@ -205,6 +224,8 @@ class WC_Notes_Run_Db_Update {
 		);
 
 		$note->save();
+
+		return $note->get_id();
 	}
 
 	/**
@@ -212,15 +233,17 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * This is the last notice (3 out of 3 notices) displayed to the user.
 	 *
-	 * @param int $note_id Note id to update.
+	 * @param int|Note $note_id Note id to update.
 	 */
 	private static function update_done_notice( $note_id ) {
+		$note = ( $note_id instanceof Note ) ? $note_id : new Note( $note_id );
+
 		$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
 			add_query_arg(
 				array(
 					'wc-hide-notice' => 'update',
 				),
-				wc_get_current_admin_url() ? remove_query_arg( 'do_update_woocommerce', wc_get_current_admin_url() ) : admin_url( 'admin.php?page=wc-settings' )
+				admin_url( 'admin.php?page=wc-settings' )
 			)
 		);
 
@@ -236,11 +259,9 @@ class WC_Notes_Run_Db_Update {
 			),
 		);
 
-		$note = new Note( $note_id );
-
 		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
 		if ( self::note_up_to_date( $note, $hide_notices_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
-			return $note_id;
+			return $note;
 		}
 
 		$note->set_title( __( 'WooCommerce database update done', 'woocommerce' ) );
@@ -256,6 +277,21 @@ class WC_Notes_Run_Db_Update {
 		}
 
 		$note->save();
+
+		return $note->get_id();
+	}
+
+	/**
+	 * Creates the db update note if needed.
+	 *
+	 * @return Note
+	 */
+	public static function add_notice() {
+		$note_id = self::get_current_notice();
+		$note    = new Note( $note_id ?? '' );
+
+		self::maybe_update_notice( $note );
+		return $note;
 	}
 
 	/**
@@ -268,6 +304,8 @@ class WC_Notes_Run_Db_Update {
 	 * store owner hasn't acknowledged the successful db update), still show the Thanks notice.
 	 * If the db does not need an update, and the notice has been actioned, then notice should *not* be shown.
 	 * The notice should also be hidden if the db does not need an update and the notice does not exist.
+	 *
+	 * @deprecated 10.3.0
 	 */
 	public static function show_reminder() {
 		$needs_db_update = \WC_Install::needs_db_update();

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -78,8 +78,11 @@ class WC_Notes_Run_Db_Update {
 		}
 
 		$note = new Note( $note_id );
-		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
-		$note->save();
+
+		if ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$note->save();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -68,7 +68,7 @@ class WC_Notes_Run_Db_Update {
 	 *
 	 * Retrieves the first notice of this type.
 	 *
-	 * @return Note Note or null in case no note was found.
+	 * @return Note|null Note or null in case no note was found.
 	 */
 	private static function get_current_notice() {
 		try {

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -32,6 +32,7 @@ class WC_Notes_Run_Db_Update {
 			return $note;
 		}
 
+		// If the legacy notice is not set, hide the note. This should not normally happen, but serves as a fallback.
 		if ( ! in_array( 'update', \WC_Admin_Notices::get_notices(), true ) ) {
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 			$note->save();
@@ -42,15 +43,19 @@ class WC_Notes_Run_Db_Update {
 		$needs_db_update = \WC_Install::needs_db_update();
 
 		if ( ! $needs_db_update ) {
+			// If there's no need to update the database and the note has not been actioned, update it to the thank you note.
 			if ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
 				self::update_done_notice( $note );
 			}
 		} else {
+			// If a db update is needed...
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 
 			if ( $next_scheduled_date ) {
+				// ... and scheduled, update the note to "in progress".
 				self::update_in_progress_notice( $note );
 			} else {
+				// ... and not scheduled, nudge to run the db update.
 				self::update_needed_notice( $note );
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -336,7 +336,6 @@ class WC_Install {
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_email_improvements_for_newly_installed' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_customer_stock_notifications_signups' ), 20 );
 		add_action( 'woocommerce_updated', array( __CLASS__, 'enable_email_improvements_for_existing_merchants' ), 20 );
-		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'woocommerce_update_db_to_current_version', array( __CLASS__, 'update_db_version' ) );
@@ -348,6 +347,10 @@ class WC_Install {
 		add_filter( 'cron_schedules', array( __CLASS__, 'cron_schedules' ) );
 		add_action( 'admin_init', array( __CLASS__, 'newly_installed' ) );
 		add_action( 'woocommerce_activate_legacy_rest_api_plugin', array( __CLASS__, 'maybe_install_legacy_api_plugin' ) );
+
+		// DB update notice.
+		add_filter( 'woocommerce_get_note_from_db', array( \WC_Notes_Run_Db_Update::class, 'maybe_update_notice' ), 10 );
+		add_action( 'woocommerce_hide_update_notice', array( __CLASS__, 'remove_update_db_notice' ) );
 	}
 
 	/**
@@ -414,14 +417,52 @@ class WC_Install {
 	 * Add WC Admin based db update notice.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 10.3.0
 	 */
 	public static function wc_admin_db_update_notice() {
 		if (
 			WC()->is_wc_admin_active()
 			&& false !== get_option( 'woocommerce_admin_install_timestamp' )
-			&& ! self::is_db_auto_update_enabled()
 		) {
 			new WC_Notes_Run_Db_Update();
+		}
+	}
+
+	/**
+	 * Adds the db update notice.
+	 *
+	 * @since 10.3.0
+	 */
+	private static function add_update_db_notice() {
+		if ( ! \WC_Admin_Notices::has_notice( 'update' ) ) {
+			\WC_Admin_Notices::add_notice( 'update', true );
+		}
+
+		try {
+			if ( WC()->is_wc_admin_active() && false !== get_option( 'woocommerce_admin_install_timestamp' ) ) {
+				\WC_Notes_Run_Db_Update::add_notice();
+			}
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error adding db update note: ' . $e->getMessage(), array( 'source' => 'wc-updater' ) );
+		}
+	}
+
+	/**
+	 * Removes the db update notice.
+	 *
+	 * @since 10.3.0
+	 */
+	public static function remove_update_db_notice() {
+		if ( \WC_Admin_Notices::has_notice( 'update' ) ) {
+			\WC_Admin_Notices::remove_notice( 'update', true );
+		}
+
+		try {
+			if ( WC()->is_wc_admin_active() && false !== get_option( 'woocommerce_admin_install_timestamp' ) ) {
+				\WC_Notes_Run_Db_Update::set_notice_actioned();
+			}
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error removing db update note: ' . $e->getMessage(), array( 'source' => 'wc-updater' ) );
 		}
 	}
 
@@ -488,7 +529,7 @@ class WC_Install {
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			wc_get_logger()->info( 'Manual database update triggered.', array( 'source' => 'wc-updater' ) );
 			self::update();
-			WC_Admin_Notices::add_notice( 'update', true );
+			self::add_update_db_notice();
 
 			if ( ! empty( $_GET['return_url'] ) ) { // WPCS: input var ok.
 				$return_url = esc_url_raw( wp_unslash( $_GET['return_url'] ) );
@@ -647,6 +688,7 @@ class WC_Install {
 		include_once __DIR__ . '/admin/class-wc-admin-notices.php';
 
 		WC_Admin_Notices::remove_all_notices();
+		self::remove_update_db_notice();
 	}
 
 	/**
@@ -738,7 +780,7 @@ class WC_Install {
 				wc_get_logger()->info( 'Automatic database update triggered.', array( 'source' => 'wc-updater' ) );
 				self::update();
 			} else {
-				WC_Admin_Notices::add_notice( 'update', true );
+				self::add_update_db_notice();
 			}
 		} else {
 			self::update_db_version();
@@ -847,8 +889,7 @@ class WC_Install {
 
 			// Revert back to nudge so updates are not missed.
 			if ( self::is_db_auto_update_enabled() ) {
-				WC_Admin_Notices::add_notice( 'update', true );
-				WC()->is_wc_admin_active() && new WC_Notes_Run_Db_Update();
+				self::add_update_db_notice();
 			}
 
 			return;

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -531,8 +531,23 @@ class WC_Install {
 			self::update();
 			self::add_update_db_notice();
 
-			if ( ! empty( $_GET['return_url'] ) ) { // WPCS: input var ok.
-				$return_url = esc_url_raw( wp_unslash( $_GET['return_url'] ) );
+			$return_url = $_GET['return_url'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized below before use.
+			if ( ! empty( $return_url ) ) {
+				// Try to go back to the previus page.
+				if ( 'wc-admin-referer' === $return_url ) {
+					$return_url = preg_replace( '/^.*\/wp-admin\//i', '', wp_get_referer() ? wp_get_referer() : '' );
+
+					if ( $return_url && false === strpos( $return_url, 'do_update_woocommerce' ) ) {
+						$return_url = remove_query_arg(
+							array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce', 'wc-hide-notice' ),
+							admin_url( $return_url )
+						);
+					} else {
+						$return_url = admin_url( 'admin.php?page=wc-settings' );
+					}
+				}
+
+				$return_url = esc_url_raw( wp_unslash( $return_url ) );
 				wp_safe_redirect( $return_url ); // WPCS: input var ok.
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -535,7 +535,7 @@ class WC_Install {
 			if ( ! empty( $return_url ) ) {
 				// Try to go back to the previous page.
 				if ( 'wc-admin-referer' === $return_url ) {
-					$return_url = preg_replace( '/^.*\/wp-admin\//i', '', wp_get_referer() ? wp_get_referer() : '' );
+					$return_url = preg_replace( '/^' . preg_quote( untrailingslashit( admin_url() ), '/' ) . '\/?/i', '', wp_get_referer() ? wp_get_referer() : '' );
 
 					if ( $return_url && false === strpos( $return_url, 'do_update_woocommerce' ) ) {
 						$return_url = remove_query_arg(

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -549,6 +549,7 @@ class WC_Install {
 
 				$return_url = esc_url_raw( wp_unslash( $return_url ) );
 				wp_safe_redirect( $return_url ); // WPCS: input var ok.
+				exit;
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -533,7 +533,7 @@ class WC_Install {
 
 			$return_url = $_GET['return_url'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized below before use.
 			if ( ! empty( $return_url ) ) {
-				// Try to go back to the previus page.
+				// Try to go back to the previous page.
 				if ( 'wc-admin-referer' === $return_url ) {
 					$return_url = preg_replace( '/^.*\/wp-admin\//i', '', wp_get_referer() ? wp_get_referer() : '' );
 

--- a/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
@@ -83,8 +83,7 @@ class WC_CLI_Update_Command {
 		WC_Install::update_db_version();
 		$progress->finish();
 
-		WC_Admin_Notices::remove_notice( 'update', true );
-		( new WC_Notes_Run_Db_Update() )->set_notice_actioned();
+		\WC_Install::remove_update_db_notice();
 
 		WC()->call_static(
 			WP_CLI::class,

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -61,7 +61,7 @@ class Note extends \WC_Data {
 			'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
 			'source'        => 'woocommerce',
 			'date_created'  => '0000-00-00 00:00:00',
-			'date_reminder' => '',
+			'date_reminder' => null,
 			'is_snoozable'  => false,
 			'actions'       => array(),
 			'layout'        => 'plain',

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -110,7 +110,8 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 * No note should be created/exist if db version is equal to WC code version.
 	 */
 	public function test_noop_db_update_note() {
-		update_option( 'woocommerce_db_version', WC()->version );
+		// Set the db version to the latest.
+		\WC_Install::update_db_version();
 
 		// No notes initially.
 		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
@@ -138,7 +139,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( self::get_db_update_notes() ), 'A db update note should be created if db is NOT up to date.' );
 
 		// Update the db option back.
-		update_option( 'woocommerce_db_version', WC()->version );
+		\WC_Install::update_db_version();
 	}
 
 	/**
@@ -182,7 +183,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 'update-db_run', $actions[0]->name, 'A db update note to update the database should be displayed now.' );
 
 		// Simulate database update has been performed.
-		update_option( 'woocommerce_db_version', WC()->version );
+		\WC_Install::update_db_version();
 
 		// Magic 2: update-db note to thank you note.
 		WC_Notes_Run_Db_Update::show_reminder();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
We currently have two types of db update notices (a legacy one managed via `WC_Admin_Notices`) and a wc-admin note. The install process has always handled the first one, but the second one was "automatically" updated to match the first one based on the state of the db updates.

This PR ensures that both notes are reset at plugin upgrade time and that they stay in sync.
It also makes it explicit when the notes should be added and/or removed, so we no longer need to check on every admin page load whether the note needs to be updated or not. This now happens when the note is loaded.

The changes in this PR also address the situation in #60367, where a site had an unactioned db update note prior to 10.0.x and then because of the automatic updates, the note never went away.

Closes #60367 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Ensure basic note / notice functionality:**
   1. In a mu-plugin or a snippet, enable the following code on your test site to disable automatic updates:
   ```php
   <?php
   add_filter( 'woocommerce_enable_auto_update_db', '__return_false' );
   ```
   1. Run `wp transient delete wc_installing && wp option set woocommerce_db_version 10.2.0 && wp option set woocommerce_version 10.2.0` to simulate an upgrade that doesn't involve db updates.
   1. Go to **Dashboard** and **WooCommerce > Home** and confirm that no update notice appears on either page.
   1. Run `wp transient delete wc_installing && wp option set woocommerce_db_version 10.1.0 && wp option set woocommerce_version 10.1.0` to simulate an upgrade that **does** involve db updates.
   1. Go to **Dashboard** and confirm that the legacy update notice appears.
   1. Go to **WooCommerce > Home** and confirm that the wc-admin db update note appears. Click the button and confirm that you are taken back to the **WooCommerce > Home** screen.
   1. Confirm that the notice changes to the "in progress" version both on **Dashboard** and **WooCommerce > Home**.
   1. Wait a bit for the A-S jobs to run (or run via `wp action-scheduler run`).
   1. Confirm that the notice changes to the "update done" version both on **Dashboard** and **WooCommerce > Home**.
   1. Confirm that `wp option get woocommerce_db_version` returns `10.3.0-dev`.
   1. Click the **Dismiss** button on the **Dashboard** version of the notice and confirm that no notice appears either on **Dashboard** or **WooCommerce > Home**.
1. **Ensure plugin upgrades clear previous notes:**
   1. Run `wp transient delete wc_installing && wp option set woocommerce_db_version 10.1.0 && wp option set woocommerce_version 10.1.0` to simulate an upgrade to a version with db updates.
   1. Confirm that the notices appear on both the **Dashboard** and **WooCommerce > Home** pages. Do not click any buttons.
   1. Run any pending A-S jobs with `wp action-scheduler run`.
   1. Confirm that `wp option get woocommerce_db_version` returns `10.1.0`, meaning the db update routine from `10.2.0` hasn't run yet.
   1. Disable or remove the snippet of code we added in step 1-i so that automatic updates are re-enabled.
   1. Run `wp transient delete wc_installing && wp option set woocommerce_version 10.2.0` to simulate a plugin upgrade.
   1. Confirm that `wp option get woocommerce_db_version` returns `10.1.0`, meaning nothing has changed yet.
   1. Confirm that no update notices are visible on either the **Dashboard** or the **WooCommerce > Home** screen.
   1. Run any pending A-S jobs with `wp action-scheduler run`.
   1. Confirm that `wp option get woocommerce_db_version` returns `10.3.0-dev`, which signals updates have been applied.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
