### PR TITLE
Product Summary: render the placeholder in the site editor

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
@@ -99,17 +99,6 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 
 	const summaryClassName = 'wc-block-components-product-summary';
 
-	if ( ! product ) {
-		return (
-			<div
-				className={ clsx( className, summaryClassName, {
-					[ `${ parentClassName }__product-summary` ]:
-						parentClassName,
-				} ) }
-			/>
-		);
-	}
-
 	if ( isDescendentOfSingleProductTemplate ) {
 		return (
 			<div className={ summaryClassName }>
@@ -120,6 +109,17 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 					) }
 				</p>
 			</div>
+		);
+	}
+
+	if ( ! product ) {
+		return (
+			<div
+				className={ clsx( className, summaryClassName, {
+					[ `${ parentClassName }__product-summary` ]:
+						parentClassName,
+				} ) }
+			/>
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In https://github.com/woocommerce/woocommerce/pull/60494, we updated the Product Summary block to use Product Entity when available. We introduced a regression that renders the empty summary block in the Site Editor. This PR fixes that issue.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/60494

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/aa0699c9-6f54-4889-bab7-3c175d6fde62" /> | <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/8c9aad5a-cf11-4b23-b67e-f5ef429dd579" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Single Product template.
2. Add the Product Summary block to the template.
3. Verify the placeholder is rendered.
4. Add a new page and add the Product block.
5. Choose a product, see the Product Summary block render the correct summary.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Product Summary: Ensure the placeholder is rendered in the site editor.
</details>
