### PR TITLE
Add to Cart + Options: make Product Gallery block show the selected variation image

### DIFF
--- a/plugins/woocommerce/changelog/fix-60660-update-product-gallery-based-on-variations
+++ b/plugins/woocommerce/changelog/fix-60660-update-product-gallery-based-on-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: make Product Gallery block show the selected variation image

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -37,6 +37,7 @@ export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
 
 export type ProductData = {
 	price_html?: string;
+	image_id?: number;
 	availability?: string;
 	sku?: string;
 	weight?: string;
@@ -47,6 +48,7 @@ export type ProductData = {
 	variations?: {
 		[ variationId: number ]: {
 			price_html?: string;
+			image_id?: number;
 			availability?: string;
 			sku?: string;
 			weight?: string;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -435,18 +435,25 @@ const productGallery = {
 	},
 	callbacks: {
 		listenToProductDataChanges: () => {
-			if ( ! productDataState?.productId ) {
-				return undefined;
+			const productId = productDataState?.productId;
+			if ( ! productId ) {
+				return;
 			}
+
 			const productData =
-				wooState?.products?.[ productDataState.productId ]
-					?.variations?.[ productDataState?.variationId || 0 ] ||
-				wooState?.products?.[ productDataState.productId ];
+				wooState?.products?.[ productId ]?.variations?.[
+					productDataState?.variationId || 0
+				] || wooState?.products?.[ productId ];
 
 			const imageId = productData?.image_id;
-			if ( imageId ) {
-				const { imageData } = getContext();
-				const imageIndex = imageData.indexOf( imageId );
+			if ( ! imageId ) {
+				return;
+			}
+
+			const { imageData } = getContext();
+			const imageIndex = imageData.indexOf( imageId );
+
+			if ( imageIndex >= 0 ) {
 				actions.selectImage( imageIndex );
 			}
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -7,12 +7,18 @@ import {
 	getElement,
 	withScope,
 } from '@wordpress/interactivity';
+import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
+import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
 
 /**
  * Internal dependencies
  */
 import type { ProductGalleryContext } from './types';
 import { checkOverflow } from './utils';
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
 const getContext = ( ns?: string ) =>
 	getContextFn< ProductGalleryContext >( ns );
@@ -156,6 +162,18 @@ const scrollThumbnailIntoView = ( imageId: number ) => {
 		behavior: 'smooth',
 	} );
 };
+
+const { state: productDataState } = store< ProductDataStore >(
+	'woocommerce/product-data',
+	{},
+	{ lock: universalLock }
+);
+
+const { state: wooState } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
 
 const productGallery = {
 	state: {
@@ -416,6 +434,22 @@ const productGallery = {
 		},
 	},
 	callbacks: {
+		listenToProductDataChanges: () => {
+			if ( ! productDataState?.productId ) {
+				return undefined;
+			}
+			const productData =
+				wooState?.products?.[ productDataState.productId ]
+					?.variations?.[ productDataState?.variationId || 0 ] ||
+				wooState?.products?.[ productDataState.productId ];
+
+			const imageId = productData?.image_id;
+			if ( imageId ) {
+				const { imageData } = getContext();
+				const imageIndex = imageData.indexOf( imageId );
+				actions.selectImage( imageIndex );
+			}
+		},
 		watchForChangesOnAddToCartForm: () => {
 			const context = getContext();
 			const variableProductCartForm = document.querySelector(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -70,7 +70,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( addToCartButton ).toHaveText( '4 in cart' );
 	} );
 
-	test( 'allows adding variable products to cart', async ( {
+	test.only( 'allows adding variable products to cart', async ( {
 		page,
 		pageObject,
 		editor,
@@ -129,7 +129,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			).toBeVisible();
 		} );
 
-		await test.step( 'updates stock indicator and product price when attributes are selected', async () => {
+		await test.step( 'updates blocks rendering variation data when attributes are selected', async () => {
 			// Open additional information accordion so we can check the weight.
 			await page
 				.getByRole( 'button', { name: 'Additional Information' } )
@@ -142,6 +142,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					.getByLabel( 'Additional Information', { exact: true } )
 					.getByText( '1.5 lbs' )
 			).toBeVisible();
+			// await expect( page.locator( '[data-image="136"]' ) ).toBeVisible();
 
 			await colorBlueOption.click();
 			await logoNoOption.click();
@@ -156,6 +157,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					.getByLabel( 'Additional Information', { exact: true } )
 					.getByText( '2 lbs' )
 			).toBeVisible();
+			await expect( page.locator( '[data-image="136"]' ) ).toBeHidden();
 		} );
 
 		await test.step( 'successfully adds to cart when attributes are selected', async () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -7,13 +7,28 @@ import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
  * Internal dependencies
  */
 import AddToCartWithOptionsPage from './add-to-cart-with-options.page';
+import { ProductGalleryPage } from '../product-gallery/product-gallery.page';
 
-const test = base.extend< { pageObject: AddToCartWithOptionsPage } >( {
+const test = base.extend< {
+	pageObject: AddToCartWithOptionsPage;
+	productGalleryPageObject: ProductGalleryPage;
+} >( {
 	pageObject: async ( { page, admin, editor }, use ) => {
 		const pageObject = new AddToCartWithOptionsPage( {
 			page,
 			admin,
 			editor,
+		} );
+		await use( pageObject );
+	},
+	productGalleryPageObject: async (
+		{ page, editor, frontendUtils },
+		use
+	) => {
+		const pageObject = new ProductGalleryPage( {
+			page,
+			editor,
+			frontendUtils,
 		} );
 		await use( pageObject );
 	},
@@ -70,9 +85,10 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( addToCartButton ).toHaveText( '4 in cart' );
 	} );
 
-	test.only( 'allows adding variable products to cart', async ( {
+	test( 'allows adding variable products to cart', async ( {
 		page,
 		pageObject,
+		productGalleryPageObject,
 		editor,
 	} ) => {
 		// Set a variable product as having 100 in stock and one of its variations as being out of stock.
@@ -95,6 +111,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 		);
 
 		await pageObject.updateSingleProductTemplate();
+
+		// We update to the Product Gallery block to test that it scrolls to the
+		// correct variation image.
+		const productImageGalleryBlock = await editor.getBlockByName(
+			'woocommerce/product-image-gallery'
+		);
+		await editor.selectBlocks( productImageGalleryBlock );
+		await editor.transformBlockTo( 'woocommerce/product-gallery' );
 
 		// We insert the blockified Product Details block to test that it updates
 		// with the correct variation data.
@@ -142,7 +166,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 					.getByLabel( 'Additional Information', { exact: true } )
 					.getByText( '1.5 lbs' )
 			).toBeVisible();
-			// await expect( page.locator( '[data-image="136"]' ) ).toBeVisible();
+			const visibleImage =
+				await productGalleryPageObject.getVisibleLargeImageId();
+			expect( visibleImage ).toBe( '34' );
 
 			await colorBlueOption.click();
 			await logoNoOption.click();
@@ -157,7 +183,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 					.getByLabel( 'Additional Information', { exact: true } )
 					.getByText( '2 lbs' )
 			).toBeVisible();
-			await expect( page.locator( '[data-image="136"]' ) ).toBeHidden();
+
+			await expect( async () => {
+				const newVisibleLargeImageId =
+					await productGalleryPageObject.getVisibleLargeImageId();
+
+				expect( newVisibleLargeImageId ).toBe( '35' );
+			} ).toPass( { timeout: 1_000 } );
 		} );
 
 		await test.step( 'successfully adds to cart when attributes are selected', async () => {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * CatalogSorting class.
@@ -119,7 +120,7 @@ class AddToCartForm extends AbstractBlock {
 	 */
 	private function has_all_attributes_set( $product ) {
 		// If it's not a variation product, return true.
-		if ( ! $product->is_type( 'variation' ) ) {
+		if ( ! $product->is_type( ProductType::VARIATION ) ) {
 			return true;
 		}
 
@@ -168,7 +169,7 @@ class AddToCartForm extends AbstractBlock {
 		}
 
 		// Check if all attributes are set for variation product.
-		if ( $product->is_type( 'variation' ) && ! $this->has_all_attributes_set( $product ) ) {
+		if ( $product->is_type( ProductType::VARIATION ) && ! $this->has_all_attributes_set( $product ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 use Automattic\WooCommerce\Enums\ProductType;
 
 /**
- * CatalogSorting class.
+ * AddToCartForm class.
  */
 class AddToCartForm extends AbstractBlock {
 
@@ -47,7 +47,8 @@ class AddToCartForm extends AbstractBlock {
 	 * @param WP_Block $block Block instance.
 	 */
 	protected function enqueue_assets( $attributes, $content, $block ) {
-		if ( 'stepper' !== $attributes['quantitySelectorStyle'] ) {
+		$parsed_attributes = $this->parse_attributes( $attributes );
+		if ( 'stepper' !== $parsed_attributes['quantitySelectorStyle'] ) {
 			return;
 		}
 
@@ -225,7 +226,6 @@ class AddToCartForm extends AbstractBlock {
 		$product_name = $product->get_name();
 		$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
 
-		$parsed_attributes  = $this->parse_attributes( $attributes );
 		$product_html       = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -69,9 +69,9 @@ class AddToCartForm extends AbstractBlock {
 	/**
 	 * Add increment and decrement buttons to the quantity input field.
 	 *
-	 * @param string $product_html add-to-cart form HTML.
+	 * @param string $product_html Add to Cart form HTML.
 	 * @param string $product_name Product name.
-	 * @return stringa add-to-cart form HTML with increment and decrement buttons.
+	 * @return string Add to Cart form HTML with increment and decrement buttons.
 	 */
 	private function add_steppers( $product_html, $product_name ) {
 		// Regex pattern to match the <input> element with id starting with 'quantity_'.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -90,12 +90,12 @@ class AddToCartWithOptions extends AbstractBlock {
 	 */
 	private function is_child_product_purchasable( \WC_Product $product ) {
 		// Skip variable products.
-		if ( $product->is_type( 'variable' ) ) {
+		if ( $product->is_type( ProductType::VARIABLE ) ) {
 			return false;
 		}
 
 		// Skip grouped products.
-		if ( $product->is_type( 'grouped' ) ) {
+		if ( $product->is_type( ProductType::GROUPED ) ) {
 			return false;
 		}
 
@@ -187,7 +187,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						$context = wp_interactivity_get_context();
 						$product = wc_get_product( $context['productId'] );
 
-						if ( $product instanceof \WC_Product && ( $product->is_type( 'grouped' ) || $product->has_options() ) ) {
+						if ( $product instanceof \WC_Product && ( $product->is_type( ProductType::GROUPED ) || $product->has_options() ) ) {
 							return false;
 						}
 						return true;
@@ -227,7 +227,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				'validationErrors' => array(),
 			);
 
-			if ( $product->is_type( 'variable' ) ) {
+			if ( $product->is_type( ProductType::VARIABLE ) ) {
 				$context['selectedAttributes'] = array();
 				$available_variations          = $product->get_available_variations( 'objects' );
 				foreach ( $available_variations as $variation ) {
@@ -241,7 +241,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				}
 			}
 
-			if ( $product->is_type( 'grouped' ) ) {
+			if ( $product->is_type( ProductType::GROUPED ) ) {
 				// Add context for purchasable child products.
 				$children_product_data = array();
 				foreach ( $product->get_children() as $child_product_id ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelector.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Block type for grouped product selector in add to cart with options.
@@ -31,7 +32,7 @@ class GroupedProductSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( $product instanceof \WC_Product && $product->is_type( 'grouped' ) ) {
+		if ( $product instanceof \WC_Product && $product->is_type( ProductType::GROUPED ) ) {
 
 			$p = new \WP_HTML_Tag_Processor( $content );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -123,9 +123,9 @@ class Utils {
 	 * @return bool True if the product is not purchasable or not in stock.
 	 */
 	public static function is_not_purchasable_product( $product ) {
-		if ( $product->is_type( 'simple' ) ) {
+		if ( $product->is_type( ProductType::SIMPLE ) ) {
 			return ! $product->is_in_stock() || ! $product->is_purchasable();
-		} elseif ( $product->is_type( 'variable' ) ) {
+		} elseif ( $product->is_type( ProductType::VARIABLE ) ) {
 			return ! $product->is_in_stock() || ! $product->has_purchasable_variations();
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Block type for variation selector in add to cart with options.
@@ -31,7 +32,7 @@ class VariationSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) && ! Utils::is_not_purchasable_product( $product ) ) {
+		if ( $product instanceof \WC_Product && $product->is_type( ProductType::VARIABLE ) && ! Utils::is_not_purchasable_product( $product ) ) {
 			$p = new \WP_HTML_Tag_Processor( $content );
 
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-add-to-cart-with-options-variation-selector' ) ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * ProductButton class.
@@ -154,7 +155,7 @@ class ProductButton extends AbstractBlock {
 			'hasPressedButton' => false,
 		);
 
-		if ( $product->is_type( 'grouped' ) ) {
+		if ( $product->is_type( ProductType::GROUPED ) ) {
 			$context['groupedProductIds'] = $product->get_children();
 		}
 
@@ -325,7 +326,7 @@ class ProductButton extends AbstractBlock {
 	 * @return boolean The product is purchasable.
 	 */
 	private function is_product_purchasable( $product ) {
-		if ( $product->is_type( 'grouped' ) ) {
+		if ( $product->is_type( ProductType::GROUPED ) ) {
 			$grouped_product_ids = $product->get_children();
 			foreach ( $grouped_product_ids as $child ) {
 				$child_product = wc_get_product( $child );
@@ -350,7 +351,7 @@ class ProductButton extends AbstractBlock {
 	 * @return string The inTheCartText string.
 	 */
 	private function get_in_the_cart_text( $product ) {
-		if ( $product->is_type( 'grouped' ) ) {
+		if ( $product->is_type( ProductType::GROUPED ) ) {
 			return __( 'Added to cart', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -104,7 +104,7 @@ class ProductButton extends AbstractBlock {
 		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
 		$ajax_add_to_cart_enabled = get_option( 'woocommerce_enable_ajax_add_to_cart' ) === 'yes';
 		$is_ajax_button           = ( ( $ajax_add_to_cart_enabled && $product->supports( 'ajax_add_to_cart' ) ) || $is_descendant_of_add_to_cart_form ) && $is_product_purchasable && ! $cart_redirect_after_add;
-		$html_element             = $is_ajax_button || ( $is_descendant_of_add_to_cart_form && 'external' !== $product->get_type() ) ? 'button' : 'a';
+		$html_element             = $is_ajax_button || ( $is_descendant_of_add_to_cart_form && ! $product->is_type( ProductType::EXTERNAL ) ) ? 'button' : 'a';
 		$styles_and_classes       = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classname                = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );
 		$custom_width_classes     = isset( $attributes['width'] ) ? 'has-custom-width wp-block-button__width-' . $attributes['width'] : '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -157,7 +157,39 @@ class ProductGallery extends AbstractBlock {
 			);
 
 			if ( $product->is_type( ProductType::VARIABLE ) ) {
-				$p->set_attribute( 'data-wp-init--watch-changes-on-add-to-cart-form', 'callbacks.watchForChangesOnAddToCartForm' );
+				$variations_data           = $product->get_available_variations();
+				$formatted_variations_data = array();
+				foreach ( $variations_data as $variation ) {
+					if (
+						empty( $variation['variation_id'] )
+						|| ! array_key_exists( 'image_id', $variation )
+						|| '' === $variation['image_id']
+					) {
+						continue;
+					}
+					$formatted_variations_data[ $variation['variation_id'] ] = array(
+						'image_id' => (int) $variation['image_id'],
+					);
+				}
+
+				if ( count( $formatted_variations_data ) > 0 ) {
+					wp_interactivity_state(
+						'woocommerce',
+						array(
+							'products' => array(
+								$product->get_id() => array(
+									'image_id'   => (int) $product->get_image_id(),
+									'variations' => $formatted_variations_data,
+								),
+							),
+						)
+					);
+
+					// Support legacy Add to Cart with Options block.
+					$p->set_attribute( 'data-wp-init--watch-changes-on-add-to-cart-form', 'callbacks.watchForChangesOnAddToCartForm' );
+					// Support blockified Add to Cart + Options block.
+					$p->set_attribute( 'data-wp-watch', 'callbacks.listenToProductDataChanges' );
+				}
 			}
 
 			$p->add_class( $classname );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -159,20 +159,21 @@ class ProductGallery extends AbstractBlock {
 			if ( $product->is_type( ProductType::VARIABLE ) ) {
 				$variations_data           = $product->get_available_variations();
 				$formatted_variations_data = array();
+				$has_variation_images      = false;
 				foreach ( $variations_data as $variation ) {
 					if (
 						empty( $variation['variation_id'] )
 						|| ! array_key_exists( 'image_id', $variation )
-						|| '' === $variation['image_id']
 					) {
 						continue;
 					}
+					$has_variation_images                                    = $has_variation_images || $variation['image_id'] !== $product->get_image_id();
 					$formatted_variations_data[ $variation['variation_id'] ] = array(
 						'image_id' => (int) $variation['image_id'],
 					);
 				}
 
-				if ( count( $formatted_variations_data ) > 0 ) {
+				if ( $has_variation_images ) {
 					wp_interactivity_state(
 						'woocommerce',
 						array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * ProductPrice class.
@@ -77,7 +78,7 @@ class ProductPrice extends AbstractBlock {
 
 			$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
 			$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
-			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( 'variable' );
+			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( ProductType::VARIABLE );
 
 			$wrapper_attributes = array();
 			$watch_attribute    = '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * ProductSKU class.
@@ -67,7 +68,7 @@ class ProductSKU extends AbstractBlock {
 			return '';
 		}
 
-		$is_interactive = $product->is_type( 'variable' );
+		$is_interactive = $product->is_type( ProductType::VARIABLE );
 
 		if ( $is_interactive ) {
 			$variations                = $product->get_available_variations( 'objects' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Enums\ProductType;
+
 /**
  * ProductSpecifications class.
  */
@@ -63,7 +65,7 @@ class ProductSpecifications extends AbstractBlock {
 			);
 		}
 
-		$is_interactive = $product->is_type( 'variable' );
+		$is_interactive = $product->is_type( ProductType::VARIABLE );
 
 		if ( $is_interactive ) {
 			$variations                = $product->get_available_variations( 'objects' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -3,8 +3,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Blocks\Utils\ProductAvailabilityUtils;
-use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * ProductStockIndicator class.
@@ -101,7 +101,7 @@ class ProductStockIndicator extends AbstractBlock {
 
 		$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
 		$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
-		$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product_to_render->is_type( 'variable' );
+		$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product_to_render->is_type( ProductType::VARIABLE );
 
 		if ( empty( $availability['availability'] ) && ! $is_interactive ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\ProductDataUtils;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * SingleProduct class.
@@ -177,7 +178,7 @@ class SingleProduct extends AbstractBlock {
 			return '';
 		}
 
-		if ( ! $product->is_type( 'variable' ) ) {
+		if ( ! $product->is_type( ProductType::VARIABLE ) ) {
 			return parent::render( $attributes, $content, $block );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60660.

This PR makes it so when selecting a variation in the _Add to Cart + Options_ block, the _Product Gallery_ block updates and scrolls to the variation image.

### How to test the changes in this Pull Request:
1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version. Update also the *Product Image Gallery* to the new blockified *Product Gallery* block.
3. Go to the page of a variable product in the frontend.
4. Select a variation.
5. Verify the variation image is shown in the gallery.
6. Select another variation or reset the variation selectors (so there is no variation match).
7. Verify the default product image is shown again.

https://github.com/user-attachments/assets/1cf319d3-05dd-4401-b05f-8d0fa1827038