### PR TITLE
PayPal JSSDK: Load PayPal buttons on classic checkout page

### DIFF
--- a/plugins/woocommerce/client/legacy/js/gateways/paypal.js
+++ b/plugins/woocommerce/client/legacy/js/gateways/paypal.js
@@ -41,8 +41,8 @@ jQuery(function ($) {
 		});
 	}
 
-	// Re-render when WooCommerce updates the checkout.
-	$( document.body ).on( 'updated_checkout payment_method_selected', function () {
+	// Re-render when cart is updated and the html is rerendered on the Cart page.
+	$( document.body ).on( 'updated_cart_totals', function () {
 		// If the container was replaced, re-render PayPal buttons
 		const buttonsContainer = document.getElementById( containerSelector );
 		if ( buttonsContainer && ! buttonsContainer.querySelector( 'iframe' ) ) {

--- a/plugins/woocommerce/client/legacy/js/gateways/paypal.js
+++ b/plugins/woocommerce/client/legacy/js/gateways/paypal.js
@@ -1,38 +1,13 @@
 jQuery(function ($) {
-	// PayPal JS SDK script
-	// eslint-disable-next-line max-len
-	var PAYPAL_SCRIPT = 'https://www.sandbox.paypal.com/sdk/js?client-id=' + paypal_standard.client_id + '&currency=USD&intent=capture&buyer-country=US&locale=en_US&merchant-id=sb-reivw44753332@business.example.com';
-	var script = document.createElement('script');
-	script.setAttribute('src', PAYPAL_SCRIPT);
-	script.setAttribute('data-page-type', 'checkout')
-	document.head.appendChild(script);
+	const containerSelector = 'paypal-standard-container';
 
-	// Check if the container exists
-	const container = document.getElementById('paypal-standard-container');
-	if ( !container ) {
-		return;
-	}
+	function renderButtons() {
+		const container = document.getElementById( containerSelector );
+		if ( ! container ) {
+			return;
+		}
 
-	// Wait for PayPal SDK to be loaded.
-	function waitForPayPal() {
-		return new Promise((resolve) => {
-			if ( typeof paypal !== 'undefined' ) {
-				resolve();
-				return;
-			} 
-
-			const checkPayPal = setInterval(() => {
-				if ( typeof paypal !== 'undefined' ) {
-					clearInterval(checkPayPal);
-					resolve();
-				}
-			}, 5000);
-		});
-	}
-
-	waitForPayPal().then(() => {
-
-		paypal.Buttons({
+		const buttons = paypal.Buttons( {
 			style: {
 				layout: 'vertical',
 				color: 'gold',
@@ -44,27 +19,43 @@ jQuery(function ($) {
 				// TODO: Add createOrder logic here
 			},
 
-			async onApprove(data) {
+			async onApprove( data ) {
 				// TODO: Add onApprove logic here
 			},
 
-			onError: function (err) {
+			onError: function ( err ) {
 				// TODO: Add onError logic here
 				console.error( 'PayPal error:', err );
 			},
 
-			onCancel(data) {
+			onCancel( data ) {
 				// TODO: Add onCancel logic here
+			},
+
+			onInit( data, actions ) {
+				// TODO: Add onInit logic here
 			},
 
 			onClick() {
 				// TODO: Add onClick logic here
 			},
 
-		}).render('#paypal-standard-container')
-			.catch(function (error) {
-				console.error( 'Error rendering PayPal button:', error );
-			});
-	});
+		});
 
+
+		buttons.render( container ).catch( function ( err ) {
+			console.error( 'Failed to render PayPal buttons', err );
+		});
+	}
+
+	// Re-render when WooCommerce updates the checkout.
+	$( document.body ).on( 'updated_checkout payment_method_selected', function () {
+		// If the container was replaced, re-render PayPal buttons
+		const buttonsContainer = document.getElementById( containerSelector );
+		if ( buttonsContainer && ! buttonsContainer.querySelector( 'iframe' ) ) {
+			renderButtons();
+		}
+	} );
+
+	renderButtons();
 });

--- a/plugins/woocommerce/client/legacy/js/gateways/paypal.js
+++ b/plugins/woocommerce/client/legacy/js/gateways/paypal.js
@@ -1,0 +1,70 @@
+jQuery(function ($) {
+	// PayPal JS SDK script
+	// eslint-disable-next-line max-len
+	var PAYPAL_SCRIPT = 'https://www.sandbox.paypal.com/sdk/js?client-id=' + paypal_standard.client_id + '&currency=USD&intent=capture&buyer-country=US&locale=en_US&merchant-id=sb-reivw44753332@business.example.com';
+	var script = document.createElement('script');
+	script.setAttribute('src', PAYPAL_SCRIPT);
+	script.setAttribute('data-page-type', 'checkout')
+	document.head.appendChild(script);
+
+	// Check if the container exists
+	const container = document.getElementById('paypal-standard-container');
+	if ( !container ) {
+		return;
+	}
+
+	// Wait for PayPal SDK to be loaded.
+	function waitForPayPal() {
+		return new Promise((resolve) => {
+			if ( typeof paypal !== 'undefined' ) {
+				resolve();
+				return;
+			} 
+
+			const checkPayPal = setInterval(() => {
+				if ( typeof paypal !== 'undefined' ) {
+					clearInterval(checkPayPal);
+					resolve();
+				}
+			}, 5000);
+		});
+	}
+
+	waitForPayPal().then(() => {
+
+		paypal.Buttons({
+			style: {
+				layout: 'vertical',
+				color: 'gold',
+				shape: 'rect',
+				label: 'paypal'
+			},
+
+			async createOrder() {
+				// TODO: Add createOrder logic here
+			},
+
+			async onApprove(data) {
+				// TODO: Add onApprove logic here
+			},
+
+			onError: function (err) {
+				// TODO: Add onError logic here
+				console.error( 'PayPal error:', err );
+			},
+
+			onCancel(data) {
+				// TODO: Add onCancel logic here
+			},
+
+			onClick() {
+				// TODO: Add onClick logic here
+			},
+
+		}).render('#paypal-standard-container')
+			.catch(function (error) {
+				console.error( 'Error rendering PayPal button:', error );
+			});
+	});
+
+});

--- a/plugins/woocommerce/client/legacy/js/gateways/paypal.js
+++ b/plugins/woocommerce/client/legacy/js/gateways/paypal.js
@@ -8,13 +8,6 @@ jQuery(function ($) {
 		}
 
 		const buttons = paypal.Buttons( {
-			style: {
-				layout: 'vertical',
-				color: 'gold',
-				shape: 'rect',
-				label: 'paypal'
-			},
-
 			async createOrder() {
 				// TODO: Add createOrder logic here
 			},

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
@@ -49,21 +49,32 @@ class WC_Gateway_Paypal_Buttons {
 	 * @return array
 	 */
 	public function get_options() {
-		$intent = $this->gateway->get_option( 'paymentaction' ) === 'authorization' ? 'authorize' : 'capture';
+		$common_options = $this->get_common_options();
+		$options        = array(
+			'partner-attribution-id' => 'Woo_Cart_CoreUpgrade',
+			'page-type'              => $this->get_page_type(),
+		);
 
-		$page_type = $this->get_page_type();
+		return array_merge( $common_options, $options );
+	}
+
+	/**
+	 * Get the common attributes for the PayPal JS SDK script and modules.
+	 *
+	 * @return array
+	 */
+	public function get_common_options() {
+		$intent = $this->gateway->get_option( 'paymentaction' ) === 'authorization' ? 'authorize' : 'capture';
 
 		return array(
 			// phpcs:ignore Generic.Commenting.Todo.TaskFound
-			'client-id'              => 'sb', // TODO: Get the client ID.
-			'components'             => 'buttons,funding-eligibility,messages',
-			'disable-funding'        => 'card,applepay',
-			'enable-funding'         => 'venmo,paylater',
-			'currency'               => get_woocommerce_currency(),
-			'intent'                 => $intent,
-			'merchant-id'            => $this->gateway->email,
-			'partner-attribution-id' => 'Woo_Cart_CoreUpgrade',
-			'page-type'              => $page_type,
+			'client-id'       => 'sb', // TODO: Get the client ID.
+			'components'      => 'buttons,funding-eligibility,messages',
+			'disable-funding' => 'card,applepay',
+			'enable-funding'  => 'venmo,paylater',
+			'currency'        => get_woocommerce_currency(),
+			'intent'          => $intent,
+			'merchant-id'     => $this->gateway->email,
 		);
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
@@ -51,12 +51,7 @@ class WC_Gateway_Paypal_Buttons {
 	public function get_options() {
 		$intent = $this->gateway->get_option( 'paymentaction' ) === 'authorization' ? 'authorize' : 'capture';
 
-		$page_type = 'checkout';
-		if ( is_cart() || has_block( 'woocommerce/cart' ) ) {
-			$page_type = 'cart';
-		} elseif ( is_product() ) {
-			$page_type = 'product-details';
-		}
+		$page_type = $this->get_page_type();
 
 		return array(
 			// phpcs:ignore Generic.Commenting.Todo.TaskFound
@@ -70,6 +65,22 @@ class WC_Gateway_Paypal_Buttons {
 			'partner-attribution-id' => 'Woo_Cart_CoreUpgrade',
 			'page-type'              => $page_type,
 		);
+	}
+
+	/**
+	 * Get the page type for the PayPal buttons.
+	 *
+	 * @return string
+	 */
+	public function get_page_type() {
+		$page_type = 'checkout';
+		if ( is_cart() || has_block( 'woocommerce/cart' ) ) {
+			$page_type = 'cart';
+		} elseif ( is_product() ) {
+			$page_type = 'product-details';
+		}
+
+		return $page_type;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -157,6 +157,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_processing', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
@@ -638,6 +639,33 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$version = Constants::get_constant( 'WC_VERSION' );
 
 		wp_enqueue_script( 'woocommerce_paypal_admin', WC()->plugin_url() . '/includes/gateways/paypal/assets/js/paypal-admin' . $suffix . '.js', array(), $version, true );
+	}
+
+	/**
+	 * Enqueue scripts.
+	 */
+	public function enqueue_scripts() {
+		if ( 'no' === $this->enabled ) {
+			return;
+		}
+
+		if ( ! is_checkout() ) {
+			return;
+		}
+
+		$version  = Constants::get_constant( 'WC_VERSION' );
+
+		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
+
+		wp_localize_script( 'wc-paypal-frontend', 'paypal_standard', [
+			'gateway_id'           => $this->id,
+			'ajax_url'             => admin_url( 'admin-ajax.php' ),
+			'wc_ajax_url'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'create_order_nonce'   => wp_create_nonce( 'ppjs_checkout' ),
+			'capture_order_nonce'  => wp_create_nonce( 'ppjs_checkout' ),
+		]);
+
+		wp_enqueue_script( 'wc-paypal-frontend' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -659,10 +659,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		$version   = Constants::get_constant( 'WC_VERSION' );
-		$page_type = is_checkout() ? 'checkout' : ( is_cart() ? 'cart' : null );
 		$client_id = get_option( 'paypal_client_id' );
 
-		if ( ! $client_id || ! $page_type ) {
+		if ( ! $client_id || ! is_checkout() ) {
 			return;
 		}
 
@@ -706,7 +705,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function add_paypal_sdk_attributes( $attrs ) {
-		$page_type = is_checkout() ? 'checkout' : ( is_cart() ? 'cart' : null );
+		$page_type = is_checkout() ? 'checkout' : null;
 		
 		if ( 'paypal-sdk-js' === $attrs['id'] ) {
 			$attrs['data-page-type']              = $page_type;

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -22,6 +22,10 @@ if ( ! class_exists( 'WC_Gateway_Paypal_Helper' ) ) {
 	require_once __DIR__ . '/includes/class-wc-gateway-paypal-helper.php';
 }
 
+if ( ! class_exists( 'WC_Gateway_Paypal_Buttons' ) ) {
+	require_once __DIR__ . '/class-wc-gateway-paypal-buttons.php';
+}
+
 /**
  * WC_Gateway_Paypal Class.
  */
@@ -670,30 +674,18 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		$version   = Constants::get_constant( 'WC_VERSION' );
-		$client_id = get_option( 'paypal_client_id' );
 		$is_page_supported = is_checkout() || is_cart() || is_product();
+		$buttons = new WC_Gateway_Paypal_Buttons( $this );
+		$options = $buttons->get_options();
 
-		if ( ! $client_id || ! $is_page_supported ) {
+		if ( empty( $options['client-id'] ) || ! $is_page_supported ) {
 			return;
 		}
-
-		// Load PayPal JS SDK dynamically with params.
-		$query = [
-			'client-id'       => $client_id,
-			'intent'          => $this->intent,
-			'buyer-country'   => 'US',
-			'locale'          => get_locale(),
-			'merchant-id'     => $this->email,
-			'components'      => 'buttons,funding-eligibility,messages',
-			'disable-funding' => 'card,applepay',
-			'enable-funding'  => 'venmo,paylater',
-			'currency'        => get_woocommerce_currency(),
-		];
 
 		$sdk_host = $this->testmode ? 'https://www.sandbox.paypal.com/sdk/js' : 'https://www.paypal.com/sdk/js';
 		
 		// Add PayPal JS SDK script.
-		wp_register_script( 'paypal-standard-sdk', add_query_arg( $query, $sdk_host ), [], null, false );
+		wp_register_script( 'paypal-standard-sdk', add_query_arg( $options, $sdk_host ), [], null, false );
 		wp_enqueue_script( 'paypal-standard-sdk' );
 
 		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
@@ -716,11 +708,11 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * @param string $handle Script handle.
 	 * @return array
 	 */
-	public function add_paypal_sdk_attributes( $attrs ) {
-		$page_type = is_checkout() ? 'checkout' : null;
-		
+	public function add_paypal_sdk_attributes( $attrs ) {		
 		if ( 'paypal-standard-sdk-js' === $attrs['id'] ) {
-			wc_get_logger()->debug( 'add_paypal_sdk_attributes' );
+			$buttons   = new WC_Gateway_Paypal_Buttons( $this );
+			$page_type = $buttons->get_page_type();
+	
 			$attrs['data-page-type']              = $page_type;
 			$attrs['data-partner-attribution-id'] = 'Woo_Cart_CoreUpgrade';
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -654,6 +654,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * Enqueue scripts.
 	 */
 	public function enqueue_scripts() {
+		if ( ! $this->should_use_orders_v2() ) {
+			return;
+		}
+
 		if ( 'no' === $this->enabled ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -669,6 +669,15 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Builds the PayPal payment fields area.
+	 *
+	 * @since 10.3.0
+	 */
+	public function payment_fields() {
+		echo '<div id="paypal-standard-container"></div>';
+	}
+
+	/**
 	 * Custom PayPal order received text.
 	 *
 	 * @since 3.9.0

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -676,7 +676,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$version           = Constants::get_constant( 'WC_VERSION' );
 		$is_page_supported = is_checkout() || is_cart() || is_product();
 		$buttons           = new WC_Gateway_Paypal_Buttons( $this );
-		$options           = $buttons->get_options();
+		$options           = $buttons->get_common_options();
 
 		if ( empty( $options['client-id'] ) || ! $is_page_supported ) {
 			return;

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -166,6 +166,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_filter( 'wp_script_attributes', array( $this, 'add_paypal_sdk_attributes' ) );
 
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
@@ -684,9 +685,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		wp_register_script( 'paypal-sdk', add_query_arg( $query, $sdk_host ), [], null, false );
 		wp_enqueue_script( 'paypal-sdk' );
 
-		wp_script_add_data( 'paypal-sdk', 'data-page-type', $page_type );
-		wp_script_add_data( 'paypal-sdk', 'data-partner-attribution-id', 'Woo_Cart_CoreUpgrade' );
-
 		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
 
 		wp_localize_script( 'wc-paypal-frontend', 'paypal_standard', [
@@ -698,6 +696,24 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		]);
 
 		wp_enqueue_script( 'wc-paypal-frontend' );
+	}
+
+	/**
+	 * Add PayPal SDK attributes to the script.
+	 *
+	 * @param array  $attrs Attributes.
+	 * @param string $handle Script handle.
+	 * @return array
+	 */
+	public function add_paypal_sdk_attributes( $attrs ) {
+		$page_type = is_checkout() ? 'checkout' : ( is_cart() ? 'cart' : null );
+		
+		if ( 'paypal-sdk-js' === $attrs['id'] ) {
+			$attrs['data-page-type']              = $page_type;
+			$attrs['data-partner-attribution-id'] = 'Woo_Cart_CoreUpgrade';
+		}
+
+		return $attrs;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -685,8 +685,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$sdk_host = $this->testmode ? 'https://www.sandbox.paypal.com/sdk/js' : 'https://www.paypal.com/sdk/js';
 		
 		// Add PayPal JS SDK script.
-		wp_register_script( 'paypal-sdk', add_query_arg( $query, $sdk_host ), [], null, false );
-		wp_enqueue_script( 'paypal-sdk' );
+		wp_register_script( 'paypal-standard-sdk', add_query_arg( $query, $sdk_host ), [], null, false );
+		wp_enqueue_script( 'paypal-standard-sdk' );
 
 		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
 
@@ -711,7 +711,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	public function add_paypal_sdk_attributes( $attrs ) {
 		$page_type = is_checkout() ? 'checkout' : null;
 		
-		if ( 'paypal-sdk-js' === $attrs['id'] ) {
+		if ( 'paypal-standard-sdk-js' === $attrs['id'] ) {
+			wc_get_logger()->debug( 'add_paypal_sdk_attributes' );
 			$attrs['data-page-type']              = $page_type;
 			$attrs['data-partner-attribution-id'] = 'Woo_Cart_CoreUpgrade';
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -168,6 +168,13 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'wp_script_attributes', array( $this, 'add_paypal_sdk_attributes' ) );
 
+		// Classic Checkout
+		add_action( 'woocommerce_checkout_before_customer_details', array( $this, 'render_buttons_container' ) );
+		// Classic Cart
+		add_action( 'woocommerce_after_cart_totals', array( $this, 'render_buttons_container' ) );
+		// Product
+		add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'render_buttons_container' ) );
+
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
 		} else {
@@ -664,8 +671,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		$version   = Constants::get_constant( 'WC_VERSION' );
 		$client_id = get_option( 'paypal_client_id' );
+		$is_page_supported = is_checkout() || is_cart() || is_product();
 
-		if ( ! $client_id || ! is_checkout() ) {
+		if ( ! $client_id || ! $is_page_supported ) {
 			return;
 		}
 
@@ -725,7 +733,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @since 10.3.0
 	 */
-	public function payment_fields() {
+	public function render_buttons_container() {
 		echo '<div id="paypal-standard-container"></div>';
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -165,15 +165,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_processing', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_filter( 'wp_script_attributes', array( $this, 'add_paypal_sdk_attributes' ) );
-
-		// Classic Checkout
-		add_action( 'woocommerce_checkout_before_customer_details', array( $this, 'render_buttons_container' ) );
-		// Classic Cart
-		add_action( 'woocommerce_after_cart_totals', array( $this, 'render_buttons_container' ) );
-		// Product
-		add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'render_buttons_container' ) );
 
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
@@ -198,6 +189,19 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 			// Hook for plugin upgrades.
 			add_action( 'woocommerce_updated', array( $this, 'maybe_onboard_with_transact' ) );
+
+			if ( $this->should_use_orders_v2() ) {
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+				add_filter( 'wp_script_attributes', array( $this, 'add_paypal_sdk_attributes' ) );
+		
+				// Render the buttons container to load the buttons via PayPal JS SDK.
+				// Classic checkout page.
+				add_action( 'woocommerce_checkout_before_customer_details', array( $this, 'render_buttons_container' ) );
+				// Classic cart page.
+				add_action( 'woocommerce_after_cart_totals', array( $this, 'render_buttons_container' ) );
+				// Product page.
+				add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'render_buttons_container' ) );
+			}
 		}
 	}
 
@@ -661,10 +665,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * Enqueue scripts.
 	 */
 	public function enqueue_scripts() {
-		if ( ! $this->should_use_orders_v2() ) {
-			return;
-		}
-
 		if ( 'no' === $this->enabled ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -63,6 +63,13 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	public $debug;
 
 	/**
+	 * The intent of the payment (capture or authorize).
+	 *
+	 * @var string
+	 */
+	public $intent;
+
+	/**
 	 * Email address to send payments to.
 	 *
 	 * @var string
@@ -139,6 +146,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->title                        = $this->get_option( 'title' );
 		$this->description                  = $this->get_option( 'description' );
 		$this->testmode                     = 'yes' === $this->get_option( 'testmode', 'no' );
+		$this->intent                       = 'sale' === $this->get_option( 'paymentaction', 'sale' ) ? 'capture' : 'authorize';
 		$this->debug                        = 'yes' === $this->get_option( 'debug', 'no' );
 		$this->email                        = $this->get_option( 'email' );
 		$this->receiver_email               = $this->get_option( 'receiver_email', $this->email );
@@ -649,11 +657,35 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			return;
 		}
 
-		if ( ! is_checkout() ) {
+		$version   = Constants::get_constant( 'WC_VERSION' );
+		$page_type = is_checkout() ? 'checkout' : ( is_cart() ? 'cart' : null );
+		$client_id = get_option( 'paypal_client_id' );
+
+		if ( ! $client_id || ! $page_type ) {
 			return;
 		}
 
-		$version  = Constants::get_constant( 'WC_VERSION' );
+		// Load PayPal JS SDK dynamically with params.
+		$query = [
+			'client-id'       => $client_id,
+			'intent'          => $this->intent,
+			'buyer-country'   => 'US',
+			'locale'          => get_locale(),
+			'merchant-id'     => $this->email,
+			'components'      => 'buttons,funding-eligibility,messages',
+			'disable-funding' => 'card,applepay',
+			'enable-funding'  => 'venmo,paylater',
+			'currency'        => get_woocommerce_currency(),
+		];
+
+		$sdk_host = $this->testmode ? 'https://www.sandbox.paypal.com/sdk/js' : 'https://www.paypal.com/sdk/js';
+		
+		// Add PayPal JS SDK script.
+		wp_register_script( 'paypal-sdk', add_query_arg( $query, $sdk_host ), [], null, false );
+		wp_enqueue_script( 'paypal-sdk' );
+
+		wp_script_add_data( 'paypal-sdk', 'data-page-type', $page_type );
+		wp_script_add_data( 'paypal-sdk', 'data-partner-attribution-id', 'Woo_Cart_CoreUpgrade' );
 
 		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
 
@@ -661,8 +693,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			'gateway_id'           => $this->id,
 			'ajax_url'             => admin_url( 'admin-ajax.php' ),
 			'wc_ajax_url'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			'create_order_nonce'   => wp_create_nonce( 'ppjs_checkout' ),
-			'capture_order_nonce'  => wp_create_nonce( 'ppjs_checkout' ),
+			'create_order_nonce'   => wp_create_nonce( 'create_order' ),
+			'capture_order_nonce'  => wp_create_nonce( 'capture_order' ),
 		]);
 
 		wp_enqueue_script( 'wc-paypal-frontend' );

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -197,7 +197,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			if ( $this->should_use_orders_v2() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 				add_filter( 'wp_script_attributes', array( $this, 'add_paypal_sdk_attributes' ) );
-		
+
 				// Render the buttons container to load the buttons via PayPal JS SDK.
 				// Classic checkout page.
 				add_action( 'woocommerce_checkout_before_customer_details', array( $this, 'render_buttons_container' ) );
@@ -673,30 +673,35 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			return;
 		}
 
-		$version   = Constants::get_constant( 'WC_VERSION' );
+		$version           = Constants::get_constant( 'WC_VERSION' );
 		$is_page_supported = is_checkout() || is_cart() || is_product();
-		$buttons = new WC_Gateway_Paypal_Buttons( $this );
-		$options = $buttons->get_options();
+		$buttons           = new WC_Gateway_Paypal_Buttons( $this );
+		$options           = $buttons->get_options();
 
 		if ( empty( $options['client-id'] ) || ! $is_page_supported ) {
 			return;
 		}
 
 		$sdk_host = $this->testmode ? 'https://www.sandbox.paypal.com/sdk/js' : 'https://www.paypal.com/sdk/js';
-		
+
 		// Add PayPal JS SDK script.
-		wp_register_script( 'paypal-standard-sdk', add_query_arg( $options, $sdk_host ), [], null, false );
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script( 'paypal-standard-sdk', add_query_arg( $options, $sdk_host ), array(), null, false );
 		wp_enqueue_script( 'paypal-standard-sdk' );
 
-		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', [ 'jquery' ], $version, true );
+		wp_register_script( 'wc-paypal-frontend', WC()->plugin_url() . '/client/legacy/js/gateways/paypal.js', array( 'jquery' ), $version, true );
 
-		wp_localize_script( 'wc-paypal-frontend', 'paypal_standard', [
-			'gateway_id'           => $this->id,
-			'ajax_url'             => admin_url( 'admin-ajax.php' ),
-			'wc_ajax_url'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			'create_order_nonce'   => wp_create_nonce( 'create_order' ),
-			'capture_order_nonce'  => wp_create_nonce( 'capture_order' ),
-		]);
+		wp_localize_script(
+			'wc-paypal-frontend',
+			'paypal_standard',
+			array(
+				'gateway_id'          => $this->id,
+				'ajax_url'            => admin_url( 'admin-ajax.php' ),
+				'wc_ajax_url'         => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+				'create_order_nonce'  => wp_create_nonce( 'create_order' ),
+				'capture_order_nonce' => wp_create_nonce( 'capture_order' ),
+			)
+		);
 
 		wp_enqueue_script( 'wc-paypal-frontend' );
 	}
@@ -704,15 +709,14 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	/**
 	 * Add PayPal SDK attributes to the script.
 	 *
-	 * @param array  $attrs Attributes.
-	 * @param string $handle Script handle.
+	 * @param array $attrs Attributes.
 	 * @return array
 	 */
-	public function add_paypal_sdk_attributes( $attrs ) {		
+	public function add_paypal_sdk_attributes( $attrs ) {
 		if ( 'paypal-standard-sdk-js' === $attrs['id'] ) {
 			$buttons   = new WC_Gateway_Paypal_Buttons( $this );
 			$page_type = $buttons->get_page_type();
-	
+
 			$attrs['data-page-type']              = $page_type;
 			$attrs['data-partner-attribution-id'] = 'Woo_Cart_CoreUpgrade';
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Loads PayPal JS SDK and displays PayPal, Venmo and Pay Later buttons on classic checkout. No functionality added in this PR.

Closes PAYPAL-74 

### How to test the changes in this Pull Request:
1. Add this option to enable PayPal standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`
2. Enable PayPal standard from WooCommerce > Settings > Payments.
3. Add your client ID: `wp option add paypal_client_id <your_client_id>`
4. Create a classic( shortcode ) checkout page if you already don't have one.
5. As a shopper, go to the classic checkout page and confirm that the PayPal buttons are loading.

**Note** The button position on the checkout page is a little off. I will fix in it separately.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
