### PR TITLE
Avoid lists of one Express Payment options.

### DIFF
--- a/plugins/woocommerce/changelog/60674-fix-60556-a11y-express-payments-list-of-one
+++ b/plugins/woocommerce/changelog/60674-fix-60556-a11y-express-payments-list-of-one
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Accessibility: Avoid list of one for a single express pay option on the block cart page.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -192,9 +192,9 @@ const ExpressPaymentMethods = () => {
 				) : null;
 			} )
 		) : (
-			<ExpressPayItem key="noneRegistered">
+			<div key="noneRegistered">
 				{ __( 'No registered Payment Methods', 'woocommerce' ) }
-			</ExpressPayItem>
+			</div>
 		);
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -157,6 +157,20 @@ const ExpressPaymentMethods = () => {
 	 * paymentMethodInterface itself also updates on most renders.
 	 */
 	const entries = Object.entries( paymentMethods );
+	/*
+	 * Define the elements used for the Express Payments markup.
+	 *
+	 * When multiple express payment options are available, this will use an
+	 * unordered list to display the each option.
+	 *
+	 * When only one express payment option is available, this will use a
+	 * non-sematic DIV for both the wrapper and the individual items. This
+	 * it to prevent accessibility issues caused by a list of one (which isn't
+	 * a list).
+	 */
+	const ExpressPayWrapper = entries.length > 1 ? 'ul' : 'div';
+	const ExpressPayItem = entries.length > 1 ? 'li' : 'div';
+
 	const content =
 		entries.length > 0 ? (
 			entries.map( ( [ id, paymentMethod ] ) => {
@@ -164,7 +178,7 @@ const ExpressPaymentMethods = () => {
 					? paymentMethod.edit
 					: paymentMethod.content;
 				return isValidElement( expressPaymentMethod ) ? (
-					<li key={ id } id={ `express-payment-method-${ id }` }>
+					<ExpressPayItem key={ id } id={ `express-payment-method-${ id }` }>
 						{ cloneElement( expressPaymentMethod, {
 							...paymentMethodInterface,
 							onClick: onExpressPaymentClick( id ),
@@ -174,20 +188,20 @@ const ExpressPaymentMethods = () => {
 								deprecatedSetExpressPaymentError,
 							buttonAttributes,
 						} ) }
-					</li>
+					</ExpressPayItem>
 				) : null;
 			} )
 		) : (
-			<li key="noneRegistered">
+			<ExpressPayItem key="noneRegistered">
 				{ __( 'No registered Payment Methods', 'woocommerce' ) }
-			</li>
+			</ExpressPayItem>
 		);
 
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
-			<ul className="wc-block-components-express-payment__event-buttons">
+			<ExpressPayWrapper className="wc-block-components-express-payment__event-buttons">
 				{ content }
-			</ul>
+			</ExpressPayWrapper>
 		</PaymentMethodErrorBoundary>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -178,7 +178,10 @@ const ExpressPaymentMethods = () => {
 					? paymentMethod.edit
 					: paymentMethod.content;
 				return isValidElement( expressPaymentMethod ) ? (
-					<ExpressPayItem key={ id } id={ `express-payment-method-${ id }` }>
+					<ExpressPayItem
+						key={ id }
+						id={ `express-payment-method-${ id }` }
+					>
 						{ cloneElement( expressPaymentMethod, {
 							...paymentMethodInterface,
 							onClick: onExpressPaymentClick( id ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -164,8 +164,8 @@ const ExpressPaymentMethods = () => {
 	 * unordered list to display each option.
 	 *
 	 * When only one express payment option is available, this will use a
-	 * non-sematic DIV for both the wrapper and the individual items. This
-	 * it to prevent accessibility issues caused by a list of one (which isn't
+	 * non-semantic DIV for both the wrapper and the individual items. This
+	 * is to prevent accessibility issues caused by a list of one (which isn't
 	 * a list).
 	 */
 	const ExpressPayWrapper = entries.length > 1 ? 'ul' : 'div';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -161,7 +161,7 @@ const ExpressPaymentMethods = () => {
 	 * Define the elements used for the Express Payments markup.
 	 *
 	 * When multiple express payment options are available, this will use an
-	 * unordered list to display the each option.
+	 * unordered list to display each option.
 	 *
 	 * When only one express payment option is available, this will use a
 	 * non-sematic DIV for both the wrapper and the individual items. This

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -63,6 +63,19 @@ const CartExpressPayment = () => {
 	) {
 		return null;
 	}
+	/*
+	 * Define the elements used for the Express Payments markup.
+	 *
+	 * When multiple express payment options are available, this will use an
+	 * unordered list to display each option.
+	 *
+	 * When only one express payment option is available, this will use a
+	 * non-sematic DIV for both the wrapper and the individual items. This
+	 * it to prevent accessibility issues caused by a list of one (which isn't
+	 * a list).
+	 */
+	const ExpressPayWrapper = availableExpressPaymentsCount > 1 ? 'ul' : 'div';
+	const ExpressPayItem = availableExpressPaymentsCount > 1 ? 'li' : 'div';
 
 	return (
 		<>
@@ -90,11 +103,11 @@ const CartExpressPayment = () => {
 						context={ noticeContexts.EXPRESS_PAYMENTS }
 					/>
 					{ showSkeleton ? (
-						<ul className="wc-block-components-express-payment__event-buttons">
+						<ExpressPayWrapper className="wc-block-components-express-payment__event-buttons">
 							{ Array.from( {
 								length: availableExpressPaymentsCount,
 							} ).map( ( _, index ) => (
-								<li key={ index }>
+								<ExpressPayItem key={ index }>
 									<Skeleton
 										height="48px"
 										ariaMessage={ __(
@@ -102,9 +115,9 @@ const CartExpressPayment = () => {
 											'woocommerce'
 										) }
 									/>
-								</li>
+								</ExpressPayItem>
 							) ) }
-						</ul>
+						</ExpressPayWrapper>
 					) : (
 						<ExpressPaymentMethods />
 					) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -70,8 +70,8 @@ const CartExpressPayment = () => {
 	 * unordered list to display each option.
 	 *
 	 * When only one express payment option is available, this will use a
-	 * non-sematic DIV for both the wrapper and the individual items. This
-	 * it to prevent accessibility issues caused by a list of one (which isn't
+	 * non-semantic DIV for both the wrapper and the individual items. This
+	 * is to prevent accessibility issues caused by a list of one (which isn't
 	 * a list).
 	 */
 	const ExpressPayWrapper = availableExpressPaymentsCount > 1 ? 'ul' : 'div';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -11,6 +11,7 @@ $border-width: 1px;
 		margin: 0;
 		overflow: hidden;
 		text-align: center;
+		> div,
 		> li {
 			margin: 0;
 			width: 100%;
@@ -127,6 +128,7 @@ $border-width: 1px;
 
 .wc-block-components-express-payment--cart {
 	.wc-block-components-express-payment__event-buttons {
+		> div,
 		> li {
 			padding-bottom: $gap-small;
 			text-align: center;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -31,7 +31,7 @@ jest.mock( '../express-payment/express-payment-context', () => {
 	};
 } );
 
-const mockExpressPaymentMethodNames = [ 'paypal', 'google pay', 'apple pay' ];
+const mockExpressPaymentMethodNames = [ 'paypal', 'google-pay', 'apple-pay' ];
 
 const MockExpressButton = jest.fn( ( { name } ) => (
 	<div className="boo">{ `${ name } button` }</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -124,6 +124,43 @@ describe( 'Express payment methods', () => {
 		afterAll( () => {
 			deregisterMockExpressPaymentMethods();
 		} );
+		describe( 'In an editor context', () => {
+			beforeEach( () => {
+				mockEditorContext.mockImplementation( () => ( {
+					isEditor: true,
+				} ) );
+			} );
+			it( 'should use a div for the wrapper and express payment method elements (a11y)', () => {
+				render( <ExpressPaymentMethods /> );
+				expect(
+					document.querySelector(
+						'.wc-block-components-express-payment__event-buttons'
+					)
+				).toHaveProperty( 'tagName', 'DIV' );
+				expect(
+					document.querySelector(
+						'ul.wc-block-components-express-payment__event-buttons'
+					)
+				).toBeNull();
+				const mockExpressPaymentMethodName =
+					mockExpressPaymentMethodNames[ 0 ];
+				expect(
+					document.querySelectorAll(
+						'[id^="express-payment-method-"]'
+					).length
+				).toBe( 1 );
+				expect(
+					document.querySelector(
+						`#express-payment-method-${ mockExpressPaymentMethodName }`
+					)
+				).toBeInTheDocument();
+				expect(
+					document.querySelector(
+						`#express-payment-method-${ mockExpressPaymentMethodName }`
+					)
+				).toHaveProperty( 'tagName', 'DIV' );
+			} );
+		} );
 
 		describe( 'In a frontend context', () => {
 			it( 'should use a div for the wrapper and express payment method elements (a11y)', () => {
@@ -160,6 +197,11 @@ describe( 'Express payment methods', () => {
 	} );
 
 	describe( 'Payment methods available', () => {
+		beforeEach( () => {
+			mockEditorContext.mockImplementation( () => ( {
+				isEditor: false,
+			} ) );
+		} );
 		beforeAll( () => {
 			registerMockExpressPaymentMethods();
 		} );
@@ -260,29 +302,6 @@ describe( 'Express payment methods', () => {
 						)
 					).toHaveProperty( 'tagName', 'LI' );
 				} );
-			} );
-			it( 'should use a div wrapper and individual div for a single express payment method element (a11y)', () => {
-				deregisterMockExpressPaymentMethods();
-				registerSingleMockExpressPaymentMethod();
-				render( <ExpressPaymentMethods /> );
-
-				expect(
-					document.querySelector(
-						'.wc-block-components-express-payment__event-buttons'
-					)
-				).toHaveProperty( 'tagName', 'DIV' );
-				expect(
-					document.querySelectorAll(
-						'[id^="express-payment-method-"]'
-					).length
-				).toBe( 1 );
-
-				expect(
-					document.querySelector( `#express-payment-method-paypal` )
-				).toBeInTheDocument();
-				expect(
-					document.querySelector( `#express-payment-method-paypal` )
-				).toHaveProperty( 'tagName', 'DIV' );
 			} );
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -61,6 +61,7 @@ const registerMockExpressPaymentMethods = () => {
 };
 
 const registerSingleMockExpressPaymentMethod = () => {
+	// Use the first payment method to allow use of common deregister function.
 	const mockExpressPaymentMethodName = mockExpressPaymentMethodNames[ 0 ];
 	[ mockExpressPaymentMethodName ].forEach( ( name ) => {
 		registerExpressPaymentMethod( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -118,8 +118,18 @@ describe( 'Express payment methods', () => {
 						'.wc-block-components-express-payment__event-buttons'
 					)
 				).toHaveProperty( 'tagName', 'DIV' );
+				expect(
+					document.querySelector(
+						'ul.wc-block-components-express-payment__event-buttons'
+					)
+				).toBeNull();
 				const mockExpressPaymentMethodName =
 					mockExpressPaymentMethodNames[ 0 ];
+				expect(
+					document.querySelectorAll(
+						'[id^="express-payment-method-"]'
+					).length
+				).toBe( 1 );
 				expect(
 					document.querySelector(
 						`#express-payment-method-${ mockExpressPaymentMethodName }`
@@ -218,6 +228,11 @@ describe( 'Express payment methods', () => {
 						'.wc-block-components-express-payment__event-buttons'
 					)
 				).toHaveProperty( 'tagName', 'UL' );
+				expect(
+					document.querySelectorAll(
+						'[id^="express-payment-method-"]'
+					).length
+				).toBe( mockExpressPaymentMethodNames.length );
 				mockExpressPaymentMethodNames.forEach( ( name ) => {
 					expect(
 						document.querySelector(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -163,6 +163,28 @@ describe( 'Express payment methods', () => {
 					'isPristine is deprecated since version 9.6.0. Please use isIdle instead. See: https://github.com/woocommerce/woocommerce-blocks/pull/8110'
 				);
 			} );
+
+			it( 'should use a ul wrapper and li for express payment method elements (a11y)', () => {
+				render( <ExpressPaymentMethods /> );
+
+				expect(
+					document.querySelector(
+						'.wc-block-components-express-payment__event-buttons'
+					)
+				).toHaveProperty( 'tagName', 'UL' );
+				mockExpressPaymentMethodNames.forEach( ( name ) => {
+					expect(
+						document.querySelector(
+							`#express-payment-method-${ name }`
+						)
+					).toBeInTheDocument();
+					expect(
+						document.querySelector(
+							`#express-payment-method-${ name }`
+						)
+					).toHaveProperty( 'tagName', 'LI' );
+				} );
+			} );
 		} );
 		describe( 'In an editor context', () => {
 			beforeEach( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -60,6 +60,26 @@ const registerMockExpressPaymentMethods = () => {
 	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
 };
 
+const registerSingleMockExpressPaymentMethod = () => {
+	const mockExpressPaymentMethodName = mockExpressPaymentMethodNames[ 0 ];
+	[ mockExpressPaymentMethodName ].forEach( ( name ) => {
+		registerExpressPaymentMethod( {
+			name,
+			title: `${ name } payment method`,
+			description: `A test ${ name } payment method`,
+			gatewayId: 'test-express-payment-method',
+			paymentMethodId: name,
+			content: <MockExpressButton name={ name } />,
+			edit: <MockEditorExpressButton name={ name } />,
+			canMakePayment: () => true,
+			supports: {
+				features: [ 'products' ],
+			},
+		} );
+	} );
+	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
+};
+
 const deregisterMockExpressPaymentMethods = () => {
 	mockExpressPaymentMethodNames.forEach( ( name ) => {
 		__experimentalDeRegisterExpressPaymentMethod( name );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -209,6 +209,28 @@ describe( 'Express payment methods', () => {
 					);
 				} );
 			} );
+
+			it( 'should use a ul wrapper and li for express payment method elements (a11y)', () => {
+				render( <ExpressPaymentMethods /> );
+
+				expect(
+					document.querySelector(
+						'.wc-block-components-express-payment__event-buttons'
+					)
+				).toHaveProperty( 'tagName', 'UL' );
+				mockExpressPaymentMethodNames.forEach( ( name ) => {
+					expect(
+						document.querySelector(
+							`#express-payment-method-${ name }`
+						)
+					).toBeInTheDocument();
+					expect(
+						document.querySelector(
+							`#express-payment-method-${ name }`
+						)
+					).toHaveProperty( 'tagName', 'LI' );
+				} );
+			} );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -101,6 +101,38 @@ describe( 'Express payment methods', () => {
 		} );
 	} );
 
+	describe( 'Single payment method available', () => {
+		beforeAll( () => {
+			registerSingleMockExpressPaymentMethod();
+		} );
+		afterAll( () => {
+			deregisterMockExpressPaymentMethods();
+		} );
+
+		describe( 'In a frontend context', () => {
+			it( 'should use a div for the wrapper and express payment method elements (a11y)', () => {
+				render( <ExpressPaymentMethods /> );
+				expect(
+					document.querySelector(
+						'.wc-block-components-express-payment__event-buttons'
+					)
+				).toHaveProperty( 'tagName', 'DIV' );
+				const mockExpressPaymentMethodName =
+					mockExpressPaymentMethodNames[ 0 ];
+				expect(
+					document.querySelector(
+						`#express-payment-method-${ mockExpressPaymentMethodName }`
+					)
+				).toBeInTheDocument();
+				expect(
+					document.querySelector(
+						`#express-payment-method-${ mockExpressPaymentMethodName }`
+					)
+				).toHaveProperty( 'tagName', 'DIV' );
+			} );
+		} );
+	} );
+
 	describe( 'Payment methods available', () => {
 		beforeAll( () => {
 			registerMockExpressPaymentMethods();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -100,6 +100,21 @@ describe( 'Express payment methods', () => {
 			);
 			expect( noPaymentMethods.length ).toEqual( 1 );
 		} );
+
+		it( 'should use a div for the wrapper (a11y)', () => {
+			render( <ExpressPaymentMethods /> );
+			expect(
+				document.querySelector(
+					'.wc-block-components-express-payment__event-buttons'
+				)
+			).toHaveProperty( 'tagName', 'DIV' );
+			expect(
+				document.querySelector(
+					'ul.wc-block-components-express-payment__event-buttons'
+				)
+			).toBeNull();
+			expect( document.querySelectorAll( 'li' ).length ).toBe( 0 );
+		} );
 	} );
 
 	describe( 'Single payment method available', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -235,7 +235,7 @@ describe( 'Express payment methods', () => {
 				} );
 			} );
 
-			it( 'should use a ul wrapper and li for express payment method elements (a11y)', () => {
+			it( 'should use a ul wrapper and li for multiple express payment method elements (a11y)', () => {
 				render( <ExpressPaymentMethods /> );
 
 				expect(
@@ -260,6 +260,29 @@ describe( 'Express payment methods', () => {
 						)
 					).toHaveProperty( 'tagName', 'LI' );
 				} );
+			} );
+			it( 'should use a div wrapper and individual div for a single express payment method element (a11y)', () => {
+				deregisterMockExpressPaymentMethods();
+				registerSingleMockExpressPaymentMethod();
+				render( <ExpressPaymentMethods /> );
+
+				expect(
+					document.querySelector(
+						'.wc-block-components-express-payment__event-buttons'
+					)
+				).toHaveProperty( 'tagName', 'DIV' );
+				expect(
+					document.querySelectorAll(
+						'[id^="express-payment-method-"]'
+					).length
+				).toBe( 1 );
+
+				expect(
+					document.querySelector( `#express-payment-method-paypal` )
+				).toBeInTheDocument();
+				expect(
+					document.querySelector( `#express-payment-method-paypal` )
+				).toHaveProperty( 'tagName', 'DIV' );
 			} );
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
@@ -61,6 +61,7 @@
 // Center images rendered in place of buttons in the editor
 .wc-block-components-express-payment {
 	.wc-block-components-express-payment__event-buttons {
+		> div,
 		> li {
 			pointer-events: none;
 			user-select: none;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/editor.scss
@@ -56,6 +56,7 @@
 // Center images rendered in place of buttons in the editor
 .wc-block-components-express-payment {
 	.wc-block-components-express-payment__event-buttons {
+		> div,
 		> li {
 			pointer-events: none;
 			user-select: none;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Improves the accessibility of the Express Payment buttons on the Block Cart page by avoiding lists of one.

A list of one adds noise to screen readers as the list will be announced as containing "one item" (which isn't a list), whereas a user only needs to know if there are a list of options/items if there are multiple items available.

Closes #60556
Closes WOOPYBR-66
Supersedes PR #60559

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Markup before:

```html
<ul class="wc-block-components-express-payment__event-buttons">
  <li id="express-payment-method-Dummy Express"><!-- item markup --></li>
</ul>
```

Markup after:

```html
<div class="wc-block-components-express-payment__event-buttons">
  <div id="express-payment-method-Dummy Express"><!-- item markup --></div>
</div>
```


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I used the [Dummy Gateway](https://github.com/woocommerce/woocommerce-gateway-dummy) for testing this and hacked it to add a placeholder for express payment options.

In the plugin, I added the following to the footer of the `resources/js/frontend/index.js` file:

```js
import { registerExpressPaymentMethod } from '@woocommerce/blocks-registry';
registerExpressPaymentMethod( {
	name: 'Dummy Express',
	title: 'Dummy Express',
	description: 'A setence or two about your payment method',
	gatewayId: 'dummy',
	label: <div>label</div>,
	content: <div>Dummy Payment Express</div>,
	edit: <div>edit</div>,
	canMakePayment: () => true,
	paymentMethodId: 'dummy',
} );

// Remove when testing one payment gateway only.
registerExpressPaymentMethod( {
	name: 'Dummy Express 2',
	title: 'Dummy Express 2',
	description: 'A setence or two about your payment method',
	gatewayId: 'dummy',
	label: <div>label</div>,
	content: <div>Dummy Payment Express Two</div>,
	edit: <div>edit</div>,
	canMakePayment: () => true,
	paymentMethodId: 'dummy',
} );
```

1. Hack the dummy gateway as noted above
2. Run `npm i; npm run start` on the dummy gateway
3. Activate the dummy gateway plugin
4. Add a product to the cart
5. Proceed to the block cart
6. Inspect the markup to ensure the two express pay options display as a list.
7. Remove the second gateway from the dummy gateway test code & save.
8. Reload the cart page
9. Inspect the markup to ensure the one express pay option displays using divs.

<!-- End testing instructions -->

### Testing that has already taken place:

As above

I also tested with the [Braintree gateway](https://wordpress.org/plugins/woocommerce-gateway-paypal-powered-by-braintree/) using a properly configured express payment option.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Accessibility: Avoid list of one for a single express pay option on the block cart page.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
