### PR TITLE
WPS migration: fix loading and hiding of legacy settings

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -177,7 +177,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			add_filter( 'woocommerce_my_account_my_orders_actions', array( $this, 'hide_action_buttons' ), 10, 2 );
 
 			add_filter( 'woocommerce_settings_api_form_fields_paypal', array( $this, 'maybe_remove_fields' ), 15 );
-			add_action( 'woocommerce_paypal_show_legacy_settings', array( $this, 'should_show_legacy_settings' ) );
 
 			// Hook for plugin upgrades.
 			add_action( 'woocommerce_updated', array( $this, 'maybe_onboard_with_transact' ) );
@@ -447,7 +446,11 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		// Additional details are added to the receiver email when subscriptions are enabled.
 		// We don't need this for Orders v2.
 		if ( $this->should_use_orders_v2() ) {
-			unset( $form_fields['receiver_email'] );
+			foreach ( $form_fields as $key => $field ) {
+				if ( isset( $field['is_legacy'] ) && $field['is_legacy'] ) {
+					unset( $form_fields[ $key ] );
+				}
+			}
 		}
 		return $form_fields;
 	}
@@ -774,16 +777,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$this->jetpack_connection_manager = new Jetpack_Connection_Manager( 'woocommerce' );
 		}
 		return $this->jetpack_connection_manager;
-	}
-
-	/**
-	 * Whether to show legacy settings. Hooked into the
-	 * `woocommerce_paypal_show_legacy_settings` filter.
-	 *
-	 * @return bool
-	 */
-	public function should_show_legacy_settings() {
-		return ! $this->should_use_orders_v2();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -109,6 +109,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'ipn_notification'      => array(
 		'title'       => __( 'IPN email notifications', 'woocommerce' ),
@@ -116,6 +117,7 @@ $legacy_settings = array(
 		'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
 		'default'     => 'yes',
 		'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'receiver_email'        => array(
 		'title'       => __( 'Receiver email', 'woocommerce' ),
@@ -124,6 +126,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => 'you@youremail.com',
+		'is_legacy'   => true,
 	),
 	'identity_token'        => array(
 		'title'       => __( 'PayPal identity token', 'woocommerce' ),
@@ -132,12 +135,14 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => '',
+		'is_legacy'   => true,
 	),
 	'api_details'           => array(
 		'title'       => __( 'API credentials', 'woocommerce' ),
 		'type'        => 'title',
 		/* translators: %s: URL */
 		'description' => sprintf( __( 'Enter your PayPal API credentials to process refunds via PayPal. Learn how to access your <a href="%s">PayPal API Credentials</a>.', 'woocommerce' ), 'https://developer.paypal.com/webapps/developer/docs/classic/api/apiCredentials/#create-an-api-signature' ),
+		'is_legacy'   => true,
 	),
 	'api_username'          => array(
 		'title'       => __( 'Live API username', 'woocommerce' ),
@@ -146,6 +151,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'api_password'          => array(
 		'title'       => __( 'Live API password', 'woocommerce' ),
@@ -154,6 +160,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'api_signature'         => array(
 		'title'       => __( 'Live API signature', 'woocommerce' ),
@@ -162,6 +169,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'sandbox_api_username'  => array(
 		'title'       => __( 'Sandbox API username', 'woocommerce' ),
@@ -170,6 +178,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'sandbox_api_password'  => array(
 		'title'       => __( 'Sandbox API password', 'woocommerce' ),
@@ -178,6 +187,7 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 	'sandbox_api_signature' => array(
 		'title'       => __( 'Sandbox API signature', 'woocommerce' ),
@@ -186,18 +196,8 @@ $legacy_settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
+		'is_legacy'   => true,
 	),
 );
 
-/**
- * Filters whether to show legacy settings.
- *
- * @param bool $show_legacy_settings Whether to show legacy settings.
- * @since 10.2.0
- */
-if ( apply_filters( 'woocommerce_paypal_show_legacy_settings', true ) ) {
-	$settings = array_merge( $settings, $legacy_settings );
-}
-
-
-return $settings;
+return array_merge( $settings, $legacy_settings );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Merges into feature branch: **feature/paypal-wps-migration**

Fixes an issue where legacy settings are still displayed even when the store has been migrated to Orders v2.

The issue is because due to changes in `WC_Gateway_Paypal` instantiation timing (from https://github.com/woocommerce/woocommerce/pull/60440), the filter we're using now gets hooked in too late.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that legacy settings are not shown for a migrated store, i.e. Orders v2 migration compatible and Transact onboarded.
2. Verify that legacy settings are shown for a legacy store
   ```
   add_filter( 'woocommerce_paypal_use_orders_v2', '__return_false' );
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Merges into a feature branch.

</details>
