### PR TITLE
Ensure session token is passed as a string

### DIFF
--- a/plugins/woocommerce/changelog/60692-fix-sanitize-session-token-in-the-url
+++ b/plugins/woocommerce/changelog/60692-fix-sanitize-session-token-in-the-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure session token is passed as a string

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -117,7 +117,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	private function init_session_from_request() {
-		$session_token = is_string( $_GET['session'] ?? '' ) ? wc_clean( wp_unslash( $_GET['session'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$session_token = is_string( $_GET['session'] ?? '' ) ? wc_clean( wp_unslash( $_GET['session'] ?? '' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( empty( $session_token ) || ! CartTokenUtils::validate_cart_token( $session_token ) ) {
 			return false;

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -117,7 +117,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	private function init_session_from_request() {
-		$session_token = wc_clean( wp_unslash( $_GET['session'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$session_token = is_string( $_GET['session'] ?? '' ) ? wc_clean( wp_unslash( $_GET['session'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( empty( $session_token ) || ! CartTokenUtils::validate_cart_token( $session_token ) ) {
 			return false;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes WCCOM-1791

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**On trunk**

Pass `?session[]=1` to any URLs, for example: http://localhost:8888/?session[]=1. Got fatal error:

```
Fatal error: Uncaught TypeError: Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils::validate_cart_token(): Argument #1 ($cart_token) must be of type string, array given, called in /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-session-handler.php on line 122 and defined in /var/www/html/wp-content/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php:40 Stack trace: #0 /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-session-handler.php(122): Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils::validate_cart_token(Array) #1 /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-session-handler.php(104): WC_Session_Handler->init_session_from_request() #2 /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-session-handler.php(83): WC_Session_Handler->init_session() #3 /var/www/html/wp-content/plugins/woocommerce/includes/class-woocommerce.php(1096): WC_Session_Handler->init() #4 /var/www/html/wp-content/plugins/woocommerce/includes/wc-core-functions.php(2660): WooCommerce->initialize_session() #5 /var/www/html/wp-content/plugins/woocommerce/includes/class-woocommerce.php(887): wc_load_cart() #6 /var/www/html/wp-includes/class-wp-hook.php(324): WooCommerce->init('') #7 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #8 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #9 /var/www/html/wp-settings.php(727): do_action('init') #10 /var/www/html/wp-config.php(152): require_once('/var/www/html/w...') #11 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...') #12 /var/www/html/wp-blog-header.php(13): require_once('/var/www/html/w...') #13 /var/www/html/index.php(17): require('/var/www/html/w...') #14 {main} thrown in /var/www/html/wp-content/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php on line 40
```

**Verify the fix**

Checkout this branch. Do the same request. No fatal error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure session token is passed as a string
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
