### PR TITLE
Revert copy change for marketplace link introduced in #58608

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -485,7 +485,7 @@ export const SettingsPaymentsMain = () => {
 		<TrackedLink
 			message={ __(
 				// translators: {{Link}} is a placeholder for a html element.
-				'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find additional payment options.',
+				'{{Link}}More payment options{{/Link}}',
 				'woocommerce'
 			) }
 			onClickCallback={ trackMorePaymentsOptionsClicked }

--- a/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
@@ -34,14 +34,14 @@ describe( 'SettingsPaymentsMain', () => {
 		);
 	} );
 
-	it( 'should trigger event recommendations_other_options when clicking the WooCommerce Marketplace link', () => {
+	it( 'should trigger event recommendations_other_options when clicking the more payment options link', () => {
 		render(
 			<Router>
 				<SettingsPaymentsMain />
 			</Router>
 		);
 
-		fireEvent.click( screen.getByText( 'the WooCommerce Marketplace' ) );
+		fireEvent.click( screen.getByText( 'More payment options' ) );
 
 		expect( recordEvent ).toHaveBeenCalledWith(
 			'settings_payments_recommendations_other_options',
@@ -52,7 +52,7 @@ describe( 'SettingsPaymentsMain', () => {
 		);
 	} );
 
-	it( 'should navigate to the marketplace when clicking the WooCommerce Marketplace link', () => {
+	it( 'should navigate to the marketplace when clicking the more payment options link', () => {
 		const { isFeatureEnabled } = jest.requireMock( '~/utils/features' );
 		( isFeatureEnabled as jest.Mock ).mockReturnValue( true );
 
@@ -71,7 +71,7 @@ describe( 'SettingsPaymentsMain', () => {
 			</Router>
 		);
 
-		fireEvent.click( screen.getByText( 'the WooCommerce Marketplace' ) );
+		fireEvent.click( screen.getByText( 'More payment options' ) );
 
 		expect( mockLocation.href ).toContain(
 			'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=payment-gateways'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #58608 we changed both the copy and the target for the additional payments options link on the new payment settings screen. We've since seen a drop in clicks on that link, so we're reverting the copy to what it was before, but keeping the link target as the in-app Marketplace.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WCCOM-1787](https://linear.app/a8c/issue/WCCOM-1787/revert-copy-change-on-payments-settings-screen)

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="526" height="357" alt="WooCommerce_settings_‹_WP_Test_Site_—_WordPress" src="https://github.com/user-attachments/assets/4b3e19ce-27e6-4168-9b51-ba14637f8936" /> | <img width="592" height="349" alt="WooCommerce_settings_‹_woocommerce_—_WordPress" src="https://github.com/user-attachments/assets/fd8d755a-38e2-49fc-ad38-f1a5aeb3d3a6" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch, `cd plugins/woocommerce` and `pnpm watch:build`
2. Start your local environment by running `pnpm env:start` in the same folder
3. Go to http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=checkout&other_pes_section=expanded and confirm you see the updated copy for the marketplace link
4. Run `localStorage.setItem( 'debug', 'wc-admin:*' );` in the console to log Tracks events.
5. Click the link. Confirm you're taken to the in-app marketplace set to the Payments category, and that the `wcadmin_settings_payments_recommendations_other_options` event is fired
6. Go to the `/plugins/woocommerce/client/admin` directory and run `pnpm test:js client/settings-payments/test/settings-payments-main.test.tsx`. Confirm the tests still pass
7. Please test around this issue.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Small copy change, not affecting functionality in any way

</details>
