### PR TITLE
Move products data in WooCommerce generic store to config

### DIFF
--- a/plugins/woocommerce/changelog/update-products-data-in-config
+++ b/plugins/woocommerce/changelog/update-products-data-in-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Move products data in WooCommerce generic store to config
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -1,24 +1,20 @@
 /**
  * External dependencies
  */
-import { getElement, store, getContext } from '@wordpress/interactivity';
+import {
+	getElement,
+	store,
+	getContext,
+	getConfig,
+} from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/product-data';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
-import type {
-	ProductData,
-	Store as WooCommerce,
-} from '@woocommerce/stores/woocommerce/cart';
+import type { ProductData } from '@woocommerce/stores/woocommerce/cart';
 import { sanitize } from 'dompurify'; // eslint-disable-line import/named
 
 // Stores are locked to prevent 3PD usage until the API is stable.
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
-
-const { state: wooState } = store< WooCommerce >(
-	'woocommerce',
-	{},
-	{ lock: universalLock }
-);
 
 const { state: productDataState } = store< ProductDataStore >(
 	'woocommerce/product-data',
@@ -67,10 +63,12 @@ const productElementStore = store(
 					return undefined;
 				}
 
+				const { products } = getConfig( 'woocommerce' );
+
 				return (
-					wooState?.products?.[ productDataState.productId ]
-						?.variations?.[ productDataState?.variationId || 0 ] ||
-					wooState?.products?.[ productDataState.productId ]
+					products?.[ productDataState.productId ]?.variations?.[
+						productDataState?.variationId || 0
+					] || products?.[ productDataState.productId ]
 				);
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -65,6 +65,10 @@ const productElementStore = store(
 
 				const { products } = getConfig( 'woocommerce' );
 
+				if ( ! products ) {
+					return undefined;
+				}
+
 				return (
 					products?.[ productDataState.productId ]?.variations?.[
 						productDataState?.variationId || 0

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -71,9 +71,6 @@ export type Store = {
 			items: ( OptimisticCartItem | CartItem )[];
 			totals: CartResponseTotals;
 		};
-		products?: {
-			[ productId: number ]: ProductData;
-		};
 	};
 	actions: {
 		removeCartItem: ( key: string ) => void;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -75,6 +75,8 @@ export const getProductData = (
 	let productId = id;
 	let productData: ProductData | undefined;
 
+	const { products } = getConfig( 'woocommerce' );
+
 	if (
 		productType === 'variable' &&
 		availableVariations &&
@@ -87,12 +89,12 @@ export const getProductData = (
 		if ( matchedVariation?.variation_id ) {
 			productId = matchedVariation.variation_id;
 			productData =
-				wooState?.products?.[ id ]?.variations?.[
+				products?.[ id ]?.variations?.[
 					matchedVariation?.variation_id
 				];
 		}
 	} else {
-		productData = wooState?.products?.[ productId ];
+		productData = products?.[ productId ];
 	}
 
 	if ( typeof productData !== 'object' || productData === null ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -6,9 +6,9 @@ import {
 	getContext as getContextFn,
 	getElement,
 	withScope,
+	getConfig,
 } from '@wordpress/interactivity';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
-import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
 
 /**
  * Internal dependencies
@@ -165,12 +165,6 @@ const scrollThumbnailIntoView = ( imageId: number ) => {
 
 const { state: productDataState } = store< ProductDataStore >(
 	'woocommerce/product-data',
-	{},
-	{ lock: universalLock }
-);
-
-const { state: wooState } = store< WooCommerce >(
-	'woocommerce',
 	{},
 	{ lock: universalLock }
 );
@@ -440,10 +434,12 @@ const productGallery = {
 				return;
 			}
 
+			const { products } = getConfig( 'woocommerce' );
+
 			const productData =
-				wooState?.products?.[ productId ]?.variations?.[
+				products?.[ productId ]?.variations?.[
 					productDataState?.variationId || 0
-				] || wooState?.products?.[ productId ];
+				] || products?.[ productId ];
 
 			const imageId = productData?.image_id;
 			if ( ! imageId ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -474,11 +474,8 @@ class AddToCartWithOptions extends AbstractBlock {
 				'style'                     => esc_attr( $classes_and_styles['styles'] ),
 				'data-wp-interactive'       => 'woocommerce/add-to-cart-with-options',
 				'data-wp-class--is-invalid' => '!state.isFormValid',
-				'data-wp-context'           => wp_json_encode(
-					$context,
-					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-				),
 			);
+			$context_directive  = wp_interactivity_data_wp_context( $context );
 
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
@@ -526,7 +523,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			$form_html = sprintf(
-				'<form %1$s>%2$s%3$s%4$s%5$s</form>',
+				'<form %1$s %2$s>%3$s%4$s%5$s%6$s</form>',
 				get_block_wrapper_attributes(
 					array_merge(
 						$wrapper_attributes,
@@ -544,6 +541,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						)
 					)
 				),
+				$context_directive,
 				$hooks_before,
 				$template_part_blocks,
 				$hooks_after,
@@ -603,13 +601,15 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @return string The rendered store notices HTML.
 	 */
 	protected function render_interactivity_notices_region( $form_html ) {
-		$context = array(
-			'notices' => array(),
+		$context_directive = wp_interactivity_data_wp_context(
+			array(
+				'notices' => array(),
+			)
 		);
 
 		ob_start();
 		?>
-		<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide" data-wp-context='<?php echo wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ); ?>'>
+		<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide" <?php echo $context_directive; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<template data-wp-each--notice="context.notices" data-wp-each-key="context.notice.id">
 				<div
 					class="wc-block-components-notice-banner"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -264,7 +264,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				}
 
 				$context['groupedProductIds'] = array_keys( $children_product_data );
-				wp_interactivity_state(
+				wp_interactivity_config(
 					'woocommerce',
 					array(
 						'products' => $children_product_data,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -106,7 +106,7 @@ class QuantitySelector extends AbstractBlock {
 
 		$product_quantity_constraints = AddToCartWithOptionsUtils::get_product_quantity_constraints( $product );
 
-		wp_interactivity_state(
+		wp_interactivity_config(
 			'woocommerce',
 			array(
 				'products' => array(
@@ -133,7 +133,7 @@ class QuantitySelector extends AbstractBlock {
 				);
 			}
 
-			wp_interactivity_state(
+			wp_interactivity_config(
 				'woocommerce',
 				array(
 					'products' => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -174,7 +174,7 @@ class ProductGallery extends AbstractBlock {
 				}
 
 				if ( $has_variation_images ) {
-					wp_interactivity_state(
+					wp_interactivity_config(
 						'woocommerce',
 						array(
 							'products' => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -82,6 +82,7 @@ class ProductPrice extends AbstractBlock {
 
 			$wrapper_attributes     = array();
 			$interactive_attributes = '';
+			$context_directive      = '';
 
 			if ( $is_interactive ) {
 				$variations_data           = $product->get_available_variations();
@@ -120,19 +121,21 @@ class ProductPrice extends AbstractBlock {
 
 					wp_enqueue_script_module( 'woocommerce/product-elements' );
 					$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
-					$context                                   = array(
-						'productElementKey' => 'price_html',
+					$context_directive                         = wp_interactivity_data_wp_context(
+						array(
+							'productElementKey' => 'price_html',
+						)
 					);
-					$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
 					$interactive_attributes                    = 'data-wp-watch="callbacks.updateValue" aria-live="polite" aria-atomic="true"';
 				}
 			}
 
 			return sprintf(
-				'<div %1$s><div class="wc-block-components-product-price wc-block-grid__product-price %2$s %3$s" style="%4$s" %5$s>
-					%6$s
+				'<div %1$s %2$s><div class="wc-block-components-product-price wc-block-grid__product-price %3$s %4$s" style="%5$s" %6$s>
+					%7$s
 				</div></div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
+				$context_directive,
 				esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 				esc_attr( $styles_and_classes['classes'] ),
 				esc_attr( $styles_and_classes['styles'] ?? '' ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -106,7 +106,7 @@ class ProductPrice extends AbstractBlock {
 				if ( ! $has_variation_price_html ) {
 					$is_interactive = false;
 				} else {
-					wp_interactivity_state(
+					wp_interactivity_config(
 						'woocommerce',
 						array(
 							'products' => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -79,7 +79,7 @@ class ProductSKU extends AbstractBlock {
 				);
 			}
 
-			wp_interactivity_state(
+			wp_interactivity_config(
 				'woocommerce',
 				array(
 					'products' => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -77,7 +77,7 @@ class ProductSpecifications extends AbstractBlock {
 				);
 			}
 
-			wp_interactivity_state(
+			wp_interactivity_config(
 				'woocommerce',
 				array(
 					'products' => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -136,7 +136,7 @@ class ProductStockIndicator extends AbstractBlock {
 				);
 			}
 
-			wp_interactivity_state(
+			wp_interactivity_config(
 				'woocommerce',
 				array(
 					'products' => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Moves from `wp_interactivity_state()` to `wp_interactivity_config()` for storing products' data in the WooCommerce store. Given that it's data that is not expected to change, I think using config is more appropriate than state (fcc7e3c578c3d4e6cbeeece984cb7433069534b6).
* I also took the opportunity to migrate a couple of instances from `wp_json_encode()` to `wp_interactivity_data_wp_context()` (c0df10e2f5073c517b13833b07fa139647f0cd06).

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions in the frontend.

1. In the _Single Product_ template in the frontend, try adding a product to the cart using the _Add to Cart + Options_ block and verify it works.
2. Repeat the same in a variable product page, making sure you can switch between variations and the variation data (ie: price) is updated.