### PR TITLE
Add address autocomplete usage to weekly snapshot

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3667-implement-merchant-side-tracking-for-address-autocomplete
+++ b/plugins/woocommerce/changelog/wooplug-3667-implement-merchant-side-tracking-for-address-autocomplete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracking for Address Autocomplete use

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -257,7 +257,7 @@ class WC_Tracker {
 	 */
 	public static function get_address_autocomplete_info() {
 		$data = array(
-			'enabled'            => get_option( 'woocommerce_address_autocomplete_enabled', 'no' ),
+			'enabled'            => ( 'yes' === wc_bool_to_string( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) ) ? 'yes' : 'no',
 			'providers'          => array(),
 			'preferred_provider' => '',
 		);

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -234,6 +234,9 @@ class WC_Tracker {
 		// Store email usage.
 		$data['store_emails'] = self::get_store_emails();
 
+		// Address autocomplete usage.
+		$data['address_autocomplete'] = self::get_address_autocomplete_info();
+
 		/**
 		 * Filter the data that's sent with the tracker.
 		 *
@@ -244,6 +247,47 @@ class WC_Tracker {
 		// Total seconds taken to generate snapshot (including filtered data).
 		$data['snapshot_generation_time'] = microtime( true ) - $start_time;
 
+		return $data;
+	}
+
+	/**
+	 * Get address autocomplete info.
+	 *
+	 * @return array Address autocomplete info.
+	 */
+	public static function get_address_autocomplete_info() {
+		$data = array(
+			'enabled'            => get_option( 'woocommerce_address_autocomplete_enabled', 'no' ),
+			'providers'          => array(),
+			'preferred_provider' => '',
+		);
+
+		if ( ! class_exists( \Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController::class ) ) {
+			// The option could still be set even if the class doesn't exist (e.g. if set manually in the DB).
+			$data['enabled'] = 'no';
+			return $data;
+		}
+
+		$autocomplete_controller = new \Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController();
+		$autocomplete_controller->init();
+		// Get all registered providers.
+		$providers = $autocomplete_controller->get_providers();
+		if ( is_array( $providers ) ) {
+			foreach ( $providers as $provider ) {
+				if ( ! ( $provider instanceof WC_Address_Provider ) ) {
+					continue;
+				}
+				$data['providers'][] = $provider->id;
+			}
+		}
+
+		if ( empty( $data['providers'] ) ) {
+			// If there are no providers, the feature is effectively disabled.
+			$data['enabled'] = 'no';
+			return $data;
+		}
+
+		$data['preferred_provider'] = $autocomplete_controller->get_preferred_provider();
 		return $data;
 	}
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -268,8 +268,9 @@ class WC_Tracker {
 			return $data;
 		}
 
-		$autocomplete_controller = new \Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController();
+		$autocomplete_controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController::class );
 		$autocomplete_controller->init();
+
 		// Get all registered providers.
 		$providers = $autocomplete_controller->get_providers();
 		if ( is_array( $providers ) ) {

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -288,6 +288,11 @@ class WC_Tracker {
 			return $data;
 		}
 
+		if ( 'no' === $data['enabled'] ) {
+			// If the feature is disabled, no need to go further, but we will still track which providers are available.
+			return $data;
+		}
+
 		$data['preferred_provider'] = $autocomplete_controller->get_preferred_provider();
 		return $data;
 	}

--- a/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
@@ -20,7 +20,7 @@ class AddressProviderController {
 	 *
 	 * @var string ID of preferred address provider.
 	 */
-	private $preferred_provider_option;
+	private $preferred_provider_option = '';
 
 	/**
 	 * Constructor.

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -10,6 +10,23 @@ use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
+
+/**
+ * Mock Address Provider for testing.
+ */
+class WC_Tracker_Test_MockAddressProvider extends WC_Address_Provider {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $id   Provider ID.
+	 * @param string $name Provider name.
+	 */
+	public function __construct( $id = 'mock-address-provider', $name = 'Mock Address Provider' ) {
+		$this->id   = $id;
+		$this->name = $name;
+	}
+}
+
 /**
  * Class WC_Tracker_Test
  */
@@ -354,5 +371,95 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		update_option( 'woocommerce_allow_tracking', $current_woocommerce_allow_tracking );
 		delete_option( 'woocommerce_allow_tracking_last_modified' );
 		delete_option( 'woocommerce_allow_tracking_first_optin' );
+	}
+
+	/**
+	 * @testDox Test address autocomplete tracking data.
+	 */
+	public function test_get_address_autocomplete_info() {
+		// Test when address autocomplete is disabled (default).
+		update_option( 'woocommerce_address_autocomplete_enabled', 'no' );
+		$data = WC_Tracker::get_address_autocomplete_info();
+		$this->assertEquals( 'no', $data['enabled'] );
+		$this->assertIsArray( $data['providers'] );
+		$this->assertEmpty( $data['providers'] );
+		$this->assertEquals( '', $data['preferred_provider'] );
+
+		// Test when address autocomplete is enabled but no providers registered.
+		update_option( 'woocommerce_address_autocomplete_enabled', 'yes' );
+		$data = WC_Tracker::get_address_autocomplete_info();
+		// Should be disabled if no providers are available.
+		$this->assertEquals( 'no', $data['enabled'] );
+		$this->assertEmpty( $data['providers'] );
+		$this->assertEquals( '', $data['preferred_provider'] );
+
+		// Test with a single registered provider and preferred provider set.
+		$this->register_mock_address_provider();
+		update_option( 'woocommerce_address_autocomplete_provider', 'mock-address-provider' );
+
+		update_option( 'woocommerce_address_autocomplete_enabled', 'yes' );
+		$data = WC_Tracker::get_address_autocomplete_info();
+		$this->assertEquals( 'yes', $data['enabled'] );
+		$this->assertIsArray( $data['providers'] );
+		$this->assertCount( 1, $data['providers'] );
+		$this->assertContains( 'mock-address-provider', $data['providers'] );
+		// Should return the preferred provider we set.
+		$this->assertEquals( 'mock-address-provider', $data['preferred_provider'] );
+
+		// Clean up before testing multiple providers.
+		remove_all_filters( 'woocommerce_address_providers' );
+
+		// Test with multiple registered providers and different preferred provider.
+		$this->register_multiple_mock_address_providers();
+		update_option( 'woocommerce_address_autocomplete_provider', 'mock-address-provider-two' );
+
+		$data = WC_Tracker::get_address_autocomplete_info();
+		$this->assertEquals( 'yes', $data['enabled'] );
+		$this->assertIsArray( $data['providers'] );
+		$this->assertCount( 2, $data['providers'] );
+		$this->assertContains( 'mock-address-provider', $data['providers'] );
+		$this->assertContains( 'mock-address-provider-two', $data['providers'] );
+		// Should return the second provider as preferred.
+		$this->assertEquals( 'mock-address-provider-two', $data['preferred_provider'] );
+
+		// Test with invalid preferred provider (not in the list).
+		update_option( 'woocommerce_address_autocomplete_provider', 'non-existent-provider' );
+		$data = WC_Tracker::get_address_autocomplete_info();
+		// Should still return the invalid value so we can track misconfigurations.
+		$this->assertEquals( 'non-existent-provider', $data['preferred_provider'] );
+
+		// Clean up.
+		delete_option( 'woocommerce_address_autocomplete_enabled' );
+		delete_option( 'woocommerce_address_autocomplete_provider' );
+		remove_all_filters( 'woocommerce_address_providers' );
+	}
+
+	/**
+	 * Helper method to register a mock address provider.
+	 */
+	private function register_mock_address_provider() {
+		// Register the provider instance.
+		add_filter(
+			'woocommerce_address_providers',
+			function ( $providers ) {
+				$providers[] = new WC_Tracker_Test_MockAddressProvider();
+				return $providers;
+			}
+		);
+	}
+
+	/**
+	 * Helper method to register multiple mock address providers.
+	 */
+	private function register_multiple_mock_address_providers() {
+		// Register multiple provider instances with different IDs.
+		add_filter(
+			'woocommerce_address_providers',
+			function ( $providers ) {
+				$providers[] = new WC_Tracker_Test_MockAddressProvider( 'mock-address-provider', 'Mock Address Provider' );
+				$providers[] = new WC_Tracker_Test_MockAddressProvider( 'mock-address-provider-two', 'Mock Address Provider Two' );
+				return $providers;
+			}
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -438,6 +438,8 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_address_autocomplete_enabled' );
 		delete_option( 'woocommerce_address_autocomplete_provider' );
 		remove_all_filters( 'woocommerce_address_providers' );
+		// Re-init address providers to ensure class is clean for other tests.
+		wc_get_container()->get( \Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController::class )->init();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -5,11 +5,14 @@
  * @package WooCommerce\Tests\WC_Tracker.
  */
 
+declare(strict_types=1);
+
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Ignoring test doubles.
 
 /**
  * Mock Address Provider for testing.
@@ -42,14 +45,16 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the case for woocommerce_admin_disabled filter returning true.
 		add_filter(
 			'woocommerce_admin_disabled',
-			function( $default ) {
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			function ( $default_value ) {
 				return true;
 			}
 		);
 
 		add_filter(
 			'pre_http_request',
-			function( $pre, $args, $url ) use ( &$posted_data ) {
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			function ( $pre, $args, $url ) use ( &$posted_data ) {
 				$posted_data = $args;
 				return true;
 			},
@@ -74,7 +79,8 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		add_filter(
 			'pre_http_request',
-			function( $pre, $args, $url ) use ( &$posted_data ) {
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			function ( $pre, $args, $url ) use ( &$posted_data ) {
 				$posted_data = $args;
 				return true;
 			},
@@ -94,7 +100,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_get_tracking_data_plugin_feature_compatibility() {
 		$legacy_mocks = array(
-			'get_plugins' => function() {
+			'get_plugins' => function () {
 				return array(
 					'plugin1' => array(
 						'Name' => 'Plugin 1',
@@ -425,8 +431,8 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test with invalid preferred provider (not in the list).
 		update_option( 'woocommerce_address_autocomplete_provider', 'non-existent-provider' );
 		$data = WC_Tracker::get_address_autocomplete_info();
-		// Should still return the invalid value so we can track misconfigurations.
-		$this->assertEquals( 'non-existent-provider', $data['preferred_provider'] );
+		// Should fall back to the first provider when the preferred provider doesn't exist.
+		$this->assertEquals( 'mock-address-provider', $data['preferred_provider'] );
 
 		// Clean up.
 		delete_option( 'woocommerce_address_autocomplete_enabled' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -434,6 +434,26 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Should fall back to the first provider when the preferred provider doesn't exist.
 		$this->assertEquals( 'mock-address-provider', $data['preferred_provider'] );
 
+		// Test with multiple registered providers but feature disabled.
+		$this->register_multiple_mock_address_providers();
+		update_option( 'woocommerce_address_autocomplete_enabled', 'no' );
+		update_option( 'woocommerce_address_autocomplete_provider', 'mock-address-provider-two' );
+
+		$data = WC_Tracker::get_address_autocomplete_info();
+		$this->assertEquals( 'no', $data['enabled'] );
+		$this->assertIsArray( $data['providers'] );
+		$this->assertCount( 2, $data['providers'] );
+		$this->assertContains( 'mock-address-provider', $data['providers'] );
+		$this->assertContains( 'mock-address-provider-two', $data['providers'] );
+		// Should return the second provider as preferred.
+		$this->assertEquals( '', $data['preferred_provider'] );
+
+		// Test with invalid preferred provider (not in the list) when feature is disabled.
+		update_option( 'woocommerce_address_autocomplete_provider', 'non-existent-provider' );
+		$data = WC_Tracker::get_address_autocomplete_info();
+		// Should not fall back to the first provider when the preferred provider doesn't exist.
+		$this->assertEquals( '', $data['preferred_provider'] );
+
 		// Clean up.
 		delete_option( 'woocommerce_address_autocomplete_enabled' );
 		delete_option( 'woocommerce_address_autocomplete_provider' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds Address Autocomplete data to the Weekly snapshot. The data collected is of this shape:

```
{
  enabled => "yes"|"no",
  providers => string[],
  preferred_provider => string
}
```

- `enabled` is if the feature is checked in WC -> Settings
<img width="571" height="90" alt="image" src="https://github.com/user-attachments/assets/e6f41191-293c-4573-885e-4be5b2b6ec38" />

- `providers` is a list of registered providers' IDs, for example if a store has WooPayments, and some third party provider installed on the site, it would be `[ 'woo-payments', 'third-party-provider-id' ]`
- `preferred_provider` is the selected "preferred" provider if more than one is enabled on the site. If only one provider is installed, then `preferred_provider` will be that provider's ID
<img width="673" height="243" alt="image" src="https://github.com/user-attachments/assets/079ef1b4-65d9-4d96-80ea-8ff6ac8d72bd" />

Closes WOOPLUG-3667

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**note, WC must be built in dev mode as address autocomplete is feature gated**

1. Add the following snippet:

```php
add_action(
	'wp_footer',
	function() {
		var_dump( WC_Tracker::get_address_autocomplete_info() );
	}
);
```
2. Ensure you have no address providers installed
3. Go to the front end of your site, ensure you see the data in the footer of your site with `enabled => false` and no providers or preferred provider.
4. Install a provider, e.g. Woo Payments, or Mock Provider [mock-address-provider.zip](https://github.com/user-attachments/files/22095355/mock-address-provider.zip)
5. Go to WC -> Settings and find `Address autocomplete` and enable it.
6. Repeat step 3, ensure `enabled` is true, `providers` is an array of length 1 with `mock-address-provider` and `preferred_provider` is also `mock-address-provider`
7. Add a second provider, e.g. Woo Payments or Mock Provider Germany [mock-address-provider-germany.zip](https://github.com/user-attachments/files/22095421/mock-address-provider-germany.zip)
8. Repeat step 6, ensure that `providers` is an array of length 2 with `mock-address-provider-germany` in.
9. Go to WC -> Settings and change the `Preferred address autocomplete provider` to a different provider.
10. Repeat step 6, ensure the preferred provider has changed to the one set in step 9.
11. Disable address autocomplete, repeat step 3, providers should show, but preferred provider should not show.
12. Re-enable address autocomplete, but disable all plugins that add providers.
13. Repeat step 3, ensure enabled is false and no providers or preferred provider shows.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
