### PR TITLE
Prevent order attribution install banner when file mods are not allowed

### DIFF
--- a/plugins/woocommerce/changelog/fix-60573
+++ b/plugins/woocommerce/changelog/fix-60573
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent order attribution install banner when file mods are not allowed

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -98,9 +98,7 @@ export const useOrderAttributionInstallBanner = ( { isInstalling } ) => {
 
 			return {
 				orderAttributionInstallState: installState,
-				canUserInstallPlugins:
-					currentUserCan( 'install_plugins' ) &&
-					user.woocommerce_meta.can_modify_files,
+				canUserInstallPlugins: currentUserCan( 'install_plugins' ),
 			};
 		},
 		[ currentUserCan ]

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -73,7 +73,7 @@ const shouldPromoteOrderAttribution = (
  * which determines if the banner should be displayed, checks if it has been dismissed, and provides a function to dismiss it.
  */
 export const useOrderAttributionInstallBanner = ( { isInstalling } ) => {
-	const { currentUserCan } = useUser();
+	const { currentUserCan, user } = useUser();
 	const {
 		[ USER_META_BANNER_DISMISSED ]: bannerDismissed,
 		updateUserPreferences,
@@ -98,7 +98,9 @@ export const useOrderAttributionInstallBanner = ( { isInstalling } ) => {
 
 			return {
 				orderAttributionInstallState: installState,
-				canUserInstallPlugins: currentUserCan( 'install_plugins' ),
+				canUserInstallPlugins:
+					currentUserCan( 'install_plugins' ) &&
+					user.woocommerce_meta.can_modify_files,
 			};
 		},
 		[ currentUserCan ]

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -73,7 +73,7 @@ const shouldPromoteOrderAttribution = (
  * which determines if the banner should be displayed, checks if it has been dismissed, and provides a function to dismiss it.
  */
 export const useOrderAttributionInstallBanner = ( { isInstalling } ) => {
-	const { currentUserCan, user } = useUser();
+	const { currentUserCan } = useUser();
 	const {
 		[ USER_META_BANNER_DISMISSED ]: bannerDismissed,
 		updateUserPreferences,

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -174,13 +174,7 @@ class Settings {
 			}
 		}
 
-		$user_controller = new \WP_REST_Users_Controller();
-		$request         = new \WP_REST_Request();
-		$request->set_query_params( array( 'context' => 'edit' ) );
-		$user_response     = $user_controller->get_current_item( $request );
-		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
-
-		$settings['currentUserData']      = $current_user_data;
+		$settings['currentUserData']      = WCAdminUser::get_user_data();
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );
 		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );
 		$settings['commentModeration']    = get_option( 'comment_moderation' );

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -181,7 +181,7 @@ class WCAdminUser {
 			return $user_data;
 		}
 
-		// If the user has install_plugins capability, check if file modifications are allowed
+		// If the user has install_plugins capability, check if file modifications are allowed.
 		if ( isset( $user_data['capabilities']->install_plugins ) && $user_data['capabilities']->install_plugins ) {
 			$user_data['capabilities']->install_plugins = wp_is_file_mod_allowed( 'woocommerce' );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -71,11 +71,7 @@ class WCAdminUser {
 	public function get_user_data_values( $user ) {
 		$values = array();
 		foreach ( $this->get_user_data_fields() as $field ) {
-			if ( 'can_modify_files' === $field ) {
-				$values[ $field ] = wp_is_file_mod_allowed( 'woocommerce' );
-			} else {
-				$values[ $field ] = self::get_user_data_field( $user['id'], $field );
-			}
+			$values[ $field ] = self::get_user_data_field( $user['id'], $field );
 		}
 		return $values;
 	}
@@ -117,7 +113,7 @@ class WCAdminUser {
 		 * @since 4.0.0
 		 * @param array $fields Array of fields to expose over the WP user endpoint.
 		 */
-		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown', 'can_modify_files' ) );
+		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown' ) );
 	}
 
 	/**
@@ -156,5 +152,40 @@ class WCAdminUser {
 		}
 
 		return $meta_value;
+	}
+
+	/**
+	 * Get the current user data.
+	 *
+	 * @return array User data.
+	 */
+	public static function get_user_data() {
+		$user_controller = new \WP_REST_Users_Controller();
+		$request         = new \WP_REST_Request();
+		$request->set_query_params( array( 'context' => 'edit' ) );
+		$user_response     = $user_controller->get_current_item( $request );
+		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
+		$current_user_data = self::filter_user_capabilities( $current_user_data );
+
+		return $current_user_data;
+	}
+
+	/**
+	 * Filter user capabilities to respect file modification restrictions.
+	 *
+	 * @param array $user_data User data.
+	 * @return array Filtered user data.
+	 */
+	private static function filter_user_capabilities( $user_data ) {
+		if ( ! is_array( $user_data ) || ! isset( $user_data['capabilities'] ) ) {
+			return $user_data;
+		}
+
+		// If the user has install_plugins capability, check if file modifications are allowed
+		if ( isset( $user_data['capabilities']->install_plugins ) && $user_data['capabilities']->install_plugins ) {
+			$user_data['capabilities']->install_plugins = wp_is_file_mod_allowed( 'woocommerce' );
+		}
+
+		return $user_data;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -71,7 +71,11 @@ class WCAdminUser {
 	public function get_user_data_values( $user ) {
 		$values = array();
 		foreach ( $this->get_user_data_fields() as $field ) {
-			$values[ $field ] = self::get_user_data_field( $user['id'], $field );
+			if ( 'can_modify_files' === $field ) {
+				$values[ $field ] = wp_is_file_mod_allowed( 'woocommerce' );
+			} else {
+				$values[ $field ] = self::get_user_data_field( $user['id'], $field );
+			}
 		}
 		return $values;
 	}
@@ -113,7 +117,7 @@ class WCAdminUser {
 		 * @since 4.0.0
 		 * @param array $fields Array of fields to expose over the WP user endpoint.
 		 */
-		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown' ) );
+		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown', 'can_modify_files' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -136,5 +136,7 @@ defined( 'ABSPATH' ) || exit;
 		</span>
 	<?php endif; ?>
 	<!-- A placeholder for the OA install banner React component. -->
-	<div id="order-attribution-install-banner-slotfill"></div>
+	<?php if ( WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
+		<div id="order-attribution-install-banner-slotfill"></div>
+	<?php endif; ?>
 </div>

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -136,7 +136,7 @@ defined( 'ABSPATH' ) || exit;
 		</span>
 	<?php endif; ?>
 	<!-- A placeholder for the OA install banner React component. -->
-	<?php if ( \WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
+	<?php if ( class_exists( 'WC_Marketplace_Suggestions' ) && \WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
 		<div id="order-attribution-install-banner-slotfill"></div>
 	<?php endif; ?>
 </div>

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 9.5.0
+ * @version 10.3.0
  */
 
 declare( strict_types=1 );

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -136,7 +136,7 @@ defined( 'ABSPATH' ) || exit;
 		</span>
 	<?php endif; ?>
 	<!-- A placeholder for the OA install banner React component. -->
-	<?php if ( WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
+	<?php if ( \WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
 		<div id="order-attribution-install-banner-slotfill"></div>
 	<?php endif; ?>
 </div>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
@@ -9,6 +9,8 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\OrderAttribution;
 use WC_Helper_Order;
 use WP_UnitTestCase;
 
+require_once WC_ABSPATH . '/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php';
+
 /**
  * Tests for the OrderAttribution class.
  */
@@ -138,5 +140,47 @@ class OrderAttributionTest extends WP_UnitTestCase {
 		$this->sut->output( $order );
 		ob_get_contents();
 		ob_end_clean();
+	}
+
+	/**
+	 * Test that marketplace suggestions banner is shown when suggestions are allowed.
+	 *
+	 * @return void
+	 */
+	public function test_marketplace_suggestions_banner_shown_when_allowed() {
+		$order = WC_Helper_Order::create_order();
+
+		$admin_user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_user );
+		update_option( 'woocommerce_show_marketplace_suggestions', 'yes' );
+		$this->assertTrue( \WC_Marketplace_Suggestions::allow_suggestions() );
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<div id="order-attribution-install-banner-slotfill"></div>', $output );
+	}
+
+	/**
+	 * Test that marketplace suggestions banner is not shown when suggestions are not allowed.
+	 *
+	 * @return void
+	 */
+	public function test_marketplace_suggestions_banner_not_shown_when_not_allowed() {
+		$order = WC_Helper_Order::create_order();
+
+		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
+		$this->assertFalse( \WC_Marketplace_Suggestions::allow_suggestions() );
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<div id="order-attribution-install-banner-slotfill"></div>', $output );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
@@ -34,6 +34,17 @@ class OrderAttributionTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down the test fixture.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		update_option( 'woocommerce_show_marketplace_suggestions', 'yes' );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
 	 * Test default output.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Requests to get plugin recommendations were being made on order pages in the order attribution install banner.  Requests to those endpoints should not be made when the file mods are not allowed or marketplace suggestions are disabled.

This PR addresses that in a couple ways:

1. Updates the `install_plugins` capability to be `false` when `wp_is_file_mod_allowed( 'woocommerce' )` is not true.  This matches WP's [default behavior](https://github.com/WordPress/wordpress-develop/blob/57c1af7f8e408979e11fb543f676aa929cf49c62/src/wp-includes/capabilities.php#L621-L642) for `current_user_can( 'install_plugins' )` though I'm not sure why the choice was not made by WP to apply this filter to all WP user data.
2. The banner itself is wrapped in a check so that it doesn't get loaded when marketplace suggestions and various install behavior is not enabled.

Closes #60573 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure marketplace suggestions are enabled at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Navigate to an order edit page as an admin user `/wp-admin/admin.php?page=wc-orders&action=edit&id={ID}`
2. Make sure that no console errors/warnings are shown regarding user capabilities.  If you end up in the experiment group, you should still see the order attribution install banner on a fresh site
3. Disable marketplace suggestions.
4. Navigate to an order edit page as an admin user `/wp-admin/admin.php?page=wc-orders&action=edit&id={ID}`
5. Make sure no errors are shown in the console around user capabilities.
6. Re-enable marketplace suggestions.
7. Add `define( 'DISALLOW_FILE_MODS', true );` to your wp-config.php file
8. Make sure no errors are shown in the console around user capabilities. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
