### PR TITLE
PayPal JSSDK: Add enable/disable PayPal buttons settings

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
@@ -39,7 +39,6 @@ class WC_Gateway_Paypal_Buttons {
 		$this->gateway = $gateway;
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// TODO: We also want to check the settings.
 		$this->enabled = $this->gateway->should_use_orders_v2() && 'yes' === $this->gateway->get_option( 'paypal_buttons', 'yes' );
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal-buttons.php
@@ -40,7 +40,7 @@ class WC_Gateway_Paypal_Buttons {
 
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: We also want to check the settings.
-		$this->enabled = $this->gateway->should_use_orders_v2();
+		$this->enabled = $this->gateway->should_use_orders_v2() && 'yes' === $this->gateway->get_option( 'paypal_buttons', 'yes' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -449,6 +449,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		if ( $this->should_use_orders_v2() ) {
 			unset( $form_fields['receiver_email'] );
 		}
+
+		if ( ! $this->should_use_orders_v2() ) {
+			unset( $form_fields['paypal_buttons'] );
+		}
 		return $form_fields;
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -65,6 +65,13 @@ $settings = array(
 			'authorization' => __( 'Authorize', 'woocommerce' ),
 		),
 	),
+	'paypal_buttons'   => array(
+		'title'       => __( 'PayPal Buttons', 'woocommerce' ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Enable PayPal Buttons', 'woocommerce' ),
+		'default'     => 'yes',
+		'description' => sprintf( __( 'Enable PayPal buttons to offer PayPal, Venmo and Pay Later as express checkout options on product, cart, and checkout pages.', 'woocommerce' ) ),
+	),
 	'invoice_prefix'   => array(
 		'title'       => __( 'Invoice prefix', 'woocommerce' ),
 		'type'        => 'text',

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -70,7 +70,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable PayPal Buttons', 'woocommerce' ),
 		'default'     => 'yes',
-		'description' => sprintf( __( 'Enable PayPal buttons to offer PayPal, Venmo and Pay Later as express checkout options on product, cart, and checkout pages.', 'woocommerce' ) ),
+		'description' => __( 'Enable PayPal buttons to offer PayPal, Venmo and Pay Later as express checkout options on product, cart, and checkout pages.', 'woocommerce' ),
 	),
 	'invoice_prefix'   => array(
 		'title'       => __( 'Invoice prefix', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added an option in the PayPal settings page to enable/disable PayPal button loaded via JS SDK. 

Closes PAYPAL-82


### How to test the changes in this Pull Request:
- Add this option to enable PayPal standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`
- Go to **WooCommerce > Settings > Payments > PayPal Standard**
- Confirm that there is a `PayPal Buttons` checkbox, enabled by default.
- As a shopper, add a product to your cart and go to the block checkout page.
- Confirm that PayPal buttons are loaded.
- Disable `PayPal Buttons` option in the settings page and save the changes.
- Refresh the block checkout page and confirm that the PayPal buttons are not loaded anymore.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
