### PR TITLE
Add to Cart + Options: Hide Product Quantity block when selecting a variation sold individually

### DIFF
--- a/plugins/woocommerce/changelog/update-hide-product-quantity-if-sold-individually
+++ b/plugins/woocommerce/changelog/update-hide-product-quantity-if-sold-individually
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Hide Product Quantity block when selecting a variation sold individually

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -56,6 +56,7 @@ export type ProductData = {
 			min?: number;
 			max?: number;
 			step?: number;
+			sold_individually?: boolean;
 		};
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -387,11 +387,9 @@ const { actions, state } = store<
 					selectedAttributes
 				);
 
-				if ( ! productObject ) {
-					return;
-				}
-
-				const { max, min, step } = productObject;
+				const max = productObject?.max || Infinity;
+				const min = productObject?.min || 1;
+				const step = productObject?.step || 1;
 
 				const newValue = currentValue + step;
 
@@ -426,11 +424,8 @@ const { actions, state } = store<
 					selectedAttributes
 				);
 
-				if ( ! productObject ) {
-					return;
-				}
-
-				const { min, step } = productObject;
+				const min = productObject?.min || 1;
+				const step = productObject?.step || 1;
 
 				let newValue = currentValue - step;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -387,9 +387,9 @@ const { actions, state } = store<
 					selectedAttributes
 				);
 
-				const max = productObject?.max || Infinity;
-				const min = productObject?.min || 1;
-				const step = productObject?.step || 1;
+				const max = productObject?.max ?? Infinity;
+				const min = productObject?.min ?? 1;
+				const step = productObject?.step ?? 1;
 
 				const newValue = currentValue + step;
 
@@ -424,8 +424,8 @@ const { actions, state } = store<
 					selectedAttributes
 				);
 
-				const min = productObject?.min || 1;
-				const step = productObject?.step || 1;
+				const min = productObject?.min ?? 1;
+				const step = productObject?.step ?? 1;
 
 				let newValue = currentValue - step;
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-constraints.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-constraints.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 add_action(
 	'woocommerce_init',
 	function () {
-		$tshirt_id      = wc_get_product_id_by_sku( 'woo-tshirt' );
-		$blue_hoodie_id = wc_get_product_id_by_sku( 'woo-hoodie-blue' );
+		$tshirt_id       = wc_get_product_id_by_sku( 'woo-tshirt' );
+		$blue_hoodie_id  = wc_get_product_id_by_sku( 'woo-hoodie-blue' );
+		$green_hoodie_id = wc_get_product_id_by_sku( 'woo-hoodie-green' );
 
 		add_filter(
 			'woocommerce_quantity_input_min',
@@ -47,6 +48,18 @@ add_action(
 					return 8;
 				}
 				return $max;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_is_sold_individually',
+			function ( $val, $product ) use ( $green_hoodie_id ) {
+				if ( $product->get_id() === $green_hoodie_id ) {
+					return true;
+				}
+				return $val;
 			},
 			10,
 			2

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -530,15 +530,15 @@ test.describe( 'Add to Cart + Options Block', () => {
 				);
 			} );
 
-			await test.step( 'hiddens Product Quantity input when the product is sold individually', async () => {
+			await test.step( 'hides Product Quantity input when the product is sold individually', async () => {
+				await expect( quantityInput ).toBeVisible();
+
 				const colorGreenOption = page.locator(
 					'label:has-text("Green")'
 				);
 				await colorGreenOption.click();
 
-				await expect(
-					page.getByRole( 'spinbutton', { name: 'Product quantity' } )
-				).toBeHidden();
+				await expect( quantityInput ).toBeHidden();
 			} );
 		} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -132,6 +132,24 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.goto( '/product/hoodie/' );
 
+		await test.step( 'increase and reduce quantity buttons work even when no variation is selected', async () => {
+			const increaseQuantityButton = page.getByLabel(
+				'Increase quantity of Hoodie'
+			);
+			await increaseQuantityButton.click();
+
+			const quantityInput = page.getByLabel( 'Product quantity' );
+
+			await expect( quantityInput ).toHaveValue( '2' );
+
+			const reduceQuantityButton = page.getByLabel(
+				'Reduce quantity of Hoodie'
+			);
+			await reduceQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '1' );
+		} );
+
 		// The radio input is visually hidden and, thus, not clickable. That's
 		// why we need to select the <label> instead.
 		const logoNoOption = page.locator( 'label:has-text("No")' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -511,6 +511,17 @@ test.describe( 'Add to Cart + Options Block', () => {
 					/\bdisabled\b/
 				);
 			} );
+
+			await test.step( 'hiddens Product Quantity input when the product is sold individually', async () => {
+				const colorGreenOption = page.locator(
+					'label:has-text("Green")'
+				);
+				await colorGreenOption.click();
+
+				await expect(
+					page.getByRole( 'spinbutton', { name: 'Product quantity' } )
+				).toBeHidden();
+			} );
 		} );
 
 		await test.step( 'in grouped products', async () => {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -134,7 +134,7 @@ class QuantitySelector extends AbstractBlock {
 					'min'               => $variation_quantity_constraints['min'],
 					'max'               => $variation_quantity_constraints['max'],
 					'step'              => $variation_quantity_constraints['step'],
-					'sold_individually' => $variation->is_sold_individually(),
+					'sold_individually' => (bool) $variation->is_sold_individually(),
 				);
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -150,10 +150,10 @@ class QuantitySelector extends AbstractBlock {
 			);
 
 			$wrapper_attributes['data-wp-interactive']  = 'woocommerce/product-elements';
-			$wrapper_attributes['data-wp-bind--hidden'] = 'state.productData.sold_individually';
-			$input_attributes['data-wp-bind--min']      = 'state.productData.min';
-			$input_attributes['data-wp-bind--max']      = 'state.productData.max';
-			$input_attributes['data-wp-bind--step']     = 'state.productData.step';
+			$wrapper_attributes['data-wp-bind--hidden'] = 'woocommerce/product-elements::state.productData.sold_individually';
+			$input_attributes['data-wp-bind--min']      = 'woocommerce/product-elements::state.productData.min';
+			$input_attributes['data-wp-bind--max']      = 'woocommerce/product-elements::state.productData.max';
+			$input_attributes['data-wp-bind--step']     = 'woocommerce/product-elements::state.productData.step';
 			$input_attributes['data-wp-watch']          = 'woocommerce/add-to-cart-with-options::callbacks.watchQuantityConstraints';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -102,7 +102,11 @@ class QuantitySelector extends AbstractBlock {
 			)
 		);
 
-		$input_attributes = array();
+		$wrapper_attributes = array(
+			'class' => $classes,
+			'style' => esc_attr( $classes_and_styles['styles'] ),
+		);
+		$input_attributes   = array();
 
 		$product_quantity_constraints = AddToCartWithOptionsUtils::get_product_quantity_constraints( $product );
 
@@ -127,9 +131,10 @@ class QuantitySelector extends AbstractBlock {
 			foreach ( $variations_data as $variation ) {
 				$variation_quantity_constraints                    = AddToCartWithOptionsUtils::get_product_quantity_constraints( $variation );
 				$formatted_variations_data[ $variation->get_id() ] = array(
-					'min'  => $variation_quantity_constraints['min'],
-					'max'  => $variation_quantity_constraints['max'],
-					'step' => $variation_quantity_constraints['step'],
+					'min'               => $variation_quantity_constraints['min'],
+					'max'               => $variation_quantity_constraints['max'],
+					'step'              => $variation_quantity_constraints['step'],
+					'sold_individually' => $variation->is_sold_individually(),
 				);
 			}
 
@@ -144,17 +149,13 @@ class QuantitySelector extends AbstractBlock {
 				)
 			);
 
-			$input_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
-			$input_attributes['data-wp-bind--min']   = 'state.productData.min';
-			$input_attributes['data-wp-bind--max']   = 'state.productData.max';
-			$input_attributes['data-wp-bind--step']  = 'state.productData.step';
-			$input_attributes['data-wp-watch']       = 'woocommerce/add-to-cart-with-options::callbacks.watchQuantityConstraints';
+			$wrapper_attributes['data-wp-interactive']  = 'woocommerce/product-elements';
+			$wrapper_attributes['data-wp-bind--hidden'] = 'state.productData.sold_individually';
+			$input_attributes['data-wp-bind--min']      = 'state.productData.min';
+			$input_attributes['data-wp-bind--max']      = 'state.productData.max';
+			$input_attributes['data-wp-bind--step']     = 'state.productData.step';
+			$input_attributes['data-wp-watch']          = 'woocommerce/add-to-cart-with-options::callbacks.watchQuantityConstraints';
 		}
-
-		$wrapper_attributes = array(
-			'class' => $classes,
-			'style' => esc_attr( $classes_and_styles['styles'] ),
-		);
 
 		$form = AddToCartWithOptionsUtils::make_quantity_input_interactive( $product_html, $wrapper_attributes, $input_attributes );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -23,10 +23,10 @@ class Utils {
 		$pattern = '/(<input[^>]*id="quantity_[^"]*"[^>]*\/>)/';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.decreaseQuantity" data-wp-bind--disabled="!state.allowsDecrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
+		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options::actions.decreaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options::!state.allowsDecrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.increaseQuantity" data-wp-bind--disabled="!state.allowsIncrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';
+		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options::actions.increaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options::!state.allowsIncrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';
 		$new_html    = preg_replace( $pattern, $plus_button, $quantity_html );
 		$new_html    = preg_replace( $pattern, $minus_button, $new_html );
 		return $new_html;
@@ -84,11 +84,18 @@ class Utils {
 		if ( $child_product_id ) {
 			$context['childProductId'] = $child_product_id;
 		}
-		$context_attribute = ! empty( $context ) ? ' ' . wp_interactivity_data_wp_context( $context ) : '';
+		$context_attribute = ! empty( $context ) ? wp_interactivity_data_wp_context( $context ) : '';
+
+		$wrapper_attributes = array_merge(
+			array(
+				'data-wp-interactive' => 'woocommerce/add-to-cart-with-options',
+			),
+			$wrapper_attributes
+		);
 
 		if ( ! empty( $wrapper_attributes ) ) {
 			return sprintf(
-				'<div %1$s data-wp-interactive="woocommerce/add-to-cart-with-options"%2$s>%3$s</div>',
+				'<div %1$s %2$s>%3$s</div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
 				$context_attribute,
 				$quantity_html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59443.

This PR is the second part of #59443, making it so the _Product Quantity_ block gets hidden when selecting a variation sold individually.

### How to test the changes in this Pull Request:

1. Add this code snippet to your site, changing `80` by the ID of a variation:

```PHP
add_action( 'init', function() {
	add_filter( 'woocommerce_is_sold_individually', function( $val, $product ) {
		if ( $product->get_id() === 80 ) {
			return true;
		}
		return $val;
	}, 10, 2);
});
```

2. Go to the frontend of the variable product, making sure there is the _Add to Cart + Options_ block in the template.
3. Verify that when you select the variation which is sold individually, the _Product Quantity_ block is hidden from view.
4. Try adding the variations to cart and verify the correct quantities are added. In other words, that the block doesn't try to add 2 or more items of the variation sold individually.

https://github.com/user-attachments/assets/aa1e9289-feb8-44e4-b336-7164bb6c44c2
