### PR TITLE
Fix Cart and Checkout blocks layout issues when parent element has flexbox properties

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-checkout-container-type
+++ b/plugins/woocommerce/changelog/fix-cart-checkout-container-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Cart and Checkout blocks layout issues when parent element has flexbox properties

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -1,6 +1,7 @@
 .wp-block-woocommerce-cart {
 	// Don't remove this, it marks the container for container queries used in inner blocks.
 	container-type: inline-size;
+	width: 100%;
 }
 
 .wc-block-cart {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
@@ -4,6 +4,7 @@
 
 	// Don't remove this, it marks the container for container queries used in inner blocks.
 	container-type: inline-size;
+	width: 100%;
 
 	.with-scroll-to-top__scroll-point {
 		top: -96px;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/58476 introduced container queries for Cart and Checkout blocks but suffered some issues when their parent element/block has `display: flex;` as reported in this issue https://github.com/woocommerce/woocommerce/issues/60714.

This PR adds a `width: 100%` to the elements using `container-type: inline-size` in order to fix these layout issues.

Closes https://github.com/woocommerce/woocommerce/issues/60714

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58476

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="3002" height="4094" alt="screencapture-woo-local-basket-2025-09-03-09_59_45" src="https://github.com/user-attachments/assets/17a17b3e-7ff9-42d6-abe4-be07a9a35f54" />  | <img width="3002" height="2716" alt="screencapture-woo-local-basket-2025-09-03-10_00_06" src="https://github.com/user-attachments/assets/f6217b94-e23e-4937-ab36-7d1f260155e7" /> |





<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the testing instructions in this PR and ensure it works as described https://github.com/woocommerce/woocommerce/pull/58476
2. Go to Pages > Cart and move the Cart block inside a Group block
3. Open the Group block settings and add the additional class `is-layout-flex` to give it flex properties
4. Ensure the layout isn't broken like before.
5. Go to Pages > Checkout
6. Open the Group block settings and add the additional class `is-layout-flex` to give it flex properties
7. Ensure the layout isn't broken like before.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
