### PR TITLE
Prevent added to cart notices to appear unnecessarily in Product Collection and Add to Cart + Options blocks when used in two different tabs in parallel

### DIFF
--- a/plugins/woocommerce/changelog/fix-60733-add-to-cart-notices
+++ b/plugins/woocommerce/changelog/fix-60733-add-to-cart-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent added to cart notices to appear unnecessarily in Product Collection and Add to Cart + Options blocks when used in two different tabs in parallel

--- a/plugins/woocommerce/changelog/fix-60733-add-to-cart-notices
+++ b/plugins/woocommerce/changelog/fix-60733-add-to-cart-notices
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent added to cart notices to appear unnecessarily in Product Collection and Add to Cart + Options blocks when used in two different tabs in parallel
+Prevent "Added to cart" notices from appearing unnecessarily in Product Collection and Add to Cart + Options blocks when used in two different tabs in parallel

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -155,11 +155,16 @@ const productButtonStore = {
 				{ lock: universalLock }
 			);
 
-			yield actions.addCartItem( {
-				id: state.productId,
-				quantity: state.quantity + context.quantityToAdd,
-				type: context.productType,
-			} );
+			yield actions.addCartItem(
+				{
+					id: state.productId,
+					quantity: state.quantity + context.quantityToAdd,
+					type: context.productType,
+				},
+				{
+					showAutoUpdatedNotices: false,
+				}
+			);
 
 			context.displayViewCart = true;
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -162,7 +162,7 @@ const productButtonStore = {
 					type: context.productType,
 				},
 				{
-					showAutoUpdatedNotices: false,
+					showCartUpdatesNotices: false,
 				}
 			);
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -77,8 +77,14 @@ export type Store = {
 	};
 	actions: {
 		removeCartItem: ( key: string ) => void;
-		addCartItem: ( args: ClientCartItem ) => void;
-		batchAddCartItems: ( items: ClientCartItem[] ) => void;
+		addCartItem: (
+			args: ClientCartItem,
+			options?: { showAutoUpdatedNotices?: boolean }
+		) => void;
+		batchAddCartItems: (
+			items: ClientCartItem[],
+			options?: { showAutoUpdatedNotices?: boolean }
+		) => void;
 		// Todo: Check why if I switch to an async function here the types of the store stop working.
 		refreshCartItems: () => void;
 		showNoticeError: ( error: Error | ApiErrorResponse ) => void;
@@ -282,12 +288,19 @@ const { state, actions } = store< Store >(
 				}
 			},
 
-			*addCartItem( {
-				id,
-				quantity,
-				variation,
-				updateOptimistically = true,
-			}: OptimisticCartItem ) {
+			*addCartItem(
+				{
+					id,
+					quantity,
+					variation,
+					updateOptimistically = true,
+				}: OptimisticCartItem,
+				{
+					showAutoUpdatedNotices = true,
+				}: {
+					showAutoUpdatedNotices?: boolean;
+				} = {}
+			) {
 				let item = state.cart.items.find( ( cartItem ) => {
 					if ( cartItem.type === 'variation' ) {
 						// If it's a variation, check that attributes match.
@@ -353,11 +366,13 @@ const { state, actions } = store< Store >(
 					if ( isApiErrorResponse( res, json ) )
 						throw generateError( json );
 
-					const infoNotices = getInfoNoticesFromCartUpdates(
-						state.cart,
-						json,
-						quantityChanges
-					);
+					const infoNotices = showAutoUpdatedNotices
+						? getInfoNoticesFromCartUpdates(
+								state.cart,
+								json,
+								quantityChanges
+						  )
+						: [];
 					const errorNotices = json.errors.map( generateErrorNotice );
 					yield actions.updateNotices(
 						[ ...infoNotices, ...errorNotices ],
@@ -384,7 +399,14 @@ const { state, actions } = store< Store >(
 				}
 			},
 
-			*batchAddCartItems( items: OptimisticCartItem[] ) {
+			*batchAddCartItems(
+				items: OptimisticCartItem[],
+				{
+					showAutoUpdatedNotices = true,
+				}: {
+					showAutoUpdatedNotices?: boolean;
+				} = {}
+			) {
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 
@@ -484,11 +506,13 @@ const { state, actions } = store< Store >(
 							successfulResponses.length - 1
 						]?.body as Cart;
 
-						const infoNotices = getInfoNoticesFromCartUpdates(
-							state.cart,
-							lastSuccessfulCartResponse,
-							quantityChanges
-						);
+						const infoNotices = showAutoUpdatedNotices
+							? getInfoNoticesFromCartUpdates(
+									state.cart,
+									lastSuccessfulCartResponse,
+									quantityChanges
+							  )
+							: [];
 
 						// Generate notices for any error that successful
 						// responses may contain.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -79,11 +79,11 @@ export type Store = {
 		removeCartItem: ( key: string ) => void;
 		addCartItem: (
 			args: ClientCartItem,
-			options?: { showAutoUpdatedNotices?: boolean }
+			options?: { showCartUpdatesNotices?: boolean }
 		) => void;
 		batchAddCartItems: (
 			items: ClientCartItem[],
-			options?: { showAutoUpdatedNotices?: boolean }
+			options?: { showCartUpdatesNotices?: boolean }
 		) => void;
 		// Todo: Check why if I switch to an async function here the types of the store stop working.
 		refreshCartItems: () => void;
@@ -296,9 +296,9 @@ const { state, actions } = store< Store >(
 					updateOptimistically = true,
 				}: OptimisticCartItem,
 				{
-					showAutoUpdatedNotices = true,
+					showCartUpdatesNotices = true,
 				}: {
-					showAutoUpdatedNotices?: boolean;
+					showCartUpdatesNotices?: boolean;
 				} = {}
 			) {
 				let item = state.cart.items.find( ( cartItem ) => {
@@ -366,7 +366,7 @@ const { state, actions } = store< Store >(
 					if ( isApiErrorResponse( res, json ) )
 						throw generateError( json );
 
-					const infoNotices = showAutoUpdatedNotices
+					const infoNotices = showCartUpdatesNotices
 						? getInfoNoticesFromCartUpdates(
 								state.cart,
 								json,
@@ -402,9 +402,9 @@ const { state, actions } = store< Store >(
 			*batchAddCartItems(
 				items: OptimisticCartItem[],
 				{
-					showAutoUpdatedNotices = true,
+					showCartUpdatesNotices = true,
 				}: {
-					showAutoUpdatedNotices?: boolean;
+					showCartUpdatesNotices?: boolean;
 				} = {}
 			) {
 				const previousCart = JSON.stringify( state.cart );
@@ -506,7 +506,7 @@ const { state, actions } = store< Store >(
 							successfulResponses.length - 1
 						]?.body as Cart;
 
-						const infoNotices = showAutoUpdatedNotices
+						const infoNotices = showCartUpdatesNotices
 							? getInfoNoticesFromCartUpdates(
 									state.cart,
 									lastSuccessfulCartResponse,

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -296,7 +296,7 @@ const { state, actions } = store< Store >(
 					quantity,
 					variation,
 					updateOptimistically = true,
-				}: OptimisticCartItem,
+				}: ClientCartItem,
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
 				let item = state.cart.items.find( ( cartItem ) => {
@@ -398,7 +398,7 @@ const { state, actions } = store< Store >(
 			},
 
 			*batchAddCartItems(
-				items: OptimisticCartItem[],
+				items: ClientCartItem[],
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
 				const previousCart = JSON.stringify( state.cart );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -60,6 +60,8 @@ export type ProductData = {
 	};
 };
 
+type CartUpdateOptions = { showCartUpdatesNotices?: boolean };
+
 export type Store = {
 	state: {
 		errorMessages?: {
@@ -79,11 +81,11 @@ export type Store = {
 		removeCartItem: ( key: string ) => void;
 		addCartItem: (
 			args: ClientCartItem,
-			options?: { showCartUpdatesNotices?: boolean }
+			options?: CartUpdateOptions
 		) => void;
 		batchAddCartItems: (
 			items: ClientCartItem[],
-			options?: { showCartUpdatesNotices?: boolean }
+			options?: CartUpdateOptions
 		) => void;
 		// Todo: Check why if I switch to an async function here the types of the store stop working.
 		refreshCartItems: () => void;
@@ -295,11 +297,7 @@ const { state, actions } = store< Store >(
 					variation,
 					updateOptimistically = true,
 				}: OptimisticCartItem,
-				{
-					showCartUpdatesNotices = true,
-				}: {
-					showCartUpdatesNotices?: boolean;
-				} = {}
+				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
 				let item = state.cart.items.find( ( cartItem ) => {
 					if ( cartItem.type === 'variation' ) {
@@ -401,11 +399,7 @@ const { state, actions } = store< Store >(
 
 			*batchAddCartItems(
 				items: OptimisticCartItem[],
-				{
-					showCartUpdatesNotices = true,
-				}: {
-					showCartUpdatesNotices?: boolean;
-				} = {}
+				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -542,7 +542,7 @@ const { actions, state } = store<
 						type: productType,
 					},
 					{
-						showAutoUpdatedNotices: false,
+						showCartUpdatesNotices: false,
 					}
 				);
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -534,12 +534,17 @@ const { actions, state } = store<
 					{},
 					{ lock: universalLock }
 				);
-				yield wooActions.addCartItem( {
-					id,
-					quantity: newQuantity,
-					variation: selectedAttributes,
-					type: productType,
-				} );
+				yield wooActions.addCartItem(
+					{
+						id,
+						quantity: newQuantity,
+						variation: selectedAttributes,
+						type: productType,
+					},
+					{
+						showAutoUpdatedNotices: false,
+					}
+				);
 			},
 			*handleSubmit( event: FormEvent< HTMLFormElement > ) {
 				event.preventDefault();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -122,7 +122,9 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 					{ lock: universalLock }
 				);
 
-				yield wooActions.batchAddCartItems( addedItems );
+				yield wooActions.batchAddCartItems( addedItems, {
+					showAutoUpdatedNotices: false,
+				} );
 			},
 		},
 		callbacks: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -123,7 +123,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 				);
 
 				yield wooActions.batchAddCartItems( addedItems, {
-					showAutoUpdatedNotices: false,
+					showCartUpdatesNotices: false,
 				} );
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -728,6 +728,7 @@ const { state: cartItemState } = store(
 					id: cartItemState.cartItem.id,
 					quantity: cartItemState.cartItem.quantity,
 					variation,
+					type: cartItemState.cartItem.type,
 				} );
 			},
 
@@ -748,6 +749,7 @@ const { state: cartItemState } = store(
 					id: cartItemState.cartItem.id,
 					quantity: cartItemState.cartItem.quantity + multipleOf,
 					variation,
+					type: cartItemState.cartItem.type,
 				} );
 			},
 
@@ -764,6 +766,7 @@ const { state: cartItemState } = store(
 					id: cartItemState.cartItem.id,
 					quantity: cartItemState.cartItem.quantity - multipleOf,
 					variation,
+					type: cartItemState.cartItem.type,
 				} );
 			},
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60733.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59683.

### How to test the changes in this Pull Request:

*Add to Cart + Options* block:

1. Open two tabs of the *Single Product* template where the *Add to Cart + Options* block is in use.
2. In tab 1, add the product to cart.
3. In tab 2, add the product to cart.
4. Verify there is no notice saying the product quantity was modified in the cart.

*Product Collection* block:

1. Open two tabs of the *Shop* page.
2. In tab 1, add the first product of the grid to cart.
3. In tab 2, add the second product of the grid product to cart.
4. Verify there is no notice saying the product quantity was modified in the cart.