### PR TITLE
Refactor email editor to support shared global state with another editor

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-791-integrate-the-email-editor-global-state-fixes
+++ b/packages/js/email-editor/changelog/wooprd-791-integrate-the-email-editor-global-state-fixes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Refactor usage of hooks and global Gutenberg functions to support preserving and restoring the original state

--- a/packages/js/email-editor/src/blocks/core/block-edit.tsx
+++ b/packages/js/email-editor/src/blocks/core/block-edit.tsx
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import { useCallback } from '@wordpress/element';
 import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { addFilterForEmail } from '../../config-tools/filters';
 
 interface UrlAttributes {
 	url?: string;
@@ -33,7 +37,7 @@ const setUrlAttribute =
 	};
 
 function filterSetUrlAttribute(): void {
-	addFilter(
+	addFilterForEmail(
 		'editor.BlockEdit',
 		'woocommerce-email-editor/filter-set-url-attribute',
 		setUrlAttribute

--- a/packages/js/email-editor/src/blocks/core/buttons.ts
+++ b/packages/js/email-editor/src/blocks/core/buttons.ts
@@ -11,7 +11,7 @@ function enhanceButtonsBlock() {
 	updateBlockSettings( 'core/buttons', ( current ) => ( {
 		...current,
 		supports: {
-			...current.supports,
+			...( current.supports ?? {} ),
 			layout: false, // disable block editor's layouts
 			// enable email editor's reduced flex email layout
 			__experimentalEmailFlexLayout: true, // eslint-disable-line

--- a/packages/js/email-editor/src/blocks/core/buttons.ts
+++ b/packages/js/email-editor/src/blocks/core/buttons.ts
@@ -1,32 +1,22 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks/index';
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 /**
  * Switch layout to reduced flex email layout
  * Email render engine can't handle full flex layout se we need to switch to reduced flex layout
  */
 function enhanceButtonsBlock() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/change-buttons',
-		( settings: Block, name ) => {
-			if ( name === 'core/buttons' ) {
-				return {
-					...settings,
-					supports: {
-						...settings.supports,
-						layout: false, // disable block editor's layouts
-						// enable email editor's reduced flex email layout
-						__experimentalEmailFlexLayout: true, // eslint-disable-line
-					},
-				};
-			}
-			return settings;
-		}
-	);
+	updateBlockSettings( 'core/buttons', ( current ) => ( {
+		...current,
+		supports: {
+			...current.supports,
+			layout: false, // disable block editor's layouts
+			// enable email editor's reduced flex email layout
+			__experimentalEmailFlexLayout: true, // eslint-disable-line
+		},
+	} ) );
 }
 
 export { enhanceButtonsBlock };

--- a/packages/js/email-editor/src/blocks/core/columns.tsx
+++ b/packages/js/email-editor/src/blocks/core/columns.tsx
@@ -3,8 +3,13 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { Block } from '@wordpress/blocks/index';
 import { addFilter } from '@wordpress/hooks';
+import { BlockSupports } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 const columnsEditCallback = createHigherOrderComponent(
 	( BlockEdit ) =>
@@ -49,28 +54,22 @@ const COLUMN_BLOCKS = [ 'core/column', 'core/columns' ];
  * Also, enhances the columns block to support background image.
  */
 function disableColumnsLayoutAndEnhanceColumnsBlock() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/disable-columns-layout',
-		( settings: Block, name ) => {
-			if ( COLUMN_BLOCKS.includes( name ) ) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return {
-					...settings,
-					supports: {
-						...settings.supports,
-						layout: false,
-						background: {
-							backgroundImage: true,
-						},
-					},
-				};
-			}
-
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return settings;
-		}
-	);
+	COLUMN_BLOCKS.forEach( ( blockName ) => {
+		updateBlockSettings( blockName, ( current ) => ( {
+			...current,
+			supports: {
+				...current.supports,
+				layout: false,
+				background: {
+					// Preserve any existing background supports and enable backgroundImage
+					// @ts-expect-error BlockSupports type not complete
+					...( ( current.support as BlockSupports )?.background ||
+						{} ),
+					backgroundImage: true,
+				},
+			},
+		} ) );
+	} );
 }
 
 export { deactivateStackOnMobile, disableColumnsLayoutAndEnhanceColumnsBlock };

--- a/packages/js/email-editor/src/blocks/core/columns.tsx
+++ b/packages/js/email-editor/src/blocks/core/columns.tsx
@@ -3,13 +3,13 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { addFilter } from '@wordpress/hooks';
 import { BlockSupports } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { updateBlockSettings } from '../../config-tools/block-config';
+import { addFilterForEmail } from '../../config-tools/filters';
 
 const columnsEditCallback = createHigherOrderComponent(
 	( BlockEdit ) =>
@@ -38,7 +38,7 @@ const columnsEditCallback = createHigherOrderComponent(
 );
 
 function deactivateStackOnMobile() {
-	addFilter(
+	addFilterForEmail(
 		'editor.BlockEdit',
 		'woocommerce-email-editor/deactivate-stack-on-mobile',
 		columnsEditCallback

--- a/packages/js/email-editor/src/blocks/core/columns.tsx
+++ b/packages/js/email-editor/src/blocks/core/columns.tsx
@@ -58,7 +58,7 @@ function disableColumnsLayoutAndEnhanceColumnsBlock() {
 		updateBlockSettings( blockName, ( current ) => ( {
 			...current,
 			supports: {
-				...current.supports,
+				...( current.supports || {} ),
 				layout: false,
 				background: {
 					// Preserve any existing background supports and enable backgroundImage

--- a/packages/js/email-editor/src/blocks/core/general-block-support.ts
+++ b/packages/js/email-editor/src/blocks/core/general-block-support.ts
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import {
 	Block as WPBlock,
 	BlockSupports as WPBlockSupports,
 } from '@wordpress/blocks/index';
 import domReady from '@wordpress/dom-ready';
-import {
-	store as blocksStore,
-	unregisterBlockStyle,
-	getBlockTypes,
-} from '@wordpress/blocks';
+import { getBlockTypes } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 // Extend the BlockSupports type to include shadow
 // The shadow is not included in WP6.4 but it is in WP6.5
@@ -27,20 +27,18 @@ const BLOCK_STYLES_TO_PRESERVE = [ 'core/social-links' ];
  * Disables Shadow Support for all blocks
  * Currently we are not able to read these styles in renderer
  */
-function alterSupportConfiguration() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/block-support',
-		( settings: Block ) => {
-			if ( settings.supports?.shadow ) {
-				return {
-					...settings,
-					supports: { ...settings.supports, shadow: false },
-				};
-			}
-			return settings;
+function alterSupportConfiguration(): void {
+	getBlockTypes().forEach( ( blockType: Block ) => {
+		if ( blockType.supports?.shadow ) {
+			updateBlockSettings( blockType.name, ( current ) => ( {
+				...current,
+				supports: {
+					...current.supports,
+					shadow: false,
+				},
+			} ) );
 		}
-	);
+	} );
 }
 
 /**

--- a/packages/js/email-editor/src/blocks/core/general-block-support.ts
+++ b/packages/js/email-editor/src/blocks/core/general-block-support.ts
@@ -13,6 +13,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { updateBlockSettings } from '../../config-tools/block-config';
+import { unregisterBlockStyleForEmail } from '../../config-tools/block-style';
 
 // Extend the BlockSupports type to include shadow
 // The shadow is not included in WP6.4 but it is in WP6.5
@@ -59,13 +60,13 @@ function removeBlockStyles() {
 			// Skip block styles that are in the BLOCK_STYLES_TO_PRESERVE array
 			return;
 		}
-		// @ts-expect-error Type not complete.
-		const blockStyles = select( blocksStore ).getBlockStyles( blockName );
+		const blockStyles = select( 'core/blocks' ).getBlockStyles( blockName );
 		if ( ! Array.isArray( blockStyles ) || blockStyles?.length === 0 ) {
 			return;
 		}
+
 		blockStyles.forEach( ( blockStyle ) => {
-			unregisterBlockStyle( blockName, blockStyle.name );
+			unregisterBlockStyleForEmail( blockName, blockStyle.name );
 		} );
 	} );
 }

--- a/packages/js/email-editor/src/blocks/core/group.tsx
+++ b/packages/js/email-editor/src/blocks/core/group.tsx
@@ -17,7 +17,7 @@ function disableGroupVariations() {
 				( variation ) => variation.name === 'group'
 			),
 			supports: {
-				...settings.supports,
+				...( settings.supports || {} ),
 				layout: false,
 			},
 		};

--- a/packages/js/email-editor/src/blocks/core/group.tsx
+++ b/packages/js/email-editor/src/blocks/core/group.tsx
@@ -1,33 +1,27 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { addFilter } from '@wordpress/hooks';
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 /**
  * Disables layout support for group blocks because the default layout `flex` add gaps between columns that it is not possible to support in emails.
  */
 function disableGroupVariations() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/disable-group-variations',
-		( settings, name ) => {
-			if ( name === 'core/group' ) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return {
-					...settings,
-					variations: settings.variations.filter(
-						( variation ) => variation.name === 'group'
-					),
-					supports: {
-						...settings.supports,
-						layout: false,
-					},
-				};
-			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return settings;
-		}
-	);
+	updateBlockSettings( 'core/group', ( settings ) => {
+		// @ts-expect-error: variations is not typed
+		const variations = settings.variations ?? [];
+
+		return {
+			...settings,
+			variations: variations.filter(
+				( variation ) => variation.name === 'group'
+			),
+			supports: {
+				...settings.supports,
+				layout: false,
+			},
+		};
+	} );
 }
 
 export { disableGroupVariations };

--- a/packages/js/email-editor/src/blocks/core/image.tsx
+++ b/packages/js/email-editor/src/blocks/core/image.tsx
@@ -41,7 +41,7 @@ function disableImageFilter() {
 	updateBlockSettings( 'core/image', ( current ) => ( {
 		...current,
 		supports: {
-			...current.supports,
+			...( current.supports || {} ),
 			filter: {
 				// @ts-expect-error filter is not supported in the types
 				...( ( current.supports as BlockSupports )?.filter || {} ),

--- a/packages/js/email-editor/src/blocks/core/image.tsx
+++ b/packages/js/email-editor/src/blocks/core/image.tsx
@@ -4,7 +4,12 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks/index';
+import { BlockSupports } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 const imageEditCallback = createHigherOrderComponent(
 	( BlockEdit ) =>
@@ -33,24 +38,17 @@ const imageEditCallback = createHigherOrderComponent(
  * Because CSS property filter is not supported in almost 50% of email clients we have to disable it
  */
 function disableImageFilter() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/deactivate-image-filter',
-		( settings: Block, name ) => {
-			if ( name === 'core/image' ) {
-				return {
-					...settings,
-					supports: {
-						...settings.supports,
-						filter: {
-							duetone: false,
-						},
-					},
-				};
-			}
-			return settings;
-		}
-	);
+	updateBlockSettings( 'core/image', ( current ) => ( {
+		...current,
+		supports: {
+			...current.supports,
+			filter: {
+				// @ts-expect-error filter is not supported in the types
+				...( ( current.supports as BlockSupports )?.filter || {} ),
+				duetone: false,
+			},
+		},
+	} ) );
 }
 
 function hideExpandOnClick() {

--- a/packages/js/email-editor/src/blocks/core/image.tsx
+++ b/packages/js/email-editor/src/blocks/core/image.tsx
@@ -3,13 +3,13 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { addFilter } from '@wordpress/hooks';
 import { BlockSupports } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { updateBlockSettings } from '../../config-tools/block-config';
+import { addFilterForEmail } from '../../config-tools/filters';
 
 const imageEditCallback = createHigherOrderComponent(
 	( BlockEdit ) =>
@@ -52,7 +52,7 @@ function disableImageFilter() {
 }
 
 function hideExpandOnClick() {
-	addFilter(
+	addFilterForEmail(
 		'editor.BlockEdit',
 		'woocommerce-email-editor/hide-expand-on-click',
 		imageEditCallback

--- a/packages/js/email-editor/src/blocks/core/move-to-trash.tsx
+++ b/packages/js/email-editor/src/blocks/core/move-to-trash.tsx
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { addAction } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import {
 	registerEntityAction,
 	unregisterEntityAction,
 } from '../../private-apis';
+import { addActionForEmail } from '../../config-tools/filters';
 import getTrashEmailPostAction from '../../components/header/trash-email-post';
 
 const removeDefaultMoveToTrashActionAddCustom = ( postType: string ) => {
@@ -22,7 +18,7 @@ const removeDefaultMoveToTrashActionAddCustom = ( postType: string ) => {
 
 function modifyMoveToTrashAction() {
 	// Available in WordPress 6.8+
-	addAction(
+	addActionForEmail(
 		'core.registerPostTypeSchema',
 		'woocommerce-email-editor/modify-move-to-trash-action',
 		( postType ) => {
@@ -31,7 +27,7 @@ function modifyMoveToTrashAction() {
 	);
 
 	// Support for WordPress 6.7+
-	addAction(
+	addActionForEmail(
 		'core.registerPostTypeActions',
 		'woocommerce-email-editor/modify-move-to-trash-action',
 		( postType ) => {

--- a/packages/js/email-editor/src/blocks/core/post-content.tsx
+++ b/packages/js/email-editor/src/blocks/core/post-content.tsx
@@ -1,10 +1,13 @@
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks/index';
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 function Placeholder( { layoutClassNames } ) {
 	const blockProps = useBlockProps( { className: layoutClassNames } );
@@ -38,19 +41,10 @@ function PostContentEdit( OriginalEditComponent ) {
 }
 
 function enhancePostContentBlock() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/change-post-content',
-		( settings: Block, name ) => {
-			if ( name === 'core/post-content' ) {
-				return {
-					...settings,
-					edit: PostContentEdit( settings.edit ),
-				};
-			}
-			return settings;
-		}
-	);
+	updateBlockSettings( 'core/post-content', ( current ) => ( {
+		...current,
+		edit: PostContentEdit( current.edit ),
+	} ) );
 }
 
 export { enhancePostContentBlock };

--- a/packages/js/email-editor/src/blocks/core/quote.ts
+++ b/packages/js/email-editor/src/blocks/core/quote.ts
@@ -1,30 +1,20 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks/index';
+import { updateBlockSettings } from '../../config-tools/block-config';
 
 /**
  * Remove the styles and alignment control support for the Quote block.
  */
 function enhanceQuoteBlock() {
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/change-quote',
-		( settings: Block, name ) => {
-			if ( name === 'core/quote' ) {
-				return {
-					...settings,
-					styles: [],
-					supports: {
-						...settings.supports,
-						align: [],
-					},
-				};
-			}
-			return settings;
-		}
-	);
+	updateBlockSettings( 'core/quote', ( current ) => ( {
+		...current,
+		styles: [],
+		supports: {
+			...current.supports,
+			align: [],
+		},
+	} ) );
 }
 
 export { enhanceQuoteBlock };

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -27,7 +27,6 @@ import { storeName } from '../../store';
 import { PersonalizationTagsPopover } from '../../components/personalization-tags/personalization-tags-popover';
 import { PersonalizationTagsLinkPopover } from '../../components/personalization-tags/personalization-tags-link-popover';
 import { recordEvent } from '../../events';
-import { useIsEmailEditor } from '../../hooks/use-is-email-editor';
 import {
 	registerFormatForEmail,
 	unregisterFormatForEmail,
@@ -139,12 +138,6 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 			updateBlockAttributes,
 		]
 	);
-
-	const isEmailEditor = useIsEmailEditor();
-
-	if ( ! isEmailEditor ) {
-		return null;
-	}
 
 	return (
 		<BlockControls>

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -14,7 +14,6 @@ import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as React from '@wordpress/element';
 
@@ -31,6 +30,7 @@ import { PersonalizationTagsPopover } from '../../components/personalization-tag
 import { PersonalizationTagsLinkPopover } from '../../components/personalization-tags/personalization-tags-link-popover';
 import { recordEvent } from '../../events';
 import { useIsEmailEditor } from '../../hooks/use-is-email-editor';
+import { addFilterForEmail } from '../../config-tools/filters';
 
 /**
  * Disable Rich text formats we currently cannot support
@@ -303,7 +303,7 @@ const personalizationTagsLiveContentUpdate = createHigherOrderComponent(
  * Replace written personalization tags with HTML comments in real-time.
  */
 function activatePersonalizationTagsReplacing() {
-	addFilter(
+	addFilterForEmail(
 		'editor.BlockEdit',
 		'woocommerce-email-editor/with-live-content-update',
 		personalizationTagsLiveContentUpdate

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import {
-	registerFormatType,
-	unregisterFormatType,
 	applyFormat,
 	insert,
 	create,
@@ -30,6 +28,10 @@ import { PersonalizationTagsPopover } from '../../components/personalization-tag
 import { PersonalizationTagsLinkPopover } from '../../components/personalization-tags/personalization-tags-link-popover';
 import { recordEvent } from '../../events';
 import { useIsEmailEditor } from '../../hooks/use-is-email-editor';
+import {
+	registerFormatForEmail,
+	unregisterFormatForEmail,
+} from '../../config-tools/formats';
 import { addFilterForEmail } from '../../config-tools/filters';
 
 /**
@@ -37,14 +39,17 @@ import { addFilterForEmail } from '../../config-tools/filters';
  * Note: This will remove its support for all blocks in the email editor e.g., p, h1,h2, etc
  */
 function disableCertainRichTextFormats() {
-	// remove support for inline image - We can't use it
-	unregisterFormatType( 'core/image' );
+	// Format types to disable
+	const formatTypesToDisable = [
+		'core/image', // remove support for inline image - We can't use it
+		'core/code', // remove support for Inline code - Not well formatted
+		'core/language', // remove support for Language - Not supported for now
+	];
 
-	// remove support for Inline code - Not well formatted
-	unregisterFormatType( 'core/code' );
-
-	// remove support for Language - Not supported for now
-	unregisterFormatType( 'core/language' );
+	// Unregister each format type and preserve its definition
+	formatTypesToDisable.forEach( ( formatName ) => {
+		unregisterFormatForEmail( formatName );
+	} );
 }
 
 type Props = {
@@ -210,28 +215,28 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
  * Extend the rich text formats with a button for personalization tags.
  */
 function extendRichTextFormats() {
-	registerFormatType( 'woocommerce-email-editor/shortcode', {
+	registerFormatForEmail( 'woocommerce-email-editor/shortcode', {
 		name: 'woocommerce-email-editor/shortcode',
 		title: __( 'Personalization Tags', 'woocommerce' ),
 		className: 'woocommerce-email-editor-personalization-tags',
 		tagName: 'span',
-		// @ts-expect-error attributes property is missing in build type for WPFormat type
 		attributes: {},
+		interactive: true,
 		edit: PersonalizationTagsButton,
 	} );
 
 	// Register format type for using personalization tags as link attributes
-	registerFormatType( 'woocommerce-email-editor/link-shortcode', {
+	registerFormatForEmail( 'woocommerce-email-editor/link-shortcode', {
 		name: 'woocommerce-email-editor/link-shortcode',
 		title: __( 'Personalization Tags Link', 'woocommerce' ),
 		className: 'woocommerce-email-editor-personalization-tags-link',
 		tagName: 'a',
-		// @ts-expect-error attributes property is missing in build type for WPFormat type
 		attributes: {
 			'data-link-href': 'data-link-href',
 			contenteditable: 'contenteditable',
 			style: 'style',
 		},
+		interactive: true,
 		edit: null,
 	} );
 }

--- a/packages/js/email-editor/src/blocks/core/site-logo.ts
+++ b/packages/js/email-editor/src/blocks/core/site-logo.ts
@@ -1,14 +1,14 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerBlockVariation } from '@wordpress/blocks';
+import { registerBlockVariationForEmail } from '../../config-tools';
 
 /**
  * Register a custom variation for the site logo block
  * This variation is used to display the site logo in the email editor by automatically adding some preset options.
  */
 function registerCustomSiteLogoBlockVariation() {
-	registerBlockVariation( 'core/site-logo', {
+	registerBlockVariationForEmail( 'core/site-logo', {
 		name: 'site-logo-default',
 		title: 'Site Logo',
 		attributes: {

--- a/packages/js/email-editor/src/blocks/core/social-links.tsx
+++ b/packages/js/email-editor/src/blocks/core/social-links.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { addFilter } from '@wordpress/hooks';
 import { registerBlockVariation } from '@wordpress/blocks';
 import type {
 	Block,
@@ -15,6 +14,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { updateBlockSettings } from '../../config-tools/block-config';
+import { addFilterForEmail } from '../../config-tools/filters';
+
 // Add support for top social networks
 const supportedVariations = [
 	'behance',
@@ -139,7 +140,7 @@ const disableIconColor =
 	};
 
 function removeSocialLinksIconColor(): void {
-	addFilter(
+	addFilterForEmail(
 		'editor.BlockEdit',
 		'woocommerce-email-editor/disable-social-links-icon-color',
 		disableIconColor

--- a/packages/js/email-editor/src/blocks/core/social-links.tsx
+++ b/packages/js/email-editor/src/blocks/core/social-links.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { registerBlockVariation } from '@wordpress/blocks';
 import type {
 	Block,
 	BlockConfiguration,
@@ -14,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { updateBlockSettings } from '../../config-tools/block-config';
+import { registerBlockVariationForEmail } from '../../config-tools';
 import { addFilterForEmail } from '../../config-tools/filters';
 
 // Add support for top social networks
@@ -95,7 +95,7 @@ function registerCustomSocialLinksBlockVariation() {
 		},
 	];
 
-	registerBlockVariation( 'core/social-links', {
+	registerBlockVariationForEmail( 'core/social-links', {
 		name: 'social-links-default',
 		title: 'Social Icons',
 		attributes: {

--- a/packages/js/email-editor/src/blocks/core/social-links.tsx
+++ b/packages/js/email-editor/src/blocks/core/social-links.tsx
@@ -4,9 +4,17 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockVariation } from '@wordpress/blocks';
-import type { Block, InnerBlockTemplate } from '@wordpress/blocks';
+import type {
+	Block,
+	BlockConfiguration,
+	InnerBlockTemplate,
+} from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
 // Add support for top social networks
 const supportedVariations = [
 	'behance',
@@ -40,28 +48,20 @@ const supportedVariations = [
 ];
 
 function unregisterBlockVariations() {
-	// Remove unsupported social links
-	addFilter(
-		'blocks.registerBlockType',
-		'woocommerce-email-editor/disable-social-link-variations',
-		( settings, name ) => {
-			if ( name === 'core/social-link' ) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return {
-					...settings,
-					variations: settings.variations.filter( ( variation ) =>
-						supportedVariations.includes( variation.name )
-					),
-					supports: {
-						...settings.supports,
-						layout: false,
-					},
-				};
-			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return settings;
-		}
-	);
+	// Remove unsupported social links and disable layout support
+	updateBlockSettings( 'core/social-link', ( current ) => ( {
+		...current,
+		variations:
+			// @ts-expect-error Type BlockConfiguration is missing variations.
+			( ( current as BlockConfiguration ).variations || [] ).filter(
+				( variation: { name: string } ) =>
+					supportedVariations.includes( variation.name )
+			),
+		supports: {
+			...current.supports,
+			layout: false,
+		},
+	} ) );
 }
 
 function registerCustomSocialLinksBlockVariation() {

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { unregisterFormatType } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -32,6 +33,8 @@ import { enhanceSiteLogoBlock } from './core/site-logo';
 export { getAllowedBlockNames } from './utils';
 
 export function initBlocks() {
+	// Footnote is registered by every register core block call as a side effect and causes warnings.
+	unregisterFormatType( 'core/footnote' );
 	registerCoreBlocks();
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -32,6 +32,7 @@ import { enhanceSiteLogoBlock } from './core/site-logo';
 export { getAllowedBlockNames } from './utils';
 
 export function initBlocks() {
+	registerCoreBlocks();
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();
 	hideExpandOnClick();
@@ -48,6 +49,5 @@ export function initBlocks() {
 	enhanceSocialLinksBlock();
 	modifyMoveToTrashAction();
 	enhanceSiteLogoBlock();
-	registerCoreBlocks();
 	removeBlockStylesFromAllBlocks();
 }

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { unregisterFormatType } from '@wordpress/rich-text';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -33,9 +33,11 @@ import { enhanceSiteLogoBlock } from './core/site-logo';
 export { getAllowedBlockNames } from './utils';
 
 export function initBlocks() {
-	// Footnote is registered by every register core block call as a side effect and causes warnings.
-	unregisterFormatType( 'core/footnote' );
-	registerCoreBlocks();
+	// Check if core blocks are already registered by looking for a fundamental core block
+	// 'core/paragraph' is always included in core blocks
+	if ( ! getBlockType( 'core/paragraph' ) ) {
+		registerCoreBlocks();
+	}
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();
 	hideExpandOnClick();

--- a/packages/js/email-editor/src/config-tools/block-config.ts
+++ b/packages/js/email-editor/src/config-tools/block-config.ts
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import {
+	getBlockType,
+	unregisterBlockType,
+	registerBlockType,
+} from '@wordpress/blocks';
+import type { BlockConfiguration } from '@wordpress/blocks';
+
+// Registry of first-seen/original settings for blocks we modify via these helpers.
+// Note: Store a shallow copy; callers should avoid mutating nested properties in-place.
+const originalBlockSettings = new Map<
+	string,
+	BlockConfiguration< Record< string, unknown > >
+>();
+
+export function updateBlockSettings<
+	TAttributes extends Record< string, unknown > = Record< string, unknown >
+>(
+	name: string,
+	updater: (
+		settings: BlockConfiguration< TAttributes >
+	) =>
+		| Partial< BlockConfiguration< TAttributes > >
+		| BlockConfiguration< TAttributes >
+): boolean {
+	const type = getBlockType< TAttributes >( name );
+	if ( ! type ) return false;
+
+	const { name: blockName, ...currentSettings } = type as unknown as {
+		name: string;
+	} & BlockConfiguration< TAttributes >;
+
+	try {
+		// Backup original settings the first time this block is updated.
+		if ( ! originalBlockSettings.has( blockName ) ) {
+			originalBlockSettings.set( blockName, {
+				...( currentSettings as BlockConfiguration<
+					Record< string, unknown >
+				> ),
+			} );
+		}
+
+		const patch = updater(
+			currentSettings as BlockConfiguration< TAttributes >
+		);
+		const nextSettings = {
+			...( currentSettings as BlockConfiguration< TAttributes > ),
+			...( patch as Partial< BlockConfiguration< TAttributes > > ),
+		} as BlockConfiguration< TAttributes >;
+
+		unregisterBlockType( blockName );
+		registerBlockType< TAttributes >( blockName, nextSettings );
+		return true;
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to update block settings for', name, e );
+		return false;
+	}
+}
+
+/**
+ * Restore original settings for all blocks modified via these helpers.
+ * Returns the list of block names successfully restored.
+ */
+export function restoreAllModifiedBlockSettings(): string[] {
+	const restored: string[] = [];
+	for ( const [ blockName, original ] of originalBlockSettings.entries() ) {
+		try {
+			unregisterBlockType( blockName );
+			// original is a BlockConfiguration; re-register as-is
+			registerBlockType( blockName, original );
+			restored.push( blockName );
+			originalBlockSettings.delete( blockName );
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.error(
+				'Failed to restore block settings for',
+				blockName,
+				e
+			);
+		}
+	}
+	return restored;
+}

--- a/packages/js/email-editor/src/config-tools/block-style.ts
+++ b/packages/js/email-editor/src/config-tools/block-style.ts
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { registerBlockStyle, unregisterBlockStyle } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+
+export type BlockStyle = { name: string; label: string; isDefault?: boolean };
+
+const newlyRegisteredStyles = new Set< string >();
+const preservedUnregisteredStyles = new Map< string, BlockStyle[] >();
+
+function makeKey( blockName: string, styleName: string ): string {
+	return `${ blockName }||${ styleName }`;
+}
+
+export function registerBlockStyleForEmail(
+	blockName: string,
+	style: BlockStyle
+): void {
+	registerBlockStyle( blockName, style );
+	newlyRegisteredStyles.add( makeKey( blockName, style.name ) );
+}
+
+export function unregisterBlockStyleForEmail(
+	blockName: string,
+	styleName: string
+): void {
+	// Try to preserve the style definition before unregistering
+	const currentStyles =
+		select( 'core/blocks' ).getBlockStyles( blockName ) || [];
+	const found = currentStyles.find( ( s ) => s.name === styleName );
+	if ( found ) {
+		const list = preservedUnregisteredStyles.get( blockName ) || [];
+		if ( ! list.find( ( s ) => s.name === styleName ) ) {
+			list.push( found as BlockStyle );
+			preservedUnregisteredStyles.set( blockName, list );
+		}
+	}
+	unregisterBlockStyle( blockName, styleName );
+}
+
+export function resetBlockStyles(): void {
+	// Remove styles registered by email editor
+	for ( const key of newlyRegisteredStyles ) {
+		const [ blockName, styleName ] = key.split( '||' );
+		unregisterBlockStyle( blockName, styleName );
+	}
+	newlyRegisteredStyles.clear();
+
+	// Restore preserved styles
+	for ( const [
+		blockName,
+		styles,
+	] of preservedUnregisteredStyles.entries() ) {
+		styles.forEach( ( style ) => registerBlockStyle( blockName, style ) );
+		preservedUnregisteredStyles.delete( blockName );
+	}
+}

--- a/packages/js/email-editor/src/config-tools/block-variations.ts
+++ b/packages/js/email-editor/src/config-tools/block-variations.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import {
+	registerBlockVariation,
+	unregisterBlockVariation,
+	type BlockVariation,
+} from '@wordpress/blocks';
+
+const newlyRegisteredVariations = new Set< string >();
+
+function makeKey( blockName: string, variationName: string ): string {
+	return `${ blockName }||${ variationName }`;
+}
+
+export function registerBlockVariationForEmail(
+	blockName: string,
+	variation: BlockVariation
+): void {
+	registerBlockVariation( blockName, variation );
+	newlyRegisteredVariations.add( makeKey( blockName, variation.name ) );
+}
+
+export function resetBlockVariations(): void {
+	// Remove variations added by email editor
+	for ( const key of newlyRegisteredVariations ) {
+		const [ blockName, variationName ] = key.split( '||' );
+		unregisterBlockVariation( blockName, variationName );
+	}
+	newlyRegisteredVariations.clear();
+}

--- a/packages/js/email-editor/src/config-tools/filters.ts
+++ b/packages/js/email-editor/src/config-tools/filters.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+// Store registered email filters so they can be removed on cleanup
+const emailFiltersRegistry = new Set< string >();
+
+function makeKey( hookName: string, namespace: string ): string {
+	return `${ hookName }||${ namespace }`;
+}
+
+/**
+ * Adds a filter and stores the pair (hookName, namespace) for later cleanup.
+ * Mirrors addFilter API.
+ */
+export function addFilterForEmail<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TCallback extends ( ...args: any[] ) => any
+>(
+	hookName: string,
+	namespace: string,
+	callback: TCallback,
+	priority?: number
+): void {
+	addFilter( hookName, namespace, callback, priority );
+	emailFiltersRegistry.add( makeKey( hookName, namespace ) );
+}
+
+/**
+ * Removes all filters that were registered via addFilterForEmail.
+ */
+export function clearEmailFilters(): void {
+	for ( const key of emailFiltersRegistry ) {
+		const [ hookName, namespace ] = key.split( '||' );
+		removeFilter( hookName, namespace );
+		emailFiltersRegistry.delete( key );
+	}
+}

--- a/packages/js/email-editor/src/config-tools/filters.ts
+++ b/packages/js/email-editor/src/config-tools/filters.ts
@@ -1,10 +1,16 @@
 /**
  * External dependencies
  */
-import { addFilter, removeFilter } from '@wordpress/hooks';
+import {
+	addFilter,
+	removeFilter,
+	addAction,
+	removeAction,
+} from '@wordpress/hooks';
 
-// Store registered email filters so they can be removed on cleanup
+// Store registered email filters and actions so they can be removed on cleanup
 const emailFiltersRegistry = new Set< string >();
+const emailActionsRegistry = new Set< string >();
 
 function makeKey( hookName: string, namespace: string ): string {
 	return `${ hookName }||${ namespace }`;
@@ -28,6 +34,23 @@ export function addFilterForEmail<
 }
 
 /**
+ * Adds an action and stores the pair (hookName, namespace) for later cleanup.
+ * Mirrors addAction API.
+ */
+export function addActionForEmail<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TCallback extends ( ...args: any[] ) => any
+>(
+	hookName: string,
+	namespace: string,
+	callback: TCallback,
+	priority?: number
+): void {
+	addAction( hookName, namespace, callback, priority );
+	emailActionsRegistry.add( makeKey( hookName, namespace ) );
+}
+
+/**
  * Removes all filters that were registered via addFilterForEmail.
  */
 export function clearEmailFilters(): void {
@@ -36,4 +59,23 @@ export function clearEmailFilters(): void {
 		removeFilter( hookName, namespace );
 		emailFiltersRegistry.delete( key );
 	}
+}
+
+/**
+ * Removes all actions that were registered via addActionForEmail.
+ */
+export function clearEmailActions(): void {
+	for ( const key of emailActionsRegistry ) {
+		const [ hookName, namespace ] = key.split( '||' );
+		removeAction( hookName, namespace );
+		emailActionsRegistry.delete( key );
+	}
+}
+
+/**
+ * Removes all filters and actions that were registered via addFilterForEmail and addActionForEmail.
+ */
+export function clearAllEmailHooks(): void {
+	clearEmailFilters();
+	clearEmailActions();
 }

--- a/packages/js/email-editor/src/config-tools/formats.ts
+++ b/packages/js/email-editor/src/config-tools/formats.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
+
+// Based on import('./register-format-type').WPFormat
+type WPFormat = {
+	name: string;
+	tagName: string;
+	interactive: boolean;
+	title: string;
+	// WPFormat.edit uses Function which is not allowed in type definitions
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	edit: any;
+	className?: string;
+	attributes?: Record< string, string >;
+};
+
+// Registry to track changes applied by the email editor
+const newlyRegisteredFormats = new Set< string >();
+const preservedUnregisteredFormats = new Map< string, WPFormat >();
+
+/**
+ * Registers a format and records it for potential cleanup.
+ * If the format already exists, it will be replaced and the previous definition will be preserved.
+ */
+export function registerFormatForEmail(
+	name: string,
+	settings: WPFormat
+): void {
+	registerFormatType( name, settings );
+	newlyRegisteredFormats.add( name );
+}
+
+/**
+ * Unregisters a format, preserving its current definition so it can be restored later.
+ */
+export function unregisterFormatForEmail( name: string ): void {
+	const previous = unregisterFormatType( name );
+	if ( previous ) {
+		preservedUnregisteredFormats.set( name, previous );
+	}
+}
+
+/**
+ * Restores formats to the state before email-editor changes:
+ * - Re-register all formats that we unregistered and preserved
+ * - Remove formats that were registered by the email editor
+ * The order is: remove newly registered first, then restore preserved definitions.
+ */
+export function resetFormats(): void {
+	// Remove formats introduced by the email editor
+	for ( const name of newlyRegisteredFormats ) {
+		unregisterFormatType( name );
+	}
+	newlyRegisteredFormats.clear();
+
+	// Restore preserved formats
+	for ( const [ name, format ] of preservedUnregisteredFormats.entries() ) {
+		registerFormatType( name, format );
+		preservedUnregisteredFormats.delete( name );
+	}
+}

--- a/packages/js/email-editor/src/config-tools/index.ts
+++ b/packages/js/email-editor/src/config-tools/index.ts
@@ -7,13 +7,11 @@ export * from './block-variations';
 /**
  * Internal dependencies
  */
-import {
-	resetBlockStyles,
-	resetBlockVariations,
-	resetFormats,
-	clearAllEmailHooks,
-	restoreAllModifiedBlockSettings,
-} from '.';
+import { resetBlockStyles } from './block-style';
+import { resetBlockVariations } from './block-variations';
+import { resetFormats } from './formats';
+import { clearAllEmailHooks } from './filters';
+import { restoreAllModifiedBlockSettings } from './block-config';
 
 export function cleanupConfigurationChanges(): void {
 	restoreAllModifiedBlockSettings();

--- a/packages/js/email-editor/src/config-tools/index.ts
+++ b/packages/js/email-editor/src/config-tools/index.ts
@@ -1,0 +1,5 @@
+export * from './block-config';
+export * from './filters';
+export * from './formats';
+export * from './block-style';
+export * from './block-variations';

--- a/packages/js/email-editor/src/config-tools/index.ts
+++ b/packages/js/email-editor/src/config-tools/index.ts
@@ -4,11 +4,14 @@ export * from './formats';
 export * from './block-style';
 export * from './block-variations';
 
+/**
+ * Internal dependencies
+ */
 import {
 	resetBlockStyles,
 	resetBlockVariations,
 	resetFormats,
-	clearEmailFilters,
+	clearAllEmailHooks,
 	restoreAllModifiedBlockSettings,
 } from '.';
 
@@ -17,5 +20,5 @@ export function cleanupConfigurationChanges(): void {
 	resetBlockStyles();
 	resetBlockVariations();
 	resetFormats();
-	clearEmailFilters();
+	clearAllEmailHooks();
 }

--- a/packages/js/email-editor/src/config-tools/index.ts
+++ b/packages/js/email-editor/src/config-tools/index.ts
@@ -3,3 +3,19 @@ export * from './filters';
 export * from './formats';
 export * from './block-style';
 export * from './block-variations';
+
+import {
+	resetBlockStyles,
+	resetBlockVariations,
+	resetFormats,
+	clearEmailFilters,
+	restoreAllModifiedBlockSettings,
+} from '.';
+
+export function cleanupConfigurationChanges(): void {
+	restoreAllModifiedBlockSettings();
+	resetBlockStyles();
+	resetBlockVariations();
+	resetFormats();
+	clearEmailFilters();
+}

--- a/packages/js/email-editor/src/editor-hooks.ts
+++ b/packages/js/email-editor/src/editor-hooks.ts
@@ -3,12 +3,15 @@
  */
 import { ComponentType } from 'react';
 import { MediaUpload } from '@wordpress/media-utils';
-import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import { addFilterForEmail } from './config-tools';
 
 export const initHooks = (): void => {
 	// see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-upload/README.md
 	const replaceMediaUpload = (): ComponentType => MediaUpload;
-	addFilter(
+	addFilterForEmail(
 		'editor.MediaUpload',
 		'woocommerce/email-editor/replace-media-upload',
 		replaceMediaUpload

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select, dispatch } from '@wordpress/data';
 import {
 	StrictMode,
 	createRoot,
@@ -10,6 +10,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
+import { store as editorStore } from '@wordpress/editor';
 import '@wordpress/format-library'; // Enables text formatting capabilities
 
 /**
@@ -139,11 +140,15 @@ export function ExperimentalEmailEditor( {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 
 	useLayoutEffect( () => {
+		const backupEditorSettings = select( editorStore ).getEditorSettings();
 		onInit();
 		setIsInitialized( true );
 		// Cleanup global editor settings
 		return () => {
 			cleanupConfigurationChanges();
+			dispatch( editorStore ).updateEditorSettings(
+				backupEditorSettings
+			);
 		};
 	}, [] );
 

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -145,10 +145,13 @@ export function ExperimentalEmailEditor( {
 		setIsInitialized( true );
 		// Cleanup global editor settings
 		return () => {
-			cleanupConfigurationChanges();
-			dispatch( editorStore ).updateEditorSettings(
-				backupEditorSettings
-			);
+			try {
+				cleanupConfigurationChanges();
+			} finally {
+				dispatch( editorStore ).updateEditorSettings(
+					backupEditorSettings
+				);
+			}
 		};
 	}, [] );
 

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -46,8 +46,8 @@ function Editor( {
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { settings } = useSelect(
-		( select ) => ( {
-			settings: select( storeName ).getInitialEditorSettings(),
+		( sel ) => ( {
+			settings: sel( storeName ).getInitialEditorSettings(),
 		} ),
 		[]
 	);

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -32,6 +32,7 @@ import {
 	useRemoveSavingFailedNotices,
 	useFilterEditorContentStylesheets,
 } from './hooks';
+import { cleanupConfigurationChanges } from './config-tools';
 
 function Editor( {
 	postId,
@@ -140,6 +141,10 @@ export function ExperimentalEmailEditor( {
 	useLayoutEffect( () => {
 		onInit();
 		setIsInitialized( true );
+		// Cleanup global editor settings
+		return () => {
+			cleanupConfigurationChanges();
+		};
 	}, [] );
 
 	const WrappedEditor = applyFilters(

--- a/packages/js/email-editor/src/store/store.ts
+++ b/packages/js/email-editor/src/store/store.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
+
 import {
 	ReduxStoreConfig,
 	StoreDescriptor as GenericStoreDescriptor,
@@ -31,6 +32,12 @@ const getConfig = () =>
 export type EditorStoreConfig = ReturnType< typeof getConfig >;
 
 export const createStore = () => {
+	// Check if store is already registered
+	const storeState = select( storeName );
+	if ( storeState !== undefined ) {
+		return select( storeName );
+	}
+
 	const store = createReduxStore( storeName, getConfig() );
 	register( store );
 	return store;

--- a/packages/js/email-editor/src/text-hooks.ts
+++ b/packages/js/email-editor/src/text-hooks.ts
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { addFilterForEmail } from './config-tools';
 
 /**
  * Replace text in the email editor.
@@ -20,7 +24,7 @@ export const initTextHooks = (): void => {
 			},
 	};
 
-	addFilter(
+	addFilterForEmail(
 		'i18n.gettext',
 		'woocommerce/email-editor/override-text',
 		( translation, text, domain ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses issues related to the usage of the email editor next to the default post editor in a single-page app. Many enhancements we do for the email editor are done via functions and hooks that have a global effect, and they may alter not only the email editor but also the post editor.

The idea of this approach is to clean up the changes to the global state when the editor unmounts. In order to do that,
the PR introduces the so-called "Config tools" (Note: I'm happy to change the name. Feel free to suggest a better one).

The config tools are a set of functions that wrap the Gutenberg functions we use to make the modifications. These functions capture the original state when they are used. Then there is a restore function that restores the original values, unregisters filters, etc.

#### The config tools functions

**Filters & Actions** 

- addFilterForEmail - Add filter with cleanup tracking
- addActionForEmail  - Add action with cleanup tracking
- clearEmailFilters - Remove all filters registered via addFilterForEmail
- clearEmailActions - Remove all actions registered via addActionForEmail
- clearAllEmailHooks - Remove all filters and actions registered for email

**RichText Format Management**

- registerFormatForEmail - Register rich text format with cleanup tracking
- unregisterFormatForEmail- Unregister format while preserving original definition
- resetFormats - Restore all formats to pre-email-editor state

**Block Variations**

registerBlockVariationForEmail- Register block variation with cleanup tracking
resetBlockVariations - Remove all block variations added by email editor

**Block Styles**

- registerBlockStyleForEmail - Register block style with cleanup tracking
- unregisterBlockStyleForEmail - Unregister style while preserving original
- resetBlockStyles - Restore all block styles to original state

**Block Configuration**
Note: This is a replacement for `blocks.registerBlockType` filter that is might be triggered before email editor is even rendered.

- updateBlockSettings - Update block settings with backup/restore capability
- restoreAllModifiedBlockSettings  - Restore original settings for all modified blocks

This PR also replaces usage of the original functions with the config tools functions.

Related to WOOPRD-791 .


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Test the email editor integrated in Woo to see if it works as expected

1. Enable email editor in WooCommerce > Settings > Advanced > Features
2. Go to WooCommerce > Settings > Emails and open an email
3. Verify that the modifications to blocks and block tools are applied (see https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/email-editor/src/blocks/core for the changes we do).

Test that the email editor works properly when integrated in a single-page application.

1. You can setup the application to fetch the package from local source `"@woocommerce/email-editor": "file:../../woocommerce/packages/js/email-editor"`
2. Build the editor package `pnpm --filter=@woocommerce/email-editor build`
3. Build the application
4. Open the application and see that editor works as expected and when you switched to the post editor the changes were reverted

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
