### PR TITLE
Update the Add to Cart + Options block so attributes are automatically selected when they match the URL parameters

### DIFF
--- a/plugins/woocommerce/changelog/fix-60743-select-attribute-from-url
+++ b/plugins/woocommerce/changelog/fix-60743-select-attribute-from-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the Add to Cart + Options block so attributes are automatically selected when they match the URL parameters

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -60,14 +60,15 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 
 		$attributes = $this->parse_attributes( $attributes );
 
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
+		// `$attributes['style']` is the layout selector ("pills" | "dropdown"), not the block supports style object.
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes', 'style' ) );
 
 		$field_style = $attributes['style'];
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'class' => esc_attr( $classes_and_styles['classes'] ),
-				'style' => esc_attr( $classes_and_styles['styles'] ),
+				'class' => $classes_and_styles['classes'],
+				'style' => $classes_and_styles['styles'],
 			)
 		);
 
@@ -161,17 +162,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				function () {
 					$context = wp_interactivity_get_context();
 
-					if ( isset( $_GET[ $context['name'] ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						$selected_attribute = $this->get_default_selected_attribute( $context['name'], $context['options'] );
-
-						if ( $context['option']['value'] === $selected_attribute ) {
-							return true;
-						}
-					} else {
-						return $context['option']['isSelected'];
-					}
-
-					return false;
+					return $context['option']['value'] === $context['selectedValue'];
 				},
 			)
 		);
@@ -244,6 +235,8 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 			$attribute_terms
 		);
 
+		$selected_attribute = $this->get_default_selected_attribute( $attribute_slug, $attribute_terms );
+
 		$options = '';
 		foreach ( $attribute_terms as $attribute_term ) {
 			$option_attributes = array(
@@ -255,8 +248,6 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'options' => $attribute_terms,
 				),
 			);
-
-			$selected_attribute = $this->get_default_selected_attribute( $attribute_slug, $attribute_terms );
 
 			if ( $attribute_term['value'] === $selected_attribute || ( ! isset( $_GET[ $attribute_slug ] ) && $attribute_term['isSelected'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$option_attributes['selected'] = 'selected';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -249,7 +249,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				),
 			);
 
-			if ( $attribute_term['value'] === $selected_attribute || ( ! isset( $_GET[ $attribute_slug ] ) && $attribute_term['isSelected'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $attribute_term['value'] === $selected_attribute ) {
 				$option_attributes['selected'] = 'selected';
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -271,7 +271,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'data-wp-context'    => array(
 						'name'          => $attribute_slug,
 						'options'       => $attribute_terms,
-						'selectedValue' => $this->get_default_selected_attribute( $attribute_slug, $attribute_terms ),
+						'selectedValue' => $selected_attribute,
 					),
 					'data-wp-init'       => 'callbacks.setDefaultSelectedAttribute',
 					'data-wp-on--change' => 'actions.handleDropdownChange',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -58,35 +58,30 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 
 		$attribute_slug = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
 
-		if ( isset( $attribute_slug ) ) {
+		$attributes = $this->parse_attributes( $attributes );
 
-			$attributes = $this->parse_attributes( $attributes );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
-			$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
+		$field_style = $attributes['style'];
 
-			$field_style = $attributes['style'];
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => esc_attr( $classes_and_styles['classes'] ),
+				'style' => esc_attr( $classes_and_styles['styles'] ),
+			)
+		);
 
-			$wrapper_attributes = get_block_wrapper_attributes(
-				array(
-					'class' => esc_attr( $classes_and_styles['classes'] ),
-					'style' => esc_attr( $classes_and_styles['styles'] ),
-				)
-			);
-
-			if ( 'dropdown' === $field_style ) {
-				$content = $this->render_dropdown( $attributes, $content, $block );
-			} else {
-				$content = $this->render_pills( $attributes, $content, $block );
-			}
-
-			return sprintf(
-				'<div %s>%s</div>',
-				$wrapper_attributes,
-				$content
-			);
+		if ( 'dropdown' === $field_style ) {
+			$content = $this->render_dropdown( $attributes, $content, $block );
+		} else {
+			$content = $this->render_pills( $attributes, $content, $block );
 		}
 
-		return '';
+		return sprintf(
+			'<div %s>%s</div>',
+			$wrapper_attributes,
+			$content
+		);
 	}
 
 	/**
@@ -126,10 +121,13 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 */
 	protected function get_default_selected_attribute( $attribute_slug, $attribute_terms ) {
 		if ( isset( $_GET[ $attribute_slug ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$attribute_slug_from_request = sanitize_title( wp_unslash( $_GET[ $attribute_slug ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			foreach ( $attribute_terms as $attribute_term ) {
-				if ( sanitize_title( $attribute_term['value'] ) === $attribute_slug_from_request ) {
-					return $attribute_term['value'];
+			$raw = wp_unslash( $_GET[ $attribute_slug ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( is_string( $raw ) ) {
+				$attribute_slug_from_request = sanitize_title( $raw );
+				foreach ( $attribute_terms as $attribute_term ) {
+					if ( sanitize_title( $attribute_term['value'] ) === $attribute_slug_from_request ) {
+						return $attribute_term['value'];
+					}
 				}
 			}
 		} else {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -120,13 +120,23 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	/**
 	 * Get the default selected attribute.
 	 *
-	 * @param array $attribute_terms The attribute's.
+	 * @param string $attribute_slug The attribute's slug.
+	 * @param array  $attribute_terms The attribute's terms.
 	 * @return string|null The default selected attribute.
 	 */
-	protected function get_default_selected_attribute( $attribute_terms ) {
-		foreach ( $attribute_terms as $attribute_term ) {
-			if ( $attribute_term['isSelected'] ) {
-				return $attribute_term['value'];
+	protected function get_default_selected_attribute( $attribute_slug, $attribute_terms ) {
+		if ( isset( $_GET[ $attribute_slug ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$attribute_slug_from_request = sanitize_title( wp_unslash( $_GET[ $attribute_slug ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			foreach ( $attribute_terms as $attribute_term ) {
+				if ( sanitize_title( $attribute_term['value'] ) === $attribute_slug_from_request ) {
+					return $attribute_term['value'];
+				}
+			}
+		} else {
+			foreach ( $attribute_terms as $attribute_term ) {
+				if ( $attribute_term['isSelected'] ) {
+					return $attribute_term['value'];
+				}
 			}
 		}
 
@@ -152,7 +162,18 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'isOptionSelected' =>
 				function () {
 					$context = wp_interactivity_get_context();
-					return $context['option']['isSelected'];
+
+					if ( isset( $_GET[ $context['name'] ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+						$selected_attribute = $this->get_default_selected_attribute( $context['name'], $context['options'] );
+
+						if ( $context['option']['value'] === $selected_attribute ) {
+							return true;
+						}
+					} else {
+						return $context['option']['isSelected'];
+					}
+
+					return false;
 				},
 			)
 		);
@@ -192,7 +213,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'data-wp-context' => array(
 						'name'          => $attribute_slug,
 						'options'       => $attribute_terms,
-						'selectedValue' => $this->get_default_selected_attribute( $attribute_terms ),
+						'selectedValue' => $this->get_default_selected_attribute( $attribute_slug, $attribute_terms ),
 						'focused'       => '',
 					),
 					'data-wp-init'    => 'callbacks.setDefaultSelectedAttribute',
@@ -237,7 +258,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				),
 			);
 
-			if ( $attribute_term['isSelected'] ) {
+			$selected_attribute = $this->get_default_selected_attribute( $attribute_slug, $attribute_terms );
+
+			if ( $attribute_term['value'] === $selected_attribute || ( ! isset( $_GET[ $attribute_slug ] ) && $attribute_term['isSelected'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$option_attributes['selected'] = 'selected';
 			}
 
@@ -259,7 +282,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'data-wp-context'    => array(
 						'name'          => $attribute_slug,
 						'options'       => $attribute_terms,
-						'selectedValue' => $this->get_default_selected_attribute( $attribute_terms ),
+						'selectedValue' => $this->get_default_selected_attribute( $attribute_slug, $attribute_terms ),
 					),
 					'data-wp-init'       => 'callbacks.setDefaultSelectedAttribute',
 					'data-wp-on--change' => 'actions.handleDropdownChange',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -322,7 +322,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertMatchesRegularExpression(
-			'/<input[^>]*checked(?:=" checked")?[^>]*type="radio"[^>]*value="small-slug"[^>]*>/',
+			'/<input[^>]*checked(?:="checked")?[^>]*type="radio"[^>]*value="small-slug"[^>]*>/',
 			$markup,
 			'The "small" size option should be checked when set as the default attribute.'
 		);
@@ -332,10 +332,12 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertMatchesRegularExpression(
-			'/<input[^>]*checked(?:=" checked")?[^>]*type="radio"[^>]*value="medium-slug"[^>]*>/',
+			'/<input[^>]*checked(?:="checked")?[^>]*type="radio"[^>]*value="medium-slug"[^>]*>/',
 			$markup,
 			'The "medium" size option should be checked when set in the URL parameters.'
 		);
+
+		unset( $_GET['attribute_pa_size'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -262,7 +262,8 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the default option is set in variable products.
+	 * Tests that the default attributes are selected when defined in product
+	 * data or in the URL parameters.
 	 */
 	public function test_variable_product_default_option_render() {
 		global $product;
@@ -291,6 +292,18 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			)
 		);
 
+		$fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'red-slug',
+				'pa_size'  => 'medium-slug',
+			),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
 		// Sync the variable product to update its children list.
 		\WC_Product_Variable::sync( $product_id );
 
@@ -312,6 +325,16 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			'/<input[^>]*checked(?:=" checked")?[^>]*type="radio"[^>]*value="small-slug"[^>]*>/',
 			$markup,
 			'The "small" size option should be checked when set as the default attribute.'
+		);
+
+		$_GET['attribute_pa_size'] = 'medium-slug';
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertMatchesRegularExpression(
+			'/<input[^>]*checked(?:=" checked")?[^>]*type="radio"[^>]*value="medium-slug"[^>]*>/',
+			$markup,
+			'The "medium" size option should be checked when set in the URL parameters.'
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60743.

In classic templates, it was possible to pass the attribute slugs and values in the URL, and they would be automatically selected. This PR implements the same behavior in the _Add to Cart + Options_ block.

### How to test the changes in this Pull Request:

1. Go to the frontend of a variable product that is using the *Add to Cart + Options* block.
2. Add this to the URL and reload the page: `?attribute_pa_color=red`. (You might need to change the attribute slug or values)
3. Verify the _Red_ attribute is selected by default.
4. Repeat with the _Add to Cart + Options_ dropdown display style.

Before | After
--- | ---
<img src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/2696c4aa-f5f9-44d8-819d-e9c7b2141653/9e66c60f-9dd3-401e-bb1f-9515432974ee?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi8yNjk2YzRhYS1mNWY5LTQ0ZDgtODE5ZC1lOWM3YjIxNDE2NTMvOWU2NmM2MGYtOWRkMy00MDFlLWJiMWYtOTUxNTQzMjk3NGVlIiwiaWF0IjoxNzU2OTA0Njk3LCJleHAiOjMzMzI3NDY0Njk3fQ.sgox9BXBJZPs6y1pk1BrhW-6RTJT8DDVFGsDo61BxMQ " alt="imatge.png" width="1033" data-linear-height="921" /> | <img width="1033" height="921" alt="Captura de pantalla de 2025-09-03 15-03-39" src="https://github.com/user-attachments/assets/2b6e4221-7a32-4c2d-a670-bd705a956df2" />
