### PR TITLE
Fix deprecation notice in PHPCS

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpcs-deprecation
+++ b/plugins/woocommerce/changelog/fix-phpcs-deprecation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Addresses a PHPCS deprecation notice.
+
+

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -43,7 +43,9 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="woocommerce" />
+			<property name="text_domain" type="array">
+				<element value="woocommerce" />
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a PHPCS deprecation notice due to our usage of comma-separated values in phpcs.xml for 'array' properties. Relates to https://github.com/woocommerce/woocommerce-sniffs/issues/43, which https://github.com/woocommerce/woocommerce-sniffs/pull/44 fixed for the WooCommerce sniffs, with one remaining warning coming from our own `phpcs.xml`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `trunk`.
1. Run `./vendor/bin/phpcs` from within `plugins/woocommerce` and confirm that you see this deprecation warning:
   ```
   DEPRECATED: Passing an array of values to a property using a comma-separated string
   was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.
   The deprecated syntax was used for property "text_domain"
   for sniff "WordPress.WP.I18n".
   Pass array values via <element [key="..." ]value="..."> nodes instead.
   ```
1. Check out this branch (`fix/phpcs-deprecation`).
1. Run `./vendor/bin/phpcs` from within `plugins/woocommerce` and confirm that this warning is no longer in the output.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
