### PR TITLE
Reduce dummy calls to SELECT * FROM wp_posts WHERE ID = -1 LIMIT 1

### DIFF
--- a/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
+++ b/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without
+

--- a/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
+++ b/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
-Comment: Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without
+Comment: Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without Shop Page set.
 

--- a/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
+++ b/plugins/woocommerce/changelog/60766-update-make-fewer-calls-to-get_posts-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
-Comment: Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without Shop Page set.
+Comment: Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without
 

--- a/plugins/woocommerce/patterns/banner.php
+++ b/plugins/woocommerce/patterns/banner.php
@@ -38,7 +38,7 @@ $second_description = __( 'Get your favorite vinyl at record-breaking prices.', 
 			<div class="wp-block-buttons" style="margin-top:20px;margin-bottom:0">
 				<!-- wp:button {"style":{"typography":{"fontSize":"16px"},"border":{"width":"0px","style":"none"}},"className":"is-style-fill"} -->
 				<div class="wp-block-button has-custom-font-size is-style-fill" style="font-size:16px">
-					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="border-style:none;border-width:0px;">
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;">
 						<?php echo esc_html( $banner_button ); ?>
 					</a>
 				</div>

--- a/plugins/woocommerce/patterns/hero-product-3-split.php
+++ b/plugins/woocommerce/patterns/hero-product-3-split.php
@@ -103,7 +103,7 @@ $third_description  = __( "The Retro Glass Jug's classic silhouette effortlessly
 				<!-- wp:buttons -->
 				<div class="wp-block-buttons"><!-- wp:button -->
 					<div class="wp-block-button">
-						<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'woocommerce' ); ?></a>
+						<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'woocommerce' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>

--- a/plugins/woocommerce/patterns/hero-product-chessboard.php
+++ b/plugins/woocommerce/patterns/hero-product-chessboard.php
@@ -59,7 +59,7 @@ $button = __( 'Shop home decor', 'woocommerce' );
 				<div class="wp-block-buttons" style="margin-top:64px">
 					<!-- wp:button {"textAlign":"left"} -->
 					<div class="wp-block-button has-custom-font-size">
-						<a class="wp-block-button__link has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>"><?php echo esc_html( $button ); ?></a>
+						<a class="wp-block-button__link has-text-align-left wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php echo esc_html( $button ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				</div>

--- a/plugins/woocommerce/patterns/hero-product-split.php
+++ b/plugins/woocommerce/patterns/hero-product-split.php
@@ -26,7 +26,7 @@ $hero_title = __( 'Keep dry with 50% off rain jackets', 'woocommerce' );
 			<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop the sale', 'woocommerce' ); ?></a>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop the sale', 'woocommerce' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/plugins/woocommerce/patterns/just-arrived-full-hero.php
+++ b/plugins/woocommerce/patterns/just-arrived-full-hero.php
@@ -30,7 +30,7 @@ $pattern_image       = plugins_url( 'assets/images/pattern-placeholders/man-pers
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>"><?php echo esc_html( $pattern_button ); ?></a>
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>"><?php echo esc_html( $pattern_button ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/plugins/woocommerce/patterns/product-collection-featured-products-5-columns.php
+++ b/plugins/woocommerce/patterns/product-collection-featured-products-5-columns.php
@@ -44,7 +44,7 @@ $collection_title = __( 'Shop new arrivals', 'woocommerce' );
 		<div class="wp-block-buttons alignwide">
 			<!-- wp:button {"textAlign":"center"} -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">
+				<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>">
 					<?php esc_html_e( 'Shop All', 'woocommerce' ); ?>
 				</a>
 			</div>

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -441,7 +441,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Block content.
 	 */
 	private static function get_homepage_cover_block( $image ) {
-		$shop_url = get_permalink( wc_get_page_id( 'shop' ) );
+		$shop_url = wc_get_page_permalink( 'shop' );
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:cover {"url":"' . esc_url( $image['url'] ) . '","id":' . intval( $image['id'] ) . ',"dimRatio":0} -->
 			<div class="wp-block-cover" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce' ) . '","textColor":"white","fontSize":"large"} -->

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -51,7 +51,7 @@ class Cart extends AbstractBlock {
 	 * Register block pattern for Empty Cart Message to make it translatable.
 	 */
 	public function register_patterns() {
-		$shop_permalink = wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : '';
+		$shop_permalink = wc_get_page_permalink( 'shop' );
 
 		register_block_pattern(
 			'woocommerce/cart-heading',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -40,7 +40,7 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
 		ob_start();
-		$shop_url                     = get_permalink( wc_get_page_id( 'shop' ) );
+		$shop_url                     = wc_get_page_permalink( 'shop' );
 		$default_start_shopping_label = __( 'Start shopping', 'woocommerce' );
 		$start_shopping_label         = $attributes['startShoppingButtonLabel'] ? $attributes['startShoppingButtonLabel'] : $default_start_shopping_label;
 		$wrapper_attributes           = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__shopping-button' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WCCOM-1748 .

For some shops that don't have Shop page set in WC settings, like ours, `wc_get_page_id()` can return `-1`, which in turn triggered `get_permalink()` to call `get_posts(-1)`. It's a fast query that doesn't do much, but we don't need it at all. There's upcoming fix in WP 6.9 (still some way to go) https://core.trac.wordpress.org/ticket/63850 which will prevent the query, but in context of WooCommerce, `wc_get_page_permalink()` looks like a much neater solution anyway.

<img width="681" height="165" alt="image" src="https://github.com/user-attachments/assets/61a4d438-d375-4eed-a962-7e5fef3c6d4c" />


2000 calls to each method made from WP-env CLI, to ensure performance is not degraded
```
# Old method, no shop page set
wp> $e = (function(){ $s = microtime(true); for($i=0;$i<2000;$i++) get_permalink( wc_get_page_id( 'shop' ) ); return microtime(true)-$s; })();
wp> printf("%.2f ms (%.4f s)\n", $e*1000, $e);
169.53 ms (0.1695 s)

# New method, no shop page set
wp> $e = (function(){ $s = microtime(true); for($i=0;$i<2000;$i++) wc_get_page_permalink( 'shop' ); return microtime(true)-$s; })();
wp> printf("%.2f ms (%.4f s)\n", $e*1000, $e);
18.56 ms (0.0186 s)

# Old method, shop page is set
wp> $e = (function(){ $s = microtime(true); for($i=0;$i<2000;$i++) get_permalink( wc_get_page_id( 'shop' ) ); return microtime(true)-$s; })();
wp> printf("%.2f ms (%.4f s)\n", $e*1000, $e);
33.78 ms (0.0338 s)

# New method, shop page is set
wp> $e = (function(){ $s = microtime(true); for($i=0;$i<2000;$i++) wc_get_page_permalink( 'shop' ); return microtime(true)-$s; })();
wp> printf("%.2f ms (%.4f s)\n", $e*1000, $e);
23.59 ms (0.0236 s)
```

Based on that, it looks that `wc_get_page_permalink( 'shop' )` is more performant (although honestly the numbers are based on 2000 calls, so let's not treat it as perf improvement) than `get_permalink( wc_get_page_id( 'shop' ) )`, especially when Shop Page is not set.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   8 duplicate queries: <img width="1726" height="127" alt="Screenshot 2025-09-04 at 13 03 26" src="https://github.com/user-attachments/assets/c87391ad-d163-4ce5-a8b5-2bbf9ed6201c" />    |   No duplicate queries: <img width="205" height="169" alt="image" src="https://github.com/user-attachments/assets/954ba4a9-9231-4a42-9501-259cf179222d" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and start the container
```
nvm use
cd plugins/woocommerce
pnpm install --frozen-lock-file
pnpm run build
pnpm wp-env start
``` 
3. Optional: go to `/wp-admin/options-permalink.php` and set some permalinks
4. Install query monitor and activate it
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=products` and confirm that Shop Page is set
5. Create a new page and add to it some of the updated patterns
6. Confirm that shop links link to your shop page
7. Open wp shell `pnpm -- wp-env run cli wp shell`
8. Clear Shop Page option `delete_option( 'woocommerce_shop_page_id' );`
9. Flush cache `wp_cache_flush();`
10. Create a new page with the same patterns (do not copy content of the previous page as it'd copy the links too, add patterns to the page again).
11. Save the page and confirm that the "shop" links are now linking to your home page
12. In Query monitor notice that you have no duplicate queries
13. Checkout `trunk`
14. Refresh the page you created (on the frontend). Notice that in query monitor now you'll see 8 duplicate queries.
15. Please test around this issue.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Use wc_get_page_permalink() in patterns to reduce unnecessary queries for shops without 

</details>
