### PR TITLE
Email Editor: Add email rendering only for gallery block

### DIFF
--- a/packages/php/email-editor/changelog/add-gallery-email-rendering
+++ b/packages/php/email-editor/changelog/add-gallery-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add email rendering instructions for the core/gallery block.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -77,7 +77,7 @@ class Gallery extends Abstract_Block_Renderer {
 		// First, try to find a linked image (most common case).
 		if ( preg_match( '/<a[^>]*href=(["\'])(.*?)\1[^>]*>(\s*<img[^>]*>)\s*<\/a>/s', $html_content, $link_matches ) ) {
 			// Validate and sanitize the link URL.
-			$sanitized_url = esc_url_raw( $link_matches[2] );
+			$sanitized_url = esc_url( $link_matches[2] );
 			if ( ! empty( $sanitized_url ) ) {
 				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
 				if ( '' !== $sanitized_img ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -28,18 +28,8 @@ class Gallery extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
-		$inner_blocks = $parsed_block['innerBlocks'] ?? array();
-
-		// Process inner blocks to get gallery images.
-		$gallery_images = array();
-
-		foreach ( $inner_blocks as $block ) {
-			if ( 'core/image' === $block['blockName'] ) {
-				$rendered_image = render_block( $block );
-				// Extract image with link information from the original block data.
-				$gallery_images[] = $this->extract_image_with_link( $rendered_image, $block );
-			}
-		}
+		// Extract images directly from the block content (more efficient than re-rendering).
+		$gallery_images = $this->extract_images_from_gallery_content( $block_content, $parsed_block );
 
 		// If we don't have any images, return empty.
 		if ( empty( $gallery_images ) ) {
@@ -51,75 +41,60 @@ class Gallery extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Extract image with link information from block data.
+	 * Extract all images from gallery content with their links and captions.
 	 *
-	 * @param string $rendered_image The rendered image block HTML.
-	 * @param array  $block The original block data.
-	 * @return string Image HTML with proper link handling.
+	 * @param string $block_content The rendered gallery block HTML.
+	 * @param array  $parsed_block The parsed block data.
+	 * @return array Array of sanitized image HTML strings.
 	 */
-	private function extract_image_with_link( string $rendered_image, array $block ): string {
-		// Check if there's a link in the original innerHTML.
-		if ( isset( $block['innerHTML'] ) ) {
-			$inner_html = $block['innerHTML'];
+	private function extract_images_from_gallery_content( string $block_content, array $parsed_block ): array {
+		$gallery_images = array();
+		$inner_blocks   = $parsed_block['innerBlocks'] ?? array();
 
-			// Look for a link around the image in the original HTML.
-			if ( preg_match( '/<a[^>]*href=(["\'])(.*?)\1[^>]*>(\s*<img[^>]*>)\s*<\/a>/s', $inner_html, $link_matches ) ) {
-				// Validate and sanitize the link URL.
-				$sanitized_url = esc_url_raw( $link_matches[2] );
-				if ( empty( $sanitized_url ) ) {
-					// If URL is invalid, fall back to image without link.
-					return $this->remove_figure_wrapper( $rendered_image );
+		// Extract images from inner blocks data where the actual image HTML is stored.
+		foreach ( $inner_blocks as $block ) {
+			if ( 'core/image' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
+				$extracted_image = $this->extract_image_from_html( $block['innerHTML'] );
+				if ( ! empty( $extracted_image ) ) {
+					$gallery_images[] = $extracted_image;
 				}
-
-				// Extract the linked image and caption separately.
-				$linked_image = '<a href="' . $sanitized_url . '">' . $link_matches[3] . '</a>';
-
-				// Extract caption if it exists.
-				$caption = '';
-				if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $inner_html, $caption_matches ) ) {
-					$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
-					$caption           = '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
-				}
-
-				return $linked_image . $caption;
 			}
 		}
 
-		// Fallback to the original method if no link is found.
-		return $this->remove_figure_wrapper( $rendered_image );
+		return $gallery_images;
 	}
 
 	/**
-	 * Remove figure wrapper from rendered image block for email compatibility.
+	 * Extract and sanitize image with optional link and caption from HTML content.
+	 * This is the unified method that handles all image extraction scenarios.
 	 *
-	 * @param string $rendered_image Rendered image HTML.
-	 * @return string Image HTML without figure wrapper.
+	 * @param string $html_content HTML content containing the image.
+	 * @return string Sanitized image HTML with proper link and caption handling.
 	 */
-	private function remove_figure_wrapper( string $rendered_image ): string {
-		// Extract the img element and caption, preserving any links around the image.
+	private function extract_image_from_html( string $html_content ): string {
 		$result = '';
 
-		// Check if the image is wrapped in a link.
-		if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $rendered_image, $link_matches ) ) {
-			// Image is linked - validate and sanitize the link URL.
-			$sanitized_href = esc_url_raw( $link_matches[1] );
-			if ( ! empty( $sanitized_href ) ) {
-				$sanitized_img = wp_kses_post( $link_matches[2] );
-				$result       .= '<a href="' . $sanitized_href . '">' . $sanitized_img . '</a>';
+		// First, try to find a linked image (most common case).
+		if ( preg_match( '/<a[^>]*href=(["\'])(.*?)\1[^>]*>(\s*<img[^>]*>)\s*<\/a>/s', $html_content, $link_matches ) ) {
+			// Validate and sanitize the link URL.
+			$sanitized_url = esc_url_raw( $link_matches[2] );
+			if ( ! empty( $sanitized_url ) ) {
+				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
+				$result       .= '<a href="' . $sanitized_url . '">' . $sanitized_img . '</a>';
 			} else {
 				// If URL is invalid, extract just the image without link.
-				$result .= wp_kses_post( $link_matches[2] );
+				$result .= Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
 			}
-		} elseif ( preg_match( '/<img[^>]*>/', $rendered_image, $img_matches ) ) {
+		} elseif ( preg_match( '/<img[^>]*>/', $html_content, $img_matches ) ) {
 			// Image is not linked - just extract the img element with sanitization.
-			$result .= wp_kses_post( $img_matches[0] );
+			$result .= Html_Processing_Helper::sanitize_image_html( $img_matches[0] );
 		}
 
 		// Extract the caption if it exists (handle both figcaption and span formats).
-		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $rendered_image, $caption_matches ) ) {
+		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $html_content, $caption_matches ) ) {
 			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
 			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
-		} elseif ( preg_match( '/<span class="wp-element-caption"[^>]*>(.*?)<\/span>/s', $rendered_image, $caption_matches ) ) {
+		} elseif ( preg_match( '/<span class="wp-element-caption"[^>]*>(.*?)<\/span>/s', $html_content, $caption_matches ) ) {
 			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
 			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
 		}
@@ -265,6 +240,7 @@ class Gallery extends Abstract_Block_Renderer {
 			$row_cells
 		);
 	}
+
 
 	/**
 	 * Get the columns value from block attributes.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
+
+/**
+ * Gallery block renderer.
+ * This renderer handles core/gallery blocks with proper email-friendly HTML layout.
+ */
+class Gallery extends Abstract_Block_Renderer {
+	/**
+	 * Renders the gallery block content using a table-based layout.
+	 *
+	 * @param string            $block_content Block content.
+	 * @param array             $parsed_block Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$inner_blocks = $parsed_block['innerBlocks'] ?? array();
+
+		// Process inner blocks to get gallery images.
+		$gallery_images = array();
+		foreach ( $inner_blocks as $block ) {
+			if ( 'core/image' === $block['blockName'] ) {
+				$rendered_image = render_block( $block );
+				// Extract image with link information from the original block data.
+				$gallery_images[] = $this->extract_image_with_link( $rendered_image, $block );
+			}
+		}
+
+		// If we don't have any images, return empty.
+		if ( empty( $gallery_images ) ) {
+			return '';
+		}
+
+		// Build the email-friendly layout.
+		return $this->build_email_layout( $gallery_images, $parsed_block, $block_content, $rendering_context );
+	}
+
+	/**
+	 * Extract image with link information from block data.
+	 *
+	 * @param string $rendered_image The rendered image block HTML.
+	 * @param array  $block The original block data.
+	 * @return string Image HTML with proper link handling.
+	 */
+	private function extract_image_with_link( string $rendered_image, array $block ): string {
+		// Check if the block has link destination information.
+		$block_attrs      = $block['attrs'] ?? array();
+		$link_destination = $block_attrs['linkDestination'] ?? 'none';
+
+		// If there's a link destination, extract the linked image directly from innerHTML.
+		if ( 'none' !== $link_destination && isset( $block['innerHTML'] ) ) {
+			$inner_html = $block['innerHTML'];
+
+			// Look for a link around the image in the original HTML.
+			if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $inner_html, $link_matches ) ) {
+				// Extract the linked image and caption separately.
+				$linked_image = '<a href="' . $link_matches[1] . '">' . $link_matches[2] . '</a>';
+
+				// Extract caption if it exists.
+				$caption = '';
+				if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $inner_html, $caption_matches ) ) {
+					$caption = '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+				}
+
+				return $linked_image . $caption;
+			}
+		}
+
+		// Fallback to the original method if no link is found.
+		return $this->remove_figure_wrapper( $rendered_image );
+	}
+
+	/**
+	 * Remove figure wrapper from rendered image block for email compatibility.
+	 *
+	 * @param string $rendered_image Rendered image HTML.
+	 * @return string Image HTML without figure wrapper.
+	 */
+	private function remove_figure_wrapper( string $rendered_image ): string {
+		// Extract the img element and caption, preserving any links around the image.
+		$result = '';
+
+		// Check if the image is wrapped in a link.
+		if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $rendered_image, $link_matches ) ) {
+			// Image is linked - preserve the link.
+			$result .= '<a href="' . $link_matches[1] . '">' . $link_matches[2] . '</a>';
+		} elseif ( preg_match( '/<img[^>]*>/', $rendered_image, $img_matches ) ) {
+			// Image is not linked - just extract the img element.
+			$result .= $img_matches[0];
+		}
+
+		// Extract the caption if it exists (handle both figcaption and span formats).
+		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $rendered_image, $caption_matches ) ) {
+			$result .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+		} elseif ( preg_match( '/<span class="wp-element-caption"[^>]*>(.*?)<\/span>/s', $rendered_image, $caption_matches ) ) {
+			$result .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract gallery-level caption from the original block content.
+	 *
+	 * @param string $block_content Original block content.
+	 * @return string Gallery caption or empty string if not found.
+	 */
+	private function extract_gallery_caption( string $block_content ): string {
+		// Look for gallery-level caption: <figcaption class="blocks-gallery-caption wp-element-caption">.
+		if ( preg_match( '/<figcaption class="blocks-gallery-caption[^"]*"[^>]*>(.*?)<\/figcaption>/s', $block_content, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build the email-friendly layout for gallery blocks.
+	 *
+	 * @param array             $gallery_images Array of image HTML strings.
+	 * @param array             $parsed_block Full parsed block data.
+	 * @param string            $block_content Original block content.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string Rendered HTML.
+	 */
+	private function build_email_layout( array $gallery_images, array $parsed_block, string $block_content, Rendering_Context $rendering_context ): string {
+		// Get original wrapper classes from block content.
+		$original_wrapper_classname = ( new Dom_Document_Helper( $block_content ) )->get_attribute_value_by_tag_name( 'figure', 'class' ) ?? '';
+
+		// Get gallery attributes.
+		$block_attrs = $parsed_block['attrs'] ?? array();
+		$columns     = $this->get_columns_from_attributes( $block_attrs );
+
+		// Extract gallery-level caption from the original block content.
+		$gallery_caption = $this->extract_gallery_caption( $block_content );
+
+		// Get block styles using the Styles_Helper.
+		$block_styles = Styles_Helper::get_block_styles( $block_attrs, $rendering_context, array( 'padding', 'border', 'background', 'background-color', 'color' ) );
+		$block_styles = Styles_Helper::extend_block_styles(
+			$block_styles,
+			array(
+				'width'           => '100%',
+				'border-collapse' => 'collapse',
+				'text-align'      => 'left',
+			)
+		);
+
+		// Apply class and style attributes to the wrapper table.
+		$table_attrs = array(
+			'class' => 'email-block-gallery ' . $original_wrapper_classname,
+			'style' => $block_styles['css'],
+			'align' => 'left',
+			'width' => '100%',
+		);
+
+		// Add email width to cell attributes if available.
+		$cell_attrs = array();
+		if ( isset( $parsed_block['email_attrs']['width'] ) ) {
+			$cell_attrs['width'] = $parsed_block['email_attrs']['width'];
+		}
+
+		// Build the gallery rows with proper table structure.
+		$gallery_content = $this->build_gallery_table( $gallery_images, $columns );
+
+		// Add gallery caption if it exists.
+		if ( ! empty( $gallery_caption ) ) {
+			$gallery_content .= '<br><div class="blocks-gallery-caption wp-element-caption" style="font-size: 13px; line-height: 1.0; text-align: center;">' . $gallery_caption . '</div>';
+		}
+
+		// Use Table_Wrapper_Helper for the main container (following tiled gallery pattern).
+		return Table_Wrapper_Helper::render_table_wrapper( $gallery_content, $table_attrs, $cell_attrs );
+	}
+
+	/**
+	 * Build the gallery table structure with proper rows and cells.
+	 * Uses the tiled gallery pattern: separate tables for each row, then wrap in main table.
+	 *
+	 * @param array $gallery_images Array of image HTML strings.
+	 * @param int   $columns Number of columns.
+	 * @return string Gallery table HTML.
+	 */
+	private function build_gallery_table( array $gallery_images, int $columns ): string {
+		$content_parts = array();
+		$image_count   = count( $gallery_images );
+		$cell_padding  = 8; // 0.5em equivalent (approximately 8px)
+
+		// Process images in chunks based on columns to create rows.
+		for ( $i = 0; $i < $image_count; $i += $columns ) {
+			$row_images      = array_slice( $gallery_images, $i, $columns );
+			$content_parts[] = $this->build_gallery_row_table( $row_images, $columns, $cell_padding );
+		}
+
+		return implode( '', $content_parts );
+	}
+
+	/**
+	 * Build a single gallery row as a separate table (following tiled gallery pattern).
+	 *
+	 * @param array $row_images Images for this row.
+	 * @param int   $total_columns Total number of columns.
+	 * @param int   $cell_padding Cell padding.
+	 * @return string Row table HTML.
+	 */
+	private function build_gallery_row_table( array $row_images, int $total_columns, int $cell_padding ): string {
+		$images_in_row = count( $row_images );
+		$row_cells     = '';
+
+		// If this row has fewer images than total columns, make the single image span full width.
+		if ( $images_in_row < $total_columns ) {
+			foreach ( $row_images as $image_html ) {
+				$cell_attrs = array(
+					'style'   => sprintf( 'width: 100%%; padding: %dpx; vertical-align: top; text-align: center;', $cell_padding ),
+					'valign'  => 'top',
+					'colspan' => $total_columns,
+				);
+				$row_cells .= Table_Wrapper_Helper::render_table_cell( $image_html, $cell_attrs );
+			}
+		} else {
+			// Normal multi-column layout.
+			$cell_width_percent = 100 / $total_columns;
+
+			foreach ( $row_images as $image_html ) {
+				$cell_attrs = array(
+					'style'  => sprintf(
+						'width: %.2f%%; padding: %dpx; vertical-align: top; text-align: center;',
+						$cell_width_percent,
+						$cell_padding
+					),
+					'valign' => 'top',
+				);
+				$row_cells .= Table_Wrapper_Helper::render_table_cell( $image_html, $cell_attrs );
+			}
+		}
+
+		// Create a separate table for this row (following tiled gallery pattern).
+		return sprintf(
+			'<table role="presentation" style="width: 100%%; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
+			$row_cells
+		);
+	}
+
+	/**
+	 * Get the columns value from block attributes.
+	 *
+	 * @param array $block_attrs Block attributes.
+	 * @return int Number of columns (1-5).
+	 */
+	private function get_columns_from_attributes( array $block_attrs ): int {
+		$columns = $block_attrs['columns'] ?? 3;
+
+		// Ensure the columns are within reasonable bounds.
+		$columns = max( 1, min( 5, (int) $columns ) );
+
+		return $columns;
+	}
+}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -80,14 +80,22 @@ class Gallery extends Abstract_Block_Renderer {
 			$sanitized_url = esc_url_raw( $link_matches[2] );
 			if ( ! empty( $sanitized_url ) ) {
 				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
-				$result       .= '<a href="' . $sanitized_url . '">' . $sanitized_img . '</a>';
+				if ( '' !== $sanitized_img ) {
+					$result .= '<a href="' . $sanitized_url . '">' . $sanitized_img . '</a>';
+				}
 			} else {
 				// If URL is invalid, extract just the image without link.
-				$result .= Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
+				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
+				if ( '' !== $sanitized_img ) {
+					$result .= $sanitized_img;
+				}
 			}
 		} elseif ( preg_match( '/<img[^>]*>/', $html_content, $img_matches ) ) {
 			// Image is not linked - just extract the img element with sanitization.
-			$result .= Html_Processing_Helper::sanitize_image_html( $img_matches[0] );
+			$sanitized_img = Html_Processing_Helper::sanitize_image_html( $img_matches[0] );
+			if ( '' !== $sanitized_img ) {
+				$result .= $sanitized_img;
+			}
 		}
 
 		// Extract the caption if it exists (handle both figcaption and span formats).

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Html_Processing_Helper;
 
 /**
  * Gallery block renderer.
@@ -63,13 +64,21 @@ class Gallery extends Abstract_Block_Renderer {
 
 			// Look for a link around the image in the original HTML.
 			if ( preg_match( '/<a[^>]*href=(["\'])(.*?)\1[^>]*>(\s*<img[^>]*>)\s*<\/a>/s', $inner_html, $link_matches ) ) {
+				// Validate and sanitize the link URL.
+				$sanitized_url = esc_url_raw( $link_matches[2] );
+				if ( empty( $sanitized_url ) ) {
+					// If URL is invalid, fall back to image without link.
+					return $this->remove_figure_wrapper( $rendered_image );
+				}
+
 				// Extract the linked image and caption separately.
-				$linked_image = '<a href="' . esc_url( $link_matches[2] ) . '">' . $link_matches[3] . '</a>';
+				$linked_image = '<a href="' . $sanitized_url . '">' . $link_matches[3] . '</a>';
 
 				// Extract caption if it exists.
 				$caption = '';
 				if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $inner_html, $caption_matches ) ) {
-					$caption = '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+					$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
+					$caption           = '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
 				}
 
 				return $linked_image . $caption;
@@ -92,10 +101,15 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Check if the image is wrapped in a link.
 		if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $rendered_image, $link_matches ) ) {
-			// Image is linked - preserve the link with sanitized href and img.
-			$sanitized_href = esc_url( $link_matches[1] );
-			$sanitized_img  = wp_kses_post( $link_matches[2] );
-			$result        .= '<a href="' . $sanitized_href . '">' . $sanitized_img . '</a>';
+			// Image is linked - validate and sanitize the link URL.
+			$sanitized_href = esc_url_raw( $link_matches[1] );
+			if ( ! empty( $sanitized_href ) ) {
+				$sanitized_img = wp_kses_post( $link_matches[2] );
+				$result       .= '<a href="' . $sanitized_href . '">' . $sanitized_img . '</a>';
+			} else {
+				// If URL is invalid, extract just the image without link.
+				$result .= wp_kses_post( $link_matches[2] );
+			}
 		} elseif ( preg_match( '/<img[^>]*>/', $rendered_image, $img_matches ) ) {
 			// Image is not linked - just extract the img element with sanitization.
 			$result .= wp_kses_post( $img_matches[0] );
@@ -103,9 +117,11 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Extract the caption if it exists (handle both figcaption and span formats).
 		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $rendered_image, $caption_matches ) ) {
-			$result .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
+			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
 		} elseif ( preg_match( '/<span class="wp-element-caption"[^>]*>(.*?)<\/span>/s', $rendered_image, $caption_matches ) ) {
-			$result .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $caption_matches[1] . '</div>';
+			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
+			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
 		}
 
 		return $result;
@@ -120,7 +136,7 @@ class Gallery extends Abstract_Block_Renderer {
 	private function extract_gallery_caption( string $block_content ): string {
 		// Look for gallery-level caption: <figcaption class="blocks-gallery-caption wp-element-caption">.
 		if ( preg_match( '/<figcaption class="blocks-gallery-caption[^"]*"[^>]*>(.*?)<\/figcaption>/s', $block_content, $matches ) ) {
-			return trim( $matches[1] );
+			return Html_Processing_Helper::sanitize_caption_html( trim( $matches[1] ) );
 		}
 
 		return '';
@@ -159,7 +175,7 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Apply class and style attributes to the wrapper table.
 		$table_attrs = array(
-			'class' => 'email-block-gallery ' . $original_wrapper_classname,
+			'class' => 'email-block-gallery ' . Html_Processing_Helper::clean_css_classes( $original_wrapper_classname ),
 			'style' => $block_styles['css'],
 			'align' => 'left',
 			'width' => '100%',
@@ -220,7 +236,7 @@ class Gallery extends Abstract_Block_Renderer {
 		// If there is exactly one image, span full width; otherwise distribute width evenly across the images in this row.
 		if ( 1 === $images_in_row ) {
 			$cell_attrs = array(
-				'style'   => sprintf( 'width: 100%%; padding: %dpx; vertical-align: top; text-align: center;', $cell_padding ),
+				'style'   => sprintf( 'width: %s; padding: %dpx; vertical-align: top; text-align: center;', Html_Processing_Helper::sanitize_css_value( '100%' ), $cell_padding ),
 				'valign'  => 'top',
 				'colspan' => $total_columns,
 			);
@@ -232,8 +248,8 @@ class Gallery extends Abstract_Block_Renderer {
 			foreach ( $row_images as $image_html ) {
 				$cell_attrs = array(
 					'style'  => sprintf(
-						'width: %.2f%%; padding: %dpx; vertical-align: top; text-align: center;',
-						$cell_width_percent,
+						'width: %s; padding: %dpx; vertical-align: top; text-align: center;',
+						Html_Processing_Helper::sanitize_css_value( sprintf( '%.2f%%', $cell_width_percent ) ),
 						$cell_padding
 					),
 					'valign' => 'top',
@@ -244,7 +260,8 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Create a separate table for this row (following tiled gallery pattern).
 		return sprintf(
-			'<table role="presentation" style="width: 100%%; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
+			'<table role="presentation" style="width: %s; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
+			Html_Processing_Helper::sanitize_css_value( '100%' ),
 			$row_cells
 		);
 	}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -31,6 +31,7 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Process inner blocks to get gallery images.
 		$gallery_images = array();
+
 		foreach ( $inner_blocks as $block ) {
 			if ( 'core/image' === $block['blockName'] ) {
 				$rendered_image = render_block( $block );
@@ -56,18 +57,14 @@ class Gallery extends Abstract_Block_Renderer {
 	 * @return string Image HTML with proper link handling.
 	 */
 	private function extract_image_with_link( string $rendered_image, array $block ): string {
-		// Check if the block has link destination information.
-		$block_attrs      = $block['attrs'] ?? array();
-		$link_destination = $block_attrs['linkDestination'] ?? 'none';
-
-		// If there's a link destination, extract the linked image directly from innerHTML.
-		if ( 'none' !== $link_destination && isset( $block['innerHTML'] ) ) {
+		// Check if there's a link in the original innerHTML.
+		if ( isset( $block['innerHTML'] ) ) {
 			$inner_html = $block['innerHTML'];
 
 			// Look for a link around the image in the original HTML.
-			if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $inner_html, $link_matches ) ) {
+			if ( preg_match( '/<a[^>]*href=(["\'])(.*?)\1[^>]*>(\s*<img[^>]*>)\s*<\/a>/s', $inner_html, $link_matches ) ) {
 				// Extract the linked image and caption separately.
-				$linked_image = '<a href="' . $link_matches[1] . '">' . $link_matches[2] . '</a>';
+				$linked_image = '<a href="' . esc_url( $link_matches[2] ) . '">' . $link_matches[3] . '</a>';
 
 				// Extract caption if it exists.
 				$caption = '';
@@ -95,11 +92,13 @@ class Gallery extends Abstract_Block_Renderer {
 
 		// Check if the image is wrapped in a link.
 		if ( preg_match( '/<a[^>]*href="([^"]*)"[^>]*>(<img[^>]*>)<\/a>/', $rendered_image, $link_matches ) ) {
-			// Image is linked - preserve the link.
-			$result .= '<a href="' . $link_matches[1] . '">' . $link_matches[2] . '</a>';
+			// Image is linked - preserve the link with sanitized href and img.
+			$sanitized_href = esc_url( $link_matches[1] );
+			$sanitized_img  = wp_kses_post( $link_matches[2] );
+			$result        .= '<a href="' . $sanitized_href . '">' . $sanitized_img . '</a>';
 		} elseif ( preg_match( '/<img[^>]*>/', $rendered_image, $img_matches ) ) {
-			// Image is not linked - just extract the img element.
-			$result .= $img_matches[0];
+			// Image is not linked - just extract the img element with sanitization.
+			$result .= wp_kses_post( $img_matches[0] );
 		}
 
 		// Extract the caption if it exists (handle both figcaption and span formats).
@@ -218,19 +217,17 @@ class Gallery extends Abstract_Block_Renderer {
 		$images_in_row = count( $row_images );
 		$row_cells     = '';
 
-		// If this row has fewer images than total columns, make the single image span full width.
-		if ( $images_in_row < $total_columns ) {
-			foreach ( $row_images as $image_html ) {
-				$cell_attrs = array(
-					'style'   => sprintf( 'width: 100%%; padding: %dpx; vertical-align: top; text-align: center;', $cell_padding ),
-					'valign'  => 'top',
-					'colspan' => $total_columns,
-				);
-				$row_cells .= Table_Wrapper_Helper::render_table_cell( $image_html, $cell_attrs );
-			}
+		// If there is exactly one image, span full width; otherwise distribute width evenly across the images in this row.
+		if ( 1 === $images_in_row ) {
+			$cell_attrs = array(
+				'style'   => sprintf( 'width: 100%%; padding: %dpx; vertical-align: top; text-align: center;', $cell_padding ),
+				'valign'  => 'top',
+				'colspan' => $total_columns,
+			);
+			$row_cells .= Table_Wrapper_Helper::render_table_cell( $row_images[0], $cell_attrs );
 		} else {
-			// Normal multi-column layout.
-			$cell_width_percent = 100 / $total_columns;
+			// Evenly distribute available width among the images in this row.
+			$cell_width_percent = 100 / $images_in_row;
 
 			foreach ( $row_images as $image_html ) {
 				$cell_attrs = array(

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -99,12 +99,19 @@ class Gallery extends Abstract_Block_Renderer {
 		}
 
 		// Extract the caption if it exists (handle both figcaption and span formats).
-		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $html_content, $caption_matches ) ) {
-			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
-			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
-		} elseif ( preg_match( '/<span class="wp-element-caption"[^>]*>(.*?)<\/span>/s', $html_content, $caption_matches ) ) {
-			$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[1] );
-			$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
+		// Enhanced security: validate container attributes before extracting content.
+		if ( preg_match( '/(<figcaption[^>]*>)(.*?)(<\/figcaption>)/s', $html_content, $caption_matches ) ) {
+			// Validate the figcaption container attributes for security.
+			if ( Html_Processing_Helper::validate_container_attributes( $caption_matches[1] . $caption_matches[3] ) ) {
+				$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[2] );
+				$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
+			}
+		} elseif ( preg_match( '/(<span class="wp-element-caption"[^>]*>)(.*?)(<\/span>)/s', $html_content, $caption_matches ) ) {
+			// Validate the span container attributes for security.
+			if ( Html_Processing_Helper::validate_container_attributes( $caption_matches[1] . $caption_matches[3] ) ) {
+				$sanitized_caption = Html_Processing_Helper::sanitize_caption_html( $caption_matches[2] );
+				$result           .= '<br><div class="wp-element-caption" style="font-size: 13px; line-height: 1.0;">' . $sanitized_caption . '</div>';
+			}
 		}
 
 		return $result;
@@ -118,8 +125,12 @@ class Gallery extends Abstract_Block_Renderer {
 	 */
 	private function extract_gallery_caption( string $block_content ): string {
 		// Look for gallery-level caption: <figcaption class="blocks-gallery-caption wp-element-caption">.
-		if ( preg_match( '/<figcaption class="blocks-gallery-caption[^"]*"[^>]*>(.*?)<\/figcaption>/s', $block_content, $matches ) ) {
-			return Html_Processing_Helper::sanitize_caption_html( trim( $matches[1] ) );
+		// Enhanced security: validate container attributes before extracting content.
+		if ( preg_match( '/(<figcaption class="blocks-gallery-caption[^"]*"[^>]*>)(.*?)(<\/figcaption>)/s', $block_content, $matches ) ) {
+			// Validate the figcaption container attributes for security.
+			if ( Html_Processing_Helper::validate_container_attributes( $matches[1] . $matches[3] ) ) {
+				return Html_Processing_Helper::sanitize_caption_html( trim( $matches[2] ) );
+			}
 		}
 
 		return '';

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Columns;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Fallback;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Group;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Image;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\List_Block;
@@ -65,6 +66,7 @@ class Initializer {
 	 * 3. Add the renderer case in the get_block_renderer method
 	 */
 	const RENDER_ONLY_BLOCK_TYPES = array(
+		'core/gallery',
 		'core/media-text',
 		'core/audio',
 		'core/embed',
@@ -213,6 +215,9 @@ class Initializer {
 				break;
 			case 'core/table':
 				$renderer = new Table();
+				break;
+			case 'core/gallery':
+				$renderer = new Gallery();
 				break;
 			case 'core/media-text':
 				$renderer = new Media_Text();

--- a/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
@@ -384,73 +384,73 @@ class Html_Processing_Helper {
 	 * @return string Sanitized image HTML.
 	 */
 	public static function sanitize_image_html( string $image_html ): string {
-		// Extract img tag using regex for more reliable processing.
+		// If no HTML tags, return as-is.
+		if ( false === strpos( $image_html, '<' ) ) {
+			return $image_html;
+		}
+
+		// Extract img tag using regex for reliable processing.
 		if ( ! preg_match( '/<img[^>]*>/i', $image_html, $matches ) ) {
 			return $image_html;
 		}
 
 		$img_tag              = $matches[0];
 		$sanitized_attributes = array();
+		$has_src              = false;
 
-		// Extract and sanitize individual attributes.
-		if ( preg_match_all( '/(\w+)=(["\'])(.*?)\2/', $img_tag, $attr_matches, PREG_SET_ORDER ) ) {
-			foreach ( $attr_matches as $attr_match ) {
-				$attr_name  = strtolower( $attr_match[1] );
-				$attr_value = $attr_match[3];
+		// Extract and sanitize individual attributes using WP_HTML_Tag_Processor for attribute processing.
+		$html = new \WP_HTML_Tag_Processor( $img_tag );
+		if ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			$attributes = $html->get_attribute_names_with_prefix( '' );
+			if ( is_array( $attributes ) ) {
+				foreach ( $attributes as $attr_name ) {
+					$attr_value = $html->get_attribute( $attr_name );
 
-				// Sanitize specific attributes.
-				switch ( $attr_name ) {
-					case 'src':
-						// Sanitize image source URL.
-						$sanitized_src = esc_url( $attr_value );
-						if ( ! empty( $sanitized_src ) ) {
-							$sanitized_attributes[] = $attr_name . '="' . $sanitized_src . '"';
-						}
-						break;
+					// Sanitize specific attributes.
+					switch ( $attr_name ) {
+						case 'src':
+							// Sanitize image source URL.
+							$sanitized_src = esc_url( (string) $attr_value );
+							if ( ! empty( $sanitized_src ) ) {
+								$sanitized_attributes[] = $attr_name . '="' . $sanitized_src . '"';
+								$has_src                = true;
+							}
+							break;
 
-					case 'alt':
-					case 'width':
-					case 'height':
-						// Sanitize text attributes.
-						$sanitized_attributes[] = $attr_name . '="' . esc_attr( $attr_value ) . '"';
-						break;
+						case 'alt':
+						case 'width':
+						case 'height':
+							// Sanitize text attributes.
+							$sanitized_attributes[] = $attr_name . '="' . esc_attr( (string) $attr_value ) . '"';
+							break;
 
-					case 'class':
-						// Clean CSS classes.
-						$cleaned_classes = self::clean_css_classes( $attr_value );
-						if ( ! empty( $cleaned_classes ) ) {
-							$sanitized_attributes[] = $attr_name . '="' . $cleaned_classes . '"';
-						}
-						break;
+						case 'class':
+							// Clean CSS classes.
+							$cleaned_classes = self::clean_css_classes( (string) $attr_value );
+							if ( ! empty( $cleaned_classes ) ) {
+								$sanitized_attributes[] = $attr_name . '="' . $cleaned_classes . '"';
+							}
+							break;
 
-					case 'style':
-						// Sanitize inline styles - only allow safe properties for email rendering.
-						$sanitized_styles = self::sanitize_image_styles( $attr_value );
-						if ( ! empty( $sanitized_styles ) ) {
-							$sanitized_attributes[] = $attr_name . '="' . $sanitized_styles . '"';
-						}
-						break;
-
-					// Skip unknown attributes for security.
+						case 'style':
+							// Sanitize inline styles - only allow safe properties for email rendering.
+							$sanitized_styles = self::sanitize_image_styles( (string) $attr_value );
+							if ( ! empty( $sanitized_styles ) ) {
+								$sanitized_attributes[] = $attr_name . '="' . $sanitized_styles . '"';
+							}
+							break;
+					}
 				}
 			}
 		}
 
-		// Rebuild the img tag with sanitized attributes.
-		if ( empty( $sanitized_attributes ) ) {
+		// If no valid src attribute, return empty string.
+		if ( ! $has_src ) {
 			return '';
 		}
 
-		// Ensure we have a src attribute - without it, the image is invalid.
-		$has_src = false;
-		foreach ( $sanitized_attributes as $attr ) {
-			if ( str_starts_with( $attr, 'src=' ) ) {
-				$has_src = true;
-				break;
-			}
-		}
-
-		if ( ! $has_src ) {
+		// Rebuild the img tag with sanitized attributes.
+		if ( empty( $sanitized_attributes ) ) {
 			return '';
 		}
 

--- a/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
@@ -400,7 +400,7 @@ class Html_Processing_Helper {
 
 		// Extract and sanitize individual attributes using WP_HTML_Tag_Processor for attribute processing.
 		$html = new \WP_HTML_Tag_Processor( $img_tag );
-		if ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+		if ( $html->next_tag() ) {
 			$attributes = $html->get_attribute_names_with_prefix( '' );
 			if ( is_array( $attributes ) ) {
 				foreach ( $attributes as $attr_name ) {

--- a/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
@@ -428,7 +428,7 @@ class Html_Processing_Helper {
 							// Clean CSS classes.
 							$cleaned_classes = self::clean_css_classes( (string) $attr_value );
 							if ( ! empty( $cleaned_classes ) ) {
-								$sanitized_attributes[] = $attr_name . '="' . $cleaned_classes . '"';
+								$sanitized_attributes[] = $attr_name . '="' . esc_attr( $cleaned_classes ) . '"';
 							}
 							break;
 
@@ -436,7 +436,7 @@ class Html_Processing_Helper {
 							// Sanitize inline styles - only allow safe properties for email rendering.
 							$sanitized_styles = self::sanitize_image_styles( (string) $attr_value );
 							if ( ! empty( $sanitized_styles ) ) {
-								$sanitized_attributes[] = $attr_name . '="' . $sanitized_styles . '"';
+								$sanitized_attributes[] = $attr_name . '="' . esc_attr( $sanitized_styles ) . '"';
 							}
 							break;
 					}

--- a/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
@@ -170,6 +170,12 @@ class Html_Processing_Helper {
 			return;
 		}
 
+		// Block all event handler attributes (on*) - Critical security fix.
+		if ( str_starts_with( $attr_name, 'on' ) ) {
+			$html->remove_attribute( $attr_name );
+			return;
+		}
+
 		switch ( $attr_name ) {
 			case 'href':
 				// Only allow http, https, mailto, and tel protocols.
@@ -266,6 +272,18 @@ class Html_Processing_Helper {
 					$html->remove_attribute( $attr_name );
 				}
 				break;
+
+			default:
+				// Handle data-* attributes with strict validation.
+				if ( str_starts_with( $attr_name, 'data-' ) ) {
+					if ( ! preg_match( '/^[a-zA-Z0-9\-_]+$/', (string) $attr_value ) ) {
+						$html->remove_attribute( $attr_name );
+					}
+					break;
+				}
+				// Default deny policy: Remove any attribute not explicitly allowed.
+				$html->remove_attribute( $attr_name );
+				break;
 		}
 	}
 
@@ -306,6 +324,55 @@ class Html_Processing_Helper {
 			'letter-spacing',
 			'text-transform',
 		);
+	}
+
+	/**
+	 * Validate HTML container attributes for security before content extraction.
+	 * This method checks if a container element (like figcaption, span) has safe attributes.
+	 *
+	 * @param string $container_html Full container HTML (e.g., <figcaption class="...">content</figcaption>).
+	 * @return bool True if container attributes are safe, false otherwise.
+	 */
+	public static function validate_container_attributes( string $container_html ): bool {
+		// Use WP_HTML_Tag_Processor to validate container attributes.
+		$html = new \WP_HTML_Tag_Processor( $container_html );
+		if ( ! $html->next_tag() ) {
+			return false;
+		}
+
+		// Get all attributes and validate each one using our existing validation logic.
+		$attributes = $html->get_attribute_names_with_prefix( '' );
+		if ( is_array( $attributes ) ) {
+			foreach ( $attributes as $attr_name ) {
+				// Use the same validation logic as validate_caption_attribute for consistency.
+				$attr_value = $html->get_attribute( $attr_name );
+				if ( null === $attr_value ) {
+					continue;
+				}
+
+				// Block event handlers immediately.
+				if ( str_starts_with( $attr_name, 'on' ) ) {
+					return false;
+				}
+
+				// Apply the same validation rules as caption attributes.
+				// Create a temporary processor to test validation.
+				$escaped_value = htmlspecialchars( (string) $attr_value, ENT_QUOTES, 'UTF-8' );
+				$temp_html     = new \WP_HTML_Tag_Processor( '<span ' . $attr_name . '="' . $escaped_value . '">test</span>' );
+				if ( $temp_html->next_tag() ) {
+					$original_value = $temp_html->get_attribute( $attr_name );
+					self::validate_caption_attribute( $temp_html, $attr_name );
+					$validated_value = $temp_html->get_attribute( $attr_name );
+
+					// If attribute was removed during validation, container is unsafe.
+					if ( null !== $original_value && null === $validated_value ) {
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-html-processing-helper.php
@@ -376,4 +376,121 @@ class Html_Processing_Helper {
 
 		return $final_html;
 	}
+
+	/**
+	 * Sanitize image HTML while preserving necessary attributes for email rendering.
+	 *
+	 * @param string $image_html Raw image HTML.
+	 * @return string Sanitized image HTML.
+	 */
+	public static function sanitize_image_html( string $image_html ): string {
+		// Extract img tag using regex for more reliable processing.
+		if ( ! preg_match( '/<img[^>]*>/i', $image_html, $matches ) ) {
+			return $image_html;
+		}
+
+		$img_tag              = $matches[0];
+		$sanitized_attributes = array();
+
+		// Extract and sanitize individual attributes.
+		if ( preg_match_all( '/(\w+)=(["\'])(.*?)\2/', $img_tag, $attr_matches, PREG_SET_ORDER ) ) {
+			foreach ( $attr_matches as $attr_match ) {
+				$attr_name  = strtolower( $attr_match[1] );
+				$attr_value = $attr_match[3];
+
+				// Sanitize specific attributes.
+				switch ( $attr_name ) {
+					case 'src':
+						// Sanitize image source URL.
+						$sanitized_src = esc_url( $attr_value );
+						if ( ! empty( $sanitized_src ) ) {
+							$sanitized_attributes[] = $attr_name . '="' . $sanitized_src . '"';
+						}
+						break;
+
+					case 'alt':
+					case 'width':
+					case 'height':
+						// Sanitize text attributes.
+						$sanitized_attributes[] = $attr_name . '="' . esc_attr( $attr_value ) . '"';
+						break;
+
+					case 'class':
+						// Clean CSS classes.
+						$cleaned_classes = self::clean_css_classes( $attr_value );
+						if ( ! empty( $cleaned_classes ) ) {
+							$sanitized_attributes[] = $attr_name . '="' . $cleaned_classes . '"';
+						}
+						break;
+
+					case 'style':
+						// Sanitize inline styles - only allow safe properties for email rendering.
+						$sanitized_styles = self::sanitize_image_styles( $attr_value );
+						if ( ! empty( $sanitized_styles ) ) {
+							$sanitized_attributes[] = $attr_name . '="' . $sanitized_styles . '"';
+						}
+						break;
+
+					// Skip unknown attributes for security.
+				}
+			}
+		}
+
+		// Rebuild the img tag with sanitized attributes.
+		if ( empty( $sanitized_attributes ) ) {
+			return '';
+		}
+
+		// Ensure we have a src attribute - without it, the image is invalid.
+		$has_src = false;
+		foreach ( $sanitized_attributes as $attr ) {
+			if ( str_starts_with( $attr, 'src=' ) ) {
+				$has_src = true;
+				break;
+			}
+		}
+
+		if ( ! $has_src ) {
+			return '';
+		}
+
+		return '<img ' . implode( ' ', $sanitized_attributes ) . '>';
+	}
+
+	/**
+	 * Sanitize inline styles for image elements - only allow safe properties for email rendering.
+	 *
+	 * @param string $style_value Raw style value.
+	 * @return string Sanitized style value.
+	 */
+	private static function sanitize_image_styles( string $style_value ): string {
+		$sanitized_styles = array();
+		$style_parts      = explode( ';', $style_value );
+
+		foreach ( $style_parts as $style_part ) {
+			$style_part = trim( $style_part );
+			if ( empty( $style_part ) ) {
+				continue;
+			}
+
+			$property_parts = explode( ':', $style_part, 2 );
+			if ( count( $property_parts ) !== 2 ) {
+				continue;
+			}
+
+			$property = trim( strtolower( $property_parts[0] ) );
+			$value    = trim( $property_parts[1] );
+
+			// Allow safe CSS properties for images in email rendering.
+			$safe_properties = array( 'width', 'height', 'max-width', 'max-height', 'display', 'margin', 'padding', 'border', 'border-radius' );
+			if ( in_array( $property, $safe_properties, true ) ) {
+				$sanitized_value = self::sanitize_css_value( $value );
+				if ( ! empty( $sanitized_value ) ) {
+					$sanitized_styles[] = $property . ': ' . $sanitized_value;
+				}
+			}
+		}
+
+		return implode( '; ', $sanitized_styles );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -288,73 +288,30 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test it handles different linkTo values with proper link verification.
+	 * Test it handles image links when present in innerHTML.
 	 */
-	public function testItHandlesDifferentLinkToValues(): void {
-		// Test 1: Per-image linkDestination takes precedence over gallery-level linkTo.
-		$parsed_gallery_with_image_links = $this->parsed_gallery;
+	public function testItHandlesImageLinks(): void {
+		// Test with linked images in innerHTML.
+		$parsed_gallery_with_links = $this->parsed_gallery;
 
-		// Set gallery-level linkTo to 'none' but individual images have their own linkDestination.
-		$parsed_gallery_with_image_links['attrs']['linkTo'] = 'none';
+		// Update first image to have a link in innerHTML.
+		$parsed_gallery_with_links['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image1.jpg"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/></a><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
 
-		// Update first image to have 'media' linkDestination with linked innerHTML.
-		$parsed_gallery_with_image_links['innerBlocks'][0]['attrs']['linkDestination'] = 'media';
-		$parsed_gallery_with_image_links['innerBlocks'][0]['innerHTML']                = '<figure class="wp-block-image size-large"><a href="https://example.com/image1.jpg"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/></a><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
+		// Update second image to have a different link in innerHTML.
+		$parsed_gallery_with_links['innerBlocks'][1]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/?attachment_id=2"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/></a><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
 
-		// Update second image to have 'attachment' linkDestination with linked innerHTML.
-		$parsed_gallery_with_image_links['innerBlocks'][1]['attrs']['linkDestination'] = 'attachment';
-		$parsed_gallery_with_image_links['innerBlocks'][1]['innerHTML']                = '<figure class="wp-block-image size-large"><a href="https://example.com/?attachment_id=2"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/></a><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
+		// Third image has no link.
+		$parsed_gallery_with_links['innerBlocks'][2]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/><figcaption class="wp-element-caption">Caption 3</figcaption></figure>';
 
-		$rendered_with_image_links = $this->gallery_renderer->render( '', $parsed_gallery_with_image_links, $this->rendering_context );
+		$rendered_with_links = $this->gallery_renderer->render( '', $parsed_gallery_with_links, $this->rendering_context );
 
-		// Verify that per-image links are preserved.
-		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_with_image_links );
-		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=2">', $rendered_with_image_links );
+		// Verify that links are preserved when present in innerHTML.
+		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_with_links );
+		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=2">', $rendered_with_links );
 
-		// Test 2: Gallery-level linkTo fallback when images don't have individual linkDestination.
-		$parsed_gallery_fallback = $this->parsed_gallery;
-
-		// Set gallery-level linkTo to 'media'.
-		$parsed_gallery_fallback['attrs']['linkTo'] = 'media';
-
-		// Remove individual linkDestination from images (they should fall back to gallery-level).
-		$parsed_gallery_fallback['innerBlocks'][0]['attrs']['linkDestination'] = 'none';
-		$parsed_gallery_fallback['innerBlocks'][1]['attrs']['linkDestination'] = 'none';
-		$parsed_gallery_fallback['innerBlocks'][2]['attrs']['linkDestination'] = 'none';
-
-		// Update innerHTML to include gallery-level links.
-		$parsed_gallery_fallback['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image1.jpg"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/></a><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
-		$parsed_gallery_fallback['innerBlocks'][1]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image2.jpg"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/></a><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
-		$parsed_gallery_fallback['innerBlocks'][2]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image3.jpg"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/></a><figcaption class="wp-element-caption">Caption 3</figcaption></figure>';
-
-		$rendered_fallback = $this->gallery_renderer->render( '', $parsed_gallery_fallback, $this->rendering_context );
-
-		// Verify that gallery-level links are used.
-		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_fallback );
-		$this->assertStringContainsString( '<a href="https://example.com/image2.jpg">', $rendered_fallback );
-		$this->assertStringContainsString( '<a href="https://example.com/image3.jpg">', $rendered_fallback );
-
-		// Test 3: No links when linkTo is 'none' and images have no individual links.
-		$parsed_gallery_no_links                    = $this->parsed_gallery;
-		$parsed_gallery_no_links['attrs']['linkTo'] = 'none';
-
-		// Ensure all images have 'none' linkDestination.
-		$parsed_gallery_no_links['innerBlocks'][0]['attrs']['linkDestination'] = 'none';
-		$parsed_gallery_no_links['innerBlocks'][1]['attrs']['linkDestination'] = 'none';
-		$parsed_gallery_no_links['innerBlocks'][2]['attrs']['linkDestination'] = 'none';
-
-		// Update innerHTML to have no links.
-		$parsed_gallery_no_links['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
-		$parsed_gallery_no_links['innerBlocks'][1]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
-		$parsed_gallery_no_links['innerBlocks'][2]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/><figcaption class="wp-element-caption">Caption 3</figcaption></figure>';
-
-		$rendered_no_links = $this->gallery_renderer->render( '', $parsed_gallery_no_links, $this->rendering_context );
-
-		// Verify that no anchor tags are present.
-		$this->assertStringNotContainsString( '<a href=', $rendered_no_links );
-		$this->assertStringContainsString( '<img src="https://example.com/image1.jpg"', $rendered_no_links );
-		$this->assertStringContainsString( '<img src="https://example.com/image2.jpg"', $rendered_no_links );
-		$this->assertStringContainsString( '<img src="https://example.com/image3.jpg"', $rendered_no_links );
+		// Verify that images without links don't get wrapped in anchor tags.
+		$this->assertStringContainsString( '<img src="https://example.com/image3.jpg"', $rendered_with_links );
+		$this->assertStringNotContainsString( '<a href="https://example.com/image3.jpg">', $rendered_with_links );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -288,29 +288,73 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test it handles different linkTo values
+	 * Test it handles different linkTo values with proper link verification.
 	 */
 	public function testItHandlesDifferentLinkToValues(): void {
-		// Test with linkTo: none.
-		$parsed_gallery_none                    = $this->parsed_gallery;
-		$parsed_gallery_none['attrs']['linkTo'] = 'none';
+		// Test 1: Per-image linkDestination takes precedence over gallery-level linkTo.
+		$parsed_gallery_with_image_links = $this->parsed_gallery;
 
-		$rendered_none = $this->gallery_renderer->render( '', $parsed_gallery_none, $this->rendering_context );
-		$this->assertStringContainsString( 'image1.jpg', $rendered_none );
+		// Set gallery-level linkTo to 'none' but individual images have their own linkDestination.
+		$parsed_gallery_with_image_links['attrs']['linkTo'] = 'none';
 
-		// Test with linkTo: media.
-		$parsed_gallery_media                    = $this->parsed_gallery;
-		$parsed_gallery_media['attrs']['linkTo'] = 'media';
+		// Update first image to have 'media' linkDestination with linked innerHTML.
+		$parsed_gallery_with_image_links['innerBlocks'][0]['attrs']['linkDestination'] = 'media';
+		$parsed_gallery_with_image_links['innerBlocks'][0]['innerHTML']                = '<figure class="wp-block-image size-large"><a href="https://example.com/image1.jpg"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/></a><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
 
-		$rendered_media = $this->gallery_renderer->render( '', $parsed_gallery_media, $this->rendering_context );
-		$this->assertStringContainsString( 'image1.jpg', $rendered_media );
+		// Update second image to have 'attachment' linkDestination with linked innerHTML.
+		$parsed_gallery_with_image_links['innerBlocks'][1]['attrs']['linkDestination'] = 'attachment';
+		$parsed_gallery_with_image_links['innerBlocks'][1]['innerHTML']                = '<figure class="wp-block-image size-large"><a href="https://example.com/?attachment_id=2"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/></a><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
 
-		// Test with linkTo: attachment.
-		$parsed_gallery_attachment                    = $this->parsed_gallery;
-		$parsed_gallery_attachment['attrs']['linkTo'] = 'attachment';
+		$rendered_with_image_links = $this->gallery_renderer->render( '', $parsed_gallery_with_image_links, $this->rendering_context );
 
-		$rendered_attachment = $this->gallery_renderer->render( '', $parsed_gallery_attachment, $this->rendering_context );
-		$this->assertStringContainsString( 'image1.jpg', $rendered_attachment );
+		// Verify that per-image links are preserved.
+		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_with_image_links );
+		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=2">', $rendered_with_image_links );
+
+		// Test 2: Gallery-level linkTo fallback when images don't have individual linkDestination.
+		$parsed_gallery_fallback = $this->parsed_gallery;
+
+		// Set gallery-level linkTo to 'media'.
+		$parsed_gallery_fallback['attrs']['linkTo'] = 'media';
+
+		// Remove individual linkDestination from images (they should fall back to gallery-level).
+		$parsed_gallery_fallback['innerBlocks'][0]['attrs']['linkDestination'] = 'none';
+		$parsed_gallery_fallback['innerBlocks'][1]['attrs']['linkDestination'] = 'none';
+		$parsed_gallery_fallback['innerBlocks'][2]['attrs']['linkDestination'] = 'none';
+
+		// Update innerHTML to include gallery-level links.
+		$parsed_gallery_fallback['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image1.jpg"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/></a><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
+		$parsed_gallery_fallback['innerBlocks'][1]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image2.jpg"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/></a><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
+		$parsed_gallery_fallback['innerBlocks'][2]['innerHTML'] = '<figure class="wp-block-image size-large"><a href="https://example.com/image3.jpg"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/></a><figcaption class="wp-element-caption">Caption 3</figcaption></figure>';
+
+		$rendered_fallback = $this->gallery_renderer->render( '', $parsed_gallery_fallback, $this->rendering_context );
+
+		// Verify that gallery-level links are used.
+		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_fallback );
+		$this->assertStringContainsString( '<a href="https://example.com/image2.jpg">', $rendered_fallback );
+		$this->assertStringContainsString( '<a href="https://example.com/image3.jpg">', $rendered_fallback );
+
+		// Test 3: No links when linkTo is 'none' and images have no individual links.
+		$parsed_gallery_no_links                    = $this->parsed_gallery;
+		$parsed_gallery_no_links['attrs']['linkTo'] = 'none';
+
+		// Ensure all images have 'none' linkDestination.
+		$parsed_gallery_no_links['innerBlocks'][0]['attrs']['linkDestination'] = 'none';
+		$parsed_gallery_no_links['innerBlocks'][1]['attrs']['linkDestination'] = 'none';
+		$parsed_gallery_no_links['innerBlocks'][2]['attrs']['linkDestination'] = 'none';
+
+		// Update innerHTML to have no links.
+		$parsed_gallery_no_links['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Caption 1</figcaption></figure>';
+		$parsed_gallery_no_links['innerBlocks'][1]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Caption 2</figcaption></figure>';
+		$parsed_gallery_no_links['innerBlocks'][2]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/><figcaption class="wp-element-caption">Caption 3</figcaption></figure>';
+
+		$rendered_no_links = $this->gallery_renderer->render( '', $parsed_gallery_no_links, $this->rendering_context );
+
+		// Verify that no anchor tags are present.
+		$this->assertStringNotContainsString( '<a href=', $rendered_no_links );
+		$this->assertStringContainsString( '<img src="https://example.com/image1.jpg"', $rendered_no_links );
+		$this->assertStringContainsString( '<img src="https://example.com/image2.jpg"', $rendered_no_links );
+		$this->assertStringContainsString( '<img src="https://example.com/image3.jpg"', $rendered_no_links );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Tests\Integration\Integrations\Core\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Email_Editor;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery;
+
+/**
+ * Integration test for Gallery class
+ */
+class Gallery_Test extends \Email_Editor_Integration_Test_Case {
+	/**
+	 * Gallery renderer instance
+	 *
+	 * @var Gallery
+	 */
+	private $gallery_renderer;
+
+	/**
+	 * Gallery block configuration
+	 *
+	 * @var array
+	 */
+	private $parsed_gallery = array(
+		'blockName'   => 'core/gallery',
+		'attrs'       => array(
+			'columns'     => 2,
+			'randomOrder' => true,
+			'linkTo'      => 'none',
+		),
+		'innerHTML'   => '<figure class="wp-block-gallery has-nested-images columns-2 is-cropped"></figure>',
+		'innerBlocks' => array(
+			0 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 1,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Caption 1</figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Caption 1</figcaption></figure>',
+				),
+			),
+			1 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 2,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Caption 2</figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Caption 2</figcaption></figure>',
+				),
+			),
+			2 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 3,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/><figcaption class="wp-element-caption">Caption 3</figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image3.jpg" alt="Image 3" class="wp-image-3"/><figcaption class="wp-element-caption">Caption 3</figcaption></figure>',
+				),
+			),
+		),
+	);
+
+	/**
+	 * Rendering context instance.
+	 *
+	 * @var Rendering_Context
+	 */
+	private $rendering_context;
+
+	/**
+	 * Set up before each test
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->di_container->get( Email_Editor::class )->initialize();
+		$this->gallery_renderer  = new Gallery();
+		$theme_controller        = $this->di_container->get( Theme_Controller::class );
+		$this->rendering_context = new Rendering_Context( $theme_controller->get_theme() );
+	}
+
+	/**
+	 * Test it renders gallery content
+	 */
+	public function testItRendersGalleryContent(): void {
+		$rendered = $this->gallery_renderer->render( '', $this->parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered );
+		$this->assertStringContainsString( 'image2.jpg', $rendered );
+		$this->assertStringContainsString( 'image3.jpg', $rendered );
+	}
+
+	/**
+	 * Test it handles different column counts
+	 */
+	public function testItHandlesDifferentColumnCounts(): void {
+		// Test 1 column.
+		$parsed_gallery_1_col                     = $this->parsed_gallery;
+		$parsed_gallery_1_col['attrs']['columns'] = 1;
+
+		$rendered_1_col = $this->gallery_renderer->render( '', $parsed_gallery_1_col, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_1_col );
+
+		// Test 3 columns.
+		$parsed_gallery_3_col                     = $this->parsed_gallery;
+		$parsed_gallery_3_col['attrs']['columns'] = 3;
+
+		$rendered_3_col = $this->gallery_renderer->render( '', $parsed_gallery_3_col, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_3_col );
+
+		// Test 5 columns (maximum).
+		$parsed_gallery_5_col                     = $this->parsed_gallery;
+		$parsed_gallery_5_col['attrs']['columns'] = 5;
+
+		$rendered_5_col = $this->gallery_renderer->render( '', $parsed_gallery_5_col, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_5_col );
+	}
+
+	/**
+	 * Test it handles invalid column counts
+	 */
+	public function testItHandlesInvalidColumnCounts(): void {
+		// Test 0 columns (should default to 3).
+		$parsed_gallery_0_col                     = $this->parsed_gallery;
+		$parsed_gallery_0_col['attrs']['columns'] = 0;
+
+		$rendered_0_col = $this->gallery_renderer->render( '', $parsed_gallery_0_col, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_0_col );
+
+		// Test 10 columns (should be limited to 5).
+		$parsed_gallery_10_col                     = $this->parsed_gallery;
+		$parsed_gallery_10_col['attrs']['columns'] = 10;
+
+		$rendered_10_col = $this->gallery_renderer->render( '', $parsed_gallery_10_col, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_10_col );
+	}
+
+	/**
+	 * Test it handles custom styling
+	 */
+	public function testItHandlesCustomStyling(): void {
+		$parsed_gallery                   = $this->parsed_gallery;
+		$parsed_gallery['attrs']['style'] = array(
+			'border'  => array(
+				'color'  => '#123456',
+				'radius' => '10px',
+				'width'  => '2px',
+				'style'  => 'solid',
+			),
+			'color'   => array(
+				'background' => '#abcdef',
+			),
+			'spacing' => array(
+				'padding' => array(
+					'bottom' => '5px',
+					'left'   => '15px',
+					'right'  => '20px',
+					'top'    => '10px',
+				),
+			),
+		);
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'background-color:#abcdef;', $rendered );
+		$this->assertStringContainsString( 'border-color:#123456;', $rendered );
+		$this->assertStringContainsString( 'border-radius:10px;', $rendered );
+		$this->assertStringContainsString( 'border-width:2px;', $rendered );
+		$this->assertStringContainsString( 'border-style:solid;', $rendered );
+		$this->assertStringContainsString( 'padding-bottom:5px;', $rendered );
+		$this->assertStringContainsString( 'padding-left:15px;', $rendered );
+		$this->assertStringContainsString( 'padding-right:20px;', $rendered );
+		$this->assertStringContainsString( 'padding-top:10px;', $rendered );
+	}
+
+	/**
+	 * Test it handles custom color and background
+	 */
+	public function testItHandlesCustomColorAndBackground(): void {
+		$parsed_gallery                                    = $this->parsed_gallery;
+		$parsed_gallery['attrs']['style']['color']['text'] = '#123456';
+		$parsed_gallery['attrs']['style']['color']['background'] = '#654321';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'color:#123456;', $rendered );
+		$this->assertStringContainsString( 'background-color:#654321;', $rendered );
+	}
+
+	/**
+	 * Test it preserves classes set by editor
+	 */
+	public function testItPreservesClassesSetByEditor(): void {
+		$parsed_gallery = $this->parsed_gallery;
+		$content        = '<figure class="wp-block-gallery has-nested-images columns-2 is-cropped editor-class-1 another-class"></figure>';
+
+		$rendered = $this->gallery_renderer->render( $content, $parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'wp-block-gallery has-nested-images columns-2 is-cropped editor-class-1 another-class', $rendered );
+	}
+
+
+	/**
+	 * Test it correctly extracts images and removes figure wrappers
+	 */
+	public function testItCorrectlyExtractsImagesAndRemovesFigureWrappers(): void {
+		$parsed_gallery = $this->parsed_gallery;
+		// Update innerBlocks with test image.
+		$parsed_gallery['innerBlocks'] = array(
+			0 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 1,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="test-image.jpg" alt="Test Image" class="wp-image-1"/><figcaption class="wp-element-caption">Test Caption</figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="test-image.jpg" alt="Test Image" class="wp-image-1"/><figcaption class="wp-element-caption">Test Caption</figcaption></figure>',
+				),
+			),
+		);
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'test-image.jpg', $rendered );
+		$this->assertStringContainsString( 'Test Caption', $rendered );
+		// Should not contain the figure wrapper.
+		$this->assertStringNotContainsString( '<figure class="wp-block-image', $rendered );
+	}
+
+	/**
+	 * Test it handles gallery with captions
+	 */
+	public function testItHandlesGalleryWithCaptions(): void {
+		$parsed_gallery = $this->parsed_gallery;
+		// Update innerBlocks with test images with captions.
+		$parsed_gallery['innerBlocks'] = array(
+			0 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 1,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Photo by <a href="https://example.com">Photographer</a></figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt="Image 1" class="wp-image-1"/><figcaption class="wp-element-caption">Photo by <a href="https://example.com">Photographer</a></figcaption></figure>',
+				),
+			),
+			1 => array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => 2,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Another photo</figcaption></figure>',
+				'innerContent' => array(
+					0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt="Image 2" class="wp-image-2"/><figcaption class="wp-element-caption">Another photo</figcaption></figure>',
+				),
+			),
+		);
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered );
+		$this->assertStringContainsString( 'image2.jpg', $rendered );
+		$this->assertStringContainsString( 'Photo by', $rendered );
+		$this->assertStringContainsString( 'Another photo', $rendered );
+		$this->assertStringContainsString( 'href="https://example.com"', $rendered );
+	}
+
+	/**
+	 * Test it handles different linkTo values
+	 */
+	public function testItHandlesDifferentLinkToValues(): void {
+		// Test with linkTo: none.
+		$parsed_gallery_none                    = $this->parsed_gallery;
+		$parsed_gallery_none['attrs']['linkTo'] = 'none';
+
+		$rendered_none = $this->gallery_renderer->render( '', $parsed_gallery_none, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_none );
+
+		// Test with linkTo: media.
+		$parsed_gallery_media                    = $this->parsed_gallery;
+		$parsed_gallery_media['attrs']['linkTo'] = 'media';
+
+		$rendered_media = $this->gallery_renderer->render( '', $parsed_gallery_media, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_media );
+
+		// Test with linkTo: attachment.
+		$parsed_gallery_attachment                    = $this->parsed_gallery;
+		$parsed_gallery_attachment['attrs']['linkTo'] = 'attachment';
+
+		$rendered_attachment = $this->gallery_renderer->render( '', $parsed_gallery_attachment, $this->rendering_context );
+		$this->assertStringContainsString( 'image1.jpg', $rendered_attachment );
+	}
+
+	/**
+	 * Test gallery caption support.
+	 */
+	public function testItHandlesGalleryCaption(): void {
+		// Create a gallery with caption.
+		$gallery_with_caption = '<!-- wp:gallery {"columns":2} -->
+<figure class="wp-block-gallery has-nested-images columns-2 is-cropped">
+<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="image1.jpg" alt=""/></figure>
+<!-- /wp:image -->
+<!-- wp:image {"id":2,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="image2.jpg" alt=""/></figure>
+<!-- /wp:image -->
+<figcaption class="blocks-gallery-caption wp-element-caption">Gallery caption</figcaption>
+</figure>
+<!-- /wp:gallery -->';
+
+		$parsed_gallery                = parse_blocks( $gallery_with_caption )[0];
+		$parsed_gallery['innerBlocks'] = array(
+			array(
+				'blockName' => 'core/image',
+				'attrs'     => array(
+					'id'              => 1,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerHTML' => '<figure class="wp-block-image size-large"><img src="image1.jpg" alt=""/></figure>',
+			),
+			array(
+				'blockName' => 'core/image',
+				'attrs'     => array(
+					'id'              => 2,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerHTML' => '<figure class="wp-block-image size-large"><img src="image2.jpg" alt=""/></figure>',
+			),
+		);
+
+		$rendered = $this->gallery_renderer->render( $gallery_with_caption, $parsed_gallery, $this->rendering_context );
+
+		// Check that gallery caption is rendered and centered.
+		$this->assertStringContainsString( 'Gallery caption', $rendered );
+		$this->assertStringContainsString( 'blocks-gallery-caption', $rendered );
+		$this->assertStringContainsString( 'text-align: center', $rendered );
+	}
+}

--- a/packages/php/email-editor/tests/unit/stubs.php
+++ b/packages/php/email-editor/tests/unit/stubs.php
@@ -83,6 +83,31 @@ if ( ! function_exists( 'esc_url_raw' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_url' ) ) {
+	/**
+	 * Mock esc_url function.
+	 *
+	 * @param string $url URL to sanitize.
+	 * @return string Sanitized URL or empty string if invalid.
+	 */
+	function esc_url( $url ) {
+		return esc_url_raw( $url );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	/**
+	 * Mock esc_attr function.
+	 *
+	 * @param string $text Text to escape.
+	 * @return string Escaped text.
+	 */
+	function esc_attr( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8', false );
+	}
+}
+
+
 // Dummy WP classes.
 // phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
 if ( ! class_exists( \WP_Theme_JSON::class ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

- Closes https://linear.app/a8c/issue/WOOPRD-784/core-blocks-add-gallery-formatting
- Adds email rendering instructions for the Gallery block only, not email editor support.
- **Planned follow-up:** use caption sanitization and validation from https://github.com/woocommerce/woocommerce/pull/60787

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="476" height="767" alt="Screenshot 2025-09-04 at 5 38 57 PM" src="https://github.com/user-attachments/assets/6275937a-cf03-4107-a640-c79962ca562d" />   |   <img width="453" height="522" alt="Screenshot 2025-09-04 at 5 38 02 PM" src="https://github.com/user-attachments/assets/2f04e8d5-1caf-4ae9-b58a-4e0bce8405e2" />    |

Outlook 2021:

<img width="472" height="693" alt="Screenshot 2025-09-04 at 5 51 31 PM" src="https://github.com/user-attachments/assets/49f9f45a-1945-4196-bbd9-213a1157967e" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a Gallery block to a post.
3. Send a test email.
4. Check that the gallery has formatting (it's not just a list of images).
5. Try changing the number of columns in the block settings (1-5).
6. Try changing the link setting in the toolbar settings.
7. Try adding a gallery caption.

Note this rendering doesn't support alignment options, which don't work very well in email.

<!-- End testing instructions -->

### Testing that has already taken place:

I tested by copying these changes to WPCOM, adding a file loader to the renderer class, and sandboxing the API. Let me know if you'd like detailed steps.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
