### PR TITLE
Fix email listings links

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5490-broken-action-links-when-wordpress-is-installed-in-a
+++ b/plugins/woocommerce/changelog/wooplug-5490-broken-action-links-when-wordpress-is-installed-in-a
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email listings links if WordPress is installed in a subdirectory

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -4,6 +4,7 @@
 import { useState, useMemo } from '@wordpress/element';
 import { edit, external } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
+import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 // @ts-expect-error - We need to use this /wp see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#dataviews
 import { DataViews, View } from '@wordpress/dataviews/wp'; // eslint-disable-line @woocommerce/dependency-group
@@ -127,13 +128,17 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				callback: ( items: EmailType[] ) => {
 					const email = items[ 0 ];
 					if ( email.post_id ) {
-						window.location.href = `/wp-admin/post.php?post=${ encodeURIComponent(
-							email.post_id
-						) }&action=edit`;
+						window.location.href = getAdminLink(
+							`post.php?post=${ encodeURIComponent(
+								email.post_id
+							) }&action=edit`
+						);
 					} else {
-						window.location.href = `/wp-admin/admin.php?page=wc-settings&tab=email&section=${ encodeURIComponent(
-							email.email_key
-						) }`;
+						window.location.href = getAdminLink(
+							`admin.php?page=wc-settings&tab=email&section=${ encodeURIComponent(
+								email.email_key
+							) }`
+						);
 					}
 				},
 				isPrimary: true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If WordPress was installed in a subfolder
the links in the email listings were not working properly.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPLUG-5490] #60780.

(For Bug Fixes) Bug introduced in PR #56641.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="2188" height="1240" alt="Markup 2025-09-05 at 11 18 26" src="https://github.com/user-attachments/assets/7c24b040-6c88-4b81-98bf-f024c0daef90" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WordPress installation in a folder, for example, using Jurassic Ninja (Create a new multisite, add a new site). Example: https://dreamily-everyday.jurassic.ninja/bikes/wp-admin
2. Install WooCommerce and enable the new Email Editor Alpha
3. Visit the emails settings page: https://dreamily-everyday.jurassic.ninja/bikes/wp-admin/admin.php?page=wc-settings&tab=email
4. Click "Edit email" or "Preview", both links need to be working

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
