### PR TITLE
Performance: Strip the `rel=self` link from the report response as it is built by the Reports/Controller

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-2074-exclude-target-hints-from-analytics-report-data
+++ b/plugins/woocommerce/changelog/WOOPLUG-2074-exclude-target-hints-from-analytics-report-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Strip the `rel=self` link from the report response as it is built by the Reports/Controller to avoid the performance penalty from building target hints.

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -117,7 +117,8 @@ class Controller extends GenericController {
 	 * Get analytics report data and endpoints.
 	 */
 	private function get_analytics_report_data() {
-		$request  = new \WP_REST_Request( 'GET', '/wc-analytics/reports' );
+		$request = new \WP_REST_Request( 'GET', '/wc-analytics/reports' );
+
 		/**
 		 * Performance hack to strip the `rel=self` link from the report response as it is built by the Reports/Controller
 		 * to avoid the expensive calls to WP_REST_Server::get_target_hints_for_link().
@@ -133,6 +134,7 @@ class Controller extends GenericController {
 
 			return $response;
 		};
+		
 		add_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );
 		$response = rest_do_request( $request );
 		remove_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -134,7 +134,7 @@ class Controller extends GenericController {
 
 			return $response;
 		};
-		
+
 		add_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );
 		$response = rest_do_request( $request );
 		remove_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -118,7 +118,24 @@ class Controller extends GenericController {
 	 */
 	private function get_analytics_report_data() {
 		$request  = new \WP_REST_Request( 'GET', '/wc-analytics/reports' );
+		/**
+		 * Performance hack to strip the `rel=self` link from the report response as it is built by the Reports/Controller
+		 * to avoid the expensive calls to WP_REST_Server::get_target_hints_for_link().
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 *
+		 * @return mixed
+		 */
+		$remove_self_link_from_prepared_internal_response = function ( $response ) {
+			if ( is_callable( array( $response, 'remove_link' ) ) ) {
+				$response->remove_link( 'self' );
+			}
+
+			return $response;
+		};
+		add_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );
 		$response = rest_do_request( $request );
+		remove_filter( 'woocommerce_rest_prepare_report', $remove_self_link_from_prepared_internal_response );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Improves [WOOPLUG-2074](https://linear.app/a8c/issue/WOOPLUG-2074) https://github.com/woocommerce/woocommerce/issues/45729

This modifies `Admin\API\Reports\PerformanceIndicators\Controller::get_analytics_report_data()` by adding a filter to `woocommerce_rest_prepare_report` just before making an internal request to the reports endpoint to get the list of reports available.  This added filter removes the `self` links from each item so that `WP_REST_Server::get_target_hints_for_link()` is not run against the link.  

The target hints are not needed in this context and running `WP_REST_Server::get_target_hints_for_link()` is relatively expensive as the route has to be matched to a handler, checking against all of the handlers currently registered with the server. 

In local analysis, this showed around a 15ms improvement with the default loading of controllers when analytics are active.

Trunk:
<img width="998" height="488" alt="Screenshot 2025-09-05 at 4 50 39 PM" src="https://github.com/user-attachments/assets/4da5384e-167c-4ef0-bba6-97dd5a71ab19" />

vs this branch:

<img width="993" height="519" alt="Screenshot 2025-09-05 at 4 51 45 PM" src="https://github.com/user-attachments/assets/eef3a64c-a6d3-4d9e-806b-e474240d3b63" />

While this 15ms improvement is minimal, it is a precursor to lazy loading analytics endpoints in #60684.  While not loading the wc-analytics endpoints at all improved all of the WP core REST endpoints, there were penalties on other URIs where the wc-analytics endpoints were still loaded, but later than other controllers because the calls to `WP_REST_Server::get_target_hints_for_link()` would have to search through many more routes to find the matching endpoint, changing the impact of it go from 15ms to ~60-75ms.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go To WooCommerce -> Settings -> Features -> Advanced
2. Enable Analytics
3. Go to the Analytics menu and sub menu items and verify that charts still work.
