### PR TITLE
@woocommerce/email-editor: Export `createStore` and `SendPreviewEmail`

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-704-add-send-test-preview-action-and-preview-in-new-tab-actions
+++ b/packages/js/email-editor/changelog/wooprd-704-add-send-test-preview-action-and-preview-in-new-tab-actions
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Export `SendPreviewEmail` component `createStore`
+Export `SendPreviewEmail` component and `createStore`

--- a/packages/js/email-editor/changelog/wooprd-704-add-send-test-preview-action-and-preview-in-new-tab-actions
+++ b/packages/js/email-editor/changelog/wooprd-704-add-send-test-preview-action-and-preview-in-new-tab-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Export `SendPreviewEmail` component `createStore`

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -7,7 +7,7 @@ import { initialize } from './editor';
  * The unique identifier used to register the email editor data store.
  * This store manages the email editor's state and settings.
  */
-export { storeName } from './store';
+export { storeName, createStore } from './store';
 
 /**
  * This method is used to initialize the email editor.
@@ -44,3 +44,5 @@ export function initializeEditor( htmlId: string ) {
 }
 
 export { ExperimentalEmailEditor } from './editor';
+
+export { SendPreviewEmail } from './components/preview';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Export the `createStore` function and the `SendPreviewEmail` component to allow using the send preview email modal outside of the email editor.

Related to [WOOPRD-704](https://linear.app/a8c/issue/WOOPRD-704/add-send-test-preview-action-and-preview-in-new-tab-actions-to-emails).

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

* Code review.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Export `SendPreviewEmail` component `createStore`
</details>
