### PR TITLE
Split Product Quantity store from Add to Cart + Options

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-data-source-ii
+++ b/plugins/woocommerce/changelog/fix-product-data-source-ii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Move Product Quantity state and actions to its own store
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -225,15 +225,21 @@ const { actions, state } = store<
 						context.quantity[ Number( id ) ] = value;
 					} );
 				} else {
-					const id = context.childProductId || productId;
-
 					context.quantity = {
 						...context.quantity,
-						[ id ]: value,
+						[ productId ]: value,
 					};
 				}
 
-				actions.validateQuantity( productId, value );
+				const productObject = getProductData(
+					productDataState.productId,
+					context.selectedAttributes
+				);
+				if ( productObject?.type === 'grouped' ) {
+					actions.validateGroupedProductQuantity();
+				} else {
+					actions.validateQuantity( productId, value );
+				}
 			},
 			addError: ( error: AddToCartError ): string => {
 				const { validationErrors } = state;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import type { FormEvent } from 'react';
 import { store, getContext, getConfig } from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
@@ -142,7 +141,7 @@ export type AddToCartWithOptionsStore = {
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
 		addToCart: () => void;
-		handleSubmit: ( event: FormEvent< HTMLFormElement > ) => void;
+		handleSubmit: ( event: SubmitEvent ) => void;
 	};
 };
 
@@ -312,7 +311,7 @@ const { actions, state } = store<
 					}
 				);
 			},
-			*handleSubmit( event: FormEvent< HTMLFormElement > ) {
+			*handleSubmit( event: SubmitEvent ) {
 				event.preventDefault();
 
 				const { isFormValid } = state;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { FormEvent, HTMLElementEvent } from 'react';
+import type { FormEvent } from 'react';
 import { store, getContext, getConfig } from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
@@ -52,22 +52,6 @@ const { state: productDataState } = store< ProductDataStore >(
 	{ lock: universalLock }
 );
 
-const getInputElementFromEvent = (
-	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
-) => {
-	let inputElement = null;
-
-	if ( event.target instanceof HTMLButtonElement ) {
-		inputElement = event.target.parentElement?.querySelector( '.qty' );
-	}
-
-	if ( event.target instanceof HTMLInputElement ) {
-		inputElement = event.target;
-	}
-
-	return inputElement;
-};
-
 export const getProductData = (
 	id: number,
 	selectedAttributes: SelectedAttributes[]
@@ -117,24 +101,6 @@ export const getProductData = (
 	};
 };
 
-const getInputData = (
-	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
-) => {
-	const inputElement = getInputElementFromEvent( event );
-
-	if ( ! inputElement ) {
-		return;
-	}
-
-	const parsedValue = Number( inputElement.value );
-	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
-
-	return {
-		currentValue,
-		inputElement,
-	};
-};
-
 export const getNewQuantity = (
 	productId: number,
 	quantity: number,
@@ -163,36 +129,19 @@ export const getNewQuantity = (
 	return currentQuantity + quantity;
 };
 
-export const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
-	const event = new Event( 'change', { bubbles: true } );
-	inputElement.dispatchEvent( event );
-};
-
 export type AddToCartWithOptionsStore = {
 	state: {
 		isFormValid: boolean;
-		allowsDecrease: boolean;
-		allowsIncrease: boolean;
 		noticeIds: string[];
 		validationErrors: AddToCartError[];
+		quantity: Record< number, number >;
+		selectedAttributes: SelectedAttributes[];
 	};
 	actions: {
-		validateQuantity: ( value?: number ) => void;
-		setQuantity: ( value: number ) => void;
+		validateQuantity: ( productId: number, value?: number ) => void;
+		setQuantity: ( productId: number, value: number ) => void;
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
-		increaseQuantity: (
-			event: HTMLElementEvent< HTMLButtonElement >
-		) => void;
-		decreaseQuantity: (
-			event: HTMLElementEvent< HTMLButtonElement >
-		) => void;
-		handleQuantityBlur: (
-			event: HTMLElementEvent< HTMLInputElement >
-		) => void;
-		handleQuantityCheckboxChange: (
-			event: HTMLElementEvent< HTMLInputElement >
-		) => void;
 		addToCart: () => void;
 		handleSubmit: ( event: FormEvent< HTMLFormElement > ) => void;
 	};
@@ -219,51 +168,17 @@ const { actions, state } = store<
 			get isFormValid(): boolean {
 				return state.validationErrors.length === 0;
 			},
-			get allowsDecrease() {
-				const { quantity, childProductId, selectedAttributes } =
-					getContext< Context >();
-
-				if ( childProductId ) {
-					return quantity[ childProductId ] > 0;
-				}
-
-				const productObject = getProductData(
-					productDataState.productId,
-					selectedAttributes
-				);
-
-				if ( ! productObject ) {
-					return true;
-				}
-
-				const { id, min, step } = productObject;
-
-				const currentQuantity = quantity[ id ] || 0;
-
-				return currentQuantity - step >= min;
+			get quantity(): Record< number, number > {
+				const context = getContext< Context >();
+				return context.quantity || {};
 			},
-			get allowsIncrease() {
-				const { quantity, childProductId, selectedAttributes } =
-					getContext< Context >();
-
-				const productObject = getProductData(
-					childProductId || productDataState.productId,
-					selectedAttributes
-				);
-
-				if ( ! productObject ) {
-					return true;
-				}
-
-				const { id, max, step } = productObject;
-
-				const currentQuantity = quantity[ id ] || 0;
-
-				return currentQuantity + step <= max;
+			get selectedAttributes(): SelectedAttributes[] {
+				const context = getContext< Context >();
+				return context.selectedAttributes || [];
 			},
 		},
 		actions: {
-			validateQuantity( value?: number ) {
+			validateQuantity( productId: number, value?: number ) {
 				actions.clearErrors( 'invalid-quantities' );
 
 				if ( typeof value !== 'number' ) {
@@ -274,7 +189,7 @@ const { actions, state } = store<
 
 				// If selected quantity is invalid, add an error.
 				const productObject = getProductData(
-					productDataState.productId,
+					productId,
 					selectedAttributes
 				);
 
@@ -293,29 +208,24 @@ const { actions, state } = store<
 					} );
 				}
 			},
-			setQuantity( value: number ) {
+			setQuantity( productId: number, value: number ) {
 				const context = getContext< Context >();
 				const { products } = getConfig(
 					'woocommerce'
 				) as WooCommerceConfig;
-				const variations =
-					products?.[ productDataState.productId ]?.variations;
+				const variations = products?.[ productId ].variations;
 
 				if ( variations ) {
 					const variationIds = Object.keys( variations );
 					// Set the quantity for all variations, so when switching
 					// variations the quantity persists.
-					const idsToUpdate = [
-						productDataState.productId,
-						...variationIds,
-					];
+					const idsToUpdate = [ productId, ...variationIds ];
 
 					idsToUpdate.forEach( ( id ) => {
 						context.quantity[ Number( id ) ] = value;
 					} );
 				} else {
-					const id =
-						context.childProductId || productDataState.productId;
+					const id = context.childProductId || productId;
 
 					context.quantity = {
 						...context.quantity,
@@ -323,7 +233,7 @@ const { actions, state } = store<
 					};
 				}
 
-				actions.validateQuantity( value );
+				actions.validateQuantity( productId, value );
 			},
 			addError: ( error: AddToCartError ): string => {
 				const { validationErrors } = state;
@@ -348,131 +258,6 @@ const { actions, state } = store<
 					// Clear all.
 					validationErrors.length = 0;
 				}
-			},
-			increaseQuantity: (
-				event: HTMLElementEvent< HTMLButtonElement >
-			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
-					return;
-				}
-				const { currentValue, inputElement } = inputData;
-
-				const { childProductId, selectedAttributes } =
-					getContext< Context >();
-
-				const productObject = getProductData(
-					childProductId || productDataState.productId,
-					selectedAttributes
-				);
-
-				const max = productObject?.max ?? Infinity;
-				const min = productObject?.min ?? 1;
-				const step = productObject?.step ?? 1;
-
-				const newValue = currentValue + step;
-
-				if ( newValue <= max ) {
-					const updatedValue = Math.max( min, newValue );
-					actions.setQuantity( updatedValue );
-					inputElement.value = updatedValue.toString();
-					dispatchChangeEvent( inputElement );
-				}
-			},
-			decreaseQuantity: (
-				event: HTMLElementEvent< HTMLButtonElement >
-			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
-					return;
-				}
-				const { currentValue, inputElement } = inputData;
-
-				const { childProductId, selectedAttributes } =
-					getContext< Context >();
-
-				const productObject = getProductData(
-					childProductId || productDataState.productId,
-					selectedAttributes
-				);
-
-				const min = productObject?.min ?? 1;
-				const step = productObject?.step ?? 1;
-
-				let newValue = currentValue - step;
-
-				// In grouped product children, we allow decreasing the value
-				// down to 0, even if the minimum value is greater than 0.
-				if ( childProductId && newValue < min ) {
-					if ( currentValue > min ) {
-						newValue = min;
-					} else {
-						newValue = 0;
-					}
-				}
-
-				if ( newValue !== currentValue ) {
-					actions.setQuantity( newValue );
-
-					inputElement.value = newValue.toString();
-					dispatchChangeEvent( inputElement );
-				}
-			},
-			// We need to listen to blur events instead of change events because
-			// the change event isn't triggered in invalid numbers (ie: writting
-			// letters) if the current value is already invalid or an empty string.
-			handleQuantityBlur: (
-				event: HTMLElementEvent< HTMLInputElement >
-			) => {
-				const { childProductId, selectedAttributes } =
-					getContext< Context >();
-
-				let min = 1;
-				const productObject = getProductData(
-					childProductId || productDataState.productId,
-					selectedAttributes
-				);
-
-				if ( productObject ) {
-					// In grouped products, we reset invalid inputs to ''.
-					if (
-						( Number.isNaN( event.target.valueAsNumber ) ||
-							event.target.valueAsNumber === 0 ) &&
-						childProductId
-					) {
-						actions.setQuantity( 0 );
-						if ( Number.isNaN( event.target.valueAsNumber ) ) {
-							event.target.value = '';
-						}
-						dispatchChangeEvent( event.target );
-						return;
-					}
-
-					min = productObject.min;
-				}
-
-				// In other product types, we reset inputs to `min` if they are
-				// 0 or NaN.
-				const newValue =
-					Number.isFinite( event.target.valueAsNumber ) &&
-					event.target.valueAsNumber > 0
-						? event.target.valueAsNumber
-						: min;
-
-				actions.setQuantity( newValue );
-				event.target.value = newValue.toString();
-				dispatchChangeEvent( event.target );
-			},
-			handleQuantityCheckboxChange: (
-				event: HTMLElementEvent< HTMLInputElement >
-			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
-					return;
-				}
-				const { inputElement } = inputData;
-
-				actions.setQuantity( inputElement.checked ? 1 : 0 );
 			},
 			*addToCart() {
 				// Todo: Use the module exports instead of `store()` once the

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -27,7 +27,6 @@ export type Context = {
 	validationErrors: AddToCartError[];
 	tempQuantity: number;
 	groupedProductIds: number[];
-	childProductId: number;
 };
 
 export type AddToCartError = {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -23,7 +23,7 @@ const universalLock =
 export type GroupedProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		actions: {
-			validateQuantity: ( value?: number ) => void;
+			validateGroupedProductQuantity: () => void;
 			batchAddToCart: () => void;
 		};
 		callbacks: {
@@ -35,7 +35,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 	'woocommerce/add-to-cart-with-options',
 	{
 		actions: {
-			validateQuantity() {
+			validateGroupedProductQuantity() {
 				actions.clearErrors( 'invalid-quantities' );
 
 				const { errorMessages } = getConfig();
@@ -134,7 +134,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 		},
 		callbacks: {
 			validateQuantities() {
-				actions.validateQuantity();
+				actions.validateGroupedProductQuantity();
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -12,5 +12,6 @@
 		"interactivity": true
 	},
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"style": "file:../woocommerce/add-to-cart-with-options-quantity-selector-style.css"
+	"style": "file:../woocommerce/add-to-cart-with-options-quantity-selector-style.css",
+	"viewScriptModule": "woocommerce/add-to-cart-with-options-quantity-selector"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -209,18 +209,18 @@ store< QuantitySelectorStore >(
 				if ( productObject ) {
 					const { min, step } = productObject;
 					newValue = currentValue - step;
-					newValue = Math.max( min, newValue );
 
-					// In grouped product children, we allow decreasing the value
-					// down to 0, even if the minimum value is greater than 0.
-					if (
-						parentProductObject?.type === 'grouped' &&
-						newValue < min
-					) {
-						if ( currentValue > min ) {
-							newValue = min;
+					if ( newValue < min ) {
+						// In grouped product children, we allow decreasing the value
+						// down to 0, even if the minimum value is greater than 0.
+						if ( parentProductObject?.type === 'grouped' ) {
+							if ( currentValue > min ) {
+								newValue = min;
+							} else {
+								newValue = 0;
+							}
 						} else {
-							newValue = 0;
+							newValue = min;
 						}
 					}
 				}
@@ -245,7 +245,7 @@ store< QuantitySelectorStore >(
 				let min = 1;
 				const { productId } = getContext< Context >();
 				const productObject = getProductData(
-					productId,
+					productDataState.productId,
 					selectedAttributes
 				);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -243,7 +243,6 @@ store< QuantitySelectorStore >(
 			) => {
 				const { selectedAttributes } = addToCartWithOptionsStore.state;
 				let min = 1;
-				const { productId } = getContext< Context >();
 				const productObject = getProductData(
 					productDataState.productId,
 					selectedAttributes
@@ -252,6 +251,8 @@ store< QuantitySelectorStore >(
 				if ( ! productObject ) {
 					return;
 				}
+
+				const { productId } = getContext< Context >();
 
 				// In grouped products, we reset invalid inputs to ''.
 				if (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -208,7 +208,7 @@ store< QuantitySelectorStore >(
 				}
 			},
 			// We need to listen to blur events instead of change events because
-			// the change event isn't triggered in invalid numbers (ie: writting
+			// the change event isn't triggered in invalid numbers (ie: writing
 			// letters) if the current value is already invalid or an empty string.
 			handleQuantityBlur: (
 				event: HTMLElementEvent< HTMLInputElement >

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -1,0 +1,328 @@
+/**
+ * External dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+import '@woocommerce/stores/woocommerce/product-data';
+import type { HTMLElementEvent } from 'react';
+import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
+
+/**
+ * Internal dependencies
+ */
+import { getProductData } from '../frontend';
+import type { AddToCartWithOptionsStore } from '../frontend';
+
+export type Context = {
+	productId: number;
+};
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const addToCartWithOptionsStore = store< AddToCartWithOptionsStore >(
+	'woocommerce/add-to-cart-with-options',
+	{},
+	{ lock: universalLock }
+);
+
+const { state: productDataState } = store< ProductDataStore >(
+	'woocommerce/product-data',
+	{},
+	{ lock: universalLock }
+);
+
+const getInputElementFromEvent = (
+	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
+) => {
+	let inputElement = null;
+
+	if ( event.target instanceof HTMLButtonElement ) {
+		inputElement = event.target.parentElement?.querySelector( '.qty' );
+	}
+
+	if ( event.target instanceof HTMLInputElement ) {
+		inputElement = event.target;
+	}
+
+	return inputElement;
+};
+
+const getInputData = (
+	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
+) => {
+	const inputElement = getInputElementFromEvent( event );
+
+	if ( ! inputElement ) {
+		return;
+	}
+
+	const parsedValue = Number( inputElement.value );
+	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
+
+	return {
+		currentValue,
+		inputElement,
+	};
+};
+
+export const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
+	const event = new Event( 'change', { bubbles: true } );
+	inputElement.dispatchEvent( event );
+};
+
+export type QuantitySelectorStore = {
+	state: {
+		allowsDecrease: boolean;
+		allowsIncrease: boolean;
+	};
+	actions: {
+		increaseQuantity: (
+			event: HTMLElementEvent< HTMLButtonElement >
+		) => void;
+		decreaseQuantity: (
+			event: HTMLElementEvent< HTMLButtonElement >
+		) => void;
+		handleQuantityBlur: (
+			event: HTMLElementEvent< HTMLInputElement >
+		) => void;
+		handleQuantityCheckboxChange: (
+			event: HTMLElementEvent< HTMLInputElement >
+		) => void;
+	};
+};
+
+store< QuantitySelectorStore >(
+	'woocommerce/add-to-cart-with-options-quantity-selector',
+	{
+		state: {
+			get allowsDecrease() {
+				const { quantity, selectedAttributes } =
+					addToCartWithOptionsStore.state;
+
+				// Note: in grouped products, this will be the parent product.
+				// We handle grouped products decrease differently because we
+				// allow setting the quantity to 0.
+				const productObject = getProductData(
+					productDataState.productId,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return true;
+				}
+
+				if ( productObject.type === 'grouped' ) {
+					const { productId } = getContext< Context >();
+
+					return quantity[ productId ] > 0;
+				}
+
+				const { id, min, step } = productObject;
+
+				const currentQuantity = quantity[ id ] || 0;
+
+				return currentQuantity - step >= min;
+			},
+			get allowsIncrease() {
+				const { quantity, selectedAttributes } =
+					addToCartWithOptionsStore.state;
+
+				const { productId } = getContext< Context >();
+
+				const productObject = getProductData(
+					productId,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { id, max, step } = productObject;
+
+				const currentQuantity = quantity[ id ] || 0;
+
+				return currentQuantity + step <= max;
+			},
+		},
+		actions: {
+			increaseQuantity: (
+				event: HTMLElementEvent< HTMLButtonElement >
+			) => {
+				const inputData = getInputData( event );
+				if ( ! inputData ) {
+					return;
+				}
+				const { currentValue, inputElement } = inputData;
+
+				const { productId } = getContext< Context >();
+				const { selectedAttributes } = addToCartWithOptionsStore.state;
+
+				const productObject = getProductData(
+					productId,
+					selectedAttributes
+				);
+
+				let newValue = currentValue + 1;
+				if ( productObject ) {
+					const { max, min, step } = productObject;
+					newValue = currentValue + step;
+					newValue = Math.max( min, Math.min( max, newValue ) );
+				}
+
+				addToCartWithOptionsStore.actions.setQuantity(
+					productId,
+					newValue
+				);
+				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
+			},
+			decreaseQuantity: (
+				event: HTMLElementEvent< HTMLButtonElement >
+			) => {
+				const inputData = getInputData( event );
+				if ( ! inputData ) {
+					return;
+				}
+				const { currentValue, inputElement } = inputData;
+
+				const { productId } = getContext< Context >();
+				const { selectedAttributes } = addToCartWithOptionsStore.state;
+
+				const parentProductObject = getProductData(
+					productDataState.productId,
+					selectedAttributes
+				);
+
+				let productObject = parentProductObject;
+
+				if ( parentProductObject?.type === 'grouped' ) {
+					productObject = getProductData(
+						productId,
+						selectedAttributes
+					);
+				}
+
+				let newValue = currentValue - 1;
+
+				if ( productObject ) {
+					const { min, step } = productObject;
+					newValue = currentValue - step;
+					newValue = Math.max( min, newValue );
+
+					// In grouped product children, we allow decreasing the value
+					// down to 0, even if the minimum value is greater than 0.
+					if (
+						parentProductObject?.type === 'grouped' &&
+						newValue < min
+					) {
+						if ( currentValue > min ) {
+							newValue = min;
+						} else {
+							newValue = 0;
+						}
+					}
+				}
+
+				if ( newValue !== currentValue ) {
+					addToCartWithOptionsStore.actions.setQuantity(
+						productId,
+						newValue
+					);
+
+					inputElement.value = newValue.toString();
+					dispatchChangeEvent( inputElement );
+				}
+			},
+			// We need to listen to blur events instead of change events because
+			// the change event isn't triggered in invalid numbers (ie: writting
+			// letters) if the current value is already invalid or an empty string.
+			handleQuantityBlur: (
+				event: HTMLElementEvent< HTMLInputElement >
+			) => {
+				const { selectedAttributes } = addToCartWithOptionsStore.state;
+				let min = 1;
+				const { productId } = getContext< Context >();
+				const productObject = getProductData(
+					productId,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return;
+				}
+
+				// In grouped products, we reset invalid inputs to ''.
+				if (
+					( Number.isNaN( event.target.valueAsNumber ) ||
+						event.target.valueAsNumber === 0 ) &&
+					productObject.type === 'grouped'
+				) {
+					addToCartWithOptionsStore.actions.setQuantity(
+						productId,
+						0
+					);
+					if ( Number.isNaN( event.target.valueAsNumber ) ) {
+						event.target.value = '';
+					}
+					dispatchChangeEvent( event.target );
+					return;
+				}
+
+				let childProductObject = null;
+
+				if ( productObject.type === 'grouped' ) {
+					childProductObject = getProductData(
+						productId,
+						selectedAttributes
+					);
+
+					if ( ! childProductObject ) {
+						return;
+					}
+				} else {
+					childProductObject = productObject;
+				}
+
+				min = childProductObject.min;
+
+				// In other product types, we reset inputs to `min` if they are
+				// 0 or NaN.
+				const newValue =
+					Number.isFinite( event.target.valueAsNumber ) &&
+					event.target.valueAsNumber > 0
+						? event.target.valueAsNumber
+						: min;
+
+				addToCartWithOptionsStore.actions.setQuantity(
+					productId,
+					newValue
+				);
+				event.target.value = newValue.toString();
+				dispatchChangeEvent( event.target );
+			},
+			handleQuantityCheckboxChange: (
+				event: HTMLElementEvent< HTMLInputElement >
+			) => {
+				const { productId } = getContext< Context >();
+				const { selectedAttributes } = addToCartWithOptionsStore.state;
+				const productObject = getProductData(
+					productId,
+					selectedAttributes
+				);
+				const inputData = getInputData( event );
+				if ( ! inputData || ! productObject ) {
+					return;
+				}
+				const { inputElement } = inputData;
+
+				addToCartWithOptionsStore.actions.setQuantity(
+					productId,
+					inputElement.checked ? 1 : 0
+				);
+			},
+		},
+	},
+	{ lock: universalLock }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, getElement } from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/product-data';
 import type { HTMLElementEvent } from 'react';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
@@ -31,40 +31,6 @@ const { state: productDataState } = store< ProductDataStore >(
 	{},
 	{ lock: universalLock }
 );
-
-const getInputElementFromEvent = (
-	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
-) => {
-	let inputElement = null;
-
-	if ( event.target instanceof HTMLButtonElement ) {
-		inputElement = event.target.parentElement?.querySelector( '.qty' );
-	}
-
-	if ( event.target instanceof HTMLInputElement ) {
-		inputElement = event.target;
-	}
-
-	return inputElement;
-};
-
-const getInputData = (
-	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
-) => {
-	const inputElement = getInputElementFromEvent( event );
-
-	if ( ! inputElement ) {
-		return;
-	}
-
-	const parsedValue = Number( inputElement.value );
-	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
-
-	return {
-		currentValue,
-		inputElement,
-	};
-};
 
 export const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
 	const event = new Event( 'change', { bubbles: true } );
@@ -150,11 +116,14 @@ store< QuantitySelectorStore >(
 			increaseQuantity: (
 				event: HTMLElementEvent< HTMLButtonElement >
 			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
+				const inputElement =
+					event.target.parentElement?.querySelector( '.qty' );
+
+				if ( ! ( inputElement instanceof HTMLInputElement ) ) {
 					return;
 				}
-				const { currentValue, inputElement } = inputData;
+
+				const currentValue = Number( inputElement.value ) || 0;
 
 				const { productId } = getContext< Context >();
 				const { selectedAttributes } = addToCartWithOptionsStore.state;
@@ -181,11 +150,14 @@ store< QuantitySelectorStore >(
 			decreaseQuantity: (
 				event: HTMLElementEvent< HTMLButtonElement >
 			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
+				const inputElement =
+					event.target.parentElement?.querySelector( '.qty' );
+
+				if ( ! ( inputElement instanceof HTMLInputElement ) ) {
 					return;
 				}
-				const { currentValue, inputElement } = inputData;
+
+				const currentValue = Number( inputElement.value ) || 0;
 
 				const { productId } = getContext< Context >();
 				const { selectedAttributes } = addToCartWithOptionsStore.state;
@@ -303,24 +275,18 @@ store< QuantitySelectorStore >(
 				event.target.value = newValue.toString();
 				dispatchChangeEvent( event.target );
 			},
-			handleQuantityCheckboxChange: (
-				event: HTMLElementEvent< HTMLInputElement >
-			) => {
-				const { productId } = getContext< Context >();
-				const { selectedAttributes } = addToCartWithOptionsStore.state;
-				const productObject = getProductData(
-					productId,
-					selectedAttributes
-				);
-				const inputData = getInputData( event );
-				if ( ! inputData || ! productObject ) {
+			handleQuantityCheckboxChange: () => {
+				const element = getElement();
+
+				if ( ! ( element.ref instanceof HTMLInputElement ) ) {
 					return;
 				}
-				const { inputElement } = inputData;
+
+				const { productId } = getContext< Context >();
 
 				addToCartWithOptionsStore.actions.setQuantity(
 					productId,
-					inputElement.checked ? 1 : 0
+					element.ref.checked ? 1 : 0
 				);
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -3,7 +3,7 @@
  */
 import { store, getContext, getElement } from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/product-data';
-import type { HTMLElementEvent } from 'react';
+import type { HTMLElementEvent } from '@woocommerce/types';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -14,7 +14,8 @@ import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-d
 /**
  * Internal dependencies
  */
-import { dispatchChangeEvent, getProductData } from '../frontend';
+import { getProductData } from '../frontend';
+import { dispatchChangeEvent } from '../quantity-selector/frontend';
 import type {
 	AddToCartWithOptionsStore,
 	Context as AddToCartWithOptionsStoreContext,
@@ -346,17 +347,20 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					const { min, max } = productObject;
 
 					let newValue = currentValue;
-					if ( quantity[ productObject.id ] < min ) {
+					if ( currentValue < min ) {
 						newValue = min;
-					} else if ( quantity[ productObject.id ] > max ) {
+					} else if ( currentValue > max ) {
 						newValue = max;
 					}
 
 					if (
 						newValue !== ref.valueAsNumber ||
-						newValue !== quantity[ productObject.id ]
+						newValue !== currentValue
 					) {
-						actions.setQuantity( newValue );
+						actions.setQuantity(
+							productDataState.productId,
+							newValue
+						);
 
 						ref.value = newValue.toString();
 						dispatchChangeEvent( ref );

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -33,6 +33,10 @@ const entries = {
 	// Product elements frontend module. Share by several blocks.
 	'woocommerce/product-elements':
 		'./assets/js/atomic/blocks/product-elements/frontend.ts',
+	// Add to cart with options quantity selector frontend module used by the
+	// Product Quantity block and the Grouped Product Selector block.
+	'woocommerce/add-to-cart-with-options-quantity-selector':
+		'./assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts',
 
 	// Other
 	'@woocommerce/stores/woocommerce/cart':

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -46,7 +46,6 @@ const blocks = {
 		customDir:
 			'add-to-cart-with-options/grouped-product-selector/product-item-selector',
 	},
-
 	'add-to-cart-with-options-grouped-product-item-label': {
 		customDir:
 			'add-to-cart-with-options/grouped-product-selector/product-item-label',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -158,14 +158,21 @@ class GroupedProductItemSelector extends AbstractBlock {
 		$markup  = '';
 
 		if ( $product ) {
+			$is_interactive = false;
 			if ( ! $product->is_purchasable() || $product->has_options() || ! $product->is_in_stock() ) {
 				$markup = $this->get_button_markup( $product );
 			} elseif ( $product->is_sold_individually() ) {
-				$markup = $this->get_checkbox_markup( $product );
+				$is_interactive = true;
+				$markup         = $this->get_checkbox_markup( $product );
 			} else {
-				$markup = $this->get_quantity_selector_markup( $product );
+				$is_interactive = true;
+				$markup         = $this->get_quantity_selector_markup( $product );
 			}
-			wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options-quantity-selector' );
+
+			if ( $is_interactive ) {
+				wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options-quantity-selector' );
+			}
+
 			if ( $markup ) {
 				$markup = '<div class="wp-block-add-to-cart-with-options-grouped-product-item-selector wc-block-add-to-cart-with-options-grouped-product-item-selector">' . $markup . '</div>';
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -137,8 +137,9 @@ class GroupedProductItemSelector extends AbstractBlock {
 				esc_html( wp_strip_all_tags( wc_price( $product->get_price() ) ) )
 			);
 		}
-		$context_attribute = wp_interactivity_data_wp_context( array( 'childProductId' => $product->get_id() ) );
-		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-on--change="actions.handleQuantityCheckboxChange" ' . $context_attribute . ' aria-label="' . esc_attr( $label ) . '" />';
+
+		$context_attribute = wp_interactivity_data_wp_context( array( 'productId' => $product->get_id() ) );
+		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-interactive="woocommerce/add-to-cart-with-options-quantity-selector" data-wp-on--change="actions.handleQuantityCheckboxChange" ' . $context_attribute . ' aria-label="' . esc_attr( $label ) . '"/>';
 	}
 
 	/**
@@ -164,7 +165,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 			} else {
 				$markup = $this->get_quantity_selector_markup( $product );
 			}
-
+			wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options-quantity-selector' );
 			if ( $markup ) {
 				$markup = '<div class="wp-block-add-to-cart-with-options-grouped-product-item-selector wc-block-add-to-cart-with-options-grouped-product-item-selector">' . $markup . '</div>';
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -149,7 +149,6 @@ class QuantitySelector extends AbstractBlock {
 				)
 			);
 
-			$wrapper_attributes['data-wp-interactive']  = 'woocommerce/product-elements';
 			$wrapper_attributes['data-wp-bind--hidden'] = 'woocommerce/product-elements::state.productData.sold_individually';
 			$input_attributes['data-wp-bind--min']      = 'woocommerce/product-elements::state.productData.min';
 			$input_attributes['data-wp-bind--max']      = 'woocommerce/product-elements::state.productData.max';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -23,10 +23,10 @@ class Utils {
 		$pattern = '/(<input[^>]*id="quantity_[^"]*"[^>]*\/>)/';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options::actions.decreaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options::!state.allowsDecrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
+		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options-quantity-selector::actions.decreaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options-quantity-selector::!state.allowsDecrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options::actions.increaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options::!state.allowsIncrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';
+		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="woocommerce/add-to-cart-with-options-quantity-selector::actions.increaseQuantity" data-wp-bind--disabled="woocommerce/add-to-cart-with-options-quantity-selector::!state.allowsIncrease" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';
 		$new_html    = preg_replace( $pattern, $plus_button, $quantity_html );
 		$new_html    = preg_replace( $pattern, $minus_button, $new_html );
 		return $new_html;
@@ -71,7 +71,7 @@ class Utils {
 			$processor->get_attribute( 'type' ) === 'number' &&
 			strpos( $processor->get_attribute( 'name' ), 'quantity' ) !== false
 		) {
-			$processor->set_attribute( 'data-wp-on--blur', 'woocommerce/add-to-cart-with-options::actions.handleQuantityBlur' );
+			$processor->set_attribute( 'data-wp-on--blur', 'woocommerce/add-to-cart-with-options-quantity-selector::actions.handleQuantityBlur' );
 
 			foreach ( $input_attributes as $attribute => $value ) {
 				$processor->set_attribute( $attribute, $value );
@@ -88,21 +88,21 @@ class Utils {
 
 		$wrapper_attributes = array_merge(
 			array(
-				'data-wp-interactive' => 'woocommerce/add-to-cart-with-options',
+				'data-wp-interactive' => 'woocommerce/add-to-cart-with-options-quantity-selector',
 			),
 			$wrapper_attributes
 		);
 
-		if ( ! empty( $wrapper_attributes ) ) {
-			return sprintf(
-				'<div %1$s %2$s>%3$s</div>',
-				get_block_wrapper_attributes( $wrapper_attributes ),
-				$context_attribute,
-				$quantity_html
-			);
-		}
+		global $product;
 
-		return '<div data-wp-interactive="woocommerce/add-to-cart-with-options"' . $context_attribute . '>' . $quantity_html . '</div>';
+		$context_attribute = wp_interactivity_data_wp_context( array( 'productId' => $child_product_id ? $child_product_id : $product->get_id() ) );
+
+		return sprintf(
+			'<div %1$s data-wp-interactive="woocommerce/add-to-cart-with-options-quantity-selector"%2$s>%3$s</div>',
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			$context_attribute,
+			$quantity_html
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -92,7 +92,7 @@ class Utils {
 		$context_attribute = wp_interactivity_data_wp_context( array( 'productId' => $child_product_id ? $child_product_id : $product->get_id() ) );
 
 		return sprintf(
-			'<div %1$s data-wp-interactive="woocommerce/add-to-cart-with-options-quantity-selector"%2$s>%3$s</div>',
+			'<div %1$s %2$s>%3$s</div>',
 			get_block_wrapper_attributes( $wrapper_attributes ),
 			$context_attribute,
 			$quantity_html

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -80,12 +80,6 @@ class Utils {
 
 		$quantity_html = $processor->get_updated_html();
 
-		$context = array();
-		if ( $child_product_id ) {
-			$context['childProductId'] = $child_product_id;
-		}
-		$context_attribute = ! empty( $context ) ? wp_interactivity_data_wp_context( $context ) : '';
-
 		$wrapper_attributes = array_merge(
 			array(
 				'data-wp-interactive' => 'woocommerce/add-to-cart-with-options-quantity-selector',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -89,7 +89,13 @@ class Utils {
 
 		global $product;
 
-		$context_attribute = wp_interactivity_data_wp_context( array( 'productId' => $child_product_id ? $child_product_id : $product->get_id() ) );
+		$context_attribute = wp_interactivity_data_wp_context(
+			array(
+				'productId' => $child_product_id || ! $product instanceof \WC_Product ?
+					$child_product_id :
+					$product->get_id(),
+			)
+		);
 
 		return sprintf(
 			'<div %1$s %2$s>%3$s</div>',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR breaks the _Add to Cart + Options_ store in two, so all state and actions related to the quantity selector in the _Product Quantity_ block are in their own store. IMO the way things were done until now was quite confusing, because actions like `increaseQuantity`, `decreaseQuantity` or states like `allowsDecrease` and `allowsIncrease` were defined at the top-level _Add to Cart + Options_ store, but they only belonged to one input field. That worked fine for simple products, but became confusing with variable and, especially, grouped products. It required us to set specific context depending on the product type (ie: `childProductId`) and we ended up with a lot of ifs in the code. Hopefully this PR makes things simpler and, eventually, it might make it easier to reuse the _Product Quantity_ block in other extensions.

Actions like `setQuantity()` and `validateQuanitity()` are still at the _Add to Cart + Options_ block level, but now they require a product id.

So the _tl;dr_ is:

* Everything closely related to the DOM events in input fields, buttons, etc. is in the new quantity selector store.
* Everything related to handling form state (like keeping track of quantities) is kept at the _Add to Cart + Options_ block.

### How to test the changes in this Pull Request:

This PR doesn't introduce any functionality changes, so testing means making sure there are no regressions.

1. Test the frontend of different product types using the _Add to Cart + Options_ block.
2. Verify you can increase and decrease quantities and, when adding products to cart, the right quantities are added.