### PR TITLE
Various `FeaturesController` enhancements

### DIFF
--- a/plugins/woocommerce/changelog/fix-39147
+++ b/plugins/woocommerce/changelog/fix-39147
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Various improvements to feature registration.
+Improved feature compatibility checks and added support for 'Learn more' links in settings.

--- a/plugins/woocommerce/changelog/fix-39147
+++ b/plugins/woocommerce/changelog/fix-39147
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Various improvements to feature registration.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5932,7 +5932,7 @@ img.help_tip {
 }
 
 /**
- * Settings / Advanced / Features / Emails
+ * Settings / Advanced / Features
  */
 .woocommerce_page_wc-settings {
 	.wc-settings-row-woocommerce_custom_orders_table_enabled td.forminp {
@@ -5942,8 +5942,23 @@ img.help_tip {
 	.wc-settings-row-woocommerce_custom_orders_table_data_sync_enabled td.forminp {
 		padding-top: 0;
 	}
+
 	#email_notification_settings-description {
 		margin-top: 16px;
+	}
+
+	.learn-more-link {
+		margin: 0 0 0 10px;
+
+		&::before {
+			@include iconbeforedashicons("\f348");
+			vertical-align: middle;
+			font-size: 1.1em;
+		}
+
+		a {
+			margin: 0 0 0 4px;
+		}
 	}
 }
 

--- a/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
+++ b/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
@@ -13,14 +13,14 @@ final class FeaturePluginCompatibility {
 	 *
 	 * @var string
 	 */
-	const COMPATIBLE = 'compatible';
+	public const COMPATIBLE = 'compatible';
 
 	/**
 	 * Plugins are incompatible by default with the feature.
 	 *
 	 * @var string
 	 */
-	const INCOMPATIBLE = 'incompatible';
+	public const INCOMPATIBLE = 'incompatible';
 
 	/**
 	 * Plugin compatibility with the feautre is yet to be determined. Internal use only.
@@ -28,14 +28,14 @@ final class FeaturePluginCompatibility {
 	 * @internal
 	 * @var string
 	 */
-	const UNCERTAIN = 'uncertain';
+	public const UNCERTAIN = 'uncertain';
 
 	/**
 	 * Valid values for registration of feature compatibility.
 	 *
 	 * @var string[]
 	 */
-	const VALID_REGISTRATION_VALUES = array(
+	public const VALID_REGISTRATION_VALUES = array(
 		self::COMPATIBLE,
 		self::INCOMPATIBLE,
 	);

--- a/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
+++ b/plugins/woocommerce/src/Enums/FeaturePluginCompatibility.php
@@ -1,0 +1,42 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Enums;
+
+/**
+ * Enum class for feature plugin compatibility.
+ */
+final class FeaturePluginCompatibility {
+
+	/**
+	 * Plugins are compatible by default with the feature.
+	 *
+	 * @var string
+	 */
+	const COMPATIBLE = 'compatible';
+
+	/**
+	 * Plugins are incompatible by default with the feature.
+	 *
+	 * @var string
+	 */
+	const INCOMPATIBLE = 'incompatible';
+
+	/**
+	 * Plugin compatibility with the feautre is yet to be determined. Internal use only.
+	 *
+	 * @internal
+	 * @var string
+	 */
+	const UNCERTAIN = 'uncertain';
+
+	/**
+	 * Valid values for registration of feature compatibility.
+	 *
+	 * @var string[]
+	 */
+	const VALID_REGISTRATION_VALUES = array(
+		self::COMPATIBLE,
+		self::INCOMPATIBLE,
+	);
+}

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\CostOfGoodsSold;
 
+use Automattic\WooCommerce\Enums\FeaturePluginCompatibility;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 
@@ -56,7 +57,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 			'description'                  => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
 			'is_experimental'              => false,
 			'enabled_by_default'           => false,
-			'default_plugin_compatibility' => \Automattic\WooCommerce\Enums\FeaturePluginCompatibility::COMPATIBLE,
+			'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 		);
 
 		$features_controller->add_feature_definition(

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -56,7 +56,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 			'description'                  => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
 			'is_experimental'              => false,
 			'enabled_by_default'           => false,
-			'default_plugin_compatibility' => 'compatible',
+			'default_plugin_compatibility' => \Automattic\WooCommerce\Enums\FeaturePluginCompatibility::COMPATIBLE,
 		);
 
 		$features_controller->add_feature_definition(

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -53,9 +53,10 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 	 */
 	public function add_feature_definition( $features_controller ) {
 		$definition = array(
-			'description'        => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
-			'is_experimental'    => false,
-			'enabled_by_default' => false,
+			'description'                  => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
+			'is_experimental'              => false,
+			'enabled_by_default'           => false,
+			'default_plugin_compatibility' => 'compatible',
 		);
 
 		$features_controller->add_feature_definition(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -581,7 +581,7 @@ class CustomOrdersTableController {
 			'enabled_by_default'           => false,
 			'order'                        => 50,
 			'setting'                      => $this->get_hpos_setting_for_feature(),
-			'default_plugin_compatibility' => 'incompatible',
+			'default_plugin_compatibility' => \Automattic\WooCommerce\Enums\FeaturePluginCompatibility::INCOMPATIBLE,
 			'additional_settings'          => array(
 				$this->get_hpos_setting_for_sync(),
 			),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Caches\OrderCacheController;
+use Automattic\WooCommerce\Enums\FeaturePluginCompatibility;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
@@ -581,7 +582,7 @@ class CustomOrdersTableController {
 			'enabled_by_default'           => false,
 			'order'                        => 50,
 			'setting'                      => $this->get_hpos_setting_for_feature(),
-			'default_plugin_compatibility' => \Automattic\WooCommerce\Enums\FeaturePluginCompatibility::INCOMPATIBLE,
+			'default_plugin_compatibility' => FeaturePluginCompatibility::INCOMPATIBLE,
 			'additional_settings'          => array(
 				$this->get_hpos_setting_for_sync(),
 			),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -581,7 +581,7 @@ class CustomOrdersTableController {
 			'enabled_by_default'                  => false,
 			'order'                               => 50,
 			'setting'                             => $this->get_hpos_setting_for_feature(),
-			'plugins_are_incompatible_by_default' => true,
+			'default_plugin_compatibility'        => 'incompatible',
 			'additional_settings'                 => array(
 				$this->get_hpos_setting_for_sync(),
 			),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -576,13 +576,13 @@ class CustomOrdersTableController {
 	 */
 	public function add_feature_definition( $features_controller ) {
 		$definition = array(
-			'option_key'                          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-			'is_experimental'                     => false,
-			'enabled_by_default'                  => false,
-			'order'                               => 50,
-			'setting'                             => $this->get_hpos_setting_for_feature(),
-			'default_plugin_compatibility'        => 'incompatible',
-			'additional_settings'                 => array(
+			'option_key'                   => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			'is_experimental'              => false,
+			'enabled_by_default'           => false,
+			'order'                        => 50,
+			'setting'                      => $this->get_hpos_setting_for_feature(),
+			'default_plugin_compatibility' => 'incompatible',
+			'additional_settings'          => array(
 				$this->get_hpos_setting_for_sync(),
 			),
 		);

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\PluginUtil;
+use Automattic\WooCommerce\Enums\FeaturePluginCompatibility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -235,7 +236,7 @@ class FeaturesController {
 			'disable_ui'                   => false,
 			'enabled_by_default'           => false,
 			'is_experimental'              => true,
-			'default_plugin_compatibility' => 'compatible',
+			'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			'skip_compatibility_checks'    => false,
 			'name'                         => $name,
 			'order'                        => 10,
@@ -256,8 +257,8 @@ class FeaturesController {
 		$args = wp_parse_args( $args, $defaults );
 
 		// Sanitize 'default_plugin_compatibility'.
-		if ( ! in_array( $args['default_plugin_compatibility'], array( 'compatible', 'incompatible' ), true ) ) {
-			$args['default_plugin_compatibility'] = wc_string_to_bool( $args['default_plugin_compatibility'] ) ? 'compatible' : 'incompatible';
+		if ( ! in_array( $args['default_plugin_compatibility'], FeaturePluginCompatibility::VALID_REGISTRATION_VALUES, true ) ) {
+			$args['default_plugin_compatibility'] = wc_string_to_bool( $args['default_plugin_compatibility'] ) ? FeaturePluginCompatibility::COMPATIBLE : FeaturePluginCompatibility::INCOMPATIBLE;
 		}
 
 		// Support 'is_legacy' flag for backwards compatibility.
@@ -316,7 +317,7 @@ class FeaturesController {
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'product_block_editor'        => array(
 				'name'                         => __( 'New product editor', 'woocommerce' ),
@@ -324,14 +325,14 @@ class FeaturesController {
 				'is_experimental'              => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'cart_checkout_blocks'        => array(
 				'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 				'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
 				'is_experimental'              => false,
 				'disable_ui'                   => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'rate_limit_checkout'         => array(
 				'name'                         => __( 'Rate limit Checkout', 'woocommerce' ),
@@ -344,7 +345,7 @@ class FeaturesController {
 				'disable_ui'                   => false,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'marketplace'                 => array(
 				'name'                         => __( 'Marketplace', 'woocommerce' ),
@@ -356,7 +357,7 @@ class FeaturesController {
 				'enabled_by_default'           => true,
 				'disable_ui'                   => true,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
@@ -369,7 +370,7 @@ class FeaturesController {
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 			),
 			'site_visibility_badge'       => array(
@@ -381,7 +382,7 @@ class FeaturesController {
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 				'disabled'                     => false,
 			),
@@ -394,7 +395,7 @@ class FeaturesController {
 				'is_experimental'              => true,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'option_key'                   => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
 			'hpos_datastore_caching'      => array(
@@ -406,7 +407,7 @@ class FeaturesController {
 				'is_experimental'              => true,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'disable_ui'                   => false,
 				'option_key'                   => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
@@ -430,7 +431,7 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				 */
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 				'setting'                      => array(
 					'disabled' => function () use ( $tracking_enabled ) {
@@ -461,7 +462,7 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/issues/55540
 				 */
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 			),
 			'blueprint'                   => array(
@@ -482,7 +483,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => false,
 			),
 			'block_email_editor'          => array(
@@ -502,7 +503,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'enabled_by_default'           => false,
 			),
 			'point_of_sale'               => array(
@@ -523,7 +524,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks'    => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_experimental'              => true,
 			),
 			'fulfillments'                => array(
@@ -535,13 +536,13 @@ class FeaturesController {
 				'enabled_by_default'           => false,
 				'disable_ui'                   => true,
 				'is_experimental'              => false,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'experimental-iapi-mini-cart' => array(
 				'name'                         => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
 				'description'                  => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
 				'is_experimental'              => true,
-				'default_plugin_compatibility' => 'compatible',
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 		);
 
@@ -564,8 +565,8 @@ class FeaturesController {
 		foreach ( array_keys( $this->features ) as $feature_id ) {
 			if ( ! isset( $this->compatibility_info_by_feature[ $feature_id ] ) ) {
 				$this->compatibility_info_by_feature[ $feature_id ] = array(
-					'compatible'   => array(),
-					'incompatible' => array(),
+					FeaturePluginCompatibility::COMPATIBLE => array(),
+					FeaturePluginCompatibility::INCOMPATIBLE => array(),
 				);
 			}
 		}
@@ -678,7 +679,7 @@ class FeaturesController {
 			throw new \InvalidArgumentException( esc_html( "The WooCommerce feature '$feature_id' doesn't exist" ) );
 		}
 
-		$default_plugin_compatibility = $feature_definition['default_plugin_compatibility'] ?? 'compatible';
+		$default_plugin_compatibility = $feature_definition['default_plugin_compatibility'] ?? FeaturePluginCompatibility::COMPATIBLE;
 
 		// Filter below is only fired for backwards compatibility with (now removed) get_plugins_are_incompatible_by_default().
 		/**
@@ -690,9 +691,9 @@ class FeaturesController {
 		 *
 		 * @since 9.2.0
 		 */
-		$incompatible_by_default = (bool) apply_filters( 'woocommerce_plugins_are_incompatible_with_feature_by_default', 'incompatible' === $default_plugin_compatibility, $feature_id );
+		$incompatible_by_default = (bool) apply_filters( 'woocommerce_plugins_are_incompatible_with_feature_by_default', FeaturePluginCompatibility::INCOMPATIBLE === $default_plugin_compatibility, $feature_id );
 
-		return $incompatible_by_default ? 'incompatible' : 'compatible';
+		return $incompatible_by_default ? FeaturePluginCompatibility::INCOMPATIBLE : FeaturePluginCompatibility::COMPATIBLE;
 	}
 
 	/**
@@ -814,8 +815,8 @@ class FeaturesController {
 		// Register compatibility by plugin.
 		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin, $plugin_id );
 
-		$key          = $positive_compatibility ? 'compatible' : 'incompatible';
-		$opposite_key = $positive_compatibility ? 'incompatible' : 'compatible';
+		$key          = $positive_compatibility ? FeaturePluginCompatibility::COMPATIBLE : FeaturePluginCompatibility::INCOMPATIBLE;
+		$opposite_key = $positive_compatibility ? FeaturePluginCompatibility::INCOMPATIBLE : FeaturePluginCompatibility::COMPATIBLE;
 		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_id ], $key );
 		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_id ], $opposite_key );
 
@@ -828,7 +829,7 @@ class FeaturesController {
 		}
 
 		// Register compatibility by feature.
-		$key = $positive_compatibility ? 'compatible' : 'incompatible';
+		$key = $positive_compatibility ? FeaturePluginCompatibility::COMPATIBLE : FeaturePluginCompatibility::INCOMPATIBLE;
 
 		if ( ! in_array( $plugin_id, $this->compatibility_info_by_feature[ $feature_id ][ $key ], true ) ) {
 			$this->compatibility_info_by_feature[ $feature_id ][ $key ][] = $plugin_id;
@@ -903,24 +904,24 @@ class FeaturesController {
 
 		if ( ! isset( $this->compatibility_info_by_plugin[ $plugin_name ] ) ) {
 			return array(
-				'compatible'   => array(),
-				'incompatible' => array(),
-				'uncertain'    => array_keys( $features ),
+				FeaturePluginCompatibility::COMPATIBLE   => array(),
+				FeaturePluginCompatibility::INCOMPATIBLE => array(),
+				FeaturePluginCompatibility::UNCERTAIN    => array_keys( $features ),
 			);
 		}
 
-		$info                 = $this->compatibility_info_by_plugin[ $plugin_name ];
-		$info['compatible']   = array_values( array_intersect( array_keys( $features ), $info['compatible'] ) );
-		$info['incompatible'] = array_values( array_intersect( array_keys( $features ), $info['incompatible'] ) );
-		$info['uncertain']    = array_values( array_diff( array_keys( $features ), $info['compatible'], $info['incompatible'] ) );
+		$info = $this->compatibility_info_by_plugin[ $plugin_name ];
+		$info[ FeaturePluginCompatibility::COMPATIBLE ]   = array_values( array_intersect( array_keys( $features ), $info[ FeaturePluginCompatibility::COMPATIBLE ] ) );
+		$info[ FeaturePluginCompatibility::INCOMPATIBLE ] = array_values( array_intersect( array_keys( $features ), $info[ FeaturePluginCompatibility::INCOMPATIBLE ] ) );
+		$info[ FeaturePluginCompatibility::UNCERTAIN ]    = array_values( array_diff( array_keys( $features ), $info[ FeaturePluginCompatibility::COMPATIBLE ], $info[ FeaturePluginCompatibility::INCOMPATIBLE ] ) );
 
 		if ( $resolve_uncertain ) {
-			foreach ( $info['uncertain'] as $feature_id ) {
+			foreach ( $info[ FeaturePluginCompatibility::UNCERTAIN ] as $feature_id ) {
 				$key            = $this->get_default_plugin_compatibility( $feature_id );
 				$info[ $key ][] = $feature_id;
 			}
 
-			$info['uncertain'] = array();
+			$info[ FeaturePluginCompatibility::UNCERTAIN ] = array();
 		}
 
 		return $info;
@@ -941,18 +942,18 @@ class FeaturesController {
 		$woo_aware_plugins = $this->plugin_util->get_woocommerce_aware_plugins( $active_only );
 		if ( ! $this->feature_exists( $feature_id ) ) {
 			return array(
-				'compatible'   => array(),
-				'incompatible' => array(),
-				'uncertain'    => $woo_aware_plugins,
+				FeaturePluginCompatibility::COMPATIBLE   => array(),
+				FeaturePluginCompatibility::INCOMPATIBLE => array(),
+				FeaturePluginCompatibility::UNCERTAIN    => $woo_aware_plugins,
 			);
 		}
 
 		$info = $this->compatibility_info_by_feature[ $feature_id ];
-		ArrayUtil::ensure_key_is_array( $info, 'uncertain' );
+		ArrayUtil::ensure_key_is_array( $info, FeaturePluginCompatibility::UNCERTAIN );
 
 		// Resolve uncertain plugin compatibility?
-		$uncertain_plugins = array_values( array_diff( $woo_aware_plugins, $info['compatible'], $info['incompatible'] ) );
-		$key               = $resolve_uncertain ? $this->get_default_plugin_compatibility( $feature_id ) : 'uncertain';
+		$uncertain_plugins = array_values( array_diff( $woo_aware_plugins, $info[ FeaturePluginCompatibility::COMPATIBLE ], $info[ FeaturePluginCompatibility::INCOMPATIBLE ] ) );
+		$key               = $resolve_uncertain ? $this->get_default_plugin_compatibility( $feature_id ) : FeaturePluginCompatibility::UNCERTAIN;
 		$info[ $key ]      = array_merge( $info[ $key ], $uncertain_plugins );
 
 		return $info;
@@ -1370,11 +1371,11 @@ class FeaturesController {
 		unset( $this->compatibility_info_by_plugin[ $plugin_name ] );
 
 		foreach ( array_keys( $this->compatibility_info_by_feature ) as $feature ) {
-			$compatibles = $this->compatibility_info_by_feature[ $feature ]['compatible'];
-			$this->compatibility_info_by_feature[ $feature ]['compatible'] = array_diff( $compatibles, array( $plugin_name ) );
+			$compatibles = $this->compatibility_info_by_feature[ $feature ][ FeaturePluginCompatibility::COMPATIBLE ];
+			$this->compatibility_info_by_feature[ $feature ][ FeaturePluginCompatibility::COMPATIBLE ] = array_diff( $compatibles, array( $plugin_name ) );
 
-			$incompatibles = $this->compatibility_info_by_feature[ $feature ]['incompatible'];
-			$this->compatibility_info_by_feature[ $feature ]['incompatible'] = array_diff( $incompatibles, array( $plugin_name ) );
+			$incompatibles = $this->compatibility_info_by_feature[ $feature ][ FeaturePluginCompatibility::INCOMPATIBLE ];
+			$this->compatibility_info_by_feature[ $feature ][ FeaturePluginCompatibility::INCOMPATIBLE ] = array_diff( $incompatibles, array( $plugin_name ) );
 		}
 	}
 
@@ -1478,15 +1479,15 @@ class FeaturesController {
 		foreach ( $relevant_plugins as $plugin ) {
 			$compatibility_info = $this->get_compatible_features_for_plugin( $plugin, true );
 
-			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
+			$incompatibles = array_filter( $compatibility_info[ FeaturePluginCompatibility::INCOMPATIBLE ], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
 			if ( ! empty( $incompatibles ) ) {
 				$incompatible_plugins = true;
 				break;
 			}
 
-			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
+			$uncertains = array_filter( $compatibility_info[ FeaturePluginCompatibility::UNCERTAIN ], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
 			foreach ( $uncertains as $feature_id ) {
-				if ( 'compatible' !== $this->get_default_plugin_compatibility( $feature_id ) ) {
+				if ( FeaturePluginCompatibility::COMPATIBLE !== $this->get_default_plugin_compatibility( $feature_id ) ) {
 					$incompatible_plugins = true;
 					break;
 				}
@@ -1622,7 +1623,7 @@ class FeaturesController {
 
 		$features                   = $this->get_feature_definitions();
 		$feature_compatibility_info = $this->get_compatible_features_for_plugin( $plugin_file, true );
-		$incompatible_features      = array_merge( $feature_compatibility_info['incompatible'], $feature_compatibility_info['uncertain'] );
+		$incompatible_features      = array_merge( $feature_compatibility_info[ FeaturePluginCompatibility::INCOMPATIBLE ], $feature_compatibility_info[ FeaturePluginCompatibility::UNCERTAIN ] );
 		$incompatible_features      = array_values(
 			array_filter(
 				$incompatible_features,

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1622,8 +1622,8 @@ class FeaturesController {
 		}
 
 		$features                   = $this->get_feature_definitions();
-		$feature_compatibility_info = $this->get_compatible_features_for_plugin( $plugin_file, true );
-		$incompatible_features      = array_merge( $feature_compatibility_info[ FeaturePluginCompatibility::INCOMPATIBLE ], $feature_compatibility_info[ FeaturePluginCompatibility::UNCERTAIN ] );
+		$feature_compatibility_info = $this->get_compatible_features_for_plugin( $plugin_file, true, true );
+		$incompatible_features      = $feature_compatibility_info[ FeaturePluginCompatibility::INCOMPATIBLE ];
 		$incompatible_features      = array_values(
 			array_filter(
 				$incompatible_features,

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1007,7 +1007,7 @@ class FeaturesController {
 	 * @param string $feature_id The feature id to check.
 	 * @return bool TRUE if the compatibility checks should be skipped.
 	 */
-	public function skip_compatibility_checks( string $feature_id ): bool {
+	public function should_skip_compatibility_checks( string $feature_id ): bool {
 		$features = $this->get_feature_definitions();
 
 		return ! empty( $features[ $feature_id ]['skip_compatibility_checks'] );
@@ -1303,7 +1303,7 @@ class FeaturesController {
 			}
 		}
 
-		if ( ! $this->skip_compatibility_checks( $feature_id ) && ! $disabled && $this->verify_did_woocommerce_init() ) {
+		if ( ! $this->should_skip_compatibility_checks( $feature_id ) && ! $disabled && $this->verify_did_woocommerce_init() ) {
 			$plugin_info_for_feature = $this->get_compatible_plugins_for_feature( $feature_id, true );
 			$desc_tip                = $this->plugin_util->generate_incompatible_plugin_feature_warning( $feature_id, $plugin_info_for_feature );
 		}
@@ -1434,8 +1434,8 @@ class FeaturesController {
 				$features_considered_incompatible = array_filter(
 					$this->plugin_util->get_items_considered_incompatible( $feature_id, $compatibility_info ),
 					$only_enabled_features ?
-						fn( $id ) => $this->feature_is_enabled( $id ) && ! $this->skip_compatibility_checks( $id ) :
-						fn( $id ) => ! $this->skip_compatibility_checks( $id )
+						fn( $id ) => $this->feature_is_enabled( $id ) && ! $this->should_skip_compatibility_checks( $id ) :
+						fn( $id ) => ! $this->should_skip_compatibility_checks( $id )
 				);
 				if ( in_array( $feature_id, $features_considered_incompatible, true ) ) {
 					$incompatibles[] = $plugin_name;
@@ -1478,13 +1478,13 @@ class FeaturesController {
 		foreach ( $relevant_plugins as $plugin ) {
 			$compatibility_info = $this->get_compatible_features_for_plugin( $plugin, true );
 
-			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $id ) => ! $this->skip_compatibility_checks( $id ) );
+			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
 			if ( ! empty( $incompatibles ) ) {
 				$incompatible_plugins = true;
 				break;
 			}
 
-			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $id ) => ! $this->skip_compatibility_checks( $id ) );
+			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $id ) => ! $this->should_skip_compatibility_checks( $id ) );
 			foreach ( $uncertains as $feature_id ) {
 				if ( 'compatible' !== $this->get_default_plugin_compatibility( $feature_id ) ) {
 					$incompatible_plugins = true;
@@ -1627,7 +1627,7 @@ class FeaturesController {
 			array_filter(
 				$incompatible_features,
 				function ( $feature_id ) {
-					return ! $this->skip_compatibility_checks( $feature_id );
+					return ! $this->should_skip_compatibility_checks( $feature_id );
 				}
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -680,20 +680,6 @@ class FeaturesController {
 	}
 
 	/**
-	 * Check if plugins that don't declare compatibility nor incompatibility with a given feature
-	 * are to be considered incompatible with that feature.
-	 *
-	 * @deprecated since 10.3.0. {@see FeaturesController::are_plugins_compatible_by_default()} and {@see FeaturesController::get_default_plugin_compatibility()}.
-	 *
-	 * @param string $feature_id Feature id to check.
-	 * @return bool True if plugins that don't declare compatibility nor incompatibility with the feature will be considered incompatible with the feature.
-	 * @throws \InvalidArgumentException The feature doesn't exist.
-	 */
-	public function get_plugins_are_incompatible_by_default( string $feature_id ): bool {
-		return ! $this->are_plugins_compatible_by_default( $feature_id );
-	}
-
-	/**
 	 * Check whether plugins that don't explicitly declare (in)compatibility are to be considered (in)compatible with a feature.
 	 *
 	 * @param string $feature_id Feature id to check.
@@ -718,7 +704,7 @@ class FeaturesController {
 
 		$default_plugin_compatibility = $feature_definition['default_plugin_compatibility'] ?? 'compatible';
 
-		// Filter below is only fired for backwards compatibility with get_plugins_are_incompatible_by_default().
+		// Filter below is only fired for backwards compatibility with (now removed) get_plugins_are_incompatible_by_default().
 		/**
 		 * Filter to determine if plugins that don't declare compatibility nor incompatibility with a given feature
 		 * are to be considered incompatible with that feature.
@@ -1037,19 +1023,6 @@ class FeaturesController {
 		}
 
 		return "woocommerce_feature_{$feature_id}_enabled";
-	}
-
-	/**
-	 * Checks whether a feature id corresponds to a legacy feature
-	 * (a feature that existed prior to the implementation of the features engine).
-	 *
-	 * @deprecated since 10.3.0, use {@see FeaturesController::skip_compatibility_checks()} instead.
-	 *
-	 * @param string $feature_id The feature id to check.
-	 * @return bool True if the id corresponds to a legacy feature.
-	 */
-	public function is_legacy_feature( string $feature_id ): bool {
-		return $this->skip_compatibility_checks( $feature_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -907,9 +907,9 @@ class FeaturesController {
 	 *
 	 * This method can't be called before the 'woocommerce_init' hook is fired.
 	 *
-	 * @param string $plugin_name Plugin name, in the form 'directory/file.php'.
+	 * @param string $plugin_name           Plugin name, in the form 'directory/file.php'.
 	 * @param bool   $enabled_features_only True to return only names of enabled plugins.
-	 * @param bool   $resolve_uncertain True to resolve the uncertain features to compatible or incompatible.
+	 * @param bool   $resolve_uncertain     True to resolve the uncertain features to compatible or incompatible.
 	 * @return array An array having a 'compatible' and an 'incompatible' key, each holding an array of feature ids.
 	 */
 	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false, bool $resolve_uncertain = false ): array {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1436,8 +1436,8 @@ class FeaturesController {
 				$features_considered_incompatible = array_filter(
 					$this->plugin_util->get_items_considered_incompatible( $feature_id, $compatibility_info ),
 					$only_enabled_features ?
-						fn( $feature_id ) => $this->feature_is_enabled( $feature_id ) && ! $this->skip_compatibility_checks( $feature_id ) :
-						fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id )
+						fn( $id ) => $this->feature_is_enabled( $id ) && ! $this->skip_compatibility_checks( $id ) :
+						fn( $id ) => ! $this->skip_compatibility_checks( $id )
 				);
 				if ( in_array( $feature_id, $features_considered_incompatible, true ) ) {
 					$incompatibles[] = $plugin_name;
@@ -1480,13 +1480,13 @@ class FeaturesController {
 		foreach ( $relevant_plugins as $plugin ) {
 			$compatibility_info = $this->get_compatible_features_for_plugin( $plugin, true );
 
-			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id ) );
+			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $id ) => ! $this->skip_compatibility_checks( $id ) );
 			if ( ! empty( $incompatibles ) ) {
 				$incompatible_plugins = true;
 				break;
 			}
 
-			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id ) );
+			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $id ) => ! $this->skip_compatibility_checks( $id ) );
 			foreach ( $uncertains as $feature_id ) {
 				if ( 'compatible' !== $this->get_default_plugin_compatibility( $feature_id ) ) {
 					$incompatible_plugins = true;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -680,16 +680,6 @@ class FeaturesController {
 	}
 
 	/**
-	 * Check whether plugins that don't explicitly declare (in)compatibility are to be considered (in)compatible with a feature.
-	 *
-	 * @param string $feature_id Feature id to check.
-	 * @return bool TRUE if plugins that don't declare (in)compatibility are to be considered compatible with the feature.
-	 */
-	public function are_plugins_compatible_by_default( string $feature_id ): bool {
-		return 'compatible' === $this->get_default_plugin_compatibility( $feature_id );
-	}
-
-	/**
 	 * Get the default plugin compatibility for a given feature.
 	 *
 	 * @param string $feature_id Feature id to check.
@@ -816,8 +806,8 @@ class FeaturesController {
 	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
 	 * @since 10.1.0
 	 *
-	 * @param string $feature_id Unique feature ID.
-	 * @param string $plugin_file Raw plugin file path (full or 'directory/file.php').
+	 * @param string $feature_id             Unique feature ID.
+	 * @param string $plugin_file            Raw plugin file path (full or 'directory/file.php').
 	 * @param bool   $positive_compatibility True if declaring compatibility, false if declaring incompatibility.
 	 * @return bool True on successful registration, false if the feature does not exist.
 	 * @throws \Exception If the plugin attempts to declare both compatibility and incompatibility for the same feature.
@@ -1512,7 +1502,7 @@ class FeaturesController {
 
 			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id ) );
 			foreach ( $uncertains as $feature_id ) {
-				if ( ! $this->are_plugins_compatible_by_default( $feature_id ) ) {
+				if ( 'compatible' !== $this->get_default_plugin_compatibility( $feature_id ) ) {
 					$incompatible_plugins = true;
 					break;
 				}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -238,6 +238,7 @@ class FeaturesController {
 			'order'                               => 10,
 			'default_plugin_compatibility' => 'compatible',
 			'skip_compatibility_checks'    => false,
+			'learn_more_url'               => '',
 		);
 
 		if ( empty( $args['default_plugin_compatibility'] ) ) {
@@ -487,10 +488,11 @@ class FeaturesController {
 			),
 			'block_email_editor'          => array(
 				'name'               => __( 'Block Email Editor (alpha)', 'woocommerce' ),
-				'description'        => __(
-					'Enable the block-based email editor for transactional emails. <a href="https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256" target="_blank">Learn more</a>',
+				'description'               => __(
+					'Enable the block-based email editor for transactional emails.',
 					'woocommerce'
 				),
+				'learn_more_url'            => 'https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256',
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -1350,6 +1352,14 @@ class FeaturesController {
 		);
 
 		$feature_setting = wp_parse_args( $setting_definition, $feature_setting_defaults );
+
+		if ( ! empty( $feature['learn_more_url'] ) ) {
+			$feature_setting['desc'] .= sprintf(
+				'<span class="learn-more-link"><a href="%s" target="_blank">%s</a></span>',
+				esc_attr( $feature['learn_more_url'] ),
+				esc_html__( 'Learn more', 'woocommerce' )
+			);
+		}
 
 		/**
 		 * Allows to modify feature setting that will be used to render in the feature page.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -908,9 +908,10 @@ class FeaturesController {
 	 *
 	 * @param string $plugin_name Plugin name, in the form 'directory/file.php'.
 	 * @param bool   $enabled_features_only True to return only names of enabled plugins.
+	 * @param bool   $resolve_uncertain True to resolve the uncertain features to compatible or incompatible.
 	 * @return array An array having a 'compatible' and an 'incompatible' key, each holding an array of feature ids.
 	 */
-	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
+	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false, bool $resolve_uncertain = false ): array {
 		$this->process_pending_declarations();
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
@@ -934,7 +935,18 @@ class FeaturesController {
 		$info                 = $this->compatibility_info_by_plugin[ $plugin_name ];
 		$info['compatible']   = array_values( array_intersect( array_keys( $features ), $info['compatible'] ) );
 		$info['incompatible'] = array_values( array_intersect( array_keys( $features ), $info['incompatible'] ) );
-		$info['uncertain']    = array_values( array_diff( array_keys( $features ), $info['compatible'], $info['incompatible'] ) );
+		$info['uncertain']    = array();
+
+		$uncertain_features = array_values( array_diff( array_keys( $features ), $info['compatible'], $info['incompatible'] ) );
+
+		if ( $resolve_uncertain ) {
+			foreach ( $uncertain_features as $feature_id ) {
+				$key = $this->get_default_plugin_compatibility( $feature_id );
+				$info[ $key ][] = $feature_id;
+			}
+		} else {
+			$info['uncertain'] = $uncertain_features;
+		}
 
 		return $info;
 	}
@@ -944,9 +956,10 @@ class FeaturesController {
 	 *
 	 * @param string $feature_id Feature id.
 	 * @param bool   $active_only True to return only active plugins.
+	 * @param bool   $resolve_uncertain True to resolve the uncertain plugins to compatible or incompatible.
 	 * @return array An array having a 'compatible', an 'incompatible' and an 'uncertain' key, each holding an array of plugin names.
 	 */
-	public function get_compatible_plugins_for_feature( string $feature_id, bool $active_only = false ): array {
+	public function get_compatible_plugins_for_feature( string $feature_id, bool $active_only = false, bool $resolve_uncertain = false ): array {
 		$this->process_pending_declarations();
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
@@ -959,8 +972,13 @@ class FeaturesController {
 			);
 		}
 
-		$info              = $this->compatibility_info_by_feature[ $feature_id ];
-		$info['uncertain'] = array_values( array_diff( $woo_aware_plugins, $info['compatible'], $info['incompatible'] ) );
+		$info = $this->compatibility_info_by_feature[ $feature_id ];
+		ArrayUtil::ensure_key_is_array( $info, 'uncertain' );
+
+		// Resolve uncertain plugin compatibility?
+		$uncertain_plugins = array_values( array_diff( $woo_aware_plugins, $info['compatible'], $info['incompatible'] ) );
+		$key          = $resolve_uncertain ? $this->get_default_plugin_compatibility( $feature_id ) : 'uncertain';
+		$info[ $key ] = array_merge( $info[ $key ], $uncertain_plugins );
 
 		return $info;
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -235,11 +235,28 @@ class FeaturesController {
 			'enabled_by_default'                  => false,
 			'is_experimental'                     => true,
 			'is_legacy'                           => false,
-			'plugins_are_incompatible_by_default' => false,
 			'name'                                => $name,
 			'order'                               => 10,
+			'default_plugin_compatibility' => 'compatible',
 		);
-		$args     = wp_parse_args( $args, $defaults );
+
+		if ( empty( $args['default_plugin_compatibility'] ) ) {
+			wc_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					'Assuming positive compatibility by default will be deprecated in the future. Please set \'default_plugin_compatibility\' for feature "%s".',
+					esc_html( $slug )
+				),
+				'10.3.0'
+			);
+		}
+
+		$args = wp_parse_args( $args, $defaults );
+
+		// Sanitize 'default_plugin_compatibility'.
+		if ( ! in_array( $args['default_plugin_compatibility'], array( 'compatible', 'incompatible' ), true ) ) {
+			$args['default_plugin_compatibility'] = wc_string_to_bool( $args['default_plugin_compatibility'] ) ? 'compatible' : 'incompatible';
+		}
 
 		$this->features[ $slug ] = $args;
 	}
@@ -642,18 +659,44 @@ class FeaturesController {
 	 * Check if plugins that don't declare compatibility nor incompatibility with a given feature
 	 * are to be considered incompatible with that feature.
 	 *
+	 * @deprecated since 10.3.0. {@see FeaturesController::are_plugins_compatible_by_default()} and {@see FeaturesController::get_default_plugin_compatibility()}.
+	 *
 	 * @param string $feature_id Feature id to check.
 	 * @return bool True if plugins that don't declare compatibility nor incompatibility with the feature will be considered incompatible with the feature.
 	 * @throws \InvalidArgumentException The feature doesn't exist.
 	 */
 	public function get_plugins_are_incompatible_by_default( string $feature_id ): bool {
+		return ! $this->are_plugins_compatible_by_default( $feature_id );
+	}
+
+	/**
+	 * Check whether plugins that don't explicitly declare (in)compatibility are to be considered (in)compatible with a feature.
+	 *
+	 * @param string $feature_id Feature id to check.
+	 * @return bool TRUE if plugins that don't declare (in)compatibility are to be considered compatible with the feature.
+	 */
+	public function are_plugins_compatible_by_default( string $feature_id ): bool {
+		return 'compatible' === $this->get_default_plugin_compatibility( $feature_id );
+	}
+
+	/**
+	 * Get the default plugin compatibility for a given feature.
+	 *
+	 * @param string $feature_id
+	 * @return string
+	 * @throws Error
+	 * @throws ContainerException
+	 * @throws Exception
+	 */
+	public function get_default_plugin_compatibility( string $feature_id ): string {
 		$feature_definition = $this->get_feature_definitions()[ $feature_id ] ?? null;
 		if ( is_null( $feature_definition ) ) {
 			throw new \InvalidArgumentException( esc_html( "The WooCommerce feature '$feature_id' doesn't exist" ) );
 		}
 
-		$incompatible_by_default = $feature_definition['plugins_are_incompatible_by_default'] ?? false;
+		$default_plugin_compatibility = $feature_definition['default_plugin_compatibility'] ?? 'compatible';
 
+		// Filter below is only fired for backwards compatibility with get_plugins_are_incompatible_by_default().
 		/**
 		 * Filter to determine if plugins that don't declare compatibility nor incompatibility with a given feature
 		 * are to be considered incompatible with that feature.
@@ -663,7 +706,9 @@ class FeaturesController {
 		 *
 		 * @since 9.2.0
 		 */
-		return (bool) apply_filters( 'woocommerce_plugins_are_incompatible_with_feature_by_default', $incompatible_by_default, $feature_id );
+		$incompatible_by_default = (bool) apply_filters( 'woocommerce_plugins_are_incompatible_with_feature_by_default', 'incompatible' === $default_plugin_compatibility, $feature_id );
+
+		return $incompatible_by_default ? 'incompatible' : 'compatible';
 	}
 
 	/**
@@ -799,7 +844,6 @@ class FeaturesController {
 		}
 
 		// Register compatibility by feature.
-
 		$key = $positive_compatibility ? 'compatible' : 'incompatible';
 
 		if ( ! in_array( $plugin_id, $this->compatibility_info_by_feature[ $feature_id ][ $key ], true ) ) {
@@ -1433,7 +1477,7 @@ class FeaturesController {
 
 			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $feature_id ) => ! $this->is_legacy_feature( $feature_id ) );
 			foreach ( $uncertains as $feature_id ) {
-				if ( $this->get_plugins_are_incompatible_by_default( $feature_id ) ) {
+				if ( ! $this->are_plugins_compatible_by_default( $feature_id ) ) {
 					$incompatible_plugins = true;
 					break;
 				}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -912,17 +912,15 @@ class FeaturesController {
 		$info                 = $this->compatibility_info_by_plugin[ $plugin_name ];
 		$info['compatible']   = array_values( array_intersect( array_keys( $features ), $info['compatible'] ) );
 		$info['incompatible'] = array_values( array_intersect( array_keys( $features ), $info['incompatible'] ) );
-		$info['uncertain']    = array();
-
-		$uncertain_features = array_values( array_diff( array_keys( $features ), $info['compatible'], $info['incompatible'] ) );
+		$info['uncertain']    = array_values( array_diff( array_keys( $features ), $info['compatible'], $info['incompatible'] ) );
 
 		if ( $resolve_uncertain ) {
-			foreach ( $uncertain_features as $feature_id ) {
+			foreach ( $info['uncertain'] as $feature_id ) {
 				$key            = $this->get_default_plugin_compatibility( $feature_id );
 				$info[ $key ][] = $feature_id;
 			}
-		} else {
-			$info['uncertain'] = $uncertain_features;
+
+			$info['uncertain'] = array();
 		}
 
 		return $info;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -202,7 +202,7 @@ class FeaturesController {
 	 * @param array  $args {
 	 *     Properties that make up the feature definition. Each of these properties can also be set as a
 	 *     callback function, as long as that function returns the specified type.
-     *
+	 *
 	 *     @type string  $default_plugin_compatibility The default plugin compatibility for the feature: either 'compatible' or 'incompatible'. Required.
 	 *     @type array[] $additional_settings          An array of definitions for additional settings controls related to
 	 *                                                 the feature that will display on the Features screen. See the Settings API
@@ -348,8 +348,8 @@ class FeaturesController {
 				'default_plugin_compatibility' => 'compatible',
 			),
 			'rate_limit_checkout'         => array(
-				'name'                        => __( 'Rate limit Checkout', 'woocommerce' ),
-				'description'                 => sprintf(
+				'name'                         => __( 'Rate limit Checkout', 'woocommerce' ),
+				'description'                  => sprintf(
 					// translators: %s is the URL to the rate limiting documentation.
 					__( 'Enables rate limiting for Checkout place order and Store API /checkout endpoint. To further control this, refer to <a href="%s" target="_blank">rate limiting documentation</a>.', 'woocommerce' ),
 					'https://developer.woocommerce.com/docs/apis/store-api/rate-limiting/'
@@ -375,66 +375,65 @@ class FeaturesController {
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
 			'order_attribution'           => array(
-				'name'                      => __( 'Order Attribution', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Order Attribution', 'woocommerce' ),
+				'description'                  => __(
 					'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
 					'woocommerce'
 				),
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
-				'skip_compatibility_checks' => true,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => false,
+				'is_experimental'              => false,
 			),
 			'site_visibility_badge'       => array(
-				'name'                      => __( 'Site visibility badge', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Site visibility badge', 'woocommerce' ),
+				'description'                  => __(
 					'Enable the site visibility badge in the WordPress admin bar',
 					'woocommerce'
 				),
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
-				'skip_compatibility_checks' => true,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => false,
-				'disabled'                  => false,
+				'is_experimental'              => false,
+				'disabled'                     => false,
 			),
 			'hpos_fts_indexes'            => array(
-				'name'                      => __( 'HPOS Full text search indexes', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'HPOS Full text search indexes', 'woocommerce' ),
+				'description'                  => __(
 					'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
 					'woocommerce'
 				),
-				'is_experimental'           => true,
-				'enabled_by_default'        => false,
-				'skip_compatibility_checks' => true,
+				'is_experimental'              => true,
+				'enabled_by_default'           => false,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'option_key'                => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
+				'option_key'                   => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
 			'hpos_datastore_caching'      => array(
-				'name'                      => __( 'HPOS Data Caching', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'HPOS Data Caching', 'woocommerce' ),
+				'description'                  => __(
 					'Enable order data caching in the datastore. This feature only works with high-performance order storage.',
 					'woocommerce'
 				),
-				'is_experimental'           => true,
-				'enabled_by_default'        => false,
-				'skip_compatibility_checks' => true,
+				'is_experimental'              => true,
+				'enabled_by_default'           => false,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'disable_ui'                => false,
-				'option_key'                => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
+				'disable_ui'                   => false,
+				'option_key'                   => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
 			'remote_logging'              => array(
-				'name'                      => __( 'Remote Logging', 'woocommerce' ),
-				'description'               => sprintf(
+				'name'                         => __( 'Remote Logging', 'woocommerce' ),
+				'description'                  => sprintf(
 					/* translators: %1$s: opening link tag, %2$s: closing link tag */
 					__( 'Allow WooCommerce to send error logs and non-sensitive diagnostic data to help improve WooCommerce. This feature requires %1$susage tracking%2$s to be enabled.', 'woocommerce' ),
 					'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
 					'</a>'
 				),
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
-				'default_plugin_compatibility' => 'compatible',
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
 
 				/*
 				 * This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -444,14 +443,14 @@ class FeaturesController {
 				 *
 				 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				 */
-				'skip_compatibility_checks' => true,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => false,
-				'setting'                   => array(
+				'is_experimental'              => false,
+				'setting'                      => array(
 					'disabled' => function () use ( $tracking_enabled ) {
 						return ! $tracking_enabled;
 					},
-				'desc_tip'                  => function () use ( $tracking_enabled ) {
+					'desc_tip' => function () use ( $tracking_enabled ) {
 						if ( ! $tracking_enabled ) {
 							return __( '⚠ Usage tracking must be enabled to use remote logging.', 'woocommerce' );
 						}
@@ -460,8 +459,8 @@ class FeaturesController {
 				),
 			),
 			'email_improvements'          => array(
-				'name'                      => __( 'Email improvements', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Email improvements', 'woocommerce' ),
+				'description'                  => __(
 					'Enable modern email design for transactional emails',
 					'woocommerce'
 				),
@@ -475,18 +474,18 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/issues/39147
 				 * @see https://github.com/woocommerce/woocommerce/issues/55540
 				 */
-				'skip_compatibility_checks' => true,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => false,
+				'is_experimental'              => false,
 			),
 			'blueprint'                   => array(
-				'name'                      => __( 'Blueprint (beta)', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Blueprint (beta)', 'woocommerce' ),
+				'description'                  => __(
 					'Enable blueprint to import and export settings in bulk',
 					'woocommerce'
 				),
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -496,17 +495,17 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'skip_compatibility_checks' => true,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => false,
+				'is_experimental'              => false,
 			),
 			'block_email_editor'          => array(
-				'name'                      => __( 'Block Email Editor (alpha)', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Block Email Editor (alpha)', 'woocommerce' ),
+				'description'                  => __(
 					'Enable the block-based email editor for transactional emails.',
 					'woocommerce'
 				),
-				'learn_more_url'            => 'https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256',
+				'learn_more_url'               => 'https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256',
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -516,18 +515,18 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'skip_compatibility_checks' => true,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'enabled_by_default'        => false,
+				'enabled_by_default'           => false,
 			),
 			'point_of_sale'               => array(
-				'name'                      => __( 'Point of Sale', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Point of Sale', 'woocommerce' ),
+				'description'                  => __(
 					'Enable Point of Sale functionality in the WooCommerce mobile apps.',
 					'woocommerce'
 				),
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -537,25 +536,25 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'skip_compatibility_checks' => true,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'is_experimental'           => true,
+				'is_experimental'              => true,
 			),
 			'fulfillments'                => array(
-				'name'               => __( 'Order Fulfillments', 'woocommerce' ),
-				'description'        => __(
+				'name'                         => __( 'Order Fulfillments', 'woocommerce' ),
+				'description'                  => __(
 					'Enable the Order Fulfillments feature to manage order fulfillment and shipping.',
 					'woocommerce'
 				),
-				'enabled_by_default' => false,
-				'disable_ui'         => true,
-				'is_experimental'    => false,
+				'enabled_by_default'           => false,
+				'disable_ui'                   => true,
+				'is_experimental'              => false,
 				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental-iapi-mini-cart' => array(
-				'name'            => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
-				'description'     => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
-				'is_experimental' => true,
+				'name'                         => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
+				'description'                  => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
+				'is_experimental'              => true,
 				'default_plugin_compatibility' => 'compatible',
 			),
 		);
@@ -709,7 +708,7 @@ class FeaturesController {
 	 *
 	 * @param string $feature_id Feature id to check.
 	 * @return string Either 'compatible' or 'incompatible'.
-	 * @throws InvalidArgumentException If the feature doesn't exist.
+	 * @throws \InvalidArgumentException If the feature doesn't exist.
 	 */
 	public function get_default_plugin_compatibility( string $feature_id ): string {
 		$feature_definition = $this->get_feature_definitions()[ $feature_id ] ?? null;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -309,24 +309,26 @@ class FeaturesController {
 
 		$legacy_features = array(
 			'analytics'                   => array(
-				'name'                      => __( 'Analytics', 'woocommerce' ),
-				'description'               => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
-				'option_key'                => Analytics::TOGGLE_OPTION_NAME,
-				'is_experimental'           => false,
-				'enabled_by_default'        => true,
-				'disable_ui'                => false,
-				'skip_compatibility_checks' => true,
+				'name'                         => __( 'Analytics', 'woocommerce' ),
+				'description'                  => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
+				'option_key'                   => Analytics::TOGGLE_OPTION_NAME,
+				'is_experimental'              => false,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'product_block_editor'        => array(
-				'name'                      => __( 'New product editor', 'woocommerce' ),
-				'description'               => __( 'Try the new product editor (Beta)', 'woocommerce' ),
-				'is_experimental'           => true,
-				'disable_ui'                => false,
-				'skip_compatibility_checks' => true,
-				'disabled'                  => function () {
+				'name'                         => __( 'New product editor', 'woocommerce' ),
+				'description'                  => __( 'Try the new product editor (Beta)', 'woocommerce' ),
+				'is_experimental'              => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => 'compatible',
+				'disabled'                     => function () {
 					return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
 				},
-				'desc_tip'                  => function () {
+				'desc_tip'                     => function () {
 					$string = '';
 					if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
 						$string = __(
@@ -339,33 +341,36 @@ class FeaturesController {
 				},
 			),
 			'cart_checkout_blocks'        => array(
-				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-				'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
-				'is_experimental' => false,
-				'disable_ui'      => true,
+				'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+				'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+				'is_experimental'              => false,
+				'disable_ui'                   => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'rate_limit_checkout'         => array(
-				'name'                      => __( 'Rate limit Checkout', 'woocommerce' ),
-				'description'               => sprintf(
+				'name'                        => __( 'Rate limit Checkout', 'woocommerce' ),
+				'description'                 => sprintf(
 					// translators: %s is the URL to the rate limiting documentation.
 					__( 'Enables rate limiting for Checkout place order and Store API /checkout endpoint. To further control this, refer to <a href="%s" target="_blank">rate limiting documentation</a>.', 'woocommerce' ),
 					'https://developer.woocommerce.com/docs/apis/store-api/rate-limiting/'
 				),
-				'is_experimental'           => false,
-				'disable_ui'                => false,
-				'enabled_by_default'        => false,
-				'skip_compatibility_checks' => true,
+				'is_experimental'              => false,
+				'disable_ui'                   => false,
+				'enabled_by_default'           => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'marketplace'                 => array(
-				'name'                      => __( 'Marketplace', 'woocommerce' ),
-				'description'               => __(
+				'name'                         => __( 'Marketplace', 'woocommerce' ),
+				'description'                  => __(
 					'New, faster way to find extensions and themes for your WooCommerce store',
 					'woocommerce'
 				),
-				'is_experimental'           => false,
-				'enabled_by_default'        => true,
-				'disable_ui'                => true,
-				'skip_compatibility_checks' => true,
+				'is_experimental'              => false,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => true,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
@@ -378,6 +383,7 @@ class FeaturesController {
 				'enabled_by_default'        => true,
 				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => false,
 			),
 			'site_visibility_badge'       => array(
@@ -389,6 +395,7 @@ class FeaturesController {
 				'enabled_by_default'        => true,
 				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => false,
 				'disabled'                  => false,
 			),
@@ -401,6 +408,7 @@ class FeaturesController {
 				'is_experimental'           => true,
 				'enabled_by_default'        => false,
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'option_key'                => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
 			'hpos_datastore_caching'      => array(
@@ -412,6 +420,7 @@ class FeaturesController {
 				'is_experimental'           => true,
 				'enabled_by_default'        => false,
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'disable_ui'                => false,
 				'option_key'                => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
@@ -425,6 +434,7 @@ class FeaturesController {
 				),
 				'enabled_by_default'        => true,
 				'disable_ui'                => false,
+				'default_plugin_compatibility' => 'compatible',
 
 				/*
 				 * This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -435,6 +445,7 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				 */
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => false,
 				'setting'                   => array(
 					'disabled' => function () use ( $tracking_enabled ) {
@@ -465,6 +476,7 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/issues/55540
 				 */
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => false,
 			),
 			'blueprint'                   => array(
@@ -485,6 +497,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => false,
 			),
 			'block_email_editor'          => array(
@@ -504,6 +517,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'enabled_by_default'        => false,
 			),
 			'point_of_sale'               => array(
@@ -524,6 +538,7 @@ class FeaturesController {
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
 				'skip_compatibility_checks' => true,
+				'default_plugin_compatibility' => 'compatible',
 				'is_experimental'           => true,
 			),
 			'fulfillments'                => array(
@@ -535,11 +550,13 @@ class FeaturesController {
 				'enabled_by_default' => false,
 				'disable_ui'         => true,
 				'is_experimental'    => false,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental-iapi-mini-cart' => array(
 				'name'            => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
 				'description'     => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
 				'is_experimental' => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -231,13 +231,13 @@ class FeaturesController {
 	 */
 	public function add_feature_definition( $slug, $name, array $args = array() ) {
 		$defaults = array(
-			'disable_ui'                          => false,
-			'enabled_by_default'                  => false,
-			'is_experimental'                     => true,
-			'name'                                => $name,
-			'order'                               => 10,
+			'disable_ui'                   => false,
+			'enabled_by_default'           => false,
+			'is_experimental'              => true,
 			'default_plugin_compatibility' => 'compatible',
 			'skip_compatibility_checks'    => false,
+			'name'                         => $name,
+			'order'                        => 10,
 			'learn_more_url'               => '',
 		);
 
@@ -308,24 +308,24 @@ class FeaturesController {
 
 		$legacy_features = array(
 			'analytics'                   => array(
-				'name'               => __( 'Analytics', 'woocommerce' ),
-				'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
-				'option_key'         => Analytics::TOGGLE_OPTION_NAME,
-				'is_experimental'    => false,
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
+				'name'                      => __( 'Analytics', 'woocommerce' ),
+				'description'               => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
+				'option_key'                => Analytics::TOGGLE_OPTION_NAME,
+				'is_experimental'           => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
 			),
 			'product_block_editor'        => array(
-				'name'            => __( 'New product editor', 'woocommerce' ),
-				'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
-				'is_experimental' => true,
-				'disable_ui'      => false,
-				'disabled'        => function () {
+				'name'                      => __( 'New product editor', 'woocommerce' ),
+				'description'               => __( 'Try the new product editor (Beta)', 'woocommerce' ),
+				'is_experimental'           => true,
+				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
+				'disabled'                  => function () {
 					return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
 				},
-				'desc_tip'        => function () {
+				'desc_tip'                  => function () {
 					$string = '';
 					if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
 						$string = __(
@@ -344,86 +344,86 @@ class FeaturesController {
 				'disable_ui'      => true,
 			),
 			'rate_limit_checkout'         => array(
-				'name'               => __( 'Rate limit Checkout', 'woocommerce' ),
-				'description'        => sprintf(
+				'name'                      => __( 'Rate limit Checkout', 'woocommerce' ),
+				'description'               => sprintf(
 					// translators: %s is the URL to the rate limiting documentation.
 					__( 'Enables rate limiting for Checkout place order and Store API /checkout endpoint. To further control this, refer to <a href="%s" target="_blank">rate limiting documentation</a>.', 'woocommerce' ),
 					'https://developer.woocommerce.com/docs/apis/store-api/rate-limiting/'
 				),
-				'is_experimental'    => false,
-				'disable_ui'         => false,
-				'enabled_by_default' => false,
+				'is_experimental'           => false,
+				'disable_ui'                => false,
+				'enabled_by_default'        => false,
 				'skip_compatibility_checks' => true,
 			),
 			'marketplace'                 => array(
-				'name'               => __( 'Marketplace', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'Marketplace', 'woocommerce' ),
+				'description'               => __(
 					'New, faster way to find extensions and themes for your WooCommerce store',
 					'woocommerce'
 				),
-				'is_experimental'    => false,
-				'enabled_by_default' => true,
-				'disable_ui'         => true,
+				'is_experimental'           => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => true,
 				'skip_compatibility_checks' => true,
 			),
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
 			'order_attribution'           => array(
-				'name'               => __( 'Order Attribution', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'Order Attribution', 'woocommerce' ),
+				'description'               => __(
 					'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
 					'woocommerce'
 				),
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
-				'is_experimental'    => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => false,
 			),
 			'site_visibility_badge'       => array(
-				'name'               => __( 'Site visibility badge', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'Site visibility badge', 'woocommerce' ),
+				'description'               => __(
 					'Enable the site visibility badge in the WordPress admin bar',
 					'woocommerce'
 				),
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
-				'is_experimental'    => false,
-				'disabled'           => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => false,
+				'disabled'                  => false,
 			),
 			'hpos_fts_indexes'            => array(
-				'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'HPOS Full text search indexes', 'woocommerce' ),
+				'description'               => __(
 					'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
 					'woocommerce'
 				),
-				'is_experimental'    => true,
-				'enabled_by_default' => false,
-				'option_key'         => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
+				'is_experimental'           => true,
+				'enabled_by_default'        => false,
 				'skip_compatibility_checks' => true,
+				'option_key'                => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
 			'hpos_datastore_caching'      => array(
-				'name'               => __( 'HPOS Data Caching', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'HPOS Data Caching', 'woocommerce' ),
+				'description'               => __(
 					'Enable order data caching in the datastore. This feature only works with high-performance order storage.',
 					'woocommerce'
 				),
-				'is_experimental'    => true,
-				'enabled_by_default' => false,
-				'disable_ui'         => false,
-				'option_key'         => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
+				'is_experimental'           => true,
+				'enabled_by_default'        => false,
 				'skip_compatibility_checks' => true,
+				'disable_ui'                => false,
+				'option_key'                => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
 			'remote_logging'              => array(
-				'name'               => __( 'Remote Logging', 'woocommerce' ),
-				'description'        => sprintf(
+				'name'                      => __( 'Remote Logging', 'woocommerce' ),
+				'description'               => sprintf(
 					/* translators: %1$s: opening link tag, %2$s: closing link tag */
 					__( 'Allow WooCommerce to send error logs and non-sensitive diagnostic data to help improve WooCommerce. This feature requires %1$susage tracking%2$s to be enabled.', 'woocommerce' ),
 					'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
 					'</a>'
 				),
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 
 				/*
 				 * This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -433,13 +433,13 @@ class FeaturesController {
 				 *
 				 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				 */
-				'is_experimental'    => false,
-				'setting'            => array(
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => false,
+				'setting'                   => array(
 					'disabled' => function () use ( $tracking_enabled ) {
 						return ! $tracking_enabled;
 					},
-					'desc_tip' => function () use ( $tracking_enabled ) {
+				'desc_tip'                  => function () use ( $tracking_enabled ) {
 						if ( ! $tracking_enabled ) {
 							return __( '⚠ Usage tracking must be enabled to use remote logging.', 'woocommerce' );
 						}
@@ -448,8 +448,8 @@ class FeaturesController {
 				),
 			),
 			'email_improvements'          => array(
-				'name'            => __( 'Email improvements', 'woocommerce' ),
-				'description'     => __(
+				'name'                      => __( 'Email improvements', 'woocommerce' ),
+				'description'               => __(
 					'Enable modern email design for transactional emails',
 					'woocommerce'
 				),
@@ -463,17 +463,17 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/issues/39147
 				 * @see https://github.com/woocommerce/woocommerce/issues/55540
 				 */
-				'is_experimental' => false,
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => false,
 			),
 			'blueprint'                   => array(
-				'name'               => __( 'Blueprint (beta)', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'Blueprint (beta)', 'woocommerce' ),
+				'description'               => __(
 					'Enable blueprint to import and export settings in bulk',
 					'woocommerce'
 				),
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -483,11 +483,11 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'is_experimental'    => false,
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => false,
 			),
 			'block_email_editor'          => array(
-				'name'               => __( 'Block Email Editor (alpha)', 'woocommerce' ),
+				'name'                      => __( 'Block Email Editor (alpha)', 'woocommerce' ),
 				'description'               => __(
 					'Enable the block-based email editor for transactional emails.',
 					'woocommerce'
@@ -502,17 +502,17 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'enabled_by_default' => false,
 				'skip_compatibility_checks' => true,
+				'enabled_by_default'        => false,
 			),
 			'point_of_sale'               => array(
-				'name'               => __( 'Point of Sale', 'woocommerce' ),
-				'description'        => __(
+				'name'                      => __( 'Point of Sale', 'woocommerce' ),
+				'description'               => __(
 					'Enable Point of Sale functionality in the WooCommerce mobile apps.',
 					'woocommerce'
 				),
-				'enabled_by_default' => true,
-				'disable_ui'         => false,
+				'enabled_by_default'        => true,
+				'disable_ui'                => false,
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -522,8 +522,8 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'is_experimental'    => true,
 				'skip_compatibility_checks' => true,
+				'is_experimental'           => true,
 			),
 			'fulfillments'                => array(
 				'name'               => __( 'Order Fulfillments', 'woocommerce' ),
@@ -689,11 +689,9 @@ class FeaturesController {
 	/**
 	 * Get the default plugin compatibility for a given feature.
 	 *
-	 * @param string $feature_id
-	 * @return string
-	 * @throws Error
-	 * @throws ContainerException
-	 * @throws Exception
+	 * @param string $feature_id Feature id to check.
+	 * @return string Either 'compatible' or 'incompatible'.
+	 * @throws InvalidArgumentException If the feature doesn't exist.
 	 */
 	public function get_default_plugin_compatibility( string $feature_id ): string {
 		$feature_definition = $this->get_feature_definitions()[ $feature_id ] ?? null;
@@ -941,7 +939,7 @@ class FeaturesController {
 
 		if ( $resolve_uncertain ) {
 			foreach ( $uncertain_features as $feature_id ) {
-				$key = $this->get_default_plugin_compatibility( $feature_id );
+				$key            = $this->get_default_plugin_compatibility( $feature_id );
 				$info[ $key ][] = $feature_id;
 			}
 		} else {
@@ -977,8 +975,8 @@ class FeaturesController {
 
 		// Resolve uncertain plugin compatibility?
 		$uncertain_plugins = array_values( array_diff( $woo_aware_plugins, $info['compatible'], $info['incompatible'] ) );
-		$key          = $resolve_uncertain ? $this->get_default_plugin_compatibility( $feature_id ) : 'uncertain';
-		$info[ $key ] = array_merge( $info[ $key ], $uncertain_plugins );
+		$key               = $resolve_uncertain ? $this->get_default_plugin_compatibility( $feature_id ) : 'uncertain';
+		$info[ $key ]      = array_merge( $info[ $key ], $uncertain_plugins );
 
 		return $info;
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -325,20 +325,6 @@ class FeaturesController {
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => 'compatible',
-				'disabled'                     => function () {
-					return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
-				},
-				'desc_tip'                     => function () {
-					$string = '';
-					if ( version_compare( get_bloginfo( 'version' ), '6.2', '<' ) ) {
-						$string = __(
-							'⚠ This feature is compatible with WordPress version 6.2 or higher.',
-							'woocommerce'
-						);
-					}
-
-					return $string;
-				},
 			),
 			'cart_checkout_blocks'        => array(
 				'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -200,31 +200,32 @@ class FeaturesController {
 	 * @param string $slug The ID slug of the feature.
 	 * @param string $name The name of the feature that will appear on the Features screen and elsewhere.
 	 * @param array  $args {
-	 *     Optional. Properties that make up the feature definition. Each of these properties can also be set as a
+	 *     Properties that make up the feature definition. Each of these properties can also be set as a
 	 *     callback function, as long as that function returns the specified type.
-	 *
-	 *     @type array[] $additional_settings An array of definitions for additional settings controls related to
-	 *                                        the feature that will display on the Features screen. See the Settings API
-	 *                                        for the schema of these props.
-	 *     @type string  $description         A brief description of the feature, used as an input label if the feature
-	 *                                        setting is a checkbox.
-	 *     @type bool    $disabled            True to disable the setting field for this feature on the Features screen,
-	 *                                        so it can't be changed.
-	 *     @type bool    $disable_ui          Set to true to hide the setting field for this feature on the
-	 *                                        Features screen. Defaults to false.
-	 *     @type bool    $enabled_by_default  Set to true to have this feature by opt-out instead of opt-in.
-	 *                                        Defaults to false.
-	 *     @type bool    $is_experimental     Set to true to display this feature under the "Experimental" heading on
-	 *                                        the Features screen. Features set to experimental are also omitted from
-	 *                                        the features list in some cases. Defaults to true.
-	 *     @type bool    $is_legacy           Set to true if this feature existed before the FeaturesController class
-	 *                                        was introduced. Features set to legacy also do not produce warnings about
-	 *                                        incompatible plugins. Defaults to false.
-	 *     @type string  $option_key          The key name for the option that enables/disables the feature.
-	 *     @type int     $order               The order that the feature will appear in the list on the Features screen.
-	 *                                        Higher number = higher in the list. Defaults to 10.
-	 *     @type array   $setting             The properties used by the Settings API to render the setting control on
-	 *                                        the Features screen. See the Settings API for the schema of these props.
+     *
+	 *     @type string  $default_plugin_compatibility The default plugin compatibility for the feature: either 'compatible' or 'incompatible'. Required.
+	 *     @type array[] $additional_settings          An array of definitions for additional settings controls related to
+	 *                                                 the feature that will display on the Features screen. See the Settings API
+	 *                                                 for the schema of these props.
+	 *     @type string  $description                  A brief description of the feature, used as an input label if the feature
+	 *                                                 setting is a checkbox.
+	 *     @type bool    $disabled                     True to disable the setting field for this feature on the Features screen,
+	 *                                                 so it can't be changed.
+	 *     @type bool    $disable_ui                   Set to true to hide the setting field for this feature on the
+	 *                                                 Features screen. Defaults to false.
+	 *     @type bool    $enabled_by_default           Set to true to have this feature by opt-out instead of opt-in.
+	 *                                                 Defaults to false.
+	 *     @type bool    $is_experimental              Set to true to display this feature under the "Experimental" heading on
+	 *                                                 the Features screen. Features set to experimental are also omitted from
+	 *                                                 the features list in some cases. Defaults to true.
+	 *     @type bool    $skip_compatibility_checks    Set to true if the feature should not produce warnings about incompatible plugins.
+	 *                                                 Defaults to false.
+	 *     @type string  $learn_more_url               The URL to the learn more page for the feature.
+	 *     @type string  $option_key                   The key name for the option that enables/disables the feature.
+	 *     @type int     $order                        The order that the feature will appear in the list on the Features screen.
+	 *                                                 Higher number = higher in the list. Defaults to 10.
+	 *     @type array   $setting                      The properties used by the Settings API to render the setting control on
+	 *                                                 the Features screen. See the Settings API for the schema of these props.
 	 * }
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -234,10 +234,10 @@ class FeaturesController {
 			'disable_ui'                          => false,
 			'enabled_by_default'                  => false,
 			'is_experimental'                     => true,
-			'is_legacy'                           => false,
 			'name'                                => $name,
 			'order'                               => 10,
 			'default_plugin_compatibility' => 'compatible',
+			'skip_compatibility_checks'    => false,
 		);
 
 		if ( empty( $args['default_plugin_compatibility'] ) ) {
@@ -256,6 +256,11 @@ class FeaturesController {
 		// Sanitize 'default_plugin_compatibility'.
 		if ( ! in_array( $args['default_plugin_compatibility'], array( 'compatible', 'incompatible' ), true ) ) {
 			$args['default_plugin_compatibility'] = wc_string_to_bool( $args['default_plugin_compatibility'] ) ? 'compatible' : 'incompatible';
+		}
+
+		// Support 'is_legacy' flag for backwards compatibility.
+		if ( ! empty( $args['is_legacy'] ) ) {
+			$args['skip_compatibility_checks'] = true;
 		}
 
 		$this->features[ $slug ] = $args;
@@ -308,15 +313,15 @@ class FeaturesController {
 				'is_experimental'    => false,
 				'enabled_by_default' => true,
 				'disable_ui'         => false,
-				'is_legacy'          => true,
+				'skip_compatibility_checks' => true,
 			),
 			'product_block_editor'        => array(
 				'name'            => __( 'New product editor', 'woocommerce' ),
 				'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 				'is_experimental' => true,
 				'disable_ui'      => false,
-				'is_legacy'       => true,
 				'disabled'        => function () {
+				'skip_compatibility_checks' => true,
 					return version_compare( get_bloginfo( 'version' ), '6.2', '<' );
 				},
 				'desc_tip'        => function () {
@@ -347,7 +352,7 @@ class FeaturesController {
 				'is_experimental'    => false,
 				'disable_ui'         => false,
 				'enabled_by_default' => false,
-				'is_legacy'          => true,
+				'skip_compatibility_checks' => true,
 			),
 			'marketplace'                 => array(
 				'name'               => __( 'Marketplace', 'woocommerce' ),
@@ -358,7 +363,7 @@ class FeaturesController {
 				'is_experimental'    => false,
 				'enabled_by_default' => true,
 				'disable_ui'         => true,
-				'is_legacy'          => true,
+				'skip_compatibility_checks' => true,
 			),
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
@@ -370,8 +375,8 @@ class FeaturesController {
 				),
 				'enabled_by_default' => true,
 				'disable_ui'         => false,
-				'is_legacy'          => true,
 				'is_experimental'    => false,
+				'skip_compatibility_checks' => true,
 			),
 			'site_visibility_badge'       => array(
 				'name'               => __( 'Site visibility badge', 'woocommerce' ),
@@ -381,9 +386,9 @@ class FeaturesController {
 				),
 				'enabled_by_default' => true,
 				'disable_ui'         => false,
-				'is_legacy'          => true,
 				'is_experimental'    => false,
 				'disabled'           => false,
+				'skip_compatibility_checks' => true,
 			),
 			'hpos_fts_indexes'            => array(
 				'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
@@ -393,8 +398,8 @@ class FeaturesController {
 				),
 				'is_experimental'    => true,
 				'enabled_by_default' => false,
-				'is_legacy'          => true,
 				'option_key'         => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
+				'skip_compatibility_checks' => true,
 			),
 			'hpos_datastore_caching'      => array(
 				'name'               => __( 'HPOS Data Caching', 'woocommerce' ),
@@ -404,9 +409,9 @@ class FeaturesController {
 				),
 				'is_experimental'    => true,
 				'enabled_by_default' => false,
-				'is_legacy'          => true,
 				'disable_ui'         => false,
 				'option_key'         => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
+				'skip_compatibility_checks' => true,
 			),
 			'remote_logging'              => array(
 				'name'               => __( 'Remote Logging', 'woocommerce' ),
@@ -427,9 +432,9 @@ class FeaturesController {
 				 *
 				 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				 */
-				'is_legacy'          => true,
 				'is_experimental'    => false,
 				'setting'            => array(
+				'skip_compatibility_checks' => true,
 					'disabled' => function () use ( $tracking_enabled ) {
 						return ! $tracking_enabled;
 					},
@@ -457,8 +462,8 @@ class FeaturesController {
 				 * @see https://github.com/woocommerce/woocommerce/issues/39147
 				 * @see https://github.com/woocommerce/woocommerce/issues/55540
 				 */
-				'is_legacy'       => true,
 				'is_experimental' => false,
+				'skip_compatibility_checks' => true,
 			),
 			'blueprint'                   => array(
 				'name'               => __( 'Blueprint (beta)', 'woocommerce' ),
@@ -477,8 +482,8 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'is_legacy'          => true,
 				'is_experimental'    => false,
+				'skip_compatibility_checks' => true,
 			),
 			'block_email_editor'          => array(
 				'name'               => __( 'Block Email Editor (alpha)', 'woocommerce' ),
@@ -495,8 +500,8 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'is_legacy'          => true,
 				'enabled_by_default' => false,
+				'skip_compatibility_checks' => true,
 			),
 			'point_of_sale'               => array(
 				'name'               => __( 'Point of Sale', 'woocommerce' ),
@@ -515,8 +520,8 @@ class FeaturesController {
 				*
 				* @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 				*/
-				'is_legacy'          => true,
 				'is_experimental'    => true,
+				'skip_compatibility_checks' => true,
 			),
 			'fulfillments'                => array(
 				'name'               => __( 'Order Fulfillments', 'woocommerce' ),
@@ -1003,13 +1008,27 @@ class FeaturesController {
 	 * Checks whether a feature id corresponds to a legacy feature
 	 * (a feature that existed prior to the implementation of the features engine).
 	 *
+	 * @deprecated since 10.3.0, use {@see FeaturesController::skip_compatibility_checks()} instead.
+	 *
 	 * @param string $feature_id The feature id to check.
 	 * @return bool True if the id corresponds to a legacy feature.
 	 */
 	public function is_legacy_feature( string $feature_id ): bool {
+		return $this->skip_compatibility_checks( $feature_id );
+	}
+
+	/**
+	 * Check if the compatibility checks should be skipped for a given feature.
+	 *
+	 * @since 10.3.0
+	 *
+	 * @param string $feature_id The feature id to check.
+	 * @return bool TRUE if the compatibility checks should be skipped.
+	 */
+	public function skip_compatibility_checks( string $feature_id ): bool {
 		$features = $this->get_feature_definitions();
 
-		return ! empty( $features[ $feature_id ]['is_legacy'] );
+		return ! empty( $features[ $feature_id ]['skip_compatibility_checks'] );
 	}
 
 	/**
@@ -1302,7 +1321,7 @@ class FeaturesController {
 			}
 		}
 
-		if ( ! $this->is_legacy_feature( $feature_id ) && ! $disabled && $this->verify_did_woocommerce_init() ) {
+		if ( ! $this->skip_compatibility_checks( $feature_id ) && ! $disabled && $this->verify_did_woocommerce_init() ) {
 			$plugin_info_for_feature = $this->get_compatible_plugins_for_feature( $feature_id, true );
 			$desc_tip                = $this->plugin_util->generate_incompatible_plugin_feature_warning( $feature_id, $plugin_info_for_feature );
 		}
@@ -1425,8 +1444,8 @@ class FeaturesController {
 				$features_considered_incompatible = array_filter(
 					$this->plugin_util->get_items_considered_incompatible( $feature_id, $compatibility_info ),
 					$only_enabled_features ?
-						fn( $feature_id ) => $this->feature_is_enabled( $feature_id ) && ! $this->is_legacy_feature( $feature_id ) :
-						fn( $feature_id ) => ! $this->is_legacy_feature( $feature_id )
+						fn( $feature_id ) => $this->feature_is_enabled( $feature_id ) && ! $this->skip_compatibility_checks( $feature_id ) :
+						fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id )
 				);
 				if ( in_array( $feature_id, $features_considered_incompatible, true ) ) {
 					$incompatibles[] = $plugin_name;
@@ -1469,13 +1488,13 @@ class FeaturesController {
 		foreach ( $relevant_plugins as $plugin ) {
 			$compatibility_info = $this->get_compatible_features_for_plugin( $plugin, true );
 
-			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $feature_id ) => ! $this->is_legacy_feature( $feature_id ) );
+			$incompatibles = array_filter( $compatibility_info['incompatible'], fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id ) );
 			if ( ! empty( $incompatibles ) ) {
 				$incompatible_plugins = true;
 				break;
 			}
 
-			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $feature_id ) => ! $this->is_legacy_feature( $feature_id ) );
+			$uncertains = array_filter( $compatibility_info['uncertain'], fn( $feature_id ) => ! $this->skip_compatibility_checks( $feature_id ) );
 			foreach ( $uncertains as $feature_id ) {
 				if ( ! $this->are_plugins_compatible_by_default( $feature_id ) ) {
 					$incompatible_plugins = true;
@@ -1618,7 +1637,7 @@ class FeaturesController {
 			array_filter(
 				$incompatible_features,
 				function ( $feature_id ) {
-					return ! $this->is_legacy_feature( $feature_id );
+					return ! $this->skip_compatibility_checks( $feature_id );
 				}
 			)
 		);

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Utilities;
 
+use Automattic\WooCommerce\Enums\FeaturePluginCompatibility;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Utilities\PluginInstaller;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -320,7 +321,7 @@ class PluginUtil {
 	 * @return array Items in 'incompatible' and 'uncertain' if plugins are incompatible by default with the feature; only items in 'incompatible' otherwise.
 	 */
 	public function get_items_considered_incompatible( string $feature_id, array $compatibility_info ): array {
-		$incompatible_by_default = 'compatible' !== wc_get_container()->get( FeaturesController::class )->get_default_plugin_compatibility( $feature_id );
+		$incompatible_by_default = FeaturePluginCompatibility::COMPATIBLE !== wc_get_container()->get( FeaturesController::class )->get_default_plugin_compatibility( $feature_id );
 
 		return $incompatible_by_default ?
 			array_merge( $compatibility_info['incompatible'], $compatibility_info['uncertain'] ) :

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -320,7 +320,7 @@ class PluginUtil {
 	 * @return array Items in 'incompatible' and 'uncertain' if plugins are incompatible by default with the feature; only items in 'incompatible' otherwise.
 	 */
 	public function get_items_considered_incompatible( string $feature_id, array $compatibility_info ): array {
-		$incompatible_by_default = wc_get_container()->get( FeaturesController::class )->get_plugins_are_incompatible_by_default( $feature_id );
+		$incompatible_by_default = ! wc_get_container()->get( FeaturesController::class )->are_plugins_compatible_by_default( $feature_id );
 
 		return $incompatible_by_default ?
 			array_merge( $compatibility_info['incompatible'], $compatibility_info['uncertain'] ) :

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -312,8 +312,8 @@ class PluginUtil {
 
 	/**
 	 * Filter plugin/feature compatibility info, returning the names of the plugins/features that are considered incompatible.
-	 * "Uncertain" information will be included or not depending on the value of the value of the 'plugins_are_incompatible_by_default'
-	 * flag in the feature definition (default is true).
+	 * "Uncertain" information will be included or not depending on the value of the value of the 'default_plugin_compatibility'
+	 * flag in the feature definition (default is 'compatible').
 	 *
 	 * @param string $feature_id Feature id.
 	 * @param array  $compatibility_info Array containing "compatible', 'incompatible' and 'uncertain' keys.

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -320,7 +320,7 @@ class PluginUtil {
 	 * @return array Items in 'incompatible' and 'uncertain' if plugins are incompatible by default with the feature; only items in 'incompatible' otherwise.
 	 */
 	public function get_items_considered_incompatible( string $feature_id, array $compatibility_info ): array {
-		$incompatible_by_default = ! wc_get_container()->get( FeaturesController::class )->are_plugins_compatible_by_default( $feature_id );
+		$incompatible_by_default = 'compatible' !== wc_get_container()->get( FeaturesController::class )->get_default_plugin_compatibility( $feature_id );
 
 		return $incompatible_by_default ?
 			array_merge( $compatibility_info['incompatible'], $compatibility_info['uncertain'] ) :

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -118,41 +118,25 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
 
-		$pluginutil_mock = new class() extends PluginUtil {
-			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-			public function is_woocommerce_aware_plugin( $plugin ): bool {
-				if ( 'plugin1' === $plugin ) {
-					return false;
+		$pluginutil_mock = $this->createMock( PluginUtil::class );
+		$pluginutil_mock->method( 'is_woocommerce_aware_plugin' )
+			->willReturnCallback( fn ( $plugin ) => 'plugin1' === $plugin ? false : true );
+
+		$featurescontroller_mock = $this->createMock( FeaturesController::class );
+		$featurescontroller_mock
+			->method( 'get_compatible_features_for_plugin' )
+			->willReturnCallback(
+				function ( $plugin_name ) {
+					switch ( $plugin_name ) {
+						case 'plugin1':
+							return array();
+						case 'plugin2':
+							return array( 'compatible' => array( 'feature1' ), 'incompatible' => array( 'feature2' ), 'uncertain' => array( 'feature3' ) );
+						case 'plugin3':
+							return array( 'compatible' => array( 'feature2' ), 'incompatible' => array(), 'uncertain' => array( 'feature1', 'feature3' ) );
+					}
 				}
-
-				return true;
-			}
-		};
-
-		$featurescontroller_mock = new class() extends FeaturesController {
-			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-			public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
-				$compat = array();
-				switch ( $plugin_name ) {
-					case 'plugin2':
-						$compat = array(
-							'compatible'   => array( 'feature1' ),
-							'incompatible' => array( 'feature2' ),
-							'uncertain'    => array( 'feature3' ),
-						);
-						break;
-					case 'plugin3':
-						$compat = array(
-							'compatible'   => array( 'feature2' ),
-							'incompatible' => array(),
-							'uncertain'    => array( 'feature1', 'feature3' ),
-						);
-						break;
-				}
-
-				return $compat;
-			}
-		};
+			);
 
 		$container = wc_get_container();
 		$container->get( PluginUtil::class ); // Ensure that the class is loaded.

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -131,9 +131,20 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 						case 'plugin1':
 							return array();
 						case 'plugin2':
-							return array( 'compatible' => array( 'feature1' ), 'incompatible' => array( 'feature2' ), 'uncertain' => array( 'feature3' ) );
+							return array(
+								'compatible'   => array( 'feature1' ),
+								'incompatible' => array( 'feature2' ),
+								'uncertain'    => array( 'feature3' ),
+							);
 						case 'plugin3':
-							return array( 'compatible' => array( 'feature2' ), 'incompatible' => array(), 'uncertain' => array( 'feature1', 'feature3' ) );
+							return array(
+								'compatible'   => array( 'feature2' ),
+								'incompatible' => array(),
+								'uncertain'    => array(
+									'feature1',
+									'feature3',
+								),
+							);
 					}
 				}
 			);

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -988,10 +988,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'custom_order_tables'  => array(
-						'name'               => __( 'High-Performance order storage', 'woocommerce' ),
-						'is_experimental'    => false,
-						'enabled_by_default' => false,
-						'option_key'         => CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+						'name'                         => __( 'High-Performance order storage', 'woocommerce' ),
+						'is_experimental'              => false,
+						'enabled_by_default'           => false,
+						'option_key'                   => CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 						'default_plugin_compatibility' => 'incompatible',
 					),
 					'cart_checkout_blocks' => array(

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -992,7 +992,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 						'is_experimental'    => false,
 						'enabled_by_default' => false,
 						'option_key'         => CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-						'plugins_are_incompatible_by_default' => true,
+						'default_plugin_compatibility' => 'incompatible',
 					),
 					'cart_checkout_blocks' => array(
 						'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -74,24 +74,28 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	public function register_dummy_features( $features_controller ) {
 		$features = array(
 			'mature1'       => array(
-				'name'            => 'Mature feature 1',
-				'description'     => 'The mature feature number 1',
-				'is_experimental' => false,
+				'name'                         => 'Mature feature 1',
+				'description'                  => 'The mature feature number 1',
+				'is_experimental'              => false,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'mature2'       => array(
-				'name'            => 'Mature feature 2',
-				'description'     => 'The mature feature number 2',
-				'is_experimental' => false,
+				'name'                         => 'Mature feature 2',
+				'description'                  => 'The mature feature number 2',
+				'is_experimental'              => false,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental1' => array(
-				'name'            => 'Experimental feature 1',
-				'description'     => 'The experimental feature number 1',
-				'is_experimental' => true,
+				'name'                         => 'Experimental feature 1',
+				'description'                  => 'The experimental feature number 1',
+				'is_experimental'              => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental2' => array(
-				'name'            => 'Experimental feature 2',
-				'description'     => 'The experimental feature number 2',
-				'is_experimental' => true,
+				'name'                         => 'Experimental feature 2',
+				'description'                  => 'The experimental feature number 2',
+				'is_experimental'              => true,
+				'default_plugin_compatibility' => 'compatible',
 			),
 		);
 
@@ -547,34 +551,40 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'mature1'       => array(
-						'name'            => 'Mature feature 1',
-						'description'     => 'The mature feature number 1',
-						'is_experimental' => false,
+						'name'                         => 'Mature feature 1',
+						'description'                  => 'The mature feature number 1',
+						'is_experimental'              => false,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'mature2'       => array(
-						'name'            => 'Mature feature 2',
-						'description'     => 'The mature feature number 2',
-						'is_experimental' => false,
+						'name'                         => 'Mature feature 2',
+						'description'                  => 'The mature feature number 2',
+						'is_experimental'              => false,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'mature3'       => array(
-						'name'            => 'Mature feature 3',
-						'description'     => 'The mature feature number 3',
-						'is_experimental' => false,
+						'name'                         => 'Mature feature 3',
+						'description'                  => 'The mature feature number 3',
+						'is_experimental'              => false,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental1' => array(
-						'name'            => 'Experimental feature 1',
-						'description'     => 'The experimental feature number 1',
-						'is_experimental' => true,
+						'name'                         => 'Experimental feature 1',
+						'description'                  => 'The experimental feature number 1',
+						'is_experimental'              => true,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental2' => array(
-						'name'            => 'Experimental feature 2',
-						'description'     => 'The experimental feature number 2',
-						'is_experimental' => true,
+						'name'                         => 'Experimental feature 2',
+						'description'                  => 'The experimental feature number 2',
+						'is_experimental'              => true,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental3' => array(
-						'name'            => 'Experimental feature 3',
-						'description'     => 'The experimental feature number 3',
-						'is_experimental' => true,
+						'name'                         => 'Experimental feature 3',
+						'description'                  => 'The experimental feature number 3',
+						'is_experimental'              => true,
+						'default_plugin_compatibility' => 'compatible',
 					),
 				);
 
@@ -890,15 +900,17 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'custom_order_tables'  => array(
-						'name'               => __( 'High-Performance order storage', 'woocommerce' ),
-						'is_experimental'    => true,
-						'enabled_by_default' => false,
+						'name'                         => __( 'High-Performance order storage', 'woocommerce' ),
+						'is_experimental'              => true,
+						'enabled_by_default'           => false,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'cart_checkout_blocks' => array(
-						'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-						'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
-						'is_experimental' => false,
-						'disable_ui'      => true,
+						'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+						'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+						'is_experimental'              => false,
+						'disable_ui'                   => true,
+						'default_plugin_compatibility' => 'compatible',
 					),
 				);
 
@@ -995,10 +1007,11 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 						'default_plugin_compatibility' => 'incompatible',
 					),
 					'cart_checkout_blocks' => array(
-						'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-						'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
-						'is_experimental' => false,
-						'disable_ui'      => true,
+						'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+						'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+						'is_experimental'              => false,
+						'disable_ui'                   => true,
+						'default_plugin_compatibility' => 'compatible',
 					),
 				);
 

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -253,11 +253,11 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 				$features = array(
 					'test_feature_1' => array(
 						'name' => 'Test feature 1',
-						'plugins_are_incompatible_by_default' => true,
+						'default_plugin_compatibility' => 'incompatible',
 					),
 					'test_feature_2' => array(
 						'name' => 'Test feature 2',
-						'plugins_are_incompatible_by_default' => false,
+						'default_plugin_compatibility' => 'compatible',
 					),
 					'test_feature_3' => array(
 						'name' => 'Test feature 2',

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -260,7 +260,8 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'test_feature_3' => array(
-						'name' => 'Test feature 2',
+						'name'                         => 'Test feature 3',
+						'default_plugin_compatibility' => 'compatible',
 					),
 				);
 
@@ -337,7 +338,7 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		);
 
 		$features_controller = wc_get_container()->get( FeaturesController::class );
-		$features_controller->add_feature_definition( 'test_feature', 'Test Feature' );
+		$features_controller->add_feature_definition( 'test_feature', 'Test Feature', array( 'default_plugin_compatibility' => 'compatible' ) );
 
 		// Simulate declaration (should not call get_plugins yet).
 		$this->simulate_inside_before_woocommerce_init_hook();

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -252,11 +252,11 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'test_feature_1' => array(
-						'name' => 'Test feature 1',
+						'name'                         => 'Test feature 1',
 						'default_plugin_compatibility' => 'incompatible',
 					),
 					'test_feature_2' => array(
-						'name' => 'Test feature 2',
+						'name'                         => 'Test feature 2',
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'test_feature_3' => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR implements a few enhancements to the `FeaturesController`, mostly renaming a few feature properties, simplifying resolution of compatible/incompatible plugins/features and adding support for a "Learn more" link.

In particular, this PR:

- Replaces `plugins_are_incompatible_by_default` (which defaulted to `false`) with `default_plugin_compatibility` which admits values `compatible` or `incompatible`.
  This new property is now "mandatory", which I think will help with anyone adding new features to stop for a moment and think whether plugins should be considered compatible or incompatible with the feature, instead of either abusing legacy features (as we've seen so far) in order to avoid compatibility checks.
- Removes the `is_legacy` flag and replaces it with `skip_compatibility_checks` (defaults to `false`). It's best for any feature to be explicit about default compatibility and/or the need to avoid compat. checks instead of using the "legacy" flag, which isn't particularly self-explanatory.
- Adds a `$resolve_uncertain` argument to `FeaturesController::get_compatible_features_for_plugin()` and `FeaturesController::get_compatible_plugins_for_feature()` so that the `uncertain` key is not populated for the returned arrays and instead `default_plugin_compatibility` is used to classify plugins/features into compatible or incompatible.
- Adds a `learn_more_url` property that features can use to show a standardized link that points to docs or information about the feature.

Closes #39147 and #56162.

<!--
#### ❓ For discussion
I'm not sure whether there's any benefit to tagging plugins/features as `uncertain` and if both `FeaturesController::get_compatible_features_for_plugin()` and `FeaturesController::get_compatible_plugins_for_feature()` should have `$resolve_uncertain = true` by default, resulting only in the `compatible` and `incompatible` categories, allowing 3rd party code to quickly determine whether something is compatible or incompatible without having to take anything else into account. Internally, the `FeaturesController` already knows whether the compatibility was explicitly declared or a result of applying the `default_plugin_compatibility` rule for the feature, but this is probably not something we should expose. Should we go ahead and remove that?
-->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Setup
1. Check out this branch and rebuild the plugin (`pnpm run build` from within `plugins/woocommerce`) so that CSS assets are up to date.
1. Create a file `my-test-woo-plugin.php` in `wp-content/plugins/` with the following contents:
   ```php
   <?php
   /**
    * Plugin Name: My Test Woo Plugin
    * Description: Does not do anything useful.
    * WC tested up to: 10.0.0
    */
   
   add_action(
	   'before_woocommerce_init',
	   function() {
		   \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
	   }
   );
   ```

   We will use this plugin to test the different compatibility scenarios.
1. Go to **Plugins** on the backend and activate it the newly created **My Test Woo Plugin**.
1. Activate the following PHP snippet on your test site (for example, as a .php file in `wp-content/mu-plugins/`):
   ```php
   <?php
   
   add_action(
       'woocommerce_register_feature_definitions',
       function( $f ) {
           $f->add_feature_definition(
               'my-test-feature',
               'My Test Feature',
               array(
                   'default_plugin_compatibility' => 'compatible',
                   'skip_compatibility_checks'    => false,
                   'description' => 'This is a test feature.',
                   'learn_more_url' => 'https://www.woocommerce.com/',
               )
           );
       }
   );
   ```
1. Go to **WooCommerce > Settings > Advanced > Features** and confirm that a new **My Test Feature** feature appears. It should have a "Learn more" link that points to WooCommerce.com.
   <img width="540" height="70" alt="Screenshot 2025-09-11 at 10 53 00" src="https://github.com/user-attachments/assets/97c44155-c313-49e8-abbc-dd9f189e0723" />
1. Check off the above feature to activate it and click **Save changes**.
1. Keep a browser tab open with this settings page for easier testing.

#### Tests

1. **Missing `default_plugin_compatibility` triggers a doing-it-wrong notice:**
   1. Temporarily comment out the `'default_plugin_compatibility' => 'compatible',` line in your feature snippet.
   1. Refresh the WC settings page and confirm that the following doing it wrong notice is logged:
      > add_feature_definition was called incorrectly. Assuming positive compatibility by default will be deprecated in the future. Please set 'default_plugin_compatibility' for feature "my-test-feature".
   1. Restore the line and save the snippet again.
1. **`default_plugin_compatibility` determines assumed plugin compatibility**:
   1. Ensure no plugin compatibility notices appear on the settings screen.
   1. In your snippet, change `'default_plugin_compatibility' => 'compatible'` to `'default_plugin_compatibility' => 'incompatible'`.
   1. Refresh the settings page.
   1. Because your test plugin doesn't explicitly declare itself as compatible with this feature, your settings page should now show a warning at the top as well as under the test feature like this:
      <img width="1016" height="66" alt="Screenshot 2025-09-11 at 11 05 57" src="https://github.com/user-attachments/assets/5933510e-bf00-40c4-8bdc-5fa70e631c4b" />
      <img width="916" height="101" alt="Screenshot 2025-09-11 at 11 05 54" src="https://github.com/user-attachments/assets/8bb83187-67b8-43d7-a322-95193aacdf1e" />
   1. Add the following compatibility declaration to your test plugin, below the existing one:
      ```php
      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'my-test-feature', __FILE__, true );
      ```

      Save the changes.
   1. Refresh the settings page.
   1. Depending on whether you have other WC-aware plugins, the compat warning at the top should've disappeared or at least **My Test Woo Plugin** shouldn't be listed anymore among the incompatible plugins.
   1. In your snippet, change `'default_plugin_compatibility' => 'incompatible'` to `'default_plugin_compatibility' => 'compatible'` once again.
   1. In your test plugin, change the compatibility declaration for `my-test-feature` from `true` to `false` (indicating incompatibility).
   1. Refresh the settings page and confirm that the warnings are back.
1. **`skip_compatibility_checks` allows features to bypass checks without changing compatibility resolution:**
   1. In your snippet, change `'skip_compatibility_checks' => false` to `'skip_compatibility_checks' => true`.
   1. No warnings should appear anymore.
   1. Confirm that internally the plugin is still considered incompatible. Run the following command in a `wp shell`:
      ```
      wc_get_container()->get( 'Automattic\WooCommerce\Internal\Features\FeaturesController' )->get_compatible_plugins_for_feature( 'my-test-feature' );
      ```

      Confirm that `my-test-woo-plugin.php` is listed under the `incompatible` array.

<!-- End testing instructions -->