### PR TITLE
Improve accessibility and usability of address autocomplete

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5083-improve-accessibility-of-suggestions-component
+++ b/plugins/woocommerce/changelog/wooplug-5083-improve-accessibility-of-suggestions-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve accessibility of address autocomplete feature

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -126,6 +126,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					if ( wrapper ) {
 						wrapper.classList.add( 'autocomplete-available' );
 					}
+					// Add combobox role and ARIA attributes for accessibility
+					addressInput.setAttribute( 'role', 'combobox' );
+					addressInput.setAttribute( 'aria-autocomplete', 'list' );
+					addressInput.setAttribute( 'aria-expanded', 'false' );
+					addressInput.setAttribute( 'aria-haspopup', 'listbox' );
 				}
 				return;
 			}
@@ -816,6 +821,16 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			const countryInput = addressInputs[ type ][ 'country' ];
 			if ( addressInput && countryInput ) {
 				addressInput.addEventListener( 'input', function () {
+					// Unset any active suggestion when user types
+					if ( suggestionsLists[ type ] ) {
+						const activeLi = suggestionsLists[ type ].querySelector( 'li.active' );
+						if ( activeLi ) {
+							activeLi.classList.remove( 'active' );
+							activeLi.setAttribute( 'aria-selected', 'false' );
+						}
+						addressInput.removeAttribute( 'aria-activedescendant' );
+						activeSuggestionIndices[ type ] = -1;
+					}
 					displaySuggestions( this.value, countryInput.value, type );
 				} );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -165,6 +165,9 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			addressInputs[ type ][ 'address_1' ] = document.getElementById(
 				`${ type }_address_1`
 			);
+			addressInputs[ type ][ 'address_2' ] = document.getElementById(
+				`${ type }_address_2`
+			);
 			addressInputs[ type ][ 'city' ] = document.getElementById(
 				`${ type }_city`
 			);
@@ -183,6 +186,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		addressTypes.forEach( ( type ) => {
 			cacheAddressFields( type );
 			const addressInput = addressInputs[ type ][ 'address_1' ];
+			const address2Input = addressInputs[ type ][ 'address_2' ];
 			const cityInput = addressInputs[ type ][ 'city' ];
 			const countryInput = addressInputs[ type ][ 'country' ];
 			const postcodeInput = addressInputs[ type ][ 'postcode' ];
@@ -218,6 +222,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 				addressInputs[ type ] = {};
 				addressInputs[ type ][ 'address_1' ] = addressInput;
+				addressInputs[ type ][ 'address_2' ] = address2Input;
 				addressInputs[ type ][ 'city' ] = cityInput;
 				addressInputs[ type ][ 'country' ] = countryInput;
 				addressInputs[ type ][ 'postcode' ] = postcodeInput;
@@ -738,6 +743,9 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 						addressInputs[ type ][ 'address_2' ],
 						addressData.address_2
 					);
+				} else {
+					// Clear address_2 if not provided in address data
+					setFieldValue( addressInputs[ type ][ 'address_2' ], '' );
 				}
 				if ( addressData.city ) {
 					setFieldValue(

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -191,10 +191,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		addressTypes.forEach( ( type ) => {
 			cacheAddressFields( type );
 			const addressInput = addressInputs[ type ][ 'address_1' ];
-			const address2Input = addressInputs[ type ][ 'address_2' ];
-			const cityInput = addressInputs[ type ][ 'city' ];
 			const countryInput = addressInputs[ type ][ 'country' ];
-			const postcodeInput = addressInputs[ type ][ 'postcode' ];
 
 			if ( addressInput ) {
 				// Create suggestions container if it doesn't exist.
@@ -224,13 +221,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					searchIcon.className = 'address-search-icon';
 					addressInput.parentNode.appendChild( searchIcon );
 				}
-
-				addressInputs[ type ] = {};
-				addressInputs[ type ][ 'address_1' ] = addressInput;
-				addressInputs[ type ][ 'address_2' ] = address2Input;
-				addressInputs[ type ][ 'city' ] = cityInput;
-				addressInputs[ type ][ 'country' ] = countryInput;
-				addressInputs[ type ][ 'postcode' ] = postcodeInput;
 
 				suggestionsContainers[ type ] = document.getElementById(
 					`address_suggestions_${ type }`

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -884,6 +884,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 								type,
 								selectedItem.dataset.id
 							);
+							// Return focus to the address input after selection
+							addressInput.focus();
 						}
 					} else if ( e.key === 'Escape' ) {
 						hideSuggestions( type );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -485,7 +485,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					li.setAttribute( 'aria-label', suggestion.label );
 					li.id = `suggestion-item-${ type }-${ index }`;
 					li.dataset.id = suggestion.id;
-					li.setAttribute( 'tabindex', '-1' );
 
 					li.textContent = ''; // Clear existing content.
 					const labelParts = getHighlightedLabel(

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -296,7 +296,24 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			// This is achieved by removing and re-adding the element to trigger browser updates.
 			const parentElement = input.parentElement;
 			if ( parentElement ) {
+				// Store the current value to preserve it
+				const currentValue = input.value;
+
+				// Mark that we're manipulating the DOM to prevent checkout updates
+				input.setAttribute( 'data-autocomplete-manipulating', 'true' );
+
 				parentElement.appendChild( parentElement.removeChild( input ) );
+
+				// Restore the value if it was lost
+				if ( input.value !== currentValue ) {
+					input.value = currentValue;
+				}
+
+				// Remove the manipulation flag after a brief delay
+				setTimeout( function () {
+					input.removeAttribute( 'data-autocomplete-manipulating' );
+				}, 10 );
+
 				input.focus();
 			}
 		}
@@ -320,7 +337,24 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			// This is achieved by removing and re-adding the element to trigger browser updates.
 			const parentElement = input.parentElement;
 			if ( parentElement ) {
+				// Store the current value to preserve it
+				const currentValue = input.value;
+
+				// Mark that we're manipulating the DOM to prevent checkout updates
+				input.setAttribute( 'data-autocomplete-manipulating', 'true' );
+
 				parentElement.appendChild( parentElement.removeChild( input ) );
+
+				// Restore the value if it was lost
+				if ( input.value !== currentValue ) {
+					input.value = currentValue;
+				}
+
+				// Remove the manipulation flag after a brief delay
+				setTimeout( function () {
+					input.removeAttribute( 'data-autocomplete-manipulating' );
+				}, 10 );
+
 				if ( shouldFocus ) {
 					input.focus();
 				}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -709,6 +709,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				return;
 			}
 
+			// Check if addressInputs exists for this type
+			if ( ! addressInputs[ type ] ) {
+				return;
+			}
+
 			if ( addressData.country ) {
 				setFieldValue(
 					addressInputs[ type ][ 'country' ],
@@ -730,6 +735,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			addressSelectionTimeout = setTimeout( function () {
 				// Cache address fields again as they may have updated following the country change.
 				cacheAddressFields( type );
+
+				// Check if addressInputs exists for this type after re-caching
+				if ( ! addressInputs[ type ] ) {
+					return;
+				}
 
 				// Set all available fields.
 				// Only set fields if the address data property exists and has a value.
@@ -807,6 +817,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 		// Initialize event handlers for each address type.
 		addressTypes.forEach( ( type ) => {
+			// Check if addressInputs exists for this type
+			if ( ! addressInputs[ type ] ) {
+				return;
+			}
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const countryInput = addressInputs[ type ][ 'country' ];
 			if ( addressInput && countryInput ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -584,11 +584,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				suggestionsContainer.style.marginTop =
 					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
 				addressInput.setAttribute( 'aria-expanded', 'true' );
+				suggestionsList.id = `address_suggestions_${ type }_list`;
 				addressInput.setAttribute(
 					'aria-controls',
 					`address_suggestions_${ type }_list`
 				);
-				suggestionsList.id = `address_suggestions_${ type }_list`;
 				// Don't auto-highlight first suggestion for better screen reader accessibility
 				activeSuggestionIndices[ type ] = -1;
 
@@ -758,7 +758,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					);
 				} else {
 					// Clear address_2 if not provided in address data
-					setFieldValue( addressInputs[ type ][ 'address_2' ], '' );
+					const addr2El = addressInputs[ type ][ 'address_2' ];
+					if ( addr2El && addr2El.value ) {
+						setFieldValue( addr2El, '' );
+					}
 				}
 				if ( addressData.city ) {
 					setFieldValue(
@@ -891,7 +894,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 							].querySelector(
 								`li#suggestion-item-${ type }-${ activeSuggestionIndices[ type ] }`
 							);
-							console.log( selectedItem );
 							if (
 								! selectedItem ||
 								! selectedItem.dataset ||

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -891,6 +891,17 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 							].querySelector(
 								`li#suggestion-item-${ type }-${ activeSuggestionIndices[ type ] }`
 							);
+							console.log( selectedItem );
+							if (
+								! selectedItem ||
+								! selectedItem.dataset ||
+								! selectedItem.dataset.id
+							) {
+								// The selected item was invalid, hide suggestions and re-enable autofill.
+								hideSuggestions( type );
+								enableBrowserAutofill( addressInput );
+								return;
+							}
 							// Hide suggestions immediately for better UX.
 							hideSuggestions( type );
 							enableBrowserAutofill( addressInput );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -823,7 +823,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				addressInput.addEventListener( 'input', function () {
 					// Unset any active suggestion when user types
 					if ( suggestionsLists[ type ] ) {
-						const activeLi = suggestionsLists[ type ].querySelector( 'li.active' );
+						const activeLi =
+							suggestionsLists[ type ].querySelector(
+								'li.active'
+							);
 						if ( activeLi ) {
 							activeLi.classList.remove( 'active' );
 							activeLi.setAttribute( 'aria-selected', 'false' );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -482,6 +482,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				safeSuggestions.forEach( ( suggestion, index ) => {
 					const li = document.createElement( 'li' );
 					li.setAttribute( 'role', 'option' );
+					li.setAttribute( 'aria-label', suggestion.label );
 					li.id = `suggestion-item-${ type }-${ index }`;
 					li.dataset.id = suggestion.id;
 					li.setAttribute( 'tabindex', '-1' );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -350,10 +350,14 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					input.value = currentValue;
 				}
 
-				// Remove the manipulation flag after a brief delay
-				setTimeout( function () {
-					input.removeAttribute( 'data-autocomplete-manipulating' );
-				}, 10 );
+				// Remove the manipulation flag after a brief delay. Use two rAFs to ensure layout/assistive tech settle.
+				requestAnimationFrame( function () {
+					requestAnimationFrame( function () {
+						input.removeAttribute(
+							'data-autocomplete-manipulating'
+						);
+					} );
+				} );
 
 				if ( shouldFocus ) {
 					input.focus();
@@ -978,6 +982,16 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					target !== addressInputs[ type ][ 'address_1' ]
 				) {
 					hideSuggestions( type );
+					// Restore native autofill after manual dismissal.
+					if (
+						addressInputs[ type ] &&
+						addressInputs[ type ][ 'address_1' ]
+					) {
+						enableBrowserAutofill(
+							addressInputs[ type ][ 'address_1' ],
+							false
+						);
+					}
 				}
 			} );
 		} );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -147,6 +147,14 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			if ( wrapper ) {
 				wrapper.classList.remove( 'autocomplete-available' );
 			}
+			// Remove all ARIA attributes when no provider is available
+			addressInput.removeAttribute( 'role' );
+			addressInput.removeAttribute( 'aria-autocomplete' );
+			addressInput.removeAttribute( 'aria-expanded' );
+			addressInput.removeAttribute( 'aria-haspopup' );
+			addressInput.removeAttribute( 'aria-activedescendant' );
+			addressInput.removeAttribute( 'aria-owns' );
+			addressInput.removeAttribute( 'aria-controls' );
 		}
 	}
 
@@ -577,7 +585,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
 				addressInput.setAttribute( 'aria-expanded', 'true' );
 				addressInput.setAttribute(
-					'aria-owns',
+					'aria-controls',
 					`address_suggestions_${ type }_list`
 				);
 				suggestionsList.id = `address_suggestions_${ type }_list`;
@@ -643,7 +651,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			suggestionsContainer.style.display = 'none';
 			addressInput.setAttribute( 'aria-expanded', 'false' );
 			addressInput.removeAttribute( 'aria-activedescendant' );
-			addressInput.removeAttribute( 'aria-owns' );
+			addressInput.removeAttribute( 'aria-controls' );
 			activeSuggestionIndices[ type ] = -1;
 
 			// Remove blur event listener when suggestions are hidden

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -200,8 +200,12 @@ jQuery( function ( $ ) {
 		init_checkout: function () {
 			$( document.body ).trigger( 'update_checkout' );
 		},
-		maybe_input_changed: function ( e ) {
-			// Check if this is an address_1 field with an active provider
+		/**
+		 * Check if an address_1 field has an active autocomplete provider and should skip checkout updates
+		 * @param {Event} e - The event object
+		 * @return {boolean} true if updates should be skipped, false otherwise
+		 */
+		should_skip_address_update: function ( e ) {
 			var target = e.target || e.srcElement;
 			if (
 				target &&
@@ -213,7 +217,7 @@ jQuery( function ( $ ) {
 					target.getAttribute( 'data-autocomplete-manipulating' ) ===
 					'true'
 				) {
-					return;
+					return true;
 				}
 
 				var type = target.id.replace( '_address_1', '' );
@@ -227,11 +231,52 @@ jQuery( function ( $ ) {
 					if (
 						window.wc.addressAutocomplete.activeProvider[ type ]
 					) {
-						// Provider is available - don't trigger update on change event
-						// Updates will be handled by blur event instead
-						return;
+						return true;
 					}
 				}
+			}
+			return false;
+		},
+		/**
+		 * Check if an address_1 field has an active autocomplete provider and should trigger checkout updates on blur
+		 * @param {Event} e - The event object
+		 * @return {boolean} true if updates should be triggered, false otherwise
+		 */
+		should_trigger_address_blur_update: function ( e ) {
+			var target = e.target || e.srcElement;
+			if (
+				target &&
+				( target.id === 'billing_address_1' ||
+					target.id === 'shipping_address_1' )
+			) {
+				// Skip if we're manipulating the DOM for autocomplete
+				if (
+					target.getAttribute( 'data-autocomplete-manipulating' ) ===
+					'true'
+				) {
+					return false;
+				}
+
+				var type = target.id.replace( '_address_1', '' );
+
+				// Check if window.wc.addressAutocomplete exists and has an active provider
+				if (
+					window.wc &&
+					window.wc.addressAutocomplete &&
+					window.wc.addressAutocomplete.activeProvider
+				) {
+					if (
+						window.wc.addressAutocomplete.activeProvider[ type ]
+					) {
+						return true;
+					}
+				}
+			}
+			return false;
+		},
+		maybe_input_changed: function ( e ) {
+			if ( wc_checkout_form.should_skip_address_update( e ) ) {
+				return;
 			}
 
 			if ( wc_checkout_form.dirtyInput ) {
@@ -239,75 +284,17 @@ jQuery( function ( $ ) {
 			}
 		},
 		input_changed: function ( e ) {
-			// Check if this is an address_1 field with an active provider
-			var target = e.target || e.srcElement;
-			if (
-				target &&
-				( target.id === 'billing_address_1' ||
-					target.id === 'shipping_address_1' )
-			) {
-				// Skip if we're manipulating the DOM for autocomplete
-				if (
-					target.getAttribute( 'data-autocomplete-manipulating' ) ===
-					'true'
-				) {
-					return;
-				}
-
-				var type = target.id.replace( '_address_1', '' );
-
-				// Check if window.wc.addressAutocomplete exists and has an active provider
-				if (
-					window.wc &&
-					window.wc.addressAutocomplete &&
-					window.wc.addressAutocomplete.activeProvider
-				) {
-					if (
-						window.wc.addressAutocomplete.activeProvider[ type ]
-					) {
-						// Provider is available - don't trigger update on change event
-						// Updates will be handled by blur event instead
-						return;
-					}
-				}
+			if ( wc_checkout_form.should_skip_address_update( e ) ) {
+				return;
 			}
 
 			wc_checkout_form.dirtyInput = e.target;
 			wc_checkout_form.maybe_update_checkout();
 		},
 		address_field_blur: function ( e ) {
-			var target = e.target || e.srcElement;
-
-			// Only trigger update if this is an address_1 field with an active provider
-			if (
-				target &&
-				( target.id === 'billing_address_1' ||
-					target.id === 'shipping_address_1' )
-			) {
-				// Skip if we're manipulating the DOM for autocomplete
-				if (
-					target.getAttribute( 'data-autocomplete-manipulating' ) ===
-					'true'
-				) {
-					return;
-				}
-
-				var type = target.id.replace( '_address_1', '' );
-
-				// Check if window.wc.addressAutocomplete exists and has an active provider
-				if (
-					window.wc &&
-					window.wc.addressAutocomplete &&
-					window.wc.addressAutocomplete.activeProvider
-				) {
-					if (
-						window.wc.addressAutocomplete.activeProvider[ type ]
-					) {
-						// Provider is available - trigger checkout update on blur
-						wc_checkout_form.dirtyInput = target;
-						wc_checkout_form.maybe_update_checkout();
-					}
-				}
+			if ( wc_checkout_form.should_trigger_address_blur_update( e ) ) {
+				wc_checkout_form.dirtyInput = e.target;
+				wc_checkout_form.maybe_update_checkout();
 			}
 		},
 		queue_update_checkout: function ( e ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -209,6 +209,19 @@ jQuery( function ( $ ) {
 				return true;
 			}
 
+			// Check if we're in an address_1 field with active autocomplete suggestions
+			var target = e.target || e.srcElement;
+			if ( target && ( target.id === 'billing_address_1' || target.id === 'shipping_address_1' ) ) {
+				// Check if suggestions are currently visible for this field
+				var type = target.id.replace( '_address_1', '' );
+				var suggestionsContainer = document.getElementById( 'address_suggestions_' + type );
+				
+				if ( suggestionsContainer && suggestionsContainer.style.display !== 'none' ) {
+					// Suggestions are visible - don't queue any updates while typing/navigating
+					return true;
+				}
+			}
+
 			wc_checkout_form.dirtyInput = this;
 			wc_checkout_form.reset_update_checkout_timer();
 			wc_checkout_form.updateTimer = setTimeout(

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -74,6 +74,13 @@ jQuery( function ( $ ) {
 				this.queue_update_checkout
 			);
 
+			// Handle blur on address_1 fields when autocomplete provider is available
+			this.$checkout_form.on(
+				'blur',
+				'#billing_address_1, #shipping_address_1',
+				this.address_field_blur
+			);
+
 			// Address fields
 			this.$checkout_form.on(
 				'change',
@@ -194,13 +201,114 @@ jQuery( function ( $ ) {
 			$( document.body ).trigger( 'update_checkout' );
 		},
 		maybe_input_changed: function ( e ) {
+			// Check if this is an address_1 field with an active provider
+			var target = e.target || e.srcElement;
+			if (
+				target &&
+				( target.id === 'billing_address_1' ||
+					target.id === 'shipping_address_1' )
+			) {
+				// Skip if we're manipulating the DOM for autocomplete
+				if (
+					target.getAttribute( 'data-autocomplete-manipulating' ) ===
+					'true'
+				) {
+					return;
+				}
+
+				var type = target.id.replace( '_address_1', '' );
+
+				// Check if window.wc.addressAutocomplete exists and has an active provider
+				if (
+					window.wc &&
+					window.wc.addressAutocomplete &&
+					window.wc.addressAutocomplete.activeProvider
+				) {
+					if (
+						window.wc.addressAutocomplete.activeProvider[ type ]
+					) {
+						// Provider is available - don't trigger update on change event
+						// Updates will be handled by blur event instead
+						return;
+					}
+				}
+			}
+
 			if ( wc_checkout_form.dirtyInput ) {
 				wc_checkout_form.input_changed( e );
 			}
 		},
 		input_changed: function ( e ) {
+			// Check if this is an address_1 field with an active provider
+			var target = e.target || e.srcElement;
+			if (
+				target &&
+				( target.id === 'billing_address_1' ||
+					target.id === 'shipping_address_1' )
+			) {
+				// Skip if we're manipulating the DOM for autocomplete
+				if (
+					target.getAttribute( 'data-autocomplete-manipulating' ) ===
+					'true'
+				) {
+					return;
+				}
+
+				var type = target.id.replace( '_address_1', '' );
+
+				// Check if window.wc.addressAutocomplete exists and has an active provider
+				if (
+					window.wc &&
+					window.wc.addressAutocomplete &&
+					window.wc.addressAutocomplete.activeProvider
+				) {
+					if (
+						window.wc.addressAutocomplete.activeProvider[ type ]
+					) {
+						// Provider is available - don't trigger update on change event
+						// Updates will be handled by blur event instead
+						return;
+					}
+				}
+			}
+
 			wc_checkout_form.dirtyInput = e.target;
 			wc_checkout_form.maybe_update_checkout();
+		},
+		address_field_blur: function ( e ) {
+			var target = e.target || e.srcElement;
+
+			// Only trigger update if this is an address_1 field with an active provider
+			if (
+				target &&
+				( target.id === 'billing_address_1' ||
+					target.id === 'shipping_address_1' )
+			) {
+				// Skip if we're manipulating the DOM for autocomplete
+				if (
+					target.getAttribute( 'data-autocomplete-manipulating' ) ===
+					'true'
+				) {
+					return;
+				}
+
+				var type = target.id.replace( '_address_1', '' );
+
+				// Check if window.wc.addressAutocomplete exists and has an active provider
+				if (
+					window.wc &&
+					window.wc.addressAutocomplete &&
+					window.wc.addressAutocomplete.activeProvider
+				) {
+					if (
+						window.wc.addressAutocomplete.activeProvider[ type ]
+					) {
+						// Provider is available - trigger checkout update on blur
+						wc_checkout_form.dirtyInput = target;
+						wc_checkout_form.maybe_update_checkout();
+					}
+				}
+			}
 		},
 		queue_update_checkout: function ( e ) {
 			var code = e.keyCode || e.which || 0;
@@ -209,16 +317,29 @@ jQuery( function ( $ ) {
 				return true;
 			}
 
-			// Check if we're in an address_1 field with active autocomplete suggestions
+			// Check if we're in an address_1 field with an active provider
 			var target = e.target || e.srcElement;
-			if ( target && ( target.id === 'billing_address_1' || target.id === 'shipping_address_1' ) ) {
-				// Check if suggestions are currently visible for this field
+			if (
+				target &&
+				( target.id === 'billing_address_1' ||
+					target.id === 'shipping_address_1' )
+			) {
+				// Check if an autocomplete provider is available for this field
 				var type = target.id.replace( '_address_1', '' );
-				var suggestionsContainer = document.getElementById( 'address_suggestions_' + type );
-				
-				if ( suggestionsContainer && suggestionsContainer.style.display !== 'none' ) {
-					// Suggestions are visible - don't queue any updates while typing/navigating
-					return true;
+
+				// Check if window.wc.addressAutocomplete exists and has an active provider
+				if (
+					window.wc &&
+					window.wc.addressAutocomplete &&
+					window.wc.addressAutocomplete.activeProvider
+				) {
+					if (
+						window.wc.addressAutocomplete.activeProvider[ type ]
+					) {
+						// Provider is available - don't queue updates while typing
+						// Updates will be triggered on blur instead
+						return true;
+					}
 				}
 			}
 
@@ -987,11 +1108,11 @@ jQuery( function ( $ ) {
 		clear_coupon_input: function () {
 			const $coupon_field = $( '#coupon_code' );
 			$coupon_field
-				.val('')
-				.removeClass('has-error')
-				.removeAttr('aria-invalid')
-				.removeAttr('aria-describedby')
-				.next('.coupon-error-notice')
+				.val( '' )
+				.removeClass( 'has-error' )
+				.removeAttr( 'aria-invalid' )
+				.removeAttr( 'aria-describedby' )
+				.next( '.coupon-error-notice' )
 				.remove();
 		},
 		submit: function ( evt ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes the following changes:

- Ensures the arrow keys work in Firefox when navigating between suggestions with voiceover active
- Ensures focus is not stolen when navigating between suggestions or typing into the address box
- Ensure address2 is filled if the API returns an entry for it
- Adds some more aria- attributes to the address input
- Prevents pushing changes to the server when suggestions are open - previously all keypresses would cause a request to the server.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5083

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use Jurassic Ninja to run this live branch. Install WooPayments and activate it in test mode.
2. You will need to add this snippet via the code snippets plugin for the feature to be available:
```php
add_filter('woocommerce_admin_features', function( $f ) {
	$f[] = 'experimental-blocks';
	return $f;
}, 10, 1);
```
3. Go to WC -> Settings -> General and activate "Enable Predictive Address Search"
4. Use various browsers to test the functionality of address autocomplete, including using arrow keys to navigate between suggestions and enter key to select them. Note, in Safari, arrow keys do not trigger the `keydown` event. It seems [this is intentional](https://bugs.webkit.org/show_bug.cgi?id=16429).
5. Test with voiceover on and ensure the component is accessible and reads the correct information out during use.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
