### PR TITLE
Add support for contentRef to ExperimentalEmailEditor component

### DIFF
--- a/packages/js/email-editor/changelog/email-editor-content-ref-support
+++ b/packages/js/email-editor/changelog/email-editor-content-ref-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for contentRef property to the experimental editor component

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -45,7 +45,7 @@ function Editor( {
 	postId: number | string;
 	postType: string;
 	isPreview?: boolean;
-	contentRef?: React.RefObject< HTMLDivElement >;
+	contentRef?: React.Ref< HTMLDivElement > | null;
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { settings } = useSelect(
@@ -141,7 +141,7 @@ export function ExperimentalEmailEditor( {
 	postId: string;
 	postType: string;
 	isPreview?: boolean;
-	contentRef?: React.RefObject< HTMLDivElement >;
+	contentRef?: React.Ref< HTMLDivElement > | null;
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { store as editorStore } from '@wordpress/editor';
+import { useMergeRefs } from '@wordpress/compose';
 import '@wordpress/format-library'; // Enables text formatting capabilities
 
 /**
@@ -39,10 +40,12 @@ function Editor( {
 	postId,
 	postType,
 	isPreview = false,
+	contentRef = null,
 }: {
 	postId: number | string;
 	postType: string;
 	isPreview?: boolean;
+	contentRef?: React.RefObject< HTMLDivElement >;
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { settings } = useSelect(
@@ -61,7 +64,8 @@ function Editor( {
 		setIsInitialized( true );
 	}, [ postId, postType, setEmailPost ] );
 
-	const contentRef = useFilterEditorContentStylesheets();
+	const stylesContentRef = useFilterEditorContentStylesheets();
+	const mergedContentRef = useMergeRefs( [ stylesContentRef, contentRef ] );
 
 	if ( ! isInitialized ) {
 		return null;
@@ -80,7 +84,7 @@ function Editor( {
 				postId={ postId }
 				postType={ postType }
 				settings={ editorSettings }
-				contentRef={ contentRef }
+				contentRef={ mergedContentRef }
 			/>
 		</StrictMode>
 	);
@@ -132,10 +136,12 @@ export function ExperimentalEmailEditor( {
 	postId,
 	postType,
 	isPreview = false,
+	contentRef = null,
 }: {
 	postId: string;
 	postType: string;
 	isPreview?: boolean;
+	contentRef?: React.RefObject< HTMLDivElement >;
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 
@@ -169,6 +175,7 @@ export function ExperimentalEmailEditor( {
 			postId={ postId }
 			postType={ postType }
 			isPreview={ isPreview }
+			contentRef={ contentRef }
 		/>
 	);
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the contentRef property to the ExperimentalEditor component, which is meant for usage in a SPA.
This property allows access to the email content element from the outside. This is helpful, for example, for the preview mode, where we can capture clicks and redirect to the editor.

Related to WOOPRD-709.

### How to test the changes in this Pull Request:

- Code review
- Here is a basic example that could be used to test it:
```js
export function EmailEditorWithClickCapture() {
    const contentRef = useRef<HTMLDivElement>(null);

    useEffect(() => {
      const el = contentRef.current;
      if (!el) return;
  
      const handleClick = (event: MouseEvent) => {
        const target = event.target as HTMLElement;
        console.log('Clicked inside email content:', target);
      };
  
      el.addEventListener('click', handleClick);
      return () => el.removeEventListener('click', handleClick);
      }, []);

      return (
        <ExperimentalEmailEditor
          postId="123"
          postType="woo_email"
          contentRef={contentRef}
        />
    );
  }
  ```
