### PR TITLE
Update the email editor PHP package in the Woo core to 1.5.0

### DIFF
--- a/plugins/woocommerce/changelog/bump-email-editor-150
+++ b/plugins/woocommerce/changelog/bump-email-editor-150
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use latest email editor version 1.5.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -48,7 +48,7 @@
 		"pelago/emogrifier": "^8.0",
 		"woocommerce/action-scheduler": "3.9.3",
 		"woocommerce/blueprint": "*",
-		"woocommerce/email-editor": "1.4.2",
+		"woocommerce/email-editor": "1.5.0",
 		"wordpress/abilities-api": "^0.1.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41e229864536946c8f7731eb30d57f2a",
+    "content-hash": "5b72cd066b457917cffd2fce63d3b491",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1486,11 +1486,11 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/php/email-editor",
-                "reference": "ca7559af8b101ec7b56f27b61cf39e7d14b824e7"
+                "reference": "69061b6442bfd146a3f3d66bd1d0c4c66f72c74e"
             },
             "require": {
                 "pelago/emogrifier": "^8.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the email editor package in the WooCommerce plugin. Note: We include the latest code anyway, but we need to do the update for Jetpack autoloader to know the correct version.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

There is no change in the code so seeing automated tests passing should be enough to verify the change didn't break build.
