### PR TITLE
Un-gate address autocomplete feature

### DIFF
--- a/plugins/woocommerce/changelog/remove-experimental-flag-autocomplete
+++ b/plugins/woocommerce/changelog/remove-experimental-flag-autocomplete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add address autocomplete API without feature gate.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -49,58 +49,55 @@ class WC_Settings_General extends WC_Settings_Page {
 			$currency_code_options[ $code ] = $name . ' (' . get_woocommerce_currency_symbol( $code ) . ') — ' . esc_html( $code );
 		}
 
-		$enable_address_autocomplete_setting             = array();
 		$address_autocomplete_preferred_provider_setting = array();
 		$address_autocomplete_setting_desc_tip           = __( 'Suggest full addresses for customer as they type.', 'woocommerce' );
 
-		if ( Features::is_enabled( 'experimental-blocks' ) ) {
-			// This is in a try because getting the class from the container may fail if the class is not available.
-			// If it fails, these settings should not be shown as the feature is not available.
-			try {
-				$address_provider_class         = wc_get_container()->get( AddressProviderController::class );
-				$address_autocomplete_providers = $address_provider_class->get_providers();
-				$address_autocomplete_available = ! empty( $address_autocomplete_providers );
+		// This is in a try because getting the class from the container may fail if the class is not available.
+		// If it fails, these settings should not be shown as the feature is not available.
+		try {
+			$address_provider_class         = wc_get_container()->get( AddressProviderController::class );
+			$address_autocomplete_providers = $address_provider_class->get_providers();
+			$address_autocomplete_available = ! empty( $address_autocomplete_providers );
 
-				if ( ! $address_autocomplete_available ) {
-					// translators: %s: WooPayments URL.
-					$address_autocomplete_setting_desc_tip .= ' ' . sprintf( __( 'To use this feature, you need to install an address provider such as <a href="%s">WooPayments</a>.', 'woocommerce' ), 'https://woocommerce.com/products/woocommerce-payments/' );
-				}
-
-				$enable_address_autocomplete_setting = array(
-					'id'       => 'woocommerce_address_autocomplete_enabled',
-					'desc'     => __( 'Enable predictive address search', 'woocommerce' ),
-					'name'     => __( 'Address autocomplete', 'woocommerce' ),
-					'type'     => 'checkbox',
-					'disabled' => ! $address_autocomplete_available,
-					'desc_tip' => $address_autocomplete_setting_desc_tip,
-					'default'  => 'no',
-				);
-
-				// If no providers are available, make sure the checkbox is unchecked.
-				if ( ! $address_autocomplete_available ) {
-					$enable_address_autocomplete_setting['value'] = false;
-				}
-
-				if ( count( $address_autocomplete_providers ) > 1 ) {
-					$address_provider_options = array();
-					foreach ( $address_autocomplete_providers as $address_provider ) {
-						$address_provider_options[ $address_provider->id ] = $address_provider->name;
-					}
-					$address_autocomplete_preferred_provider_setting = array(
-						'id'      => 'woocommerce_address_autocomplete_provider',
-						'name'    => __( 'Preferred address autocomplete provider', 'woocommerce' ),
-						'type'    => 'select',
-						'class'   => 'wc-enhanced-select',
-						'default' => $address_autocomplete_providers[0]->id ?? '',
-						'options' => $address_provider_options,
-					);
-				}
-			} catch ( \Exception $e ) {
-				// If the class is not available, we don't want to show the setting.
-				wc_get_logger()->log( 'error', 'Error getting address provider class: ' . $e->getMessage() );
-				$enable_address_autocomplete_setting             = array();
-				$address_autocomplete_preferred_provider_setting = array();
+			if ( ! $address_autocomplete_available ) {
+				// translators: %s: WooPayments URL.
+				$address_autocomplete_setting_desc_tip .= ' ' . sprintf( __( 'To use this feature, you need to install an address provider such as <a href="%s">WooPayments</a>.', 'woocommerce' ), 'https://woocommerce.com/products/woocommerce-payments/' );
 			}
+
+			$enable_address_autocomplete_setting = array(
+				'id'       => 'woocommerce_address_autocomplete_enabled',
+				'desc'     => __( 'Enable predictive address search', 'woocommerce' ),
+				'name'     => __( 'Address autocomplete', 'woocommerce' ),
+				'type'     => 'checkbox',
+				'disabled' => ! $address_autocomplete_available,
+				'desc_tip' => $address_autocomplete_setting_desc_tip,
+				'default'  => 'no',
+			);
+
+			// If no providers are available, make sure the checkbox is unchecked.
+			if ( ! $address_autocomplete_available ) {
+				$enable_address_autocomplete_setting['value'] = false;
+			}
+
+			if ( count( $address_autocomplete_providers ) > 1 ) {
+				$address_provider_options = array();
+				foreach ( $address_autocomplete_providers as $address_provider ) {
+					$address_provider_options[ $address_provider->id ] = $address_provider->name;
+				}
+				$address_autocomplete_preferred_provider_setting = array(
+					'id'      => 'woocommerce_address_autocomplete_provider',
+					'name'    => __( 'Preferred address autocomplete provider', 'woocommerce' ),
+					'type'    => 'select',
+					'class'   => 'wc-enhanced-select',
+					'default' => $address_autocomplete_providers[0]->id ?? '',
+					'options' => $address_provider_options,
+				);
+			}
+		} catch ( \Exception $e ) {
+			// If the class is not available, we don't want to show the setting.
+			wc_get_logger()->log( 'error', 'Error getting address provider class: ' . $e->getMessage() );
+			$enable_address_autocomplete_setting             = array();
+			$address_autocomplete_preferred_provider_setting = array();
 		}
 
 		$settings =

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -381,13 +381,11 @@ class WC_Frontend_Scripts {
 			),
 		);
 
-		if ( Features::is_enabled( 'experimental-blocks' ) ) {
-			$scripts['wc-address-autocomplete'] = array(
-				'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
-				'deps'    => array( 'jquery', 'woocommerce', 'wc-dompurify' ),
-				'version' => $version,
-			);
-		}
+		$scripts['wc-address-autocomplete'] = array(
+			'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
+			'deps'    => array( 'jquery', 'woocommerce', 'wc-dompurify' ),
+			'version' => $version,
+		);
 
 		return $scripts;
 	}
@@ -440,14 +438,12 @@ class WC_Frontend_Scripts {
 			),
 		);
 
-		if ( Features::is_enabled( 'experimental-blocks' ) ) {
-			$register_styles['wc-address-autocomplete'] = array(
-				'src'     => self::get_asset_url( 'assets/css/address-autocomplete.css' ),
-				'deps'    => array(),
-				'version' => $version,
-				'has_rtl' => false,
-			);
-		}
+		$register_styles['wc-address-autocomplete'] = array(
+			'src'     => self::get_asset_url( 'assets/css/address-autocomplete.css' ),
+			'deps'    => array(),
+			'version' => $version,
+			'has_rtl' => false,
+		);
 
 		foreach ( $register_styles as $name => $props ) {
 			self::register_style( $name, $props['src'], $props['deps'], $props['version'], 'all', $props['has_rtl'] );
@@ -488,16 +484,16 @@ class WC_Frontend_Scripts {
 		if ( is_checkout() ) {
 			self::enqueue_script( 'wc-checkout' );
 		}
-		if ( is_checkout() && Features::is_enabled( 'experimental-blocks' ) ) {
-			$address_provider_service = wc_get_container()->get( AddressProviderController::class );
-			if ( $address_provider_service && method_exists( $address_provider_service, 'get_providers' ) ) {
-				$registered_providers = $address_provider_service->get_providers();
-				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
-					self::enqueue_script( 'wc-address-autocomplete' );
-					self::enqueue_style( 'wc-address-autocomplete' );
-				}
+
+		$address_provider_service = wc_get_container()->get( AddressProviderController::class );
+		if ( $address_provider_service && method_exists( $address_provider_service, 'get_providers' ) ) {
+			$registered_providers = $address_provider_service->get_providers();
+			if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
+				self::enqueue_script( 'wc-address-autocomplete' );
+				self::enqueue_style( 'wc-address-autocomplete' );
 			}
 		}
+
 		if ( is_add_payment_method_page() ) {
 			self::enqueue_script( 'wc-add-payment-method' );
 		}
@@ -661,23 +657,22 @@ class WC_Frontend_Scripts {
 					/* translators: %s: Order history URL on My Account section */
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
 				);
-				if ( Features::is_enabled( 'experimental-blocks' ) ) {
-					$providers                   = wc_get_container()->get( AddressProviderController::class )->get_providers();
-					$params['address_providers'] = array_map(
-						function ( $provider ) {
-							// Sanitize provider data before sending to frontend.
-							return array(
-								'id'            => sanitize_key( $provider->id ),
-								'name'          => sanitize_text_field( $provider->name ),
-								'branding_html' => wp_kses(
-									trim( (string) ( $provider->branding_html ?? '' ) ),
-									'post'
-								),
-							);
-						},
-						$providers
-					);
-				}
+
+				$providers                   = wc_get_container()->get( AddressProviderController::class )->get_providers();
+				$params['address_providers'] = array_map(
+					function ( $provider ) {
+						// Sanitize provider data before sending to frontend.
+						return array(
+							'id'            => sanitize_key( $provider->id ),
+							'name'          => sanitize_text_field( $provider->name ),
+							'branding_html' => wp_kses(
+								trim( (string) ( $provider->branding_html ?? '' ) ),
+								'post'
+							),
+						);
+					},
+					$providers
+				);
 				break;
 			case 'wc-address-i18n':
 				$params = array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Remove the `experimental-blocks` check from address autocomplete which was being used to block the feature from being visible in production.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Payments and activate test mode.
2. Visit the shortcode checkout and enter an address into the "address 1" field - ensure autocomplete works and you can select addresses and they update the rest of the form correctly.
3. Test separate address completions for shipping and billing.
4. Complete the order and verify the correct address was saved to the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
