### PR TITLE
Featured Product block: convert to inner blocks

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -95,16 +95,9 @@
 		"previewProduct": {
 			"type": "object",
 			"default": null
-		},
-		"showDesc": {
-			"type": "boolean",
-			"default": true
-		},
-		"showPrice": {
-			"type": "boolean",
-			"default": true
 		}
 	},
+	"hasInnerBlocks": true,
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -30,6 +30,13 @@
 		},
 		"multiple": true
 	},
+	"allowedBlocks": [
+		"core/post-title",
+		"core/buttons",
+		"core/heading",
+		"woocommerce/product-price",
+		"woocommerce/product-summary"
+	],
 	"attributes": {
 		"alt": {
 			"type": "string",
@@ -95,9 +102,19 @@
 		"previewProduct": {
 			"type": "object",
 			"default": null
+		},
+		"showDesc": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPrice": {
+			"type": "boolean",
+			"default": true
+		},
+		"__woocommerceBlockVersion": {
+			"type": "number"
 		}
 	},
-	"hasInnerBlocks": true,
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -12,7 +12,7 @@ import metadata from './block.json';
 interface BlockAttributes {
 	showDesc?: boolean;
 	showPrice?: boolean;
-	[ key: string ]: any;
+	[ key: string ]: unknown;
 }
 
 // Version 1: Migration from legacy showDesc/showPrice attributes to inner blocks
@@ -45,7 +45,7 @@ const v1 = {
 				level: 2,
 				isLink: false,
 				__woocommerceNamespace:
-					'woocommerce/product-query/product-title',
+					'woocommerce/product-collection/product-title',
 			} )
 		);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance, createBlock } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+interface BlockAttributes {
+	showDesc?: boolean;
+	showPrice?: boolean;
+	[ key: string ]: any;
+}
+
+// Version 1: Migration from legacy showDesc/showPrice attributes to inner blocks
+const v1 = {
+	attributes: {
+		...metadata.attributes,
+		showDesc: {
+			type: 'boolean',
+			default: true,
+		},
+		showPrice: {
+			type: 'boolean',
+			default: true,
+		},
+	},
+	save: () => <InnerBlocks.Content />,
+	isEligible: ( attributes: BlockAttributes ) => {
+		// If the block has showDesc or showPrice attributes as boolean values, it's a legacy block
+		// and it should be migrated to use inner blocks instead.
+		return (
+			typeof attributes.showDesc === 'boolean' ||
+			typeof attributes.showPrice === 'boolean'
+		);
+	},
+	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
+		const { showDesc, showPrice, ...otherAttributes } = attributes;
+
+		innerBlocks.unshift(
+			createBlock( 'core/post-title', {
+				level: 2,
+				isLink: false,
+				__woocommerceNamespace:
+					'woocommerce/product-query/product-title',
+			} )
+		);
+
+		if ( showPrice ) {
+			innerBlocks.push( createBlock( 'woocommerce/product-price' ) );
+		}
+
+		if ( showDesc ) {
+			innerBlocks.push(
+				createBlock( 'woocommerce/product-summary', {
+					showDescriptionIfEmpty: true,
+					summaryLength: 80,
+				} )
+			);
+		}
+
+		return [ otherAttributes, innerBlocks ];
+	},
+};
+
+export default [ v1 ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -58,6 +58,7 @@ const v1 = {
 				createBlock( 'woocommerce/product-summary', {
 					showDescriptionIfEmpty: true,
 					summaryLength: 80,
+					textAlign: 'center',
 				} )
 			);
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -30,12 +30,9 @@ const v1 = {
 	},
 	save: () => <InnerBlocks.Content />,
 	isEligible: ( attributes: BlockAttributes ) => {
-		// If the block has showDesc or showPrice attributes as boolean values, it's a legacy block
-		// and it should be migrated to use inner blocks instead.
-		return (
-			typeof attributes.showDesc === 'boolean' ||
-			typeof attributes.showPrice === 'boolean'
-		);
+		// If the block has showDesc or showPrice attributes are not explicitly set to false,
+		// it's a legacy block and it should be migrated to use inner blocks instead.
+		return attributes.showDesc !== false || attributes.showPrice !== false;
 	},
 	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
 		const { showDesc, showPrice, ...otherAttributes } = attributes;
@@ -44,16 +41,19 @@ const v1 = {
 			createBlock( 'core/post-title', {
 				level: 2,
 				isLink: false,
+				textAlign: 'center',
 				__woocommerceNamespace:
 					'woocommerce/product-collection/product-title',
 			} )
 		);
 
-		if ( showPrice ) {
+		// We check if these legacy attributes are explicitly set to false, because
+		// the default value is true (i.e. `undefined` meant `true`).
+		if ( showPrice !== false ) {
 			innerBlocks.push( createBlock( 'woocommerce/product-price' ) );
 		}
 
-		if ( showDesc ) {
+		if ( showDesc !== false ) {
 			innerBlocks.push(
 				createBlock( 'woocommerce/product-summary', {
 					showDescriptionIfEmpty: true,
@@ -67,7 +67,15 @@ const v1 = {
 			);
 		}
 
-		return [ otherAttributes, innerBlocks ];
+		return [
+			{
+				...otherAttributes,
+				showDesc: false,
+				showPrice: false,
+				__woocommerceBlockVersion: 2,
+			},
+			innerBlocks,
+		];
 	},
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -37,24 +37,8 @@ const v1 = {
 	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
 		const { showDesc, showPrice, ...otherAttributes } = attributes;
 
-		innerBlocks.unshift(
-			createBlock( 'core/post-title', {
-				level: 2,
-				isLink: false,
-				textAlign: 'center',
-				__woocommerceNamespace:
-					'woocommerce/product-collection/product-title',
-			} )
-		);
-
-		// We check if these legacy attributes are explicitly set to false, because
-		// the default value is true (i.e. `undefined` meant `true`).
-		if ( showPrice !== false ) {
-			innerBlocks.push( createBlock( 'woocommerce/product-price' ) );
-		}
-
 		if ( showDesc !== false ) {
-			innerBlocks.push(
+			innerBlocks.unshift(
 				createBlock( 'woocommerce/product-summary', {
 					showDescriptionIfEmpty: true,
 					summaryLength: 80,
@@ -66,6 +50,26 @@ const v1 = {
 				} )
 			);
 		}
+
+		// We check if these legacy attributes are explicitly set to false, because
+		// the default value is true (i.e. `undefined` meant `true`).
+		if ( showPrice !== false ) {
+			innerBlocks.unshift(
+				createBlock( 'woocommerce/product-price', {
+					textAlign: 'center',
+				} )
+			);
+		}
+
+		innerBlocks.unshift(
+			createBlock( 'core/post-title', {
+				level: 2,
+				isLink: false,
+				textAlign: 'center',
+				__woocommerceNamespace:
+					'woocommerce/product-collection/product-title',
+			} )
+		);
 
 		return [
 			{

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -58,7 +58,11 @@ const v1 = {
 				createBlock( 'woocommerce/product-summary', {
 					showDescriptionIfEmpty: true,
 					summaryLength: 80,
-					textAlign: 'center',
+					style: {
+						typography: {
+							textAlign: 'center',
+						},
+					},
 				} )
 			);
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/index.tsx
@@ -11,9 +11,11 @@ import './editor.scss';
 import Block from './block';
 import { register } from '../register';
 import { example } from './example';
+import deprecated from './deprecated';
 import metadata from './block.json';
 
 register( Block, example, metadata, {
+	deprecated,
 	icon: {
 		src: (
 			<Icon

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -304,7 +304,6 @@ export const withInspectorControls =
 			mediaSrc,
 			overlayColor,
 			overlayGradient,
-			showDesc,
 			backgroundColor,
 			style,
 		} = attributes;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -48,7 +48,6 @@ interface InspectorControlsRequiredAttributes
 	> {
 	alt: string;
 	backgroundImageSrc: string;
-	contentPanel: JSX.Element | undefined;
 }
 
 interface InspectorControlsProps extends InspectorControlsRequiredAttributes {
@@ -88,7 +87,6 @@ type WithInspectorControlsProps< T extends EditorBlock< T > > =
 export const InspectorControls = ( {
 	alt,
 	backgroundImageSrc,
-	contentPanel,
 	dimRatio,
 	focalPoint,
 	hasParallax,
@@ -333,7 +331,6 @@ export const withInspectorControls =
 				<InspectorControls
 					alt={ alt }
 					backgroundImageSrc={ backgroundImageSrc }
-					contentPanel={ undefined }
 					dimRatio={ dimRatio }
 					focalPoint={ focalPoint }
 					hasParallax={ hasParallax }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -79,7 +79,6 @@ interface WithInspectorControlsProductProps< T >
 	extends WithInspectorControlsRequiredProps< T > {
 	category: never;
 	product: ProductResponseItem;
-	showPrice: boolean;
 }
 
 type WithInspectorControlsProps< T extends EditorBlock< T > > =
@@ -307,6 +306,7 @@ export const withInspectorControls =
 			mediaSrc,
 			overlayColor,
 			overlayGradient,
+			showDesc,
 			backgroundColor,
 			style,
 		} = attributes;
@@ -321,19 +321,6 @@ export const withInspectorControls =
 			customGradientAttribute: 'overlayGradient',
 		} );
 
-		const contentPanel =
-			name === BLOCK_NAMES.featuredProduct ? (
-				<ToggleControl
-					label={ __( 'Show price', 'woocommerce' ) }
-					checked={ showPrice }
-					onChange={ () =>
-						setAttributes( {
-							showPrice: ! showPrice,
-						} )
-					}
-				/>
-			) : undefined;
-
 		const { backgroundImageSrc } = useBackgroundImage( {
 			item,
 			mediaId,
@@ -346,7 +333,7 @@ export const withInspectorControls =
 				<InspectorControls
 					alt={ alt }
 					backgroundImageSrc={ backgroundImageSrc }
-					contentPanel={ contentPanel }
+					contentPanel={ undefined }
 					dimRatio={ dimRatio }
 					focalPoint={ focalPoint }
 					hasParallax={ hasParallax }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -235,6 +235,8 @@ export const withFeaturedItem =
 									'core/post-title',
 									'core/buttons',
 									'core/heading',
+									'woocommerce/product-price',
+									'woocommerce/product-summary',
 								] }
 								template={ [
 									[
@@ -245,6 +247,17 @@ export const withFeaturedItem =
 											textAlign: 'center',
 											__woocommerceNamespace:
 												PRODUCT_TITLE_VARIATION_NAME,
+										},
+									],
+									[
+										'woocommerce/product-price',
+										{ textAlign: 'center' },
+									],
+									[
+										'woocommerce/product-summary',
+										{
+											showDescriptionIfEmpty: true,
+											summaryLength: 80,
 										},
 									],
 									[
@@ -278,7 +291,10 @@ export const withFeaturedItem =
 
 			return (
 				<BlockContextProvider
-					value={ { termId: category.term_id, termTaxonomy: 'product_cat' } }
+					value={ {
+						termId: category.term_id,
+						termTaxonomy: 'product_cat',
+					} }
 				>
 					<div className={ `${ className }__inner-blocks` }>
 						<InnerBlocks
@@ -446,14 +462,6 @@ export const withFeaturedItem =
 									className={ `${ className }__variation` }
 									dangerouslySetInnerHTML={ {
 										__html: product.variation,
-									} }
-								/>
-							) }
-							{ showPrice && (
-								<div
-									className={ `${ className }__price` }
-									dangerouslySetInnerHTML={ {
-										__html: product.price_html,
 									} }
 								/>
 							) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -40,8 +40,6 @@ import {
 	getClassPrefixFromName,
 } from './utils';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { VARIATION_NAME as PRODUCT_TITLE_VARIATION_NAME } from '../product-collection/variations/elements/product-title';
 
 interface WithFeaturedItemConfig extends GenericBlockUIConfig {
@@ -257,8 +255,12 @@ export const withFeaturedItem =
 										'woocommerce/product-summary',
 										{
 											showDescriptionIfEmpty: true,
+											style: {
+												typography: {
+													textAlign: 'center',
+												},
+											},
 											summaryLength: 80,
-											textAlign: 'center',
 										},
 									],
 									[
@@ -364,8 +366,6 @@ export const withFeaturedItem =
 				minHeight,
 				overlayColor,
 				overlayGradient,
-				showDesc,
-				showPrice,
 				style,
 				textColor,
 			} = attributes;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -159,6 +159,8 @@ export const withFeaturedItem =
 		// set the default value in the block.json.
 		useEffect( () => {
 			setAttributes( {
+				showDesc: false,
+				showPrice: false,
 				__woocommerceBlockVersion: 2,
 			} );
 		}, [ setAttributes ] );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -69,6 +69,7 @@ export interface FeaturedItemRequiredAttributes {
 		isBackgroundVisible: boolean;
 		message?: string | null;
 	};
+	__woocommerceBlockVersion: number;
 }
 
 interface FeaturedCategoryRequiredAttributes
@@ -153,6 +154,15 @@ export const withFeaturedItem =
 		const [ parentContainerDimension, setParentContainerDimension ] =
 			useState< BgImageDimensions >( { height: 0, width: 0 } );
 
+		// We need to manually set this property to make sure we can reliably
+		// distinguish between legacy and new block versions. We can't just
+		// set the default value in the block.json.
+		useEffect( () => {
+			setAttributes( {
+				__woocommerceBlockVersion: 2,
+			} );
+		}, [ setAttributes ] );
+
 		useEffect( () => {
 			// Observes the resizable block's dimension changes.
 			const observer = new ResizeObserver( ( entries ) => {
@@ -229,13 +239,6 @@ export const withFeaturedItem =
 					>
 						<div className={ `${ className }__inner-blocks` }>
 							<InnerBlocks
-								allowedBlocks={ [
-									'core/post-title',
-									'core/buttons',
-									'core/heading',
-									'woocommerce/product-price',
-									'woocommerce/product-summary',
-								] }
 								template={ [
 									[
 										'core/post-title',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -239,60 +239,65 @@ export const withFeaturedItem =
 					<BlockContextProvider
 						value={ { postId: product.id, postType: 'product' } }
 					>
-						<div className={ `${ className }__inner-blocks` }>
-							<InnerBlocks
-								template={ [
-									[
-										'core/post-title',
-										{
-											isLink: true,
-											level: 2,
-											textAlign: 'center',
-											__woocommerceNamespace:
-												PRODUCT_TITLE_VARIATION_NAME,
-										},
-									],
-									[
-										'woocommerce/product-price',
-										{ textAlign: 'center' },
-									],
-									[
-										'woocommerce/product-summary',
-										{
-											showDescriptionIfEmpty: true,
-											style: {
-												typography: {
-													textAlign: 'center',
-												},
-											},
-											summaryLength: 80,
-										},
-									],
-									[
-										'core/buttons',
-										{
-											layout: {
-												type: 'flex',
-												justifyContent: 'center',
-											},
-										},
+						<ProductDataContextProvider
+							product={ product }
+							isLoading={ isLoading }
+						>
+							<div className={ `${ className }__inner-blocks` }>
+								<InnerBlocks
+									template={ [
 										[
-											[
-												'core/button',
-												{
-													text: __(
-														'Shop now',
-														'woocommerce'
-													),
-													url: product.permalink,
+											'core/post-title',
+											{
+												isLink: true,
+												level: 2,
+												textAlign: 'center',
+												__woocommerceNamespace:
+													PRODUCT_TITLE_VARIATION_NAME,
+											},
+										],
+										[
+											'woocommerce/product-price',
+											{ textAlign: 'center' },
+										],
+										[
+											'woocommerce/product-summary',
+											{
+												showDescriptionIfEmpty: true,
+												style: {
+													typography: {
+														textAlign: 'center',
+													},
 												},
+												summaryLength: 80,
+											},
+										],
+										[
+											'core/buttons',
+											{
+												layout: {
+													type: 'flex',
+													justifyContent: 'center',
+												},
+											},
+											[
+												[
+													'core/button',
+													{
+														text: __(
+															'Shop now',
+															'woocommerce'
+														),
+														url: product.permalink,
+													},
+												],
 											],
 										],
-									],
-								] }
-								templateLock={ false }
-							/>
-						</div>
+									] }
+									templateLock={ false }
+								/>
+							</div>
+						</ProductDataContextProvider>
 					</BlockContextProvider>
 				);
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -258,6 +258,7 @@ export const withFeaturedItem =
 										{
 											showDescriptionIfEmpty: true,
 											summaryLength: 80,
+											textAlign: 'center',
 										},
 									],
 									[

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
@@ -82,7 +82,7 @@ const LayoutEditor = ( {
 				</InspectorControls>
 				<div className={ baseClassName }>
 					<BlockContextProvider
-						value={ { postId: 65, postType: 'product' } }
+						value={ { postId: product?.id, postType: 'product' } }
 					>
 						<InnerBlocks
 							template={ DEFAULT_INNER_BLOCKS }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
@@ -113,20 +113,20 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 
 			if ( $block_name === $block['blockName'] ) {
 				array_pop( $this->featured_item_inner_blocks_names );
-				
-				// Handle core blocks that need global post manipulation
+
+				// Handle core blocks that need global post manipulation.
 				if ( 'core/post-excerpt' === $block_name || 'core/post-title' === $block_name ) {
 					global $post;
 					$post = get_post( $this->featured_item_id );
-					
+
 					if ( $post instanceof \WP_Post ) {
 						setup_postdata( $post );
 					}
 				}
-				
-				$context['postId'] = $this->featured_item_id;
+
+				$context['postId']   = $this->featured_item_id;
 				$context['postType'] = 'product';
-				$this->current_item = wc_get_product( $this->featured_item_id );
+				$this->current_item  = wc_get_product( $this->featured_item_id );
 			}
 		}
 	}
@@ -141,23 +141,23 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 	 * @return array Updated block context.
 	 */
 	public function update_context( $context, $parsed_block, $parent_block ) {
-		// Check if this is a featured item block and extract all inner block names
+		// Check if this is a featured item block and extract all inner block names.
 		if ( ( 'woocommerce/featured-product' === $parsed_block['blockName'] || 'woocommerce/featured-category' === $parsed_block['blockName'] )
 			&& isset( $parsed_block['attrs'] ) ) {
-				
+
 			$item = $this->get_item( $parsed_block['attrs'] );
 			if ( $item instanceof \WC_Product ) {
 				$this->featured_item_id = $item->get_id();
-				
+
 				$this->featured_item_inner_blocks_names = array_reverse(
 					$this->extract_featured_item_inner_block_names( $parsed_block )
 				);
 			}
 		}
 
-		// Replace post context for featured item inner blocks
+		// Replace post context for featured item inner blocks.
 		$this->replace_post_for_featured_item_inner_block( $parsed_block, $context );
-		
+
 		return $context;
 	}
 
@@ -174,7 +174,7 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 		if ( $this->current_item ) {
 			wp_reset_postdata();
 		}
-		
+
 		return $block_content;
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
@@ -255,12 +255,13 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 			}
 		}
 
+		// Render additional attributes (e.g. description/price) for legacy compatibility.
+		$output .= $this->render_attributes( $item, $attributes );
+
 		if ( ! empty( $content ) ) {
 			$output .= sprintf( '<div class="wc-block-%s__inner-blocks">%s</div>', $this->block_name, $content );
 		}
 
-		// Render additional attributes (e.g. description/price) for legacy compatibility.
-		$output .= $this->render_attributes( $item, $attributes );
 		$output .= '</div>';
 		$output .= '</div>';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -71,37 +71,39 @@ class FeaturedProduct extends FeaturedItem {
 	 * @return string
 	 */
 	protected function render_attributes( $product, $attributes ) {
-		$desc_str = sprintf(
-			'<div class="wc-block-featured-product__description">%s</div>',
-			wc_format_content( wp_kses_post( $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ) )
-		);
-
-		$price_str = sprintf(
-			'<div class="wc-block-featured-product__price">%s</div>',
-			wp_kses_post( $product->get_price_html() )
-		);
-
-		// Legacy title for backward compatibility when no inner title blocks exist.
-		$legacy_title = sprintf(
-			'<h2 class="wc-block-featured-product__title">%s</h2>',
-			wp_kses_post( $product->get_title() )
-		);
-		if ( $product->is_type( ProductType::VARIATION ) ) {
-			$legacy_title .= sprintf(
-				'<h3 class="wc-block-featured-product__variation">%s</h3>',
-				wp_kses_post( wc_get_formatted_variation( $product, true, true, false ) )
-			);
-		}
-
 		$output = '';
-		if ( ! empty( $attributes['useLegacyTitle'] ) ) {
+
+		// Backwards compatibility: Only render legacy attributes if they exist as boolean values
+		// This allows us to distinguish between old blocks (with boolean props) and new blocks (without these props)
+		if ( array_key_exists( 'showDesc', $attributes ) && is_bool( $attributes['showDesc'] ) ) {
+			$legacy_title = sprintf(
+				'<h2 class="wc-block-featured-product__title">%s</h2>',
+				wp_kses_post( $product->get_title() )
+			);
+			if ( $product->is_type( ProductType::VARIATION ) ) {
+				$legacy_title .= sprintf(
+					'<h3 class="wc-block-featured-product__variation">%s</h3>',
+					wp_kses_post( wc_get_formatted_variation( $product, true, true, false ) )
+				);
+			}
+
 			$output .= $legacy_title;
-		}
-		if ( $attributes['showDesc'] ) {
-			$output .= $desc_str;
-		}
-		if ( $attributes['showPrice'] ) {
-			$output .= $price_str;
+
+			if ( $attributes['showDesc'] ) {
+				$desc_str = sprintf(
+					'<div class="wc-block-featured-product__description">%s</div>',
+					wc_format_content( wp_kses_post( $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ) )
+				);
+				$output .= $desc_str;
+			}
+
+			if ( $attributes['showPrice'] ) {
+				$price_str = sprintf(
+					'<div class="wc-block-featured-product__price">%s</div>',
+					wp_kses_post( $product->get_price_html() )
+				);
+				$output .= $price_str;
+			}
 		}
 
 		return $output;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -73,8 +73,8 @@ class FeaturedProduct extends FeaturedItem {
 	protected function render_attributes( $product, $attributes ) {
 		$output = '';
 
-		// Backwards compatibility: Only render legacy attributes if they exist as boolean values
-		// This allows us to distinguish between old blocks (with boolean props) and new blocks (without these props)
+		// Backwards compatibility: Only render legacy attributes if they exist as boolean values.
+		// This allows us to distinguish between old blocks (with boolean props) and new blocks (without these props).
 		if ( array_key_exists( 'showDesc', $attributes ) && is_bool( $attributes['showDesc'] ) ) {
 			$legacy_title = sprintf(
 				'<h2 class="wc-block-featured-product__title">%s</h2>',
@@ -94,7 +94,7 @@ class FeaturedProduct extends FeaturedItem {
 					'<div class="wc-block-featured-product__description">%s</div>',
 					wc_format_content( wp_kses_post( $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ) )
 				);
-				$output .= $desc_str;
+				$output   .= $desc_str;
 			}
 
 			if ( $attributes['showPrice'] ) {
@@ -102,7 +102,7 @@ class FeaturedProduct extends FeaturedItem {
 					'<div class="wc-block-featured-product__price">%s</div>',
 					wp_kses_post( $product->get_price_html() )
 				);
-				$output .= $price_str;
+				$output   .= $price_str;
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -73,9 +73,7 @@ class FeaturedProduct extends FeaturedItem {
 	protected function render_attributes( $product, $attributes ) {
 		$output = '';
 
-		// Backwards compatibility: Only render legacy attributes if they exist as boolean values.
-		// This allows us to distinguish between old blocks (with boolean props) and new blocks (without these props).
-		if ( array_key_exists( 'showDesc', $attributes ) && is_bool( $attributes['showDesc'] ) ) {
+		if ( ! isset( $attributes['__woocommerceBlockVersion'] ) ) {
 			$legacy_title = sprintf(
 				'<h2 class="wc-block-featured-product__title">%s</h2>',
 				wp_kses_post( $product->get_title() )
@@ -89,7 +87,10 @@ class FeaturedProduct extends FeaturedItem {
 
 			$output .= $legacy_title;
 
-			if ( $attributes['showDesc'] ) {
+			if (
+				! isset( $attributes['showDesc'] ) ||
+				( isset( $attributes['showDesc'] ) && false !== $attributes['showDesc'] )
+			) {
 				$desc_str = sprintf(
 					'<div class="wc-block-featured-product__description">%s</div>',
 					wc_format_content( wp_kses_post( $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ) )
@@ -97,7 +98,10 @@ class FeaturedProduct extends FeaturedItem {
 				$output   .= $desc_str;
 			}
 
-			if ( $attributes['showPrice'] ) {
+			if (
+				! isset( $attributes['showPrice'] ) ||
+				( isset( $attributes['showPrice'] ) && false !== $attributes['showPrice'] )
+			) {
 				$price_str = sprintf(
 					'<div class="wc-block-featured-product__price">%s</div>',
 					wp_kses_post( $product->get_price_html() )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -63,12 +63,6 @@ class ProductPrice extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( ! empty( $content ) ) {
-			parent::register_block_type_assets();
-			$this->register_chunk_translations( [ $this->block_name ] );
-			return $content;
-		}
-
 		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
 		$product = wc_get_product( $post_id );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSummary.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSummary.php
@@ -192,12 +192,6 @@ class ProductSummary extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( ! empty( $content ) ) {
-			parent::register_block_type_assets();
-			$this->register_chunk_translations( [ $this->block_name ] );
-			return $content;
-		}
-
 		$post_id = $block->context['postId'] ?? '';
 		$product = wc_get_product( $post_id );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is part of https://github.com/woocommerce/woocommerce/pull/60779 (see base). The Featured Category and Featured Product block share a significant amount of code, so they needed to be addressed simultaneously. For this reason, I chose to split up the base PR into three:

1. A PR blockifying the Featured Product (This).
2. A PR blockifying the Featured Category.
3. A main PR (#60779) unifying these changes.

In this PR, the inner components of the Featured Product block are transformed to Inner Blocks, using variations of core blocks. We still need to ensure backwards compatibility, however.

This PR:

1. Removes the toggles in the inspector controls to enable the display of description and price.
2. Moves all the internal components (title, description and price) to inner blocks equivalents.
3. Makes sure the old block still renders correctly in the front-end.
4. Makes sure the old block migrates automatically to inner blocks when a page is accessed through the editor.

Closes #60858.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="712" height="551" alt="Screenshot 2025-09-10 at 18 20 14" src="https://github.com/user-attachments/assets/e57f5ae5-38a1-4701-b9d4-9b3955c2bb12" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Clean version

1. Open a page, add the “Featured Product” block.
2. Select a product.
3. Verify that the block is added and contains:
   a. The correct Product Title,
   b. The correct Product Summary,
   c. The correct Product Price,
   d. A call to action in the form of core buttons.
4. Play around with the settings, layout and positions of all the inner blocks (including removing them).
5. Save and verify it works on the front-end.

#### Front-end Backwards compatibility

1. Checkout `trunk` and add an old “Featured Product” block to a page.
2. Checkout this branch without going to the editor.
3. Load the page containing this block on the front-end.
4. Verify that the block still is rendered correctly on the front-end, respecting the settings of the legacy block.

#### Migration

1. After the steps above, go to the editor.
2. Verify that the legacy block has been migrated to the inner blocks, respecting all the settings (i.e. if “show description” was toggled off, there should not be a description block).
3. Save and verify it works on the front-end.

#### Known issues

1. While creating this PR, I noticed that the Product Title block (as variation of `core/post-title`) doesn't correctly get context from variable products. This can be seen by selecting a product variation in the Single Product block, and see that it didn't work.

More context in this issue: https://github.com/woocommerce/woocommerce/issues/60860

2. Please focus on the code changes on this PR, some CI issues (like failing linting) are due to the changes introduced in the base PR, and are going to be addressed there once the two secondary PRs are merged into that.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry will be part of the main PR.

</details>
