### PR TITLE
Redirect to the current URL when adding a product to cart using the Add to Cart + Options block in legacy mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-60773-add-to-cart-with-options-action-current-page
+++ b/plugins/woocommerce/changelog/fix-60773-add-to-cart-with-options-action-current-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Redirect to the current URL when adding a product to cart using the Add to Cart + Options block in legacy mode

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -481,6 +481,8 @@ class AddToCartWithOptions extends AbstractBlock {
 			$form_attributes         = '';
 			$legacy_mode             = $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add;
 			if ( $legacy_mode ) {
+				$action_url = home_url( add_query_arg( null, null ) );
+
 				// If an extension is hoooking into the form or we need to redirect to the cart,
 				// we fall back to a regular HTML form.
 				$form_attributes = array(
@@ -489,10 +491,10 @@ class AddToCartWithOptions extends AbstractBlock {
 						 * Filter the add to cart form action.
 						 *
 						 * @since 10.0.0
-						 * @param string $permalink The product permalink.
-						 * @return string The add to cart form action.
+						 * @param string $action_url The add to cart form action URL, defaulting to the current page.
+						 * @return string The add to cart form action URL.
 						 */
-						apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() )
+						apply_filters( 'woocommerce_add_to_cart_form_action', $action_url )
 					),
 					'method'  => 'post',
 					'enctype' => 'multipart/form-data',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -87,7 +87,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	 * Outputs an example URL to test the form action.
 	 */
 	public function hook_into_woocommerce_add_to_cart_form_action_filter() {
-		echo 'https://example.com';
+		return 'https://example.com';
 	}
 
 	/**
@@ -241,6 +241,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	 * @covers AddToCartWithOptions::render
 	 */
 	public function test_form_fallback() {
+		add_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'hook_into_woocommerce_add_to_cart_form_action_filter' ) );
 		global $product;
 		$product = new \WC_Product_Simple();
 		$product->set_regular_price( 10 );
@@ -250,18 +251,17 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'action="https://example.com"', $markup, 'The form has an action that redirects to the product page when redirect after add is enabled.' );
+		$this->assertStringContainsString( 'action="https://example.com"', $markup, 'The form has an action that redirects to the page defined by the woocommerce_add_to_cart_form_action filter.' );
 		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when redirect after add is enabled.' );
 
 		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringNotContainsString( 'action="https://example.com"', $markup, 'The form doesn\'t have an action that redirects to the product page when redirect after add is disabled.' );
+		$this->assertStringNotContainsString( 'action="https://example.com"', $markup, 'The form doesn\'t have an action that redirects to the page defined by the woocommerce_add_to_cart_form_action filter when redirect after add is disabled.' );
 		$this->assertStringContainsString( 'data-wp-on--submit', $markup, 'The form has an on submit event when redirect after add is disabled.' );
 
 		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
-		add_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'hook_into_woocommerce_add_to_cart_form_action_filter' ) );
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -82,6 +82,15 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hook into the woocommerce_add_to_cart_form_action filter.
+	 *
+	 * Outputs an example URL to test the form action.
+	 */
+	public function hook_into_woocommerce_add_to_cart_form_action_filter() {
+		echo 'https://example.com';
+	}
+
+	/**
 	 * Tests that the correct content is rendered for each product type.
 	 */
 	public function test_product_type_add_to_cart_render() {
@@ -241,24 +250,26 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form has an action that redirects to the product page when redirect after add is enabled.' );
+		$this->assertStringContainsString( 'action="https://example.com"', $markup, 'The form has an action that redirects to the product page when redirect after add is enabled.' );
 		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when redirect after add is enabled.' );
 
 		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringNotContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form doesn\'t have an action that redirects to the product page when redirect after add is disabled.' );
+		$this->assertStringNotContainsString( 'action="https://example.com"', $markup, 'The form doesn\'t have an action that redirects to the product page when redirect after add is disabled.' );
 		$this->assertStringContainsString( 'data-wp-on--submit', $markup, 'The form has an on submit event when redirect after add is disabled.' );
 
 		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
+		add_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'hook_into_woocommerce_add_to_cart_form_action_filter' ) );
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form has an action that redirects to the product page when an extension hooks into the form.' );
+		$this->assertStringContainsString( 'action="https://example.com"', $markup, 'The form has an action that redirects to the page defined by the woocommerce_add_to_cart_form_action filter.' );
 		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when an extension hooks into the form.' );
 
 		remove_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
+		remove_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'hook_into_woocommerce_add_to_cart_form_action_filter' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As mentioned in https://github.com/woocommerce/woocommerce/issues/60773#issuecomment-3274162837, the _Add to Cart + Options_ block was redirecting to the product page when adding to cart in 'legacy mode' (aka, when an extension is modifying the form). This PR updates it so it keeps the shopper in the current URL, this is more similar to the iAPI-powered mode and to the non-blockified _Add to Cart with Options_ block.

### How to test the changes in this Pull Request:

1. Install an extension that hooks into the Add-to-Cart form. For example, [Product Add-Ons](https://woocommerce.com/products/product-add-ons/).
2. Edit a product and add an add-on to it.
3. Create a new post.
4. Add the _Product_ block, select the product you edited in step 2, and update to the blockified _Add to Cart + Options_ block.
5. In the frontend of that post, add the product to your cart.
6. Verify the page reloaded, but you stayed in the post page, instead of being redirected to the product page.

https://github.com/user-attachments/assets/df27e300-8d6d-490e-9d7e-39ba1188bfe0
