### PR TITLE
Ensure child themes load parent fonts in coming soon mode.

### DIFF
--- a/plugins/woocommerce/changelog/fix-coming-soon-child-themes-load-parent-fonts
+++ b/plugins/woocommerce/changelog/fix-coming-soon-child-themes-load-parent-fonts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure child themes load parent fonts in coming soon mode

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -183,9 +183,11 @@ class ComingSoonRequestHandler {
 	}
 
 	/**
-	 * Filters the theme.json data to add the Inter and Cardo fonts when they don't exist.
+	 * Filters the theme.json data to add Coming Soon fonts.
+	 * This runs after child theme merging to ensure parent theme fonts are included.
 	 *
-	 * @param WP_Theme_JSON $theme_json The theme json object.
+	 * @param WP_Theme_JSON_Data $theme_json The theme json data object.
+	 * @return WP_Theme_JSON_Data The filtered theme json data.
 	 */
 	public function experimental_filter_theme_json_theme( $theme_json ) {
 		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
@@ -194,6 +196,36 @@ class ComingSoonRequestHandler {
 
 		$theme_data = $theme_json->get_data();
 		$font_data  = $theme_data['settings']['typography']['fontFamilies']['theme'] ?? array();
+
+		// Check if the current theme is a child theme. And if so, merge the parent theme fonts with the existing fonts.
+		if ( wp_get_theme()->parent() ) {
+			$parent_theme           = wp_get_theme()->parent();
+			$parent_theme_json_file = $parent_theme->get_file_path( 'theme.json' );
+
+			if ( is_readable( $parent_theme_json_file ) ) {
+				$parent_theme_json_data = json_decode( file_get_contents( $parent_theme_json_file ), true );
+
+				if ( isset( $parent_theme_json_data['settings']['typography']['fontFamilies'] ) ) {
+					$parent_fonts = $parent_theme_json_data['settings']['typography']['fontFamilies'];
+
+					// Merge parent theme fonts with existing fonts.
+					foreach ( $parent_fonts as $parent_font ) {
+						$found = false;
+						foreach ( $font_data as $existing_font ) {
+							if ( isset( $parent_font['name'] ) && isset( $existing_font['name'] ) &&
+							$parent_font['name'] === $existing_font['name'] ) {
+								$found = true;
+								break;
+							}
+						}
+
+						if ( ! $found ) {
+							$font_data[] = $parent_font;
+						}
+					}
+				}
+			}
+		}
 
 		$fonts_to_add = array(
 			array(
@@ -225,7 +257,7 @@ class ComingSoonRequestHandler {
 			),
 		);
 
-		// Loops through all existing fonts and append when the font's name is not found.
+		// Add WooCommerce fonts if they don't already exist
 		foreach ( $fonts_to_add as $font_to_add ) {
 			$found = false;
 			foreach ( $font_data as $font ) {

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -203,7 +203,7 @@ class ComingSoonRequestHandler {
 			$parent_theme_json_file = $parent_theme->get_file_path( 'theme.json' );
 
 			if ( is_readable( $parent_theme_json_file ) ) {
-				$parent_theme_json_data = json_decode( file_get_contents( $parent_theme_json_file ), true );
+				$parent_theme_json_data = json_decode( file_get_contents( $parent_theme_json_file ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 				if ( isset( $parent_theme_json_data['settings']['typography']['fontFamilies'] ) ) {
 					$parent_fonts = $parent_theme_json_data['settings']['typography']['fontFamilies'];

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -257,7 +257,7 @@ class ComingSoonRequestHandler {
 			),
 		);
 
-		// Add WooCommerce fonts if they don't already exist
+		// Add WooCommerce fonts if they don't already exist.
 		foreach ( $fonts_to_add as $font_to_add ) {
 			$found = false;
 			foreach ( $font_data as $font ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When loading theme.json in Coming Soon mode check if we are a child theme and if so, load in parent fonts.

Closes [WOOPLUG-5455](https://linear.app/a8c/issue/WOOPLUG-5455/coming-soon-only-wc-inter-and-cardo-fonts-are-loaded-with-an-active)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="3002" height="1574" alt="CleanShot 2025-09-10 at 11 49 48@2x" src="https://github.com/user-attachments/assets/cbeb3b70-6a26-48cb-8744-cc669d4faeb4" /> | <img width="3008" height="1566" alt="CleanShot 2025-09-10 at 11 49 58@2x" src="https://github.com/user-attachments/assets/b04f255f-3155-4920-a75e-4f12a440d89f" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Download TT5 child theme here [twentytwentyfive-child.zip](https://github.com/user-attachments/files/22253279/twentytwentyfive-child.zip) and upload to your site & activate
2. Enable Coming Soon mode in your store `/wp-admin/admin.php?page=wc-settings&tab=site-visibility`
3. Visit the store in a different browser where youre logged out. Ensure fonts are loaded correctly. If they aren't you'll typically be able to tell by looking at header/footer navigation fonts as seen in before screenshot.
4. Try adding some additional fonts in your child theme and check they load too

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
