### PR TITLE
Add to Cart + Options block: fix adding grouped products to cart from Product block and add extra e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/add-add-to-cart-with-options-extra-tests
+++ b/plugins/woocommerce/changelog/add-add-to-cart-with-options-extra-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add extra e2e tests to Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -492,6 +492,11 @@ const { actions, state } = store<
 					return;
 				}
 
+				if ( productType === 'grouped' ) {
+					yield actions.batchAddToCart();
+					return;
+				}
+
 				const { quantity } = getContext< Context >();
 
 				const newQuantity = getNewQuantity(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -24,7 +24,7 @@ export type GroupedProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		actions: {
 			validateQuantity: ( value?: number ) => void;
-			addToCart: () => void;
+			batchAddToCart: () => void;
 		};
 		callbacks: {
 			validateQuantities: () => void;
@@ -84,7 +84,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 					} );
 				}
 			},
-			*addToCart() {
+			*batchAddToCart() {
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.
 				yield import( '@woocommerce/stores/woocommerce/cart' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -776,12 +776,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await pageObject.createPostWithProductBlock( 't-shirt' );
 
 		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart',
+			name: 'Add to cart: “T-Shirt”',
 		} );
 
 		await addToCartButton.click();
 
-		await expect( addToCartButton ).toHaveText( '1 in cart' );
+		await expect(
+			page.getByRole( 'button', { name: '1 in cart', exact: true } )
+		).toBeVisible();
 	} );
 
 	test( 'allows adding variable products to cart when inside the Product block', async ( {
@@ -798,11 +800,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		const addToCartButton = page.getByRole( 'button', {
 			name: 'Add to cart',
+			exact: true,
 		} );
 
 		await addToCartButton.click();
 
-		await expect( addToCartButton ).toHaveText( '1 in cart' );
+		await expect(
+			page.getByRole( 'button', { name: '1 in cart', exact: true } )
+		).toBeVisible();
 	} );
 
 	test( 'allows adding grouped products to cart when inside the Product block', async ( {
@@ -818,10 +823,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		const addToCartButton = page.getByRole( 'button', {
 			name: 'Add to cart',
+			exact: true,
 		} );
 
 		await addToCartButton.click();
 
-		await expect( addToCartButton ).toHaveText( 'Added to cart' );
+		await expect(
+			page.getByRole( 'button', { name: 'Added to cart', exact: true } )
+		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -158,7 +158,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 		const colorBlueOption = page.locator( 'label:has-text("Blue")' );
 		const colorGreenOption = page.locator( 'label:has-text("Green")' );
 		const colorRedOption = page.locator( 'label:has-text("Red")' );
-		const addToCartButton = page.getByText( 'Add to cart' ).first();
+		const addToCartButton = page
+			.getByRole( 'button', { name: 'Add to cart' } )
+			.first();
 		const productPrice = page
 			.locator( '.wp-block-woocommerce-product-price' )
 			.first();
@@ -221,6 +223,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( productPrice ).toHaveText( /\$42.00 – \$45.00.*/ );
 			await expect( page.getByText( '100 in stock' ) ).toBeVisible();
 			await expect( page.getByText( 'SKU: woo-hoodie' ) ).toBeVisible();
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 			await expect(
 				page
 					.getByLabel( 'Additional Information', { exact: true } )
@@ -776,14 +779,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await pageObject.createPostWithProductBlock( 't-shirt' );
 
 		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart: “T-Shirt”',
+			name: 'Add to cart',
 		} );
 
 		await addToCartButton.click();
 
-		await expect(
-			page.getByRole( 'button', { name: '1 in cart', exact: true } )
-		).toBeVisible();
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
 	} );
 
 	test( 'allows adding variable products to cart when inside the Product block', async ( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -215,6 +215,26 @@ test.describe( 'Add to Cart + Options Block', () => {
 			} ).toPass( { timeout: 1_000 } );
 		} );
 
+		await test.step( 'resets blocks rendering variation data when attributes are deselected', async () => {
+			await colorBlueOption.click();
+
+			await expect( productPrice ).toHaveText( /\$42.00 – \$45.00.*/ );
+			await expect( page.getByText( '100 in stock' ) ).toBeVisible();
+			await expect( page.getByText( 'SKU: woo-hoodie' ) ).toBeVisible();
+			await expect(
+				page
+					.getByLabel( 'Additional Information', { exact: true } )
+					.getByText( '1.5 lbs' )
+			).toBeVisible();
+			await expect( page.getByText( variationDescription ) ).toBeHidden();
+			await expect( async () => {
+				const newVisibleLargeImageId =
+					await productGalleryPageObject.getVisibleLargeImageId();
+
+				expect( newVisibleLargeImageId ).toBe( '34' );
+			} ).toPass( { timeout: 1_000 } );
+		} );
+
 		await test.step( 'successfully adds to cart when attributes are selected', async () => {
 			await colorGreenOption.click();
 
@@ -747,5 +767,61 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect(
 			page.getByLabel( 'Quantity of T-Shirt in your cart.' )
 		).toHaveValue( '1' );
+	} );
+
+	test( 'allows adding simple products to cart when inside the Product block', async ( {
+		page,
+		pageObject,
+	} ) => {
+		await pageObject.createPostWithProductBlock( 't-shirt' );
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
+	} );
+
+	test( 'allows adding variable products to cart when inside the Product block', async ( {
+		page,
+		pageObject,
+	} ) => {
+		await pageObject.createPostWithProductBlock( 'hoodie' );
+
+		const colorBlueOption = page.locator( 'label:has-text("Blue")' );
+		const logoYesOption = page.locator( 'label:has-text("Yes")' );
+
+		await colorBlueOption.click();
+		await logoYesOption.click();
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
+	} );
+
+	test( 'allows adding grouped products to cart when inside the Product block', async ( {
+		page,
+		pageObject,
+	} ) => {
+		await pageObject.createPostWithProductBlock( 'logo-collection' );
+
+		const increaseQuantityButton = page.getByLabel(
+			'Increase quantity of T-Shirt'
+		);
+		await increaseQuantityButton.click();
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( 'Added to cart' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -66,13 +66,7 @@ class AddToCartWithOptionsPage {
 		);
 	}
 
-	async updateSingleProductTemplate() {
-		await this.admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//single-product`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
+	async updateAddToCartWithOptionsBlock() {
 		const addToCartFormBlock = await this.editor.getBlockByName(
 			'woocommerce/add-to-cart-form'
 		);
@@ -83,6 +77,35 @@ class AddToCartWithOptionsPage {
 				name: 'Upgrade to the Add to Cart + Options block',
 			} )
 			.click();
+	}
+
+	async updateSingleProductTemplate() {
+		await this.admin.visitSiteEditor( {
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		await this.updateAddToCartWithOptionsBlock();
+	}
+
+	async createPostWithProductBlock( product: string ) {
+		await this.admin.createNewPost();
+		await this.editor.insertBlock( { name: 'woocommerce/single-product' } );
+		const singleProductBlock = await this.editor.getBlockByName(
+			'woocommerce/single-product'
+		);
+
+		await singleProductBlock
+			.locator( `input[type="radio"][value="${ product }"]` )
+			.nth( 0 )
+			.click();
+
+		await singleProductBlock.getByText( 'Done' ).click();
+
+		await this.updateAddToCartWithOptionsBlock();
+
+		await this.editor.publishAndVisitPost();
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is a regression in `trunk` prevents grouped products from being added to the cart through the _Product_ block when using the _Add to Cart + Options_ block. The way it was implemented was a bit brittle because it relied on `grouped-product-selector/frontend.ts` overriding the `addToCart()` action from `add-to-cart-with-options/frontend.ts`. In this PR, I'm renaming the action to avoid conflicts, which I think is more reliable and easier to understand.

I added tests to prevent this kind of regressions in the future + a test to make sursiblinggs blocks are reset when unselecting a variation. That's unrelated to this PR, but given that it's a small test step, I thought I would merge it in this PR anyway. :slightly_smiling_face: 

### How to test the changes in this Pull Request:

1. Create a post and add two _Product_ blocks: in the first one, select a grouped product, in the second one, select a variable product.
2. In both of them, update to the blockified _Add to Cart + Options_ block.
3. Visit that post in the frontend.
4. Verify you can add products to cart.

https://github.com/user-attachments/assets/fe627ca2-ea56-4cef-a41c-36660b21e5fa