### PR TITLE
Turn Cost of Goods Sold into a non-experimental feature

### DIFF
--- a/plugins/woocommerce/changelog/pr-60847
+++ b/plugins/woocommerce/changelog/pr-60847
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Turn Cost of Goods Sold into a non-experimental feature

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -54,7 +54,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 	public function add_feature_definition( $features_controller ) {
 		$definition = array(
 			'description'        => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
-			'is_experimental'    => true,
+			'is_experimental'    => false,
 			'enabled_by_default' => false,
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Until now the Cost of Goods Sold feature was considered experimental. That's no longer the case, so this pull request moves the feature from the "Experimental" section to the regular features section in the features settings page:

<img width="1397" height="1252" alt="image" src="https://github.com/user-attachments/assets/a031dd54-b648-4eb7-a67c-e8a1011bea22" />

### How to test the changes in this Pull Request:

1. Open WooCommerce - Settings - Advanced - Features and verify that Cost of Goods Sold is not in the "Experimental" section, as in the screenshot above.
2. Activate the feature and run the following in the shell, you should get `1`:

```
wp eval 'echo wc_get_container()->get(Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController::class)->feature_is_enabled();'
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
