### PR TITLE
iAPI-powered MiniCart: Support legacy cart events

### DIFF
--- a/plugins/woocommerce/changelog/60849-wooplug-5503-iapi-powered-minicart-counter-and-total-price-not-updated-on
+++ b/plugins/woocommerce/changelog/60849-wooplug-5503-iapi-powered-minicart-counter-and-total-price-not-updated-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support legacy event listeners

--- a/plugins/woocommerce/changelog/60849-wooplug-5503-iapi-powered-minicart-counter-and-total-price-not-updated-on
+++ b/plugins/woocommerce/changelog/60849-wooplug-5503-iapi-powered-minicart-counter-and-total-price-not-updated-on
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Support legacy event listeners
+Support legacy event listeners in iAPI-powered minicart.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
@@ -54,18 +54,10 @@ export const translateJQueryEventToNative = (
 	// Name of the jQuery event to listen to.
 	jQueryEventName: string,
 	// Name of the native event to dispatch.
-	nativeEventName: string,
-	// Whether the event bubbles.
-	bubbles = false,
-	// Whether the event is cancelable.
-	cancelable = false
+	nativeEventName: string
 ): ( () => void ) => {
-	if ( typeof jQuery !== 'function' ) {
-		return () => void null;
-	}
-
 	const eventDispatcher = () => {
-		dispatchEvent( nativeEventName, { bubbles, cancelable } );
+		dispatchEvent( nativeEventName, {} );
 	};
 
 	jQuery( document ).on( jQueryEventName, eventDispatcher );

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts
@@ -15,8 +15,8 @@ interface DispatchedEventProperties {
 	element?: Element | null;
 }
 
-// Borrowing dispatchEvent from base-utils. Later we should move that
-// code to a script module.
+// Borrowing `dispatchEvent` and `translateJQueryEventToNative` from base-utils.
+// Later we should move that code to a script module.
 export const dispatchEvent = (
 	name: string,
 	{
@@ -48,4 +48,26 @@ export const triggerAddedToCartEvent = ( {
 		cancelable: true,
 		detail: { preserveCartData },
 	} );
+};
+
+export const translateJQueryEventToNative = (
+	// Name of the jQuery event to listen to.
+	jQueryEventName: string,
+	// Name of the native event to dispatch.
+	nativeEventName: string,
+	// Whether the event bubbles.
+	bubbles = false,
+	// Whether the event is cancelable.
+	cancelable = false
+): ( () => void ) => {
+	if ( typeof jQuery !== 'function' ) {
+		return () => void null;
+	}
+
+	const eventDispatcher = () => {
+		dispatchEvent( nativeEventName, { bubbles, cancelable } );
+	};
+
+	jQuery( document ).on( jQueryEventName, eventDispatcher );
+	return () => jQuery( document ).off( jQueryEventName, eventDispatcher );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -22,6 +22,7 @@ import {
 	normalizeCurrencyResponse,
 } from '../../../../packages/prices/utils/currency';
 import { CartItem, Currency } from '../../types';
+import { translateJQueryEventToNative } from '../../base/stores/woocommerce/legacy-events';
 
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
@@ -69,7 +70,7 @@ type MiniCart = {
 		openDrawer: () => void;
 		closeDrawer: () => void;
 		overlayCloseDrawer: ( e: MouseEvent ) => void;
-		setupOpenDrawerListener: () => void;
+		setupEventListeners: () => void;
 		disableScrollingOnBody: () => void;
 	};
 };
@@ -194,7 +195,27 @@ store< MiniCart >(
 		},
 
 		callbacks: {
-			setupOpenDrawerListener() {
+			*setupEventListeners() {
+				if ( 'jQuery' in window ) {
+					// Make it so we can read jQuery events triggered by WC Core elements.
+					translateJQueryEventToNative(
+						'added_to_cart',
+						'wc-blocks_added_to_cart'
+					);
+					translateJQueryEventToNative(
+						'removed_from_cart',
+						'wc-blocks_removed_from_cart'
+					);
+				}
+				document.body.addEventListener(
+					'wc-blocks_added_to_cart',
+					actions.refreshCartItems
+				);
+				document.body.addEventListener(
+					'wc-blocks_removed_from_cart',
+					actions.refreshCartItems
+				);
+
 				if ( addToCartBehaviour === 'open_drawer' ) {
 					document.body.addEventListener(
 						'wc-blocks_added_to_cart',
@@ -203,6 +224,14 @@ store< MiniCart >(
 				}
 
 				return () => {
+					document.body.removeEventListener(
+						'wc-blocks_added_to_cart',
+						actions.refreshCartItems
+					);
+					document.body.removeEventListener(
+						'wc-blocks_removed_from_cart',
+						actions.refreshCartItems
+					);
 					document.body.removeEventListener(
 						'wc-blocks_added_to_cart',
 						callbacks.openDrawer

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -196,16 +196,19 @@ store< MiniCart >(
 
 		callbacks: {
 			*setupEventListeners() {
+				let removeJQueryAddedToCartEvent = () => {};
+				let removeJQueryRemovedFromCartEvent = () => {};
 				if ( 'jQuery' in window ) {
 					// Make it so we can read jQuery events triggered by WC Core elements.
-					translateJQueryEventToNative(
+					removeJQueryAddedToCartEvent = translateJQueryEventToNative(
 						'added_to_cart',
 						'wc-blocks_added_to_cart'
 					);
-					translateJQueryEventToNative(
-						'removed_from_cart',
-						'wc-blocks_removed_from_cart'
-					);
+					removeJQueryRemovedFromCartEvent =
+						translateJQueryEventToNative(
+							'removed_from_cart',
+							'wc-blocks_removed_from_cart'
+						);
 				}
 				document.body.addEventListener(
 					'wc-blocks_added_to_cart',
@@ -236,6 +239,10 @@ store< MiniCart >(
 						'wc-blocks_added_to_cart',
 						callbacks.openDrawer
 					);
+					if ( 'jQuery' in window ) {
+						removeJQueryAddedToCartEvent();
+						removeJQueryRemovedFromCartEvent();
+					}
 				};
 			},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -196,8 +196,10 @@ store< MiniCart >(
 
 		callbacks: {
 			*setupEventListeners() {
-				let removeJQueryAddedToCartEvent = () => {};
-				let removeJQueryRemovedFromCartEvent = () => {};
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				const noop = () => {};
+				let removeJQueryAddedToCartEvent = noop;
+				let removeJQueryRemovedFromCartEvent = noop;
 				if ( 'jQuery' in window ) {
 					// Make it so we can read jQuery events triggered by WC Core elements.
 					removeJQueryAddedToCartEvent = translateJQueryEventToNative(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -585,7 +585,7 @@ class MiniCart extends AbstractBlock {
 		
 			<div
 				data-wp-interactive="woocommerce/mini-cart"
-				data-wp-init="callbacks.setupOpenDrawerListener"
+				data-wp-init="callbacks.setupEventListeners"
 				data-wp-watch="callbacks.disableScrollingOnBody"
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo wp_interactivity_data_wp_context( $context ); ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this PR, I'm adding support to legacy cart events to ensure the minicart is updated when items are added through HTML that doesn't use the most recent methods.

Closes #60819.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**Before**

https://github.com/user-attachments/assets/024f253e-5015-4b05-9b6b-7e65e6ccddc4


**After**

https://github.com/user-attachments/assets/f43d039e-f9d0-435e-bbf7-efec65701335


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install a classic theme like Twenty Fifteen.
2. Go to Appeareance -> Widgets.
3. Add the minicart block.
4. Go to the shop page or to a category page.
5. Add a product to the cart.
6. Check the minicart is properly updated.

You can change the minicart block setting to open the drawer and check it works as well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Support legacy event listeners in iAPI-powered minicart.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
