### PR TITLE
Update used token for publishing test reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
       - name: 'Publish report to dashboard'
         if: ${{ !! steps.merge-artifacts.outputs.artifact-id }}
         env:
-          GH_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+          GH_TOKEN: ${{ secrets.TEST_REPORTS_DISPATCH_WORKFLOW_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPORT_NAME: ${{ matrix.report }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -89,7 +89,7 @@ export default defineConfig( {
 	retries: CI ? 1 : 0,
 	repeatEach: REPEAT_EACH ? Number( REPEAT_EACH ) : 1,
 	workers: 1,
-	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
+	reportSlowTests: { max: 5, threshold: 30 * 1000 },
 	reporter,
 	maxFailures: E2E_MAX_FAILURES ? Number( E2E_MAX_FAILURES ) : 0,
 	forbidOnly: !! CI,

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -89,7 +89,7 @@ export default defineConfig( {
 	retries: CI ? 1 : 0,
 	repeatEach: REPEAT_EACH ? Number( REPEAT_EACH ) : 1,
 	workers: 1,
-	reportSlowTests: { max: 5, threshold: 30 * 1000 },
+	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
 	reporter,
 	maxFailures: E2E_MAX_FAILURES ? Number( E2E_MAX_FAILURES ) : 0,
 	forbidOnly: !! CI,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the token used to run the test reports workflow in woocommerce-test-reports.

Context: pcShBQ-3yn-p2#comment-5345

### How to test the changes in this Pull Request:

Check CI, the Test reports job. It should be successful.
See [job](https://github.com/woocommerce/woocommerce/actions/runs/17614588451/job/50045864128?pr=60850), which successfully triggered https://github.com/woocommerce/woocommerce-test-reports/actions/runs/17615043851