### PR TITLE
Only store customer data in the session if it's not the default customer

### DIFF
--- a/plugins/woocommerce/changelog/performance-57780-avoid-storing-customer
+++ b/plugins/woocommerce/changelog/performance-57780-avoid-storing-customer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Only store customer data in the session if it's not the default customer

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -89,8 +89,12 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 
 		$data = $this->get_customer_session_data( $customer );
 
-		if ( ! $this->is_default_customer_data( $data ) ) {
+		if ( $this->is_default_customer_data( $data ) ) {
+			// Clear the customer from the session if it matches the default.
+			WC()->session->set( 'customer', null );
+		} else {
 			WC()->session->set( 'customer', $data );
+		}
 		}
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -263,7 +263,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 	/**
 	 * Returns whether the customer data is the same as a default customer.
 	 *
-	 * @param $customer_data array The customer data to check.
+	 * @param array $customer_data The customer data to check.
 	 * @return bool
 	 */
 	private function is_default_customer_data( array $customer_data ): bool {

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -87,41 +87,11 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 			return;
 		}
 
-		$data = array();
-		foreach ( $this->session_keys as $session_key ) {
-			$function_key = $session_key;
-			if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
-				$session_key = str_replace( 'billing_', '', $session_key );
-			}
-			if ( 'meta_data' === $session_key ) {
-				/**
-				 * Filter the allowed session meta data keys.
-				 *
-				 * If the customer object contains any meta data with these keys, it will be stored within the WooCommerce session.
-				 *
-				 * @since 8.7.0
-				 * @param array $allowed_keys The allowed meta data keys.
-				 * @param WC_Customer $customer The customer object.
-				 */
-				$allowed_keys = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
+		$data = $this->get_customer_session_data( $customer );
 
-				$session_value = array();
-				foreach ( $customer->get_meta_data() as $meta_data ) {
-					if ( in_array( $meta_data->key, $allowed_keys, true ) ) {
-						$session_value[] = array(
-							'key'   => $meta_data->key,
-							'value' => $meta_data->value,
-						);
-					}
-				}
-				$data['meta_data'] = $session_value;
-			} else {
-				$session_value        = $customer->{"get_$function_key"}( 'edit' );
-				$data[ $session_key ] = (string) $session_value;
-			}
+		if ( ! $this->is_default_customer_data( $data ) ) {
+			WC()->session->set( 'customer', $data );
 		}
-
-		WC()->session->set( 'customer', $data );
 	}
 
 	/**
@@ -244,5 +214,62 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 	 */
 	public function get_total_spent( &$customer ) {
 		return 0;
+	}
+
+	/**
+	 * Get the customer data to store in the session.
+	 *
+	 * @param WC_Customer $customer Customer object.
+	 * @return array
+	 */
+	private function get_customer_session_data( $customer ) {
+		$data = array();
+		foreach ( $this->session_keys as $session_key ) {
+			$function_key = $session_key;
+			if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
+				$session_key = str_replace( 'billing_', '', $session_key );
+			}
+			if ( 'meta_data' === $session_key ) {
+				/**
+				 * Filter the allowed session meta data keys.
+				 *
+				 * If the customer object contains any meta data with these keys, it will be stored within the WooCommerce session.
+				 *
+				 * @since 8.7.0
+				 * @param array $allowed_keys The allowed meta data keys.
+				 * @param WC_Customer $customer The customer object.
+				 */
+				$allowed_keys = apply_filters( 'woocommerce_customer_allowed_session_meta_keys', array(), $customer );
+
+				$session_value = array();
+				foreach ( $customer->get_meta_data() as $meta_data ) {
+					if ( in_array( $meta_data->key, $allowed_keys, true ) ) {
+						$session_value[] = array(
+							'key'   => $meta_data->key,
+							'value' => $meta_data->value,
+						);
+					}
+				}
+				$data['meta_data'] = $session_value;
+			} else {
+				$session_value        = $customer->{"get_$function_key"}( 'edit' );
+				$data[ $session_key ] = (string) $session_value;
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns whether the customer data is the same as a default customer.
+	 *
+	 * @param $customer_data array The customer data to check.
+	 * @return bool
+	 */
+	private function is_default_customer_data( array $customer_data ): bool {
+		$default_customer = new WC_Customer();
+		$this->set_defaults( $default_customer );
+
+		return $customer_data === $this->get_customer_session_data( $default_customer );
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -95,7 +95,6 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 		} else {
 			WC()->session->set( 'customer', $data );
 		}
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -34,6 +34,39 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Ensure that customer data is only set in the session if it is not the default customer data.
+	 */
+	public function test_customer_data_is_set_in_session_if_is_not_the_default_customer_data() {
+		$customer = new WC_Customer();
+		$customer->set_billing_email( 'email@woocommerce.com' );
+
+		$session_data = new WC_Customer_Data_Store_Session();
+		$session_data->save_to_session( $customer );
+
+		$customer_from_session = WC()->session->get( 'customer' );
+		$this->assertNotEmpty( $customer_from_session );
+		$this->assertEquals( 'email@woocommerce.com', $customer_from_session['email'] );
+	}
+
+	/**
+	 * Ensure that customer data is not set in the session if it is the default customer data.
+	 */
+	public function test_customer_data_is_not_set_in_session_if_is_the_default_customer_data() {
+		WC()->session->init();
+		WC()->session->set_customer_session_cookie( true );
+
+		$customer = $this->get_default_customer();
+		// $customer->set_billing_email( 'email@woocommerce.com' );
+		$data_store = new WC_Customer_Data_Store_Session();
+		$data_store->save_to_session( $customer );
+		WC()->session->save_data();
+
+		$session_data = WC()->session->get_session_data();
+
+		$this->assertArrayNotHasKey( 'customer', $session_data );
+	}
+
+	/**
 	 * Customer objects with a mixture of billing and shipping addresses.
 	 *
 	 * Each inner dataset is organized as follows:
@@ -102,7 +135,7 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 		};
 
 		return array(
-			'has_billing_address_only' => array(
+			'has_billing_address_only'              => array(
 				$cust1_closure,
 				true,
 				true,
@@ -112,7 +145,7 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 				false,
 				false,
 			),
-			'separate_billing_state_same_country' => array(
+			'separate_billing_state_same_country'   => array(
 				$cust3_closure,
 				false,
 				true,
@@ -123,5 +156,21 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 				true,
 			),
 		);
+	}
+
+	/**
+	 * Get a customer with the default location.
+	 *
+	 * @return WC_Customer
+	 */
+	private function get_default_customer(): WC_Customer {
+		$location = wc_get_customer_default_location();
+
+		$customer = new WC_Customer();
+		$customer->set_shipping_country( $location['country'] );
+		$customer->set_shipping_state( $location['state'] );
+		$customer->set_billing_country( $location['country'] );
+		$customer->set_billing_state( $location['state'] );
+		return $customer;
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -55,8 +55,7 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 		WC()->session->init();
 		WC()->session->set_customer_session_cookie( true );
 
-		$customer = $this->get_default_customer();
-		// $customer->set_billing_email( 'email@woocommerce.com' );
+		$customer   = $this->get_default_customer();
 		$data_store = new WC_Customer_Data_Store_Session();
 		$data_store->save_to_session( $customer );
 		WC()->session->save_data();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR avoids storing the customer data in the session if it's the default customer data, meaning the customer has not introduced any of their data (like email, address, etc.) in the checkout yet.
This is part of the ongoing effort to remove the customer from the session data whenever it isn't needed so that the entire session can be destroyed, the session cookie removed, and pages cached.

Part of https://github.com/woocommerce/woocommerce/issues/60339

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following snippet to temporarily print the value of store_api_draft_order:
```php
add_action(
	'wp_head',
	function () {
		$session = WC()->session;
		echo '<pre>' . print_r( $session->get_session_data(), true ) . '</pre>';
	}
);
```

2. Add a product to the cart, go to the checkout page, and ensure you don't see the `customer` key printed in the session data.
3. In the checkout page, enter the email and click the `Place order` button.
4. Refresh and ensure the `customer` key is now in the session data and the email field is prefilled with the email you just entered.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
