### PR TITLE
Prevent updating draft order on the checkout GET request

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5341-investigate-empty-order-addresses-on-block-checkout-2
+++ b/plugins/woocommerce/changelog/wooplug-5341-investigate-empty-order-addresses-on-block-checkout-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent updating draft order on checkout GET route if it already exists

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -198,7 +198,9 @@ class Checkout extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$this->create_or_update_draft_order( $request );
+		if ( ! $this->order ) {
+			$this->create_or_update_draft_order( $request );
+		}
 		return $this->prepare_item_for_response(
 			(object) [
 				'order'          => $this->order,

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -571,13 +571,17 @@ class Checkout extends AbstractCartRoute {
 			true
 		);
 
-		return $this->prepare_item_for_response(
+		$response = $this->prepare_item_for_response(
 			(object) [
 				'order'          => wc_get_order( $this->order ),
 				'payment_result' => $payment_result,
 			],
 			$request
 		);
+
+		// Unset the order so it is not reused in subsequent requests (edge case, but possible as illustrated in AdditionalFields::test_previous_values_are_loaded_in_checkout).
+		$this->order = null;
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- This PR skips updating the draft order on checkout get requests if it already exists, if no draft order exists, one will be created.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5341

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Add an item to your cart and go to the Checkout page.
2. Run this snippet in your console (update the checkoutUrl)

```js
(function() {
  const target = "/v1/batch";
  const checkoutUrl = "http://your-domain/checkout";

  const triggerCheckoutGet = () => {
    console.log("%cDetected POST to /v1/batch → pulling checkout page", "color: green");
    setTimeout(() => {
      fetch(checkoutUrl, {
        method: "GET",
        credentials: "include", // keep cookies/session
        headers: {
          "Referrer": window.location.href
        }
      })
      .then(res => res.text())
      .then(html => {
        console.log("%cCheckout HTML fetched:", "color: blue", html);
      })
      .catch(err => console.error("Checkout GET failed:", err));
    }, 50); // slight delay
  };

  // Intercept XHR
  const origOpen = XMLHttpRequest.prototype.open;
  XMLHttpRequest.prototype.open = function(method, url) {
    if (method.toUpperCase() === "POST" && url.includes(target)) {
      triggerCheckoutGet();
    }
    return origOpen.apply(this, arguments);
  };

  // Intercept fetch
  const origFetch = window.fetch;
  window.fetch = function(input, init) {
    const url = typeof input === "string" ? input : input.url;
    const method = (init && init.method) || "GET";

    if (method.toUpperCase() === "POST" && url.includes(target)) {
      triggerCheckoutGet();
    }
    return origFetch.apply(this, arguments);
  };

  console.log("%cWatcher active: Will GET checkout after POST /v1/batch", "color: orange; font-weight:bold;");
})();
```
3. Update the shipping and or billing addresses.
4. Reload the page and ensure the updates you made persisted.
5. Repeat and ensure checkout works and the correct address is saved in the order dashboard.

### Smoke testing/other tests (with and without the snippet from above)

1. Modify multiple fields several times without reloading. Check out and ensure the correct address information is saved.
2. Modify things like email, selected shipping option and payment options. Ensure the changes persist and that checkout works with the correct data saved.
3. Install the custom fields tester (https://github.com/woocommerce/additional-checkout-fields-tester) and ensure the fields modified here are saved and persisted too.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
