### PR TITLE
POC: Allow WYSIWYG editing for Custom Product Types

### DIFF
--- a/plugins/woocommerce/changelog/improve-add-custom-product-types-editor-support
+++ b/plugins/woocommerce/changelog/improve-add-custom-product-types-editor-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow WYSIWYG editing of custom product types via the experimental template-part filter

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -45,10 +45,12 @@ const AddToCartOptionsEdit = (
 
 	const productType =
 		product?.id === undefined ? currentProductType?.slug : product?.type;
-	const editorSupportedProductTypes = getSetting( 'editorSupportedProductTypes', [] ) as string[];
+	const editorSupportedProductTypes = getSetting(
+		'editorSupportedProductTypes',
+		[]
+	) as string[];
 	const isTemplatePartSupported =
-		productType &&
-		editorSupportedProductTypes.includes( productType );
+		productType && editorSupportedProductTypes.includes( productType );
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -12,6 +12,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { useProduct } from '@woocommerce/entities';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -44,9 +45,10 @@ const AddToCartOptionsEdit = (
 
 	const productType =
 		product?.id === undefined ? currentProductType?.slug : product?.type;
-	const isCoreProductType =
+	const editorSupportedProductTypes = getSetting( 'editorSupportedProductTypes', [] ) as string[];
+	const isTemplatePartSupported =
 		productType &&
-		[ 'simple', 'variable', 'external', 'grouped' ].includes( productType );
+		editorSupportedProductTypes.includes( productType );
 
 	return (
 		<>
@@ -56,7 +58,7 @@ const AddToCartOptionsEdit = (
 			<BlockControls>
 				<ToolbarProductTypeGroup />
 			</BlockControls>
-			{ isCoreProductType ? (
+			{ isTemplatePartSupported ? (
 				<AddToCartWithOptionsEditTemplatePart
 					productType={ productType }
 				/>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -37,8 +37,31 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		if ( is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->asset_data_registry->add( 'productTypes', wc_get_product_types() );
+			$this->asset_data_registry->add( 'editorSupportedProductTypes', $this->get_editor_supported_product_types() );
 			$this->asset_data_registry->add( 'addToCartWithOptionsTemplatePartIds', $this->get_template_part_ids() );
 		}
+	}
+
+	/**
+	 * Get the editor supported product types.
+	 *
+	 * @return array Array of product types.
+	 */
+	protected function get_editor_supported_product_types() {
+
+		$product_types        = array_keys( wc_get_product_types() );
+		$core_product_types   = $this->get_core_product_types();
+		$custom_product_types = array_diff( $product_types, $core_product_types );
+
+		// If the product type has an experimental filter to locate a template part, add it to the supported product types.
+		$supported_product_types = $core_product_types;
+		foreach ( $custom_product_types as $product_type ) {
+			if ( has_filter( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part' ) ) {
+				$supported_product_types[] = $product_type;
+			}
+		}
+
+		return $supported_product_types;
 	}
 
 	/**
@@ -132,7 +155,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$slug = $product_type . '-product-add-to-cart-with-options';
 
-		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+		if ( in_array( $product_type, $this->get_core_product_types(), true ) ) {
 			$template_part_path = Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html';
 		} else {
 			/**
@@ -169,7 +192,6 @@ class AddToCartWithOptions extends AbstractBlock {
 				$template_slug_to_load   = $theme_has_template_part ? get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 			}
 			$template_part = get_block_template( $template_slug_to_load . '//' . $slug, 'wp_template_part' );
-
 			if ( $template_part && ! empty( $template_part->content ) ) {
 				$template_part_contents = $template_part->content;
 			}
@@ -550,7 +572,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			ob_start();
 
-			if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+			if ( in_array( $product_type, $this->get_core_product_types(), true ) ) {
 
 				$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
 				remove_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
@@ -641,5 +663,19 @@ class AddToCartWithOptions extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get core product types.
+	 *
+	 * @return array Array of product types.
+	 */
+	private function get_core_product_types() {
+		return array(
+			ProductType::SIMPLE,
+			ProductType::EXTERNAL,
+			ProductType::VARIABLE,
+			ProductType::GROUPED,
+		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -56,12 +56,12 @@ class AddToCartWithOptions extends AbstractBlock {
 		// If the product type has an experimental filter to locate a template part, add it to the supported product types.
 		$supported_product_types = $core_product_types;
 		foreach ( $custom_product_types as $product_type ) {
-			if ( has_filter( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part' ) ) {
+			if ( false !== has_filter( '__experimental_woocommerce_' . sanitize_key( $product_type ) . '_add_to_cart_with_options_block_template_part' ) ) {
 				$supported_product_types[] = $product_type;
 			}
 		}
 
-		return $supported_product_types;
+		return array_values( array_unique( $supported_product_types ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Editing WYSIWYG mode is currently not supported for custom product types.

There is currently an experimental hook that allows you to render a custom template file for any product type, but it only works on the frontend. In Edit mode, supported product types are limited to the core ones. All custom types default to a skeleton:

<img width="1012" height="336" alt="bookable-screen-skeleton" src="https://github.com/user-attachments/assets/f28f65bb-2381-45e3-815b-a7a6a52301e1" />

### Proposed Solution
I'm not entirely sure why support in the Editor was hardcoded, but if it was due to a lack of criteria on what's considered WYSIWYG-ready, this PR proposes exactly that. The idea is to enable loading the default template part for the custom product type, but only for those product types that already hook into the existing experimental hook.

While this isn't yet the ideal way to extend this block, I see it as a step in the right direction to expose more extensibility entries and hopefully help us pave the way towards ideal APIs. 

That said, with this PR, fully supporting a product type's WYSIWYG editing experience involves a two-step process:

1. Add the experimental filter. For example, for a product type like "booking," that would be: `__experimental_woocommerce_booking_add_to_cart_with_options_block_template_part`:
```php
add_filter(
    '__experimental_woocommerce_[type]_add_to_cart_with_options_block_template_part', 
    function() {
        return 'path/to/template/[type]-add-to-cart-with-options.html';
    }
);
```
4. Hook into WP's `get_block_template()` function and initialize the template instance. Similar to this:
```php
add_filter( 
    'get_block_template',
    function( $block_template, $id, $template_type ) {
        if ( $block_template instanceof WP_Block_Template ) {
            return $block_template;
        }
     
        if ( 'wp_template_part' !== $template_type && 'woocommerce/woocommerce//[type]-product-add-to-cart-with-options' !== $id ) {
            return $block_template;
        }
     
        $parts                = explode( '//', $id, 2 );
        list( $theme, $slug ) = $parts;
     
        $template_part              = new WP_Block_Template();
        $template_part->id          = $id;
        $template_part->type        = $template_type;
        $template_part->content     = wc_bookings_get_template_file_contents(),
        $template_part->theme       = $theme;
        $template_part->slug        = $slug;
        $template_part->title       = '[Type] Product Add to Cart + Options';
        $template_part->description = 'Template used to display the Add to Cart + Options form for [Type] Products.';
        $template_part->area        = 'add-to-cart-with-options';
        $template_part->status      = 'publish';
        $template_part->post_types  = array();
     
        return $template_part;
    },
    10,
    3
);
```

### Considerations

If the proposal above meets the needs of this block, I wonder if the filtering of block templates could (or should) also be included in Core. However, if we reach consensus here, we can probably revisit this one later. Also, worth noting that this filtering feels like an alternative to a potential (currently missing) `register_block_template_part()` for plugins.

### Screenshots or screen recordings:
<img width="1001" height="273" alt="bookable-edit-mode" src="https://github.com/user-attachments/assets/87757fbe-3c99-4e54-b3bf-d281d2a85476" />

<img width="1467" height="726" alt="after-experimental-hook" src="https://github.com/user-attachments/assets/dc663b6b-3cf0-4f3b-ab13-54d06c8b86e7" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Prerequisites
- Ensure your store uses a custom product type (e.g., booking)
- Install the two PHP snippets above in your `functions.php` file or your plugin's init function.
  - Make sure to replace `[type]` with your product type.
  - Create a simple template in your plugin folder and specify the path in the experimental filter.
#### Validation steps
- Edit the Single Product template.
- Ensure the new Add-to-Card with Options block is being used. If not, click on the upgrade nudge in the inspector controls and save.
- Click on your product type in the block's type visibility selector, and verify your template file loads correctly in the Site Editor.
- Make changes and confirm saving works as expected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
