### PR TITLE
[Migrator]: Preserve the initial attribute mapping from Shopify

### DIFF
--- a/plugins/woocommerce/changelog/fix-attribute-mapping
+++ b/plugins/woocommerce/changelog/fix-attribute-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Correctly map the varitions and attribute from Shopify

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -575,7 +575,7 @@ class WooCommerceProductImporter {
 	 * @param array               $attributes_data Standardized attribute data from mapper.
 	 */
 	private function setup_attributes( WC_Product_Variable $product, array $attributes_data ): void {
-		$woo_attributes = array();
+		$woo_attributes                  = array();
 		$this->current_attribute_mapping = array();
 
 		foreach ( $attributes_data as $attribute_info ) {

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -608,7 +608,17 @@ class WooCommerceProductImporter {
 
 				register_taxonomy(
 					$taxonomy_name,
+					/**
+					 * Filters the object types associated with the attribute taxonomy.
+					 *
+					 * @param array $object_types Array of object types.
+					 */
 					apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ),
+					/**
+					 * Filters the arguments for registering the attribute taxonomy.
+					 *
+					 * @param array $args Array of taxonomy registration arguments.
+					 */
 					apply_filters(
 						'woocommerce_taxonomy_args_' . $taxonomy_name,
 						array(

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -659,6 +659,19 @@ class WooCommerceProductImporter {
 
 		$attribute_taxonomy_map = $this->current_attribute_mapping;
 
+		// Build fallback mapping from product attributes if current mapping is empty.
+		if ( empty( $attribute_taxonomy_map ) ) {
+			$product_attributes = $product->get_attributes();
+			foreach ( $product_attributes as $taxonomy => $attribute_obj ) {
+				if ( $attribute_obj->get_variation() ) {
+					$attribute_label = wc_attribute_label( $taxonomy, $product );
+					// Store mapping with both original case and lowercase for case-insensitive lookup.
+					$attribute_taxonomy_map[ $attribute_label ]               = $taxonomy;
+					$attribute_taxonomy_map[ strtolower( $attribute_label ) ] = $taxonomy;
+				}
+			}
+		}
+
 		foreach ( $variations_data as $var_data ) {
 			$original_variant_id = $var_data['original_id'] ?? null;
 			if ( ! $original_variant_id ) {
@@ -737,9 +750,10 @@ class WooCommerceProductImporter {
 			if ( ! empty( $var_data['attributes'] ) && is_array( $var_data['attributes'] ) ) {
 				foreach ( $var_data['attributes'] as $attr_name => $attr_value ) {
 					if ( isset( $attribute_taxonomy_map[ $attr_name ] ) ) {
-						$taxonomy                             = $attribute_taxonomy_map[ $attr_name ];
-						$term_slug                            = sanitize_title( $attr_value );
-						$wc_variation_attributes[ $taxonomy ] = $term_slug;
+						$taxonomy                                           = $attribute_taxonomy_map[ $attr_name ];
+						$term_slug                                          = sanitize_title( $attr_value );
+						$normalized_attribute_name                          = wc_variation_attribute_name( $taxonomy );
+						$wc_variation_attributes[ $normalized_attribute_name ] = $term_slug;
 					} else {
 						wc_get_logger()->warning( "Attribute taxonomy mapping not found for option '{$attr_name}' while processing variation {$original_variant_id}.", array( 'source' => 'wc-migrator' ) );
 					}

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -605,8 +605,7 @@ class WooCommerceProductImporter {
 					wc_get_logger()->warning( "Failed to create attribute '{$attr_name}': " . $attribute_id->get_error_message(), array( 'source' => 'wc-migrator' ) );
 					continue;
 				}
-				
-				// Immediately register the taxonomy so it's available for term insertion in the same request.
+
 				register_taxonomy(
 					$taxonomy_name,
 					apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ),

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -107,6 +107,8 @@ class WooCommerceProductImporter {
 		$start_time   = microtime( true );
 		$product_name = $product_data['name'] ?? 'Unknown Product';
 
+		$this->current_attribute_mapping = array();
+
 		try {
 			wc_get_logger()->info( "Starting import for product: {$product_name}", array( 'source' => 'wc-migrator' ) );
 

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -611,12 +611,14 @@ class WooCommerceProductImporter {
 					/**
 					 * Filters the object types associated with the attribute taxonomy.
 					 *
+					 * @since 10.2.0
 					 * @param array $object_types Array of object types.
 					 */
 					apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ),
 					/**
 					 * Filters the arguments for registering the attribute taxonomy.
 					 *
+					 * @since 10.2.0
 					 * @param array $args Array of taxonomy registration arguments.
 					 */
 					apply_filters(

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -750,9 +750,10 @@ class WooCommerceProductImporter {
 			if ( ! empty( $var_data['attributes'] ) && is_array( $var_data['attributes'] ) ) {
 				foreach ( $var_data['attributes'] as $attr_name => $attr_value ) {
 					if ( isset( $attribute_taxonomy_map[ $attr_name ] ) ) {
-						$taxonomy                                           = $attribute_taxonomy_map[ $attr_name ];
-						$term_slug                                          = sanitize_title( $attr_value );
-						$normalized_attribute_name                          = wc_variation_attribute_name( $taxonomy );
+						$taxonomy                  = $attribute_taxonomy_map[ $attr_name ];
+						$term_slug                 = sanitize_title( $attr_value );
+						$normalized_attribute_name = wc_variation_attribute_name( $taxonomy );
+
 						$wc_variation_attributes[ $normalized_attribute_name ] = $term_slug;
 					} else {
 						wc_get_logger()->warning( "Attribute taxonomy mapping not found for option '{$attr_name}' while processing variation {$original_variant_id}.", array( 'source' => 'wc-migrator' ) );

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -605,6 +605,26 @@ class WooCommerceProductImporter {
 					wc_get_logger()->warning( "Failed to create attribute '{$attr_name}': " . $attribute_id->get_error_message(), array( 'source' => 'wc-migrator' ) );
 					continue;
 				}
+				
+				// Immediately register the taxonomy so it's available for term insertion in the same request.
+				register_taxonomy(
+					$taxonomy_name,
+					apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ),
+					apply_filters(
+						'woocommerce_taxonomy_args_' . $taxonomy_name,
+						array(
+							'labels'       => array(
+								'name' => $attr_name,
+							),
+							'hierarchical' => false,
+							'show_ui'      => false,
+							'show_in_rest' => true,
+							'query_var'    => true,
+							'rewrite'      => false,
+							'public'       => false,
+						)
+					)
+				);
 			} else {
 				$attribute_id = wc_attribute_taxonomy_id_by_name( $taxonomy_name );
 			}

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -74,6 +74,13 @@ class WooCommerceProductImporter {
 	);
 
 	/**
+	 * Mapping of original attribute names to taxonomy names for current product.
+	 *
+	 * @var array
+	 */
+	private array $current_attribute_mapping = array();
+
+	/**
 	 * Constructor - parameterless to support WooCommerce DI container.
 	 */
 	public function __construct() {
@@ -569,6 +576,7 @@ class WooCommerceProductImporter {
 	 */
 	private function setup_attributes( WC_Product_Variable $product, array $attributes_data ): void {
 		$woo_attributes = array();
+		$this->current_attribute_mapping = array();
 
 		foreach ( $attributes_data as $attribute_info ) {
 			$attr_name    = $attribute_info['name'] ?? null;
@@ -626,6 +634,8 @@ class WooCommerceProductImporter {
 			$woo_attribute->set_visible( $attribute_info['is_visible'] ?? true );
 			$woo_attribute->set_variation( $attribute_info['is_variation'] ?? true );
 			$woo_attributes[] = $woo_attribute;
+
+			$this->current_attribute_mapping[ $attr_name ] = $taxonomy_name;
 		}
 
 		$product->set_attributes( $woo_attributes );
@@ -645,17 +655,7 @@ class WooCommerceProductImporter {
 		$variation_count = count( $variations_data );
 		wc_get_logger()->debug( "Syncing {$variation_count} variations for product ID {$parent_product_id}", array( 'source' => 'wc-migrator' ) );
 
-		$attribute_taxonomy_map = array();
-		$product_attributes     = $product->get_attributes();
-
-		foreach ( $product_attributes as $taxonomy => $attribute_obj ) {
-			if ( $attribute_obj->get_variation() ) {
-				$attribute_label = wc_attribute_label( $taxonomy, $product );
-				// Store mapping with both original case and lowercase for case-insensitive lookup.
-				$attribute_taxonomy_map[ $attribute_label ]               = $taxonomy;
-				$attribute_taxonomy_map[ strtolower( $attribute_label ) ] = $taxonomy;
-			}
-		}
+		$attribute_taxonomy_map = $this->current_attribute_mapping;
 
 		foreach ( $variations_data as $var_data ) {
 			$original_variant_id = $var_data['original_id'] ?? null;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Currently the varitions from Shopify doesn't get imported correctly as the initial mapping are lost in the transition. This PR preserves the original mappings.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Use the store creds you have:

1. Migrate a product that alrady have variations. We have a fairly complex product setup with the following product type or feel free to create your own.
2. Run `wp wc migrate products --product-type="Cycling Jersey" --status=active`
3. Validate all the attributes and their values are being mapped correctly.
4. Validate that the variations are being mapped correctly with their values.
<img width="700" height="864" alt="image" src="https://github.com/user-attachments/assets/38786e0b-0535-4034-89d7-2790acc34cfc" />

<img width="729" height="712" alt="image" src="https://github.com/user-attachments/assets/1060fdc6-355a-4ae1-8789-2001853ed863" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
