### PR TITLE
Fix Reviews Form block always showing the 'Be the first to review' message

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-review-form-first-review-message
+++ b/plugins/woocommerce/changelog/fix-product-review-form-first-review-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Reviews Form block always showing the 'Be the first to review' message

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -45,8 +45,8 @@ class ProductReviewForm extends AbstractBlock {
 			return '<p class="woocommerce-verification-required">' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
 		}
 
-		$interactivy_state  = [];
-		$interactivy_config = [
+		$interactivity_state  = [];
+		$interactivity_config = [
 			'reviewRatingEnabled' => wc_review_ratings_enabled(),
 		];
 
@@ -117,12 +117,12 @@ class ProductReviewForm extends AbstractBlock {
 		}
 
 		if ( wc_review_ratings_enabled() ) {
-			$interactivy_state['selectedStar']            = '';
-			$interactivy_state['hoveredStar']             = '0';
-			$interactivy_state['ratingError']             = '';
-			$interactivy_state['hasRatingError']          = false;
-			$interactivy_config['i18nRequiredRatingText'] = esc_attr__( 'Please select a rating', 'woocommerce' );
-			$interactivy_config['reviewRatingRequired']   = wc_review_ratings_required();
+			$interactivity_state['selectedStar']            = '';
+			$interactivity_state['hoveredStar']             = '0';
+			$interactivity_state['ratingError']             = '';
+			$interactivity_state['hasRatingError']          = false;
+			$interactivity_config['i18nRequiredRatingText'] = esc_attr__( 'Please select a rating', 'woocommerce' );
+			$interactivity_config['reviewRatingRequired']   = wc_review_ratings_required();
 
 			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-selector" id="comment-form-rating-label">' .
 				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
@@ -166,11 +166,11 @@ class ProductReviewForm extends AbstractBlock {
 			$p->set_attribute( 'data-wp-on--submit', 'actions.handleSubmit' );
 		}
 
-		if ( ! empty( $interactivy_state ) ) {
-			wp_interactivity_state( 'woocommerce/product-reviews', $interactivy_state );
+		if ( ! empty( $interactivity_state ) ) {
+			wp_interactivity_state( 'woocommerce/product-reviews', $interactivity_state );
 		}
-		if ( ! empty( $interactivy_config ) ) {
-			wp_interactivity_config( 'woocommerce/product-reviews', $interactivy_config );
+		if ( ! empty( $interactivity_config ) ) {
+			wp_interactivity_config( 'woocommerce/product-reviews', $interactivity_config );
 		}
 
 		return $p->get_updated_html();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -66,7 +66,7 @@ class ProductReviewForm extends AbstractBlock {
 		$commenter    = wp_get_current_commenter();
 		$comment_form = [
 			/* translators: %s is product title */
-			'title_reply'         => get_comments_number( $block->context['postId'] ) > 0 ? esc_html__( 'Add a review', 'woocommerce' ) : sprintf( esc_html__( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), get_the_title() ),
+			'title_reply'         => $product->get_review_count() > 0 ? esc_html__( 'Add a review', 'woocommerce' ) : sprintf( esc_html__( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), esc_html( get_the_title( $block->context['postId'] ) ) ),
 			/* translators: %s is product title */
 			'title_reply_to'      => esc_html__( 'Leave a Reply to %s', 'woocommerce' ),
 			'title_reply_before'  => '<span id="reply-title" class="comment-reply-title" role="heading" aria-level="3">',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -66,7 +66,7 @@ class ProductReviewForm extends AbstractBlock {
 		$commenter    = wp_get_current_commenter();
 		$comment_form = [
 			/* translators: %s is product title */
-			'title_reply'         => have_comments() ? esc_html__( 'Add a review', 'woocommerce' ) : sprintf( esc_html__( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), get_the_title() ),
+			'title_reply'         => get_comments_number( $block->context['postId'] ) > 0 ? esc_html__( 'Add a review', 'woocommerce' ) : sprintf( esc_html__( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), get_the_title() ),
 			/* translators: %s is product title */
 			'title_reply_to'      => esc_html__( 'Leave a Reply to %s', 'woocommerce' ),
 			'title_reply_before'  => '<span id="reply-title" class="comment-reply-title" role="heading" aria-level="3">',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Issue reported by @ellenbauer.

The _Reviews Form_ block was always displaying the 'Be the first to review' message, even when the product already had reviews.

This PR fixes this by using `$product->get_review_count()` instead of [`have_comments()`](https://developer.wordpress.org/reference/functions/have_comments/).

### How to test the changes in this Pull Request:

1. Make sure your _Single Product_ template has the blockified _Product Details_ block. Update it otherwise.
2. Go to a product without any reviews.
3. Verify the message above the Reviews Form says: 'Be the first to review'.
4. Post a review.
5. Verify the message above the Reviews Form says: 'Add a review'.

With 0 reviews | With 1 review
--- | ---
<img width="668" height="952" alt="imatge" src="https://github.com/user-attachments/assets/bddb39f0-a09a-4aa9-a0c0-fde6aa8158ec" /> | <img width="668" height="952" alt="imatge" src="https://github.com/user-attachments/assets/130a388b-e110-4508-9f34-6e430cf2423a" />

