### PR TITLE
[Payments NOX] Update More PES section button label when extension already installed

### DIFF
--- a/plugins/woocommerce/changelog/update-change-other-pes-cta-when-extension-already-installed
+++ b/plugins/woocommerce/changelog/update-change-other-pes-cta-when-extension-already-installed
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Use a different button label for other payments extensions recommendations that are already installed.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -255,27 +255,23 @@ export const OtherPaymentGateways = ( {
 
 							<div className="other-payment-gateways__content__grid">
 								{ categorySuggestions.map( ( extension ) => {
-									// Determine the extension CTA label based on its status and whether we are
-									// installing/activating it.
-									const isInstallingOrActivatingExtension =
+									const isPluginAlreadyInstalled =
+										extension.plugin.status === 'installed';
+
+									// Is the button currently busy, either installing or activating the plugin?
+									const isCurrentlyBusy =
 										installingPlugin === extension.id;
-									let ctaLabel =
-										isInstallingOrActivatingExtension
-											? __( 'Installing', 'woocommerce' )
-											: __( 'Install', 'woocommerce' );
-									if (
-										extension.plugin.status === 'installed'
-									) {
-										ctaLabel =
-											isInstallingOrActivatingExtension
-												? __(
-														'Activating',
-														'woocommerce'
-												  )
-												: __(
-														'Activate',
-														'woocommerce'
-												  );
+
+									// By default, the CTA is to install a plugin.
+									let ctaLabel = isCurrentlyBusy
+										? __( 'Installing', 'woocommerce' )
+										: __( 'Install', 'woocommerce' );
+
+									// If the plugin is already installed, the CTA is to activate it.
+									if ( isPluginAlreadyInstalled ) {
+										ctaLabel = isCurrentlyBusy
+											? __( 'Activating', 'woocommerce' )
+											: __( 'Activate', 'woocommerce' );
 									}
 
 									return (
@@ -336,7 +332,7 @@ export const OtherPaymentGateways = ( {
 															)
 														}
 														isBusy={
-															isInstallingOrActivatingExtension
+															isCurrentlyBusy
 														}
 														disabled={
 															!! installingPlugin

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -254,86 +254,101 @@ export const OtherPaymentGateways = ( {
 							</div>
 
 							<div className="other-payment-gateways__content__grid">
-								{ categorySuggestions.map( ( extension ) => (
-									<div
-										className="other-payment-gateways__content__grid-item"
-										key={ extension.id }
-									>
-										<img
-											className="other-payment-gateways__content__grid-item-image"
-											src={ extension.icon }
-											alt={
-												decodeEntities(
-													extension.title
-												) + ' logo'
-											}
-										/>
-										<div className="other-payment-gateways__content__grid-item__content">
-											<span className="other-payment-gateways__content__grid-item__content__title">
-												{ extension.title }
-												{ extension?._incentive && (
-													<IncentiveStatusBadge
-														incentive={
-															extension._incentive
+								{ categorySuggestions.map( ( extension ) => {
+									// Determine the extension CTA label based on its status and whether we are
+									// installing/activating it.
+									const isInstallingOrActivatingExtension =
+										installingPlugin === extension.id;
+									let ctaLabel =
+										isInstallingOrActivatingExtension
+											? __( 'Installing', 'woocommerce' )
+											: __( 'Install', 'woocommerce' );
+									if (
+										extension.plugin.status === 'installed'
+									) {
+										ctaLabel =
+											isInstallingOrActivatingExtension
+												? __(
+														'Activating',
+														'woocommerce'
+												  )
+												: __(
+														'Activate',
+														'woocommerce'
+												  );
+									}
+
+									return (
+										<div
+											className="other-payment-gateways__content__grid-item"
+											key={ extension.id }
+										>
+											<img
+												className="other-payment-gateways__content__grid-item-image"
+												src={ extension.icon }
+												alt={
+													decodeEntities(
+														extension.title
+													) + ' logo'
+												}
+											/>
+											<div className="other-payment-gateways__content__grid-item__content">
+												<span className="other-payment-gateways__content__grid-item__content__title">
+													{ extension.title }
+													{ extension?._incentive && (
+														<IncentiveStatusBadge
+															incentive={
+																extension._incentive
+															}
+														/>
+													) }
+													{ /* All payment extension suggestions are official. */ }
+													<OfficialBadge
+														variant="expanded"
+														suggestionId={
+															extension.id
 														}
 													/>
-												) }
-												{ /* All payment extension suggestions are official. */ }
-												<OfficialBadge
-													variant="expanded"
-													suggestionId={
-														extension.id
-													}
-												/>
-											</span>
-											<span className="other-payment-gateways__content__grid-item__content__description">
-												{ decodeEntities(
-													extension.description
-												) }
-											</span>
-											<div className="other-payment-gateways__content__grid-item__content__actions">
-												<Button
-													variant="link"
-													onClick={ () =>
-														setUpPlugin(
-															extension,
-															null, // Suggested gateways won't have an onboarding URL.
-															// Only provide the attach link if not already installed.
-															extension.plugin
-																.status ===
-																'not_installed'
-																? extension
-																		._links
-																		?.attach
-																		?.href ??
-																		null
-																: null,
-															'wc_settings_payments__other_payment_options'
-														)
-													}
-													isBusy={
-														installingPlugin ===
-														extension.id
-													}
-													disabled={
-														!! installingPlugin
-													}
-												>
-													{ installingPlugin ===
-													extension.id
-														? __(
-																'Installing',
-																'woocommerce'
-														  )
-														: __(
-																'Install',
-																'woocommerce'
-														  ) }
-												</Button>
+												</span>
+												<span className="other-payment-gateways__content__grid-item__content__description">
+													{ decodeEntities(
+														extension.description
+													) }
+												</span>
+												<div className="other-payment-gateways__content__grid-item__content__actions">
+													<Button
+														variant="link"
+														onClick={ () =>
+															setUpPlugin(
+																extension,
+																null, // Suggested gateways won't have an onboarding URL.
+																// Only provide the attach link if not already installed.
+																extension.plugin
+																	.status ===
+																	'not_installed'
+																	? extension
+																			._links
+																			?.attach
+																			?.href ??
+																			null
+																	: null,
+																'wc_settings_payments__other_payment_options'
+															)
+														}
+														isBusy={
+															isInstallingOrActivatingExtension
+														}
+														disabled={
+															!! installingPlugin
+														}
+													>
+														{ ctaLabel }
+													</Button>
+												</div>
 											</div>
 										</div>
-									</div>
-								) ) }
+									);
+								} ) }
 							</div>
 						</div>
 					);


### PR DESCRIPTION
Closes WOOPLUG-5516

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the extension is already installed, we replace "Install" with "Activate" to be more precise with the action taken when the button is clicked.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this PR's branch locally and build WooCommerce.
2. Go to the Payments settings page and select a business location that has more recommendations (e.g., US)
3. Expand the "More payment options" section and notice that extensions that are not yet installed feature the "Install" button CTA.
4. Install one such extension, and the CTA label should change to "Installing" during the process.
5. Deactivate the previously installed extension via the contextual menu and notice that the recommendation is shown in the "More payment options" section with the "Activate" CTA button label.
<img width="1307" height="536" alt="Screenshot 2025-09-11 at 12 31 50" src="https://github.com/user-attachments/assets/bd0583b8-3d57-467a-9510-127df7ee399b" />

6. Click on "Activate" and the label should change to "Activating" during the process.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
