### PR TITLE
Rename Variation Selector: Attribute Options 'style' attribute to 'optionStyle'

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-selector-rename-style-attribute
+++ b/plugins/woocommerce/changelog/fix-variation-selector-rename-style-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Rename Variation Selector: Attribute Options 'style' attribute to 'optionStyle'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -8,7 +8,7 @@
 		"woocommerce/add-to-cart-with-options-variation-selector-attribute"
 	],
 	"attributes": {
-		"style": {
+		"optionStyle": {
 			"type": "string",
 			"enum": [ "pills", "dropdown" ],
 			"default": "pills"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -10,8 +10,7 @@
 	"attributes": {
 		"optionStyle": {
 			"type": "string",
-			"enum": [ "pills", "dropdown" ],
-			"default": "pills"
+			"enum": [ "pills", "dropdown" ]
 		}
 	},
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -95,7 +95,7 @@ export default function AttributeOptionsEdit(
 				<PanelBody title={ __( 'Style', 'woocommerce' ) }>
 					<ToggleGroupControl
 						label={ __( 'Style', 'woocommerce' ) }
-						value={ optionStyle }
+						value={ optionStyle ?? 'pills' }
 						onChange={ ( option ) => {
 							if ( option !== 'pills' && option !== 'dropdown' ) {
 								return;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -96,11 +96,14 @@ export default function AttributeOptionsEdit(
 					<ToggleGroupControl
 						label={ __( 'Style', 'woocommerce' ) }
 						value={ optionStyle ?? 'pills' }
-						onChange={ ( option ) => {
-							if ( option !== 'pills' && option !== 'dropdown' ) {
+						onChange={ ( newOptionStyle ) => {
+							if (
+								newOptionStyle !== 'pills' &&
+								newOptionStyle !== 'dropdown'
+							) {
 								return;
 							}
-							setAttributes( { optionStyle: option } );
+							setAttributes( { optionStyle: newOptionStyle } );
 						} }
 						isBlock
 						hideLabelFromVision

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -81,7 +81,7 @@ export default function AttributeOptionsEdit(
 	const { data: attribute } =
 		useCustomDataContext< ProductResponseAttributeItem >( 'attribute' );
 
-	if ( ! attribute ) return;
+	if ( ! attribute ) return null;
 
 	const options = attribute.terms.map( ( term, index ) => ( {
 		value: term.slug,
@@ -98,12 +98,13 @@ export default function AttributeOptionsEdit(
 						value={ optionStyle ?? 'pills' }
 						onChange={ ( newOptionStyle ) => {
 							if (
-								newOptionStyle !== 'pills' &&
-								newOptionStyle !== 'dropdown'
+								newOptionStyle === 'pills' ||
+								newOptionStyle === 'dropdown'
 							) {
-								return;
+								setAttributes( {
+									optionStyle: newOptionStyle,
+								} );
 							}
-							setAttributes( { optionStyle: newOptionStyle } );
 						} }
 						isBlock
 						hideLabelFromVision
@@ -122,9 +123,7 @@ export default function AttributeOptionsEdit(
 			</InspectorControls>
 
 			<Disabled>
-				{ optionStyle === 'pills' ? (
-					<Pills id={ attribute.taxonomy } options={ options } />
-				) : (
+				{ optionStyle === 'dropdown' ? (
 					<select
 						id={ attribute.taxonomy }
 						className="wc-block-add-to-cart-with-options-variation-selector-attribute-options__dropdown"
@@ -135,6 +134,8 @@ export default function AttributeOptionsEdit(
 							</option>
 						) ) }
 					</select>
+				) : (
+					<Pills id={ attribute.taxonomy } options={ options } />
 				) }
 			</Disabled>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -22,7 +22,7 @@ import { useThemeColors } from '../../../../shared/hooks/use-theme-colors';
 
 interface Attributes {
 	className?: string;
-	style?: 'pills' | 'dropdown';
+	optionStyle?: 'pills' | 'dropdown';
 }
 
 function Pills( {
@@ -61,7 +61,7 @@ export default function AttributeOptionsEdit(
 	props: BlockEditProps< Attributes >
 ) {
 	const { attributes, setAttributes } = props;
-	const { className, style } = attributes;
+	const { className, optionStyle } = attributes;
 
 	const blockProps = useBlockProps( {
 		className,
@@ -94,9 +94,13 @@ export default function AttributeOptionsEdit(
 			<InspectorControls>
 				<PanelBody title={ __( 'Style', 'woocommerce' ) }>
 					<ToggleGroupControl
-						value={ style }
-						onChange={ ( option: 'pills' | 'dropdown' ) => {
-							setAttributes( { style: option } );
+						label={ __( 'Style', 'woocommerce' ) }
+						value={ optionStyle }
+						onChange={ ( option ) => {
+							if ( option !== 'pills' && option !== 'dropdown' ) {
+								return;
+							}
+							setAttributes( { optionStyle: option } );
 						} }
 						isBlock
 						hideLabelFromVision
@@ -115,7 +119,7 @@ export default function AttributeOptionsEdit(
 			</InspectorControls>
 
 			<Disabled>
-				{ style === 'pills' ? (
+				{ optionStyle === 'pills' ? (
 					<Pills id={ attribute.taxonomy } options={ options } />
 				) : (
 					<select

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -31,7 +31,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	private function parse_attributes( $attributes ) {
 		// These should match what's set in JS `registerBlockType`.
 		$defaults = array(
-			'style' => 'pills',
+			'optionStyle' => 'pills',
 		);
 
 		return wp_parse_args( $attributes, $defaults );
@@ -60,10 +60,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 
 		$attributes = $this->parse_attributes( $attributes );
 
-		// `$attributes['style']` is the layout selector ("pills" | "dropdown"), not the block supports style object.
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes', 'style' ) );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
-		$field_style = $attributes['style'];
+		$option_style = $attributes['optionStyle'];
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
@@ -72,7 +71,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 			)
 		);
 
-		if ( 'dropdown' === $field_style ) {
+		if ( 'dropdown' === $option_style ) {
 			$content = $this->render_dropdown( $attributes, $content, $block );
 		} else {
 			$content = $this->render_pills( $attributes, $content, $block );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -23,21 +23,6 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-variation-selector-attribute-options';
 
 	/**
-	 * Get the block's attributes.
-	 *
-	 * @param array $attributes Block attributes. Default empty array.
-	 * @return array  Block attributes merged with defaults.
-	 */
-	private function parse_attributes( $attributes ) {
-		// These should match what's set in JS `registerBlockType`.
-		$defaults = array(
-			'optionStyle' => 'pills',
-		);
-
-		return wp_parse_args( $attributes, $defaults );
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -58,11 +43,15 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 
 		$attribute_slug = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
 
-		$attributes = $this->parse_attributes( $attributes );
-
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
-		$option_style = $attributes['optionStyle'];
+		$option_style = array_key_exists( 'optionStyle', $attributes ) ? $attributes['optionStyle'] : null;
+
+		// During the beta period, `optionStyle` was called `style`, so we check
+		// `style` for backwards compatibility.
+		if ( ! $option_style && array_key_exists( 'style', $attributes ) && 'dropdown' === $attributes['style'] ) {
+			$option_style = 'dropdown';
+		}
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the _Variation Selector: Attribute Options_ block, we allow selecting between _Pills_ and _Dropdown_ styles. We were saving the value in the `style` attribute, but that might conflict if in the future we add styling options to that block (ie: border, spacing, etc.). So I think it's better to rename it to something else. I also implemented some basic backwards compatibility checks to make sure that if a store had selected _Dropdown_ in the beta version of the block, they won't be updated to the _Pills_ style.

### How to test the changes in this Pull Request:

1. In `trunk`, edit the _Single Product_ template, update to the blockified _Add to Cart + Options_ block, edit the _Variable Product_ view and switch the pills to dropdowns.
2. Switch to this branch.
3. In the frontend of a variable product, verify you still see the dropdowns instead of the pills.
4. Edit the template again and verify toggling between pills and dropdowns still works.

Note: there is a glitch that if the previous style was _Dropdown_, the toggle incorrectly defaults to _Pills_. Things get back to normal once the toggle is interacted with. Considering the block is in beta and backwards compatibility is guaranteed in the frontend, I lean towards not adding extra complexity to the code for this, but happy to discuss. :slightly_smiling_face: 

<img width="1556" height="870" alt="imatge" src="https://github.com/user-attachments/assets/a0c50c0d-3169-466b-b491-174470256752" />

