### PR TITLE
Fix begin_checkout event not tracked id Google Analytics for WooCommerce

### DIFF
--- a/plugins/woocommerce/changelog/storma-60-begin-checkout-event-is-not-tracked-on-checkout
+++ b/plugins/woocommerce/changelog/storma-60-begin-checkout-event-is-not-tracked-on-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix render-checkout-form event was possibly triggered too early for 3rd party scripts to catch

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -4,6 +4,7 @@
 import type { ReactElement } from 'react';
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
+import domReady from '@wordpress/dom-ready';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
 import { useEffect } from '@wordpress/element';
@@ -21,7 +22,9 @@ const FrontendBlock = ( {
 
 	// Ignore changes to dispatchCheckoutEvent callback so this is ran on first mount only.
 	useEffect( () => {
-		dispatchCheckoutEvent( 'render-checkout-form' );
+		domReady( () => {
+			dispatchCheckoutEvent( 'render-checkout-form' );
+		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The event render-checkout-form was triggered too early, before 3rd-party plugins had a chance to hook into it.
The issue was revealed in the Google Analytics for WooCommerce plugin, where the `begin_checkout` event was reported not to be triggered in E2E tests.

I attempted to work around it in Google Analytics for WooCommerce, but the fix was becoming quite complex.

Closes STORMA-60.

(For Bug Fixes) Bug introduced in PR # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

1. Install [Google Analytics Integration](https://cs.wordpress.org/plugins/woocommerce-google-analytics-integration/) 
2. Go to Settings ( WooCommerce → Settings → Integration → Google Analytics )
3. Set up analytics: Allow all events and set some tracking ID (e.g. G-28QSQJCS9D)
4. Install an extension for debugging GA tracking, like [Google Analytics Debugger Extension](https://chromewebstore.google.com/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) or [Tag Assistant (official)](https://tagassistant.google.com/)
5. Go to the shop, add an item to the cart, and go to checkout. Note: don't use admin account it is not tracked
6. Observe that `begin_checkout` is tracked (When using Google Analytics Debugger Extension, it is visible in console)

<!-- End testing instructions -->
