### PR TITLE
Address customer effort score tracks critical uncaught type error

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5510-customereffortscoretracks-critical-uncaught-typeerror
+++ b/plugins/woocommerce/changelog/wooplug-5510-customereffortscoretracks-critical-uncaught-typeerror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Customer Effort Score track queue logic to avoid PHP errors around wrong type coming from wp_options.

--- a/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
+++ b/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
@@ -242,6 +242,8 @@ class CustomerEffortScoreTracks {
 			array()
 		);
 
+		$queue = is_array( $queue ) ? $queue : array();
+
 		$has_duplicate = array_filter(
 			$queue,
 			function ( $queue_item ) use ( $item ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This makes a small change to the Customer Effort Score tracks logic to check the queu data coming from a WP option. We are blindly passing this data into the `array_filter` function which always expects an array. There are cases where this option turns out to be a string or boolean, like here: 10218923-zd-a8c, this makes sure we always check the type to be an array.

Closes #WOOPLUG-5510

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**I am unaware of the exact way sites introduce a string or boolean value for this option, but it does seem to happen on the odd occasion, the testing instructions will include a manual approach**

1. Create a new site and make sure tracking is enabled under **WooCommerce > Settings > Advanced > woocommerce.com**
2. Go to **WooCommerce > Home** and open your console
3. Trigger this `wp.data.dispatch( wc.data.optionsStore ).updateOptions({ 'woocommerce_ces_tracks_queue': true})`, which set the tracks queu option to a boolean ( you can also set it to a string ).
4. Go to **Products > Add new** and try to add a new product or update one
5. On a new site an notice should correctly pop up asking how it was to edit the product.
<img width="559" height="234" alt="Screenshot 2025-09-11 at 15 25 44" src="https://github.com/user-attachments/assets/e568e891-ac64-47cf-813b-f39c9e605fb4" />

6. Open your console and trigger `wp.data.select( wc.data.optionsStore ).getOption('woocommerce_ces_tracks_queue')` ( the second time should show the value ), it should not be the boolean or string anymore but an array.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>