### PR TITLE
iAPI MiniCart: Compatibility with integration registry

### DIFF
--- a/plugins/woocommerce/changelog/60877-wooplug-5515-iapi-mini-block-beta-compatibility-with-woocommerce
+++ b/plugins/woocommerce/changelog/60877-wooplug-5515-iapi-mini-block-beta-compatibility-with-woocommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix iAPI minicart compatibility with WooCommerce extensions using IntegrationInterface.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -625,6 +625,7 @@ const { state: cartItemState } = store(
 					itemData: {
 						key: string;
 						attribute: string;
+						name: string;
 						value: string;
 						hidden: string;
 					};
@@ -640,7 +641,10 @@ const { state: cartItemState } = store(
 				}
 
 				const dataItemAttrKey =
-					dataItemAttr.key || dataItemAttr.attribute;
+					dataItemAttr.key ||
+					dataItemAttr.attribute ||
+					dataItemAttr.name;
+
 				// Decode entities.
 				const nameTxt = document.createElement( 'textarea' );
 				nameTxt.innerHTML = dataItemAttrKey + ':';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -494,6 +494,13 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function render_experimental_iapi_mini_cart( $attributes, $content, $block ) {
 		wp_enqueue_script_module( $this->get_full_block_name() );
+
+		// Enqueue all integration scripts registered for this block.
+		$integration_script_handles = $this->integration_registry->get_all_registered_script_handles();
+		foreach ( $integration_script_handles as $handle ) {
+			wp_enqueue_script( $handle );
+		}
+
 		$this->register_cart_interactivity( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 		$this->initialize_shared_config( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 		$this->placeholder_image( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -142,8 +142,8 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									>
 									</div>
 									<div class="wc-block-cart-item__prices">
-										<span data-wp-text="state.beforeItemPrice"></span>
 										<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price">
+											<span data-wp-text="state.beforeItemPrice"></span>
 											<span class="screen-reader-text">
 												<?php esc_html_e( 'Previous price:', 'woocommerce' ); ?>
 											</span>
@@ -152,12 +152,14 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 												<?php esc_html_e( 'Discounted price:', 'woocommerce' ); ?>
 											</span>
 											<ins data-wp-text="state.itemPrice" class="wc-block-components-product-price__value is-discounted"></ins>
+											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
 										<span data-wp-bind--hidden="state.cartItemHasDiscount" class="price wc-block-components-product-price">
+											<span data-wp-text="state.beforeItemPrice"></span>
 											<span data-wp-text="state.itemPrice" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value">
 											</span>
+											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
-										<span data-wp-text="state.afterItemPrice"></span>
 									</div>
 									<div 
 										data-wp-bind--hidden="!state.cartItemHasDiscount" 


### PR DESCRIPTION
### Submission Review Guidelines:

  -   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding 
  Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
  -   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
  -   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
  -   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

  ### Changes proposed in this Pull Request:

#### What

This PR fixes compatibility issues between WooCommerce extensions like WooCommerce Subscriptions.

1. Extensions using `IntegrationInterface` were not working correctly with the new iAPI minicart as integration scripts were not being registered by the `AbstractBlock` class because `get_block_type_script()` returns `null`.
2. The filtered `before` and `after` price content was incorrectly positioned in the HTML of the new iAPI minicart.
3. Product metadata was not displaying due to missing `name` field fallback.

  Closes #60864.

  ### Screenshots or screen recordings:

  <!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
  <!-- This section can be removed if not applicable. -->

  | Before | After |
  | ------ | ----- |
  |<img width="520" height="305" alt="Screenshot 2025-09-11 at 16 10 57" src="https://github.com/user-attachments/assets/f277866d-3922-4b25-a895-34eeab8b5e0c" /> | <img width="520" height="305" alt="Screenshot 2025-09-11 at 16 10 34" src="https://github.com/user-attachments/assets/37c0a9ab-2839-48ac-88d7-61c7e6250fe7" /> |


  ### How to test the changes in this Pull Request:

  1. **Setup:** Install WooCommerce Subscriptions 
  3. **Enable IAPI minicart**
  4. **Create test products:** Create subscription products with signup fees
  5. **Add to cart:** Add the products to cart and open the minicart
  7. **Verify metadata displays:** Confirm subscription texts and other product metadata appear correctly in the IAPI minicart
  8. **Enable gifts**: in WooCommerce Subscription settings
  9. **Verify metadata displays:** Confirm gift box works
  11. **Test React fallback:** Disable the iAPI version and verify the React-based minicart still works as expected

  ### Changelog entry

  -   [x] Automatically create a changelog entry from the details below.

  <details>
  <summary>Changelog Entry Details</summary>

  #### Significance
  -   [x] Patch

  #### Type
  -   [x] Fix - Fixes an existing bug

  #### Message
  Fix iAPI minicart compatibility with WooCommerce extensions using IntegrationInterface.

  </details>