### PR TITLE
Move address autocomplete provider setting and encode script data

### DIFF
--- a/plugins/woocommerce/changelog/fix-update-address-autocomplete-settings
+++ b/plugins/woocommerce/changelog/fix-update-address-autocomplete-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Address Autocomplete settings to be tied to the correct script and escaped as JSON

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -13,11 +13,11 @@ var serverProviders = [];
 try {
 	if (
 		window &&
-		window.wc_checkout_params &&
-		window.wc_checkout_params.address_providers
+		window.wc_address_autocomplete_params &&
+		window.wc_address_autocomplete_params.address_providers
 	) {
 		serverProviders = JSON.parse(
-			window.wc_checkout_params.address_providers
+			window.wc_address_autocomplete_params.address_providers
 		);
 	}
 } catch ( e ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -9,16 +9,16 @@ window.wc.addressAutocomplete = window.wc.addressAutocomplete || {
 	activeProvider: { billing: null, shipping: null },
 };
 
-var serverProviders = [];
+let serverProviders = [];
 try {
-	if (
-		window &&
-		window.wc_address_autocomplete_params &&
-		window.wc_address_autocomplete_params.address_providers
-	) {
-		serverProviders = JSON.parse(
-			window.wc_address_autocomplete_params.address_providers
-		);
+	if ( window && window.wc_address_autocomplete_params ) {
+		const raw = window.wc_address_autocomplete_params.address_providers;
+		if ( typeof raw === 'string' ) {
+			const parsed = JSON.parse( raw );
+			serverProviders = Array.isArray( parsed ) ? parsed : [];
+		} else if ( Array.isArray( raw ) ) {
+			serverProviders = raw;
+		}
 	}
 } catch ( e ) {
 	console.error( 'Invalid address providers JSON:', e );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -9,6 +9,21 @@ window.wc.addressAutocomplete = window.wc.addressAutocomplete || {
 	activeProvider: { billing: null, shipping: null },
 };
 
+var serverProviders = [];
+try {
+	if (
+		window &&
+		window.wc_checkout_params &&
+		window.wc_checkout_params.address_providers
+	) {
+		serverProviders = JSON.parse(
+			window.wc_checkout_params.address_providers
+		);
+	}
+} catch ( e ) {
+	console.error( 'Invalid address providers JSON:', e );
+}
+
 /**
  * Register an address autocomplete provider
  *
@@ -38,17 +53,6 @@ function registerAddressAutocompleteProvider( provider ) {
 
 		if ( typeof provider.select !== 'function' ) {
 			throw new Error( 'Address provider must have a select function' );
-		}
-
-		// Check if provider is registered on server.
-		var serverProviders = [];
-		if (
-			window &&
-			window.wc_checkout_params &&
-			Array.isArray( window.wc_checkout_params.address_providers ) &&
-			window.wc_checkout_params.address_providers.length > 0
-		) {
-			serverProviders = window.wc_checkout_params.address_providers;
 		}
 
 		if ( ! Array.isArray( serverProviders ) ) {
@@ -102,11 +106,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 	 */
 	function setActiveProvider( country, type ) {
 		// Get server providers list (already ordered by preference).
-		const serverProviders =
-			( window &&
-				window.wc_checkout_params &&
-				window.wc_checkout_params.address_providers ) ||
-			[];
 
 		// Check providers in preference order (server handles preferred provider ordering).
 		for ( const serverProvider of serverProviders ) {
@@ -501,12 +500,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				const activeProvider =
 					window.wc.addressAutocomplete.activeProvider[ type ];
 				if ( activeProvider && activeProvider.id ) {
-					// Get the server provider data to access branding_html.
-					const serverProviders =
-						( window &&
-							window.wc_checkout_params &&
-							window.wc_checkout_params.address_providers ) ||
-						[];
 					const serverProvider = serverProviders.find(
 						( provider ) => provider.id === activeProvider.id
 					);

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -363,14 +363,14 @@ describe( 'Address Suggestions Component', () => {
 		// Setup window object
 		Object.assign( global.window, {
 			wc_address_autocomplete_params: {
-				address_providers: [
+				address_providers: JSON.stringify( [
 					{
 						id: 'test-provider',
 						name: 'Test provider',
 						branding_html:
 							'<div class="provider-branding">Powered by Test Provider</div>',
 					},
-				],
+				] ),
 			},
 		} );
 
@@ -1289,13 +1289,14 @@ describe( 'Address Suggestions Component', () => {
 
 		test( 'should not create branding element when provider has no branding_html', async () => {
 			// Update window object to have no branding_html
-			global.window.wc_address_autocomplete_params.address_providers = [
-				{
-					id: 'test-provider',
-					name: 'Test provider',
-					// No branding_html
-				},
-			];
+			global.window.wc_address_autocomplete_params.address_providers =
+				JSON.stringify( [
+					{
+						id: 'test-provider-2',
+						name: 'Test provider 2',
+						// No branding_html
+					},
+				] );
 
 			// Re-initialize the module
 			jest.resetModules();

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -1296,7 +1296,9 @@ describe( 'Address Suggestions Component', () => {
 
 			// Re-register provider
 			window.wc.addressAutocomplete.registerAddressAutocompleteProvider( {
-				...mockProvider,
+				search: mockProvider,
+				select: mockProvider,
+				canSearch: mockProvider,
 				id: 'mock-provider-unbranded',
 			} );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -370,6 +370,10 @@ describe( 'Address Suggestions Component', () => {
 						branding_html:
 							'<div class="provider-branding">Powered by Test Provider</div>',
 					},
+					{
+						id: 'test-provider-unbranded',
+						name: 'Test provider unbranded',
+					},
 				] ),
 			},
 		} );
@@ -497,6 +501,7 @@ describe( 'Address Suggestions Component', () => {
 
 	afterEach( () => {
 		jest.clearAllMocks();
+		window.wc.addressAutocomplete.providers = [];
 	} );
 
 	describe( 'DOM Initialization', () => {
@@ -886,10 +891,6 @@ describe( 'Address Suggestions Component', () => {
 		} );
 
 		test( 'should select address with Enter key', async () => {
-			const suggestions = document.querySelectorAll(
-				'#address_suggestions_billing .suggestions-list li'
-			);
-
 			// Navigate to first suggestion first
 			let keydownEvent = new KeyboardEvent( 'keydown', {
 				key: 'ArrowDown',
@@ -1288,24 +1289,16 @@ describe( 'Address Suggestions Component', () => {
 		} );
 
 		test( 'should not create branding element when provider has no branding_html', async () => {
-			// Update window object to have no branding_html
-			global.window.wc_address_autocomplete_params.address_providers =
-				JSON.stringify( [
-					{
-						id: 'test-provider-2',
-						name: 'Test provider 2',
-						// No branding_html
-					},
-				] );
-
 			// Re-initialize the module
 			jest.resetModules();
+			window.wc.addressAutocomplete.providers = [];
 			require( '../address-autocomplete' );
 
 			// Re-register provider
-			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
-				mockProvider
-			);
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider( {
+				...mockProvider,
+				id: 'mock-provider-unbranded',
+			} );
 
 			// Trigger DOMContentLoaded again
 			const event = new Event( 'DOMContentLoaded' );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -7,13 +7,13 @@ describe( 'Address Autocomplete Provider Registration', () => {
 		delete global.window.wc;
 		// Reset the window object and providers before each test
 		Object.assign( global.window, {
-			wc_checkout_params: {
-				address_providers: [
+			wc_address_autocomplete_params: {
+				address_providers: JSON.stringify( [
 					{ id: 'test-provider', name: 'Test provider' },
 					{ id: 'wc-payments', name: 'WooCommerce Payments' },
 					{ id: 'provider-1', name: 'Provider 1' },
 					{ id: 'provider-2', name: 'Provider 2' },
-				],
+				] ),
 			},
 		} );
 
@@ -55,9 +55,9 @@ describe( 'Address Autocomplete Provider Registration', () => {
 		} );
 	} );
 
-	test( 'should handle missing wc_checkout_params', () => {
+	test( 'should handle missing wc_address_autocomplete_params', () => {
 		delete global.window.wc; // ensure fresh load
-		global.window.wc_checkout_params = undefined;
+		global.window.wc_address_autocomplete_params = undefined;
 		jest.resetModules();
 		require( '../address-autocomplete' );
 		const validProvider = {
@@ -80,7 +80,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 
 	test( 'should handle invalid address_providers type', () => {
 		delete global.window.wc; // ensure fresh load
-		global.window.wc_checkout_params = undefined;
+		global.window.wc_address_autocomplete_params = undefined;
 		jest.resetModules();
 		require( '../address-autocomplete' );
 		const validProvider = {
@@ -362,7 +362,7 @@ describe( 'Address Suggestions Component', () => {
 
 		// Setup window object
 		Object.assign( global.window, {
-			wc_checkout_params: {
+			wc_address_autocomplete_params: {
 				address_providers: [
 					{
 						id: 'test-provider',
@@ -1289,7 +1289,7 @@ describe( 'Address Suggestions Component', () => {
 
 		test( 'should not create branding element when provider has no branding_html', async () => {
 			// Update window object to have no branding_html
-			global.window.wc_checkout_params.address_providers = [
+			global.window.wc_address_autocomplete_params.address_providers = [
 				{
 					id: 'test-provider',
 					name: 'Test provider',

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -644,7 +644,8 @@ class WC_Frontend_Scripts {
 				);
 				break;
 			case 'wc-checkout':
-				$params = array(
+				$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
+				$params    = array(
 					'ajax_url'                  => WC()->ajax_url(),
 					'wc_ajax_url'               => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 					'update_order_review_nonce' => wp_create_nonce( 'update-order-review' ),
@@ -656,22 +657,22 @@ class WC_Frontend_Scripts {
 					'debug_mode'                => Constants::is_true( 'WP_DEBUG' ),
 					/* translators: %s: Order history URL on My Account section */
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
-				);
-
-				$providers                   = wc_get_container()->get( AddressProviderController::class )->get_providers();
-				$params['address_providers'] = array_map(
-					function ( $provider ) {
-						// Sanitize provider data before sending to frontend.
-						return array(
-							'id'            => sanitize_key( $provider->id ),
-							'name'          => sanitize_text_field( $provider->name ),
-							'branding_html' => wp_kses(
-								trim( (string) ( $provider->branding_html ?? '' ) ),
-								'post'
-							),
-						);
-					},
-					$providers
+					'address_providers'         => wp_json_encode(
+						array_map(
+							function ( $provider ) {
+								// Escape provider data before sending to frontend.
+								return array(
+									'id'            => $provider->id,
+									'name'          => $provider->name,
+									'branding_html' => wp_kses(
+										trim( (string) ( $provider->branding_html ?? '' ) ),
+										'post'
+									),
+								);
+							},
+							$providers
+						),
+					),
 				);
 				break;
 			case 'wc-address-i18n':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -659,8 +659,13 @@ class WC_Frontend_Scripts {
 				);
 				break;
 			case 'wc-address-autocomplete':
-				$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
-				$params    = array(
+				$providers = array();
+				try {
+					$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
+				} catch ( Throwable $e ) {
+					wc_get_logger()->error( 'Could not get address providers for wc-address-autocomplete script: ' . $e->getMessage(), array( 'source' => 'address-autocomplete' ) );
+				}
+				$params = array(
 					'address_providers' => wp_json_encode(
 						array_map(
 							function ( $provider ) {

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -644,7 +644,7 @@ class WC_Frontend_Scripts {
 				);
 				break;
 			case 'wc-checkout':
-				$params    = array(
+				$params = array(
 					'ajax_url'                  => WC()->ajax_url(),
 					'wc_ajax_url'               => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 					'update_order_review_nonce' => wp_create_nonce( 'update-order-review' ),

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -644,7 +644,6 @@ class WC_Frontend_Scripts {
 				);
 				break;
 			case 'wc-checkout':
-				$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
 				$params    = array(
 					'ajax_url'                  => WC()->ajax_url(),
 					'wc_ajax_url'               => WC_AJAX::get_endpoint( '%%endpoint%%' ),
@@ -657,7 +656,12 @@ class WC_Frontend_Scripts {
 					'debug_mode'                => Constants::is_true( 'WP_DEBUG' ),
 					/* translators: %s: Order history URL on My Account section */
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
-					'address_providers'         => wp_json_encode(
+				);
+				break;
+			case 'wc-address-autocomplete':
+				$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
+				$params    = array(
+					'address_providers' => wp_json_encode(
 						array_map(
 							function ( $provider ) {
 								// Escape provider data before sending to frontend.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is based on https://github.com/woocommerce/woocommerce/pull/60840/

- Encode the server-registered autocomplete settings using `wp_json_encode` to prevent malicious data being output in the inline script
- Move the `address_providers` option into the main array for frontend script data (previously it was on its own, but this is because it was behind a feature flag and added conditionally)
- Update the autocomplete script to parse the now-encoded provider data and use that.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Payments and activate test mode.
2. Visit the shortcode checkout and enter an address into the "address 1" field - ensure autocomplete works and you can select addresses and they update the rest of the form correctly.
3. Test separate address completions for shipping and billing.
4. Complete the order and verify the correct address was saved to the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
