### PR TITLE
Pass product object to woocommerce_add_to_cart_handler

### DIFF
--- a/plugins/woocommerce/changelog/issues-60884-add-to-cart-handler-param
+++ b/plugins/woocommerce/changelog/issues-60884-add-to-cart-handler-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add product object as parameter to woocommerce_add_to_cart_handler_$product_type hook

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -841,7 +841,7 @@ class WC_Form_Handler {
 		} elseif ( ProductType::GROUPED === $add_to_cart_handler ) {
 			$was_added_to_cart = self::add_to_cart_handler_grouped( $product_id );
 		} elseif ( has_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler ) ) {
-			do_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler, $url ); // Custom handler.
+			do_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler, $url, $adding_to_cart ); // Custom handler.
 		} else {
 			$was_added_to_cart = self::add_to_cart_handler_simple( $product_id );
 		}


### PR DESCRIPTION
Adds an extra param to the action hook. 

Closes #60884 