### PR TITLE
Avoid returning product name if product is private or draft

### DIFF
--- a/plugins/woocommerce/changelog/update-cart-add-item-respect-private-draft-product-name
+++ b/plugins/woocommerce/changelog/update-cart-add-item-respect-private-draft-product-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Dont return product name in add-to-cart endpoint if product is draft or private

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -1201,6 +1201,19 @@ class CartController {
 	}
 
 	/**
+	 * Get product name, hiding it for draft and private products.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return string
+	 */
+	protected function get_product_name( \WC_Product $product ) {
+		if ( $product->get_status() === ProductStatus::DRAFT || $product->get_status() === ProductStatus::PRIVATE ) {
+			return '';
+		}
+		return $product->get_name();
+	}
+
+	/**
 	 * Default exception thrown when an item cannot be added to the cart.
 	 *
 	 * @throws RouteException Exception with code woocommerce_rest_product_not_purchasable.
@@ -1208,13 +1221,21 @@ class CartController {
 	 * @param \WC_Product $product Product object associated with the cart item.
 	 */
 	protected function throw_default_product_exception( \WC_Product $product ) {
-		throw new RouteException(
-			'woocommerce_rest_product_not_purchasable',
-			sprintf(
+		$product_name = $this->get_product_name( $product );
+
+		if ( empty( $product_name ) ) {
+			$message = esc_html__( 'This product is not available for purchase.', 'woocommerce' );
+		} else {
+			$message = sprintf(
 				/* translators: %s: product name */
 				esc_html__( '&quot;%s&quot; is not available for purchase.', 'woocommerce' ),
-				$product->get_name()
-			),
+				esc_html( $product_name )
+			);
+		}
+
+		throw new RouteException(
+			'woocommerce_rest_product_not_purchasable',
+			$message, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			400
 		);
 	}

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -1224,7 +1224,7 @@ class CartController {
 		$product_name = $this->get_product_name( $product );
 
 		if ( empty( $product_name ) ) {
-			$message = esc_html__( 'This product is not available for purchase.', 'woocommerce' );
+			$message = esc_html__( 'This item is not available for purchase.', 'woocommerce' );
 		} else {
 			$message = sprintf(
 				/* translators: %s: product name */

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -1224,18 +1224,18 @@ class CartController {
 		$product_name = $this->get_product_name( $product );
 
 		if ( empty( $product_name ) ) {
-			$message = esc_html__( 'This item is not available for purchase.', 'woocommerce' );
+			$message = __( 'This item is not available for purchase.', 'woocommerce' );
 		} else {
 			$message = sprintf(
 				/* translators: %s: product name */
-				esc_html__( '&quot;%s&quot; is not available for purchase.', 'woocommerce' ),
-				esc_html( $product_name )
+				__( '&quot;%s&quot; is not available for purchase.', 'woocommerce' ),
+				$product_name
 			);
 		}
 
 		throw new RouteException(
 			'woocommerce_rest_product_not_purchasable',
-			$message, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			esc_html( $message ),
 			400
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces a new method in the `CartController` to get the product name but respect the status of the product.

Closes [WOOPLUG-5485](https://linear.app/a8c/issue/WOOPLUG-5485/draftprivate-product-names-are-visible-when-adding-to-cart-in-store)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update a product so its draft or private
2. Send a request to the `POST /wp-json/wc/store/v1/cart/add-item` endpoint with the following payload `{"id":[DRAFT_PRODUCT_ID],"quantity":1}`
3. Ensure the response returns `This item is not available for purchase.`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
