### PR TITLE
Increase timeout for SVN operations in release workflow to 30 mins

### DIFF
--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -211,7 +211,7 @@ jobs:
             --message "Tagging version $RELEASE_TAG." \
             --no-auth-cache \
             --non-interactive \
-            --config-option=servers:global:http-timeout=600
+            --config-option=servers:global:http-timeout=1800
 
       - name: Commit to tag only
         if: ${{ needs.get-and-validate-release-asset.outputs.overwrite_trunk != 1 }}
@@ -238,4 +238,4 @@ jobs:
             --message "Tagging version $RELEASE_TAG." \
             --no-auth-cache \
             --non-interactive \
-            --config-option=servers:global:http-timeout=600
+            --config-option=servers:global:http-timeout=1800


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Due to SVN timeouts that seem to be a bit more common during the release of `-beta.1` due to the larger set of changes, it'd be good to increase the SVN timeout to at least 30 mins to see if that solves the connection issues.

In any case, re-running the `Release: Upload release to WordPress.org` in case of failure is safe because: (1) SVN commit should is atomic (2) if `trunk` is already up to date, we just commit to the tag (3) if the tag already exists, we bail out.

See p1756738127639119-slack-C01DT6U03HC.