### PR TITLE
Fix index key length for status on wc_order_stats table

### DIFF
--- a/plugins/woocommerce/changelog/fix-60790
+++ b/plugins/woocommerce/changelog/fix-60790
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix index key length for status on wc_order_stats table

--- a/plugins/woocommerce/changelog/fix-60790
+++ b/plugins/woocommerce/changelog/fix-60790
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: performance
 
 Fix index key length for status on wc_order_stats table

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1946,12 +1946,12 @@ CREATE TABLE {$wpdb->prefix}wc_order_stats (
 	shipping_total double DEFAULT 0 NOT NULL,
 	net_total double DEFAULT 0 NOT NULL,
 	returning_customer tinyint(1) DEFAULT NULL,
-	status varchar(200) NOT NULL,
+	status varchar(20) NOT NULL,
 	customer_id bigint(20) unsigned NOT NULL,
 	PRIMARY KEY (order_id),
 	KEY date_created (date_created),
 	KEY customer_id (customer_id),
-	KEY status (status({$max_index_length}))
+	KEY status (status)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 	order_item_id bigint(20) unsigned NOT NULL,

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -645,6 +645,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @internal
 	 * @param int $order_id Order ID.
+	 * @return void
 	 */
 	public static function maybe_update_order_statuses_cache( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -656,6 +657,18 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				wp_cache_set( self::ORDERS_STATUSES_ALL_CACHE_KEY, $statuses, 'woocommerce_analytics', YEAR_IN_SECONDS );
 			}
 		}
+	}
+
+	/**
+	 * Ensure the order status will present in `get_all_statuses` call result.
+	 *
+	 * @deprecated 10.3.0 Use maybe_update_order_statuses_cache().
+	 * @param int $order_id Order ID.
+	 * @return void
+	 */
+	public static function maybe_update_order_statuses_transient( $order_id ) {
+		wc_deprecated_function( __METHOD__, '10.3.0', __CLASS__ . '::maybe_update_order_statuses_cache()' );
+		return self::maybe_update_order_statuses_cache( $order_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -620,20 +620,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get all statuses that have been synced.
 	 *
-	 * @return array Unique order statuses.
+	 * @return string[] Unique order statuses.
 	 */
 	public static function get_all_statuses() {
 		global $wpdb;
 
 		$statuses = wp_cache_get( self::ORDERS_STATUSES_ALL_CACHE_KEY, 'woocommerce_analytics' );
 		if ( false === $statuses ) {
-			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
 			$table_name = self::get_db_table_name();
-			$statuses   = $wpdb->get_col(
-				"SELECT DISTINCT status FROM {$table_name}"
-			);
-			/* phpcs:enable */
-
+			$statuses   = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT status FROM %i', $table_name ) );
 			wp_cache_set( self::ORDERS_STATUSES_ALL_CACHE_KEY, $statuses, 'woocommerce_analytics', YEAR_IN_SECONDS );
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -668,7 +668,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function maybe_update_order_statuses_transient( $order_id ) {
 		wc_deprecated_function( __METHOD__, '10.3.0', __CLASS__ . '::maybe_update_order_statuses_cache()' );
-		return self::maybe_update_order_statuses_cache( $order_id );
+		self::maybe_update_order_statuses_cache( $order_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -22,9 +22,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	use OrderAttributionMeta;
 
 	/**
-	 * The transient name.
+	 * The cache key for order statuses.
 	 */
-	const ORDERS_STATUSES_ALL_TRANSIENT = 'woocommerce_analytics_orders_statuses_all';
+	const ORDERS_STATUSES_ALL_CACHE_KEY = 'woocommerce_analytics_orders_statuses_all';
 
 	/**
 	 * Dynamically sets the date column name based on configuration
@@ -42,7 +42,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @internal
 	 */
 	final public static function init() {
-		add_action( 'woocommerce_analytics_update_order_stats', array( __CLASS__, 'maybe_update_order_statuses_transient' ) );
+		add_action( 'woocommerce_analytics_update_order_stats', array( __CLASS__, 'maybe_update_order_statuses_cache' ) );
 	}
 
 	/**
@@ -625,7 +625,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function get_all_statuses() {
 		global $wpdb;
 
-		$statuses = get_transient( self::ORDERS_STATUSES_ALL_TRANSIENT );
+		$statuses = wp_cache_get( self::ORDERS_STATUSES_ALL_CACHE_KEY, 'woocommerce_analytics' );
 		if ( false === $statuses ) {
 			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
 			$table_name = self::get_db_table_name();
@@ -634,7 +634,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			);
 			/* phpcs:enable */
 
-			set_transient( self::ORDERS_STATUSES_ALL_TRANSIENT, $statuses, YEAR_IN_SECONDS );
+			wp_cache_set( self::ORDERS_STATUSES_ALL_CACHE_KEY, $statuses, 'woocommerce_analytics', YEAR_IN_SECONDS );
 		}
 
 		return $statuses;
@@ -646,14 +646,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @internal
 	 * @param int $order_id Order ID.
 	 */
-	public static function maybe_update_order_statuses_transient( $order_id ) {
+	public static function maybe_update_order_statuses_cache( $order_id ) {
 		$order = wc_get_order( $order_id );
 		if ( $order ) {
 			$status   = self::normalize_order_status( $order->get_status() );
 			$statuses = self::get_all_statuses();
 			if ( ! in_array( $status, $statuses, true ) ) {
 				$statuses[] = $status;
-				set_transient( self::ORDERS_STATUSES_ALL_TRANSIENT, $statuses, YEAR_IN_SECONDS );
+				wp_cache_set( self::ORDERS_STATUSES_ALL_CACHE_KEY, $statuses, 'woocommerce_analytics', YEAR_IN_SECONDS );
 			}
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Our index key length was incorrectly set to `200` (or max of `191`) for the `status` column in the `wc_order_stats` table, probably either a typo or concern for longer statuses.  However, statuses are capped to 20 characters in other tables and this prevents the indexes from working.

This PR reduces the character length to 20 for that column and updates the status related methods to use WP_Cache instead of transients.
Closes #60790  .

### Performance Metrics

Previous: 0.146s
After: .0001s
Delta: 99.93% decrease
Scaled site savings: 1.46s (estimated on 1m order site, linear scale for full table scan) 

### Screenshots or screen recordings:

**Before**
<img width="438" height="184" alt="Screenshot 2025-09-12 at 7 59 23 AM" src="https://github.com/user-attachments/assets/abdddf47-f025-4a3e-a1f8-e153271bd035" />
**After**
<img width="424" height="177" alt="Screenshot 2025-09-12 at 7 58 47 AM" src="https://github.com/user-attachments/assets/9e74e89e-89fd-47f8-bbf9-8261e9c925c9" />

<img width="576" height="413" alt="Screenshot 2025-09-12 at 8 07 37 AM" src="https://github.com/user-attachments/assets/89495a17-1796-49c2-9167-45e340eba353" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Performance Testing

1. Create a scaled site with at least 100k orders
2. Before checking out this PR or running DB updates, query your distinct statuses: `SELECT DISTINCT status FROM wp_wc_order_stats`
3. Note the query time
4. Check out this branch and trigger DB deltas: `wp transient delete wc_installing && wp option set woocommerce_db_version 10.1.0 && wp option set woocommerce_version 10.1.0`
5. Note that the index is updating on the table
6. Run the query again `SELECT DISTINCT status FROM wp_wc_order_stats`
7. Note the improved time

#### Regression Testing

1. Install a plugin like [Query Monitor](https://wordpress.org/plugins/query-monitor/) to monitor SQL queries
2. Modify an order stats row to include an unregistered status: **`UPDATE wp_wc_order_stats SET `status` = 'wc-my-custom-status' WHERE `order_id` = '{ORDER_ID}';`
3. Navigate to the Analytics -> Settings page
4. Make sure that all settings are shown, including the newly added unregistered status
5. Install a persistent cache, like Docket Cache
6. Navigate back to the Analytics -> Settings page
7. Refresh the page
8. Make sure that this query is not run: `SELECT DISTINCT status FROM wp_wc_order_stats`


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
