### PR TITLE
Add add-to-cart paths to robots.txt file

### DIFF
--- a/plugins/woocommerce/changelog/update-60810
+++ b/plugins/woocommerce/changelog/update-60810
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add add-to-cart paths to robots.txt file

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1130,6 +1130,7 @@ final class WooCommerce {
 		$above[] = "Disallow: $path/wp-content/uploads/wc-logs/";
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_transient_files/";
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_uploads/";
+		$above[] = 'Disallow: /*?add-to-cart=';
 
 		$lines = array_merge( $above, $below );
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1131,6 +1131,7 @@ final class WooCommerce {
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_transient_files/";
 		$above[] = "Disallow: $path/wp-content/uploads/woocommerce_uploads/";
 		$above[] = 'Disallow: /*?add-to-cart=';
+		$above[] = 'Disallow: /*?*add-to-cart=';
 
 		$lines = array_merge( $above, $below );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bots are able to follow many routes, but the add-to-cart requests in particular add additional load to servers and are not cached.

This PR prevents bots from following any paths with the add to cart params.

Closes #60810 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<img width="507" height="116" alt="Screenshot 2025-09-12 at 12 21 54 PM" src="https://github.com/user-attachments/assets/9e95ba3b-56fd-4b88-9ba7-4c2a68a2f03b" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open your site's robots.txt file `http://yoursite.com/robots.txt`
2. Check that `Disallow: /*?add-to-cart=` has been added
3. Validate the file with some test URLs using a tool like https://technicalseo.com/tools/robots-txt/
4. Make sure that any paths with `add-to-cart` are not allowed with bot agents

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
