### PR TITLE
Fix individually sold products not being added to cart when they are children of a grouped product

### DIFF
--- a/plugins/woocommerce/changelog/fix-individually-sold-products-grouped-products
+++ b/plugins/woocommerce/changelog/fix-individually-sold-products-grouped-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix individually sold products not being added to cart when they are children of a grouped product

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -266,7 +266,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			.first();
 
 		await test.step( 'displays an error when attempting to add grouped products with zero quantity', async () => {
-			await expect( addToCartButton ).toHaveClass( /disabled/ );
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 
 			// There is the chance the button might be clicked before the iAPI
 			// stores have been loaded.
@@ -286,7 +286,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			);
 			await increaseQuantityButton.click();
 
-			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
 			await increaseQuantityButton.click();
 
@@ -322,7 +322,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					name: 'Added to cart',
 					exact: true,
 				} )
-			).toHaveClass( /disabled/ );
+			).toHaveClass( /\bdisabled\b/ );
 		} );
 
 		await test.step( 'products sold individually can be added to cart', async () => {
@@ -334,7 +334,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			);
 			await individuallySoldProductCheckbox.click();
 
-			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
 			await addToCartButton.click();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -244,6 +244,15 @@ test.describe( 'Add to Cart + Options Block', () => {
 		pageObject,
 		editor,
 	} ) => {
+		// Make Hoodie with Logo to be sold individually.
+		const cliOutput = await wpCLI(
+			`post list --post_type=product --field=ID --name="Hoodie with Logo" --format=ids`
+		);
+		const hoodieWithLogoProductId = cliOutput.stdout.match( /\d+/g )?.pop();
+		await wpCLI(
+			`wc product update ${ hoodieWithLogoProductId } --sold_individually=true --user=1`
+		);
+
 		await pageObject.updateSingleProductTemplate();
 
 		await editor.saveSiteEditorEntities( {
@@ -252,9 +261,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.goto( '/logo-collection' );
 
-		const addToCartButton = page.getByText( 'Add to cart' ).first();
+		const addToCartButton = page
+			.getByRole( 'button', { name: 'Add to cart' } )
+			.first();
 
 		await test.step( 'displays an error when attempting to add grouped products with zero quantity', async () => {
+			await expect( addToCartButton ).toHaveClass( /disabled/ );
+
 			// There is the chance the button might be clicked before the iAPI
 			// stores have been loaded.
 			await expect( async () => {
@@ -272,11 +285,19 @@ test.describe( 'Add to Cart + Options Block', () => {
 				'Increase quantity of Beanie'
 			);
 			await increaseQuantityButton.click();
+
+			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
+
 			await increaseQuantityButton.click();
 
 			await addToCartButton.click();
 
-			await expect( page.getByText( 'Added to cart' ) ).toBeVisible();
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Added to cart',
+					exact: true,
+				} )
+			).toBeVisible();
 
 			await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
 		} );
@@ -295,6 +316,36 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( quantityInput ).toHaveValue( '0' );
 
 			await expect( reduceQuantityButton ).toBeDisabled();
+
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Added to cart',
+					exact: true,
+				} )
+			).toHaveClass( /disabled/ );
+		} );
+
+		await test.step( 'products sold individually can be added to cart', async () => {
+			await page.reload();
+
+			const individuallySoldProductCheckbox = page.getByRole(
+				'checkbox',
+				{ name: 'Buy one of Hoodie with Logo' }
+			);
+			await individuallySoldProductCheckbox.click();
+
+			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
+
+			await addToCartButton.click();
+
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Added to cart',
+					exact: true,
+				} )
+			).toBeVisible();
+
+			await expect( page.getByLabel( '3 items in cart' ) ).toBeVisible();
 		} );
 	} );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -137,7 +137,8 @@ class GroupedProductItemSelector extends AbstractBlock {
 				esc_html( wp_strip_all_tags( wc_price( $product->get_price() ) ) )
 			);
 		}
-		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-on--change="actions.handleQuantityCheckboxChange" />';
+		$context_attribute = wp_interactivity_data_wp_context( array( 'childProductId' => $product->get_id() ) );
+		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-on--change="actions.handleQuantityCheckboxChange" ' . $context_attribute . ' aria-label="' . esc_attr( $label ) . '" />';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Issue reported by @dinhtungdu in https://github.com/woocommerce/woocommerce/pull/60846#pullrequestreview-3222755582. The quantity state was not being set (because the product ID was missing from the context) when checking/unchecking the checkbox of individually sold products inside a grouped product. This PR fixes that and adds e2e tests to prevent future regressions.

The issue is also reproducible in WC 10.2, so this PR will need to be backported.

### How to test the changes in this Pull Request:

1. Make sure you have a grouped product with a child product that is set individually.
2. Go to the frontend of the grouped product, making sure the page is using the _Add to Cart + Options_ block.
3. Try adding the product sold individually to cart.
4. Verify it works and there are no JS errors.

https://github.com/user-attachments/assets/09d89b1a-d977-4d75-a516-a6c7d560bfdc