### PR TITLE
Ensure chrome browser autocomplete is disabled when using address autocomplete feature

### DIFF
--- a/plugins/woocommerce/changelog/fix-autocomplete-chrome
+++ b/plugins/woocommerce/changelog/fix-autocomplete-chrome
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure autocomplete is disabled properly when using addresss autofill

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -282,11 +282,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param input {HTMLInputElement} The input element to disable autofill for.
 		 */
 		function disableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) === 'off' ) {
+			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
 				return;
 			}
 
-			input.setAttribute( 'autocomplete', 'off' );
+			input.setAttribute( 'autocomplete', 'none' );
 			input.setAttribute( 'data-lpignore', 'true' );
 			input.setAttribute( 'data-op-ignore', 'true' );
 			input.setAttribute( 'data-1p-ignore', 'true' );
@@ -323,7 +323,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param shouldFocus {boolean} Whether to focus the input after enabling autofill.
 		 */
 		function enableBrowserAutofill( input, shouldFocus = true ) {
-			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
+			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
 				return;
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -282,11 +282,18 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param input {HTMLInputElement} The input element to disable autofill for.
 		 */
 		function disableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
+			const autocompleteAttr = input.getAttribute( 'autocomplete' );
+			if ( autocompleteAttr === 'off' || autocompleteAttr === 'none' ) {
 				return;
 			}
 
 			input.setAttribute( 'autocomplete', 'none' );
+
+			let userAgent = navigator.userAgent;
+			if ( userAgent.match( /firefox|fxios/i ) ) {
+				input.setAttribute( 'autocomplete', 'off' );
+			}
+
 			input.setAttribute( 'data-lpignore', 'true' );
 			input.setAttribute( 'data-op-ignore', 'true' );
 			input.setAttribute( 'data-1p-ignore', 'true' );
@@ -323,7 +330,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param shouldFocus {boolean} Whether to focus the input after enabling autofill.
 		 */
 		function enableBrowserAutofill( input, shouldFocus = true ) {
-			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
+			const autocompleteAttr = input.getAttribute( 'autocomplete' );
+			if ( autocompleteAttr !== 'none' && autocompleteAttr !== 'off' ) {
 				return;
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -282,18 +282,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param input {HTMLInputElement} The input element to disable autofill for.
 		 */
 		function disableBrowserAutofill( input ) {
-			const autocompleteAttr = input.getAttribute( 'autocomplete' );
-			if ( autocompleteAttr === 'off' || autocompleteAttr === 'none' ) {
+			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
 				return;
 			}
 
 			input.setAttribute( 'autocomplete', 'none' );
-
-			let userAgent = navigator.userAgent;
-			if ( userAgent.match( /firefox|fxios/i ) ) {
-				input.setAttribute( 'autocomplete', 'off' );
-			}
-
 			input.setAttribute( 'data-lpignore', 'true' );
 			input.setAttribute( 'data-op-ignore', 'true' );
 			input.setAttribute( 'data-1p-ignore', 'true' );
@@ -330,8 +323,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param shouldFocus {boolean} Whether to focus the input after enabling autofill.
 		 */
 		function enableBrowserAutofill( input, shouldFocus = true ) {
-			const autocompleteAttr = input.getAttribute( 'autocomplete' );
-			if ( autocompleteAttr !== 'none' && autocompleteAttr !== 'off' ) {
+			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
 				return;
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -1087,7 +1087,7 @@ describe( 'Address Suggestions Component', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
 
 			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
-				'off'
+				'none'
 			);
 			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
 				'true'
@@ -1503,7 +1503,7 @@ describe( 'Address Suggestions Component', () => {
 
 			// Verify autofill is disabled
 			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
-				'off'
+				'none'
 			);
 
 			// Blur the input


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Set the `autocomplete` attribute to `none` instead of `off` to disable it in Chrome.

### How to test the changes in this Pull Request:

1. In Chrome, add a saved address, so that it shows up when you try to fill in forms.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Test this in Chrome only. Firefox and Safari have known limitations.

1. Add an address to the browser's saved addresses
2. Enable address autocomplete, either by installing WooPayments or using the mock testing plugin: 
[mock-address-provider.zip](https://github.com/user-attachments/files/22336031/mock-address-provider.zip) then going to WC -> Settings -> General and checking `Enable predictive address search`
3. Go to the shortcode checkout, select a country, and start typing a string that matches your saved address into address 1.
4. Your saved address should appear as an option until you type your third character and autocomplete kicks in.
5. Delete text until fewer than 3 characters are entered, autofill should be re-enabled.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
