### PR TITLE
Allow WYSIWYG Editing for Custom Product Types

### DIFF
--- a/plugins/woocommerce/changelog/add-wysiwyg-for-custom-product-types
+++ b/plugins/woocommerce/changelog/add-wysiwyg-for-custom-product-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enabled WYSIWYG editing for custom product types via formerly frontend-only experimental hook

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -9,7 +9,6 @@ import {
 	useInnerBlocksProps,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { getSetting } from '@woocommerce/settings';
 
 const TemplatePartInnerBlocks = ( {
 	blockProps,
@@ -65,16 +64,10 @@ const TemplatePartInnerBlocks = ( {
 };
 
 export const AddToCartWithOptionsEditTemplatePart = ( {
-	productType,
+	templatePartId,
 }: {
-	productType: string;
+	templatePartId: string;
 } ) => {
-	const addToCartWithOptionsTemplatePartIds = getSetting(
-		'addToCartWithOptionsTemplatePartIds',
-		{}
-	) as Record< string, string | null >;
-
-	const templatePartId = addToCartWithOptionsTemplatePartIds?.[ productType ];
 
 	const blockProps = useBlockProps();
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -68,7 +68,6 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 }: {
 	templatePartId: string;
 } ) => {
-
 	const blockProps = useBlockProps();
 
 	if ( ! templatePartId ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -21,6 +21,7 @@ import { DowngradeNotice } from '../components/downgrade-notice';
 import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import type { Attributes } from '../types';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
+import { getSetting } from '@woocommerce/settings';
 
 const AddToCartOptionsEdit = (
 	props: BlockEditProps< Attributes > & { context?: { postId?: number } }
@@ -44,9 +45,12 @@ const AddToCartOptionsEdit = (
 
 	const productType =
 		product?.id === undefined ? currentProductType?.slug : product?.type;
-	const isCoreProductType =
-		productType &&
-		[ 'simple', 'variable', 'external', 'grouped' ].includes( productType );
+	const addToCartWithOptionsTemplatePartIds = getSetting(
+		'addToCartWithOptionsTemplatePartIds',
+		{}
+	) as Record< string, string | null >;
+
+	const templatePartId = addToCartWithOptionsTemplatePartIds?.[ productType ];
 
 	return (
 		<>
@@ -56,9 +60,9 @@ const AddToCartOptionsEdit = (
 			<BlockControls>
 				<ToolbarProductTypeGroup />
 			</BlockControls>
-			{ isCoreProductType ? (
+			{ templatePartId ? (
 				<AddToCartWithOptionsEditTemplatePart
-					productType={ productType }
+					templatePartId={ templatePartId }
 				/>
 			) : (
 				<div { ...blockProps }>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -12,6 +12,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { useProduct } from '@woocommerce/entities';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { DowngradeNotice } from '../components/downgrade-notice';
 import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import type { Attributes } from '../types';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
-import { getSetting } from '@woocommerce/settings';
 
 const AddToCartOptionsEdit = (
 	props: BlockEditProps< Attributes > & { context?: { postId?: number } }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
 use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
@@ -24,6 +23,17 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'add-to-cart-with-options';
+
+	/**
+	 * Initialize the block.
+	 */
+	public function initialize() {
+		parent::initialize();
+		// Hint: We only need to backfill default template parts for the REST API requests via the Site Editor.
+		if ( WC()->is_rest_api_request() ) {
+			add_filter( 'get_block_template', array( $this, 'experimental_ensure_custom_product_type_template_parts' ), 10, 3 );
+		}
+	}
 
 	/**
 	 * Extra data passed through from server to client for block.
@@ -47,11 +57,18 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @return array Array of product types with their corresponding template part IDs.
 	 */
 	protected function get_template_part_ids() {
-		$product_types = array_keys( wc_get_product_types() );
-		$current_theme = wp_get_theme()->get_stylesheet();
+		$product_types      = array_keys( wc_get_product_types() );
+		$core_product_types = Utils::get_core_product_types();
+		$current_theme      = wp_get_theme()->get_stylesheet();
 
 		$template_part_ids = array();
 		foreach ( $product_types as $product_type ) {
+
+			// Skip custom product types that don't have a default template part.
+			if ( ! in_array( $product_type, $core_product_types, true ) && false === has_filter( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part' ) ) {
+				continue;
+			}
+
 			$slug = $product_type . '-product-add-to-cart-with-options';
 
 			// Check if theme template exists.
@@ -132,7 +149,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$slug = $product_type . '-product-add-to-cart-with-options';
 
-		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+		if ( in_array( $product_type, Utils::get_core_product_types(), true ) ) {
 			$template_part_path = Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html';
 		} else {
 			/**
@@ -575,7 +592,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			ob_start();
 
-			if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+			if ( in_array( $product_type, Utils::get_core_product_types(), true ) ) {
 
 				$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
 				remove_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
@@ -666,5 +683,86 @@ class AddToCartWithOptions extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Ensure template parts for custom product types are available for the block.
+	 *
+	 * @param \WP_Block_Template $block_template The block template.
+	 * @param string             $id             The block template ID.
+	 * @param string             $template_type  The block template type.
+	 * @return \WP_Block_Template|null The block template, or null if not found.
+	 */
+	public function experimental_ensure_custom_product_type_template_parts( $block_template, $id, $template_type ) {
+		if ( $block_template instanceof \WP_Block_Template ) {
+			return $block_template;
+		}
+
+		if ( 'wp_template_part' !== $template_type ) {
+			return $block_template;
+		}
+
+		$wc_prefix = 'woocommerce/woocommerce';
+		if ( 0 !== strpos( $id, $wc_prefix ) ) {
+			return $block_template;
+		}
+
+		$parts = explode( '//', $id, 2 );
+		if ( count( $parts ) < 2 ) {
+			return $block_template;
+		}
+		list( $theme, $slug ) = $parts;
+
+		$slug_suffix = '-product-add-to-cart-with-options';
+		if ( false === strpos( $slug, $slug_suffix ) ) {
+			return $block_template;
+		}
+
+		// Extract product type from slug.
+		$product_type = str_replace( $slug_suffix, '', $slug );
+		$product_type = sanitize_key( $product_type );
+
+		// Only target custom product types.
+		if ( in_array( $product_type, Utils::get_core_product_types(), true ) ) {
+			return $block_template;
+		}
+
+		$supported_types = $this->get_template_part_ids();
+		if ( ! isset( $supported_types[ $product_type ] ) ) {
+			return $block_template;
+		}
+
+		$file_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		if ( ! is_string( $file_path ) || ! file_exists( $file_path ) ) {
+			return $block_template;
+		}
+
+		$content = file_get_contents( $file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $content || '' === $content ) {
+			return $block_template;
+		}
+
+		$all_product_types       = wc_get_product_types();
+		$normalized_product_type = $all_product_types[ $product_type ] ?? $product_type;
+
+		/* translators: %s: Product type. */
+		$title = sprintf( '%s Add to Cart + Options', $normalized_product_type );
+		/* translators: %s: Product type. */
+		$description = sprintf( 'Template used to display the Add to Cart + Options form for %ss.', $normalized_product_type );
+
+		$template_part              = new \WP_Block_Template();
+		$template_part->id          = $id;
+		$template_part->type        = $template_type;
+		$template_part->content     = $content;
+		$template_part->theme       = $theme;
+		$template_part->slug        = $slug;
+		$template_part->title       = $title;
+		$template_part->description = $description;
+		$template_part->area        = 'add-to-cart-with-options';
+		$template_part->status      = 'publish';
+		$template_part->source      = 'plugin';
+		$template_part->post_types  = array();
+
+		return $template_part;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -746,9 +746,9 @@ class AddToCartWithOptions extends AbstractBlock {
 		$normalized_product_type = $all_product_types[ $product_type ] ?? $product_type;
 
 		/* translators: %s: Product type. */
-		$title = sprintf( '%s Add to Cart + Options', $normalized_product_type );
+		$title = sprintf( __( '%s Add to Cart + Options', 'woocommerce' ), $normalized_product_type );
 		/* translators: %s: Product type. */
-		$description = sprintf( 'Template used to display the Add to Cart + Options form for %ss.', $normalized_product_type );
+		$description = sprintf( __( 'Template used to display the Add to Cart + Options form for %ss.', 'woocommerce' ), $normalized_product_type );
 
 		$template_part              = new \WP_Block_Template();
 		$template_part->id          = $id;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -194,4 +194,18 @@ class Utils {
 			'step' => $step,
 		);
 	}
+
+	/**
+	 * Get Core product types.
+	 *
+	 * @return array The Core product types.
+	 */
+	public static function get_core_product_types() {
+		return array(
+			ProductType::SIMPLE,
+			ProductType::VARIABLE,
+			ProductType::GROUPED,
+			ProductType::EXTERNAL,
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR enables WYSIWYG editing mode for custom product types.

Currently, there is an experimental hook that allows you to render a custom template file for any product type, but it only functions on the frontend. In Edit mode, support for product types is limited to the core ones. All custom types default to a basic skeleton:

<img width="1012" height="336" alt="bookable-screen-skeleton" src="https://github.com/user-attachments/assets/f28f65bb-2381-45e3-815b-a7a6a52301e1" />

### Proposed Solution
The goal is to enable the default template part to load in the Site Editor for each custom product type, but only if that product type already hooks into the existing experimental hook.

If this PR is merged, fully supporting a product type's WYSIWYG editing experience requires the following snippet:

```php
add_filter(
    '__experimental_woocommerce_[product-type]_add_to_cart_with_options_block_template_part', 
    function() {
        return 'path/to/template/[product-type]-add-to-cart-with-options.html';
    }
);
```

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="1001" height="273" alt="bookable-edit-mode" src="https://github.com/user-attachments/assets/87757fbe-3c99-4e54-b3bf-d281d2a85476" />

<img width="1467" height="726" alt="after-experimental-hook" src="https://github.com/user-attachments/assets/dc663b6b-3cf0-4f3b-ab13-54d06c8b86e7" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install a plugin with a custom product type, e.g., WooCommerce Bookings.
2. Install the snippet above based on your custom product type name; create and point a local HTML file as expected.
3. Confirm your Single Product template uses the beta add-to-cart-with-options block.
4. Verify that your custom template file renders on both the Site Editor and frontend.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
