### PR TITLE
Add to Cart + Options block: trigger legacy mode only if PHP hooks are used to add form inner elements

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-legacy-mode-on-form-elements
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-legacy-mode-on-form-elements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options block: trigger legacy mode only if PHP hooks are used to add form inner elements

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -83,6 +83,23 @@ class AddToCartWithOptions extends AbstractBlock {
 	}
 
 	/**
+	 * Check if HTML content has form elements.
+	 *
+	 * @param string $html_content The HTML content.
+	 * @return bool True if the HTML content has form elements, false otherwise.
+	 */
+	public function has_form_elements( $html_content ) {
+		$processor     = new \WP_HTML_Tag_Processor( $html_content );
+		$form_elements = array( 'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'FORM' );
+		while ( $processor->next_tag() ) {
+			if ( in_array( $processor->get_tag(), $form_elements, true ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Check if a child product is purchasable.
 	 *
 	 * @param \WC_Product $product The product to check.
@@ -502,7 +519,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
-			$legacy_mode             = $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add;
+			$legacy_mode             = 'yes' === $cart_redirect_after_add || $this->has_form_elements( $hooks_before ) || $this->has_form_elements( $hooks_after );
 			if ( $legacy_mode ) {
 				$action_url = home_url( add_query_arg( null, null ) );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -523,7 +523,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			if ( $legacy_mode ) {
 				$action_url = home_url( add_query_arg( null, null ) );
 
-				// If an extension is hoooking into the form or we need to redirect to the cart,
+				// If an extension is hooking into the form or we need to redirect to the cart,
 				// we fall back to a regular HTML form.
 				$form_attributes = array(
 					'action'  => esc_url(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After thinking a bit more about https://github.com/woocommerce/woocommerce/issues/60773 during the weekend, I think the _Add to Cart + Options_ block could be a bit smarter about when to fall back to a regular HTML form (aka not powered by the iAPI).

The way it works now: if an extension prints any string in [one of these PHP actions](https://github.com/woocommerce/woocommerce/blob/71e62b893c1943cef71b3180d723a96019dce6a3/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php#L335-L484), we fall back to rendering a regular HTML form.

The way this branch works: we look into the content added by the extensions and only fall back to a regular HTML form if that content includes a form interactive element (`'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'FORM'`).

This should allow extensions that add content to the form but are not interactive (ie: a paragraph with additional info) to still keep the iAPI form.

### How to test the changes in this Pull Request:

1. Add this PHP code snippet to your site:

```PHP
add_action( 'woocommerce_after_add_to_cart_button', function() {
	echo '<p>This is a test paragraph.</p>';
} );
```

2. In the _Single Product_ template frontend (making sure you have the _Add to Cart + Options_ block enabled), add a product to cart.
3. Verify it's added to the cart without a page refresh.
4. Update the code snippet above to (or test with a real-life extension like [Product Add-Ons](https://woocommerce.com/products/product-add-ons/)):

```PHP
add_action( 'woocommerce_after_add_to_cart_button', function() {
	echo '<textarea></textarea>';
} );
```

5. Verify adding to cart now triggers a page refresh.