### PR TITLE
Introduce read multiple to shipping zones

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-5527-introduce-read-multiple-to-shipping-zones
+++ b/plugins/woocommerce/changelog/WOOPLUG-5527-introduce-read-multiple-to-shipping-zones
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Introduce WC_Shipping_Zone_Data_Store::read_multiple() to improve performance when requesting all Shipping_Zones at once.

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -25,7 +25,7 @@ class WC_Shipping_Zones {
 	 */
 	public static function get_zones( $context = 'admin' ) {
 		$zone_objects = self::get_shipping_zones();
-		$zones      = array();
+		$zones        = array();
 
 		foreach ( $zone_objects as $zone_object ) {
 			$zones[ $zone_object->get_id() ]                            = $zone_object->get_data();

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -38,19 +38,27 @@ class WC_Shipping_Zones {
 	}
 
 	/**
-	 * Retrieve the full set of shipping Zones.
+	 * Retrieve Shipping_Zone data objects for the given zone_ids.
+	 *
+	 * @param array|null $zone_ids The zone_ids of the zones to retrieve. An empty array will return no results. Use null for all zones.
+	 *
 	 * @return WC_Shipping_Zone[]
 	 */
-	public static function get_shipping_zones() {
+	public static function get_shipping_zones( ?array $zone_ids = null ) {
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
-		$raw_zones  = $data_store->get_zones();
-		$zones      = array();
+		if ( null === $zone_ids ) {
+			$raw_zones = $data_store->get_zones();
+			$zone_ids  = array_column( $raw_zones, 'zone_id' );
+		} elseif ( empty( $zone_ids ) ) {
+			return array();
+		}
 
-		foreach ( $raw_zones as $raw_zone ) {
+		$zones = array();
+		foreach ( $zone_ids as $zone_id ) {
 			$zone = new WC_Shipping_Zone();
 			$zone->set_object_read( false );
-			$zone->set_id( $raw_zone->zone_id );
-			$zones[ $raw_zone->zone_id ] = $zone;
+			$zone->set_id( $zone_id );
+			$zones[ $zone_id ] = $zone;
 		}
 
 		if ( ! empty( $zones ) ) {

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -24,16 +24,37 @@ class WC_Shipping_Zones {
 	 * @return array Array of arrays.
 	 */
 	public static function get_zones( $context = 'admin' ) {
+		$zone_objects = self::get_shipping_zones();
+		$zones      = array();
+
+		foreach ( $zone_objects as $zone_object ) {
+			$zones[ $zone_object->get_id() ]                            = $zone_object->get_data();
+			$zones[ $zone_object->get_id() ]['zone_id']                 = $zone_object->get_id();
+			$zones[ $zone_object->get_id() ]['formatted_zone_location'] = $zone_object->get_formatted_location();
+			$zones[ $zone_object->get_id() ]['shipping_methods']        = $zone_object->get_shipping_methods( false, $context );
+		}
+
+		return $zones;
+	}
+
+	/**
+	 * Retrieve the full set of shipping Zones.
+	 * @return WC_Shipping_Zone[]
+	 */
+	public static function get_shipping_zones() {
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		$raw_zones  = $data_store->get_zones();
 		$zones      = array();
 
 		foreach ( $raw_zones as $raw_zone ) {
-			$zone                                = new WC_Shipping_Zone( $raw_zone );
-			$zones[ $zone->get_id() ]            = $zone->get_data();
-			$zones[ $zone->get_id() ]['zone_id'] = $zone->get_id();
-			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
-			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, $context );
+			$zone = new WC_Shipping_Zone();
+			$zone->set_object_read( false );
+			$zone->set_id( $raw_zone->zone_id );
+			$zones[ $raw_zone->zone_id ] = $zone;
+		}
+
+		if ( ! empty( $zones ) ) {
+			$data_store->read_multiple( $zones );
 		}
 
 		return $zones;

--- a/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -72,43 +72,78 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	 * @throws Exception If invalid data store.
 	 */
 	public function read( &$zone ) {
-		global $wpdb;
+		$zones = array( $zone->get_id() => $zone );
+		$this->read_multiple( $zones );
+	}
 
-		// Zone 0 is used as a default if no other zones fit.
-		if ( 0 === $zone->get_id() || '0' === $zone->get_id() ) {
-			$this->read_zone_locations( $zone );
-			$zone->set_zone_name( __( 'Locations not covered by your other zones', 'woocommerce' ) );
-			$zone->read_meta_data();
+	/**
+	 * @param WC_Shipping_Zone[] $zones Array of zones to read keyed by the zone_id.
+	 *
+	 * @return void
+	 */
+	public function read_multiple( array &$zones ) {
+		$zone_ids = array_keys( $zones );
+		$zone_data = $this->get_zone_data_for_ids( $zone_ids );
+		foreach ( $zones as $zone_id => $zone ) {
+			if ( 0 === $zone_id || '0' === $zone_id ) {
+				$zone->set_zone_name( __( 'Locations not covered by your other zones', 'woocommerce' ) );
+			} else {
+				if ( ! isset( $zone_data[ $zone_id ] ) ) {
+					throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
+				}
+				$zone->set_zone_name( $zone_data[ $zone_id ]->zone_name );
+				$zone->set_zone_order( $zone_data[ $zone_id ]->zone_order );
+			}
+		}
+
+		$zone_locations = $this->get_zone_locations_for_ids( $zone_ids );
+		foreach ( $zone_locations as $zone_location ) {
+			if ( isset( $zones[ $zone_location->zone_id ] ) ) {
+				$zones[ $zone_location->zone_id ]->add_location( $zone_location->location_code, $zone_location->location_type );
+			}
+		}
+
+		foreach ( $zones as $zone_id => $zone ) {
 			$zone->set_object_read( true );
-
 			/**
 			 * Indicate that the WooCommerce shipping zone has been loaded.
 			 *
 			 * @param WC_Shipping_Zone $zone The shipping zone that has been loaded.
 			 */
 			do_action( 'woocommerce_shipping_zone_loaded', $zone );
-			return;
 		}
 
-		$zone_data = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT zone_name, zone_order FROM {$wpdb->prefix}woocommerce_shipping_zones WHERE zone_id = %d LIMIT 1",
-				$zone->get_id()
-			)
+	}
+
+	private function get_zone_data_for_ids( array $ids ) {
+		global $wpdb;
+
+		if ( empty( $ids ) || $ids === array( '0' ) || $ids === array( 0 ) ) {
+			return array();
+		}
+
+		$zone_ids = array_map( 'absint', $ids );
+
+		return $wpdb->get_results(
+			"SELECT zone_id, zone_name, zone_order FROM {$wpdb->prefix}woocommerce_shipping_zones " .
+			'WHERE zone_id IN ( ' . implode( ',', $zone_ids ) . ' ) ',
+			OBJECT_K
 		);
+	}
 
-		if ( ! $zone_data ) {
-			throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
+	private function get_zone_locations_for_ids( array $ids ) {
+		global $wpdb;
+
+		if ( empty( $ids ) || $ids === array( '0' ) || $ids === array( 0 ) ) {
+			return array();
 		}
 
-		$zone->set_zone_name( $zone_data->zone_name );
-		$zone->set_zone_order( $zone_data->zone_order );
-		$this->read_zone_locations( $zone );
-		$zone->read_meta_data();
-		$zone->set_object_read( true );
+		$zone_ids = array_map( 'absint', $ids );
 
-		/** This action is documented in includes/datastores/class-wc-shipping-zone-data-store.php. */
-		do_action( 'woocommerce_shipping_zone_loaded', $zone );
+		return $wpdb->get_results(
+			"SELECT zone_id, location_code, location_type FROM {$wpdb->prefix}woocommerce_shipping_zone_locations " .
+			'WHERE zone_id IN ( ' . implode( ',', $zone_ids ) . ' ) '
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -82,6 +82,8 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	 * @param WC_Shipping_Zone[] $zones Array of zones to read keyed by the zone_id.
 	 *
 	 * @return void
+	 *
+	 * @throws Exception If invalid zone_id givein for data store.
 	 */
 	public function read_multiple( array &$zones ) {
 		$zone_ids  = array_keys( $zones );
@@ -132,11 +134,13 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 
 		$zone_ids = array_map( 'absint', $ids );
 
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $zone_ids already run through absint.
 		return $wpdb->get_results(
 			"SELECT zone_id, zone_name, zone_order FROM {$wpdb->prefix}woocommerce_shipping_zones " .
 			'WHERE zone_id IN ( ' . implode( ',', $zone_ids ) . ' ) ',
 			OBJECT_K
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**
@@ -154,11 +158,12 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		}
 
 		$zone_ids = array_map( 'absint', $ids );
-
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $zone_ids already run through absint.
 		return $wpdb->get_results(
 			"SELECT zone_id, location_code, location_type FROM {$wpdb->prefix}woocommerce_shipping_zone_locations " .
 			'WHERE zone_id IN ( ' . implode( ',', $zone_ids ) . ' ) '
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -77,19 +77,21 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	}
 
 	/**
+	 * Reads multiple WC_Shipping_Zone objects from the data store.
+	 *
 	 * @param WC_Shipping_Zone[] $zones Array of zones to read keyed by the zone_id.
 	 *
 	 * @return void
 	 */
 	public function read_multiple( array &$zones ) {
-		$zone_ids = array_keys( $zones );
+		$zone_ids  = array_keys( $zones );
 		$zone_data = $this->get_zone_data_for_ids( $zone_ids );
 		foreach ( $zones as $zone_id => $zone ) {
 			if ( 0 === $zone_id || '0' === $zone_id ) {
 				$zone->set_zone_name( __( 'Locations not covered by your other zones', 'woocommerce' ) );
 			} else {
 				if ( ! isset( $zone_data[ $zone_id ] ) ) {
-					throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
+					throw new Exception( __( 'Invalid data store.', 'woocommerce' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 				}
 				$zone->set_zone_name( $zone_data[ $zone_id ]->zone_name );
 				$zone->set_zone_order( $zone_data[ $zone_id ]->zone_order );
@@ -112,13 +114,19 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 			 */
 			do_action( 'woocommerce_shipping_zone_loaded', $zone );
 		}
-
 	}
 
+	/**
+	 * Retrieve the zone data for the given zone_ids.
+	 *
+	 * @param array $ids The zone_ids to retrieve.
+	 *
+	 * @return stdClass[] An array of objects containing the zone data, keyed by the zone_id.
+	 */
 	private function get_zone_data_for_ids( array $ids ) {
 		global $wpdb;
 
-		if ( empty( $ids ) || $ids === array( '0' ) || $ids === array( 0 ) ) {
+		if ( empty( $ids ) || array( '0' ) === $ids || array( 0 ) === $ids ) {
 			return array();
 		}
 
@@ -131,10 +139,17 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		);
 	}
 
+	/**
+	 * Retrieve the zone location data for the given zone_ids.
+	 *
+	 * @param array $ids The zone_ids to retrieve.
+	 *
+	 * @return stdClass[] An array of objects containing the zone_id, location_code, and location_type for each zone location.
+	 */
 	private function get_zone_locations_for_ids( array $ids ) {
 		global $wpdb;
 
-		if ( empty( $ids ) || $ids === array( '0' ) || $ids === array( 0 ) ) {
+		if ( empty( $ids ) || array( '0' ) === $ids || array( 0 ) === $ids ) {
 			return array();
 		}
 
@@ -351,28 +366,6 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	public function get_zone_id_by_instance_id( $id ) {
 		global $wpdb;
 		return $wpdb->get_var( $wpdb->prepare( "SELECT zone_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods as methods WHERE methods.instance_id = %d LIMIT 1;", $id ) );
-	}
-
-	/**
-	 * Read location data from the database.
-	 *
-	 * @param WC_Shipping_Zone $zone Shipping zone object.
-	 */
-	private function read_zone_locations( &$zone ) {
-		global $wpdb;
-
-		$locations = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT location_code, location_type FROM {$wpdb->prefix}woocommerce_shipping_zone_locations WHERE zone_id = %d",
-				$zone->get_id()
-			)
-		);
-
-		if ( $locations ) {
-			foreach ( $locations as $location ) {
-				$zone->add_location( $location->location_code, $location->location_type );
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This introduces a new method, `WC_Shipping_Zone_Data_Store::read_multiple()`,  to the Shipping Zone datastore that will bulk query the data needed to hydrate Shipping_Zone objects as opposed to querying the data for each one individually.

This also introduces a new factory method to `WC_Shipping_Zones` as `::get_shipping_zones()` to take advantage of the new method.

Improves [WOOPLUG-5527](https://linear.app/a8c/issue/WOOPLUG-5527/woocommerce-paymentsfrontendpricesregister-free-shipping-filters) /  #60900.


### Screenshots or screen recordings:

Below are the performance differences of the `WC_Shipping_Zones::get_zones()` as called in WooCommerce core within WooCommerce -> Settings -> Shipping with 230 existing Shipping Zones.  This shows a reduction in loading time of ~92ms or 26% for that method.  

Trunk:
<img width="600" height="276" alt="Screenshot 2025-09-15 at 11 37 18 AM" src="https://github.com/user-attachments/assets/66b7de0c-2f66-4740-8d0f-fdd9905b8ef3" />

With this PR:

<img width="545" height="264" alt="Screenshot 2025-09-15 at 11 35 52 AM" src="https://github.com/user-attachments/assets/b097983b-9631-4c49-8769-546bfd66a823" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

As the JSON for the backbone data of the Shipping settings admin is rendered in page from `WC_Shipping_Zones::get_zones()` and should be unchanged in behavior, it is the best way to test that no output was affected by the change.
1.  Go to Admin -> WooCommerce -> Settings -> Shipping
2. Add multiple Shipping Zones each with multiple Locations and Methods.
3. Make sure there are no issues editing or reordering zones.
4. Refresh the page, to get newly output JSON data.
5. Continue testing editing of Shipping Zones.
<!-- End testing instructions -->
