### PR TITLE
Apply webhook delivery hook args filter to delivery pings

### DIFF
--- a/plugins/woocommerce/changelog/fix-60886
+++ b/plugins/woocommerce/changelog/fix-60886
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply webhook delivery hook args filter to delivery pings

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -340,6 +340,15 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			'cookies'     => array(),
 		);
 
+		/**
+		 * Filters the HTTP arguments for the webhook delivery.
+		 *
+		 * @since 3.3.0
+		 * @param array $http_args The HTTP arguments.
+		 * @param mixed $arg The first hook argument.
+		 * @param int   $webhook_id The webhook ID.
+		 * @return array The filtered HTTP arguments.
+		 */
 		$http_args = apply_filters( 'woocommerce_webhook_http_args', $http_args, $arg, $this->get_id() );
 
 		// Add custom headers.
@@ -606,7 +615,18 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			'body'       => 'webhook_id=' . $this->get_id(),
 		);
 
-		$test          = wp_safe_remote_post( $this->get_delivery_url(), $args );
+		/**
+		 * Filters the HTTP arguments for the webhook delivery ping.
+		 *
+		 * @since 3.3.0
+		 * @param array $args The HTTP arguments.
+		 * @param null  $arg The first hook argument. Null since this is a ping.
+		 * @param int   $webhook_id The webhook ID.
+		 * @return array The filtered HTTP arguments.
+		 */
+		$http_args = apply_filters( 'woocommerce_webhook_http_args', $args, null, $this->get_id() );
+
+		$test          = wp_safe_remote_post( $this->get_delivery_url(), $http_args );
 		$response_code = wp_remote_retrieve_response_code( $test );
 
 		if ( is_wp_error( $test ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While webhooks have the ability to add in headers and other information by use of the `woocommerce_webhook_http_args` filter, this information was not applied to delivery pings, resulting in their failure when additional info is needed in the http request.

This PR adds that filter to those requests so that the same arguments are applied.

Closes #60886 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="644" height="58" alt="Screenshot 2025-09-15 at 12 26 40 PM" src="https://github.com/user-attachments/assets/db43cb9c-851f-40ce-a487-482106294acb" /> |  <img width="700" height="60" alt="Screenshot 2025-09-15 at 12 32 21 PM" src="https://github.com/user-attachments/assets/16deef44-c674-4638-ad97-2e50e4069146" />     |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add the below `webhook-test.php` file to the root of your site's public directory
2. Add the below snippet to add in header auths to your WP site
3. Navigate to WooCommerce -> Settings -> Advanced -> Webhooks
4. Create a webhook that is `Active` and set a topic to one easily triggered (e.g., coupon creation)
5. Save the webhook
6. Note that the save is successful with no errors
7. Trigger the webhook (e.g., create a coupon if that's the trigger you chose)
8. Navigate to WooCommerce -> Status -> Logs and find your webhook logs
9. Make sure that webhook call was successful

```php
// Snippet to add header auths
add_filter( 'woocommerce_webhook_http_args', function( $args ) {
	$args['headers']['Authorization'] = 'Bearer test12345';
	return $args;
}, 10 );
```

```php
<!-- webhook-test.php -->
<?php
// Fake Quick Header Auth Test

// Grab all request headers
$headers = getallheaders();

// Define a fake expected token
$expected_token = "test12345";

http_response_code(400);

// Check if "Authorization" header exists
if (isset($headers['Authorization'])) {
    $auth_header = $headers['Authorization'];

    // For testing: expect "Bearer test12345"
    if ($auth_header === "Bearer " . $expected_token) {
        http_response_code(200);
        echo json_encode([
            "status" => "success",
            "message" => "Authorized ✅"
        ]);
    } else {
        http_response_code(401);
        echo json_encode([
            "status" => "failure",
            "message" => "Invalid token ❌"
        ]);
    }
} else {
    echo json_encode([
        "status" => "error",
        "message" => "Authorization header missing ⚠️"
    ]);
}
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
