### PR TITLE
Move Cost of Goods Sold HTML rendering filters out of template files

### DIFF
--- a/plugins/woocommerce/changelog/pr-60928
+++ b/plugins/woocommerce/changelog/pr-60928
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Move Cost of Goods Sold HTML rendering filters out of template files

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2605,4 +2605,34 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->set_prop( 'cogs_total_value', $value );
 		}
 	}
+
+	/**
+	 * Return the HTML to render the total Cost of Goods Sold for the order.
+	 *
+	 * @param array|null $wc_price_arg Arguments to be passed to wc_price, defaults to an array containing only the currency symbol.
+	 * @return string
+	 */
+	public function get_cogs_total_value_html( ?array $wc_price_arg = null ) {
+		if ( ! $this->cogs_is_enabled( __METHOD__ ) || ! $this->has_cogs() ) {
+			return '';
+		}
+
+		$cogs_total_value = $this->get_cogs_total_value();
+
+		/**
+		 * Filter to customize the total Cost of Goods Sold (COGS) value HTML for a given order.
+		 *
+		 * @since 10.3.0
+		 *
+		 * @param string   $total_html The formatted total COGS HTML.
+		 * @param float    $total      The total COGS value.
+		 * @param WC_Order $order      The order object.
+		 */
+		return apply_filters(
+			'woocommerce_order_cogs_total_value_html',
+			wc_price( $cogs_total_value, $wc_price_arg ?? array( 'currency' => $this->get_currency() ) ),
+			$cogs_total_value,
+			$this
+		);
+	}
 }

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2612,7 +2612,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param array|null $wc_price_arg Arguments to be passed to wc_price, defaults to an array containing only the currency symbol.
 	 * @return string
 	 */
-	public function get_cogs_total_value_html( ?array $wc_price_arg = null ) {
+	public function get_cogs_total_value_html( ?array $wc_price_arg = null ): string {
 		if ( ! $this->cogs_is_enabled( __METHOD__ ) || ! $this->has_cogs() ) {
 			return '';
 		}

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -75,20 +75,7 @@ $item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $i
 				echo wp_kses_post( $item->get_cogs_value_html() );
 
 				$refunded_cost = $order->get_cogs_refunded_for_item( $item_id );
-
-				if ( $refunded_cost ) {
-					/**
-					 * Filter to customize the refunded Cost of Goods Sold (COGS) value HTML for a given order item.
-					 *
-					 * @since 10.3.0
-					 *
-					 * @param string $refunded_html The formatted refunded COGS HTML.
-					 * @param float  $refunded_cost The refunded cost value.
-					 * @param array  $item          The order item data.
-					 * @param WC_Order $order       The order object.
-					 */
-					echo '<small class="refunded">' . apply_filters( 'woocommerce_order_item_cogs_refunded_html', wc_price( $refunded_cost, $wc_price_arg ), $refunded_cost, $item, $order ) . '</small>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				}
+				echo wp_kses_post( $item->get_cogs_refund_value_html( $refunded_cost, $wc_price_arg, $order ) );
 				?>
 			</div>
 		</td>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -296,18 +296,7 @@ if ( wc_tax_enabled() ) {
 				<td class="label cost-total"><?php esc_html_e( 'Cost Total', 'woocommerce' ); ?>:</td>
 				<td width="1%"></td>
 				<td class="total cost-total">
-					<?php
-					/**
-					 * Filter to customize the total Cost of Goods Sold (COGS) value HTML for a given order.
-					 *
-					 * @since 10.3.0
-					 *
-					 * @param string   $total_html The formatted total COGS HTML.
-					 * @param float    $total      The total COGS value.
-					 * @param WC_Order $order      The order object.
-					 */
-					echo apply_filters( 'woocommerce_order_cogs_total_value_html', wc_price( $order->get_cogs_total_value(), array( 'currency' => $order->get_currency() ) ), $order->get_cogs_total_value(), $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					?>
+					<?php echo wp_kses_post( $order->get_cogs_total_value_html() ); ?>
 				</td>
 			</tr>
 		</table>

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -631,4 +631,34 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		 */
 		return apply_filters( 'woocommerce_order_item_cogs_per_item_tooltip', $tooltip_text, $cost_per_item, $formatted_cost_per_item, $this );
 	}
+
+	/**
+	 * Returns the refunded Cost of Goods Sold value in html format.
+	 *
+	 * @param float         $refunded_cost The refunded value.
+	 * @param array|null    $wc_price_arg Arguments to be passed to wc_price, defaults to an array containing only the currency symbol.
+	 * @param WC_Order|null $order Order that contains this line item, if null, get_order will be invoked.
+	 *
+	 * @return string
+	 */
+	public function get_cogs_refund_value_html( float $refunded_cost, ?array $wc_price_arg = null, ?WC_Order $order = null ) {
+		if ( ! $this->cogs_is_enabled( __METHOD__ ) || ! $this->has_cogs() ) {
+			return '';
+		}
+
+		$order ??= $this->get_order();
+		$html    = $refunded_cost ? '<small class="refunded">' . wc_price( $refunded_cost, $wc_price_arg ?? array( 'currency' => $order->get_currency() ) ) . '</small>' : '';
+
+		/**
+		 * Filter to customize the refunded Cost of Goods Sold (COGS) value HTML for a given order item.
+		 *
+		 * @since 10.3.0
+		 *
+		 * @param string $refunded_html The formatted refunded COGS HTML.
+		 * @param float  $refunded_cost The refunded cost value.
+		 * @param array  $item          The order item data.
+		 * @param WC_Order $order       The order object.
+		 */
+		return apply_filters( 'woocommerce_order_item_cogs_refunded_html', $html, $refunded_cost, $this, $order );
+	}
 }

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -641,11 +641,14 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 *
 	 * @return string
 	 */
-	public function get_cogs_refund_value_html( float $refunded_cost, ?array $wc_price_arg = null, ?WC_Order $order = null ) {
+	public function get_cogs_refund_value_html( float $refunded_cost, ?array $wc_price_arg = null, ?WC_Order $order = null ): string {
 		if ( ! $this->cogs_is_enabled( __METHOD__ ) || ! $this->has_cogs() ) {
 			return '';
 		}
 
+		if ( $refunded_cost > 0 ) {
+			$refunded_cost = -$refunded_cost;
+		}
 		$order ??= $this->get_order();
 		$html    = $refunded_cost ? '<small class="refunded">' . wc_price( $refunded_cost, $wc_price_arg ?? array( 'currency' => $order->get_currency() ) ) . '</small>' : '';
 
@@ -655,8 +658,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		 * @since 10.3.0
 		 *
 		 * @param string $refunded_html The formatted refunded COGS HTML.
-		 * @param float  $refunded_cost The refunded cost value.
-		 * @param array  $item          The order item data.
+		 * @param float  $refunded_cost The refunded cost value (always zero or a negative number).
+		 * @param WC_Order_Item $item   The order item object.
 		 * @param WC_Order $order       The order object.
 		 */
 		return apply_filters( 'woocommerce_order_item_cogs_refunded_html', $html, $refunded_cost, $this, $order );

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -8,41 +8,81 @@
 declare( strict_types=1 );
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
 
 /**
  * WC_Order_Item_Product unit tests.
  */
 class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
+	use CogsAwareUnitTestSuiteTrait;
+
+	/**
+	 * The product used for the tests.
+	 *
+	 * @var WC_Product_Simple
+	 */
+	private WC_Product_Simple $product;
+
+	/**
+	 * The order item used for the tests.
+	 *
+	 * @var WC_Order_Item_Product
+	 */
+	private WC_Order_Item_Product $item;
+
+	/**
+	 * The order used for the tests.
+	 *
+	 * @var WC_Order
+	 */
+	private WC_Order $order;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->order   = WC_Helper_Order::create_order();
+
+		$this->item = new WC_Order_Item_Product();
+		$this->item->set_product( $this->product );
+		$this->item->set_quantity( 1 );
+		$this->item->set_order_id( $this->order->get_id() );
+		$this->item->save();
+
+		$this->order->add_item( $this->item );
+		$this->order->save();
+	}
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->disable_cogs_feature();
+	}
 
 	/**
 	 * Test that backorder meta is excluded from formatted meta data
 	 * for completed orders.
 	 */
 	public function test_get_formatted_meta_data_excludes_backorder_on_completed() {
-		// 1. Setup: Create product and set backorders allowed.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_manage_stock( true );
-		$product->set_stock_quantity( 0 );
-		$product->set_backorders( 'notify' ); // Allow backorders with notification.
-		$product->save();
+		// 1. Set backorders allowed for the product.
+		$this->product->set_manage_stock( true );
+		$this->product->set_stock_quantity( 0 );
+		$this->product->set_backorders( 'notify' ); // Allow backorders with notification.
+		$this->product->save();
 
-		// 2. Create Order and add product item.
-		$order = WC_Helper_Order::create_order();
-		$item  = new WC_Order_Item_Product();
-		$item->set_product( $product );
-		$item->set_quantity( 1 );
-		$item->set_order_id( $order->get_id() );
-
-		// 3. Add backorder meta.
+		// 2. Add backorder meta.
 		$backorder_meta_key = 'Backordered';
-		$item->add_meta_data( $backorder_meta_key, 1, true ); // Value typically is the backordered quantity.
-		$item->save();
-		$order->add_item( $item );
-		$order->save();
+		$this->item->add_meta_data( $backorder_meta_key, 1, true ); // Value typically is the backordered quantity.
+		$this->item->save();
 
-		// 4. Assert: Check meta exists before completion.
-		$item_id                = $item->get_id();
-		$order_item             = $order->get_item( $item_id ); // Re-fetch item from order.
+		// 3. Assert: Check meta exists before completion.
+		$item_id                = $this->item->get_id();
+		$order_item             = $this->order->get_item( $item_id ); // Re-fetch item from order.
 		$formatted_meta_before  = $order_item->get_formatted_meta_data();
 		$found_backorder_before = false;
 		foreach ( $formatted_meta_before as $meta ) {
@@ -53,12 +93,12 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		}
 		$this->assertTrue( $found_backorder_before, 'Backorder meta should exist before order completion.' );
 
-		// 5. Complete the order.
-		$order->update_status( OrderStatus::COMPLETED );
-		$order->save();
+		// 4. Complete the order.
+		$this->order->update_status( OrderStatus::COMPLETED );
+		$this->order->save();
 
-		// 6. Assert: Check meta is excluded after completion.
-		$order_item_after_complete = $order->get_item( $item_id ); // Re-fetch item again after status change.
+		// 5. Assert: Check meta is excluded after completion.
+		$order_item_after_complete = $this->order->get_item( $item_id ); // Re-fetch item again after status change.
 		$formatted_meta_after      = $order_item_after_complete->get_formatted_meta_data();
 		$found_backorder_after     = false;
 		foreach ( $formatted_meta_after as $meta ) {
@@ -70,7 +110,67 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		$this->assertFalse( $found_backorder_after, 'Backorder meta should be excluded after order completion.' );
 
 		// Clean up.
-		WC_Helper_Product::delete_product( $product->get_id() );
-		WC_Helper_Order::delete_order( $order->get_id() );
+		WC_Helper_Product::delete_product( $this->product->get_id() );
+		WC_Helper_Order::delete_order( $this->order->get_id() );
+	}
+
+	/**
+	 * @testdox 'doing it wrong' is thrown, if the Cost of Goods Sold feature is disabled.
+	 */
+	public function test_get_refund_html_with_cogs_disabled() {
+		$this->expect_doing_it_wrong_cogs_disabled( 'WC_Order_Item::get_cogs_refund_value_html' );
+
+		$this->item->get_cogs_refund_value_html( -12.34 );
+	}
+
+	/**
+	 * @testdox Test get_cogs_refund_value_html with implicit WC_Price and order arguments.
+	 *
+	 * @param bool $negative_refund_argument True to pass a negative refund amount, false to pass a positive amount.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 */
+	public function test_get_refund_html_with_implicit_arguments( bool $negative_refund_argument ) {
+		$this->enable_cogs_feature();
+
+		$refund_amount = 12.34;
+		$actual        = $this->item->get_cogs_refund_value_html( $negative_refund_argument ? -12.34 : 12.34 );
+		$expected      = sprintf( '<small class="refunded">%s</small>', wc_price( -12.34, array( 'currency' => $this->order->get_currency() ) ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox Test get_cogs_refund_value_html with explicit WC_Price and order arguments.
+	 */
+	public function test_get_refund_html_with_explicit_arguments() {
+		$this->enable_cogs_feature();
+
+		$wc_price_args = array( 'currency' => '!' );
+		$actual        = $this->item->get_cogs_refund_value_html( -12.34, $wc_price_args, $this->order );
+		$expected      = sprintf( '<small class="refunded">%s</small>', wc_price( -12.34, array( 'currency' => '!' ) ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox Test the woocommerce_order_item_cogs_refunded_html filter invoked by get_cogs_refund_value_html.
+	 */
+	public function test_get_refund_html_with_filter() {
+		$this->enable_cogs_feature();
+
+		$refunded_cost = -12.34;
+		add_filter(
+			'woocommerce_order_item_cogs_refunded_html',
+			function ( $html, $refunded_cost, $item, $order ) {
+				return sprintf( 'cost: %s, item: %s, order: %s', $refunded_cost, $item->get_id(), $order->get_id() );
+			},
+			10,
+			4
+		);
+
+		$actual = $this->item->get_cogs_refund_value_html( $refunded_cost, );
+		remove_all_filters( 'woocommerce_order_item_cogs_refunded_html' );
+		$expected = sprintf( 'cost: %s, item: %s, order: %s', $refunded_cost, $this->item->get_id(), $this->order->get_id() );
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/60361 introduced two new filters to control how the COGS values are rendered in the order details page in the admin area. This pull request moves these filters from the HTML template files to the appropriate classes:

* `woocommerce_order_item_cogs_refunded_html` is moved from `html-order-item.php` to a new `WC_Order_Item::get_cogs_refund_value_html` method.
* `woocommerce_order_cogs_total_value_html` is moved from `html-order-items.php` to a new `WC_Abstract_Order::get_cogs_total_value_html` method.

Additionally, the behavior of `woocommerce_order_item_cogs_refunded_html` is slightly modified: now the HTML passed to the filter will include the enclosing `<small>` element too.

### How to test the changes in this Pull Request:

1. Create an order that includes items with COGS values, make partial and total redunds for some of the items.
2. Add the following code snippet (using a snippets plugin, or directly in `woocommerce.php` if you are testing locally), then go to the orders list in the admin area and load the order, you should see the modified HTML in the "Cost" column for each item and in the "Cost Total" section at the bottom: 

```php
add_filter( 'woocommerce_order_item_cogs_refunded_html', function ( $html, $refunded_cost, $item, $order ) {
    return $refunded_cost ?
        sprintf('%s <small style="opacity:.7;" class="refunded">[REFUNDED COGS FILTER ✅] - refunded %s - item %s - order %s </small>', $html, $refunded_cost, $item->get_id(), $order->get_id())
        : 0;
}, 10, 4 );

add_filter( 'woocommerce_order_cogs_total_value_html', function ( $html, $cogs_total, $order ) {
    return sprintf('%s <span style="opacity:.7;">[TOTAL COGS FILTER ✅] - total %s - order %s </span>', $html, $cogs_total, $order->get_id());
}, 10, 3 );
```

<img width="1001" height="171" alt="image" src="https://github.com/user-attachments/assets/7d3679f4-d44c-45ed-b805-da2481fd3205" />
<img width="292" height="176" alt="image" src="https://github.com/user-attachments/assets/79f49321-4468-4aaa-a28f-b461be99b92e" />

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
