### PR TITLE
Fix sync order products refund test

### DIFF
--- a/plugins/woocommerce/changelog/update-fix-test_sync_order_products_refund_one_product_then_full_refund
+++ b/plugins/woocommerce/changelog/update-fix-test_sync_order_products_refund_one_product_then_full_refund
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooCommerce: Fix sync order products refund test

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -19,6 +19,21 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  * @todo Finish up unit testing to verify bug-free product reports.
  */
 class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
+	public function setUp(): void {
+		parent::setUp();
+
+		// Force new logic of full refund in analytics/products.
+        delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+
+        // In case any check depends on the DB version (not always necessary, but safe):
+        update_option( 'woocommerce_db_version', '10.2.0' );
+    }
+
+    public function tearDown(): void {
+        // Clean in case any test changes options.
+        delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+        parent::tearDown();
+    }
 
 	/**
 	 * Test the calculations and querying works correctly for the base case of 1 product.
@@ -796,12 +811,12 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( '-2', $result[0]->product_qty );
-		$this->assertEquals( -60.000000, $result[0]->product_net_revenue );    // -($30 product_2 * 2).
-		$this->assertEquals( -33.333333, $result[0]->shipping_amount );        // -($100 shipping / 6 total items * 2 product_2 ).
-		$this->assertEquals( -3.333333, $result[0]->shipping_tax_amount );     // -($10 shipping tax / 6 total items * 2 product_2 ).
-		$this->assertEquals( -6, $result[0]->tax_amount );                     // -($30 product_2 * 10% tax * 2 quantity).
+		$this->assertEqualsWithDelta( -60.000000, $result[0]->product_net_revenue, 0.000001 );    // -($30 product_2 * 2).
+		$this->assertEqualsWithDelta( -33.333333, $result[0]->shipping_amount, 0.000001 );        // -($100 shipping / 6 total items * 2 product_2 ).
+		$this->assertEqualsWithDelta( -3.333333, $result[0]->shipping_tax_amount, 0.000001 );     // -($10 shipping tax / 6 total items * 2 product_2 ).
+		$this->assertEqualsWithDelta( -6, $result[0]->tax_amount, 0.000001 );                     // -($30 product_2 * 10% tax * 2 quantity).
 		$this->assertEquals( 0, $result[0]->coupon_amount );
-		$this->assertEquals( -102.666667, $result[0]->product_gross_revenue ); // product_net_revenue + shipping_amount + shipping_tax_amount + tax_amount.
+		$this->assertEqualsWithDelta( -102.666667, $result[0]->product_gross_revenue, 0.000001 ); // product_net_revenue + shipping_amount + shipping_tax_amount + tax_amount.
 	}
 
 	/**
@@ -1063,20 +1078,20 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( '-2', $result[0]->product_qty );
-		$this->assertEquals( -60.000000, $result[0]->product_net_revenue ); // -($30 product_2 * 2).
-		$this->assertEquals( -33.333333, $result[0]->shipping_amount );     // -($100 shipping / 6 total items * 2 product_2 ).
+		$this->assertEqualsWithDelta( -60.000000, $result[0]->product_net_revenue, 0.000001 ); // -($30 product_2 * 2).
+		$this->assertEqualsWithDelta( -33.333333, $result[0]->shipping_amount, 0.000001 );     // -($100 shipping / 6 total items * 2 product_2 ).
 
 		// 10% tax: $100 shipping * 0.1 = $10.
 		// 5% compound tax: $100 shipping * 1.1 * 0.05 = $5.5.
 		// -($10 + $5.5) / 6 total items * 2 product_2 = -$5.166667.
-		$this->assertEquals( -5.166667, $result[0]->shipping_tax_amount );
+		$this->assertEqualsWithDelta( -5.166667, $result[0]->shipping_tax_amount, 0.000001 );
 
 		// 10% tax: $30 product_2 * 0.1 = $3.
 		// 5% compound tax: $30 product_2 * 1.1 * 0.05 = $1.65.
 		// -($3 + $1.65) * 2 quantity = -$9.3.
-		$this->assertEquals( -9.3, $result[0]->tax_amount );
+		$this->assertEqualsWithDelta( -9.3, $result[0]->tax_amount, 0.000001 );
 
 		$this->assertEquals( 0, $result[0]->coupon_amount );
-		$this->assertEquals( -107.8, $result[0]->product_gross_revenue ); // product_net_revenue + shipping_amount + shipping_tax_amount + tax_amount.
+		$this->assertEqualsWithDelta( -107.8, $result[0]->product_gross_revenue, 0.000001 ); // product_net_revenue + shipping_amount + shipping_tax_amount + tax_amount.
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -27,9 +27,6 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 
 		// Force new logic of full refund in analytics/products.
 		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
-
-		// In case any check depends on the DB version (not always necessary, but safe).
-		update_option( 'woocommerce_db_version', '10.2.0' );
 	}
 
 	/*

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -19,21 +19,27 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  * @todo Finish up unit testing to verify bug-free product reports.
  */
 class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
+	/*
+	 * Setup test case.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 
 		// Force new logic of full refund in analytics/products.
-        delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
 
-        // In case any check depends on the DB version (not always necessary, but safe):
-        update_option( 'woocommerce_db_version', '10.2.0' );
-    }
+		// In case any check depends on the DB version (not always necessary, but safe).
+		update_option( 'woocommerce_db_version', '10.2.0' );
+	}
 
-    public function tearDown(): void {
-        // Clean in case any test changes options.
-        delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
-        parent::tearDown();
-    }
+	/*
+	 * Tear down test case.
+	 */
+	public function tearDown(): void {
+		// Clean in case any test changes options.
+		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+		parent::tearDown();
+	}
 
 	/**
 	 * Test the calculations and querying works correctly for the base case of 1 product.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  * @todo Finish up unit testing to verify bug-free product reports.
  */
 class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
-	/*
+	/**
 	 * Setup test case.
 	 */
 	public function setUp(): void {
@@ -29,7 +29,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
 	}
 
-	/*
+	/**
 	 * Tear down test case.
 	 */
 	public function tearDown(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#### Changes proposed in this Pull Request:

* Force the new refunds mode for Analytics Products tests by clearing woocommerce_analytics_uses_old_full_refund_data in setUp().
This aligns expected values with the current refunds logic used by the datastore.
* Replace strict float comparisons with assertEqualsWithDelta(...) to avoid precision issues under PHP 8.x.

* Touches only test code: `plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

```bash
pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- "--testsuite=wc-phpunit-legacy"
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
