### PR TITLE
Fix select2 single spacing and order data padding

### DIFF
--- a/plugins/woocommerce/changelog/60933-fix-order-select2-spacing
+++ b/plugins/woocommerce/changelog/60933-fix-order-select2-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Select2 single dropdown spacing issue in admin interface

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1856,7 +1856,7 @@ ul.wc_coupon_list_block {
 }
 
 #order_data {
-	padding: 23px 24px 12px;
+	padding: 24px;
 
 	h2 {
 		margin: 0;
@@ -8082,6 +8082,7 @@ table.bar_chart {
 
 	.select2-selection--single {
 		height: 40px;
+		margin-bottom: 0;
 
 		.select2-selection__rendered {
 			line-height: 40px;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This PR fixes a CSS issue where Select2 single-selection dropdowns had a negative bottom margin (-4px) that caused them to overlap with elements below them in the WooCommerce admin interface.

The fix adds `margin-bottom: 0` to override the default negative margin from `select2.scss`, ensuring proper spacing between form elements.

### Screenshots or screen recordings:

**Before**:

<img width="1354" height="654" alt="CleanShot 2025-09-16 at 11 30 35@2x" src="https://github.com/user-attachments/assets/1165c613-d39d-4717-86ce-e7a61ca3075c" />

<img width="1402" height="654" alt="CleanShot 2025-09-16 at 11 30 57@2x" src="https://github.com/user-attachments/assets/6e137b0d-e87e-46c9-83e3-6b1d3d6d9e2a" />

**After**:

<img width="1388" height="714" alt="CleanShot 2025-09-16 at 11 29 26@2x" src="https://github.com/user-attachments/assets/f3f5227c-6a72-4f8f-9996-778e53234f19" />

<img width="1400" height="700" alt="CleanShot 2025-09-16 at 11 31 24@2x" src="https://github.com/user-attachments/assets/7c92a96e-f178-4115-b7ab-43f916c0968e" />

### How to test the changes in this Pull Request:

1. Navigate to **WooCommerce > Orders** and click to edit an existing order
2. Observe the "Order Data" section and ensure the Status/Customer fields are well spaced.
3. Observe the "Order Data" section and ensure there is a good amount of padding for the entire section.

### Testing that has already taken place:

- Tested on local development environment with WordPress 6.7 and WooCommerce trunk
- Verified fix in Chrome, Firefox, and Safari browsers
- Confirmed that multi-select Select2 dropdowns are not affected
- Validated that the change only affects `.select2-selection--single` elements
- Confirmed that other "single" select dropdowns are not negatively affected

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message
Fix Select2 single dropdown spacing issue in admin interface

</details>