### PR TITLE
iAPI MiniCart: Remove unnecessary type check that hid variation metadata for non-variation item types

### DIFF
--- a/plugins/woocommerce/changelog/60935-wooplug-5515-iapi-mini-block-beta-compatibility-with-woocommerce-2
+++ b/plugins/woocommerce/changelog/60935-wooplug-5515-iapi-mini-block-beta-compatibility-with-woocommerce-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+iAPI Mini Cart: remove unnecessary type check that hid variation metadata for non-variation item types (e.g., `subscription_variation`);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -721,11 +721,7 @@ const { state: cartItemState } = store(
 				const { dataProperty } = getContext< {
 					dataProperty: DataProperty;
 				} >();
-				return (
-					cartItemState.cartItem[ dataProperty ].length === 0 ||
-					( dataProperty === 'variation' &&
-						cartItemState.cartItem.type !== 'variation' )
-				);
+				return cartItemState.cartItem[ dataProperty ].length === 0;
 			},
 
 			get shouldHideSingleProductDetails(): boolean {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow up on https://github.com/woocommerce/woocommerce/pull/60877.

Remove an unnecessary client-side check in `plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts` that prevented variation metadata from rendering unless the cart item type was strictly `variation`. This guard blocked valid variation data for other variation-like product types (for example, `subscription_variation`), causing variation details to be hidden in the iAPI Mini Cart.

- The removed check was discussed and approved to be dropped in review feedback, noting that the `variation` array is already empty when not applicable, so the extra type guard is redundant. See review context: [PR 60877 review comment](https://github.com/woocommerce/woocommerce/pull/60877#pullrequestreview-3228792317).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="513" height="254" alt="Screenshot 2025-09-16 at 13 17 36" src="https://github.com/user-attachments/assets/12d7aabc-d573-457f-b1f7-0cbcc0044e44" />| <img width="513" height="254" alt="Screenshot 2025-09-16 at 13 17 53" src="https://github.com/user-attachments/assets/2ea8377b-c09e-49e2-b949-d32f3cb0521d" />|

### How to test the changes in this Pull Request:

1. Activate the new iAPI Mini Cart using WooCommerce -> Settings -> Advanced -> Features.
2. Install and activate WooCommerce Subscriptions.
3. Create a product that has variation data:
   - A standard variable product with attributes/variations.
   - A `subscription_variation` product (from WooCommerce Subscriptions).
4. Add each product to the cart and open the Mini Cart.
5. Confirm:
   - For variation products, the variation metadata (attributes/options) is visible.
   - For non-variation products, no extra spacing or empty variation container appears.
7. Compare spacing with React Mini Cart behavior to verify parity.

### Testing that has already taken place:

- Local manual testing with variable products to verify variation details render as expected.
- Verified that non-variation items do not show empty blocks and that overall Mini Cart layout remains unchanged.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

iAPI Mini Cart: remove unnecessary type check that hid variation metadata for non-variation item types (e.g., `subscription_variation`);
</details>