### PR TITLE
WooCommerce: tests: isolate refund mode and guard lookup assertions

### DIFF
--- a/plugins/woocommerce/changelog/update-fix-test_sync_order_products_refund_one_product
+++ b/plugins/woocommerce/changelog/update-fix-test_sync_order_products_refund_one_product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+tests: Isolate refund mode and guard lookup assertions

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -820,6 +820,11 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 			)
 		);
 
+		$this->assertNotEmpty(
+			$result,
+			'No lookup rows found for the refund; check full-refund mode and queue processing.'
+		);
+
 		$this->assertEquals( '-2', $result[0]->product_qty );
 		$this->assertEqualsWithDelta( -60.000000, $result[0]->product_net_revenue, 0.000001 );    // -($30 product_2 * 2).
 		$this->assertEqualsWithDelta( -33.333333, $result[0]->shipping_amount, 0.000001 );        // -($100 shipping / 6 total items * 2 product_2 ).

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -24,17 +24,24 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		// Save original value (includes the case "no exists").
+		$this->original_old_refund_opt = get_option( 'woocommerce_analytics_uses_old_full_refund_data', null );
 
-		// Force new logic of full refund in analytics/products.
-		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+		// Force new mode explicitly.
+		update_option( 'woocommerce_analytics_uses_old_full_refund_data', 'no' );
 	}
 
 	/**
 	 * Tear down test case.
 	 */
 	public function tearDown(): void {
-		// Clean in case any test changes options.
-		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+		// Restore exactly as it was.
+		if ( null === $this->original_old_refund_opt ) {
+			delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
+		} else {
+			update_option( 'woocommerce_analytics_uses_old_full_refund_data', $this->original_old_refund_opt );
+		}
+
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Save the original `woocommerce_analytics_uses_old_full_refund_data` option in `setUp()` and restore it in `tearDown()`.
- Force new refund logic only inside this class to avoid leaking state into other suites.
- Add `assertNotEmpty($result)` before accessing `$result[0]` in the full refund tests, to prevent "Undefined array key 0" errors and give clearer failure messages.

Closes # .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions):

1. Run the legacy PHPUnit suite with 
```
pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --testsuite=wc-phpunit-legacy
```
2. Ensure that `WC_Admin_Tests_Reports_Products` passes consistently without leaking refund mode state to other suites.
3. Verify that failures in lookup queries are reported by `assertNotEmpty` instead of PHP notices.

### Testing that has already taken place:

- Local run of `wc-phpunit-legacy` suite on PHP 8.4.
- Verified that tests with full refunds now fail clearly if lookup rows are missing.
- Confirmed that other suites (e.g. `Reports_Orders_Stats`) no longer show duplicated `num_items_sold` caused by global state leaks.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix refund products reports tests by isolating refund mode state and guarding lookup queries.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Not required if the change is only for tests.

</details>

