### PR TITLE
Add to Cart Button: disable optimistic updates if product is sold individually and is already in the cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-sold-individually-optimistic-updates
+++ b/plugins/woocommerce/changelog/fix-sold-individually-optimistic-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart Button: disable optimistic updates if product is sold individually and is already in the cart

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -213,7 +213,15 @@ const productButtonStore = {
 				addToCartWithOptionsState?.isFormValid
 			) {
 				context.hasPressedButton = true;
-				context.animationStatus = AnimationStatus.SLIDE_OUT;
+
+				// Only animate if the quantity number changes and there is no
+				// animation in progress.
+				if (
+					context.tempQuantity !== state.quantity &&
+					context.animationStatus === AnimationStatus.IDLE
+				) {
+					context.animationStatus = AnimationStatus.SLIDE_OUT;
+				}
 			}
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -337,13 +337,11 @@ const { state, actions } = store< Store >(
 				// the cart.
 				let updatedItem = null;
 				if ( item ) {
-					if ( item.key ) {
-						quantityChanges.cartItemsPendingQuantity = [ item.key ];
-					}
 					const isSoldIndividually =
 						isCartItem( item ) && item.sold_individually;
 					updatedItem = { ...item, quantity };
-					if ( ! isSoldIndividually ) {
+					if ( item.key && ! isSoldIndividually ) {
+						quantityChanges.cartItemsPendingQuantity = [ item.key ];
 						item.quantity = quantity;
 					}
 				} else {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -40,7 +40,6 @@ export type OptimisticCartItem = {
 	quantity: number;
 	variation?: CartVariationItem[];
 	type: string;
-	updateOptimistically?: boolean;
 };
 
 export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
@@ -305,12 +304,7 @@ const { state, actions } = store< Store >(
 			},
 
 			*addCartItem(
-				{
-					id,
-					quantity,
-					variation,
-					updateOptimistically = true,
-				}: ClientCartItem,
+				{ id, quantity, variation }: ClientCartItem,
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
 				let item = state.cart.items.find( ( cartItem ) => {
@@ -339,12 +333,17 @@ const { state, actions } = store< Store >(
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 
-				// Optimistically updates the number of items in the cart.
+				// In some cases, optimistically update the number of items in
+				// the cart.
+				let updatedItem = null;
 				if ( item ) {
 					if ( item.key ) {
 						quantityChanges.cartItemsPendingQuantity = [ item.key ];
 					}
-					if ( updateOptimistically ) {
+					const isSoldIndividually =
+						isCartItem( item ) && item.sold_individually;
+					updatedItem = { ...item, quantity };
+					if ( ! isSoldIndividually ) {
 						item.quantity = quantity;
 					}
 				} else {
@@ -354,9 +353,8 @@ const { state, actions } = store< Store >(
 						variation,
 					} as OptimisticCartItem;
 					quantityChanges.productsPendingAdd = [ id ];
-					if ( updateOptimistically ) {
-						state.cart.items.push( item );
-					}
+					state.cart.items.push( item );
+					updatedItem = item;
 				}
 
 				// Updates the database.
@@ -369,7 +367,7 @@ const { state, actions } = store< Store >(
 								Nonce: state.nonce,
 								'Content-Type': 'application/json',
 							},
-							body: JSON.stringify( item ),
+							body: JSON.stringify( updatedItem ),
 						}
 					);
 					const json: Cart = yield res.json();

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -333,8 +333,9 @@ const { state, actions } = store< Store >(
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 
-				// In some cases, optimistically update the number of items in
-				// the cart.
+				// Optimistically update the number of items in the cart except
+				// if the product is sold individually and is already in the
+				// cart.
 				let updatedItem = null;
 				if ( item ) {
 					const isSoldIndividually =


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60811.

This PR removes optimistic updates in the _Add to Cart Button_ block if it's an individually sold product and the product is already in the cart. I also took the chance to remove the `updateOptimistically` parameter from `addCartItem()`, as it wasn't used anywhere.

### How to test the changes in this Pull Request:

1. Update a product so it's sold individually and add it to your cart.
2. In the _Shop_ page, try adding it to your cart again.
3. Verify the button didn't animate and it didn't show _2 in cart_.

https://github.com/user-attachments/assets/9d062507-a16a-4603-9c30-a3e64338c1b3

4. Now go to the _Single_ Product page, making sure it's using the _Add to Cart + Options_ block.
5. Try adding the product to your cart again.
3. Verify the button didn't animate and it didn't show _2 in cart_.

https://github.com/user-attachments/assets/cedc86ed-9025-48bc-9c7f-934a7e3f2b07
