### PR TITLE
Add to Cart + Options: skip adding default values to variations data object

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-non-default-variation-data
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-non-default-variation-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: skip adding default values to variations data object

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -47,6 +47,21 @@ export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
 	variation?: SelectedAttributes[];
 };
 
+export type VariationData = {
+	attributes: Record< string, string >;
+	is_in_stock?: boolean;
+	price_html?: string;
+	image_id?: number;
+	availability?: string;
+	sku?: string;
+	weight?: string;
+	dimensions?: string;
+	min?: number;
+	max?: number;
+	step?: number;
+	sold_individually?: boolean;
+};
+
 export type ProductData = {
 	type: string;
 	price_html?: string;
@@ -58,23 +73,7 @@ export type ProductData = {
 	min?: number;
 	max?: number;
 	step?: number;
-	variations?: {
-		[ variationId: number ]: {
-			attributes: Record< string, string >;
-			is_in_stock: boolean;
-			type: string;
-			price_html?: string;
-			image_id?: number;
-			availability?: string;
-			sku?: string;
-			weight?: string;
-			dimensions?: string;
-			min?: number;
-			max?: number;
-			step?: number;
-			sold_individually?: boolean;
-		};
-	};
+	variations?: Record< number, VariationData >;
 };
 
 type CartUpdateOptions = { showCartUpdatesNotices?: boolean };

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -53,6 +53,7 @@ export type VariationData = {
 	price_html?: string;
 	image_id?: number;
 	availability?: string;
+	variation_description?: string;
 	sku?: string;
 	weight?: string;
 	dimensions?: string;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -6,6 +6,7 @@ import type {
 	Store as WooCommerce,
 	SelectedAttributes,
 	ProductData,
+	VariationData,
 	WooCommerceConfig,
 } from '@woocommerce/stores/woocommerce/cart';
 import '@woocommerce/stores/woocommerce/product-data';
@@ -55,10 +56,11 @@ export const getProductData = (
 	selectedAttributes: SelectedAttributes[]
 ) => {
 	let productId = id;
-	let productData: ProductData | undefined;
+	let productData: ProductData | VariationData | undefined;
 
 	const { products } = getConfig( 'woocommerce' ) as WooCommerceConfig;
 
+	let type = null;
 	if ( selectedAttributes && selectedAttributes.length > 0 ) {
 		if ( ! products || ! products[ id ] ) {
 			return null;
@@ -70,13 +72,14 @@ export const getProductData = (
 		);
 		if ( matchedVariation?.variation_id ) {
 			productId = matchedVariation.variation_id;
-			productData =
-				products?.[ id ]?.variations?.[
-					matchedVariation?.variation_id
-				];
+			productData = products?.[ id ]?.variations?.[
+				matchedVariation?.variation_id
+			] as VariationData;
+			type = 'variation';
 		}
 	} else {
-		productData = products?.[ productId ];
+		productData = products?.[ productId ] as ProductData;
+		type = productData?.type;
 	}
 
 	if ( typeof productData !== 'object' || productData === null ) {
@@ -96,6 +99,7 @@ export const getProductData = (
 		min,
 		max,
 		step,
+		type,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -60,7 +60,7 @@ export const getProductData = (
 
 	const { products } = getConfig( 'woocommerce' ) as WooCommerceConfig;
 
-	let type = null;
+	let type: ProductData[ 'type' ] | 'variation' | null = null;
 	if ( selectedAttributes && selectedAttributes.length > 0 ) {
 		if ( ! products || ! products[ id ] ) {
 			return null;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -241,7 +241,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			);
 
 			if ( $product->is_type( ProductType::VARIABLE ) ) {
-				$variation_data                = array();
+				$variations_data               = array();
 				$context['selectedAttributes'] = array();
 				$available_variations          = $product->get_available_variations( 'objects' );
 				foreach ( $available_variations as $variation ) {
@@ -250,11 +250,14 @@ class AddToCartWithOptions extends AbstractBlock {
 					// input for all variations, so we want quantities to be in sync.
 					$context['quantity'][ $variation->get_id() ] = $default_quantity;
 
-					$variation_data[ $variation->get_id() ] = array(
-						'is_in_stock' => $variation->is_in_stock(),
-						'attributes'  => $variation->get_variation_attributes(),
-						'type'        => $variation->get_type(),
+					$variation_data = array(
+						'attributes' => $variation->get_variation_attributes(),
 					);
+					if ( $variation->is_in_stock() ) {
+						$variation_data['is_in_stock'] = $variation->is_in_stock();
+					}
+
+					$variations_data[ $variation->get_id() ] = $variation_data;
 				}
 
 				wp_interactivity_config(
@@ -262,7 +265,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					array(
 						'products' => array(
 							$product->get_id() => array(
-								'variations' => $variation_data,
+								'variations' => $variations_data,
 							),
 						),
 					)

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -254,7 +254,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						'attributes' => $variation->get_variation_attributes(),
 					);
 					if ( $variation->is_in_stock() ) {
-						$variation_data['is_in_stock'] = $variation->is_in_stock();
+						$variation_data['is_in_stock'] = true;
 					}
 
 					$variations_data[ $variation->get_id() ] = $variation_data;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -129,13 +129,23 @@ class QuantitySelector extends AbstractBlock {
 			$variations_data           = $product->get_available_variations( 'objects' );
 			$formatted_variations_data = array();
 			foreach ( $variations_data as $variation ) {
-				$variation_quantity_constraints                    = AddToCartWithOptionsUtils::get_product_quantity_constraints( $variation );
-				$formatted_variations_data[ $variation->get_id() ] = array(
-					'min'               => $variation_quantity_constraints['min'],
-					'max'               => $variation_quantity_constraints['max'],
-					'step'              => $variation_quantity_constraints['step'],
-					'sold_individually' => (bool) $variation->is_sold_individually(),
-				);
+				$variation_quantity_constraints = AddToCartWithOptionsUtils::get_product_quantity_constraints( $variation );
+				$variation_data                 = array();
+
+				// Only add variation data if it's different than the defaults.
+				if ( 1 !== $variation_quantity_constraints['min'] ) {
+					$variation_data['min'] = $variation_quantity_constraints['min'];
+				}
+				if ( null !== $variation_quantity_constraints['max'] ) {
+					$variation_data['max'] = $variation_quantity_constraints['max'];
+				}
+				if ( 1 !== $variation_quantity_constraints['step'] ) {
+					$variation_data['step'] = $variation_quantity_constraints['step'];
+				}
+				if ( $variation->is_sold_individually() ) {
+					$variation_data['sold_individually'] = true;
+				}
+				$formatted_variations_data[ $variation->get_id() ] = $variation_data;
 			}
 
 			wp_interactivity_config(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationDescription.php
@@ -39,9 +39,12 @@ class VariationDescription extends AbstractBlock {
 		$variations                = $product->get_available_variations( 'objects' );
 		$formatted_variations_data = array();
 		foreach ( $variations as $variation ) {
-			$formatted_variations_data[ $variation->get_id() ] = array(
-				'variation_description' => wp_kses_post( wc_format_content( $variation->get_description() ) ),
-			);
+			$variation_description = $variation->get_description();
+			if ( is_string( $variation_description ) && ! empty( $variation_description ) ) {
+				$formatted_variations_data[ $variation->get_id() ] = array(
+					'variation_description' => wp_kses_post( wc_format_content( $variation_description ) ),
+				);
+			}
 		}
 
 		wp_interactivity_config(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -168,11 +168,12 @@ class ProductGallery extends AbstractBlock {
 						continue;
 					}
 
-					if ( $variation['image_id'] && $variation['image_id'] !== $product->get_image_id() ) {
+					$variation_image_id = (int) $variation['image_id'];
+					if ( $variation_image_id && $variation_image_id !== (int) $product->get_image_id() ) {
 						$has_variation_images = true;
 
 						$formatted_variations_data[ $variation['variation_id'] ] = array(
-							'image_id' => (int) $variation['image_id'],
+							'image_id' => $variation_image_id,
 						);
 					}
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -167,10 +167,14 @@ class ProductGallery extends AbstractBlock {
 					) {
 						continue;
 					}
-					$has_variation_images                                    = $has_variation_images || $variation['image_id'] !== $product->get_image_id();
-					$formatted_variations_data[ $variation['variation_id'] ] = array(
-						'image_id' => (int) $variation['image_id'],
-					);
+
+					if ( $variation['image_id'] && $variation['image_id'] !== $product->get_image_id() ) {
+						$has_variation_images = true;
+
+						$formatted_variations_data[ $variation['variation_id'] ] = array(
+							'image_id' => (int) $variation['image_id'],
+						);
+					}
 				}
 
 				if ( $has_variation_images ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -130,10 +130,12 @@ class ProductStockIndicator extends AbstractBlock {
 			$variations                = $product_to_render->get_available_variations( 'objects' );
 			$formatted_variations_data = array();
 			foreach ( $variations as $variation ) {
-				$variation_availability                            = $variation->get_availability();
-				$formatted_variations_data[ $variation->get_id() ] = array(
-					'availability' => $variation_availability['availability'],
-				);
+				$variation_availability = $variation->get_availability();
+				if ( is_string( $variation_availability['availability'] ) && ! empty( $variation_availability['availability'] ) ) {
+					$formatted_variations_data[ $variation->get_id() ] = array(
+						'availability' => $variation_availability['availability'],
+					);
+				}
 			}
 
 			wp_interactivity_config(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/57727.

Until now, when rendering a variable product with the _Add to Cart + Options_ block we were printing all variation data needed by sibling blocks, even when some values were empty or missing. While this wasn't a problem for products with only a few variations, the resulting object became unnecessarily large for products with hundreds of variations.

In this PR I refactored the logic so that only non-default and non-empty variation data is printed. For example, if `min` or `step` are `1`, or if the variation description is an empty string, we skip printing them. This reduces the output size in products with many variations.

### How to test the changes in this Pull Request:

1. Go to the frontend of a variable product (making sure it's using the _Add to Cart + Options_ block).
2. Using your browser inspector, look for an element with id `#wp-script-module-data-@wordpress/interactivity`.
3. Verify the object doesn't contain unnecessary variation data (ie: empty strings). You can alternatively compare its size relative to the same object in `trunk`.
4. Smoke test the controls to make sure you can still toggle attributes and add the product to cart.

`trunk` | This branch
--- | ---
<img width="937" height="564" alt="imatge" src="https://github.com/user-attachments/assets/0b8b59f5-b7b6-4501-9832-fda947d78d8b" /> | <img width="937" height="564" alt="imatge" src="https://github.com/user-attachments/assets/587b838d-55a1-4449-b0af-4315cb2b5425" />
