### PR TITLE
Fatal Error in email style sync controller

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-846-fatal-error-in-next-admin
+++ b/packages/php/email-editor/changelog/wooprd-846-fatal-error-in-next-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Fatal error when reading site stiles for some themes

--- a/packages/php/email-editor/changelog/wooprd-846-fatal-error-in-next-admin
+++ b/packages/php/email-editor/changelog/wooprd-846-fatal-error-in-next-admin
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix Fatal error when reading site stiles for some themes
+Fix Fatal error when reading site styles for some themes

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -225,19 +225,8 @@ class Site_Style_Sync_Controller {
 	private function convert_color_styles( array $color_styles ): array {
 		$email_colors = array();
 
-		if ( isset( $color_styles['background'] ) ) {
-			$background = $this->resolve_style_value( $color_styles['background'] );
-			if ( $background ) {
-				$email_colors['background'] = $background;
-			}
-		}
-
-		if ( isset( $color_styles['text'] ) ) {
-			$text = $this->resolve_style_value( $color_styles['text'] );
-			if ( $text ) {
-				$email_colors['text'] = $text;
-			}
-		}
+		$this->resolve_and_assign( $color_styles, 'background', $email_colors );
+		$this->resolve_and_assign( $color_styles, 'text', $email_colors );
 
 		return $email_colors;
 	}
@@ -251,31 +240,14 @@ class Site_Style_Sync_Controller {
 	private function convert_typography_styles( array $typography_styles ): array {
 		$email_typography = array();
 
-		// Convert font family to email-safe alternative.
-		if ( isset( $typography_styles['fontFamily'] ) ) {
-			$font_family = $this->resolve_style_value( $typography_styles['fontFamily'] );
-			if ( $font_family ) {
-				$email_typography['fontFamily'] = $this->convert_to_email_safe_font( $font_family );
-			}
-		}
+		// Handle special cases with processors.
+		$this->resolve_and_assign( $typography_styles, 'fontFamily', $email_typography, array( $this, 'convert_to_email_safe_font' ) );
+		$this->resolve_and_assign( $typography_styles, 'fontSize', $email_typography, array( $this, 'convert_to_px_size' ) );
 
-		// Convert font size to px if needed.
-		if ( isset( $typography_styles['fontSize'] ) ) {
-			$font_size = $this->resolve_style_value( $typography_styles['fontSize'] );
-			if ( $font_size ) {
-				$email_typography['fontSize'] = $this->convert_to_px_size( $font_size );
-			}
-		}
-
-		// Preserve email-compatible typography properties.
+		// Handle compatible properties without processing.
 		$compatible_props = array( 'fontWeight', 'fontStyle', 'lineHeight', 'letterSpacing', 'textTransform', 'textDecoration' );
 		foreach ( $compatible_props as $prop ) {
-			if ( isset( $typography_styles[ $prop ] ) ) {
-				$email_typography_value = $this->resolve_style_value( $typography_styles[ $prop ] );
-				if ( $email_typography_value ) {
-					$email_typography[ $prop ] = $email_typography_value;
-				}
-			}
+			$this->resolve_and_assign( $typography_styles, $prop, $email_typography );
 		}
 
 		return $email_typography;
@@ -290,21 +262,8 @@ class Site_Style_Sync_Controller {
 	private function convert_spacing_styles( array $spacing_styles ): array {
 		$email_spacing = array();
 
-		// Convert padding to px values.
-		if ( isset( $spacing_styles['padding'] ) ) {
-			$padding = $this->resolve_style_value( $spacing_styles['padding'] );
-			if ( $padding ) {
-				$email_spacing['padding'] = $this->convert_spacing_values( $padding );
-			}
-		}
-
-		// Convert blockGap to px if present.
-		if ( isset( $spacing_styles['blockGap'] ) ) {
-			$block_gap = $this->resolve_style_value( $spacing_styles['blockGap'] );
-			if ( $block_gap ) {
-				$email_spacing['blockGap'] = $this->convert_to_px_size( $block_gap );
-			}
-		}
+		$this->resolve_and_assign( $spacing_styles, 'padding', $email_spacing, array( $this, 'convert_spacing_values' ) );
+		$this->resolve_and_assign( $spacing_styles, 'blockGap', $email_spacing, array( $this, 'convert_to_px_size' ) );
 
 		// Note: We intentionally skip margin as it's not supported in email renderer.
 
@@ -357,6 +316,29 @@ class Site_Style_Sync_Controller {
 		}
 
 		return $email_element;
+	}
+
+	/**
+	 * Resolve and assign a single style property
+	 *
+	 * @param array         $styles     The source styles array.
+	 * @param string        $property   The property key to resolve.
+	 * @param array         $target     The target array to assign the value to.
+	 * @param callable|null $processor  Optional processor function for the resolved value.
+	 * @return bool True if the property was resolved and assigned, false otherwise.
+	 */
+	private function resolve_and_assign( array $styles, string $property, array &$target, ?callable $processor = null ): bool {
+		if ( ! isset( $styles[ $property ] ) ) {
+			return false;
+		}
+
+		$resolved = $this->resolve_style_value( $styles[ $property ] );
+		if ( ! $resolved ) {
+			return false;
+		}
+
+		$target[ $property ] = $processor ? $processor( $resolved ) : $resolved;
+		return true;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -226,11 +226,17 @@ class Site_Style_Sync_Controller {
 		$email_colors = array();
 
 		if ( isset( $color_styles['background'] ) ) {
-			$email_colors['background'] = $color_styles['background'];
+			$background = $this->resolve_style_value( $color_styles['background'] );
+			if ( $background ) {
+				$email_colors['background'] = $background;
+			}
 		}
 
 		if ( isset( $color_styles['text'] ) ) {
-			$email_colors['text'] = $color_styles['text'];
+			$text = $this->resolve_style_value( $color_styles['text'] );
+			if ( $text ) {
+				$email_colors['text'] = $text;
+			}
 		}
 
 		return $email_colors;
@@ -247,19 +253,28 @@ class Site_Style_Sync_Controller {
 
 		// Convert font family to email-safe alternative.
 		if ( isset( $typography_styles['fontFamily'] ) ) {
-			$email_typography['fontFamily'] = $this->convert_to_email_safe_font( $typography_styles['fontFamily'] );
+			$font_family = $this->resolve_style_value( $typography_styles['fontFamily'] );
+			if ( $font_family ) {
+				$email_typography['fontFamily'] = $this->convert_to_email_safe_font( $font_family );
+			}
 		}
 
 		// Convert font size to px if needed.
 		if ( isset( $typography_styles['fontSize'] ) ) {
-			$email_typography['fontSize'] = $this->convert_to_px_size( $typography_styles['fontSize'] );
+			$font_size = $this->resolve_style_value( $typography_styles['fontSize'] );
+			if ( $font_size ) {
+				$email_typography['fontSize'] = $this->convert_to_px_size( $font_size );
+			}
 		}
 
 		// Preserve email-compatible typography properties.
 		$compatible_props = array( 'fontWeight', 'fontStyle', 'lineHeight', 'letterSpacing', 'textTransform', 'textDecoration' );
 		foreach ( $compatible_props as $prop ) {
 			if ( isset( $typography_styles[ $prop ] ) ) {
-				$email_typography[ $prop ] = $typography_styles[ $prop ];
+				$email_typography_value = $this->resolve_style_value( $typography_styles[ $prop ] );
+				if ( $email_typography_value ) {
+					$email_typography[ $prop ] = $email_typography_value;
+				}
 			}
 		}
 
@@ -277,12 +292,18 @@ class Site_Style_Sync_Controller {
 
 		// Convert padding to px values.
 		if ( isset( $spacing_styles['padding'] ) ) {
-			$email_spacing['padding'] = $this->convert_spacing_values( $spacing_styles['padding'] );
+			$padding = $this->resolve_style_value( $spacing_styles['padding'] );
+			if ( $padding ) {
+				$email_spacing['padding'] = $this->convert_spacing_values( $padding );
+			}
 		}
 
 		// Convert blockGap to px if present.
 		if ( isset( $spacing_styles['blockGap'] ) ) {
-			$email_spacing['blockGap'] = $this->convert_to_px_size( $spacing_styles['blockGap'] );
+			$block_gap = $this->resolve_style_value( $spacing_styles['blockGap'] );
+			if ( $block_gap ) {
+				$email_spacing['blockGap'] = $this->convert_to_px_size( $block_gap );
+			}
 		}
 
 		// Note: We intentionally skip margin as it's not supported in email renderer.
@@ -336,6 +357,30 @@ class Site_Style_Sync_Controller {
 		}
 
 		return $email_element;
+	}
+
+	/**
+	 * Styles may contain references to other styles.
+	 * This function resolves the reference to the actual value.
+	 * https://make.wordpress.org/core/2022/10/11/reference-styles-values-in-theme-json/
+	 * It is not allowed to reference another reference so we don't need to check recursively.
+	 *
+	 * @param mixed $style_value Style value that might contain a reference.
+	 * @return mixed Resolved style value or null when the reference is not found.
+	 */
+	private function resolve_style_value( $style_value ) {
+		// Check if this is a reference array.
+		if ( is_array( $style_value ) && isset( $style_value['ref'] ) ) {
+			$ref = $style_value['ref'];
+			if ( ! is_string( $ref ) || empty( $ref ) ) {
+				return null;
+			}
+			$path = explode( '.', $ref );
+
+			return _wp_array_get( $this->get_site_theme()->get_data(), $path, null );
+		}
+
+		return $style_value;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a PHP Fatal error: 
```
Uncaught TypeError: Automattic\WooCommerce\EmailEditor\Engine\Site_Style_Sync_Controller::convert_to_email_safe_font(): Argument #1 ($font_family) must be of type string, array given
```

I found the array passed to the function was actually a reference (https://make.wordpress.org/core/2022/10/11/reference-styles-values-in-theme-json/).

I attempted to solve this issue by adding support for referenced values. References that don't point to a value are skipped. 

Closes WOOPRD-846

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59757.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Activate block editor WooCommerce > Settings > Advanced > Features
2. Install and activate a theme that uses referenced values (e.g. [Assembler](https://wordpress.com/theme/assembler))
3. Access the block email editor via WooCommerce > Settings > Emails
4. Observe the issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
