### PR TITLE
Update Product Elements registration logic

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5538-update-product-elements-registration-logic
+++ b/plugins/woocommerce/changelog/wooplug-5538-update-product-elements-registration-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve template slug recognition in mechanism registering product blocks. Assure compatibility with WordPress 6.9

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { isEmpty } from '@woocommerce/types';
 
 /**
  * Settings for product block registration.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -96,23 +96,6 @@ export class BlockRegistrationManager {
 	}
 
 	/**
-	 * Parses a template ID from various possible formats.
-	 * Handles both string and number inputs due to Gutenberg changes.
-	 *
-	 * @param {string | number | undefined} templateId - The template ID to parse
-	 * @return {string | undefined} The parsed template ID
-	 */
-	private parseTemplateId(
-		templateId: string | number | undefined
-	): string | undefined {
-		const parsedTemplateId = isNumber( templateId )
-			? undefined
-			: templateId;
-
-		return parsedTemplateId?.split( '//' )[ 1 ];
-	}
-
-	/**
 	 * Initializes subscriptions for template changes and block registration.
 	 * Sets up listeners for both the site editor and post editor contexts.
 	 */
@@ -159,14 +142,11 @@ export class BlockRegistrationManager {
 				// Unsubscribe from the main subscription since we've detected our context
 				unsubscribe();
 
-				// @ts-expect-error getCurrentPostId is not typed
-				const postId = editorSelectors.getCurrentPostId();
+				// @ts-expect-error getEditedPostSlug is not typed
+				const postSlug = editorSelectors.getEditedPostSlug();
 
 				// Set initial template ID
-				this.currentTemplateId =
-					typeof postId === 'string'
-						? this.parseTemplateId( postId )
-						: undefined;
+				this.currentTemplateId = postSlug;
 
 				// Handle the initial template change
 				this.handleTemplateChange( undefined );
@@ -174,10 +154,9 @@ export class BlockRegistrationManager {
 				// Set up the template change listener
 				subscribe( () => {
 					const previousTemplateId = this.currentTemplateId;
-					this.currentTemplateId = this.parseTemplateId(
-						// @ts-expect-error getCurrentPostId is not typed
-						editorSelectors.getCurrentPostId()
-					);
+					this.currentTemplateId =
+						// @ts-expect-error getEditedPostSlug is not typed
+						editorSelectors.getEditedPostSlug();
 
 					if ( previousTemplateId !== this.currentTemplateId ) {
 						this.handleTemplateChange( previousTemplateId );

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { isNumber, isEmpty } from '@woocommerce/types';
 
 /**
  * Settings for product block registration.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR replaces the `getCurrentPostId` with `getEditedPostSlug` method to get template slug. This is due to upcoming update in Gutenberg (aiming at WordPress 6.9) where `getCurrentPostId` starts to actually return post IDs even for templates and we can't rely on it for block registration anymore.

Closes https://github.com/woocommerce/woocommerce/issues/60946

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

For developers, test the following with:
- GB disabled
- GB enabled - branch `trunk`

#### Switching between Single Product template and others

1. Go to Single Product template
2. Try to insert Product Price anywhere on the template
3. **Expected:** it's available in the whole template
4. Switch to Product Catalog template
5. Try to insert Product Price anywhere on the template
6. **Expected:** it isn't available in the whole template
7. Try to insert Product Price within Product Collection
8. **Expected:** you can insert it in Product Collection

#### In post editor

1. Create new post
2. Try to insert Product Price anywhere on the template
3. **Expected:** it isn't available 
4. Insert Product block and choose some product
5. Try to insert Product Price in Product block (`isAvailableOnPostEditor: true`)
6. **Expected:** you can insert it in Product
7. Try to insert Product Image Gallery in Product (`isAvailableOnPostEditor: false`)
8. **Expected:** it isn't available 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
