### PR TITLE
Change checkout form to use individual smaller forms to prevent autofill breaking in Safari

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5541-bug-safari-autocomplete-overwrites-shipping-address-state
+++ b/plugins/woocommerce/changelog/wooplug-5541-bug-safari-autocomplete-overwrites-shipping-address-state
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Change checkout form to be a div, and instead be composed of smaller forms

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
@@ -32,7 +32,7 @@ export const createFieldProps = (
 	errorId: `${ fieldAddressType }_${ field?.key }`,
 	label: ( field?.required ? field?.label : field?.optionalLabel ) || '',
 	autoCapitalize: field?.autocapitalize,
-	autoComplete: field?.autocomplete,
+	autoComplete: `${ fieldAddressType } ${ field?.autocomplete }`,
 	errorMessage: field?.errorMessage || '',
 	required: field?.required,
 	placeholder: field?.placeholder,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -30,7 +30,7 @@ const FrontendBlock = ( {
 
 	return (
 		<Main className={ clsx( 'wc-block-checkout__main', className ) }>
-			<form
+			<div
 				aria-label={ __( 'Checkout', 'woocommerce' ) }
 				className={ clsx(
 					'wc-block-components-form wc-block-checkout__form',
@@ -41,7 +41,7 @@ const FrontendBlock = ( {
 				) }
 			>
 				{ children }
-			</form>
+			</div>
 		</Main>
 	);
 };

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
@@ -58,37 +58,38 @@ const FormStep = ( {
 	const Element = legend || title ? 'fieldset' : 'div';
 
 	return (
-		<Element
-			className={ clsx( className, 'wc-block-components-checkout-step', {
-				'wc-block-components-checkout-step--with-step-number':
-					showStepNumber,
-				'wc-block-components-checkout-step--disabled': disabled,
-			} ) }
-			id={ id }
-			disabled={ disabled }
-		>
-			{ !! ( legend || title ) && (
-				<legend className="screen-reader-text">
-					{ legend || title }
-				</legend>
-			) }
-			{ !! title && (
-				<StepHeading
-					title={ title }
-					stepHeadingContent={ stepHeadingContent() }
-				/>
-			) }
-			<div className="wc-block-components-checkout-step__container">
-				{ !! description && (
-					<p className="wc-block-components-checkout-step__description">
-						{ description }
-					</p>
+		<form id={ id }>
+			<Element
+				className={ clsx( className, 'wc-block-components-checkout-step', {
+					'wc-block-components-checkout-step--with-step-number':
+						showStepNumber,
+					'wc-block-components-checkout-step--disabled': disabled,
+				} ) }
+				disabled={ disabled }
+			>
+				{ !! ( legend || title ) && (
+					<legend className="screen-reader-text">
+						{ legend || title }
+					</legend>
 				) }
-				<div className="wc-block-components-checkout-step__content">
-					{ children }
+				{ !! title && (
+					<StepHeading
+						title={ title }
+						stepHeadingContent={ stepHeadingContent() }
+					/>
+				) }
+				<div className="wc-block-components-checkout-step__container">
+					{ !! description && (
+						<p className="wc-block-components-checkout-step__description">
+							{ description }
+						</p>
+					) }
+					<div className="wc-block-components-checkout-step__content">
+						{ children }
+					</div>
 				</div>
-			</div>
-		</Element>
+			</Element>
+		</form>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
@@ -55,11 +55,12 @@ const FormStep = ( {
 }: FormStepProps ): JSX.Element => {
 	// If the form step doesn't have a legend or title, render a <div> instead
 	// of a <fieldset>.
-	const Element = legend || title ? 'fieldset' : 'div';
+	const FormElement = legend || title ? 'form' : 'div';
+	const InnerElement = legend || title ? 'fieldset' : 'div';
 
 	return (
-		<form id={ id }>
-			<Element
+		<FormElement id={ id }>
+			<InnerElement
 				className={ clsx(
 					className,
 					'wc-block-components-checkout-step',
@@ -92,8 +93,8 @@ const FormStep = ( {
 						{ children }
 					</div>
 				</div>
-			</Element>
-		</form>
+			</InnerElement>
+		</FormElement>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
@@ -60,11 +60,15 @@ const FormStep = ( {
 	return (
 		<form id={ id }>
 			<Element
-				className={ clsx( className, 'wc-block-components-checkout-step', {
-					'wc-block-components-checkout-step--with-step-number':
-						showStepNumber,
-					'wc-block-components-checkout-step--disabled': disabled,
-				} ) }
+				className={ clsx(
+					className,
+					'wc-block-components-checkout-step',
+					{
+						'wc-block-components-checkout-step--with-step-number':
+							showStepNumber,
+						'wc-block-components-checkout-step--disabled': disabled,
+					}
+				) }
 				disabled={ disabled }
 			>
 				{ !! ( legend || title ) && (

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/test/__snapshots__/index.js.snap
@@ -1,256 +1,275 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormStep fieldset legend should default to legend prop when title and legend are defined 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
-    Lorem Ipsum 2
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
-      Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
+      Lorem Ipsum 2
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should apply id and className props 1`] = `
 <div
-  className="my-classname wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
   id="my-id"
 >
   <div
-    className="wc-block-components-checkout-step__container"
+    className="my-classname wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__container"
     >
-      Dolor sit amet
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`FormStep should remove step number CSS class if prop is false 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step"
+    disabled={false}
   >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
       Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should render a div if no title or legend is provided 1`] = `
-<div
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
+<div>
   <div
-    className="wc-block-components-checkout-step__container"
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__container"
     >
-      Dolor sit amet
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`FormStep should render a fieldset if a legend is provided 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
-    Lorem Ipsum 2
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <div
-      className="wc-block-components-checkout-step__content"
+    <legend
+      className="screen-reader-text"
     >
-      Dolor sit amet
+      Lorem Ipsum 2
+    </legend>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
     </div>
-  </div>
-</fieldset>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should render a fieldset with heading if a title is provided 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
       Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should render step description 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
       Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <p
-      className="wc-block-components-checkout-step__description"
-    >
-      This is the description
-    </p>
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <p
+        className="wc-block-components-checkout-step__description"
+      >
+        This is the description
+      </p>
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should render step heading content 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+    disabled={false}
   >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
       Lorem Ipsum
-    </h2>
-    <span
-      className="wc-block-components-checkout-step__heading-content"
-    >
-      <span>
-        Some context to render next to the heading
-      </span>
-    </span>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
+      <span
+        className="wc-block-components-checkout-step__heading-content"
+      >
+        <span>
+          Some context to render next to the heading
+        </span>
+      </span>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;
 
 exports[`FormStep should set disabled prop to the fieldset element when disabled is true 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number wc-block-components-checkout-step--disabled"
-  disabled={true}
->
-  <legend
-    className="screen-reader-text"
+<form>
+  <fieldset
+    className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number wc-block-components-checkout-step--disabled"
+    disabled={true}
   >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      className="wc-block-components-title wc-block-components-checkout-step__title"
+    <legend
+      className="screen-reader-text"
     >
       Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
+    </legend>
     <div
-      className="wc-block-components-checkout-step__content"
+      className="wc-block-components-checkout-step__heading"
     >
-      Dolor sit amet
+      <h2
+        className="wc-block-components-title wc-block-components-checkout-step__title"
+      >
+        Lorem Ipsum
+      </h2>
     </div>
-  </div>
-</fieldset>
+    <div
+      className="wc-block-components-checkout-step__container"
+    >
+      <div
+        className="wc-block-components-checkout-step__content"
+      >
+        Dolor sit amet
+      </div>
+    </div>
+  </fieldset>
+</form>
 `;

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/test/index.js
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/test/index.js
@@ -97,4 +97,36 @@ describe( 'FormStep', () => {
 
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
+
+	test( 'should render div wrapper when no title or legend provided', () => {
+		const component = TestRenderer.create(
+			<FormStep id="test-div">Content without form</FormStep>
+		);
+
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'div' );
+		expect( json.props.id ).toBe( 'test-div' );
+	} );
+
+	test( 'should render form wrapper when title is provided', () => {
+		const component = TestRenderer.create(
+			<FormStep id="test-form" title="Test Title">Content with form</FormStep>
+		);
+
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'form' );
+		expect( json.props.id ).toBe( 'test-form' );
+		expect( json.children[0].type ).toBe( 'fieldset' );
+	} );
+
+	test( 'should render form wrapper when legend is provided', () => {
+		const component = TestRenderer.create(
+			<FormStep id="test-form-legend" legend="Test Legend">Content with form</FormStep>
+		);
+
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'form' );
+		expect( json.props.id ).toBe( 'test-form-legend' );
+		expect( json.children[0].type ).toBe( 'fieldset' );
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Safari has a "feature" where it ignores autocomplete attributes and determines which fields to autocomplete based on some other black-box heuristics. To get around this, I have demarcated each checkout step into its own form. There are supposed workarounds such as prefixing the autocomplete attribute, but none of these tested successfully. 

- Changes the main checkout form to be a div
- Wraps the fieldsets into individual forms, one for each address step (contact, shipping, billing)
- Update autocomplete attribute to prefix with the form type

Closes WOOPLUG-5541

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using Safari, save some addresses so that sites will use them for autofill. Ensure you have two addresses added, e.g. one in UK and one in US.
2. Add an item to your cart and go to the Checkout block.
3. In the shipping address, fill in your address using autofill. Ensure the billing form remains unaffected.
4. In the billing address, fill in your address using the other address from autofill. Ensure the shipping form remains unaffected.
5. Check out and ensure the values submitted are correct.
6. Try in other browsers e.g. Chrome and Firefox and ensure autofilled values work and only affect the desired form.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
