### PR TITLE
Add to Cart + Options: don't disable optimistic updates when adding grouped product children to cart if only one fails

### DIFF
--- a/plugins/woocommerce/changelog/fix-60979-grouped-products-optimistic-updates-on-failure
+++ b/plugins/woocommerce/changelog/fix-60979-grouped-products-optimistic-updates-on-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: don't disable optimistic updates when adding grouped product children to cart if only one fails

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -438,6 +438,8 @@ const { state, actions } = store< Store >(
 							existingItem.quantity = item.quantity;
 							if ( existingItem.key ) {
 								quantityChanges.cartItemsPendingQuantity = [
+									...( quantityChanges.cartItemsPendingQuantity ??
+										[] ),
 									existingItem.key,
 								];
 							}
@@ -509,6 +511,15 @@ const { state, actions } = store< Store >(
 						  )
 						: [];
 
+					if (
+						errorResponses.length > 0 &&
+						successfulResponses.length === 0
+					) {
+						throw generateError(
+							errorResponses[ 0 ].body as ApiErrorResponse
+						);
+					}
+
 					// Only update the cart and trigger events if there is at least one successful response.
 					if ( successfulResponses.length > 0 ) {
 						const lastSuccessfulCartResponse = successfulResponses[
@@ -572,12 +583,6 @@ const { state, actions } = store< Store >(
 								generateErrorNotice( body as ApiErrorResponse )
 							)
 					);
-
-					if ( errorResponses.length > 0 ) {
-						throw generateError(
-							errorResponses[ 0 ].body as ApiErrorResponse
-						);
-					}
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -495,6 +495,10 @@ const { state, actions } = store< Store >(
 
 					const json: BatchResponse = yield res.json();
 
+					// Checks if the response contains an error.
+					if ( isApiErrorResponse( res, json ) )
+						throw generateError( json );
+
 					const errorResponses = Array.isArray( json.responses )
 						? json.responses.filter(
 								( response ) =>
@@ -510,15 +514,6 @@ const { state, actions } = store< Store >(
 									response.status < 300
 						  )
 						: [];
-
-					if (
-						errorResponses.length > 0 &&
-						successfulResponses.length === 0
-					) {
-						throw generateError(
-							errorResponses[ 0 ].body as ApiErrorResponse
-						);
-					}
 
 					// Only update the cart and trigger events if there is at least one successful response.
 					if ( successfulResponses.length > 0 ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -501,12 +501,6 @@ const { state, actions } = store< Store >(
 						  )
 						: [];
 
-					if ( errorResponses.length > 0 ) {
-						throw generateError(
-							errorResponses[ 0 ].body as ApiErrorResponse
-						);
-					}
-
 					const successfulResponses = Array.isArray( json.responses )
 						? json.responses.filter(
 								( response ) =>
@@ -578,6 +572,12 @@ const { state, actions } = store< Store >(
 								generateErrorNotice( body as ApiErrorResponse )
 							)
 					);
+
+					if ( errorResponses.length > 0 ) {
+						throw generateError(
+							errorResponses[ 0 ].body as ApiErrorResponse
+						);
+					}
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -370,6 +370,43 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await expect( page.getByLabel( '3 items in cart' ) ).toBeVisible();
 		} );
+
+		await test.step( 'if one product is added to cart and another product fails, optimistic updates are applied and an eror is displayed', async () => {
+			await page.reload();
+
+			// Try to add the individually sold product to cart again (it will fail).
+			const individuallySoldProductCheckbox = page.getByRole(
+				'checkbox',
+				{ name: 'Buy one of Hoodie with Logo' }
+			);
+			await individuallySoldProductCheckbox.click();
+
+			// Try to add another product to cart again (it will succeed).
+			const beanieIncreaseQuantityButton = page.getByLabel(
+				'Increase quantity of Beanie'
+			);
+			await beanieIncreaseQuantityButton.click();
+
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
+			await addToCartButton.click();
+
+			// Verify button updated successfully.
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Added to cart',
+					exact: true,
+				} )
+			).toBeVisible();
+			// Verify error message is displayed.
+			await expect(
+				page.getByText(
+					'The quantity of "Hoodie with Logo" cannot be changed'
+				)
+			).toBeVisible();
+			// Verify optimistic updates were applied, so the product that was
+			// successfully added to cart is counted.
+			await expect( page.getByLabel( '4 items in cart' ) ).toBeVisible();
+		} );
 	} );
 
 	test( "doesn't allow selecting invalid variations in pills mode", async ( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -371,7 +371,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( page.getByLabel( '3 items in cart' ) ).toBeVisible();
 		} );
 
-		await test.step( 'if one product is added to cart and another product fails, optimistic updates are applied and an eror is displayed', async () => {
+		await test.step( 'if one product succeeds and another fails, optimistic updates are applied and an error is displayed', async () => {
 			await page.reload();
 
 			// Try to add the individually sold product to cart again (it will fail).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #60979.

(For Bug Fixes) Bug introduced in PR #60132.

In `trunk`, if a single grouped product child failed to be added to cart, all optimistic updates were skipped, causing the cart state to get out of sync with the server. This PR prevents that, so if some products were added to cart successfully, the cart state is updated accordingly.

### How to test the changes in this Pull Request:
1. Create a grouped product with at least two single products as children. One of them sold individually.
2. In the frontend, using the *Add to Cart + Options* block, add the product sold individually to cart.
3. Now, try adding both products at once: the one sold individually and the other one.
4. Notice an error notice appears, and verify the cart status updated (you can notice that because the *Mini-Cart* quantity badge did update).

https://github.com/user-attachments/assets/a9000424-7692-4186-9853-73fc72fa6ef1
