### PR TITLE
Classic Template Block: Hide from inserter and simplify logic

### DIFF
--- a/plugins/woocommerce/changelog/60993-fix-template-slug-check
+++ b/plugins/woocommerce/changelog/60993-fix-template-slug-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Classic Template Block: Hide from inserter and simplify logic

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
@@ -4,9 +4,7 @@
 import {
 	BlockInstance,
 	createBlock,
-	getBlockType,
 	registerBlockType,
-	unregisterBlockType,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
@@ -18,7 +16,7 @@ import {
 import { Button, Placeholder, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
-import { useDispatch, subscribe, useSelect, select } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
@@ -203,8 +203,6 @@ const Edit = ( {
 	const templatePlaceholder = templateDetails?.placeholder ?? 'fallback';
 	const templateType = templateDetails?.type ?? 'fallback';
 
-	console.log( 'templateSlug', templateSlug );
-
 	useEffect(
 		() =>
 			setAttributes( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
@@ -30,11 +30,7 @@ import { store as editorStore } from '@wordpress/editor';
 import './editor.scss';
 import './style.scss';
 import { BLOCK_SLUG, TEMPLATES, TYPES } from './constants';
-import {
-	isClassicTemplateBlockRegisteredWithAnotherTitle,
-	hasTemplateSupportForClassicTemplateBlock,
-	getTemplateDetailsBySlug,
-} from './utils';
+import { getTemplateDetailsBySlug } from './utils';
 import {
 	blockifiedProductCatalogConfig,
 	blockifiedProductTaxonomyConfig,
@@ -194,18 +190,17 @@ const Edit = ( {
 		};
 	}, [] );
 
-	const template = useEntityRecord< {
-		slug: string;
-		title: {
-			rendered?: string;
-			row: string;
-		};
-	} >( 'postType', 'wp_template', currentPostId );
+	const template = useEntityRecord(
+		'postType',
+		'wp_template',
+		currentPostId
+	);
 
 	const templateDetails = getTemplateDetailsBySlug(
-		attributes.template,
+		template.record?.slug as string,
 		TEMPLATES
 	);
+
 	const templateTitle =
 		template.record?.title.rendered?.toLowerCase() ?? attributes.template;
 	const templatePlaceholder = templateDetails?.placeholder ?? 'fallback';
@@ -278,166 +273,58 @@ const Edit = ( {
 	);
 };
 
-const registerClassicTemplateBlock = ( {
-	template,
-	inserter,
-}: {
-	template?: string | null;
-	inserter: boolean;
-} ) => {
-	/**
-	 * The 'WooCommerce Legacy Template' block was renamed to 'WooCommerce Classic Template', however, the internal block
-	 * name 'woocommerce/legacy-template' needs to remain the same. Otherwise, it would result in a corrupt block when
-	 * loaded for users who have customized templates using the legacy-template (since the internal block name is
-	 * stored in the database).
-	 *
-	 * See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5861 for more context
-	 */
-	registerBlockType( BLOCK_SLUG, {
-		title:
-			template && TEMPLATES[ template ]
-				? TEMPLATES[ template ].title
-				: __( 'WooCommerce Classic Template', 'woocommerce' ),
-		icon: (
-			<Icon
-				icon={ box }
-				className="wc-block-editor-components-block-icon"
+registerBlockType( BLOCK_SLUG, {
+	title: __( 'WooCommerce Classic Template', 'woocommerce' ),
+	icon: (
+		<Icon icon={ box } className="wc-block-editor-components-block-icon" />
+	),
+	category: 'woocommerce',
+	apiVersion: 3,
+	keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
+	description: __(
+		'Renders classic WooCommerce PHP template.',
+		'woocommerce'
+	),
+	supports: {
+		interactivity: {
+			clientNavigation: false,
+		},
+		align: [ 'wide', 'full' ],
+		html: false,
+		multiple: false,
+		reusable: false,
+		inserter: false,
+	},
+	attributes: {
+		/**
+		 * Template attribute is used to determine which core PHP template gets rendered.
+		 */
+		template: {
+			type: 'string',
+			default: 'any',
+		},
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
+	},
+	edit: ( {
+		attributes,
+		clientId,
+		setAttributes,
+	}: BlockEditProps< Attributes > ) => {
+		const newTemplate = slug ?? attributes.template;
+
+		return (
+			<Edit
+				attributes={ {
+					...attributes,
+					template: newTemplate,
+				} }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
 			/>
-		),
-		category: 'woocommerce',
-		apiVersion: 3,
-		keywords: [ __( 'WooCommerce', 'woocommerce' ) ],
-		description:
-			template && TEMPLATES[ template ]
-				? TEMPLATES[ template ].description
-				: __(
-						'Renders classic WooCommerce PHP templates.',
-						'woocommerce'
-				  ),
-		supports: {
-			interactivity: {
-				clientNavigation: false,
-			},
-			align: [ 'wide', 'full' ],
-			html: false,
-			multiple: false,
-			reusable: false,
-			inserter,
-		},
-		attributes: {
-			/**
-			 * Template attribute is used to determine which core PHP template gets rendered.
-			 */
-			template: {
-				type: 'string',
-				default: 'any',
-			},
-			align: {
-				type: 'string',
-				default: 'wide',
-			},
-		},
-		edit: ( {
-			attributes,
-			clientId,
-			setAttributes,
-		}: BlockEditProps< Attributes > ) => {
-			const newTemplate = template ?? attributes.template;
-
-			return (
-				<Edit
-					attributes={ {
-						...attributes,
-						template: newTemplate,
-					} }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-				/>
-			);
-		},
-		save: () => null,
-	} );
-};
-
-// @todo Refactor when there will be possible to show a block according on a template/post with a Gutenberg API. https://github.com/WordPress/gutenberg/pull/41718
-let previousEditedTemplate: string | number | null = null;
-let isBlockRegistered = false;
-let isBlockInInserter = false;
-const handleRegisterClassicTemplateBlock = ( {
-	template,
-	inserter,
-}: {
-	template: string | null;
-	inserter: boolean;
-} ) => {
-	if ( isBlockRegistered ) {
-		unregisterBlockType( BLOCK_SLUG );
-	}
-	isBlockInInserter = inserter;
-	isBlockRegistered = true;
-	registerClassicTemplateBlock( {
-		template,
-		inserter,
-	} );
-};
-
-subscribe( () => {
-	// We use blockCount to know if we are editing a template or in the navigation.
-	const blockCount = select( blockEditorStore )?.getBlockCount() as number;
-	const templateSlug = select( 'core/editor' )?.getEditedPostSlug() as
-		| string
-		| null;
-	const editedTemplate = blockCount && blockCount > 0 ? templateSlug : null;
-
-	// Skip if we are in the same template, except if the block hasn't been registered yet.
-	if ( isBlockRegistered && previousEditedTemplate === editedTemplate ) {
-		return;
-	}
-	previousEditedTemplate = editedTemplate;
-
-	// Handle the case when we are not editing a template (ie: in the navigation screen).
-	if ( ! editedTemplate ) {
-		if ( ! isBlockRegistered ) {
-			handleRegisterClassicTemplateBlock( {
-				template: editedTemplate,
-				inserter: false,
-			} );
-		}
-		return;
-	}
-
-	const templateSupportsClassicTemplateBlock =
-		hasTemplateSupportForClassicTemplateBlock( editedTemplate, TEMPLATES );
-
-	// Handle the case when we are editing a template that doesn't support the Classic Template block (ie: Blog Home).
-	if ( ! templateSupportsClassicTemplateBlock && isBlockInInserter ) {
-		handleRegisterClassicTemplateBlock( {
-			template: editedTemplate,
-			inserter: false,
-		} );
-		return;
-	}
-
-	// Handle the case when we are editing a template that does support the Classic Template block (ie: Product Catalog).
-	if ( templateSupportsClassicTemplateBlock && ! isBlockInInserter ) {
-		handleRegisterClassicTemplateBlock( {
-			template: editedTemplate,
-			inserter: true,
-		} );
-		return;
-	}
-
-	// Handle the case when we are editing a template that does support the Classic Template block but it's currently registered with another title (ie: navigating from the Product Catalog template to the Product Search Results template).
-	if (
-		templateSupportsClassicTemplateBlock &&
-		isClassicTemplateBlockRegisteredWithAnotherTitle(
-			getBlockType( BLOCK_SLUG ),
-			editedTemplate
-		)
-	) {
-		handleRegisterClassicTemplateBlock( {
-			template: editedTemplate,
-			inserter: true,
-		} );
-	}
-}, 'core/blocks-editor' );
+		);
+	},
+	save: () => null,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
@@ -194,20 +194,21 @@ const Edit = ( {
 		currentPostId
 	);
 
-	const templateDetails = getTemplateDetailsBySlug(
-		template.record?.slug as string,
-		TEMPLATES
-	);
+	const templateSlug = template.record?.slug as string;
+
+	const templateDetails = getTemplateDetailsBySlug( templateSlug, TEMPLATES );
 
 	const templateTitle =
 		template.record?.title.rendered?.toLowerCase() ?? attributes.template;
 	const templatePlaceholder = templateDetails?.placeholder ?? 'fallback';
 	const templateType = templateDetails?.type ?? 'fallback';
 
+	console.log( 'templateSlug', templateSlug );
+
 	useEffect(
 		() =>
 			setAttributes( {
-				template: attributes.template,
+				template: templateSlug ?? attributes.template,
 				align: attributes.align ?? 'wide',
 			} ),
 		[ attributes.align, attributes.template, setAttributes ]

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/index.tsx
@@ -311,14 +311,9 @@ registerBlockType( BLOCK_SLUG, {
 		clientId,
 		setAttributes,
 	}: BlockEditProps< Attributes > ) => {
-		const newTemplate = slug ?? attributes.template;
-
 		return (
 			<Edit
-				attributes={ {
-					...attributes,
-					template: newTemplate,
-				} }
+				attributes={ attributes }
 				setAttributes={ setAttributes }
 				clientId={ clientId }
 			/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/utils.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	type Block,
 	type BlockInstance,
 	getBlockType,
 	createBlock,
@@ -11,14 +10,17 @@ import {
 /**
  * Internal dependencies
  */
-import { TEMPLATES } from './constants';
 import { TemplateDetails, InheritedAttributes } from './types';
 
 // Finds the most appropriate template details object for specific template keys such as single-product-hoodie.
 export function getTemplateDetailsBySlug(
-	parsedTemplate: string,
+	parsedTemplate: string | null,
 	templates: TemplateDetails
 ) {
+	if ( ! parsedTemplate ) {
+		return null;
+	}
+
 	const templateKeys = Object.keys( templates );
 	let templateDetails = null;
 
@@ -32,25 +34,6 @@ export function getTemplateDetailsBySlug(
 	}
 
 	return templateDetails;
-}
-
-export function isClassicTemplateBlockRegisteredWithAnotherTitle(
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	block: Block< any > | undefined,
-	parsedTemplate: string
-) {
-	const templateDetails = getTemplateDetailsBySlug(
-		parsedTemplate,
-		TEMPLATES
-	);
-	return block?.title !== templateDetails?.title;
-}
-
-export function hasTemplateSupportForClassicTemplateBlock(
-	parsedTemplate: string,
-	templates: TemplateDetails
-): boolean {
-	return getTemplateDetailsBySlug( parsedTemplate, templates ) ? true : false;
 }
 
 export const createArchiveTitleBlock = (

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -44,28 +44,17 @@ const getClassicTemplateBlocksInInserter = async ( {
 	const options = inserterBlocks.locator( 'role=option' );
 
 	// Filter out blocks that don't match one of the possible Classic Template block names (case-insensitive).
-	const classicTemplateBlocks = await options.evaluateAll(
-		( elements, blockNames ) => {
-			const blockOptions = elements.filter( ( element ) => {
-				return blockNames.some(
-					( name ) => element.textContent === name
-				);
-			} );
-			return blockOptions.map( ( element ) => element.textContent );
-		},
-		'WooCommerce Classic Template'
-	);
+	const classicTemplateBlocks = await options.evaluateAll( ( elements ) => {
+		const blockOptions = elements.filter( ( element ) => {
+			return element.textContent === 'WooCommerce Classic Template';
+		} );
+		return blockOptions.map( ( element ) => element.textContent );
+	} );
 
 	return classicTemplateBlocks;
 };
 
 test.describe( `${ blockData.name } Block `, () => {
-	test.beforeEach( async () => {
-		await wpCLI(
-			'option update wc_blocks_use_blockified_product_grid_block_as_template false'
-		);
-	} );
-
 	test( `is not available in the inserter`, async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
@@ -82,21 +71,22 @@ test.describe( `${ blockData.name } Block `, () => {
 		expect( classicTemplateBlocks ).toHaveLength( 0 );
 	} );
 
-	test( `can be added to a WC template`, async ( {
+	test( `is visible as default block when wc_blocks_use_blockified_product_grid_block_as_template is false`, async ( {
 		admin,
 		editor,
 		page,
 	} ) => {
+		await wpCLI(
+			'option update wc_blocks_use_blockified_product_grid_block_as_template false'
+		);
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
 
-		await editor.insertBlock( { name: blockData.slug } );
-
 		await expect(
-			await editor.getBlockByName( blockData.slug )
+			await editor.getBlockByName( blockData.name )
 		).toBeVisible();
 
 		await page.goto( '/shop/' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -18,56 +18,6 @@ const blockData: Partial< BlockData > = {
 	name: 'woocommerce/legacy-template',
 };
 
-const classicTemplateBlockNames = [
-	'WooCommerce Classic Template',
-	'Product (Classic)',
-	'Product Attribute (Classic)',
-	'Product Category (Classic)',
-	'Product Tag (Classic)',
-	"Product's Custom Taxonomy (Classic)",
-	'Product Search Results (Classic)',
-	'Product Grid (Classic)',
-];
-
-const templates = [
-	{
-		title: 'Single Product',
-		slug: 'single-product',
-		path: '/product/hoodie',
-		needsCreation: false,
-	},
-	{
-		title: 'Products by Attribute',
-		slug: 'taxonomy-product_attribute',
-		path: '/color/blue',
-		needsCreation: false,
-	},
-	{
-		title: 'Products by Category',
-		slug: 'taxonomy-product_cat',
-		path: '/product-category/clothing',
-		needsCreation: true,
-	},
-	{
-		title: 'Products by Tag',
-		slug: 'taxonomy-product_tag',
-		path: '/product-tag/recommended/',
-		needsCreation: true,
-	},
-	{
-		title: 'Product Catalog',
-		slug: 'archive-product',
-		path: '/shop/',
-		needsCreation: false,
-	},
-	{
-		title: 'Product Search Results',
-		slug: 'product-search-results',
-		path: '/?s=shirt&post_type=product',
-		needsCreation: false,
-	},
-];
-
 const getClassicTemplateBlocksInInserter = async ( {
 	editor,
 }: {
@@ -103,7 +53,7 @@ const getClassicTemplateBlocksInInserter = async ( {
 			} );
 			return blockOptions.map( ( element ) => element.textContent );
 		},
-		classicTemplateBlockNames
+		'WooCommerce Classic Template'
 	);
 
 	return classicTemplateBlocks;
@@ -116,117 +66,10 @@ test.describe( `${ blockData.name } Block `, () => {
 		);
 	} );
 
-	test( `is registered/unregistered when navigating from a non-WC template to a WC template and back`, async ( {
-		admin,
-		editor,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: `twentytwentyfour//home`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 0 );
-
-		await editor.page.getByLabel( 'Open Navigation' ).click();
-		await editor.page
-			.getByLabel( 'Product Catalog', { exact: true } )
-			.click();
-
-		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 1 );
-
-		await editor.page.getByLabel( 'Open Navigation' ).click();
-		await editor.page.getByLabel( 'Blog Home', { exact: true } ).click();
-
-		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 0 );
-	} );
-
-	test( `is registered/unregistered when navigating from a WC template to a non-WC template and back`, async ( {
-		admin,
-		editor,
-	} ) => {
+	test( `is not available in the inserter`, async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 1 );
-
-		await editor.page.getByLabel( 'Open Navigation' ).click();
-		await editor.page.getByLabel( 'Blog Home', { exact: true } ).click();
-
-		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 0 );
-
-		await editor.page.getByLabel( 'Open Navigation' ).click();
-		await editor.page
-			.getByLabel( 'Product Catalog', { exact: true } )
-			.click();
-
-		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks ).toHaveLength( 1 );
-	} );
-
-	test( `updates block title when navigating between WC templates`, async ( {
-		admin,
-		editor,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		let classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks[ 0 ] ).toBe( 'Product Grid (Classic)' );
-
-		await editor.page.getByLabel( 'Open Navigation' ).click();
-		await editor.page
-			.getByLabel( 'Product Search Results', { exact: true } )
-			.click();
-
-		classicTemplateBlocks = await getClassicTemplateBlocksInInserter( {
-			editor,
-		} );
-
-		expect( classicTemplateBlocks[ 0 ] ).toBe(
-			'Product Search Results (Classic)'
-		);
-	} );
-
-	test( `is not available when editing template parts`, async ( {
-		admin,
-		editor,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: `twentytwentyfour//header`,
-			postType: 'wp_template_part',
 			canvas: 'edit',
 		} );
 
@@ -239,93 +82,25 @@ test.describe( `${ blockData.name } Block `, () => {
 		expect( classicTemplateBlocks ).toHaveLength( 0 );
 	} );
 
-	// @see https://github.com/woocommerce/woocommerce-blocks/issues/9637
-	test( `is still available after resetting a modified WC template`, async ( {
+	test( `can be added to a WC template`, async ( {
 		admin,
 		editor,
-		wpCoreVersion,
+		page,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//single-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
 
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'Hello World' },
-		} );
+		await editor.insertBlock( { name: blockData.slug } );
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await expect(
+			await editor.getBlockByName( blockData.slug )
+		).toBeVisible();
 
-		await editor.page.getByLabel( 'Open Navigation' ).click();
+		await page.goto( '/shop/' );
 
-		await editor.revertTemplate( {
-			templateName: 'Single Product',
-		} );
-
-		if ( wpCoreVersion >= 6.8 ) {
-			const actionsButton = editor.page.getByRole( 'button', {
-				name: 'Actions',
-			} );
-			await actionsButton.click();
-		}
-
-		const editButton = editor.page.getByRole( 'menuitem', {
-			name: 'Edit',
-		} );
-
-		// Edit the template again.
-		await editButton.click();
-
-		// Verify the Classic Template block is still registered.
-		const classicTemplateBlocks = await getClassicTemplateBlocksInInserter(
-			{
-				editor,
-			}
-		);
-
-		expect( classicTemplateBlocks ).toHaveLength( 1 );
+		await expect( page.locator( 'div[data-template]' ) ).toBeVisible();
 	} );
-
-	for ( const template of templates ) {
-		test( `is rendered on ${ template.title } template`, async ( {
-			admin,
-			editor,
-			page,
-		} ) => {
-			if ( template.needsCreation ) {
-				await admin.visitSiteEditor( {
-					postType: 'wp_template',
-				} );
-				await editor.createTemplate( {
-					templateName: template.title,
-				} );
-			} else {
-				await admin.visitSiteEditor( {
-					postId: `${ BLOCK_THEME_SLUG }//${ template.slug }`,
-					postType: 'wp_template',
-					canvas: 'edit',
-				} );
-			}
-
-			const block = editor.canvas.locator(
-				`[data-type="${ blockData.name }"]`
-			);
-
-			await expect( block ).toBeVisible();
-
-			if ( template.needsCreation ) {
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
-			}
-
-			await page.goto( template.path );
-
-			await expect( page.locator( 'div[data-template]' ) ).toBeVisible();
-		} );
-	}
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


This PR hides the Classic Template block from the inserter. This allows us to simplify the Classic Template block registration logic by removing the dynamic block registration system and replacing it with a simpler, static approach. The changes focus on making the code more maintainable and reducing complexity while maintaining the core functionality.

The only downside is that, now, block title and block description are static and not depend on the template slug. I think that this is acceptable. 


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you're on a fresh site or a site without custom templates.
2. Set `wc_blocks_use_blockified_product_grid_block_as_template` wp option to `no`.
3. Visit all the WooCommerce Template.
4. Ensure that the classic template is rendered.
5. Ensure that the classic template is rendered on the template.
6. Ensure that  "transform into blocks" button works as expected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Classic Template Block: Hide from inserter and simplify logic

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
