### PR TITLE
Revert "Fix rendering issue with RTL currency symbols in product price block (#58134)"

### DIFF
--- a/plugins/woocommerce/changelog/revert-58134
+++ b/plugins/woocommerce/changelog/revert-58134
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product price display in RTL languages

--- a/plugins/woocommerce/client/blocks/assets/css/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/style.scss
@@ -370,9 +370,3 @@ body.wc-block-product-gallery-modal-open {
 .wp-block-group.woocommerce.product .up-sells.upsells.products {
 	max-width: var(--wp--style--global--wide-size);
 }
-
-// These styles are for handling RTL currency symbols in classic themes.
-.woocommerce-Price-bidi {
-	unicode-bidi: bidi-override;
-	direction: ltr;
-}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -119,12 +119,6 @@ interface SalePriceProps {
 	 * The new price during the sale
 	 */
 	price: number | string | undefined;
-	/**
-	 * Custom style to be applied to both regular and sale price containers for RTL currency symbol handling
-	 *
-	 * Applied to both `<del>` and `<ins>` elements
-	 */
-	rtlPrefixStyles?: React.CSSProperties | undefined;
 }
 
 const SalePrice = ( {
@@ -135,7 +129,6 @@ const SalePrice = ( {
 	priceClassName,
 	priceStyle,
 	price,
-	rtlPrefixStyles,
 }: SalePriceProps ) => {
 	return (
 		<>
@@ -150,10 +143,7 @@ const SalePrice = ( {
 							'wc-block-components-product-price__regular',
 							regularPriceClassName
 						) }
-						style={ {
-							...regularPriceStyle,
-							...rtlPrefixStyles,
-						} }
+						style={ regularPriceStyle }
 					>
 						{ value }
 					</del>
@@ -172,10 +162,7 @@ const SalePrice = ( {
 							'is-discounted',
 							priceClassName
 						) }
-						style={ {
-							...priceStyle,
-							...rtlPrefixStyles,
-						} }
+						style={ priceStyle }
 					>
 						{ value }
 					</ins>
@@ -301,15 +288,6 @@ const ProductPrice = ( {
 	);
 
 	if ( isDiscounted ) {
-		// If we have rtl character in the prefix, we need to set the direction to ltr
-		// to avoid the price being displayed in the wrong direction.
-		const rtlPrefixStyles =
-			currency?.prefix && currency.prefix !== ''
-				? {
-						unicodeBidi: 'bidi-override' as const,
-						direction: 'ltr' as const,
-				  }
-				: {};
 		priceComponent = (
 			<SalePrice
 				currency={ currency }
@@ -319,7 +297,6 @@ const ProductPrice = ( {
 				regularPrice={ regularPrice }
 				regularPriceClassName={ regularPriceClassName }
 				regularPriceStyle={ regularPriceStyle }
-				rtlPrefixStyles={ rtlPrefixStyles }
 			/>
 		);
 	} else if ( minPrice !== undefined && maxPrice !== undefined ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/style.scss
@@ -24,15 +24,6 @@
 		margin-bottom: $gap-small;
 	}
 
-	.woocommerce-Price-salePrice {
-		margin-left: 0.5em;
-	}
-
-	.woocommerce-Price-bidi {
-		unicode-bidi: bidi-override;
-		direction: ltr;
-	}
-
 	ins {
 		text-decoration: none;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/__snapshots__/index.js.snap
@@ -10,41 +10,21 @@ exports[`ProductPrice should apply the format if one is provided 1`] = `
   >
     Previous price:
   </span>
-  <span
-    className="wc-block-number-format-container"
+  <del
+    className="wc-block-components-product-price__regular"
   >
-    <del
-      className="wc-block-components-product-price__regular"
-      style={
-        {
-          "direction": "ltr",
-          "unicodeBidi": "bidi-override",
-        }
-      }
-    >
-      £1.00
-    </del>
-  </span>
+    £1.00
+  </del>
   <span
     className="screen-reader-text"
   >
     Discounted price:
   </span>
-  <span
-    className="wc-block-number-format-container"
+  <ins
+    className="wc-block-components-product-price__value is-discounted"
   >
-    <ins
-      className="wc-block-components-product-price__value is-discounted"
-      style={
-        {
-          "direction": "ltr",
-          "unicodeBidi": "bidi-override",
-        }
-      }
-    >
-      £0.50
-    </ins>
-  </span>
+    £0.50
+  </ins>
    Test format
 </span>
 `;
@@ -58,40 +38,20 @@ exports[`ProductPrice should use default price if no format is provided 1`] = `
   >
     Previous price:
   </span>
-  <span
-    className="wc-block-number-format-container"
+  <del
+    className="wc-block-components-product-price__regular"
   >
-    <del
-      className="wc-block-components-product-price__regular"
-      style={
-        {
-          "direction": "ltr",
-          "unicodeBidi": "bidi-override",
-        }
-      }
-    >
-      £1.00
-    </del>
-  </span>
+    £1.00
+  </del>
   <span
     className="screen-reader-text"
   >
     Discounted price:
   </span>
-  <span
-    className="wc-block-number-format-container"
+  <ins
+    className="wc-block-components-product-price__value is-discounted"
   >
-    <ins
-      className="wc-block-components-product-price__value is-discounted"
-      style={
-        {
-          "direction": "ltr",
-          "unicodeBidi": "bidi-override",
-        }
-      }
-    >
-      £0.50
-    </ins>
-  </span>
+    £0.50
+  </ins>
 </span>
 `;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -54,11 +54,6 @@
 				grid-column: 1 / -1;
 			}
 		}
-
-		.woocommerce-Price-bidi {
-			unicode-bidi: bidi-override;
-			direction: ltr;
-		}
 	}
 
 	.quantity {

--- a/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
@@ -94,16 +94,6 @@ const FormattedMonetaryAmount = ( {
 		return null;
 	}
 
-	// If we have rtl character in the prefix, we need to set the direction to ltr
-	// to avoid the price being displayed in the wrong direction.
-	const rtlPrefixStyles =
-		currency?.prefix && currency.prefix !== ''
-			? {
-					unicodeBidi: 'bidi-override' as const,
-					direction: 'ltr' as const,
-			  }
-			: {};
-
 	const classes = clsx(
 		'wc-block-formatted-money-amount',
 		'wc-block-components-formatted-money-amount',
@@ -117,10 +107,6 @@ const FormattedMonetaryAmount = ( {
 		value: undefined,
 		currency: undefined,
 		onValueChange: undefined,
-		style: {
-			...props.style,
-			...rtlPrefixStyles,
-		},
 	};
 
 	// Wrapper for NumberFormat onValueChange which handles subunit conversion.
@@ -132,15 +118,13 @@ const FormattedMonetaryAmount = ( {
 		: () => void 0;
 
 	return (
-		<span className="wc-block-number-format-container">
-			<NumberFormat
-				className={ classes }
-				displayType={ displayType }
-				{ ...numberFormatProps }
-				value={ priceValue }
-				onValueChange={ onValueChangeWrapper }
-			/>
-		</span>
+		<NumberFormat
+			className={ classes }
+			displayType={ displayType }
+			{ ...numberFormatProps }
+			value={ priceValue }
+			onValueChange={ onValueChangeWrapper }
+		/>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/style.scss
@@ -1,8 +1,3 @@
 .wc-block-components-formatted-money-amount {
 	white-space: nowrap;
 }
-
-.wc-block-number-format-container {
-	display: inline-flex;
-	justify-content: center;
-}

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -641,7 +641,7 @@ function wc_price( $price, $args = array() ) {
 	if ( $args['in_span'] ) {
 		$formatted_price = ( $negative ? '-' : '' ) . sprintf( $args['price_format'], '<span class="woocommerce-Price-currencySymbol">' . get_woocommerce_currency_symbol( $args['currency'] ) . '</span>', $price );
 		$aria_hidden     = $args['aria-hidden'] ? ' aria-hidden="true"' : '';
-		$return          = '<span class="woocommerce-Price-amount amount"' . $aria_hidden . '><bdi class="woocommerce-Price-bidi">' . $formatted_price . '</bdi></span>';
+		$return          = '<span class="woocommerce-Price-amount amount"' . $aria_hidden . '><bdi>' . $formatted_price . '</bdi></span>';
 	} else {
 		$formatted_price = ( $negative ? '-' : '' ) . sprintf( $args['price_format'], get_woocommerce_currency_symbol( $args['currency'] ), $price );
 		$return          = $formatted_price;
@@ -1362,7 +1362,7 @@ function wc_format_sale_price( $regular_price, $sale_price ) {
 	$price .= '</span>';
 
 	// Add the sale price.
-	$price .= '<ins class="woocommerce-Price-salePrice" aria-hidden="true">' . $formatted_sale_price . '</ins>';
+	$price .= '<ins aria-hidden="true">' . $formatted_sale_price . '</ins>';
 
 	// For accessibility (a11y) we'll also display that information to screen readers.
 	$price .= '<span class="screen-reader-text">';

--- a/plugins/woocommerce/tests/e2e-pw/tests/coupons/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/coupons/cart-block-coupons.spec.js
@@ -194,7 +194,7 @@ test.describe(
 					).toBeVisible();
 					await expect(
 						page.locator(
-							'.wc-block-components-totals-discount .wc-block-components-totals-item__value'
+							'.wc-block-components-totals-discount > .wc-block-components-totals-item__value'
 						)
 					).toHaveText( discounts[ i ] );
 					await expect(

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
@@ -1087,7 +1087,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product2->get_id(), 1 );
 		WC()->cart->calculate_totals();
 
-		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&euro;</span>68,50</bdi></span>';
+		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>68,50</bdi></span>';
 		$this->assertEquals( $expected_price, WC()->cart->get_total() );
 		$this->assertEquals( '12.36', wc_round_tax_total( WC()->cart->get_total_tax( 'edit' ) ) );
 
@@ -1096,7 +1096,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product4->get_id(), 1 );
 		WC()->cart->calculate_totals();
 
-		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&euro;</span>112,00</bdi></span>';
+		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>112,00</bdi></span>';
 		$this->assertEquals( $expected_price, WC()->cart->get_total() );
 		$this->assertEquals( '20.19', wc_round_tax_total( WC()->cart->get_total_tax( 'edit' ) ) );
 
@@ -1107,7 +1107,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product6->get_id(), 1 );
 		WC()->cart->calculate_totals();
 
-		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&euro;</span>239,00</bdi></span>';
+		$expected_price = '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>239,00</bdi></span>';
 		$this->assertEquals( $expected_price, WC()->cart->get_total() );
 		$this->assertEquals( '43.09', wc_round_tax_total( WC()->cart->get_total_tax( 'edit' ) ) );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -593,35 +593,35 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_price() {
 		// Common prices.
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1.00</bdi></span>', wc_price( 1 ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1.10</bdi></span>', wc_price( 1.1 ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( 1.17 ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1,111.17</bdi></span>', wc_price( 1111.17 ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 0 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1.00</bdi></span>', wc_price( 1 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1.10</bdi></span>', wc_price( 1.1 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( 1.17 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1,111.17</bdi></span>', wc_price( 1111.17 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 0 ) );
 
 		// Different currency.
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&pound;</span>1,111.17</bdi></span>', wc_price( 1111.17, array( 'currency' => 'GBP' ) ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&pound;</span>1,111.17</bdi></span>', wc_price( 1111.17, array( 'currency' => 'GBP' ) ) );
 
 		// Negative price.
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi">-<span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( -1.17 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi>-<span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( -1.17 ) );
 
 		// Aria hidden option.
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi class="woocommerce-Price-bidi">-<span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( -1.17, array( 'aria-hidden' => true ) ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi>-<span class="woocommerce-Price-currencySymbol">&#36;</span>1.17</bdi></span>', wc_price( -1.17, array( 'aria-hidden' => true ) ) );
 
 		// Bogus prices.
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( null ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 'Q' ) );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 'ಠ_ಠ' ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( null ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 'Q' ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>0.00</bdi></span>', wc_price( 'ಠ_ಠ' ) );
 
 		// Trim zeros.
 		add_filter( 'woocommerce_price_trim_zeros', '__return_true' );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1</bdi></span>', wc_price( 1.00 ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1</bdi></span>', wc_price( 1.00 ) );
 		remove_filter( 'woocommerce_price_trim_zeros', '__return_true' );
 
 		// Ex tax label.
 		$calc_taxes = get_option( 'woocommerce_calc_taxes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>1,111.17</bdi></span> <small class="woocommerce-Price-taxLabel tax_label">(ex. tax)</small>', wc_price( '1111.17', array( 'ex_tax_label' => true ) ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>1,111.17</bdi></span> <small class="woocommerce-Price-taxLabel tax_label">(ex. tax)</small>', wc_price( '1111.17', array( 'ex_tax_label' => true ) ) );
 		update_option( 'woocommerce_calc_taxes', $calc_taxes );
 	}
 
@@ -935,7 +935,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_format_sale_price() {
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins class="woocommerce-Price-salePrice" aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;5.00.</span>', wc_format_sale_price( '10', '5' ) );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;5.00.</span>', wc_format_sale_price( '10', '5' ) );
 	}
 
 	/**
@@ -944,7 +944,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_format_price_range() {
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span> <span aria-hidden="true">&ndash;</span> <span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span><span class="screen-reader-text">Price range: &#36;10.00 through &#36;5.00</span>', wc_format_price_range( '10', '5' ) );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span> <span aria-hidden="true">&ndash;</span> <span class="woocommerce-Price-amount amount" aria-hidden="true"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span><span class="screen-reader-text">Price range: &#36;10.00 through &#36;5.00</span>', wc_format_price_range( '10', '5' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -992,7 +992,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object = new WC_Order();
 		$object->set_total( 100 );
 		$object->set_currency( 'USD' );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>100.00</bdi></span>', $object->get_formatted_order_total() );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>100.00</bdi></span>', $object->get_formatted_order_total() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data.php
@@ -265,15 +265,15 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 
 		$product = wc_get_product( $product1_id );
 		$this->assertEquals( $product1_id, $product->get_id() );
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins class="woocommerce-Price-salePrice" aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>7.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;7.00.</span>', $product->get_price_html() );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>10.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;10.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>7.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;7.00.</span>', $product->get_price_html() );
 
 		$product = wc_get_product( $product2_id );
 		$this->assertEquals( $product2_id, $product->get_id() );
-		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>20.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;20.00.</span><ins class="woocommerce-Price-salePrice" aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>16.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;16.00.</span>', $product->get_price_html() );
+		$this->assertEquals( '<del aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>20.00</bdi></span></del> <span class="screen-reader-text">Original price was: &#036;20.00.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>16.00</bdi></span></ins><span class="screen-reader-text">Current price is: &#036;16.00.</span>', $product->get_price_html() );
 
 		$product = wc_get_product( $product3_id );
 		$this->assertEquals( $product3_id, $product->get_id() );
-		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>50.00</bdi></span>', $product->get_price_html() );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>50.00</bdi></span>', $product->get_price_html() );
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit cf35de275c4d9a4495df7d2fb7dd1f4270268247.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/60986 (will close after merging to `trunk`).

Bug introduced in PR #58134 

### Screenshots or screen recordings:

Look at the product price; this is in Hebrew, which is an RTL language.

| Before | After |
| ------ | ----- |
| <img width="514" height="948" alt="CleanShot 2025-09-18 at 11 02 25@2x" src="https://github.com/user-attachments/assets/5abf306d-f752-49d5-a362-06139f701663" /> | <img width="514" height="948" alt="CleanShot 2025-09-18 at 11 02 01@2x" src="https://github.com/user-attachments/assets/a238b828-b822-4d8f-a6be-b89770b63ff5" /> |

### How to test the changes in this Pull Request:

1. Change your site to an RTL language—I've used Hebrew: he_IL (עִבְרִית)
2. Verify that the product prices still follow standard LTR flow

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
