### PR TITLE
Fix docs link to incorrect store API page

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/README.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/README.md
@@ -130,4 +130,4 @@ Modifying the server-side part of the Cart and Checkout blocks is possible using
 
 ### Extending Store API
 
-If you need to change how the Store API works, or extend the data in the responses, see [Extending the Store API](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/rest-api).
+If you need to change how the Store API works, or extend the data in the responses, see [Extending the Store API](/docs/apis/store-api/extending-store-api/).

--- a/plugins/woocommerce/changelog/fix-broken-docs-link
+++ b/plugins/woocommerce/changelog/fix-broken-docs-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Docs update only
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update incorrect link for extending StoreAPI in WC docs.

### How to test the changes in this Pull Request:


1. Go to `<monorepo root>/docs/_docu_tools` run `npm i` and `npm run start`
2. Naviagate to http://localhost:3000/docs/block-development/extensible-blocks/cart-and-checkout-blocks/#extending-store-api/ and click the `If you need to change how the Store API works, or extend the data in the responses, see Extending the Store API.` link
3. Ensure it takes you to the correct page on the docs site.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
