### PR TITLE
Improve the performance of Blocks\AssetsController::get_block_asset_resource_hints()

### DIFF
--- a/plugins/woocommerce/changelog/improve-performance-of-assetcontroller-get_script_dependency_src_array
+++ b/plugins/woocommerce/changelog/improve-performance-of-assetcontroller-get_script_dependency_src_array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve performance of uncached Block Assets dependency loading.

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -343,17 +343,38 @@ final class AssetsController {
 	 */
 	private function get_script_dependency_src_array( array $dependencies ) {
 		$wp_scripts = wp_scripts();
-		return array_reduce(
-			$dependencies,
-			function ( $src, $handle ) use ( $wp_scripts ) {
-				if ( isset( $wp_scripts->registered[ $handle ] ) ) {
-					$src[] = esc_url( add_query_arg( 'ver', $wp_scripts->registered[ $handle ]->ver, $this->get_absolute_url( $wp_scripts->registered[ $handle ]->src ) ) );
-					$src   = array_merge( $src, $this->get_script_dependency_src_array( $wp_scripts->registered[ $handle ]->deps ) );
+
+		$found_dependencies = array();
+		$this->gather_script_dependency_handles( $dependencies, $wp_scripts, $found_dependencies );
+
+		$src = array();
+		foreach ( $found_dependencies as $handle => $unused ) {
+			$src[] = esc_url( add_query_arg( 'ver', $wp_scripts->registered[ $handle ]->ver, $this->get_absolute_url( $wp_scripts->registered[ $handle ]->src ) ) );
+		}
+		return $src;
+	}
+
+	/**
+	 * Recursively gather all unique script dependency handles from a starting list.
+	 *
+	 * Traverses the dependency graph for each input handle, collecting any found handles
+	 * and their nested dependencies in the provided array. Used internally to build a
+	 * complete, deduplicated set of handles for further processing (e.g., mapping to src URLs).
+	 *
+	 * @param array      $dependencies      Array of initial script handles to process.
+	 * @param \WP_Scripts $wp_scripts       WP_Scripts instance containing all registered scripts.
+	 * @param array      $found_dependencies Reference to array in which discovered handles are stored.
+	 * @return void
+	 */
+	private function gather_script_dependency_handles( array $dependencies, \WP_Scripts $wp_scripts, &$found_dependencies = array() ) {
+		foreach ( $dependencies as $handle ) {
+			if ( isset( $wp_scripts->registered[ $handle ] ) && ! isset( $found_dependencies[ $handle ] ) ) {
+				$found_dependencies[ $handle ] = true;
+				if ( ! empty( $wp_scripts->registered[ $handle ]->deps ) ) {
+					$this->gather_script_dependency_handles( $wp_scripts->registered[ $handle ]->deps, $wp_scripts, $found_dependencies );
 				}
-				return $src;
-			},
-			array()
-		);
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -361,9 +361,10 @@ final class AssetsController {
 	 * and their nested dependencies in the provided array. Used internally to build a
 	 * complete, deduplicated set of handles for further processing (e.g., mapping to src URLs).
 	 *
-	 * @param array      $dependencies      Array of initial script handles to process.
-	 * @param \WP_Scripts $wp_scripts       WP_Scripts instance containing all registered scripts.
-	 * @param array      $found_dependencies Reference to array in which discovered handles are stored.
+	 * @param array       $dependencies       Array of initial script handles to process.
+	 * @param \WP_Scripts $wp_scripts         WP_Scripts instance containing all registered scripts.
+	 * @param array       $found_dependencies Reference to array in which discovered handles are stored.
+	 *
 	 * @return void
 	 */
 	private function gather_script_dependency_handles( array $dependencies, \WP_Scripts $wp_scripts, &$found_dependencies = array() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [WOOPLUG-5559](https://linear.app/a8c/issue/WOOPLUG-5559/blockassetscontrollerget-block-asset-resource-hints-performance-issues) / #61014.

Improves upon #51874 which added caching around the handling.

This improves upon the performance of the underlying ::get_script_dependency_src_array() method by keeping track of visited nodes to reduce recursion since many dependencies have shared dependencies that should already be accounted for.


### Screenshots or screen recordings:

| Before | After | % Change |
| ------ | ----- | ----- |
|  140.57ms      |  2.02ms   | -98.% |

Before:

<img width="1002" height="580" alt="Screenshot 2025-09-18 at 3 00 52 PM" src="https://github.com/user-attachments/assets/dd8486b6-2dbc-427c-9bfa-5c6b028ed75a" />


After

<img width="2002" height="1163" alt="Screenshot 2025-09-18 at 3 21 48 PM" src="https://github.com/user-attachments/assets/f451f428-f122-4d33-9c9a-e2a8bf30b098" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add something to your cart to trigger the preloading of cart block dependencies. 
2. Clear website cache to make sure the rendered output is from the new handling (object caching is required)
3. View the page source.  You should see a bunch of assets for prefetch:
<img width="1587" height="978" alt="Screenshot 2025-09-18 at 3 29 27 PM" src="https://github.com/user-attachments/assets/79c82f89-1091-492f-9aa6-b02fb5010c75" />

4. Save the output for comparison.
5. Re-checkout trunk.
6. Clear the website cache again.
7. View the page source again and save the ouptut.
8. Diff the two outputs to verify that no assets changed in any way.

<!-- End testing instructions -->
