### PR TITLE
Address error in woocommerce 10.2 update script for fully refunded orders

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5561-error-in-woocommerce-102-update-script
+++ b/plugins/woocommerce/changelog/wooplug-5561-error-in-woocommerce-102-update-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address update script issue where refunded $order may not exist, and disable refunded orders tool.

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3043,6 +3043,9 @@ function wc_update_1020_add_old_refunded_order_items_to_product_lookup_table() {
 		foreach ( $refunded_orders as $refunded_order ) {
 			if ( intval( $refunded_order->num_items_sold ) === 0 ) {
 				$order = wc_get_order( $refunded_order->order_id );
+				if ( ! $order ) {
+					continue;
+				}
 				// If the refund order has no line items, mark it as a full refund in orders_meta table.
 				// In the above query we already excluded orders for refunded shipping and tax, so it's safe to assume that the refund order without items is a full refund.
 				// Note that the "full" refund here means it's created by changing the order status to "Refunded", not partially refund all the items in the order.

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -185,12 +185,18 @@ class Analytics {
 		if ( OrderUtil::uses_new_full_refund_data() ) {
 			return $debug_tools;
 		}
+		$message = __( 'Warning, slow for large stores. This tool will fix the full refund data used in WooCommerce Analytics and re-import all the refunded historical data.', 'woocommerce' );
 
 		$debug_tools[ self::FULL_REFUND_FIX_DATA_TOOL_ID ] = array(
 			'name'     => __( 'Fix analytics full refund data', 'woocommerce' ),
 			'button'   => __( 'Fix', 'woocommerce' ),
-			'desc'     => __( 'This tool will fix the full refund data used in WooCommerce Analytics and re-import all the refunded historical data.', 'woocommerce' ),
+			'desc'     => sprintf(
+				'<strong class="red">%1$s</strong> %2$s',
+				__( 'Note:', 'woocommerce' ),
+				$message
+			),
 			'callback' => array( $this, 'run_full_refund_fix_data_tool' ),
+			'disabled' => true
 		);
 
 		return $debug_tools;

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -7,7 +7,6 @@ namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Contains backend logic for the Analytics feature.
@@ -21,10 +20,6 @@ class Analytics {
 	 * Clear cache tool identifier.
 	 */
 	const CACHE_TOOL_ID = 'clear_woocommerce_analytics_cache';
-	/**
-	 * Full refund fix data tool identifier.
-	 */
-	const FULL_REFUND_FIX_DATA_TOOL_ID = 'fix_woocommerce_analytics_full_refund_data';
 
 	/**
 	 * Class instance.
@@ -65,7 +60,6 @@ class Analytics {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_pages' ) );
 		add_filter( 'woocommerce_debug_tools', array( $this, 'register_cache_clear_tool' ) );
-		add_filter( 'woocommerce_debug_tools', array( $this, 'register_full_refund_fix_data_tool' ) );
 	}
 
 	/**
@@ -170,33 +164,6 @@ class Analytics {
 				'</a>'
 			),
 			'callback' => array( $this, 'run_clear_cache_tool' ),
-		);
-
-		return $debug_tools;
-	}
-
-	/**
-	 * Register the full refund fix data tool on the WooCommerce > Status > Tools page.
-	 *
-	 * @param array $debug_tools Available debug tool registrations.
-	 * @return array Filtered debug tool registrations.
-	 */
-	public function register_full_refund_fix_data_tool( $debug_tools ) {
-		if ( OrderUtil::uses_new_full_refund_data() ) {
-			return $debug_tools;
-		}
-		$message = __( 'Warning, slow for large stores. This tool will fix the full refund data used in WooCommerce Analytics and re-import all the refunded historical data.', 'woocommerce' );
-
-		$debug_tools[ self::FULL_REFUND_FIX_DATA_TOOL_ID ] = array(
-			'name'     => __( 'Fix analytics full refund data', 'woocommerce' ),
-			'button'   => __( 'Fix', 'woocommerce' ),
-			'desc'     => sprintf(
-				'<strong class="red">%1$s</strong> %2$s',
-				__( 'Note:', 'woocommerce' ),
-				$message
-			),
-			'callback' => array( $this, 'run_full_refund_fix_data_tool' ),
-			'disabled' => true,
 		);
 
 		return $debug_tools;
@@ -317,41 +284,5 @@ class Analytics {
 		Cache::invalidate();
 
 		return __( 'Analytics cache cleared.', 'woocommerce' );
-	}
-
-	/**
-	 * "Fix" full refund data by re-importing all the refunded historical data.
-	 */
-	public function run_full_refund_fix_data_tool() {
-		global $wpdb;
-
-		Cache::invalidate();
-
-		// Get every order ID where:
-		// 1. the total sales is less than 0, and
-		// 2. is not refunded shipping fee only, and
-		// 3. is not refunded tax fee only.
-		$refunded_orders = $wpdb->get_results(
-			"SELECT order_stats.order_id
-			FROM {$wpdb->prefix}wc_order_stats AS order_stats
-			WHERE order_stats.total_sales < 0 # Refunded orders
-				AND order_stats.total_sales != order_stats.shipping_total # Exclude refunded orders that only include a shipping refund
-				AND order_stats.total_sales != order_stats.tax_total # Exclude refunded orders that only include a tax refund"
-		);
-
-		delete_option( 'woocommerce_analytics_uses_old_full_refund_data' );
-		if ( $refunded_orders ) {
-			foreach ( $refunded_orders as $refunded_order ) {
-				/**
-				 * Trigger an action to schedule the data import for old refunded order items.
-				 *
-				 * @param int $order_id The ID of the order to be synced.
-				 * @since 10.2.0
-				 */
-				do_action( 'woocommerce_schedule_import', intval( $refunded_order->order_id ) );
-			}
-		}
-
-		return __( 'Re-importing refunded orders, full refund data will be updated shortly.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -196,7 +196,7 @@ class Analytics {
 				$message
 			),
 			'callback' => array( $this, 'run_full_refund_fix_data_tool' ),
-			'disabled' => true
+			'disabled' => true,
 		);
 
 		return $debug_tools;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

Addresses issue where a refunded `$order` does not exist.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #WOOPLUG-5561

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before loading this branch make sure you have WooCommerce 10.1 or earlier installed and activated.
2. Activate taxes and add a couple tax rules for your country
3. Now create several completed orders with a shipping amount and change the dates to something in the past
4. Full refund a couple of the orders, by changing the status
5. If you have HPOS enabled, go to your DB and delete at-least one of the fully refunded orders from the `wp_wc_orders` table ( the one that includes a `parent_order_id` ).
6. Now load this branch ( or install it, you can generate a zip using: `pnpm --filter=@woocommerce/plugin-woocommerce build:zip` )
7. Make sure `woocommerce_run_update_callback` is run as a scheduled action under **Status > Scheduled Actions**
8. Make sure no fatals happen.
9. Go to **WooCommerce > Status > Scheduled Actions** and make sure that there are no `import_order` actions triggered after the update.
10. Go to **WooCommerce > Tools** and make sure the **Fix analytics full refund data** tool is not listed.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
