### PR TITLE
Add to Cart + Options: fix some types

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-type-errors
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-type-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add to Cart + Options: fix some types
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
@@ -7,6 +7,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import type { BlockConfiguration } from '@wordpress/blocks';
 import { useProductDataContext } from '@woocommerce/shared-context';
 import { Spinner } from '@wordpress/components';
+import { isProductResponseItem } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ registerBlockType( metadata.name, {
 		const blockProps = useBlockProps();
 		const { isLoading, product } = useProductDataContext();
 
-		if ( isLoading ) {
+		if ( isLoading || ! isProductResponseItem( product ) ) {
 			return <Spinner />;
 		}
 		return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/edit.tsx
@@ -5,6 +5,7 @@ import { useProductDataContext } from '@woocommerce/shared-context';
 import { Disabled, Spinner } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { isProductResponseItem } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import QuantityStepper from '../../components/quantity-stepper';
 const CTA = () => {
 	const { isLoading, product } = useProductDataContext();
 
-	if ( isLoading ) {
+	if ( isLoading || ! isProductResponseItem( product ) ) {
 		return <Spinner />;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute/edit.tsx
@@ -14,6 +14,7 @@ import {
 	CustomDataProvider,
 	useProductDataContext,
 } from '@woocommerce/shared-context';
+import { isProductResponseItem } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -70,8 +71,11 @@ export default function AttributeItemTemplateEdit(
 	} );
 
 	const { product } = useProductDataContext();
+
 	const productAttributes =
-		product.type === 'variable' ? product.attributes : DEFAULT_ATTRIBUTES;
+		isProductResponseItem( product ) && product.type === 'variable'
+			? product.attributes
+			: DEFAULT_ATTRIBUTES;
 
 	const { blocks } = useSelect(
 		( select ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useProductDataContext } from '@woocommerce/shared-context';
+import { isProductResponseItem } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -21,8 +22,6 @@ export default function AddToCartWithOptionsVariationSelectorEdit(
 	const { className } = props.attributes;
 	const { current: currentProductType } = useProductTypeSelector();
 	const { product } = useProductDataContext();
-	const productType =
-		product.id === 0 ? currentProductType?.slug : product.type;
 
 	const blockProps = useBlockProps( {
 		className,
@@ -32,9 +31,11 @@ export default function AddToCartWithOptionsVariationSelectorEdit(
 		templateLock: 'all',
 	} );
 
-	// If a valid product has been provided but it's not a
-	// variable product, then don't render anything.
-	if ( product.id !== 0 && productType !== 'variable' ) {
+	const productType = ! isProductResponseItem( product )
+		? currentProductType?.slug
+		: product.type;
+
+	if ( productType !== 'variable' ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/entities/product/guards.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/product/guards.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { ProductResponseItem } from '@woocommerce/types';
+
+/**
  * Internal dependencies
  */
 import { ExternalProductResponse, ProductEntityResponse } from './types';
@@ -10,4 +15,10 @@ export const isExternalProduct = (
 		return true;
 	}
 	return false;
+};
+
+export const isProductResponseItem = (
+	product: ProductResponseItem | ProductEntityResponse | undefined
+): product is ProductResponseItem => {
+	return !! product && 'id' in product && product.id !== 0;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
@@ -53,6 +53,7 @@ const defaultProductData: ProductResponseItem = {
 	sold_individually: false,
 	add_to_cart: {
 		text: 'Add to cart',
+		single_text: 'Add to cart',
 		description: 'Add to cart',
 		url: '',
 		minimum: 1,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a `isProductResponseItem()` guard that fixes some TypeScript errors in _Add to Cart + Options_ inner blocks. I also took the chance to strengthen some checks here and there, but functionality should be the same.

### How to test the changes in this Pull Request:

This PR doesn't change any functionality, testing means making sure there are no regressions.

1. Edit the _Single Product_ template and test different product types, make sure the _Add to Cart + Options_ inner blocks are rendered correctly in the editor.

<img width="486" height="650" alt="image" src="https://github.com/user-attachments/assets/138cbc24-d203-405f-8f53-af11f40f4116" />

2. Create a post and add the _Product_. Select products from different product types and make sure the _Add to Cart + Options_ inner blocks are rendered correctly in the editor.

<img width="553" height="456" alt="image" src="https://github.com/user-attachments/assets/cbbc3b98-db4a-46bc-98d6-5fff177a947f" />