### PR TITLE
Fix date picker language issue in woocommerce analytics

### DIFF
--- a/packages/js/components/changelog/wooplug-5557-date-picker-language-issue-in-woocommerce-analytics
+++ b/packages/js/components/changelog/wooplug-5557-date-picker-language-issue-in-woocommerce-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where translated placeholder string was used to format the date, causing formatting errors.

--- a/packages/js/components/src/calendar/date-range.js
+++ b/packages/js/components/src/calendar/date-range.js
@@ -175,6 +175,7 @@ class DateRange extends Component {
 			afterError,
 			beforeError,
 			shortDateFormat,
+			shortDateFormatPlaceholder,
 			isViewportMobile,
 			isViewportSmall,
 			isInvalidDate,
@@ -190,7 +191,9 @@ class DateRange extends Component {
 					<DateInput
 						value={ afterText }
 						onChange={ partial( this.onInputChange, 'after' ) }
-						dateFormat={ shortDateFormat }
+						dateFormat={
+							shortDateFormatPlaceholder || shortDateFormat
+						}
 						label={ __( 'Start Date', 'woocommerce' ) }
 						error={ afterError }
 						describedBy={ sprintf(
@@ -199,7 +202,7 @@ class DateRange extends Component {
 								"Date input describing a selected date range's start date in format %s",
 								'woocommerce'
 							),
-							shortDateFormat
+							shortDateFormatPlaceholder || shortDateFormat
 						) }
 						onFocus={ () => this.onFocusChange( 'startDate' ) }
 					/>
@@ -209,7 +212,9 @@ class DateRange extends Component {
 					<DateInput
 						value={ beforeText }
 						onChange={ partial( this.onInputChange, 'before' ) }
-						dateFormat={ shortDateFormat }
+						dateFormat={
+							shortDateFormatPlaceholder || shortDateFormat
+						}
 						label={ __( 'End Date', 'woocommerce' ) }
 						error={ beforeError }
 						describedBy={ sprintf(
@@ -218,7 +223,7 @@ class DateRange extends Component {
 								"Date input describing a selected date range's end date in format %s",
 								'woocommerce'
 							),
-							shortDateFormat
+							shortDateFormatPlaceholder || shortDateFormat
 						) }
 						onFocus={ () => this.onFocusChange( 'endDate' ) }
 					/>
@@ -307,6 +312,10 @@ DateRange.propTypes = {
 	 * The date format in moment.js-style tokens.
 	 */
 	shortDateFormat: PropTypes.string.isRequired,
+	/**
+	 * The date format in human-readable format.
+	 */
+	shortDateFormatPlaceholder: PropTypes.string,
 	/**
 	 * A ref that the DateRange can lose focus to.
 	 * See: https://github.com/woocommerce/woocommerce-admin/pull/2929.

--- a/packages/js/components/src/date-range-filter-picker/content.js
+++ b/packages/js/components/src/date-range-filter-picker/content.js
@@ -61,6 +61,7 @@ class DatePickerContent extends Component {
 			afterError,
 			beforeError,
 			shortDateFormat,
+			shortDateFormatPlaceholder,
 		} = this.props;
 		return (
 			<div>
@@ -111,6 +112,9 @@ class DatePickerContent extends Component {
 										afterError={ afterError }
 										beforeError={ beforeError }
 										shortDateFormat={ shortDateFormat }
+										shortDateFormatPlaceholder={
+											shortDateFormatPlaceholder
+										}
 										losesFocusTo={
 											this.controlsRef.current
 										}
@@ -196,6 +200,7 @@ DatePickerContent.propTypes = {
 	afterError: PropTypes.string,
 	beforeError: PropTypes.string,
 	shortDateFormat: PropTypes.string.isRequired,
+	shortDateFormatPlaceholder: PropTypes.string,
 };
 
 export default DatePickerContent;

--- a/packages/js/components/src/date-range-filter-picker/index.js
+++ b/packages/js/components/src/date-range-filter-picker/index.js
@@ -14,7 +14,8 @@ import clsx from 'clsx';
 import DatePickerContent from './content';
 import DropdownButton from '../dropdown-button';
 
-const shortDateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
+const shortDateFormatPlaceholder = __( 'MM/DD/YYYY', 'woocommerce' );
+const shortDateFormat = 'MM/DD/YYYY';
 
 /**
  * Select a range of dates or single dates.
@@ -170,6 +171,9 @@ class DateRangeFilterPicker extends Component {
 							afterError={ afterError }
 							beforeError={ beforeError }
 							shortDateFormat={ shortDateFormat }
+							shortDateFormatPlaceholder={
+								shortDateFormatPlaceholder
+							}
 						/>
 					) }
 				/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses a bug where the translated string is being used for formatting. This tends to be work well in most cases, but some languages translate `MM/DD/YYYY` differently, for example in French it becomes: `JJ/MM/AAAA` ( this was only added earlier this year, which is why this has not been an issue prior ).

Closes #WOOPLUG-5557

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/b8625439-444b-43e8-8d6e-289630c085e7

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set the site language to French ( under **Settings > General** )
2. Go to **Dashboard > Updates** and click update languages
3. Go to Analytics
4. Click the calendar and move to the custom data range ( text should all be in french )
5. Select a date range, it should format the date in the text inputs correctly
6. Now enter a format manually in the text input, it should also work correctly

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
