### PR TITLE
Remove removed cart session data in favor of URL restore params

### DIFF
--- a/plugins/woocommerce/changelog/update-60950
+++ b/plugins/woocommerce/changelog/update-60950
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Remove removed cart session data in favor of URL restore params

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -105,7 +105,6 @@ final class WC_Cart_Session {
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
 		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
-		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
 
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
@@ -314,7 +313,6 @@ final class WC_Cart_Session {
 		$wc_session->set( 'applied_coupons', null );
 		$wc_session->set( 'coupon_discount_totals', null );
 		$wc_session->set( 'coupon_discount_tax_totals', null );
-		$wc_session->set( 'removed_cart_contents', null );
 		$wc_session->set( 'order_awaiting_payment', null );
 		$wc_session->set( 'store_api_draft_order', null );
 		$wc_session->set( 'shipping_method_counts', null );
@@ -404,7 +402,6 @@ final class WC_Cart_Session {
 		$applied_coupons            = $this->cart->get_applied_coupons();
 		$coupon_discount_totals     = $this->cart->get_coupon_discount_totals();
 		$coupon_discount_tax_totals = $this->cart->get_coupon_discount_tax_totals();
-		$removed_cart_contents      = $this->cart->get_removed_cart_contents();
 
 		/*
 		 * We want to clear out any empty/default data from the session that have no value in being stored so the session
@@ -415,7 +412,6 @@ final class WC_Cart_Session {
 		$wc_session->set( 'applied_coupons', empty( $applied_coupons ) ? null : $applied_coupons );
 		$wc_session->set( 'coupon_discount_totals', empty( $coupon_discount_totals ) ? null : $coupon_discount_totals );
 		$wc_session->set( 'coupon_discount_tax_totals', empty( $coupon_discount_tax_totals ) ? null : $coupon_discount_tax_totals );
-		$wc_session->set( 'removed_cart_contents', empty( $removed_cart_contents ) ? null : $removed_cart_contents );
 		if ( empty( $cart ) ) {
 			$this->remove_draft_order();
 		}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1380,11 +1380,20 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Restore a cart item.
 	 *
 	 * @param  string $cart_item_key Cart item key to restore to the cart.
+	 * @param  array  $cart_item_data Cart item data (optional, used when removed_cart_contents is not in session).
 	 * @return bool
 	 */
-	public function restore_cart_item( $cart_item_key ) {
+	public function restore_cart_item( $cart_item_key, $cart_item_data = null ) {
+		$restore_item = null;
+
 		if ( isset( $this->removed_cart_contents[ $cart_item_key ] ) ) {
-			$restore_item                                  = $this->removed_cart_contents[ $cart_item_key ];
+			$restore_item = $this->removed_cart_contents[ $cart_item_key ];
+			unset( $this->removed_cart_contents[ $cart_item_key ] );
+		} elseif ( $cart_item_data && is_array( $cart_item_data ) ) {
+			$restore_item = $cart_item_data;
+		}
+
+		if ( $restore_item ) {
 			$this->cart_contents[ $cart_item_key ]         = $restore_item;
 			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1412,19 +1412,25 @@ class WC_Cart extends WC_Legacy_Cart {
 			 */
 			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this, $restore_item );
 
-			$result = $this->add_to_cart( $product_id, $quantity, $variation_id, $variation, $cart_item_data );
+			$validation_result = $this->add_to_cart( $product_id, $quantity, $variation_id, $variation, $cart_item_data );
 
-			/**
-			 * Fires after a cart item is restored.
-			 *
-			 * @since 2.3.0
-			 * @param string $cart_item_key contains the id of the cart item.
-			 * @param WC_Cart $this Cart class.
-			 * @param array $restore_item The cart item data.
-			 */
-			do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this, $restore_item );
+			if ( $validation_result ) {
+				// Move the validated item from the new key to the original key if different.
+				if ( $cart_item_key !== $validation_result ) {
+					$this->cart_contents[ $cart_item_key ] = $this->cart_contents[ $validation_result ];
+					unset( $this->cart_contents[ $validation_result ] );
+				}
 
-			if ( $result ) {
+				/**
+				 * Fires after a cart item is restored.
+				 *
+				 * @since 2.3.0
+				 * @param string $cart_item_key contains the id of the cart item.
+				 * @param WC_Cart $this Cart class.
+				 * @param array $restore_item The cart item data.
+				 */
+				do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this, $restore_item );
+
 				return true;
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1394,16 +1394,39 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		if ( $restore_item ) {
-			$this->cart_contents[ $cart_item_key ]         = $restore_item;
-			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
+			$product_id   = $restore_item['product_id'] ?? 0;
+			$variation_id = $restore_item['variation_id'] ?? 0;
+			$quantity     = $restore_item['quantity'] ?? 1;
+			$variation    = $restore_item['variation'] ?? array();
 
-			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this );
+			$cart_item_data = $restore_item;
+			unset( $cart_item_data['key'], $cart_item_data['data'], $cart_item_data['data_hash'] );
 
-			unset( $this->removed_cart_contents[ $cart_item_key ] );
+			/**
+			 * Fires before a cart item is restored.
+			 *
+			 * @since 2.3.0
+			 * @param string $cart_item_key contains the id of the cart item.
+			 * @param WC_Cart $this Cart class.
+			 * @param array $restore_item The cart item data.
+			 */
+			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this, $restore_item );
 
-			do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this );
+			$result = $this->add_to_cart( $product_id, $quantity, $variation_id, $variation, $cart_item_data );
 
-			return true;
+			/**
+			 * Fires after a cart item is restored.
+			 *
+			 * @since 2.3.0
+			 * @param string $cart_item_key contains the id of the cart item.
+			 * @param WC_Cart $this Cart class.
+			 * @param array $restore_item The cart item data.
+			 */
+			do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this, $restore_item );
+
+			if ( $result ) {
+				return true;
+			}
 		}
 		return false;
 	}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -686,8 +686,7 @@ class WC_Form_Handler {
 
 			// Check if cart item data is provided in the URL (for when removed_cart_contents is not in session).
 			if ( ! empty( $_GET['undo_data'] ) ) {
-				$undo_data = wp_unslash( $_GET['undo_data'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$undo_data = json_decode( base64_decode( $undo_data ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+				$undo_data = self::get_sanitized_cart_item_data( wp_unslash( $_GET['undo_data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 
 			WC()->cart->restore_cart_item( $cart_item_key, $undo_data );
@@ -1188,6 +1187,75 @@ class WC_Form_Handler {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get sanitized cart item data.
+	 *
+	 * @param string $input_data Input data as base64 encoded JSON.
+	 * @return array|null
+	 */
+	private static function get_sanitized_cart_item_data( $input_data ) {
+		$cart_item_data = json_decode( base64_decode( $input_data ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		if ( ! is_array( $cart_item_data ) ) {
+			$cart_item_data = null;
+		} else {
+			$cart_item_data = array_intersect_key(
+				$cart_item_data,
+				array_flip(
+					array(
+						'key',
+						'product_id',
+						'variation_id',
+						'quantity',
+						'variation',
+						'data_hash',
+					)
+				)
+			);
+
+			if ( isset( $cart_item_data['key'] ) ) {
+				if ( ! preg_match( '/^[a-f0-9]{32}$/', $cart_item_data['key'] ) ) {
+					unset( $cart_item_data['key'] );
+				} else {
+					$cart_item_data['key'] = sanitize_text_field( $cart_item_data['key'] );
+				}
+			}
+			if ( isset( $cart_item_data['product_id'] ) ) {
+				$cart_item_data['product_id'] = absint( $cart_item_data['product_id'] );
+			}
+			if ( isset( $cart_item_data['variation_id'] ) ) {
+				$cart_item_data['variation_id'] = absint( $cart_item_data['variation_id'] );
+			}
+			if ( isset( $cart_item_data['quantity'] ) ) {
+				$cart_item_data['quantity'] = absint( $cart_item_data['quantity'] );
+			}
+			if ( isset( $cart_item_data['variation'] ) && is_array( $cart_item_data['variation'] ) ) {
+				$sanitized_variation = array();
+				foreach ( $cart_item_data['variation'] as $key => $value ) {
+					$sanitized_key = sanitize_title( $key );
+					if ( strpos( $sanitized_key, 'attribute_' ) === 0 && is_string( $value ) ) {
+						$sanitized_value = sanitize_text_field( $value );
+						if ( ! empty( $sanitized_value ) || '0' === $sanitized_value ) {
+							$sanitized_variation[ $sanitized_key ] = $sanitized_value;
+						}
+					}
+				}
+				$cart_item_data['variation'] = $sanitized_variation;
+			} else {
+				$cart_item_data['variation'] = array();
+			}
+			if ( isset( $cart_item_data['data_hash'] ) ) {
+				if ( ! preg_match( '/^[a-f0-9]{32}$/', $cart_item_data['data_hash'] ) ) {
+					unset( $cart_item_data['data_hash'] );
+				} else {
+					$cart_item_data['data_hash'] = sanitize_text_field( $cart_item_data['data_hash'] );
+				}
+			}
+		}
+
+		return $cart_item_data;
 	}
 }
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -665,7 +665,7 @@ class WC_Form_Handler {
 				if ( $product && $product->is_in_stock() && $product->has_enough_stock( $cart_item['quantity'] ) ) {
 					/* Translators: %s Product title. */
 					$removed_notice  = sprintf( __( '%s removed.', 'woocommerce' ), $item_removed_title );
-					$removed_notice .= ' <a href="' . esc_url( wc_get_cart_undo_url( $cart_item_key ) ) . '" class="restore-item">' . __( 'Undo?', 'woocommerce' ) . '</a>';
+					$removed_notice .= ' <a href="' . esc_url( wc_get_cart_undo_url( $cart_item_key, $cart_item ) ) . '" class="restore-item">' . __( 'Undo?', 'woocommerce' ) . '</a>';
 				} else {
 					/* Translators: %s Product title. */
 					$removed_notice = sprintf( __( '%s removed.', 'woocommerce' ), $item_removed_title );
@@ -682,8 +682,15 @@ class WC_Form_Handler {
 
 			// Undo Cart Item.
 			$cart_item_key = sanitize_text_field( wp_unslash( $_GET['undo_item'] ) );
+			$undo_data     = null;
 
-			WC()->cart->restore_cart_item( $cart_item_key );
+			// Check if cart item data is provided in the URL (for when removed_cart_contents is not in session).
+			if ( ! empty( $_GET['undo_data'] ) ) {
+				$undo_data = wp_unslash( $_GET['undo_data'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$undo_data = json_decode( base64_decode( $undo_data ), true );
+			}
+
+			WC()->cart->restore_cart_item( $cart_item_key, $undo_data );
 
 			if ( wp_get_referer() ) {
 				wp_safe_redirect( remove_query_arg( array( 'undo_item', '_wpnonce' ), wp_get_referer() ) );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -687,7 +687,7 @@ class WC_Form_Handler {
 			// Check if cart item data is provided in the URL (for when removed_cart_contents is not in session).
 			if ( ! empty( $_GET['undo_data'] ) ) {
 				$undo_data = wp_unslash( $_GET['undo_data'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$undo_data = json_decode( base64_decode( $undo_data ), true );
+				$undo_data = json_decode( base64_decode( $undo_data ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 			}
 
 			WC()->cart->restore_cart_item( $cart_item_key, $undo_data );

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4219,7 +4219,7 @@ function wc_get_cart_undo_url( $cart_item_key, $cart_item_data = null ) {
 		$item_data_for_url = $cart_item_data;
 		unset( $item_data_for_url['data'] );
 
-		$query_args['undo_data'] = base64_encode( wp_json_encode( $item_data_for_url ) );
+		$query_args['undo_data'] = base64_encode( wp_json_encode( $item_data_for_url ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	return apply_filters( 'woocommerce_get_undo_url', $cart_page_url ? wp_nonce_url( add_query_arg( $query_args, $cart_page_url ), 'woocommerce-cart' ) : '', $cart_item_key );

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4205,14 +4205,22 @@ function wc_get_cart_remove_url( $cart_item_key ) {
  *
  * @since 3.3.0
  * @param  string $cart_item_key Cart item key to undo.
+ * @param  array  $cart_item_data Cart item data (optional, used when removed_cart_contents is not in session).
  * @return string url to page
  */
-function wc_get_cart_undo_url( $cart_item_key ) {
+function wc_get_cart_undo_url( $cart_item_key, $cart_item_data = null ) {
 	$cart_page_url = wc_get_cart_url();
 
 	$query_args = array(
 		'undo_item' => $cart_item_key,
 	);
+
+	if ( $cart_item_data && is_array( $cart_item_data ) ) {
+		$item_data_for_url = $cart_item_data;
+		unset( $item_data_for_url['data'] );
+
+		$query_args['undo_data'] = base64_encode( wp_json_encode( $item_data_for_url ) );
+	}
 
 	return apply_filters( 'woocommerce_get_undo_url', $cart_page_url ? wp_nonce_url( add_query_arg( $query_args, $cart_page_url ), 'woocommerce-cart' ) : '', $cart_item_key );
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Unit tests for cart item removal functionality.
+ *
+ * @package WooCommerce\Tests\Cart
+ */
+
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+
+/**
+ * Class WC_Cart_Item_Removal_Test
+ */
+class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up test data.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		$this->cart = new WC_Cart();
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		$this->product->delete( true );
+		WC()->cart->empty_cart();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that get_removed_cart_contents returns an array.
+	 */
+	public function test_get_removed_cart_contents_returns_array() {
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertIsArray( $removed );
+		$this->assertEmpty( $removed );
+	}
+
+	/**
+	 * Test that set_removed_cart_contents works correctly.
+	 */
+	public function test_set_removed_cart_contents() {
+		$test_data = array(
+			'test_key' => array(
+				'product_id'   => 123,
+				'quantity'     => 2,
+				'variation_id' => 0,
+			),
+		);
+
+		$this->cart->set_removed_cart_contents( $test_data );
+		$removed = $this->cart->get_removed_cart_contents();
+
+		$this->assertEquals( $test_data, $removed );
+	}
+
+	/**
+	 * Test that remove_cart_item stores item in removed_cart_contents.
+	 */
+	public function test_remove_cart_item_stores_in_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->assertNotEmpty( $cart_item_key );
+
+		$cart_item = $this->cart->get_cart_item( $cart_item_key );
+		$this->assertNotEmpty( $cart_item );
+
+		$result = $this->cart->remove_cart_item( $cart_item_key );
+		$this->assertTrue( $result );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertArrayHasKey( $cart_item_key, $removed );
+		$this->assertEquals( $cart_item['product_id'], $removed[ $cart_item_key ]['product_id'] );
+		$this->assertEquals( $cart_item['quantity'], $removed[ $cart_item_key ]['quantity'] );
+		$this->assertArrayNotHasKey( 'data', $removed[ $cart_item_key ] );
+	}
+
+	/**
+	 * Test that remove_cart_item fires the correct hooks.
+	 */
+	public function test_remove_cart_item_fires_hooks() {
+		$hooks_fired = array();
+
+		add_action(
+			'woocommerce_remove_cart_item',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_remove_cart_item'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_cart_item_removed',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_cart_item_removed'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertArrayHasKey( 'woocommerce_remove_cart_item', $hooks_fired );
+		$this->assertArrayHasKey( 'woocommerce_cart_item_removed', $hooks_fired );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_remove_cart_item'][0] );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_cart_item_removed'][0] );
+	}
+
+	/**
+	 * Test restore_cart_item with removed_cart_contents (backward compatibility).
+	 */
+	public function test_restore_cart_item_with_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertEmpty( $this->cart->get_cart() );
+
+		$result = $this->cart->restore_cart_item( $cart_item_key );
+
+		$this->assertTrue( $result );
+
+		$cart_item = $this->cart->get_cart_item( $cart_item_key );
+		$this->assertNotEmpty( $cart_item );
+		$this->assertEquals( $this->product->get_id(), $cart_item['product_id'] );
+		$this->assertEquals( 2, $cart_item['quantity'] );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertArrayNotHasKey( $cart_item_key, $removed );
+	}
+
+	/**
+	 * Test restore_cart_item with provided cart item data.
+	 */
+	public function test_restore_cart_item_with_provided_data() {
+		$cart_item_data = array(
+			'product_id'   => $this->product->get_id(),
+			'variation_id' => 0,
+			'quantity'     => 3,
+			'variation'    => array(),
+			'data_hash'    => 'test_hash',
+		);
+
+		$cart_item_key = 'test_cart_key_123';
+
+		$result = $this->cart->restore_cart_item( $cart_item_key, $cart_item_data );
+		$this->assertTrue( $result );
+
+		$cart_item = $this->cart->get_cart_item( $cart_item_key );
+		$this->assertNotEmpty( $cart_item );
+		$this->assertEquals( $cart_item_data['product_id'], $cart_item['product_id'] );
+		$this->assertEquals( $cart_item_data['quantity'], $cart_item['quantity'] );
+		$this->assertInstanceOf( 'WC_Product', $cart_item['data'] );
+	}
+
+	/**
+	 * Test restore_cart_item fires the correct hooks.
+	 */
+	public function test_restore_cart_item_fires_hooks() {
+		$hooks_fired = array();
+
+		add_action(
+			'woocommerce_restore_cart_item',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_restore_cart_item'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_cart_item_restored',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_cart_item_restored'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		$cart_item_data = array(
+			'product_id'   => $this->product->get_id(),
+			'variation_id' => 0,
+			'quantity'     => 1,
+			'variation'    => array(),
+		);
+
+		$cart_item_key = 'test_cart_key_456';
+
+		$this->cart->restore_cart_item( $cart_item_key, $cart_item_data );
+
+		$this->assertArrayHasKey( 'woocommerce_restore_cart_item', $hooks_fired );
+		$this->assertArrayHasKey( 'woocommerce_cart_item_restored', $hooks_fired );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_restore_cart_item'][0] );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_cart_item_restored'][0] );
+	}
+
+	/**
+	 * Test restore_cart_item returns false for non-existent items.
+	 */
+	public function test_restore_cart_item_returns_false_for_non_existent() {
+		$result = $this->cart->restore_cart_item( 'non_existent_key' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that empty_cart clears removed_cart_contents.
+	 */
+	public function test_empty_cart_clears_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertNotEmpty( $removed );
+
+		$this->cart->empty_cart();
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertEmpty( $removed );
+	}
+
+	/**
+	 * Test wc_get_cart_undo_url removes data key from cart item data.
+	 */
+	public function test_wc_get_cart_undo_url_encodes_data() {
+		$cart_item_key  = 'test_cart_key_789';
+		$cart_item_data = array(
+			'product_id'   => $this->product->get_id(),
+			'variation_id' => 0,
+			'quantity'     => 1,
+			'variation'    => array(),
+			'data'         => $this->product, // This should be removed.
+			'data_hash'    => 'test_hash',
+		);
+
+		$undo_url = wc_get_cart_undo_url( $cart_item_key, $cart_item_data );
+
+		$parsed_url = wp_parse_url( $undo_url );
+		parse_str( $parsed_url['query'], $query_params );
+		$decoded_data = json_decode( base64_decode( $query_params['undo_data'] ), true );
+
+		$this->assertArrayNotHasKey( 'data', $decoded_data );
+		$this->assertArrayHasKey( 'product_id', $decoded_data );
+		$this->assertArrayHasKey( 'quantity', $decoded_data );
+		$this->assertArrayHasKey( 'data_hash', $decoded_data );
+	}
+
+	/**
+	 * Test that plugins can access get_removed_cart_contents method.
+	 */
+	public function test_plugins_can_access_get_removed_cart_contents() {
+		$removed_contents = $this->cart->get_removed_cart_contents();
+
+		$this->assertIsArray( $removed_contents );
+		$this->assertEmpty( $removed_contents );
+	}
+
+	/**
+	 * Test that plugins can still modify removed_cart_contents.
+	 */
+	public function test_plugins_can_modify_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents                                   = $this->cart->get_removed_cart_contents();
+		$removed_contents[ $cart_item_key ]['custom_field'] = 'plugin_added_value';
+		$this->cart->set_removed_cart_contents( $removed_contents );
+
+		$modified_contents = $this->cart->get_removed_cart_contents();
+		$this->assertEquals( 'plugin_added_value', $modified_contents[ $cart_item_key ]['custom_field'] );
+	}
+
+	/**
+	 * Test that plugins can still access removed_cart_contents after restore.
+	 */
+	public function test_plugins_can_access_removed_contents_after_restore() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents = $this->cart->get_removed_cart_contents();
+		$this->assertArrayHasKey( $cart_item_key, $removed_contents );
+
+		$this->cart->restore_cart_item( $cart_item_key );
+
+		$removed_contents_after = $this->cart->get_removed_cart_contents();
+		$this->assertArrayNotHasKey( $cart_item_key, $removed_contents_after );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\Cart
  */
 
+declare( strict_types=1 );
+
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
@@ -30,7 +32,7 @@ class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		$this->product->delete( true );
-		WC()->cart->empty_cart();
+		$this->cart->empty_cart();
 		parent::tearDown();
 	}
 
@@ -242,8 +244,11 @@ class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
 
 		$undo_url = wc_get_cart_undo_url( $cart_item_key, $cart_item_data );
 
-		$parsed_url = wp_parse_url( $undo_url );
-		parse_str( $parsed_url['query'], $query_params );
+		$parsed_url   = wp_parse_url( $undo_url );
+		$query_string = html_entity_decode( $parsed_url['query'], ENT_QUOTES, 'UTF-8' );
+		parse_str( $query_string, $query_params );
+
+		$this->assertArrayHasKey( 'undo_data', $query_params );
 		$decoded_data = json_decode( base64_decode( $query_params['undo_data'] ), true );
 
 		$this->assertArrayNotHasKey( 'data', $decoded_data );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
@@ -249,7 +249,7 @@ class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
 		parse_str( $query_string, $query_params );
 
 		$this->assertArrayHasKey( 'undo_data', $query_params );
-		$decoded_data = json_decode( base64_decode( $query_params['undo_data'] ), true );
+		$decoded_data = json_decode( base64_decode( $query_params['undo_data'] ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 
 		$this->assertArrayNotHasKey( 'data', $decoded_data );
 		$this->assertArrayHasKey( 'product_id', $decoded_data );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes `removed_cart_contents` from the session so that requests can be edge cached after a cart is emptied.  This results in much higher performance where edge caching is available and was previously missed until the session was fully cleared.

Note that this is an aggressive option to clear the cache and could cause breaks in backwards compatibility, but this PR attempts to limit that based on how we've seen this used in plugins.  Merging this PR will require setup of a dev advisory notice.

* Remove `removed_cart_contents` from the session
* Add in an `undo_data` param to allow cart items to continue to be restored via URL
* Added tests around cart item removal

Closes #60950 .

### Screenshots or screen recordings:

<img width="476" height="163" alt="Screenshot 2025-09-17 at 11 26 48 AM" src="https://github.com/user-attachments/assets/a0365241-6507-4a4e-9470-c49a05318d44" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```php
add_action(
	'wp_head',
	function () {
		$session = WC()->session;
		echo '<pre>' . print_r( $session->get_session_data(), true ) . '</pre>';
	}
);
add_action(
	'woocommerce_remove_cart_item',
	function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
		error_log( 'woocommerce_remove_cart_item' );
		error_log( print_r( $cart_item_key, true ) );
		error_log( print_r( $cart, true ) );
	},
	10,
	2
);
add_action(
	'woocommerce_cart_item_removed',
	function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
		error_log( 'woocommerce_removed_cart_item' );
		error_log( print_r( $cart_item_key, true ) );
		error_log( print_r( $cart, true ) );
	},
	10,
	2
);
```

1. Add the above snippet to your site
2. Set up a classic cart page and block
3. Note that `removed_cart_contents` does not exist in your session at the top of the screen
4. On your classic cart, add an item to the cart
5. Remove the item from the cart
6. Note that `removed_cart_contents` does not exist in the session
7. Click the "Undo?" option in the notice
8. Make sure the item is restored to the cart
9. Check your error logs and make sure that the appropriate hooks are still firing and show the correct data
10. Optionally, test with some plugins that make use of the removed_cart_contents getters, setters, hooks, or attempt to modify session.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
