### PR TITLE
Classic Template: add a new filter for consumers to control gallery assets enqueuing

### DIFF
--- a/plugins/woocommerce/changelog/61031-fix-allow-disabling-gallery-feature-for-classic-template-block
+++ b/plugins/woocommerce/changelog/61031-fix-allow-disabling-gallery-feature-for-classic-template-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Classic Template: add a new filter for consumers to control gallery assets enqueuing

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -107,22 +107,55 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	 * @see https://github.com/woocommerce/woocommerce/pull/60223
 	 */
 	public function enqueue_legacy_assets() {
-		// Legacy script dependencies for backward compatibility.
-		wp_enqueue_script( 'wc-zoom' );
-		wp_enqueue_script( 'wc-flexslider' );
-		wp_enqueue_script( 'wc-photoswipe-ui-default' );
-		wp_enqueue_style( 'photoswipe-default-skin' );
-		wp_enqueue_script( 'wc-single-product' );
-
-		add_action(
-			'wp_footer',
-			function () {
-				wc_get_template( 'single-product/photoswipe.php' );
-			}
+		$default_settings = array(
+			'zoom'       => true,
+			'flexslider' => true,
+			'photoswipe' => true,
 		);
-		add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+		/**
+		 * Filters the legacy gallery features enqueued by the Classic Template block.
+		 *
+		 * @since 10.3.0
+		 *
+		 * @param array $settings Associative array with zoom, flexslider, photoswipe flags.
+		 */
+		$filtered_settings = apply_filters( 'woocommerce_classic_template_legacy_gallery_features', $default_settings );
+		$parsed_settings   = wp_parse_args( is_array( $filtered_settings ) ? $filtered_settings : array(), $default_settings );
+		$settings          = array(
+			'zoom'       => wc_string_to_bool( $parsed_settings['zoom'] ),
+			'flexslider' => wc_string_to_bool( $parsed_settings['flexslider'] ),
+			'photoswipe' => wc_string_to_bool( $parsed_settings['photoswipe'] ),
+		);
+
+		if ( $settings['zoom'] ) {
+			wp_enqueue_script( 'wc-zoom' );
+			add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
+		} else {
+			add_filter( 'woocommerce_single_product_zoom_enabled', '__return_false' );
+		}
+
+		if ( $settings['flexslider'] ) {
+			wp_enqueue_script( 'wc-flexslider' );
+			add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+		} else {
+			add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_false' );
+		}
+
+		if ( $settings['photoswipe'] ) {
+			wp_enqueue_script( 'wc-photoswipe-ui-default' );
+			wp_enqueue_style( 'photoswipe-default-skin' );
+			add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
+			add_action(
+				'wp_footer',
+				function () {
+					wc_get_template( 'single-product/photoswipe.php' );
+				}
+			);
+		} else {
+			add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_false' );
+		}
+
+		wp_enqueue_script( 'wc-single-product' );
 	}
 
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #60223

Since #60223, We always load legacy single product assets when using the Classic Template block. This is our effort to improve the frontend performance of the single product page for block themes (by not loading legacy assets by default).

However, this poses an issue for users of the Classic Template block, as they can not opt out of legacy gallery assets anymore using `remove_theme_support`. To resolve this, this PR introduces a new filter that allows users to selectively disable the legacy gallery assets.

I chose to implement a PHP filter rather than an inspector setting because the target audience of this PR is already using the `remove_theme_support` function for removing legacy gallery assets. So a PHP filter is more relevant for them than a new inspector setting, which is accessible to all users.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet to the test site:
```php
add_filter( 'woocommerce_classic_template_legacy_gallery_features', function() {
  'zoom'       => false,
  'flexslider' => false,
  'photoswipe' => false,
} );
```
2. Ensure the single product template use Classic Template block.
```html
<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
<main class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"single-product"} /--></main>
<!-- /wp:group -->
<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
```
3. Visit a product on the frontend, confirm the legacy gallery assets isn't loaded.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Classic Template: add a new filter for consumers to control gallery assets enqueuing
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
