### PR TITLE
Check if template part is from file system before building the result from file

### DIFF
--- a/plugins/woocommerce/changelog/fix-61068
+++ b/plugins/woocommerce/changelog/fix-61068
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check if template part is from file system before building the result from file

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -287,12 +287,12 @@ class BlockTemplatesController {
 						break;
 					}
 				}
-				$fits_slug_query =
+				$fits_slug_query    =
 					! isset( $query['slug__in'] ) || in_array( $template_file->slug, $query['slug__in'], true );
-				$fits_area_query =
+				$fits_area_query    =
 					! isset( $query['area'] ) || ( property_exists( $template_file, 'area' ) && $template_file->area === $query['area'] );
 				$is_from_filesystem = isset( $template_file->path );
-				$should_include  = ! $is_custom && $fits_slug_query && $fits_area_query && $is_from_filesystem;
+				$should_include     = ! $is_custom && $fits_slug_query && $fits_area_query && $is_from_filesystem;
 
 				if ( $should_include ) {
 					$template       = BlockTemplateUtils::build_template_result_from_file( $template_file, $template_type );

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -291,7 +291,9 @@ class BlockTemplatesController {
 					! isset( $query['slug__in'] ) || in_array( $template_file->slug, $query['slug__in'], true );
 				$fits_area_query =
 					! isset( $query['area'] ) || ( property_exists( $template_file, 'area' ) && $template_file->area === $query['area'] );
-				$should_include  = ! $is_custom && $fits_slug_query && $fits_area_query;
+				$is_from_filesystem = isset( $template_file->path );
+				$should_include  = ! $is_custom && $fits_slug_query && $fits_area_query && $is_from_filesystem;
+
 				if ( $should_include ) {
 					$template       = BlockTemplateUtils::build_template_result_from_file( $template_file, $template_type );
 					$query_result[] = $template;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

From Claude:

**The Issue**
The core problem lies in how wp_template_part templates are handled. The code at line 254 calls $this->get_block_templates(), which returns a mixed array of WP_Block_Template objects. This array contains templates sourced from two places:

Database: These templates, fetched by get_block_templates_from_db(), are WP_Block_Template objects that lack a path property. Their content is already stored in the database.

Filesystem: These templates, from get_block_templates_from_woocommerce(), have a path property pointing to their file location.

The build_template_result_from_file() method, however, expects a path property to read the template's file content. When the code's loop (lines 257-299) encounters a database template, it incorrectly attempts to call this method on it, leading to a file_get_contents(null) error.

Why This Happens
Based on the stack trace and user reports, this error specifically affects template parts (wp_template_part). The logical flaw is that the code tries to "rebuild" database templates using a method designed for filesystem templates.

Database templates (WP_Block_Template objects from build_template_result_from_post()) don't need a path property because their content is retrieved directly from the database.

The code then incorrectly tries to pass these same objects to build_template_result_from_file(), which assumes a path exists.

**The Bug**
The bug is triggered by the condition at line 273: if ( 'wp_template_part' === $template_type ). Inside this block, the code fails to differentiate between templates from the database and those from the filesystem. It indiscriminately processes all template files and then attempts to call build_template_result_from_file() on database templates, which don't have the required path property, causing the fatal error.

---

While everything that Claude produced makes sense I still cannot reproduce the issue. Seems like editing WooCommerce template parts (causing them to be stored in DB) should be enough for this error to be triggered while it's not. Hence I can't reproduce the issue and eventually cannot confirm this PR fixes it.

TBC

Closes https://github.com/woocommerce/woocommerce/issues/61068

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
