### PR TITLE
fix(order): stop coupon recalculation

### DIFF
--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -455,13 +455,6 @@ function wc_save_order_items( $order_id, $items ) {
 
 	$order->update_taxes();
 
-	// Only recalculate when a coupon is applied.
-	// This allows manual discounts to be preserved when order items are saved.
-	$order_coupons = $order->get_coupons();
-	if ( ! empty( $order_coupons ) ) {
-		$order->recalculate_coupons();
-	}
-
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.


### PR DESCRIPTION
Prevent WooCommerce from recalculating coupons when changing order status.

Previously, changing an order from 'processing' to 'completed' (or another status) would trigger
`recalculate_coupons()`, which could incorrectly modify coupon discounts for products
whose prices had changed or sales had ended.

This commit adds a check to skip coupon recalculation during programmatic status changes,
ensuring that order totals and previously applied discounts remain correct.
