### PR TITLE
Revert recalculating coupons on order save

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5447-save-order-adds-vat-to-shippingfees-and-changes-totals
+++ b/plugins/woocommerce/changelog/wooplug-5447-save-order-adds-vat-to-shippingfees-and-changes-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Don't recalculate coupons on order save, which can cause recalculation of totals and taxes when nothing changed

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -454,14 +454,6 @@ function wc_save_order_items( $order_id, $items ) {
 	}
 
 	$order->update_taxes();
-
-	// Only recalculate when a coupon is applied.
-	// This allows manual discounts to be preserved when order items are saved.
-	$order_coupons = $order->get_coupons();
-	if ( ! empty( $order_coupons ) ) {
-		$order->recalculate_coupons();
-	}
-
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.

--- a/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
@@ -1690,63 +1690,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that fixed cart discount coupons maintain their total amount when quantities change in admin orders.
-	 */
-	public function test_fixed_cart_discount_quantity_change_admin_order() {
-		$price = 20;
-		// Create a product with a price of $20.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_regular_price( $price );
-		$product->save();
-
-		// Create a fixed cart discount coupon of $10.
-		$coupon = WC_Helper_Coupon::create_coupon();
-		$coupon->set_discount_type( 'fixed_cart' );
-		$coupon->set_amount( 10 );
-		$coupon->save();
-
-		// Create an order with our specific product and 1 item quantity.
-		$order = new WC_Order();
-		$order->set_status( 'processing' );
-		$order->save();
-		$order_item_id = $order->add_product( $product, 1 );
-
-		// Apply the coupon to the order.
-		$order->apply_coupon( $coupon->get_code() );
-		$order->calculate_totals();
-
-		// Verify initial discount amount is $10.
-		$coupons     = $order->get_items( 'coupon' );
-		$coupon_item = reset( $coupons );
-		$this->assertEquals( 10.0, $coupon_item->get_discount(), 'Initial discount should be $10' );
-
-		// Verify order total is $10 (original $20 - $10 discount).
-		$this->assertEquals( 10.0, $order->get_total(), 'Order total should be $10 after $10 discount' );
-
-		// Now change the quantity to 2 and save the order items.
-		$items = array(
-			'order_item_id'  => array( $order_item_id ),
-			'order_item_qty' => array( $order_item_id => 2 ),
-			'line_total'     => array( $order_item_id => 2 * $price ),
-			'line_subtotal'  => array( $order_item_id => 2 * $price ),
-		);
-
-		// Save the order items - this should trigger the coupon recalculation.
-		wc_save_order_items( $order->get_id(), $items );
-
-		// Reload the order to get updated data.
-		$order = wc_get_order( $order->get_id() );
-
-		// Verify the discount is still $10 (fixed cart discount should not increase with quantity).
-		$coupons     = $order->get_items( 'coupon' );
-		$coupon_item = reset( $coupons );
-		$this->assertEquals( 10.0, $coupon_item->get_discount(), 'Discount should remain $10 after quantity change' );
-
-		// Verify order total is $30 (original $40 - $10 discount).
-		$this->assertEquals( 30.0, $order->get_total(), 'Order total should be $30 after quantity change' );
-	}
-
-	/**
 	 * Test that manual discounts are preserved when no coupons are used in order.
 	 * This tests the logic in wc_save_order_items that only recalculates coupons when coupons exist.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reverts #59606 and #60240. 

The original issue was, that on an order with a coupon discount, when the quantity is changed, the discount would also change, surpassing the coupon's value. The fix was to recalculate coupons when order item is saved.

But this came with a couple of unintended side effects:
1. Recalculating on order stats change, without any changes in items. This sometimes caused changes in taxes and totals, which no longer match what the customer paid for.
2. Any custom hooks into coupons value was not respected when updating order.
3. When coupon expired and order was updated, the discount would disappear. 

So instead of trying to fix these issue, I chose to revert the original fix, as it caused more harm than good.

Closes #60661, closes WOOPLUG-5447, closes #61080, closes WOOPLUG-5578, closes #61025, closes WOOPLUG-5563, closes #60553, closes WOOPLUG-5400, closes #61409, closes WOOPLUG-5690.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Follow steps in #61025, #60661, and #61080 that they are no longer reproducible. 

<!-- End testing instructions -->

### Testing that has already taken place:

I've followed steps to reproduce from the above mentioned three issues to verify, they no longer were possible.
