### PR TITLE
Performance: reduce the number of slow SQL queries in customer reports

### DIFF
--- a/plugins/woocommerce/changelog/performance-WOOPLUG-5382-slow-reporting-user-queries
+++ b/plugins/woocommerce/changelog/performance-WOOPLUG-5382-slow-reporting-user-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce the number of slow SQL queries in customers reports.

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-customer-list.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-customer-list.php
@@ -263,28 +263,17 @@ class WC_Report_Customer_List extends WP_List_Table {
 
 		add_action( 'pre_user_query', array( $this, 'order_by_last_name' ) );
 
-		/**
-		 * Get users.
-		 */
-		$admin_users = new WP_User_Query(
+		$privileged_users = new WP_User_Query(
 			array(
-				'role'   => 'administrator',
-				'fields' => 'ID',
-			)
+				'fields'   => 'ID',
+				'role__in' => array( 'administrator', 'shop_manager' ),
+			),
 		);
-
-		$manager_users = new WP_User_Query(
-			array(
-				'role'   => 'shop_manager',
-				'fields' => 'ID',
-			)
-		);
-
-		$query = new WP_User_Query(
+		$query            = new WP_User_Query(
 			apply_filters(
 				'woocommerce_admin_report_customer_list_user_query_args',
 				array(
-					'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
+					'exclude' => $privileged_users->get_results(),
 					'number'  => $per_page,
 					'offset'  => ( $current_page - 1 ) * $per_page,
 				)

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-customers.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-customers.php
@@ -188,26 +188,18 @@ class WC_Report_Customers extends WC_Admin_Report {
 		$this->check_current_range_nonce( $current_range );
 		$this->calculate_current_range( $current_range );
 
-		$admin_users = new WP_User_Query(
+		$privileged_users = new WP_User_Query(
 			array(
-				'role'   => 'administrator',
-				'fields' => 'ID',
-			)
+				'fields'   => 'ID',
+				'role__in' => array( 'administrator', 'shop_manager' ),
+			),
 		);
-
-		$manager_users = new WP_User_Query(
-			array(
-				'role'   => 'shop_manager',
-				'fields' => 'ID',
-			)
-		);
-
-		$users_query = new WP_User_Query(
+		$users_query      = new WP_User_Query(
 			apply_filters(
 				'woocommerce_admin_report_customers_user_query_args',
 				array(
 					'fields'  => array( 'user_registered' ),
-					'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
+					'exclude' => $privileged_users->get_results(),
 				)
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Splitting #60676 into better-scoped PRs.

For the Customers vs guest report:

before: 2 queries (`0.0509 + 0.0419 = 0.0928 sec`)
<img width="2307" height="383" alt="Screenshot from 2025-09-23 08-49-59" src="https://github.com/user-attachments/assets/50926bfb-f97b-45ca-a119-7f7995f7873c" />

after: 1 query (`0.0616 sec`, 34% faster)
<img width="2313" height="217" alt="Screenshot from 2025-09-23 08-49-06" src="https://github.com/user-attachments/assets/d716f55e-b79c-4be3-a8cb-0cb2d5985073" />

For the customer list:

before: 2 queries (`0.8495 + 0.8910 = 1.7405 sec`)
<img width="2308" height="493" alt="Screenshot from 2025-09-23 09-01-14" src="https://github.com/user-attachments/assets/de25c5e2-d975-41ca-b738-6ef4969a4d59" />

after: 1 query (`0.8960 sec`, 49% faster)
<img width="2305" height="273" alt="Screenshot from 2025-09-23 08-59-50" src="https://github.com/user-attachments/assets/5ac0f880-8996-4d81-b704-74f5bae4e659" />

On average, it's ~40% faster fetching for privileged users: we run a single query, but do a bit heavier matching for each record.

### How to test the changes in this Pull Request:

- Ensure to have a setup with at least 10K users and `Query monitor` plugin installed
- Navigate to WooCommerce -> Reports -> Customers
- For both `Customers vs. guests` and `Customer list` click `Go` and ensure the reports are loading and verify SQL queries are as per description.

### Testing that has already taken place:

Has already been tested in #60676, but verifying the changes and executied SQL queries will not hurt.