### PR TITLE
Uninstall: drop custom WordPress index on uninstall

### DIFF
--- a/plugins/woocommerce/changelog/performance-WOOPLUG-5382-drop-custom-wp-index-on-uninstall
+++ b/plugins/woocommerce/changelog/performance-WOOPLUG-5382-drop-custom-wp-index-on-uninstall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Drop custom WordPress index on uninstall.

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -50,6 +50,12 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Load WooCommerce so we can access the container, install routines, etc, during uninstall.
 	require_once __DIR__ . '/includes/class-wc-install.php';
 
+	// Drop custom WordPress tables indexes. See \WC_Install::create_tables() for details.
+	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type';" );
+	if ( null !== $index_exists ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type;" );
+	}
+
 	// Roles + caps.
 	WC_Install::remove_roles();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Splitting #60676 into better-scoped PRs.

Drop the custom `woo_idx_comment_type` index (introduced in 2e8f02f6a423ac30498f4f716c663ecc2f11d14f back in 2016) on the comments table when uninstalling WooCommerce.

### How to test the changes in this Pull Request:

- Use live branches to spin off a test site
- Navigate to the site and ensure uninstalling WooCommerce plugin succeeds
