### PR TITLE
[Rest API v4] Allow orders to be sorted by order total

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-882-rest-api-v4-order-by-order-total-param
+++ b/plugins/woocommerce/changelog/wooprd-882-rest-api-v4-order-by-order-total-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow order data stors to sort orders by order total.

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -276,6 +276,8 @@ class WC_Data_Store_WP {
 
 		$skipped_values = array( '', array(), null );
 		$wp_query_args  = array(
+			'orderby'    => 'id',
+			'order'      => 'desc',
 			'errors'     => array(),
 			'meta_query' => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		);
@@ -472,25 +474,23 @@ class WC_Data_Store_WP {
 						'compare' => '<=',
 					);
 			}
-		} else {
-			if ( '...' !== $operator ) {
+		} elseif ( '...' !== $operator ) {
 				$wp_query_args['meta_query'][] = array(
 					'key'     => $key,
 					'value'   => $dates[0]->getTimestamp(),
 					'compare' => $operator,
 				);
-			} else {
-				$wp_query_args['meta_query'][] = array(
-					'key'     => $key,
-					'value'   => $dates[0]->getTimestamp(),
-					'compare' => '>=',
-				);
-				$wp_query_args['meta_query'][] = array(
-					'key'     => $key,
-					'value'   => $dates[1]->getTimestamp(),
-					'compare' => '<=',
-				);
-			}
+		} else {
+			$wp_query_args['meta_query'][] = array(
+				'key'     => $key,
+				'value'   => $dates[0]->getTimestamp(),
+				'compare' => '>=',
+			);
+			$wp_query_args['meta_query'][] = array(
+				'key'     => $key,
+				'value'   => $dates[1]->getTimestamp(),
+				'compare' => '<=',
+			);
 		}
 
 		return $wp_query_args;

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -276,8 +276,6 @@ class WC_Data_Store_WP {
 
 		$skipped_values = array( '', array(), null );
 		$wp_query_args  = array(
-			'orderby'    => 'id',
-			'order'      => 'desc',
 			'errors'     => array(),
 			'meta_query' => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -978,9 +978,18 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		if ( ! isset( $wp_query_args['date_query'] ) ) {
 			$wp_query_args['date_query'] = array();
 		}
+
 		if ( ! isset( $wp_query_args['meta_query'] ) ) {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$wp_query_args['meta_query'] = array();
+		}
+
+		if ( empty( $wp_query_args['orderby'] ) ) {
+			$wp_query_args['orderby'] = 'ID';
+		}
+
+		if ( empty( $wp_query_args['order'] ) ) {
+			$wp_query_args['order'] = 'desc';
 		}
 
 		$date_queries = array(

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1047,6 +1047,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
+		// Handle custom orderby paramers.
+		if ( 'total' === $wp_query_args['orderby'] ) {
+			$wp_query_args['orderby']   = 'meta_value_num';
+			$wp_query_args['meta_key']  = '_order_total'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$wp_query_args['meta_type'] = 'DECIMAL(10,' . wc_get_price_decimals() . ')';
+		}
+
 		if ( ! isset( $query_vars['paginate'] ) || ! $query_vars['paginate'] ) {
 			$wp_query_args['no_found_rows'] = true;
 		}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Orders/CollectionQuery.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Orders/CollectionQuery.php
@@ -137,6 +137,7 @@ class CollectionQuery extends AbstractCollectionQuery {
 					'title',
 					'slug',
 					'modified',
+					'total',
 				),
 				'validate_callback' => 'rest_validate_request_arg',
 			),

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -607,4 +607,66 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			$this->assertCount( $test['expected_count'], $orders, print_r( $test, true ) );
 		}
 	}
+
+	/**
+	 * Test orderby total functionality works as expected for CPT storage.
+	 */
+	public function test_orderby_total() {
+		// Create orders with different totals.
+		$order_totals = array( 100.00, 50.00, 250.50, 75.25, 500.00 );
+		$orders       = array();
+		foreach ( $order_totals as $order_total ) {
+			$order = OrderHelper::create_order();
+			$order->set_total( $order_total );
+			$order->save();
+			$orders[] = $order;
+		}
+
+		// Test ascending order.
+		$orders_asc = wc_get_orders(
+			array(
+				'orderby' => 'total',
+				'order'   => 'asc',
+				'return'  => 'ids',
+			)
+		);
+
+		$this->assertCount( 5, $orders_asc );
+
+		// Verify ascending order by checking totals.
+		$totals_asc = array();
+		foreach ( $orders_asc as $order_id ) {
+			$order        = wc_get_order( $order_id );
+			$totals_asc[] = $order->get_total();
+		}
+
+		$expected_totals_asc = array( 50.00, 75.25, 100.00, 250.50, 500.00 );
+		$this->assertEquals( $expected_totals_asc, $totals_asc, 'Orders should be sorted by total in ascending order' );
+
+		// Test descending order.
+		$orders_desc = wc_get_orders(
+			array(
+				'orderby' => 'total',
+				'order'   => 'desc',
+				'return'  => 'ids',
+			)
+		);
+
+		$this->assertCount( 5, $orders_desc );
+
+		// Verify descending order by checking totals.
+		$totals_desc = array();
+		foreach ( $orders_desc as $order_id ) {
+			$order         = wc_get_order( $order_id );
+			$totals_desc[] = $order->get_total();
+		}
+
+		$expected_totals_desc = array( 500.00, 250.50, 100.00, 75.25, 50.00 );
+		$this->assertEquals( $expected_totals_desc, $totals_desc, 'Orders should be sorted by total in descending order' );
+
+		// Clean up.
+		foreach ( $orders as $order ) {
+			$order->delete( true );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -679,4 +679,66 @@ class OrdersTableQueryTests extends \WC_Unit_Test_Case {
 			$this->assertCount( $test['expected_count'], $orders, print_r( $test, true ) );
 		}
 	}
+
+	/**
+	 * @testDox Orderby total functionality works as expected for HPOS storage.
+	 */
+	public function test_orderby_total() {
+		// Create orders with different totals.
+		$order_totals = array( 100.00, 50.00, 250.50, 75.25, 500.00 );
+		$orders       = array();
+		foreach ( $order_totals as $order_total ) {
+			$order = OrderHelper::create_order();
+			$order->set_total( $order_total );
+			$order->save();
+			$orders[] = $order;
+		}
+
+		// Test ascending order.
+		$orders_asc = wc_get_orders(
+			array(
+				'orderby' => 'total',
+				'order'   => 'asc',
+				'return'  => 'ids',
+			)
+		);
+
+		$this->assertCount( 5, $orders_asc );
+
+		// Verify ascending order by checking totals.
+		$totals_asc = array();
+		foreach ( $orders_asc as $order_id ) {
+			$order        = wc_get_order( $order_id );
+			$totals_asc[] = $order->get_total();
+		}
+
+		$expected_totals_asc = array( 50.00, 75.25, 100.00, 250.50, 500.00 );
+		$this->assertEquals( $expected_totals_asc, $totals_asc, 'Orders should be sorted by total in ascending order' );
+
+		// Test descending order.
+		$orders_desc = wc_get_orders(
+			array(
+				'orderby' => 'total',
+				'order'   => 'desc',
+				'return'  => 'ids',
+			)
+		);
+
+		$this->assertCount( 5, $orders_desc );
+
+		// Verify descending order by checking totals.
+		$totals_desc = array();
+		foreach ( $orders_desc as $order_id ) {
+			$order         = wc_get_order( $order_id );
+			$totals_desc[] = $order->get_total();
+		}
+
+		$expected_totals_desc = array( 500.00, 250.50, 100.00, 75.25, 50.00 );
+		$this->assertEquals( $expected_totals_desc, $totals_desc, 'Orders should be sorted by total in descending order' );
+
+		// Clean up.
+		foreach ( $orders as $order ) {
+			$order->delete( true );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the CPT and HPOS datastore to allow sorting by total. Added this as a supported param on rest api v4.

### How to test the changes in this Pull Request:

1. Install the beta testing plugin to enable REST API v4
2. Request GET `/wp-json/wc/v4/orders?orderby=total&order=desc&_fields=total,id`. You must be authenticated.
3. Check totals are in descending order.
4. Request GET `/wp-json/wc/v4/orders?orderby=total&order=asc&_fields=total,id`. You must be authenticated.
5. Check totals are in ascending order.
6. Go to WC > Settings > Advanced > Features. Switch to HPOS (or CPT if you're already using HPOS) and retest the above. 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
