### PR TITLE
Correctly empty address fields if an address provider sends them back empty.

### DIFF
--- a/plugins/woocommerce/changelog/fix-address-autocomplete-shortcode
+++ b/plugins/woocommerce/changelog/fix-address-autocomplete-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure address fields without valid values from provider 'select' are emptied on shortcode checkout.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -752,7 +752,7 @@ if (
 							addressData.address_2
 						);
 					} else {
-						// Clear address_2 if not provided in address data
+						// Clear address_2 if not provided in address data.
 						const addr2El = addressInputs[ type ][ 'address_2' ];
 						if ( addr2El && addr2El.value ) {
 							setFieldValue( addr2El, '' );
@@ -763,18 +763,36 @@ if (
 							addressInputs[ type ][ 'city' ],
 							addressData.city
 						);
+					} else {
+						// Clear city if not provided in address data.
+						const cityEl = addressInputs[ type ][ 'city' ];
+						if ( cityEl && cityEl.value ) {
+							setFieldValue( cityEl, '' );
+						}
 					}
 					if ( addressData.postcode ) {
 						setFieldValue(
 							addressInputs[ type ][ 'postcode' ],
 							addressData.postcode
 						);
+					} else {
+						// Clear postcode if not provided in address data.
+						const postcodeEl = addressInputs[ type ][ 'postcode' ];
+						if ( postcodeEl && postcodeEl.value ) {
+							setFieldValue( postcodeEl, '' );
+						}
 					}
 					if ( addressData.state ) {
 						setFieldValue(
 							addressInputs[ type ][ 'state' ],
 							addressData.state
 						);
+					} else {
+						// Clear state if not provided in address data.
+						const stateEl = addressInputs[ type ][ 'state' ];
+						if ( stateEl && stateEl.value ) {
+							setFieldValue( stateEl, '' );
+						}
 					}
 				}, 50 );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When selecting an address using an address provider, if the object contains an empty value for an address field, or does not contain the address field, the value should be unset.

For example, if an old address had a state, but a new address does not, state should be deleted to avoid stale data remaining in the form.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install [mock-address-provider.zip](https://github.com/user-attachments/files/22363292/mock-address-provider.zip) and go to WC -> Settings -> General, check `Enable predictive address search`.
2. In the mock-address-provider.php file, modify one of the addresses so a value returned is empty, e.g. 
```php
		'01971ca5-35d2-7514-adaf-e3bd0086bea9' => array(
			'address_1' => '1 Hacker Way',
			'city'      => 'Menlo Park',
			'postcode'  => '94025',
			'state'     => '', // <--- now this is empty
			'country'   => 'US',
		),
```
4. Go to shortcode checkout and fill the state field manually, then use the address 1 field to search for a suggestion.
5. Select this address and ensure state field is cleared correctly.
6. Choose another address with a valid state and ensure it's filled correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
