### PR TITLE
Add to Cart + Options grouped products e2e test: wait for API call to finish before reloading the page

### DIFF
--- a/plugins/woocommerce/changelog/fix-59725-wait-for-response
+++ b/plugins/woocommerce/changelog/fix-59725-wait-for-response
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add to Cart + Options grouped products e2e test: wait for API call to finish before reloading the page
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -361,6 +361,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await addToCartButton.click();
 
+			// Wait for the add to cart request to complete before proceeding.
+			// This prevents a race condition where the subsequent page.reload()
+			// could execute before the product is fully added to the cart.
+			const addToCartRequest = page.waitForResponse(
+				'**/wc/store/v1/batch**'
+			);
+
 			await expect(
 				page.getByRole( 'button', {
 					name: 'Added to cart',
@@ -369,6 +376,8 @@ test.describe( 'Add to Cart + Options Block', () => {
 			).toBeVisible();
 
 			await expect( page.getByLabel( '3 items in cart' ) ).toBeVisible();
+
+			await addToCartRequest;
 		} );
 
 		await test.step( 'if one product succeeds and another fails, optimistic updates are applied and an error is displayed', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59725.

After https://github.com/woocommerce/woocommerce/pull/60992, the '_allows adding grouped products to cart_' test started to be flaky again. I suspect the issue was that we were reloading the page before the products were actually added to cart, making the test not to behave properly. This PR should fix this by waiting for the `/wc/store/v1/batch` response.

### How to test the changes in this Pull Request:

1. Make sure all e2e tests keep passing.