### PR TITLE
[Rest API v4] Allow orders to be filtered by fulfilment status

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-836-orders-list-filter-by-fulfilment-status
+++ b/plugins/woocommerce/changelog/wooprd-836-orders-list-filter-by-fulfilment-status
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fulfilment status filtering. This feature is behind a flag.
+
+

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -276,8 +276,6 @@ class WC_Data_Store_WP {
 
 		$skipped_values = array( '', array(), null );
 		$wp_query_args  = array(
-			'orderby'    => 'id',
-			'order'      => 'desc',
 			'errors'     => array(),
 			'meta_query' => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -276,6 +276,8 @@ class WC_Data_Store_WP {
 
 		$skipped_values = array( '', array(), null );
 		$wp_query_args  = array(
+			'orderby'    => 'id',
+			'order'      => 'desc',
 			'errors'     => array(),
 			'meta_query' => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1059,7 +1059,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		// Handle fulfillment status filtering.
 		if ( ! empty( $query_vars['fulfillment_status'] ) ) {
-			$wp_query_args['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $query_vars['fulfillment_status'] );
+			$meta_query = FulfillmentUtils::get_order_fulfillment_status_meta_query( $query_vars['fulfillment_status'] );
+			if ( ! empty( $meta_query ) ) {
+				$wp_query_args['meta_query'][] = $meta_query;
+			}
 		}
 
 		// Handle custom orderby paramers.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -1054,6 +1055,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			if ( $total_query ) {
 				$wp_query_args['meta_query'][] = $total_query;
 			}
+		}
+
+		// Handle fulfillment status filtering.
+		if ( ! empty( $query_vars['fulfillment_status'] ) ) {
+			$wp_query_args['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $query_vars['fulfillment_status'] );
 		}
 
 		// Handle custom orderby paramers.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -19,6 +19,7 @@ use Exception;
 use WC_Abstract_Order;
 use WC_Data;
 use WC_Order;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -3092,6 +3093,11 @@ FROM $order_meta_table
 					'compare' => 'NOT EXISTS',
 				);
 			}
+		}
+
+		// Handle fulfillment status filtering.
+		if ( ! empty( $query_vars['fulfillment_status'] ) ) {
+			$query_vars['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $query_vars['fulfillment_status'] );
 		}
 
 		try {

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -136,7 +136,7 @@ class FulfillmentsRenderer {
 	 * @param WC_Order $order The order object.
 	 */
 	private function render_order_fulfillment_status_column_row_data( WC_Order $order ) {
-		$order_fulfillment_status = $order->meta_exists( '_fulfillment_status' ) ? $order->get_meta( '_fulfillment_status', true ) : 'no_fulfillments';
+		$order_fulfillment_status = FulfillmentUtils::get_order_fulfillment_status( $order );
 
 		echo "<div class='fulfillment-status-wrapper'>";
 		$this->render_order_fulfillment_status_badge( $order, $order_fulfillment_status );
@@ -473,22 +473,7 @@ class FulfillmentsRenderer {
 				if ( ! isset( $args['meta_query'] ) ) {
 					$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				}
-				if ( 'no_fulfillments' === $fulfillment_status ) {
-					// If the status is 'no_fulfillments', we need to check for orders that have no fulfillments.
-					$args['meta_query'][] = array(
-						'relation' => 'OR',
-						array(
-							'key'     => '_fulfillment_status',
-							'compare' => 'NOT EXISTS',
-						),
-					);
-				} else {
-					$args['meta_query'][] = array(
-						'key'     => '_fulfillment_status',
-						'value'   => $fulfillment_status,
-						'compare' => '=',
-					);
-				}
+				$args['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $fulfillment_status );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -470,10 +470,13 @@ class FulfillmentsRenderer {
 
 			// Ensure the fulfillment status is one of the allowed values.
 			if ( FulfillmentUtils::is_valid_order_fulfillment_status( $fulfillment_status ) ) {
-				if ( ! isset( $args['meta_query'] ) ) {
-					$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				$meta_query = FulfillmentUtils::get_order_fulfillment_status_meta_query( $fulfillment_status );
+				if ( ! empty( $meta_query ) ) {
+					if ( ! isset( $args['meta_query'] ) ) {
+						$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					}
+					$args['meta_query'][] = $meta_query;
 				}
-				$args['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $fulfillment_status );
 			}
 		}
 

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 use WP_REST_Request;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 
 /**
  * OrderSchema class.
@@ -516,6 +517,12 @@ class OrderSchema extends AbstractSchema {
 				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
+			'fulfillment_status'   => array(
+				'description' => __( 'The fulfillment status of the order.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
 		);
 
 		if ( $this->cogs_is_enabled() ) {
@@ -621,6 +628,7 @@ class OrderSchema extends AbstractSchema {
 			'is_editable'          => $order->is_editable(),
 			'needs_payment'        => $order->needs_payment(),
 			'needs_processing'     => $order->needs_processing(),
+			'fulfillment_status'   => FulfillmentUtils::get_order_fulfillment_status( $order ),
 		);
 
 		if ( in_array( 'line_items', $include_fields, true ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the HPOS and CPT data stores to allow orders to be filtered by fulfilment status. This is also added to REST API v4, as well as a `fulfilment_status` schema which returns the status string for easier lookup.

### How to test the changes in this Pull Request:

1. Enable REST API v4 via beta testing plugin.
2. GET `/wp-json/wc/v4/orders` and confirm `fulfilment_status` appears in the response.
3. GET `/wp-json/wc/v4/orders?fulfillment_status=no_fulfilments`  filters returned results. You can use `/wp-json/wc/v4/orders?fulfillment_status=no_fulfilments&_fields=id,fulfillment_status` to make this clearer.
4. Test some other statuses. 

<!-- End testing instructions -->

### Testing that has already taken place:

Unit tests for the filter, and manual testing via client that consumes REST API v4.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
