### PR TITLE
Don't load block templates with the woocommerce slug if the queried template was customized by the user

### DIFF
--- a/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
+++ b/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Don't load templates with the woocommerce slug if it the queried template was customized by the user
+Don't load templates with the woocommerce slug if the queried template was customized by the user

--- a/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
+++ b/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Skip loading non-WooCommerce templates when adding backwards compatibility for templates saved with the woocommerce slug
+Don't load templates with the woocommerce slug if it the queried template was customized by the user

--- a/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
+++ b/plugins/woocommerce/changelog/fix-61068-dont-load-non-wc-templates-from-db
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip loading non-WooCommerce templates when adding backwards compatibility for templates saved with the woocommerce slug

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -257,14 +257,13 @@ class BlockTemplatesController {
 		foreach ( $template_files as $template_file ) {
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
-			if (
-				'custom' === $template_file->source &&
-				(
+			if ( 'custom' === $template_file->source ) {
+				if (
 					BlockTemplateUtils::PLUGIN_SLUG === $template_file->theme ||
 					BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === $template_file->theme
-				)
-			) {
-				array_unshift( $new_templates, $template_file );
+				) {
+					array_unshift( $new_templates, $template_file );
+				}
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -722,7 +722,7 @@ class BlockTemplateUtils {
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'name',
-					'terms'    => array( self::DEPRECATED_PLUGIN_SLUG, self::PLUGIN_SLUG, get_stylesheet() ),
+					'terms'    => array( self::DEPRECATED_PLUGIN_SLUG, self::PLUGIN_SLUG ),
 				),
 			),
 		);

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -722,7 +722,7 @@ class BlockTemplateUtils {
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'name',
-					'terms'    => array( self::DEPRECATED_PLUGIN_SLUG, self::PLUGIN_SLUG ),
+					'terms'    => array( self::DEPRECATED_PLUGIN_SLUG, self::PLUGIN_SLUG, get_stylesheet() ),
 				),
 			),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #61068.

This is an alternative fix to #61068, even though it can live in parallel to #61078.

I'm still not 100% sure to understand what Polylang is doing that causes our logic to fail, but what I found out:

* For some reason, with Polylang installed, the query when fetching the `header` template part is modified, so [our check for `$is_custom` fails](https://github.com/woocommerce/woocommerce/blob/5484f94c29a0001162c8c4aa6b693dbbadb586d2/plugins/woocommerce/src/Blocks/BlockTemplatesController.php#L284-L289). In other words, our logic tries to add a template part that doesn't exist.
* I suspect the issue was introduced with [this change](https://github.com/woocommerce/woocommerce/pull/60191/files?w=1#diff-87fb992bfbbbab2fc1ab811e2c3d55c348b6ca69a7c07d3361cd055abc5bc572L344-L349). Until now, we were skipping the `foreach` logic for all custom templates. After that PR, we were only skipping it if the template was custom _and_ it belonged to the WooCommerce theme.

This PR updates that logic to return early in that foreach for all custom templates, independently of their theme. I tested with an older version of WooCommerce and it fixes the issue. With #61078, it doesn't make any difference, but I believe it's still a good idea to return as early as possible in the foreach when we know the template is not one we want to override. This also makes the logic more similar to how it was before #60191.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/60191/.

### How to test the changes in this Pull Request:

This PR doesn't include any visible changes to users, so testing is making sure there are no regressions:

1. Go to Appearance > Editor and smoke test the Site Editor.
2. Install Polylang Pro and Polylang for WooCommerce.
3. Repeat step 1.