### PR TITLE
Fix address autocomplete token fetch logic

### DIFF
--- a/plugins/woocommerce/changelog/61140-fix-address-autocomplete-fetch
+++ b/plugins/woocommerce/changelog/61140-fix-address-autocomplete-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix address autocomplete token fetch logic

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -55,6 +55,8 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	 * Loads up a JWT from cache or from the implementor side.
 	 *
 	 * @return void
+	 *
+	 * @throws \Exception
 	 */
 	public function load_jwt() {
 

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -83,6 +83,8 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 				// Clear retry data on success.
 				$this->delete_cached_option( 'jwt_retry_data' );
 				return;
+			} else {
+				throw new \Exception( 'Invalid JWT received from address service.' );
 			}
 		} catch ( \Exception $e ) {
 			$retry_data['attempts'] = isset( $retry_data['attempts'] ) ? $retry_data['attempts'] + 1 : 1;
@@ -261,6 +263,10 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	 * Enqueues the checkout script, checks if it's already registered or not so we don't duplicate, and prints out the JWT to the page to be consumed.
 	 */
 	public function load_scripts() {
+		if ( ! is_checkout() ) {
+			return;
+		}
+
 		if ( ! $this->get_jwt() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -56,7 +56,7 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	 *
 	 * @return void
 	 *
-	 * @throws \Exception
+	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing -- As we wrap the throw in a try/catch.
 	 */
 	public function load_jwt() {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPMNT-5349

Also see https://github.com/Automattic/woocommerce-payments/pull/11062

- Fixes handling of non-string values returned by the token providers, so the retries get logged and the site backs off incrementally in such scenarios
- Added a check for `is_checkout` before loading the script and fetching the token

### How to test the changes in this Pull Request:

1. Ensure WooPayments is installed and active (no need to connect an account, see below)
2. Add a debug breakpoint at the beginning of the `load_jwt` method
3. Load any non-checkout page - the breakpoint should NOT be hit 
5. Load the checkout page - the breakpoint should be hit. Step through the code.
6. If WooPayments was connected, the token should be stored successfully
7. If WooPayments was not connected, the error handling logic should be triggered

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Fix address autocomplete token fetch logic</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix address autocomplete token fetch logic

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
