### PR TITLE
Bump email editor PHP package version to 1.7.0

### DIFF
--- a/plugins/woocommerce/changelog/bump-email-editor-package-version
+++ b/plugins/woocommerce/changelog/bump-email-editor-package-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update email editor PHP package to 1.7.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -48,7 +48,7 @@
 		"pelago/emogrifier": "7.3.0",
 		"woocommerce/action-scheduler": "3.9.3",
 		"woocommerce/blueprint": "*",
-		"woocommerce/email-editor": "1.6.0",
+		"woocommerce/email-editor": "1.7.0",
 		"wordpress/abilities-api": "^0.1.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5c9996d3691446bdb66794fbca5e41f",
+    "content-hash": "dae4ea222d0291f7faa99d0d3db26ac9",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1476,11 +1476,11 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/php/email-editor",
-                "reference": "768c0e47e36f6f02ea59acdbc409a5ccd43d55d5"
+                "reference": "32123859f15220b36ca930de85f3f3d242e7417d"
             },
             "require": {
                 "pelago/emogrifier": "7.3.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR updates the email editor package in the WooCommerce plugin. Note: We include the latest code anyway, but we need to do the update for Jetpack autoloader to know the correct version.

### How to test the changes in this Pull Request:
There is no change in the code so seeing automated tests passing should be enough to verify the change didn't break build.