### PR TITLE
Cache approved download URLs valid status to prevent duplicate queries

### DIFF
--- a/plugins/woocommerce/changelog/fix-56609
+++ b/plugins/woocommerce/changelog/fix-56609
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Implement approved download dirs cache to prevent duplicate queries.

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -32,6 +32,13 @@ class Register {
 	private $mode_option = 'wc_downloads_approved_directories_mode';
 
 	/**
+	 * Internal cache for memoization of valid URLs and parent directories.
+	 *
+	 * @var array
+	 */
+	private $cache = array();
+
+	/**
 	 * Sets up the approved directories sub-system.
 	 *
 	 * @internal
@@ -240,34 +247,39 @@ class Register {
 	public function is_valid_path( string $download_url ): bool {
 		global $wpdb;
 
-		$parent_directories = array();
-
-		foreach ( ( new URL( $this->normalize_url( $download_url ) ) )->get_all_parent_urls() as $parent ) {
-			$parent_directories[] = "'" . esc_sql( $parent ) . "'";
+		$url_cache_key = 'url:' . $download_url;
+		if ( isset( $this->cache[ $url_cache_key ] ) ) {
+			return $this->cache[ $url_cache_key ];
 		}
 
-		if ( empty( $parent_directories ) ) {
-			return false;
+		$url     = new URL( $this->normalize_url( $download_url ) );
+		$parents = $url->get_all_parent_urls();
+
+		if ( ! empty( $parents ) ) {
+			sort( $parents );
+
+			$parents_sql       = "'" . implode( "','", array_map( 'esc_sql', $parents ) ) . "'";
+			$parents_cache_key = 'parents:' . md5( $parents_sql );
+
+			if ( ! isset( $this->cache[ $parents_cache_key ] ) ) {
+				// Look for a rule that matches the start of the download URL being tested. Since rules describe parent
+				// directories, we also ensure it ends with a trailing slash.
+				//
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $parents_sql is already escaped.
+				$this->cache[ $parents_cache_key ] = (bool) $wpdb->get_var(
+					"SELECT 1
+					 FROM `{$this->get_table()}`
+					 WHERE enabled = 1 AND url IN ({$parents_sql})"
+				);
+				// phpcs:enable
+			}
+
+			$this->cache[ $url_cache_key ] = $this->cache[ $parents_cache_key ];
+		} else {
+			$this->cache[ $url_cache_key ] = false;
 		}
 
-		$parent_directories = join( ',', $parent_directories );
-		$table              = $this->get_table();
-
-		// Look for a rule that matches the start of the download URL being tested. Since rules describe parent
-		// directories, we also ensure it ends with a trailing slash.
-		//
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$matches = (int) $wpdb->get_var(
-			"
-				SELECT COUNT(*)
-				FROM   {$table}
-				WHERE  enabled = 1
-				       AND url IN ( {$parent_directories} )
-			"
-		);
-		// phpcs:enable
-
-		return $matches > 0;
+		return $this->cache[ $url_cache_key ];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -131,6 +131,7 @@ class Register {
 		);
 
 		if ( false !== $wpdb->insert( $this->get_table(), $insert_fields ) ) {
+			unset( $this->cache );
 			return $wpdb->insert_id;
 		}
 
@@ -427,9 +428,13 @@ class Register {
 	 */
 	public function delete_by_id( int $id ): bool {
 		global $wpdb;
-		$table = $this->get_table();
 
-		return (bool) $wpdb->delete( $table, array( 'url_id' => $id ) );
+		if ( ! $wpdb->delete( $this->get_table(), array( 'url_id' => $id ) ) ) {
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**
@@ -439,9 +444,13 @@ class Register {
 	 */
 	public function delete_all(): bool {
 		global $wpdb;
-		$table = $this->get_table();
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (bool) $wpdb->query( "DELETE FROM $table" );
+
+		if ( ! $wpdb->query( "DELETE FROM {$this->get_table()}" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**
@@ -454,7 +463,13 @@ class Register {
 	public function enable_by_id( int $id ): bool {
 		global $wpdb;
 		$table = $this->get_table();
-		return (bool) $wpdb->update( $table, array( 'enabled' => 1 ), array( 'url_id' => $id ) );
+
+		if ( ! $wpdb->update( $table, array( 'enabled' => 1 ), array( 'url_id' => $id ) ) ) {
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**
@@ -466,8 +481,13 @@ class Register {
 	 */
 	public function disable_by_id( int $id ): bool {
 		global $wpdb;
-		$table = $this->get_table();
-		return (bool) $wpdb->update( $table, array( 'enabled' => 0 ), array( 'url_id' => $id ) );
+
+		if ( ! $wpdb->update( $this->get_table(), array( 'enabled' => 0 ), array( 'url_id' => $id ) ) ) {
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**
@@ -477,9 +497,13 @@ class Register {
 	 */
 	public function enable_all(): bool {
 		global $wpdb;
-		$table = $this->get_table();
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (bool) $wpdb->query( "UPDATE {$table} SET enabled = 1" );
+
+		if ( ! $wpdb->query( "UPDATE {$this->get_table()} SET enabled = 1" ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**
@@ -489,9 +513,14 @@ class Register {
 	 */
 	public function disable_all(): bool {
 		global $wpdb;
-		$table = $this->get_table();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (bool) $wpdb->query( "UPDATE {$table} SET enabled = 0" );
+		if ( ! $wpdb->query( "UPDATE {$this->get_table()} SET enabled = 0" ) ) {
+			return false;
+		}
+
+		unset( $this->cache );
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -49,6 +49,9 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 				'prevent_timeouts' => false,
 			)
 		);
+
+		// Clear list of approved download directories before running tests.
+		wc_get_container()->get( \Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register::class )->delete_all();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/RegisterTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/RegisterTest.php
@@ -31,6 +31,14 @@ class RegisterTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Clean up after all tests have run.
+	 */
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		static::$sut->delete_all();
+	}
+
+	/**
 	 * @testdox Test a range of filepaths and URLs that we expect to be seen as valid.
 	 */
 	public function test_valid_paths() {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -26,6 +26,14 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Clean up after all tests have run.
+	 */
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		wc_get_container()->get( \Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register::class )->delete_all();
+	}
+
+	/**
 	 * @testdox Ensure basic controls to start and stop synchronization behave as expected.
 	 */
 	public function test_basic_synchronization_controls() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR implements an in-memory cache for approved download directories checks to eliminate redundant database queries when browsing products or orders with downloadable files.

The cache is based on both download URL and parent directories, which helps when multiple files have the same set of parent directories (a common scenario).

Closes #56609.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Setup
As admin:

1. Make sure the **Query Monitor** plugin is installed and active.
1. Go to **WC > Settings > Products > Approved download directories** and make sure rules are being enforced. If you see a "Start Enforcing Rules" button, click it. Otherwise, you're good.
1. Go to **WC > Products** and create a new downloadable product, with at least a couple of files. You can use `https://wapu.us/wp-content/uploads/2021/04/wapuurepa-540x595.png` as URL for both files (or any valid URL(s)).
   I suggest leaving download limit and expiration blank for easier testing.
1. Click **View Product** at the top to go to the shop page for this new product.

#### Testing

1. On `trunk`, you should see that a few duplicate queries are reported, related to approved download dirs (at least 2-3 per downloadable file, and more if other downloadable products appear on screen):
   <img width="1487" height="120" alt="Screenshot 2025-09-29 at 11 07 45" src="https://github.com/user-attachments/assets/85f87788-1c16-497a-b8d3-812af279fa61" />
   <img width="1487" height="128" alt="Screenshot 2025-09-29 at 11 12 41" src="https://github.com/user-attachments/assets/8fcb9b3d-23f8-4f2b-9d0d-cd44c7242156" />

   Duplicate queries also appear on other screens such as **My Account > Downloads**, but the above should be enough to replicate.
1. Switch to this branch (`fix/56609`), no duplicate query should appear.
1. Go through the purchase process for this product, and confirm that you can effectively download the files, from either **My Account > Orders** or **My Account > Downloads**.
1. As admin, go to **WC > Settings > Products > Approved download directories** and find the rule for the URL you used for the downloadable product and disable it.
1. Go back to **My Account > Downloads**. The downloadable file should no longer appear.
1. Switch the rule back on, and confirm that the downloadable file appears again.

### Performance Metrics

While the queries involved are not particularly heavy (and rely on existing indexes), duplication can be problematic on sites with mostly downloadable products. Performance gains will also be higher for sites where the downloads are stored in the same parent directories.

Shop page with 10 downloadable products (each with just 2 downloadable files stored in the same directory):

**Previous:** 20 duplicate queries, totaling **0.0057s**.
**After:** 2 queries, totaling **0.0004**.
**Delta:** 92% decrease.

<!-- End testing instructions -->