### PR TITLE
Performance: Add composite index on wp_comments to optimize admin comments query

### DIFF
--- a/plugins/woocommerce/changelog/add_woo_idx_comment_date_type
+++ b/plugins/woocommerce/changelog/add_woo_idx_comment_date_type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Add composite index on wp_comments to optimize admin comments query

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -303,6 +303,9 @@ class WC_Install {
 		'10.2.0' => array(
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
+		'10.3.0' => array(
+			'wc_update_1030_add_comments_date_type_index',
+		),
 	);
 
 	/**
@@ -1644,12 +1647,19 @@ class WC_Install {
 
 		$db_delta_result = dbDelta( self::get_schema() );
 
-		$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE column_name = 'comment_type' and key_name = 'woo_idx_comment_type'" );
+		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE column_name = 'comment_type' and key_name = 'woo_idx_comment_type'" );
 
-		if ( is_null( $index_exists ) ) {
+		if ( is_null( $comment_type_index_exists ) ) {
 			// Add an index to the field comment_type to improve the response time of the query
 			// used by WC_Comments::wp_count_comments() to get the number of comments by type.
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
+		}
+
+		$date_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_date_type'" );
+
+		if ( is_null( $date_type_index_exists ) ) {
+			// Improve performance of the admin comments query when fetching the latest 25 comments while excluding reviews and internal notes.
+			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_date_type (comment_date_gmt, comment_type, comment_approved, comment_post_ID)" );
 		}
 
 		// Clear table caches.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -305,7 +305,7 @@ class WC_Install {
 		),
 		'10.3.0' => array(
 			'wc_update_1030_add_comments_date_type_index',
-    ),
+		),
 		'10.4.0' => array(
 			'wc_update_1040_add_idx_date_paid_status_parent',
 		),

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -303,10 +303,8 @@ class WC_Install {
 		'10.2.0' => array(
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
-		'10.3.0' => array(
-			'wc_update_1030_add_comments_date_type_index',
-		),
 		'10.4.0' => array(
+			'wc_update_1030_add_comments_date_type_index',
 			'wc_update_1040_add_idx_date_paid_status_parent',
 		),
 	);

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -303,8 +303,10 @@ class WC_Install {
 		'10.2.0' => array(
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
-		'10.4.0' => array(
+		'10.3.0' => array(
 			'wc_update_1030_add_comments_date_type_index',
+		),
+		'10.4.0' => array(
 			'wc_update_1040_add_idx_date_paid_status_parent',
 		),
 	);

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3108,3 +3108,20 @@ function wc_update_990_remove_email_notes() {
 function wc_update_1000_remove_patterns_toolkit_transient() {
 	delete_transient( 'ptk_patterns' );
 }
+
+/**
+ * Add an index to (comment_date_gmt, comment_type, comment_approved, comment_post_ID)
+ * on the comments table to improve the admin query that gets the latest 25 comments
+ * while excluding reviews and internal notes.
+ *
+ * @return void
+ */
+function wc_update_1030_add_comments_date_type_index() {
+	global $wpdb;
+	$date_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_date_type'" );
+
+	if ( is_null( $date_type_index_exists ) ) {
+		// Improve performance of the admin comments query when fetching the latest 25 comments while excluding reviews and internal notes.
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_date_type (comment_date_gmt, comment_type, comment_approved, comment_post_ID)" );
+	}
+}

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -55,6 +55,10 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	if ( null !== $index_exists ) {
 		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type;" );
 	}
+	$date_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_date_type';" );
+	if ( null !== $date_type_index_exists ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_date_type;" );
+	}
 
 	// Roles + caps.
 	WC_Install::remove_roles();


### PR DESCRIPTION
### The Problem

The admin "recent comments" query, as modified by WooCommerce, is hitting performance issues when fetching the latest 25 comments. The query needs to exclude product reviews (by checking `post_type <> 'product'`) and skip internal comment types (`order_note`, `webhook_delivery`, `action_log`).

This is in `wp_dashboard_recent_comments()`.

<img width="881" height="188" alt="Screenshot 2025-09-30 at 4 38 14 PM" src="https://github.com/user-attachments/assets/ade07f21-24db-4e95-acd9-b9026b4b1e91" />


Currently, MySQL and MariaDB tend to use the `comment_date_gmt` index to scan comments from newest to oldest. This works well when there are plenty of eligible comments near the top. But when recent comments are mostly product reviews or internal types, or there are no regular WordPress comments, the query has to scan through hundreds or thousands of rows, performing expensive joins for each one, just to find 25 valid results (or even 0 in some cases).

### Real World Example

A specific client site is experiencing 1-3 second query times just to discover there are zero regular WordPress comments to display. Their comments table contains 514k rows:

- ~99% are order notes (internal)
- ~1% are product reviews
- 0 regular WordPress comments

The optimizer incorrectly estimates it will only need to scan ~1,100 rows to find 25 matches, so it chooses the `comment_date_gmt` index to avoid a sort operation. In reality, it ends up scanning all 514,000 rows with expensive join operations.

We tried optimizer hints and query tweaks, but these fix performance for some data patterns while making others worse.

### The Solution

Add a composite index that lets MySQL handle both cases: (Lots of regular comments and hardly any):

```sql
CREATE INDEX woo_idx_comment_date_type
  ON wp_comments (comment_date_gmt, comment_type, comment_approved, comment_post_ID);
```

The date first ordering allows the DB to scan rows newest to oldest without sorting, and to stop as soon as it finds 25 matches. The middle columns (`comment_type`, `comment_approved`) allow for [Index Condition Pushdown](https://dev.mysql.com/doc/refman/8.4/en/index-condition-pushdown-optimization.html). Basically, it can filter out the rows belonging to unwanted comment types without having to read the entire row. And lastly, the `comment_post_ID` lets it join to `wp_posts` while only using index data.

### Limited Scope

This index only improves times on comments queries sorting by date with a limit, when the optimizer picks the "wrong" strategy (to use `comment_date_gmt` to skip later sorting). Browsing around Admin, I've only seen this in the "recent comments" query.

However, on large scale stores, the impact is pretty bad - the 1-3 seconds just to not find any recent comments. It's also on very visible page - /wp-admin/.

There are other comments queries that are suffering issues that probably also need indexes - not starting with `comment_date_gmt`. It'd be nice to solve both problems with one index, but I haven't been able to solve this particular problem with an index that doesn't begin in `comment_date_gmt`.

### Potential Overlap

Core does provide an index on `(comment_date_gmt)` only. By adding an index on `(comment_date_gmt, comment_type, comment_approved, comment_post_ID)`, the core one is made redundant. The proposed solution is done to keep Woo and Core indexes completely separate and not interfering with each other.

### Size Impact

I tested by adding the index on two datasets and checking with these queries:

```sql
SELECT
  t.table_schema,
  t.table_name,
  ROUND(t.data_length/1024/1024, 2)  AS data_mb,
  ROUND(t.index_length/1024/1024, 2) AS indexes_mb,
  ROUND((t.data_length + t.index_length)/1024/1024, 2) AS total_mb
FROM information_schema.tables AS t
WHERE t.table_schema = DATABASE()
  AND t.table_name   = 'wp_comments';

SELECT
  s.index_name,
  ROUND(SUM(s.stat_value) * @@innodb_page_size / 1024 / 1024, 2) AS index_mb
FROM mysql.innodb_index_stats AS s
WHERE s.database_name = DATABASE()
  AND s.table_name    = 'wp_comments'
  AND s.stat_name     = 'size'
GROUP BY s.index_name
ORDER BY index_mb DESC;
```

It looks like it adds about 47 bytes per row. So 100k rows is +~4.5MB, 1M rows is +~45MB, and 10M rows would be +~450MB.

| Sample (row count) | Data MB | Indexes MB (before -> after) | Δ Index MB | Index growth | Total MB (before -> after) | Δ Total MB |
|---|---:|---:|---:|---:|---:|---:|
| ~78k rows | 12.52 | 18.09 -> 21.61 | **+3.52** | **+19.5%** | 30.61 -> 34.13 | **+3.52** |
| ~388k rows | 60.59 | 59.19 -> 76.75 | **+17.56** | **+29.7%** | 119.78 -> 137.34 | **+17.56** |


### Try It Out

The query is:
```sql
SELECT wp_comments.comment_ID 
FROM wp_comments 
LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews 
ON comment_post_ID = wp_posts_to_exclude_reviews.ID 
WHERE ( ( comment_approved = '0' OR comment_approved = '1' ) ) 
AND comment_type != 'order_note' 
AND comment_type != 'webhook_delivery' 
AND comment_type != 'action_log' 
AND wp_posts_to_exclude_reviews.post_type NOT IN ('product') 
ORDER BY wp_comments.comment_date_gmt DESC LIMIT 0,25;
```

It's created by a WooCommerce filter altering the query made by the wp-admin dashboard activity widget. ([Hook addition](https://github.com/woocommerce/woocommerce/blob/eeec4049b5d6bacad3b4692c1d74270a5d8d1de3/plugins/woocommerce/includes/class-wc-comments.php#L60), [hooked function](https://github.com/woocommerce/woocommerce/blob/eeec4049b5d6bacad3b4692c1d74270a5d8d1de3/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php#L46)).

We've found that the query's performance is extremely data dependent. So I've made a repository using docker that recreates the problem data distribution, takes a timing of the query, then adds an index, and times the query again. It also does a second pass with a different data distribution, containing lots of regular comments, in order to guarantee that it isn't making it worse.

The repo is here: https://github.com/mreishus/woo-comments-query-repro

### Alternatives

* Adding `/*+ NO_ORDER_INDEX(wp_comments comment_date_gmt) */` in the SELECT part of the query filter
  * This tells MySQL and MariaDB(12+) to not use the  `comment_date_gmt` index to skip sorting, because it won't be a win.
  * For this particular client, it forces the optimizer to make the "right" choice.
  * For clients with a large amount of WordPress comments, it might make the query slower.
  * While all recent MySQLs support this, only MariaDB 12+ supports this, so support is limited.
* Change the order by clause to `ORDER BY comment_date_gmt + INTERVAL 0 SECOND`
  * This has the same effect as the  `NO_ORDER_INDEX()`.  Because the ORDER BY is now an expression, the optimizer rules out using the comment_date_gmt index to skip sorting.
  * For this particular client, it forces the optimizer to make the "right" choice.
  * For clients with a large amount of WordPress comments, it might make the query slower.

### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
|        |       |



### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.


### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>
