### PR TITLE
Remove `editMode` from Featured Item blocks attributes

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/block-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/block-controls.tsx
@@ -27,6 +27,7 @@ interface WithBlockControlsRequiredProps< T > {
 		EditorBlock< T >[ 'attributes' ];
 	setAttributes: ( attrs: Partial< BlockControlRequiredAttributes > ) => void;
 	useEditingImage: [ boolean, Dispatch< SetStateAction< boolean > > ];
+	useEditMode: [ boolean, Dispatch< SetStateAction< boolean > > ];
 }
 
 interface WithBlockControlsCategoryProps< T >
@@ -47,7 +48,6 @@ type WithBlockControlsProps< T extends EditorBlock< T > > =
 
 type BlockControlRequiredAttributes = {
 	contentAlign: BlockAlignment;
-	editMode: boolean;
 	mediaId: number;
 	mediaSrc: string;
 };
@@ -63,6 +63,7 @@ interface BlockControlsProps {
 	mediaSrc: string;
 	setAttributes: ( attrs: Partial< BlockControlRequiredAttributes > ) => void;
 	setIsEditingImage: ( value: boolean ) => void;
+	setEditMode: ( editMode: boolean ) => void;
 }
 
 interface BlockControlsConfiguration extends GenericBlockUIConfig {
@@ -81,6 +82,7 @@ export const BlockControls = ( {
 	mediaSrc,
 	setAttributes,
 	setIsEditingImage,
+	setEditMode,
 }: BlockControlsProps ) => {
 	return (
 		<BlockControlsWrapper>
@@ -125,8 +127,7 @@ export const BlockControls = ( {
 					{
 						icon: 'edit',
 						title: editLabel,
-						onClick: () =>
-							setAttributes( { editMode: ! editMode } ),
+						onClick: () => setEditMode( ! editMode ),
 						isActive: editMode,
 					},
 				] }
@@ -140,8 +141,9 @@ export const withBlockControls =
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: WithBlockControlsProps< T > ) => {
 		const [ isEditingImage, setIsEditingImage ] = props.useEditingImage;
+		const [ editMode, setEditMode ] = props.useEditMode;
 		const { attributes, category, name, product, setAttributes } = props;
-		const { contentAlign, editMode, mediaId, mediaSrc } = attributes;
+		const { contentAlign, mediaId, mediaSrc } = attributes;
 		const item = category || product;
 
 		const { backgroundImageId, backgroundImageSrc } = useBackgroundImage( {
@@ -164,6 +166,7 @@ export const withBlockControls =
 					mediaSrc={ mediaSrc }
 					setAttributes={ setAttributes }
 					setIsEditingImage={ setIsEditingImage }
+					setEditMode={ setEditMode }
 				/>
 				<Component { ...props } />
 			</>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
@@ -42,10 +42,6 @@
 			"type": "number",
 			"default": 50
 		},
-		"editMode": {
-			"type": "boolean",
-			"default": true
-		},
 		"focalPoint": {
 			"type": "object",
 			"default": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/example.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/example.ts
@@ -8,7 +8,6 @@ type ExampleBlock = Block[ 'example' ] & {
 	attributes: {
 		categoryId: 'preview' | number;
 		previewCategory: ( typeof previewCategories )[ number ];
-		editMode: false;
 	};
 };
 
@@ -16,6 +15,5 @@ export const example: ExampleBlock = {
 	attributes: {
 		categoryId: 'preview',
 		previewCategory: previewCategories[ 0 ],
-		editMode: false,
 	},
 } as const;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -43,10 +43,6 @@
 			"type": "number",
 			"default": 50
 		},
-		"editMode": {
-			"type": "boolean",
-			"default": true
-		},
 		"focalPoint": {
 			"type": "object",
 			"default": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/example.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/example.ts
@@ -8,7 +8,6 @@ type ExampleBlock = Block[ 'example' ] & {
 	attributes: {
 		productId: 'preview' | number;
 		previewProduct: ( typeof previewProducts )[ number ];
-		editMode: false;
 	};
 };
 
@@ -16,6 +15,5 @@ export const example: ExampleBlock = {
 	attributes: {
 		productId: 'preview',
 		previewProduct: previewProducts[ 0 ],
-		editMode: false,
 	},
 } as const;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/register.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/register.tsx
@@ -92,7 +92,6 @@ export function register(
 			alt: '',
 			contentAlign: 'center',
 			dimRatio: 50,
-			editMode: false,
 			hasParallax: false,
 			isRepeated: false,
 			height: getSetting( 'defaultHeight', 500 ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -117,7 +117,7 @@ export const withFeaturedItem =
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: FeaturedItemProps< T > ) => {
 		const [ isEditingImage ] = props.useEditingImage;
-		const [ _, setEditMode ] = props.useEditMode;
+		const [ , setEditMode ] = props.useEditMode;
 
 		const {
 			attributes,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -53,7 +53,6 @@ export interface FeaturedItemRequiredAttributes {
 	overlayGradient: string;
 	showDesc: boolean;
 	showPrice: boolean;
-	editMode: boolean;
 	backgroundColor: string | undefined;
 	style: { color: { background: string } };
 	backgroundColorVisibilityStatus: {
@@ -91,6 +90,7 @@ interface FeaturedItemRequiredProps< T > {
 	isLoading: boolean;
 	setAttributes: ( attrs: Partial< FeaturedItemRequiredAttributes > ) => void;
 	useEditingImage: [ boolean, Dispatch< SetStateAction< boolean > > ];
+	useEditMode: [ boolean, Dispatch< SetStateAction< boolean > > ];
 }
 
 interface FeaturedCategoryProps< T > extends FeaturedItemRequiredProps< T > {
@@ -117,6 +117,7 @@ export const withFeaturedItem =
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: FeaturedItemProps< T > ) => {
 		const [ isEditingImage ] = props.useEditingImage;
+		const [ _, setEditMode ] = props.useEditMode;
 
 		const {
 			attributes,
@@ -214,7 +215,7 @@ export const withFeaturedItem =
 					<button
 						type="button"
 						className="components-button is-secondary"
-						onClick={ () => setAttributes( { editMode: true } ) }
+						onClick={ () => setEditMode( true ) }
 					>
 						{ noSelectionButtonLabel }
 					</button>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-update-button-attributes.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-update-button-attributes.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import type { ComponentType, Dispatch, SetStateAction } from 'react';
+import type { ComponentType } from 'react';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-update-button-attributes.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/with-update-button-attributes.tsx
@@ -5,20 +5,15 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import type { ComponentType } from 'react';
+import type { ComponentType, Dispatch, SetStateAction } from 'react';
 
 /**
  * Internal dependencies
  */
 import { EditorBlock } from './types';
-
-interface WithUpdateButtonRequiredAttributes {
-	editMode: boolean;
-}
-
 interface WithUpdateButtonAttributes< T > {
-	attributes: WithUpdateButtonRequiredAttributes &
-		EditorBlock< T >[ 'attributes' ];
+	attributes: EditorBlock< T >[ 'attributes' ];
+	editMode?: boolean;
 }
 
 interface WithUpdateButtonCategoryProps< T >
@@ -41,10 +36,8 @@ export const withUpdateButtonAttributes =
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: WithUpdateButtonProps< T > ) => {
 		const [ doUrlUpdate, setDoUrlUpdate ] = useState( false );
-		const { attributes, category, clientId, product } = props;
+		const { category, clientId, editMode, product } = props;
 		const item = category || product;
-
-		const { editMode } = attributes;
 		const permalink =
 			( item as WP_REST_API_Category )?.link ||
 			( item as ProductResponseItem )?.permalink;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The attribute `editMode` is actually just a flag that determines whether the item selector should be shown in the editor. Previously, this was saved as a block attribute, which meant this was saved in the block DOM itself.

Now, we instead just use it as React state, making the end result cleaner and more appropriate.

This PR comes as a follow-up from [this comment](https://github.com/woocommerce/woocommerce/pull/59033#pullrequestreview-2961952428) by @gigitux, and [this comment](https://github.com/woocommerce/woocommerce/pull/60841#pullrequestreview-3272177418) by @Aljullu.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Smoke test the Featured Category and Featured Product block.

#### Add a block from scratch

1. Add a Featured Category block.
2. Make sure that when the block is added, it is added in `editMode` (the picker is available).
3. Select a category.
4. Click Done.
5. Ensure the block displays the correct information.
6. Save the page.
7. Check the front-end.
8. Repeat for the Featured Product block.

#### Test a block that's already there

1. On the page above, reload the editor.
2. Make sure the block does NOT show in `editMode` on reload.

#### Test an incomplete block

1. Add a new Featured Category block.
2. Do not select anything.
3. Save and reload the editor.
4. Make sure the block still loads in `editMode`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is just an internal refactoring.

</details>
