### PR TITLE
Remove 'pull_request' event for e2e tests with GB nightly

### DIFF
--- a/plugins/woocommerce/changelog/dev-remove-pull_request-event-for-e2e-wuth-gb-nightly
+++ b/plugins/woocommerce/changelog/dev-remove-pull_request-event-for-e2e-wuth-gb-nightly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: remove the pull_request trigger event for e2e tests with GB Nightly

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -304,7 +304,6 @@
 						"@woocommerce/e2e-utils-playwright"
 					],
 					"events": [
-						"pull_request",
 						"nightly-checks",
 						"release-checks",
 						"core-e2e-gutenberg"


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Remove the 'pull_request' trigger event for e2e tests with Gutenberg nightly. The job running with Gutenberg stable should be enough for PRs.

### How to test the changes in this Pull Request:

Check CI. The job `Core e2e tests - Gutenberg nightly` is not part of the running checks.


