### PR TITLE
Fix low-resolution images displayed in the Classic Template block gallery

### DIFF
--- a/plugins/woocommerce/changelog/fix-move-add_filter-calls-to-classic-template-block-render
+++ b/plugins/woocommerce/changelog/fix-move-add_filter-calls-to-classic-template-block-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix low-resolution images displayed in the Classic Template block gallery

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -120,9 +120,6 @@ class ClassicTemplate extends AbstractDynamicBlock {
 				wc_get_template( 'single-product/photoswipe.php' );
 			}
 		);
-		add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
-		add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
 	}
 
 
@@ -155,6 +152,10 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		}
 
 		if ( is_product() ) {
+			add_filter( 'woocommerce_single_product_zoom_enabled', '__return_true' );
+			add_filter( 'woocommerce_single_product_photoswipe_enabled', '__return_true' );
+			add_filter( 'woocommerce_single_product_flexslider_enabled', '__return_true' );
+
 			return $this->render_single_product();
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/61013 but for the _Classic Template_ block.

### How to test the changes in this Pull Request:

1. Edit the _Single Product_ template, adding the _Classic Template_ block. You can paste this code:

```HTML
<!-- wp:woocommerce/legacy-template {"template":"single-product"} /-->
```

2. Visit it in the frontend.
3. Verify the gallery images are full-resolution:

`release/10.2` | This branch
--- | ---
<img width="1923" height="1462" alt="imatge" src="https://github.com/user-attachments/assets/1c162c50-1f00-406a-825e-25d5f7bead39" /> | <img width="1923" height="1841" alt="imatge" src="https://github.com/user-attachments/assets/652b1b52-af56-47d7-a54d-2661108fbf75" />