### PR TITLE
Add default_plugin_compatibility option to Session Destroying

### DIFF
--- a/plugins/woocommerce/changelog/fix-session-compatiblity-marker
+++ b/plugins/woocommerce/changelog/fix-session-compatiblity-marker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set default_plugin_compatibility for new Destroy Empty Sessions feature.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -562,6 +562,7 @@ class FeaturesController {
 				'enabled_by_default' => false,
 				'is_experimental'    => true,
 				'disable_ui'         => false,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -441,6 +441,7 @@ class FeaturesController {
 						if ( ! $tracking_enabled ) {
 							return __( '⚠ Usage tracking must be enabled to use remote logging.', 'woocommerce' );
 						}
+
 						return '';
 					},
 				),
@@ -553,7 +554,7 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_legacy'                    => false,
 			),
-			'destroy-empty-sessions' => array(
+			'destroy-empty-sessions'      => array(
 				'name'                         => __( 'Clear Customer Sessions When Empty', 'woocommerce' ),
 				'description'                  => __(
 					'[Performance] Removes session cookies for non-logged in customers when session data is empty, improving page caching performance. May cause compatibility issues with extensions that depend on the session cookie without using session data.',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -553,15 +553,15 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_legacy'                    => false,
 			),
-			'destroy-empty-sessions'      => array(
-				'name'               => __( 'Clear Customer Sessions When Empty', 'woocommerce' ),
-				'description'        => __(
+			'destroy-empty-sessions' => array(
+				'name'                         => __( 'Clear Customer Sessions When Empty', 'woocommerce' ),
+				'description'                  => __(
 					'[Performance] Removes session cookies for non-logged in customers when session data is empty, improving page caching performance. May cause compatibility issues with extensions that depend on the session cookie without using session data.',
 					'woocommerce'
 				),
-				'enabled_by_default' => false,
-				'is_experimental'    => true,
-				'disable_ui'         => false,
+				'enabled_by_default'           => false,
+				'is_experimental'              => true,
+				'disable_ui'                   => false,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This sets the default `default_plugin_compatibility` marker fro the `destroy-empty-sessions` feature.

The requirement for this change was added between the original #60855 PR getting created and the one requiring the new option to be set.

(For Bug Fixes) Bug introduced in PR #60855 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Load any page with WP_DEBUG enabled.
2. Verify there are no errors caused by the "Assuming positive compatibility by default will be deprecated in the future" check.
3. 
<!-- End testing instructions -->
