### PR TITLE
Featured Category Block: Add support for inner blocks

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/block.json
@@ -3,7 +3,6 @@
 	"title": "Category Description",
 	"description": "Displays the current category description.",
 	"category": "woocommerce",
-	"icon": "text",
 	"apiVersion": 3,
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { page as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -12,5 +13,6 @@ import edit from './edit';
 // @ts-expect-error registerBlockType typing
 registerBlockType( metadata, {
 	edit,
+	icon,
 	save: () => null,
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/block.json
@@ -3,7 +3,6 @@
 	"title": "Category Title",
 	"description": "Displays the current category title and lets permitted users edit it.",
 	"category": "woocommerce",
-	"icon": "heading",
 	"apiVersion": 3,
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/block.json
@@ -3,7 +3,7 @@
 	"title": "Category Title",
 	"description": "Displays the current category title and lets permitted users edit it.",
 	"category": "woocommerce",
-	"icon": "category",
+	"icon": "heading",
 	"apiVersion": 3,
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { heading as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -12,5 +13,6 @@ import edit from './edit';
 // @ts-expect-error registerBlockType typing
 registerBlockType( metadata, {
 	edit,
+	icon,
 	save: () => null,
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/deprecated.tsx
@@ -25,12 +25,12 @@ const v1 = {
 	},
 	save: () => <InnerBlocks.Content />,
 	isEligible: ( attributes: BlockAttributes ) => {
-		// If the block has showDesc attribute as boolean value, it's a legacy block
+		// If the block has editMode attribute as boolean value, it's a legacy block
 		// and it should be migrated to use inner blocks instead.
-		return typeof attributes.showDesc === 'boolean';
+		return typeof attributes.editMode === 'boolean';
 	},
 	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
-		const { showDesc, ...otherAttributes } = attributes;
+		const { editMode, showDesc, ...otherAttributes } = attributes;
 
 		// Always add category title as first inner block
 		innerBlocks.unshift(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/deprecated.tsx
@@ -32,22 +32,23 @@ const v1 = {
 	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
 		const { editMode, showDesc, ...otherAttributes } = attributes;
 
-		// Always add category title as first inner block
-		innerBlocks.unshift(
-			createBlock( 'woocommerce/category-title', {
-				level: 2,
-				isLink: false,
-			} )
-		);
-
 		// Conditionally add category description if showDesc was true
 		if ( showDesc ) {
-			innerBlocks.push(
+			innerBlocks.unshift(
 				createBlock( 'woocommerce/category-description', {
 					textAlign: 'center',
 				} )
 			);
 		}
+
+		// Always add category title as first inner block
+		innerBlocks.unshift(
+			createBlock( 'woocommerce/category-title', {
+				level: 2,
+				isLink: false,
+				textAlign: 'center',
+			} )
+		);
 
 		return [ otherAttributes, innerBlocks ];
 	},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedCategory.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedCategory.php
@@ -94,7 +94,7 @@ class FeaturedCategory extends FeaturedItem {
 
 			$output .= $legacy_title;
 
-			if ( $attributes['showDesc'] ) {
+			if ( array_key_exists( 'showDesc', $attributes ) && $attributes['showDesc'] ) {
 				$desc_str = sprintf(
 					'<div class="wc-block-featured-category__description">%s</div>',
 					wc_format_content( wp_kses_post( $category->description ) )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedCategory.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedCategory.php
@@ -84,9 +84,9 @@ class FeaturedCategory extends FeaturedItem {
 	protected function render_attributes( $category, $attributes ) {
 		$output = '';
 
-		// Backwards compatibility: Only render legacy attributes if they exist as boolean values
-		// This allows us to distinguish between old blocks (with boolean props) and new blocks (without these props)
-		if ( array_key_exists( 'showDesc', $attributes ) && is_bool( $attributes['showDesc'] ) ) {
+		// Backwards compatibility: Only render legacy attributes if `editMode` exists as boolean value
+		// This allows us to distinguish between old and new version of the block (which accept inner blocks).
+		if ( array_key_exists( 'editMode', $attributes ) && is_bool( $attributes['editMode'] ) ) {
 			$legacy_title = sprintf(
 				'<h2 class="wc-block-featured-category__title">%s</h2>',
 				wp_kses_post( $category->name )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is related to https://github.com/woocommerce/woocommerce/pull/60841 and is part of the bigger https://github.com/woocommerce/woocommerce/pull/60779 PR, introducing support for inner blocks for both the Featured Category and Featured Product work.

This PR is much simpler than its sister PR for two reasons: (a) the Featured Category block is a much simpler block and (b) much of the changes required to allow for inner blocks support were already introduced in the base PR when I didn't know I'd split the PRs up for easier reviewing.

I still decided to make this a separate PR to also test atomically [this approach](https://github.com/woocommerce/woocommerce/pull/60841#pullrequestreview-3272177418) suggested by @Aljullu (which required rebasing onto [this PR](https://github.com/woocommerce/woocommerce/pull/61164)). In case it works well, after this is merged in the main PR, I'll apply the same to the Featured Product.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60620.
Closes WOOPLUG-5429

### Screenshots or screen recordings:

<img width="806" height="558" alt="Screenshot 2025-09-28 at 00 25 29" src="https://github.com/user-attachments/assets/a0b33102-9a9b-4166-bd85-58c3bc161a98" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Clean version

1. Open a page, add the “Featured Category” block.
2. Select a category.
3. Verify that the block is added and contains:
    a. The correct Category Title,
    b. The correct Category Description,
    c. A call to action in the form of core buttons.
4. Play around with the settings, layout and positions of all the inner blocks (including removing them).
5. Save and verify it works on the front-end.


#### Front-end Backwards compatibility
1. Checkout trunk and add an old “Featured Category” block to a page.
2. Checkout this branch without going to the editor.
3. Load the page containing this block on the front-end.
4. Verify that the block still is rendered correctly on the front-end, respecting the settings of the legacy block.

#### Migration
1. After the steps above, go to the editor.
2. Verify that the legacy block has been migrated to the inner blocks, respecting all the settings (i.e. if “show description” was toggled off, there should not be a description block).
3. Save and verify it works on the front-end.

#### Known issues
Please focus on the code changes on this PR, some CI issues (like failing linting) are due to the changes introduced in the base PR, and are going to be addressed there once the two secondary PRs are merged into that.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR is part of a larger set of PRs.

</details>
