### PR TITLE
Update PHP package version in the prepare script

### DIFF
--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -195,20 +195,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-09T21:00:45+00:00"
+            "time": "2025-09-19T19:40:19+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
-                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
                 "shasum": ""
             },
             "require": {
@@ -265,9 +265,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-24T21:30:46+00:00"
+            "time": "2025-09-19T17:43:28+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",

--- a/plugins/woocommerce/bin/composer/phpunit/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpunit/composer.lock
@@ -634,16 +634,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.27",
+            "version": "9.6.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0a9aa4440b6a9528cf360071502628d717af3e0a"
+                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0a9aa4440b6a9528cf360071502628d717af3e0a",
-                "reference": "0a9aa4440b6a9528cf360071502628d717af3e0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
                 "shasum": ""
             },
             "require": {
@@ -668,7 +668,7 @@
                 "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
+                "sebastian/exporter": "^4.0.8",
                 "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
@@ -717,7 +717,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.27"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
             },
             "funding": [
                 {
@@ -741,7 +741,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T06:18:03+00:00"
+            "time": "2025-09-24T06:29:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1184,16 +1184,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -1249,15 +1249,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/plugins/woocommerce/changelog/fix-package-conflict-part-one
+++ b/plugins/woocommerce/changelog/fix-package-conflict-part-one
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update email-editor dependency in WooCommerce composer.json to load the mirrored version

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -52,7 +52,7 @@
 		"pelago/emogrifier": "7.3.0",
 		"woocommerce/action-scheduler": "3.9.3",
 		"woocommerce/blueprint": "*",
-		"woocommerce/email-editor": "1.7.0",
+		"woocommerce/email-editor": "*",
 		"wordpress/abilities-api": "^0.1.1",
 		"wordpress/mcp-adapter": "dev-trunk#7a2d22cff92328bc94f5b1648a66ae4273e949c5"
 	},

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aa316fbb8a87613846bb8dd45006c5a",
+    "content-hash": "8b301d44a24f2b225a82f275d3b60339",
     "packages": [
         {
             "name": "automattic/block-delimiter",

--- a/tools/package-release/src/commands/prepare/index.ts
+++ b/tools/package-release/src/commands/prepare/index.ts
@@ -179,6 +179,7 @@ export default class PackagePrepare extends Command {
 						{
 							encoding: 'utf-8',
 							cwd: WOOCOMMERCE_PLUGIN_ROOT,
+							stdio: 'ignore',
 						}
 					);
 					execSync(

--- a/tools/package-release/src/commands/prepare/index.ts
+++ b/tools/package-release/src/commands/prepare/index.ts
@@ -3,6 +3,7 @@
  */
 import { CliUx, Command, Flags } from '@oclif/core';
 import { writeFileSync } from 'fs';
+import { execSync } from 'child_process';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import {
 	writeChangelog,
 	hasValidChangelogs,
 } from '../../changelogger';
+import { WOOCOMMERCE_PLUGIN_ROOT } from '../../const';
 
 /**
  * PackagePrepare class
@@ -165,6 +167,31 @@ export default class PackagePrepare extends Command {
 				jsonFilepath,
 				JSON.stringify( json, null, '\t' ) + '\n'
 			);
+
+			// if preparing a php package and the package is used in the woocommerce plugin
+			// also update the version in the plugin's composer.json and composer.lock
+			// this is done to ensure jetpack autoloader fetches the correct version of the package
+			if ( packageType === 'php' ) {
+				try {
+					// will throw an error if the package is not used in the woocommerce plugin
+					execSync(
+						`composer show ${ json.name } --no-scripts --direct --quiet`,
+						{
+							encoding: 'utf-8',
+							cwd: WOOCOMMERCE_PLUGIN_ROOT,
+						}
+					);
+					execSync(
+						`composer update ${ json.name } --no-scripts --no-plugins --quiet`,
+						{
+							encoding: 'utf-8',
+							cwd: WOOCOMMERCE_PLUGIN_ROOT,
+						}
+					);
+				} catch ( error ) {
+					// Ignore the error - package is not used in the woocommerce plugin.
+				}
+			}
 		} catch ( e ) {
 			this.error( `Can't bump version for ${ name }.` );
 		}

--- a/tools/package-release/src/const.ts
+++ b/tools/package-release/src/const.ts
@@ -1,10 +1,14 @@
 /**
  * External dependencies
  */
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 // Escape from ./tools/package-release/src
 export const MONOREPO_ROOT = dirname( dirname( dirname( __dirname ) ) );
+
+export const PLUGINS_ROOT = join( MONOREPO_ROOT, 'plugins' );
+
+export const WOOCOMMERCE_PLUGIN_ROOT = join( PLUGINS_ROOT, 'woocommerce' );
 
 // Packages that are not meant to be released by monorepo team for whatever reason.
 export const excludedPackages: string[] = [];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of https://linear.app/a8c/issue/WOOPRD-858/implement-mozart-prefixing-for-emogrifier-dependencies

(For Bug Fixes) Bug introduced in PR # .

This is the first of a series of PRs to update the pelago/emogrifier package and prevent package conflict with other plugins.

This PR primarily updates the prepare script to ensure that when preparing a PHP package for release, we also keep the Woo Core plugin version of the package up to date.

This is a required first step for the subsequent PRs, as we will need to update both the WooCommerce plugin and the Email Editor package together.

**Why**

We previously updated this from `*` to a specific package version because Jetpack Autoloader was experiencing an issue with it, causing conflicts when used with other plugins by providing an outdated package for the consumer. I.e. Jetpack's autoloader classmap seems to be read from the compose.lock file and the composer.lock file contained an outdated dependency version. More info on this PR https://github.com/woocommerce/woocommerce/pull/60390

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

--


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. cd `tools/package-release`
2. Run `pnpm run build`
3. Prepare a PHP package release e.g `bin/dev prepare @woocommerce/email-editor-config`
4. Note the composer.lock is updated to the latest version

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


### After merge:
Update the Releasing Email Editor packages doc and remove the line for “Update the package version in WooCommerce Core” 