### PR TITLE
Do not preload unnecessary endpoint data outside of wc-admin screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-48328
+++ b/plugins/woocommerce/changelog/fix-48328
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Do not preload leaderboards and performance indicators data outside of Analytics screens.

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -107,8 +107,14 @@ class Analytics {
 	 * @return array
 	 */
 	public function add_preload_endpoints( $endpoints ) {
-		$endpoints['performanceIndicators'] = '/wc-analytics/reports/performance-indicators/allowed';
-		$endpoints['leaderboards']          = '/wc-analytics/leaderboards/allowed';
+		$screen_id = ( function_exists( 'get_current_screen' ) && get_current_screen() ) ? get_current_screen()->id : '';
+
+		// Only preload endpoints on wc-admin pages.
+		if ( 'woocommerce_page_wc-admin' === $screen_id ) {
+			$endpoints['performanceIndicators'] = '/wc-analytics/reports/performance-indicators/allowed';
+			$endpoints['leaderboards']          = '/wc-analytics/leaderboards/allowed';
+		}
+
 		return $endpoints;
 	}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
The Analytics client-side code makes use of the response from endpoints `/wc-analytics/reports/performance-indicators/allowed` and `/wc-analytics/leaderboards/allowed` (available on a client-side variable). As such, Analytics backend logic indicates that [this data should be preloaded](https://github.com/woocommerce/woocommerce/blob/e327c733f86cc378c38c2ebd066e77e80aa92125/plugins/woocommerce/src/Internal/Admin/Analytics.php#L109-L113), but does this unconditionally, which means the requests are performed and the data is available [on every WC admin page](https://github.com/woocommerce/woocommerce/blob/3247c83ddc0a7fb20741c5eb26332db6e1a1394b/plugins/woocommerce/src/Internal/Admin/Settings.php#L145).

This in itself doesn't add much to the response time, but some of these responses involve triggering filters (for example, `woocommerce_leaderboards`), which seems unnecessary outside of the Analytics section, and can result in bad performance if the callbacks hooked onto those are not properly written.

This PR makes sure we only preload these endpoints if we're on a wc-admin screen.

Closes #48328.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Check out `trunk`.
1. Go to any WC admin page (such as **WC > Orders** or **Analytics**) and use your browser's console to confirm that `wcSettings.admin.dataEndpoints` has entries `leaderboards` and `performanceIndicators`:
   <img width="624" height="111" alt="Screenshot 2025-09-30 at 19 42 36" src="https://github.com/user-attachments/assets/19342327-e977-4684-b469-370b9fa7dd79" />
1. Check out this branch (`fix/48328`).
1. Ensure that `wcSettings.admin.dataEndpoints.leaderboards` and `wcSettings.admin.dataEndpoints.performanceIndicators` are now only available on wc-admin screens (such as **WC > Home** or **Analytics**) and not on other admin screens such as **WC > Orders** or **WC > Settings**.
1. (Optional) Activate a snippet such as the following one, which introduces an artificial delay, and make sure the slowdown occurs on every WC admin page (on `trunk`) but only noticed on **Analytics** screens (on `fix/48328`).
   ```php
   <?php
   add_filter(
       'woocommerce_leaderboards',
       function( $leaderboards ) {
           sleep( 5 );
           return $leaderboards;
       }
   );
   ```

<!-- End testing instructions -->