### PR TITLE
Implement meta deletion in `MetaToMetaTableMigrator`

### DIFF
--- a/plugins/woocommerce/changelog/fix-50085
+++ b/plugins/woocommerce/changelog/fix-50085
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly handle deleted meta in legacy > HPOS sync.

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -111,8 +111,19 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 
 		$to_insert = $data[0];
 		$to_update = $data[1];
+		$to_delete = $data[2] ?? array();
 
 		try {
+			// Process deletions first.
+			if ( ! empty( $to_delete ) ) {
+				$delete_queries = $this->generate_delete_sql_for_batch( $to_delete );
+
+				if ( $delete_queries ) {
+					$processed_rows_count = $this->db_query( $delete_queries );
+					$this->maybe_add_insert_or_update_error( 'delete', $processed_rows_count );
+				}
+			}
+
 			if ( ! empty( $to_insert ) ) {
 				$insert_queries       = $this->generate_insert_sql_for_batch( $to_insert );
 				$processed_rows_count = $this->db_query( $insert_queries );
@@ -132,6 +143,46 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 			'errors'    => $this->get_errors(),
 			'exception' => $exception,
 		);
+	}
+
+	private function generate_delete_sql_for_batch( array $batch ): string {
+		global $wpdb;
+
+		$table                 = $this->schema_config['destination']['meta']['table_name'];
+		$meta_id_column        = $this->schema_config['destination']['meta']['meta_id_column'];
+		$entity_id_column      = $this->schema_config['destination']['meta']['entity_id_column'];
+		$entity_id_placeholder = MigrationHelper::get_wpdb_placeholder_for_type( $this->schema_config['destination']['meta']['entity_id_type'] );
+
+		$clauses = array();
+
+		foreach ( $batch as $entity_id => $metas ) {
+			$meta_ids = array_column(
+				array_reduce( $metas, 'array_merge', array() ),
+				$meta_id_column
+			);
+
+			if ( ! $meta_ids ) {
+				continue;
+			}
+
+			$meta_id_placeholders = implode( ',', array_fill( 0, count( $meta_ids ), '%d' ) );
+
+			$clauses[] = $wpdb->prepare(
+				"( %i = {$entity_id_placeholder} AND %i IN ({$meta_id_placeholders}) )",
+				$entity_id_column,
+				$entity_id,
+				$meta_id_column,
+				...$meta_ids
+			);
+		}
+
+		if ( ! $clauses ) {
+			return '';
+		}
+
+		$clauses_sql = implode( ' OR ', $clauses );
+
+		return "DELETE FROM {$table} WHERE {$clauses_sql}";
 	}
 
 	/**
@@ -320,8 +371,19 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 	private function classify_update_insert_records( array $to_migrate, array $already_migrated ): array {
 		$to_update = array();
 		$to_insert = array();
+		$to_delete = array();
 
 		foreach ( $to_migrate as $entity_id => $rows ) {
+			// Meta keys we need to fully delete because they don't exist in the source data.
+			$no_longer_exist = array_diff_key(
+				$already_migrated[ $entity_id ] ?? array(),
+				$rows
+			);
+
+			if ( $no_longer_exist ) {
+				$to_delete[ $entity_id ] = array_merge( $to_delete[ $entity_id ] ?? array(), $no_longer_exist );
+			}
+
 			foreach ( $rows as $meta_key => $meta_values ) {
 				// If there is no corresponding record in the destination table then insert.
 				// If there is single value in both already migrated and current then update.
@@ -347,20 +409,22 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 						continue;
 					}
 
-					// There are multiple meta entries, let's find the unique entries and insert.
-					$unique_meta_values = array_diff( $meta_values, array_column( $already_migrated[ $entity_id ][ $meta_key ], 'meta_value' ) );
-					if ( 0 === count( $unique_meta_values ) ) {
-						continue;
-					}
+					// There might be multiple entries with the same value, or destination entries that no longer exist in the source data.
+					// It is easier to delete all existing entries and insert fresh new ones to honor multiplicity, etc.
+					$to_delete[ $entity_id ][ $meta_key ] = $already_migrated[ $entity_id ][ $meta_key ];
+
 					if ( ! isset( $to_insert[ $entity_id ] ) ) {
 						$to_insert[ $entity_id ] = array();
 					}
-					$to_insert[ $entity_id ][ $meta_key ] = $unique_meta_values;
+
+					$to_insert[ $entity_id ][ $meta_key ] = $meta_values;
 				}
 			}
+
+
 		}
 
-		return array( $to_insert, $to_update );
+		return array( $to_insert, $to_update, $to_delete );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -114,7 +114,6 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 		$to_delete = $data[2] ?? array();
 
 		try {
-			// Process deletions first.
 			if ( ! empty( $to_delete ) ) {
 				$delete_queries = $this->generate_delete_sql_for_batch( $to_delete );
 
@@ -145,6 +144,14 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 		);
 	}
 
+	/**
+	 * Generate delete SQL for given batch.
+	 *
+	 * @since 10.4.0
+	 *
+	 * @param array $batch List of data to generate delete SQL for. Should be in same format as output of $this->fetch_data_for_migration_for_ids.
+	 * @return string
+	 */
 	private function generate_delete_sql_for_batch( array $batch ): string {
 		global $wpdb;
 
@@ -167,6 +174,7 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 
 			$meta_id_placeholders = implode( ',', array_fill( 0, count( $meta_ids ), '%d' ) );
 
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			$clauses[] = $wpdb->prepare(
 				"( %i = {$entity_id_placeholder} AND %i IN ({$meta_id_placeholders}) )",
 				$entity_id_column,
@@ -174,6 +182,7 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 				$meta_id_column,
 				...$meta_ids
 			);
+			// phpcs:enable
 		}
 
 		if ( ! $clauses ) {
@@ -410,7 +419,7 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 					}
 
 					// There might be multiple entries with the same value, or destination entries that no longer exist in the source data.
-					// It is easier to delete all existing entries and insert fresh new ones to honor multiplicity, etc.
+					// It is easier to delete all existing entries with this meta key and insert fresh new ones to honor multiplicity, etc.
 					$to_delete[ $entity_id ][ $meta_key ] = $already_migrated[ $entity_id ][ $meta_key ];
 
 					if ( ! isset( $to_insert[ $entity_id ] ) ) {
@@ -420,8 +429,6 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 					$to_insert[ $entity_id ][ $meta_key ] = $meta_values;
 				}
 			}
-
-
 		}
 
 		return array( $to_insert, $to_update, $to_delete );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
HPOS sync (when the legacy data store is authoritative) doesn't correctly propagate changes when metadata is removed from the source tables (`postmeta` in this case). The HPOS version will contain stale data and this will never be reconciled by the sync process, regardless of it being automatic or performed manually.

This is _usually_ not something that would prevent the switch to HPOS because enabling sync is a requirement, and our implementation of sync-on-read will update orders as needed. That said, sync-on-read can be disabled and even if the store never switches to HPOS, syncs should be performed correctly.

This PR ensures that when migrating from legacy to HPOS, metadata that already exists in the destination table is first cleared before adding the new entries.

Related to #50085.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to **WC > Settings > Advanced > Features** and make sure that **WordPress posts storage** is selected as data store.
   Similarly, enable **Enable compatibility mode** to make testing easier.

   If necessary, first run `wp wc hpos sync` to sync orders.
1. Go to **WC > Orders** and create a new order with any details you like.
1. Save the order and take note of the ID.
1. Edit the order you created, ensuring there's at least 2 metadata keys, 1 with more than 1 value. Example:
   <img width="958" height="302" alt="Screenshot 2025-09-30 at 18 45 02" src="https://github.com/user-attachments/assets/9b71a7ac-9a3c-401a-99bc-f0e9abddc82b" />
   Click the **Update** button to save changes.
1. Run `wp db query "SELECT * FROM $(wp db prefix)wc_orders_meta WHERE order_id = <your order id here>"` and confirm that the metadata you added above is listed, which means it has been synced to the HPOS tables.
   <img width="288" height="50" alt="Screenshot 2025-09-30 at 18 47 05" src="https://github.com/user-attachments/assets/37eb00ee-470c-4472-9066-ddce6f817ea3" />
1. Go back to your order and remove one of the metadata rows. Save the order.
1. Run `wp db query "SELECT * FROM $(wp db prefix)wc_orders_meta WHERE order_id = <your order id here>"` again and confirm that the metadata you removed is no longer listed. 
1. Check out `trunk` and repeat steps 2-6. Confirm that in this case, the removed metadata lingers and isn't deleted from the HPOS tables. This is part of #50085.


<!-- End testing instructions -->