### PR TITLE
[Migrator]: Internal Feedback testing: Fix bug with importing variations with spaces

### DIFF
--- a/plugins/woocommerce/changelog/fix-migrator-variation
+++ b/plugins/woocommerce/changelog/fix-migrator-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Migrator: Fixed the import for variation with spaces

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/WooCommerceProductImporter.php
@@ -697,7 +697,7 @@ class WooCommerceProductImporter {
 			$woo_attribute = new \WC_Product_Attribute();
 			$woo_attribute->set_name( $taxonomy_name );
 			$woo_attribute->set_id( $attribute_id );
-			$woo_attribute->set_options( $term_slugs );
+			$woo_attribute->set_options( $term_ids );
 			$woo_attribute->set_position( $attribute_info['position'] ?? 0 );
 			$woo_attribute->set_visible( $attribute_info['is_visible'] ?? true );
 			$woo_attribute->set_variation( $attribute_info['is_variation'] ?? true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Use term ID instead of term slug to map variations, which is more robust way of mapping, It helps deal with variaiton that have spaces such as "Crop top"

<img width="605" height="433" alt="image" src="https://github.com/user-attachments/assets/72de96ab-6087-41e7-8488-fb544db0c8d6" />




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the import with ` wp wc migrate products --product-type="TShirt"`
2. Observe the variation for the “Short sleeve T-shirt product”

Before:
<img width="1022" height="378" alt="image" src="https://github.com/user-attachments/assets/a72a00ef-91d9-400e-a723-f78cee1a9a6d" />
After:
<img width="546" height="304" alt="image" src="https://github.com/user-attachments/assets/260a67e7-62c3-45f6-ae85-ac6ad29c6f91" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
