### PR TITLE
Add notice to Add to Cart + Options block encouraging users to upgrade from Product Image Gallery block to Product Gallery

### DIFF
--- a/plugins/woocommerce/changelog/fix-60911-add-notice-to-update-product-gallery-block-in-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-60911-add-notice-to-update-product-gallery-block-in-add-to-cart-with-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add notice to Add to Cart + Options block encouraging users to upgrade from Product Image Gallery block to Product Gallery

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -37,7 +37,7 @@ const Edit = ( props: BlockEditProps< { className: string } > ) => {
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>
-				<UpgradeNotice blockClientId={ props?.clientId } />
+				<UpgradeNotice blockClientId={ props.clientId } />
 			</InspectorControls>
 			<Disabled>
 				<Placeholder />

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -31,7 +31,7 @@ const Placeholder = () => {
 	);
 };
 
-const Edit = ( props: BlockEditProps< {} > ) => {
+const Edit = ( props: BlockEditProps< Record< string, never > > ) => {
 	const blockProps = useBlockProps();
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -31,7 +31,7 @@ const Placeholder = () => {
 	);
 };
 
-const Edit = ( props: BlockEditProps< { className: string } > ) => {
+const Edit = ( props: BlockEditProps< {} > ) => {
 	const blockProps = useBlockProps();
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
+import { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
+import { UpgradeNotice } from './upgrade-notice';
 import './editor.scss';
 
 const Placeholder = () => {
@@ -29,11 +31,14 @@ const Placeholder = () => {
 	);
 };
 
-const Edit = () => {
+const Edit = ( props: BlockEditProps< { className: string } > ) => {
 	const blockProps = useBlockProps();
 
 	return (
 		<div { ...blockProps }>
+			<InspectorControls>
+				<UpgradeNotice blockClientId={ props?.clientId } />
+			</InspectorControls>
 			<Disabled>
 				<Placeholder />
 			</Disabled>

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -35,6 +35,10 @@ export const UpgradeNotice = ( {
 }: {
 	blockClientId: string;
 } ) => {
+	if ( ! blockClientId ) {
+		return null;
+	}
+
 	const notice = createInterpolateElement(
 		__(
 			'Gain access to more customization options when you upgrade to the <strongText />.',

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -3,15 +3,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import { dispatch, select } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 import { findBlock } from '@woocommerce/utils';
-import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
+import { replaceBlockWithProductGallery } from '../../../../blocks/product-gallery/edit-utils';
 
 const upgradeToBlockifiedProductGallery = ( blockClientId: string ) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
@@ -22,12 +22,9 @@ const upgradeToBlockifiedProductGallery = ( blockClientId: string ) => {
 	} );
 
 	if ( foundBlock ) {
-		const newBlock = createBlock( 'woocommerce/product-gallery' );
-		dispatch( 'core/block-editor' ).replaceBlock(
-			foundBlock.clientId,
-			newBlock
-		);
+		return replaceBlockWithProductGallery( foundBlock.clientId );
 	}
+	return false;
 };
 
 export const UpgradeNotice = ( {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -35,10 +35,6 @@ export const UpgradeNotice = ( {
 }: {
 	blockClientId: string;
 } ) => {
-	if ( ! blockClientId ) {
-		return null;
-	}
-
 	const notice = createInterpolateElement(
 		__(
 			'Gain access to more customization options when you upgrade to the <strongText />.',

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -13,7 +13,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import metadata from './block.json';
 
-const upgradeToBlockifiedProductGallery = async ( blockClientId: string ) => {
+const upgradeToBlockifiedProductGallery = ( blockClientId: string ) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
 	const foundBlock = findBlock( {
 		blocks,

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -21,17 +21,13 @@ const upgradeToBlockifiedProductGallery = async ( blockClientId: string ) => {
 			block.name === metadata.name && block.clientId === blockClientId,
 	} );
 
-	if ( ! foundBlock ) {
-		return false;
+	if ( foundBlock ) {
+		const newBlock = createBlock( 'woocommerce/product-gallery' );
+		dispatch( 'core/block-editor' ).replaceBlock(
+			foundBlock.clientId,
+			newBlock
+		);
 	}
-
-	const newBlock = createBlock( 'woocommerce/product-gallery' );
-	dispatch( 'core/block-editor' ).replaceBlock(
-		foundBlock.clientId,
-		newBlock
-	);
-
-	return true;
 };
 
 export const UpgradeNotice = ( {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { dispatch, select } from '@wordpress/data';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
+import { findBlock } from '@woocommerce/utils';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const upgradeToBlockifiedProductGallery = async ( blockClientId: string ) => {
+	const blocks = select( 'core/block-editor' ).getBlocks();
+	const foundBlock = findBlock( {
+		blocks,
+		findCondition: ( block ) =>
+			block.name === metadata.name && block.clientId === blockClientId,
+	} );
+
+	if ( ! foundBlock ) {
+		return false;
+	}
+
+	const newBlock = createBlock( 'woocommerce/product-gallery' );
+	dispatch( 'core/block-editor' ).replaceBlock(
+		foundBlock.clientId,
+		newBlock
+	);
+
+	return true;
+};
+
+export const UpgradeNotice = ( {
+	blockClientId,
+}: {
+	blockClientId: string;
+} ) => {
+	const notice = createInterpolateElement(
+		__(
+			'Gain access to more customization options when you upgrade to the <strongText />.',
+			'woocommerce'
+		),
+		{
+			strongText: (
+				<strong>
+					{ __( `blockified experience`, 'woocommerce' ) }
+				</strong>
+			),
+		}
+	);
+
+	const buttonLabel = __(
+		'Upgrade to the new Product Gallery block',
+		'woocommerce'
+	);
+
+	return (
+		<UpgradeDowngradeNotice
+			isDismissible={ false }
+			actionLabel={ buttonLabel }
+			onActionClick={ () =>
+				upgradeToBlockifiedProductGallery( blockClientId )
+			}
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
+	);
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -43,7 +43,7 @@ export const DowngradeNotice = ( {
 	blockClientId: string;
 } ) => {
 	const notice = __(
-		'Switch back to the classic Add to Cart + Options block.',
+		'Facing compatibility issues with extensions? You can switch back to the classic Add to Cart with Options block.',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -3,23 +3,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { createBlock, BlockInstance } from '@wordpress/blocks';
-import { dispatch, useSelect } from '@wordpress/data';
+import { BlockInstance } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 import { findBlock } from '@woocommerce/utils';
 
-const upgradeToBlockifiedProductGallery = (
-	productImageGalleryBlockClientId: string
-) => {
-	const newBlock = createBlock( 'woocommerce/product-gallery' );
-
-	dispatch( 'core/block-editor' ).replaceBlock(
-		productImageGalleryBlockClientId,
-		newBlock
-	);
-
-	return true;
-};
+/**
+ * Internal dependencies
+ */
+import { replaceBlockWithProductGallery } from '../../../product-gallery/edit-utils';
 
 export const UpgradeProductImageGallery = () => {
 	const [ productImageGalleryBlock, setProductImageGalleryBlock ] =
@@ -61,7 +53,7 @@ export const UpgradeProductImageGallery = () => {
 			isDismissible={ false }
 			actionLabel={ buttonLabel }
 			onActionClick={ () => {
-				upgradeToBlockifiedProductGallery(
+				replaceBlockWithProductGallery(
 					productImageGalleryBlock.clientId
 				);
 				setProductImageGalleryBlock( null );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -43,7 +43,7 @@ export const UpgradeProductImageGallery = () => {
 	}, [ getBlocks, setProductImageGalleryBlock ] );
 
 	if ( ! productImageGalleryBlock ) {
-		return false;
+		return null;
 	}
 
 	const notice = __(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { createBlock, BlockInstance } from '@wordpress/blocks';
+import { dispatch, useSelect } from '@wordpress/data';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
+import { findBlock } from '@woocommerce/utils';
+
+const upgradeToBlockifiedProductGallery = (
+	productImageGalleryBlockClientId: string
+) => {
+	const newBlock = createBlock( 'woocommerce/product-gallery' );
+
+	dispatch( 'core/block-editor' ).replaceBlock(
+		productImageGalleryBlockClientId,
+		newBlock
+	);
+
+	return true;
+};
+
+export const UpgradeProductImageGallery = () => {
+	const [ productImageGalleryBlock, setProductImageGalleryBlock ] =
+		useState< BlockInstance | null >( null );
+
+	const getBlocks = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlocks;
+	}, [] );
+
+	useEffect( () => {
+		const foundBlock = findBlock( {
+			blocks: getBlocks(),
+			findCondition: ( block ) =>
+				block.name === 'woocommerce/product-image-gallery',
+		} );
+		if ( foundBlock ) {
+			setProductImageGalleryBlock( foundBlock );
+		} else {
+			setProductImageGalleryBlock( null );
+		}
+	}, [ getBlocks, setProductImageGalleryBlock ] );
+
+	if ( ! productImageGalleryBlock ) {
+		return false;
+	}
+
+	const notice = __(
+		'This template contains the classic Product Image Gallery block which is not compatible with the Add to Cart + Options block. Switch to the new Product Gallery block for a better experience.',
+		'woocommerce'
+	);
+
+	const buttonLabel = __(
+		'Upgrade to the blockified Product Gallery',
+		'woocommerce'
+	);
+
+	return (
+		<UpgradeDowngradeNotice
+			isDismissible={ false }
+			actionLabel={ buttonLabel }
+			onActionClick={ () => {
+				upgradeToBlockifiedProductGallery(
+					productImageGalleryBlock.clientId
+				);
+				setProductImageGalleryBlock( null );
+			} }
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
+	);
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -17,13 +17,9 @@ export const UpgradeProductImageGallery = () => {
 	const [ productImageGalleryBlock, setProductImageGalleryBlock ] =
 		useState< BlockInstance | null >( null );
 
-	const getBlocks = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlocks;
-	}, [] );
-
 	useEffect( () => {
 		const foundBlock = findBlock( {
-			blocks: getBlocks(),
+			blocks: select( 'core/block-editor' ).getBlocks(),
 			findCondition: ( block ) =>
 				block.name === 'woocommerce/product-image-gallery',
 		} );
@@ -32,7 +28,7 @@ export const UpgradeProductImageGallery = () => {
 		} else {
 			setProductImageGalleryBlock( null );
 		}
-	}, [ getBlocks, setProductImageGalleryBlock ] );
+	}, [ setProductImageGalleryBlock ] );
 
 	if ( ! productImageGalleryBlock ) {
 		return null;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -52,8 +52,8 @@ const AddToCartOptionsEdit = (
 	return (
 		<>
 			<InspectorControls>
-				<DowngradeNotice blockClientId={ props?.clientId } />
 				<UpgradeProductImageGallery />
+				<DowngradeNotice blockClientId={ props?.clientId } />
 			</InspectorControls>
 			<BlockControls>
 				<ToolbarProductTypeGroup />

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -18,6 +18,7 @@ import { useProduct } from '@woocommerce/entities';
  */
 import ToolbarProductTypeGroup from '../components/toolbar-type-product-selector-group';
 import { DowngradeNotice } from '../components/downgrade-notice';
+import { UpgradeProductImageGallery } from '../components/upgrade-product-image-gallery';
 import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
 import type { Attributes } from '../types';
@@ -52,6 +53,7 @@ const AddToCartOptionsEdit = (
 		<>
 			<InspectorControls>
 				<DowngradeNotice blockClientId={ props?.clientId } />
+				<UpgradeProductImageGallery />
 			</InspectorControls>
 			<BlockControls>
 				<ToolbarProductTypeGroup />

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { dispatch, select } from '@wordpress/data';
-import { UpgradeDowngradeNotice as Notice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 import { findBlock } from '@woocommerce/utils';
 import { createBlock } from '@wordpress/blocks';
 
@@ -73,12 +73,12 @@ export const UpgradeNotice = ( {
 	};
 
 	return (
-		<Notice
+		<UpgradeDowngradeNotice
 			isDismissible={ false }
 			actionLabel={ buttonLabel }
 			onActionClick={ handleClick }
 		>
 			{ notice }
-		</Notice>
+		</UpgradeDowngradeNotice>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -42,10 +42,6 @@ export const UpgradeNotice = ( {
 }: {
 	blockClientId: string;
 } ) => {
-	if ( ! blockClientId ) {
-		return null;
-	}
-
 	const notice = createInterpolateElement(
 		__(
 			'Gain access to more customization options when you upgrade to the <strongText />.',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -42,6 +42,10 @@ export const UpgradeNotice = ( {
 }: {
 	blockClientId: string;
 } ) => {
+	if ( ! blockClientId ) {
+		return null;
+	}
+
 	const notice = createInterpolateElement(
 		__(
 			'Gain access to more customization options when you upgrade to the <strongText />.',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -40,7 +40,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 		<>
 			{ isBlockTheme && (
 				<InspectorControls>
-					<UpgradeNotice blockClientId={ props?.clientId } />
+					<UpgradeNotice blockClientId={ props.clientId } />
 				</InspectorControls>
 			) }
 			<AddToCartFormSettings

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/edit-utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/edit-utils.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+
+export const replaceBlockWithProductGallery = ( blockClientId: string ) => {
+	const newBlock = createBlock( 'woocommerce/product-gallery' );
+
+	dispatch( 'core/block-editor' ).replaceBlock( blockClientId, newBlock );
+
+	return true;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/index.ts
@@ -1,2 +1,2 @@
-export * from './UpgradeDowngradeNotice';
+export * from './upgrade-downgrade-notice';
 export type * from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { Notice } from '@wordpress/components';
+import { NoticeProps } from '@wordpress/components/build-types/notice/types';
 
-export type UpgradeDowngradeNoticeProps = Omit< Notice.Props, 'actions' > & {
+export type UpgradeDowngradeNoticeProps = Omit< NoticeProps, 'actions' > & {
 	actionLabel: string;
 	onActionClick(): void;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/upgrade-downgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/upgrade-downgrade-notice/upgrade-downgrade-notice.tsx
@@ -29,7 +29,6 @@ export function UpgradeDowngradeNotice( {
 					label: actionLabel,
 					onClick: onActionClick,
 					noDefaultClasses: true,
-					// @ts-expect-error the 'variant' prop does exists.
 					variant: 'link',
 				},
 			] }

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -965,4 +965,31 @@ test.describe( 'Add to Cart + Options Block', () => {
 			page.getByRole( 'button', { name: 'Added to cart', exact: true } )
 		).toBeVisible();
 	} );
+
+	test( 'allows updating the Product Image Gallery block to the Product Gallery block', async ( {
+		page,
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.updateSingleProductTemplate();
+
+		const addToCartFormBlock = await editor.getBlockByName(
+			pageObject.BLOCK_SLUG
+		);
+		await editor.selectBlocks( addToCartFormBlock );
+
+		await expect(
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
+		).toBeHidden();
+
+		await page
+			.getByRole( 'button', {
+				name: 'Upgrade to the blockified Product Gallery',
+			} )
+			.click();
+
+		await expect(
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
+		).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As discussed in WOOPLUG-5529, we want to fix #60911 by adding a notice to the editor encouraging users of the _Add to Cart + Options_ block to update to the blockified _Product Gallery_ block. This PR implements that: if editing a template with the classic _Product Image Gallery_ block and the _Add to Cart + Options_ block, when selecting the latter a notice is shown encouraging the user to update.

I also took the chance to add an upgrade notice to the _Product Image Gallery_ block itself.

Closes #60911.

### How to test the changes in this Pull Request:

1. Edit the _Single Product_ template making sure the non-blockified _Product Image Gallery_ block and the blockified _Add to Cart + Options_ block are on the page.
2. select the _Add to Cart + Options_ block.
3. Verify in the sidebar there is a notice encouraging you to upgrade the _Product Image Gallery_ block.
4. Click on it and verify the block is updated correctly and the notice disappears.

https://github.com/user-attachments/assets/fd660a50-1078-40b3-9068-04b2fb674744

5. Undo the changes or reload the page.
6. Select the non-blockified _Product Image Gallery_ block.
7. Verify there is a notice to upgrade in the sidebar.
8. Click on it and verify the _Product Image Gallery_ block is updated to the blockified _Product Gallery (Beta)_ block.