### PR TITLE
Fix: respect theme support to control legacy script loading for block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-use-theme-support-to-control-legacy-script-loading-block-theme
+++ b/plugins/woocommerce/changelog/fix-use-theme-support-to-control-legacy-script-loading-block-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Legacy assets: respect theme support when using Classic Template or Product Image Gallery blocks with block themes.

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -510,7 +510,7 @@ class WC_Frontend_Scripts {
 		}
 
 		// Load gallery scripts on product pages only if supported.
-		if ( is_product() || ( ! empty( $post->post_content ) && strstr( $post->post_content, '[product_page' ) ) ) {
+		if ( ( is_product() && ! wp_is_block_theme() ) || ( ! empty( $post->post_content ) && strstr( $post->post_content, '[product_page' ) ) ) {
 			if ( current_theme_supports( 'wc-product-gallery-zoom' ) ) {
 				self::enqueue_script( 'wc-zoom' );
 			}

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -44,6 +44,11 @@ class WC_Template_Loader {
 		if ( self::$theme_support ) {
 			add_filter( 'template_include', array( __CLASS__, 'template_loader' ) );
 			add_filter( 'comments_template', array( __CLASS__, 'comments_template_loader' ) );
+
+			// Loads gallery scripts on Product page for FSE themes.
+			if ( wp_is_block_theme() ) {
+				self::add_support_for_product_page_gallery();
+			}
 		} else {
 			// Unsupported themes.
 			add_action( 'template_redirect', array( __CLASS__, 'unsupported_theme_init' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -108,18 +108,26 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	 */
 	public function enqueue_legacy_assets() {
 		// Legacy script dependencies for backward compatibility.
-		wp_enqueue_script( 'wc-zoom' );
-		wp_enqueue_script( 'wc-flexslider' );
-		wp_enqueue_script( 'wc-photoswipe-ui-default' );
-		wp_enqueue_style( 'photoswipe-default-skin' );
-		wp_enqueue_script( 'wc-single-product' );
+		if ( current_theme_supports( 'wc-product-gallery-zoom' ) ) {
+			wp_enqueue_script( 'wc-zoom' );
+		}
 
-		add_action(
-			'wp_footer',
-			function () {
-				wc_get_template( 'single-product/photoswipe.php' );
-			}
-		);
+		if ( current_theme_supports( 'wc-product-gallery-slider' ) ) {
+			wp_enqueue_script( 'wc-flexslider' );
+		}
+
+		if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
+			wp_enqueue_script( 'wc-photoswipe-ui-default' );
+			wp_enqueue_style( 'photoswipe-default-skin' );
+			add_action(
+				'wp_footer',
+				function () {
+					wc_get_template( 'single-product/photoswipe.php' );
+				}
+			);
+		}
+
+		wp_enqueue_script( 'wc-single-product' );
 	}
 
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImageGallery.php
@@ -53,18 +53,33 @@ class ProductImageGallery extends AbstractBlock {
 	 */
 	public function enqueue_legacy_assets() {
 		// Legacy script dependencies for backward compatibility.
-		wp_enqueue_script( 'wc-zoom' );
-		wp_enqueue_script( 'wc-flexslider' );
-		wp_enqueue_script( 'wc-photoswipe-ui-default' );
-		wp_enqueue_style( 'photoswipe-default-skin' );
-		wp_enqueue_script( 'wc-single-product' );
+		$need_single_product_script = false;
 
-		add_action(
-			'wp_footer',
-			function () {
-				wc_get_template( 'single-product/photoswipe.php' );
-			}
-		);
+		if ( current_theme_supports( 'wc-product-gallery-zoom' ) ) {
+			$need_single_product_script = true;
+			wp_enqueue_script( 'wc-zoom' );
+		}
+
+		if ( current_theme_supports( 'wc-product-gallery-slider' ) ) {
+			$need_single_product_script = true;
+			wp_enqueue_script( 'wc-flexslider' );
+		}
+
+		if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
+			$need_single_product_script = true;
+			wp_enqueue_script( 'wc-photoswipe-ui-default' );
+			wp_enqueue_style( 'photoswipe-default-skin' );
+			add_action(
+				'wp_footer',
+				function () {
+					wc_get_template( 'single-product/photoswipe.php' );
+				}
+			);
+		}
+
+		if ( $need_single_product_script ) {
+			wp_enqueue_script( 'wc-single-product' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #60223

Since #60223, We always load legacy single product assets when using the Classic Template block. This is our effort to improve the frontend performance of the single product page for block themes (by not loading legacy assets by default).

However, this poses an issue for users of the Classic Template block, as they can not opt out of legacy gallery assets anymore using `remove_theme_support`. To resolve this, this PR follows the @Aljullu brilliant suggestion to let us respect theme supports on block themes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet to the test site:
```php
remove_theme_support( 'wc-product-gallery-zoom' );
remove_theme_support( 'wc-product-gallery-lightbox' );
remove_theme_support( 'wc-product-gallery-slider' );
```
2. Ensure the single product template use Classic Template block.
```html
<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
<main class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"single-product"} /--></main>
<!-- /wp:group -->
<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
```
3. Visit a product on the frontend, confirm the legacy gallery assets isn't loaded.
<!-- End testing instructions -->
