### PR TITLE
Fix order summary description text overflow in checkout

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5618-total-amount-overflowing-order-summary-in-checkout
+++ b/plugins/woocommerce/changelog/wooplug-5618-total-amount-overflowing-order-summary-in-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order summary description text overflow in checkout

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -94,6 +94,7 @@
 		padding-left: $gap-large;
 		padding-right: $gap-small;
 		padding-bottom: $gap;
+		word-break: break-word;
 
 		p,
 		.wc-block-components-product-metadata {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Added `word-break` to account for the issue. I think this is the safest default for core. Plugins that purposefully add longer descriptions with not easily breakable strings like email addresses to product descriptions might need to do something smarter to account for the available space.

Closes #61179

### Screenshots or screen recordings:

| Before | After |
|--------|-------|
| <img width="1112" height="708" alt="CleanShot 2025-09-30 at 16 49 21@2x" src="https://github.com/user-attachments/assets/47a0e44d-d4ab-491d-94fe-606d0656abd9" /> | <img width="890" height="762" alt="CleanShot 2025-09-30 at 16 50 20@2x" src="https://github.com/user-attachments/assets/de94f731-0140-4638-ae60-cbdec2b88a48" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit any of your store products' short descriptions to contain a long, non-breakable string (like `Gift from averylongemailaddress@andadomaintoo.com`)
2. Add this product to the cart and go to checkout
3. Verify that the order summary is properly contained (that the total value is not overflowing it)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
