### PR TITLE
Adds core push notifications class and test, adds ability to check Je…

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -388,6 +388,9 @@ final class WooCommerce {
 
 		$container->get( Automattic\WooCommerce\Internal\ProductFilters\MainQueryController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ProductFilters\CacheController::class )->register();
+
+		// Push notifications.
+		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
@@ -27,10 +27,6 @@ class PushNotifications {
 		if ( ! $this->should_be_enabled() ) {
 			return;
 		}
-
-		/**
-		 * Load functionality.
-		 */
 	}
 
 	/**
@@ -45,7 +41,10 @@ class PushNotifications {
 	public function should_be_enabled(): bool {
 		$proxy = wc_get_container()->get( LegacyProxy::class );
 
-		if ( ! $proxy->get_instance_of( Jetpack_Connection_Manager::class )->is_connected() ) {
+		if (
+			! class_exists( JetpackConnectionManager::class )
+			|| ! $proxy->get_instance_of( JetpackConnectionManager::class )->is_connected()
+		) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+
+/**
+ * WC Push Notifications
+ *
+ * Class for setting up the WooCommerce-driven push notifications.
+ */
+class PushNotifications {
+	/**
+	 * Loads the push notifications class.
+	 *
+	 * @since X.X.X
+	 * @return void
+	 */
+	public function register() {
+		if ( ! $this->should_be_enabled() ) {
+			return;
+		}
+
+		/**
+		 * Load functionality.
+		 */
+	}
+
+	/**
+	 * Determines if local push notification functionality should be enabled. It
+	 * should be enabled if:
+	 * - Jetpack is connected
+	 * - WooCommerce.com account is connected
+	 *
+	 * @since X.X.X
+	 * @return bool
+	 */
+	public function should_be_enabled(): bool {
+		$proxy = wc_get_container()->get( LegacyProxy::class );
+
+		if ( ! $proxy->get_instance_of( Jetpack_Connection_Manager::class )->is_connected() ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+
+/**
+ * PushNotifications test.
+ *
+ * @covers PushNotifications
+ */
+class PushNotificationsTest extends WC_Unit_Test_Case {
+	/**
+	 * @var Jetpack_Connection_Manager|MockObject
+	 */
+	private $jetpack_connection_manager_mock;
+
+	public function test_it_can_tell_push_notifications_should_be_enabled_if_jetpack_is_connected() {
+		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$push_notifications = new PushNotifications();
+
+		$this->assertTrue( $push_notifications->should_be_enabled() );
+	}
+
+	public function test_it_can_tell_push_notifications_should_not_be_enabled_if_jetpack_is_not_connected() {
+		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$push_notifications = new PushNotifications();
+
+		$this->assertFalse( $push_notifications->should_be_enabled() );
+	}
+
+	private function set_up_jetpack_connection_manager_mock( array $methods ) {
+		$this->jetpack_connection_manager_mock = $this
+			->getMockBuilder( Jetpack_Connection_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( $methods )
+			->getMock();
+
+		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
+			array( Jetpack_Connection_Manager::class => $this->jetpack_connection_manager_mock )
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -2,9 +2,12 @@
 
 declare( strict_types = 1 );
 
-use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications;
+
+use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WC_Unit_Test_Case;
 
 /**
  * PushNotifications test.
@@ -13,10 +16,13 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
  */
 class PushNotificationsTest extends WC_Unit_Test_Case {
 	/**
-	 * @var Jetpack_Connection_Manager|MockObject
+	 * @var JetpackConnectionManager|MockObject
 	 */
 	private $jetpack_connection_manager_mock;
 
+	/**
+	 * Tests the functionality is enabled if Jetpack is connected.
+	 */
 	public function test_it_can_tell_push_notifications_should_be_enabled_if_jetpack_is_connected() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
@@ -30,6 +36,9 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $push_notifications->should_be_enabled() );
 	}
 
+	/**
+	 * Tests the functionality is disabled if Jetpack is not connected.
+	 */
 	public function test_it_can_tell_push_notifications_should_not_be_enabled_if_jetpack_is_not_connected() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
@@ -43,15 +52,20 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 		$this->assertFalse( $push_notifications->should_be_enabled() );
 	}
 
+	/**
+	 * Sets up the Jetpack connection manager mocking.
+	 *
+	 * @param array $methods The methods that will be mocked.
+	 */
 	private function set_up_jetpack_connection_manager_mock( array $methods ) {
 		$this->jetpack_connection_manager_mock = $this
-			->getMockBuilder( Jetpack_Connection_Manager::class )
+			->getMockBuilder( JetpackConnectionManager::class )
 			->disableOriginalConstructor()
 			->onlyMethods( $methods )
 			->getMock();
 
 		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
-			array( Jetpack_Connection_Manager::class => $this->jetpack_connection_manager_mock )
+			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Focus: Woo-driven Push Notifications
Team: Apps Infrastructure

Changes:
* Adds the base class that will load/control push notification functionality
* Conditionally loads the functionality if Jetpack is connected

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the relevant tests: `pnpm run test:php:env -- --filter=tests/php/includes/push-notifications`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an interim pull request to a larger feature branch, a changelog will be written for the PR into `trunk`

</details>
