### PR TITLE
Don't run the Legacy MiniCart e2e tests twice in the normal run

### DIFF
--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -76,7 +76,7 @@
 		"watch:build:storybook": "wireit",
 		"test:js": "wp-scripts test-unit-js --config tests/js/jest.config.json",
 		"test:debug": "ndb .",
-		"test:e2e": "sh ./bin/check-env.sh && pnpm playwright test --config=tests/e2e/playwright.config.ts",
+		"test:e2e": "sh ./bin/check-env.sh && pnpm playwright test --config=tests/e2e/playwright.config.ts --project=chromium",
 		"test:e2e:block-theme": "pnpm run test:e2e block_theme",
 		"test:e2e:classic-theme": "pnpm run test:e2e classic_theme",
 		"test:e2e:block-theme-with-templates": "pnpm run test:e2e block_theme_with_templates",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes an issue where some end-to-end tests for WooCommerce Blocks were running twice.

Previously, in https://github.com/woocommerce/woocommerce/pull/60823, a `legacy-mini-cart` project was added to `playwright.config.ts` to test the Mini Cart functionality with the legacy (React) implementation. However, the `test:e2e` command in the `package.json` was running all projects (both `chromium` and `legacy-mini-cart`), causing tests that matched the `legacy-mini-cart` pattern to run twice.

This change updates the `test:e2e` command to explicitly run only the `chromium` project, ensuring that:
- Regular e2e tests run once with the new iAPI Mini Cart (via `chromium` project)
- Legacy Mini Cart tests run once with the legacy React Mini Cart (via `legacy-mini-cart` project)

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/block-library test:e2e` and verify that Mini Cart tests only run once (not twice)
2. Check the console output to confirm that only the `chromium` project is being executed.
3. Run `pnpm --filter=@woocommerce/block-library test:e2e:legacy-mini-cart` and verify that the legacy Mini Cart tests run correctly with the legacy implementation.

### Testing that has already taken place:

Verified that the `test:e2e` command now only runs the `chromium` project and Mini Cart tests execute once instead of twice.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is an internal testing configuration change that does not affect the plugin functionality or user-facing features. It only modifies how end-to-end tests are executed to prevent duplicate test runs.

</details>
