### PR TITLE
WPS Migration: persist initial selected shipping option

### DIFF
--- a/plugins/woocommerce/changelog/61217-fix-initial-shipping
+++ b/plugins/woocommerce/changelog/61217-fix-initial-shipping
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Persist the initially selected shipping option in the PayPal payment page.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
@@ -309,7 +309,7 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 		if ( $order_shipping_item ) {
 			$method_id   = $order_shipping_item->get_method_id();
 			$instance_id = $order_shipping_item->get_instance_id();
-			$rate_id     = $instance_id ? "{$method_id}:{$instance_id}" : $method_id;
+			$rate_id     = ( '' === $instance_id || null === $instance_id ) ? $method_id : "{$method_id}:{$instance_id}";
 
 			return $rate_id;
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
@@ -186,6 +186,12 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 				}
 			}
 		}
+
+		// Re-apply shipping methods present on the order so totals are accurate.
+		$order_shipping_rate_id = $this->get_order_shipping_rate_id( $order );
+		if ( ! empty( $order_shipping_rate_id ) ) {
+			WC()->session->set( 'chosen_shipping_methods', array( $order_shipping_rate_id ) );
+		}
 	}
 
 	/**
@@ -246,7 +252,8 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 	 */
 	private function get_updated_shipping_options( $order, $selected_shipping_option ) {
 		WC()->cart->calculate_shipping();
-		$packages = WC()->shipping()->get_packages();
+		$packages               = WC()->shipping()->get_packages();
+		$order_shipping_rate_id = $this->get_order_shipping_rate_id( $order );
 
 		$has_selected_shipping_option = false;
 		$options                      = array();
@@ -258,7 +265,14 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 				}
 
 				$shipping_option_id = $rate->get_id();
-				$is_selected        = isset( $selected_shipping_option['id'] ) && $shipping_option_id === $selected_shipping_option['id'];
+				// If a selected shipping option is sent in the request, check if it matches the shipping option id.
+				// Otherwise, if the order has a shipping method, check if the rate id matches the shipping option id.
+				if ( isset( $selected_shipping_option['id'] ) ) {
+					$is_selected = $shipping_option_id === $selected_shipping_option['id'];
+				} else {
+					$is_selected = $shipping_option_id === $order_shipping_rate_id;
+				}
+				
 				if ( $is_selected ) {
 					$has_selected_shipping_option = true;
 				}
@@ -281,6 +295,26 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * Get the shipping rate id from the order.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @return string The shipping rate id.
+	 */
+	private function get_order_shipping_rate_id( $order ) {
+		$order_shipping_item = ! empty( $order->get_items('shipping') ) ? current( $order->get_items('shipping') ) : null;
+
+		if ( $order_shipping_item ) {
+			$method_id   = $order_shipping_item->get_method_id();
+			$instance_id = $order_shipping_item->get_instance_id();
+			$rate_id     = $instance_id ? "{$method_id}:{$instance_id}" : $method_id;
+
+			return $rate_id;
+		}
+
+		return '';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
@@ -304,7 +304,7 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 	 * @return string The shipping rate id.
 	 */
 	private function get_order_shipping_rate_id( $order ) {
-		$order_shipping_item = ! empty( $order->get_items( 'shipping' ) ) ? current( $order->get_items( 'shipping' ) ) : null;
+		$order_shipping_item = current( $order->get_items( 'shipping' ) ) ?? null;
 
 		if ( $order_shipping_item ) {
 			$method_id   = $order_shipping_item->get_method_id();

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-standard-controller.php
@@ -272,7 +272,7 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 				} else {
 					$is_selected = $shipping_option_id === $order_shipping_rate_id;
 				}
-				
+
 				if ( $is_selected ) {
 					$has_selected_shipping_option = true;
 				}
@@ -304,7 +304,7 @@ class WC_REST_Paypal_Standard_Controller extends WC_REST_Controller {
 	 * @return string The shipping rate id.
 	 */
 	private function get_order_shipping_rate_id( $order ) {
-		$order_shipping_item = ! empty( $order->get_items('shipping') ) ? current( $order->get_items('shipping') ) : null;
+		$order_shipping_item = ! empty( $order->get_items( 'shipping' ) ) ? current( $order->get_items( 'shipping' ) ) : null;
 
 		if ( $order_shipping_item ) {
 			$method_id   = $order_shipping_item->get_method_id();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Using the order's shipping method when rebuilding the cart from order data in the rest request.  
This rest endpoint is called by PayPal for `SHIPPING_ADDRESS` and `SHIPPING_OPTIONS` callback events.


Closes PAYPAL-95

### How to test the changes in this Pull Request:

1. Checkout to `trunk` branch.
2. Enable PayPal Standard: `wp option patch update woocommerce_paypal_settings _should_load 'yes'`
3. Check this P2 page (PeNR48-1Pt-p2) for instructions on PayPal Standard setup.
4. Create 3 shipping methods of $0, $10 and $20.
5. As a shopper, add a product to your cart and go to the checkout page.
6. Select the 2nd or 3rd shipping method.
7. Select PayPal from the payment methods list and click checkout.
8. You will be redirected to the PayPal page. 
9. Notice that, the shipping method you selected on the checkout page did not persist. Rather the 1st shipping method is selected.
10. Now checkout this branch.
11. Follow steps 5-8 again.
12. On the PayPal page, verify that the shipping method you selected on the checkout page is selected.
13. Complete the payment and verify that the correct amount is charged.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Persist the initially selected shipping option in the PayPal payment page. 


</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>