### PR TITLE
Add to Cart + Options: fix Grouped Product inner blocks not visible in the editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-product-not-visible-in-editor
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-product-not-visible-in-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add to Cart + Options: fix Grouped Product inner blocks not visible in the editor
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
@@ -91,7 +91,7 @@ export default function ProductItemTemplateEdit(
 	const [ products, setProducts ] = useState< ProductResponseItem[] | null >(
 		null
 	);
-	const productsLength = products?.length;
+	const productsLength = products?.length || 0;
 
 	useEffect( () => {
 		const fetchChildProducts = async ( groupedProductIds: number[] ) => {
@@ -110,12 +110,7 @@ export default function ProductItemTemplateEdit(
 				} );
 		};
 
-		if (
-			! isLoading &&
-			product &&
-			product.type === 'grouped' &&
-			productsLength === 0
-		) {
+		if ( ! isLoading && product && productsLength === 0 ) {
 			if ( isProductResponseItem( product ) ) {
 				fetchChildProducts( product.grouped_products );
 			} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a regression that caused the grouped product inner blocks not to be displayed in the _Site Editor_ when using the _Add to Cart + Options_.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/61023.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Add (if it's missing) the _Add to Cart + Options_ block.
3. Switch to the _grouped product_ type.
4. Verify inner blocks are rendered.

Before | After
--- | ---
<img width="1062" height="566" alt="imatge" src="https://github.com/user-attachments/assets/2be42f28-8924-43ec-8879-2ab2dadf3eae" /> | <img width="1062" height="566" alt="imatge" src="https://github.com/user-attachments/assets/e95214fa-3cb2-4252-8ba0-0087f78a586d" />