### PR TITLE
Add and update some comments in template classes and the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/update-template-and-add-to-cart-with-options-old-comments
+++ b/plugins/woocommerce/changelog/update-template-and-add-to-cart-with-options-old-comments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Update some old comments in template classes and the Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -32,6 +32,18 @@ const { state: productDataState } = store< ProductDataStore >(
 	{ lock: universalLock }
 );
 
+/**
+ * Manually dispatches a 'change' event on the quantity input element.
+ *
+ * When users click the plus/minus stepper buttons, no 'change' event is fired
+ * since there is no direct interaction with the input. However, some extensions
+ * rely on the change event to detect quantity changes. This function ensures
+ * those extensions continue working by programmatically dispatching the event.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/53031
+ *
+ * @param inputElement - The quantity input element to dispatch the event on.
+ */
 export const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
 	const event = new Event( 'change', { bubbles: true } );
 	inputElement.dispatchEvent( event );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
@@ -42,6 +42,18 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 	};
 };
 
+/**
+ * Manually dispatches a 'change' event on the quantity input element.
+ *
+ * When users click the plus/minus stepper buttons, no 'change' event is fired
+ * since there is no direct interaction with the input. However, some extensions
+ * rely on the change event to detect quantity changes. This function ensures
+ * those extensions continue working by programmatically dispatching the event.
+ *
+ * @see https://github.com/woocommerce/woocommerce/issues/53031
+ *
+ * @param inputElement - The quantity input element to dispatch the event on.
+ */
 const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
 	const event = new Event( 'change', { bubbles: true } );
 

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/templates/individual-template-classes.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/templates/individual-template-classes.md
@@ -24,6 +24,7 @@ This allows us to hook into WooCommerce core through the filter `woocommerce_has
 
 * Determining if the block template has to be rendered in the current page. If so, we override the value through `woocommerce_has_block_template` to resolve `true`.
 * Determining if the page that will be rendered contains a Legacy Template block, in which case we disable the compatibility layer through the `woocommerce_disable_compatibility_layer` filter.
+* Running other template-specific logic.
 
 **Return value:**
 

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateWithFallback.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateWithFallback.php
@@ -49,7 +49,7 @@ abstract class AbstractTemplateWithFallback extends AbstractTemplate {
 	}
 
 	/**
-	 * Render the block template.
+	 * Run template-specific logic when the query matches the template.
 	 */
 	abstract public function render_block_template();
 }

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateWithFallback.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateWithFallback.php
@@ -49,7 +49,14 @@ abstract class AbstractTemplateWithFallback extends AbstractTemplate {
 	}
 
 	/**
-	 * Run template-specific logic when the query matches the template.
+	 * This method is hooked to WordPress' 'template_redirect' action and allows
+	 * template classes to:
+	 * 1. Decide when block templates should be rendered based on the context.
+	 * 2. Execute specific logic, such as managing the compatibility layer for
+	 *    legacy template support.
+	 *
+	 * Child classes must implement this method to define their template
+	 * rendering conditions and any additional template-specific behavior.
 	 */
 	abstract public function render_block_template();
 }

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -45,7 +45,7 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		$queried_object = get_queried_object();

--- a/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
@@ -52,7 +52,7 @@ class ProductBrandTemplate extends AbstractTemplateWithFallback {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_brand' ) ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -46,7 +46,7 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) && ! is_search() ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
@@ -52,7 +52,7 @@ class ProductCategoryTemplate extends AbstractTemplateWithFallback {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_cat' ) ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -45,7 +45,7 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_post_type_archive( 'product' ) && is_search() ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
@@ -52,7 +52,7 @@ class ProductTagTemplate extends AbstractTemplateWithFallback {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_tag' ) ) {

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -48,7 +48,7 @@ class SingleProductTemplate extends AbstractTemplate {
 	}
 
 	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 * Run template-specific logic when the query matches this template.
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_singular( 'product' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

_(Kudos to Billow for finding these issues)_

This PR:

* Adds a comment explaining why `dispatchChangeEvent()` is needed in the non-blockified _Add to Cart with Options_ block and the blockified _Add to Cart + Options_ block.
* Updates some comments in the `render_block_template()` method of the template classes which were confusing. I replaced them with a very generic comment on purpose to avoid it getting out of sync with the code again in the future.

### How to test the changes in this Pull Request:

1. Nothing to test given that all changes are in comments.
