### PR TITLE
Remove cart contents session on next user initiated request

### DIFF
--- a/plugins/woocommerce/changelog/update-60950-3
+++ b/plugins/woocommerce/changelog/update-60950-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Remove cart contents session on next user initiated request

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -715,7 +715,9 @@ final class WC_Cart_Session {
 	 * @return bool True if expired items should be removed, false otherwise.
 	 */
 	public function clean_up_removed_cart_contents() {
-		if ( is_404() ) {
+		$is_page = is_singular() || is_archive() || is_search();
+
+		if ( is_404() || ! $is_page || is_admin() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -715,9 +715,9 @@ final class WC_Cart_Session {
 	 * @return bool True if expired items should be removed, false otherwise.
 	 */
 	public function clean_up_removed_cart_contents() {
+		// Limit to page requests initiated by the user.
 		$is_page = is_singular() || is_archive() || is_search();
-
-		if ( is_404() || ! $is_page || is_admin() ) {
+		if ( is_404() || ! $is_page ) {
 			return;
 		}
 
@@ -727,5 +727,6 @@ final class WC_Cart_Session {
 		}
 
 		WC()->session->set( 'removed_cart_contents', null );
+		$this->cart->set_removed_cart_contents( array() );
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -86,6 +86,8 @@ final class WC_Cart_Session {
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
 		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
 		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
+
+		add_action( 'template_redirect', array( $this, 'clean_up_removed_cart_contents' ) );
 	}
 
 	/**
@@ -105,7 +107,10 @@ final class WC_Cart_Session {
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
 		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
-		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
+
+		// Get removed cart contents with time-based expiration.
+		$removed_cart_contents = $this->get_processed_removed_cart_contents();
+		$this->cart->set_removed_cart_contents( $removed_cart_contents );
 
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
@@ -406,6 +411,9 @@ final class WC_Cart_Session {
 		$coupon_discount_tax_totals = $this->cart->get_coupon_discount_tax_totals();
 		$removed_cart_contents      = $this->cart->get_removed_cart_contents();
 
+		// Process removed cart contents with timestamps and expiration.
+		$processed_removed_contents = $this->set_removed_cart_contents( $removed_cart_contents );
+
 		/*
 		 * We want to clear out any empty/default data from the session that have no value in being stored so the session
 		 * can be forgotten if empty.
@@ -415,7 +423,7 @@ final class WC_Cart_Session {
 		$wc_session->set( 'applied_coupons', empty( $applied_coupons ) ? null : $applied_coupons );
 		$wc_session->set( 'coupon_discount_totals', empty( $coupon_discount_totals ) ? null : $coupon_discount_totals );
 		$wc_session->set( 'coupon_discount_tax_totals', empty( $coupon_discount_tax_totals ) ? null : $coupon_discount_tax_totals );
-		$wc_session->set( 'removed_cart_contents', empty( $removed_cart_contents ) ? null : $removed_cart_contents );
+		$wc_session->set( 'removed_cart_contents', empty( $processed_removed_contents ) ? null : $processed_removed_contents );
 		if ( empty( $cart ) ) {
 			$this->remove_draft_order();
 		}
@@ -705,5 +713,82 @@ final class WC_Cart_Session {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Get removed cart contents with time-based expiration (5 minutes).
+	 *
+	 * @return array Processed removed cart contents.
+	 */
+	private function get_processed_removed_cart_contents() {
+		$removed_contents = WC()->session->get( 'removed_cart_contents', array() );
+
+		if ( empty( $removed_contents ) ) {
+			return array();
+		}
+
+		$current_time       = time();
+		$expiration_time    = 5 * MINUTE_IN_SECONDS;
+		$processed_contents = array();
+		$has_expired_items  = false;
+
+		foreach ( $removed_contents as $key => $item ) {
+			$item_timestamp = isset( $item['removed_timestamp'] ) ? $item['removed_timestamp'] : 0;
+
+			if ( 0 === $item_timestamp ) {
+				$item['removed_timestamp'] = $current_time;
+			}
+
+			if ( ( $current_time - $item_timestamp ) > $expiration_time ) {
+				$has_expired_items = true;
+				continue;
+			}
+
+			$processed_contents[ $key ] = $item;
+		}
+
+		if ( $has_expired_items ) {
+			WC()->session->set( 'removed_cart_contents', empty( $processed_contents ) ? null : $processed_contents );
+		}
+
+		return $processed_contents;
+	}
+
+	/**
+	 * Set removed cart contents with timestamps for expiration tracking.
+	 *
+	 * @param array $removed_contents The removed cart contents to process.
+	 * @return array Processed removed cart contents with timestamps.
+	 */
+	private function set_removed_cart_contents( $removed_contents ) {
+		if ( empty( $removed_contents ) ) {
+			return array();
+		}
+
+		$current_time       = time();
+		$processed_contents = array();
+
+		foreach ( $removed_contents as $key => $item ) {
+			if ( ! isset( $item['removed_timestamp'] ) ) {
+				$item['removed_timestamp'] = $current_time;
+			}
+			$processed_contents[ $key ] = $item;
+		}
+
+		return $processed_contents;
+	}
+
+	/**
+	 * Removes items from the removed cart contents on next user initiatedrequest.
+	 *
+	 * @return bool True if expired items should be removed, false otherwise.
+	 */
+	public function clean_up_removed_cart_contents() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['undo_item'] ) ) {
+			return;
+		}
+
+		WC()->session->set( 'removed_cart_contents', null );
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -107,10 +107,7 @@ final class WC_Cart_Session {
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
 		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
-
-		// Get removed cart contents with time-based expiration.
-		$removed_cart_contents = $this->get_processed_removed_cart_contents();
-		$this->cart->set_removed_cart_contents( $removed_cart_contents );
+		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
 
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
@@ -411,9 +408,6 @@ final class WC_Cart_Session {
 		$coupon_discount_tax_totals = $this->cart->get_coupon_discount_tax_totals();
 		$removed_cart_contents      = $this->cart->get_removed_cart_contents();
 
-		// Process removed cart contents with timestamps and expiration.
-		$processed_removed_contents = $this->set_removed_cart_contents( $removed_cart_contents );
-
 		/*
 		 * We want to clear out any empty/default data from the session that have no value in being stored so the session
 		 * can be forgotten if empty.
@@ -423,7 +417,7 @@ final class WC_Cart_Session {
 		$wc_session->set( 'applied_coupons', empty( $applied_coupons ) ? null : $applied_coupons );
 		$wc_session->set( 'coupon_discount_totals', empty( $coupon_discount_totals ) ? null : $coupon_discount_totals );
 		$wc_session->set( 'coupon_discount_tax_totals', empty( $coupon_discount_tax_totals ) ? null : $coupon_discount_tax_totals );
-		$wc_session->set( 'removed_cart_contents', empty( $processed_removed_contents ) ? null : $processed_removed_contents );
+		$wc_session->set( 'removed_cart_contents', empty( $removed_cart_contents ) ? null : $removed_cart_contents );
 		if ( empty( $cart ) ) {
 			$this->remove_draft_order();
 		}
@@ -716,74 +710,15 @@ final class WC_Cart_Session {
 	}
 
 	/**
-	 * Get removed cart contents with time-based expiration (5 minutes).
-	 *
-	 * @return array Processed removed cart contents.
-	 */
-	private function get_processed_removed_cart_contents() {
-		$removed_contents = WC()->session->get( 'removed_cart_contents', array() );
-
-		if ( empty( $removed_contents ) ) {
-			return array();
-		}
-
-		$current_time       = time();
-		$expiration_time    = 5 * MINUTE_IN_SECONDS;
-		$processed_contents = array();
-		$has_expired_items  = false;
-
-		foreach ( $removed_contents as $key => $item ) {
-			$item_timestamp = isset( $item['removed_timestamp'] ) ? $item['removed_timestamp'] : 0;
-
-			if ( 0 === $item_timestamp ) {
-				$item['removed_timestamp'] = $current_time;
-			}
-
-			if ( ( $current_time - $item_timestamp ) > $expiration_time ) {
-				$has_expired_items = true;
-				continue;
-			}
-
-			$processed_contents[ $key ] = $item;
-		}
-
-		if ( $has_expired_items ) {
-			WC()->session->set( 'removed_cart_contents', empty( $processed_contents ) ? null : $processed_contents );
-		}
-
-		return $processed_contents;
-	}
-
-	/**
-	 * Set removed cart contents with timestamps for expiration tracking.
-	 *
-	 * @param array $removed_contents The removed cart contents to process.
-	 * @return array Processed removed cart contents with timestamps.
-	 */
-	private function set_removed_cart_contents( $removed_contents ) {
-		if ( empty( $removed_contents ) ) {
-			return array();
-		}
-
-		$current_time       = time();
-		$processed_contents = array();
-
-		foreach ( $removed_contents as $key => $item ) {
-			if ( ! isset( $item['removed_timestamp'] ) ) {
-				$item['removed_timestamp'] = $current_time;
-			}
-			$processed_contents[ $key ] = $item;
-		}
-
-		return $processed_contents;
-	}
-
-	/**
-	 * Removes items from the removed cart contents on next user initiatedrequest.
+	 * Removes items from the removed cart contents on next user initiated request.
 	 *
 	 * @return bool True if expired items should be removed, false otherwise.
 	 */
 	public function clean_up_removed_cart_contents() {
+		if ( is_404() ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['undo_item'] ) ) {
 			return;

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Unit tests for cart item removal functionality.
+ *
+ * @package WooCommerce\Tests\Cart
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+
+/**
+ * Class WC_Cart_Item_Removal_Test
+ */
+class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up test data.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		$this->cart = new WC_Cart();
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		$this->product->delete( true );
+		$this->cart->empty_cart();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that get_removed_cart_contents returns an array.
+	 */
+	public function test_get_removed_cart_contents_returns_array() {
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertIsArray( $removed );
+		$this->assertEmpty( $removed );
+	}
+
+	/**
+	 * Test that set_removed_cart_contents works correctly.
+	 */
+	public function test_set_removed_cart_contents() {
+		$test_data = array(
+			'test_key' => array(
+				'product_id'   => 123,
+				'quantity'     => 2,
+				'variation_id' => 0,
+			),
+		);
+
+		$this->cart->set_removed_cart_contents( $test_data );
+		$removed = $this->cart->get_removed_cart_contents();
+
+		$this->assertEquals( $test_data, $removed );
+	}
+
+	/**
+	 * Test that remove_cart_item stores item in removed_cart_contents.
+	 */
+	public function test_remove_cart_item_stores_in_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->assertNotEmpty( $cart_item_key );
+
+		$cart_item = $this->cart->get_cart_item( $cart_item_key );
+		$this->assertNotEmpty( $cart_item );
+
+		$result = $this->cart->remove_cart_item( $cart_item_key );
+		$this->assertTrue( $result );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertArrayHasKey( $cart_item_key, $removed );
+		$this->assertEquals( $cart_item['product_id'], $removed[ $cart_item_key ]['product_id'] );
+		$this->assertEquals( $cart_item['quantity'], $removed[ $cart_item_key ]['quantity'] );
+		$this->assertArrayNotHasKey( 'data', $removed[ $cart_item_key ] );
+	}
+
+	/**
+	 * Test that remove_cart_item fires the correct hooks.
+	 */
+	public function test_remove_cart_item_fires_hooks() {
+		$hooks_fired = array();
+
+		add_action(
+			'woocommerce_remove_cart_item',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_remove_cart_item'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_cart_item_removed',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_cart_item_removed'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertArrayHasKey( 'woocommerce_remove_cart_item', $hooks_fired );
+		$this->assertArrayHasKey( 'woocommerce_cart_item_removed', $hooks_fired );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_remove_cart_item'][0] );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_cart_item_removed'][0] );
+	}
+
+	/**
+	 * Test restore_cart_item with removed_cart_contents (backward compatibility).
+	 */
+	public function test_restore_cart_item_with_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertEmpty( $this->cart->get_cart() );
+
+		$result = $this->cart->restore_cart_item( $cart_item_key );
+
+		$this->assertTrue( $result );
+
+		$cart_item = $this->cart->get_cart_item( $cart_item_key );
+		$this->assertNotEmpty( $cart_item );
+		$this->assertEquals( $this->product->get_id(), $cart_item['product_id'] );
+		$this->assertEquals( 2, $cart_item['quantity'] );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertArrayNotHasKey( $cart_item_key, $removed );
+	}
+
+	/**
+	 * Test restore_cart_item fires the correct hooks.
+	 */
+	public function test_restore_cart_item_fires_hooks() {
+		$hooks_fired = array();
+
+		add_action(
+			'woocommerce_restore_cart_item',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_restore_cart_item'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_cart_item_restored',
+			function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
+				$hooks_fired['woocommerce_cart_item_restored'] = array( $cart_item_key, $cart );
+			},
+			10,
+			2
+		);
+
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$this->cart->restore_cart_item( $cart_item_key );
+
+		$this->assertArrayHasKey( 'woocommerce_restore_cart_item', $hooks_fired );
+		$this->assertArrayHasKey( 'woocommerce_cart_item_restored', $hooks_fired );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_restore_cart_item'][0] );
+		$this->assertEquals( $cart_item_key, $hooks_fired['woocommerce_cart_item_restored'][0] );
+	}
+
+	/**
+	 * Test restore_cart_item returns false for non-existent items.
+	 */
+	public function test_restore_cart_item_returns_false_for_non_existent() {
+		$result = $this->cart->restore_cart_item( 'non_existent_key' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that empty_cart clears removed_cart_contents.
+	 */
+	public function test_empty_cart_clears_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertNotEmpty( $removed );
+
+		$this->cart->empty_cart();
+
+		$removed = $this->cart->get_removed_cart_contents();
+		$this->assertEmpty( $removed );
+	}
+
+	/**
+	 * Test that plugins can access get_removed_cart_contents method.
+	 */
+	public function test_plugins_can_access_get_removed_cart_contents() {
+		$removed_contents = $this->cart->get_removed_cart_contents();
+
+		$this->assertIsArray( $removed_contents );
+		$this->assertEmpty( $removed_contents );
+	}
+
+	/**
+	 * Test that plugins can still modify removed_cart_contents.
+	 */
+	public function test_plugins_can_modify_removed_contents() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents                                   = $this->cart->get_removed_cart_contents();
+		$removed_contents[ $cart_item_key ]['custom_field'] = 'plugin_added_value';
+		$this->cart->set_removed_cart_contents( $removed_contents );
+
+		$modified_contents = $this->cart->get_removed_cart_contents();
+		$this->assertEquals( 'plugin_added_value', $modified_contents[ $cart_item_key ]['custom_field'] );
+	}
+
+	/**
+	 * Test that plugins can still access removed_cart_contents after restore.
+	 */
+	public function test_plugins_can_access_removed_contents_after_restore() {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents = $this->cart->get_removed_cart_contents();
+		$this->assertArrayHasKey( $cart_item_key, $removed_contents );
+
+		$this->cart->restore_cart_item( $cart_item_key );
+
+		$removed_contents_after = $this->cart->get_removed_cart_contents();
+		$this->assertArrayNotHasKey( $cart_item_key, $removed_contents_after );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-item-removal-test.php
@@ -238,4 +238,140 @@ class WC_Cart_Item_Removal_Test extends \WC_Unit_Test_Case {
 		$removed_contents_after = $this->cart->get_removed_cart_contents();
 		$this->assertArrayNotHasKey( $cart_item_key, $removed_contents_after );
 	}
+
+	/**
+	 * Data provider for clean_up_removed_cart_contents returns early tests.
+	 *
+	 * @return array
+	 */
+	public function data_provider_clean_up_returns_early() {
+		return array(
+			'404 page'            => array(
+				'is_404'      => true,
+				'is_singular' => false,
+				'is_archive'  => false,
+				'is_search'   => false,
+				'undo_item'   => null,
+			),
+			'non-page request'    => array(
+				'is_404'      => false,
+				'is_singular' => false,
+				'is_archive'  => false,
+				'is_search'   => false,
+				'undo_item'   => null,
+			),
+			'undo_item parameter' => array(
+				'is_404'      => false,
+				'is_singular' => true,
+				'is_archive'  => false,
+				'is_search'   => false,
+				'undo_item'   => 'test_key',
+			),
+		);
+	}
+
+	/**
+	 * Test clean_up_removed_cart_contents returns early for various conditions.
+	 *
+	 * @dataProvider data_provider_clean_up_returns_early
+	 * @param bool   $is_404      Whether this is a 404 page.
+	 * @param bool   $is_singular Whether this is a singular page.
+	 * @param bool   $is_archive  Whether this is an archive page.
+	 * @param bool   $is_search   Whether this is a search page.
+	 * @param string $undo_item   The undo_item GET parameter value.
+	 */
+	public function test_clean_up_removed_cart_contents_returns_early( $is_404, $is_singular, $is_archive, $is_search, $undo_item ) {
+		// Set up removed cart contents.
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents = $this->cart->get_removed_cart_contents();
+		$this->assertNotEmpty( $removed_contents );
+
+		if ( $undo_item ) {
+			$_GET['undo_item'] = $undo_item;
+		}
+
+		global $wp_query;
+		$original_wp_query     = $wp_query;
+		$wp_query->is_404      = $is_404;
+		$wp_query->is_singular = $is_singular;
+		$wp_query->is_archive  = $is_archive;
+		$wp_query->is_search   = $is_search;
+
+		$cart_session = new WC_Cart_Session( $this->cart );
+		$cart_session->clean_up_removed_cart_contents();
+
+		$removed_contents_after = $this->cart->get_removed_cart_contents();
+		$this->assertNotEmpty( $removed_contents_after );
+		$this->assertEquals( $removed_contents, $removed_contents_after );
+
+		if ( $undo_item ) {
+			unset( $_GET['undo_item'] );
+		}
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query = $original_wp_query;
+	}
+
+	/**
+	 * Data provider for clean_up_removed_cart_contents clears contents tests.
+	 *
+	 * @return array
+	 */
+	public function data_provider_clean_up_clears_contents() {
+		return array(
+			'singular page' => array(
+				'is_404'      => false,
+				'is_singular' => true,
+				'is_archive'  => false,
+				'is_search'   => false,
+			),
+			'archive page'  => array(
+				'is_404'      => false,
+				'is_singular' => false,
+				'is_archive'  => true,
+				'is_search'   => false,
+			),
+			'search page'   => array(
+				'is_404'      => false,
+				'is_singular' => false,
+				'is_archive'  => false,
+				'is_search'   => true,
+			),
+		);
+	}
+
+	/**
+	 * Test clean_up_removed_cart_contents clears removed_cart_contents on various page types.
+	 *
+	 * @dataProvider data_provider_clean_up_clears_contents
+	 * @param bool $is_404      Whether this is a 404 page.
+	 * @param bool $is_singular Whether this is a singular page.
+	 * @param bool $is_archive  Whether this is an archive page.
+	 * @param bool $is_search   Whether this is a search page.
+	 */
+	public function test_clean_up_removed_cart_contents_clears_contents( $is_404, $is_singular, $is_archive, $is_search ) {
+		$cart_item_key = $this->cart->add_to_cart( $this->product->get_id(), 2 );
+		$this->cart->remove_cart_item( $cart_item_key );
+
+		$removed_contents = $this->cart->get_removed_cart_contents();
+		$this->assertNotEmpty( $removed_contents );
+
+		global $wp_query;
+		$original_wp_query     = $wp_query;
+		$wp_query->is_404      = $is_404;
+		$wp_query->is_singular = $is_singular;
+		$wp_query->is_archive  = $is_archive;
+		$wp_query->is_search   = $is_search;
+
+		$cart_session = new WC_Cart_Session( $this->cart );
+		$cart_session->clean_up_removed_cart_contents();
+
+		$removed_contents_after = $this->cart->get_removed_cart_contents();
+		$this->assertEmpty( $removed_contents_after );
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query = $original_wp_query;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is an alternative approach to https://github.com/woocommerce/woocommerce/pull/61030 where bugs were discovered with Product Bundles undo implementation.

This PR removes `removed_cart_contents` from the session after the next request so that the undo functionality continues to work for the following user request and requests can be edge cached after a cart is emptied.  This results in much higher performance where edge caching is available and was previously missed until the session was fully cleared.

* Remove `removed_cart_contents` from the session on the next user request after an item was removed
* (optional) Expiration times have been added to the session data, but we can probably stick with one approach as this should not be necessary if the above is working correctly

Closes #60950 .

### Screenshots or screen recordings:

<img width="476" height="163" alt="Screenshot 2025-09-17 at 11 26 48 AM" src="https://github.com/user-attachments/assets/a0365241-6507-4a4e-9470-c49a05318d44" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```php
add_action(
	'wp_head',
	function () {
		$session = WC()->session;
		echo '<pre>' . print_r( $session->get_session_data(), true ) . '</pre>';
	}
);
add_action(
	'woocommerce_remove_cart_item',
	function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
		error_log( 'woocommerce_remove_cart_item' );
		error_log( print_r( $cart_item_key, true ) );
		error_log( print_r( $cart, true ) );
	},
	10,
	2
);
add_action(
	'woocommerce_cart_item_removed',
	function ( $cart_item_key, $cart ) use ( &$hooks_fired ) {
		error_log( 'woocommerce_removed_cart_item' );
		error_log( print_r( $cart_item_key, true ) );
		error_log( print_r( $cart, true ) );
	},
	10,
	2
);
```

1. Add the above snippet to your site
2. Set up a classic cart page and block
3. Note that `removed_cart_contents` does not exist in your session at the top of the screen
4. On your classic cart, add an item to the cart
5. Remove the item from the cart
6. Note that `removed_cart_contents` exists in the ssion
7. Click the "Undo?" option in the notice
8. Make sure the item is restored to the cart
9. Remove the item from the cart
10. Refresh the page twice (once to remove the session data and another to see it reflected in the snippet after it was remvoed)
11. Note that `removed_cart_contents` has been removed from the session
12. Check your error logs and make sure that the appropriate hooks are still firing and show the correct data
13. Optionally, test with some plugins that make use of the removed_cart_contents getters, setters, hooks, or attempt to modify session.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
