### PR TITLE
Add hook for order refund updates

### DIFF
--- a/plugins/woocommerce/changelog/fix-50085-part-2
+++ b/plugins/woocommerce/changelog/fix-50085-part-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add hook 'woocommerce_update_order_refund' for refund updates.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -94,6 +94,25 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 	}
 
 	/**
+	 * Method to update a refund in the database.
+	 *
+	 * @param \WC_Order_Refund $refund Refund object.
+	 */
+	public function update( &$refund ) {
+		parent::update( $refund );
+
+		/**
+		 * Fires when an order refund is updated.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param int              $refund_id The order refund ID.
+		 * @param \WC_Order_Refund $refund    The order refund object.
+		 */
+		do_action( 'woocommerce_update_order_refund', $refund->get_id(), $refund );
+	}
+
+	/**
 	 * Helper method that updates all the post meta for an order based on it's settings in the WC_Order class.
 	 *
 	 * @param WC_Order_Refund $refund Refund object.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -105,6 +105,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		add_action( 'woocommerce_new_order', array( $this, 'handle_updated_order' ), 100 );
 		add_action( 'woocommerce_refund_created', array( $this, 'handle_updated_order' ), 100 );
 		add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
+		add_action( 'woocommerce_update_order_refund', array( $this, 'handle_updated_order' ), 100 );
 		add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ), 9 );
 		add_action( 'wp_scheduled_delete', array( $this, 'delete_trashed_orders' ), 9 );
 		add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -144,6 +144,13 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	public function update( &$refund ) {
 		$this->persist_updates( $refund );
 		$refund->apply_changes();
+
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		/**
+		 * This action is documented in woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php.
+		 */
+		do_action( 'woocommerce_update_order_refund', $refund->get_id(), $refund );
+		// phpcs:enable
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
 This PR introduces a new `woocommerce_update_order_refund` action hook that fires whenever an order refund is updated, providing consistency with other order-related hooks and enabling better integration with HPOS sync.

Related to #50085.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start with HPOS on and compatibility mode disabled:
   ```
   wp wc hpos enable
   wp wc hpos compatibility-mode disable
   ```

   Perform a sync if the commands above fail (`wp wc hpos sync`).
1. Go to **WC > Orders > Add order** and create a new order with a few items and save it with a _Completed_ state.
1. Click **Refund** and add a manual refund for any amount.
1. Take note of the refund ID:
   <img width="1013" height="96" alt="Screenshot 2025-10-03 at 12 05 05" src="https://github.com/user-attachments/assets/38690db9-4de2-47b0-ad77-77b173646fa8" />
1. Enable compatibility mode:
   ```
   wp wc hpos sync
   wp wc hpos compatibility-mode enable
   ```
1. **(HPOS → legacy sync)**
   1. In a `wp shell` run the following commands (replace the value of `$refund_id` with the ID from above).
      ```
      wp> add_action( 'woocommerce_update_order_refund', function( $id ) { echo "Refund $id updated."; } );
      
      wp> $refund_id = 12345;
      wp> $r = wc_get_order( $refund_id );
      wp> $r->add_meta_data( 'foo', 'bar' );
      wp> $r->save();
      ```

   2. Confirm that _Refund ... updated._ is printed which proves that the hook was fired as part of the update.
   3. Confirm that the post version of the order has `bar` as value for the `foo` meta key:
      ```
      wp post meta get REFUND_ID foo
      ```
1. Switch to the legacy data store now:
   ```
   wp wc hpos disable
   ```
1. **(Legacy → HPOS sync)**
   1. Repeat steps 6.i and 6.ii.
   1. Confirm that the HPOS version of the order now has 2 `foo = bar` entries in metadata:
      ```
      wp db query "SELECT * FROM $(wp db prefix)wc_orders_meta WHERE order_id = REFUND_ID"    
      ```


<!-- End testing instructions -->