### PR TITLE
Add GET and UPDATE endpoints for individual offline payment methods to V4 API

### DIFF
--- a/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
@@ -86,6 +86,34 @@ class Controller extends AbstractController {
 				'schema' => array( $this, 'get_collection_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\w-]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the offline payment method.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -134,6 +162,255 @@ class Controller extends AbstractController {
 		}
 
 		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Check if a given request has access to read a single payment gateway.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Get a single offline payment gateway.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$gateway = $this->get_offline_gateway( $request );
+
+		if ( is_null( $gateway ) ) {
+			return new WP_Error(
+				'woocommerce_rest_payment_gateway_invalid',
+				__( 'Resource does not exist.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$gateway_data = $this->prepare_item_for_response( $gateway, $request );
+		return rest_ensure_response( $gateway_data );
+	}
+
+	/**
+	 * Check whether a given request has permission to edit payment gateways.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'payment_gateways', 'edit' ) ) {
+			return new WP_Error(
+				'woocommerce_rest_cannot_edit',
+				__( 'Sorry, you are not allowed to edit this resource.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update a single offline payment method.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$gateway = $this->get_offline_gateway( $request );
+
+		if ( is_null( $gateway ) ) {
+			return new WP_Error(
+				'woocommerce_rest_payment_gateway_invalid',
+				__( 'Resource does not exist.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Get settings.
+		$gateway->init_form_fields();
+		$settings = $gateway->settings;
+
+		// Update settings.
+		if ( isset( $request['settings'] ) ) {
+			$errors_found = false;
+			foreach ( $gateway->form_fields as $key => $field ) {
+				if ( isset( $request['settings'][ $key ] ) ) {
+					if ( is_callable( array( $this, 'validate_setting_' . $field['type'] . '_field' ) ) ) {
+						$value = $this->{'validate_setting_' . $field['type'] . '_field'}( $request['settings'][ $key ], $field );
+					} else {
+						$value = $this->validate_setting_text_field( $request['settings'][ $key ], $field );
+					}
+					if ( is_wp_error( $value ) ) {
+						$errors_found = true;
+						break;
+					}
+					$settings[ $key ] = $value;
+				}
+			}
+
+			if ( $errors_found ) {
+				return new WP_Error(
+					'rest_setting_value_invalid',
+					__( 'An invalid setting value was passed.', 'woocommerce' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		// Update if this method is enabled or not.
+		if ( isset( $request['enabled'] ) ) {
+			$settings['enabled'] = wc_bool_to_string( $request['enabled'] );
+			$gateway->enabled    = $settings['enabled'];
+		}
+
+		// Update title.
+		if ( isset( $request['title'] ) ) {
+			$settings['title'] = $this->validate_setting_text_field( $request['title'], $gateway->form_fields['title'] ?? array() );
+			$gateway->title    = $settings['title'];
+		}
+
+		// Update description.
+		if ( isset( $request['description'] ) ) {
+			$settings['description'] = $this->validate_setting_text_field( $request['description'], $gateway->form_fields['description'] ?? array() );
+			$gateway->description    = $settings['description'];
+		}
+
+		// Update options.
+		$gateway->settings = $settings;
+		update_option( $gateway->get_option_key(), apply_filters( 'woocommerce_gateway_' . $gateway->id . '_settings_values', $settings, $gateway ) );
+
+		// Update order.
+		if ( isset( $request['order'] ) ) {
+			$order                 = (array) get_option( 'woocommerce_gateway_order' );
+			$order[ $gateway->id ] = absint( $request['order'] );
+			update_option( 'woocommerce_gateway_order', $order );
+			$gateway->order = absint( $request['order'] );
+		}
+
+		$gateway_data = $this->prepare_item_for_response( $gateway, $request );
+		return rest_ensure_response( $gateway_data );
+	}
+
+	/**
+	 * Get an offline payment gateway based on the current request object.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return \WC_Payment_Gateway|null
+	 */
+	private function get_offline_gateway( $request ) {
+		$gateway          = null;
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$offline_ids      = array( 'bacs', 'cheque', 'cod' );
+
+		foreach ( $payment_gateways as $payment_gateway_id => $payment_gateway ) {
+			if ( $request['id'] !== $payment_gateway_id ) {
+				continue;
+			}
+
+			// Only allow offline payment gateways.
+			if ( ! in_array( $payment_gateway_id, $offline_ids, true ) ) {
+				continue;
+			}
+
+			$payment_gateway->id = $payment_gateway_id;
+			$gateway             = $payment_gateway;
+			break;
+		}
+
+		return $gateway;
+	}
+
+	/**
+	 * Validate text based settings.
+	 *
+	 * @param string $value The submitted value.
+	 * @param array  $setting The field settings.
+	 * @return string
+	 */
+	public function validate_setting_text_field( $value, $setting ) {
+		$value = is_null( $value ) ? '' : $value;
+		return wp_kses_post( trim( stripslashes( $value ) ) );
+	}
+
+	/**
+	 * Validate textarea based settings.
+	 *
+	 * @param string $value The submitted value.
+	 * @param array  $setting The field settings.
+	 * @return string
+	 */
+	public function validate_setting_textarea_field( $value, $setting ) {
+		$value = is_null( $value ) ? '' : $value;
+		return wp_kses(
+			trim( stripslashes( $value ) ),
+			array_merge(
+				array(
+					'iframe' => array(
+						'src'   => true,
+						'style' => true,
+						'id'    => true,
+						'class' => true,
+					),
+				),
+				wp_kses_allowed_html( 'post' )
+			)
+		);
+	}
+
+	/**
+	 * Validate checkbox based settings (with support for yes/no strings).
+	 *
+	 * @param string|bool $value The submitted value.
+	 * @param array       $setting The field settings.
+	 * @return string
+	 */
+	public function validate_setting_checkbox_field( $value, $setting ) {
+		return wc_bool_to_string( $value );
+	}
+
+	/**
+	 * Validate select based settings.
+	 *
+	 * @param string $value The submitted value.
+	 * @param array  $setting The field settings.
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_select_field( $value, $setting ) {
+		if ( array_key_exists( $value, $setting['options'] ) ) {
+			return $value;
+		} else {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+	}
+
+	/**
+	 * Validate multiselect based settings.
+	 *
+	 * @param array|string $values The submitted values.
+	 * @param array        $setting The field settings.
+	 * @return array|WP_Error
+	 */
+	public function validate_setting_multiselect_field( $values, $setting ) {
+		if ( empty( $values ) ) {
+			return array();
+		}
+
+		if ( ! is_array( $values ) ) {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$final_values = array();
+		foreach ( $values as $value ) {
+			if ( array_key_exists( $value, $setting['options'] ) ) {
+				$final_values[] = $value;
+			}
+		}
+
+		return $final_values;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
@@ -196,6 +196,7 @@ class WC_REST_Offline_Payment_Methods_V4_Controller_Tests extends WC_REST_Unit_T
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( '/wc/v4/payments/offline-methods', $routes );
 		$this->assertCount( 1, $routes['/wc/v4/payments/offline-methods'] );
+		$this->assertArrayHasKey( '/wc/v4/payments/offline-methods/(?P<id>[\w-]+)', $routes );
 	}
 
 	/**
@@ -446,5 +447,193 @@ class WC_REST_Offline_Payment_Methods_V4_Controller_Tests extends WC_REST_Unit_T
 				$this->assertContains( $field, $allowed_fields, "Field '{$field}' not declared in schema or allowed framework fields" );
 			}
 		}
+	}
+
+	/**
+	 * Test getting a single offline payment method.
+	 */
+	public function test_get_single_offline_payment_method() {
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/payments/offline-methods/bacs' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertEquals( 'bacs', $data['id'] );
+		$this->assertArrayHasKey( 'title', $data );
+		$this->assertArrayHasKey( 'enabled', $data );
+	}
+
+	/**
+	 * Test getting a single offline payment method with invalid ID.
+	 */
+	public function test_get_single_offline_payment_method_invalid_id() {
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/payments/offline-methods/invalid' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test getting a non-offline payment method returns 404.
+	 */
+	public function test_get_non_offline_payment_method() {
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/payments/offline-methods/stripe' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test getting single offline payment method without permission.
+	 */
+	public function test_get_single_offline_payment_method_without_permission() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/payments/offline-methods/bacs' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test updating a single offline payment method.
+	 */
+	public function test_update_offline_payment_method() {
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/bacs' );
+		$request->set_body_params(
+			array(
+				'enabled'     => false,
+				'title'       => 'Updated Bank Transfer',
+				'description' => 'Updated description',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'bacs', $data['id'] );
+		$this->assertEquals( false, $data['enabled'] );
+		$this->assertEquals( 'Updated Bank Transfer', $data['title'] );
+		$this->assertEquals( 'Updated description', $data['description'] );
+	}
+
+	/**
+	 * Test updating offline payment method settings.
+	 */
+	public function test_update_offline_payment_method_settings() {
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/bacs' );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'instructions' => 'New payment instructions',
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'settings', $data );
+
+		// Verify the instruction was updated.
+		$settings = $data['settings'];
+		$instructions_setting = array_values(
+			array_filter(
+				$settings,
+				function ( $setting ) {
+					return isset( $setting['id'] ) && 'instructions' === $setting['id'];
+				}
+			)
+		);
+
+		if ( ! empty( $instructions_setting ) ) {
+			$this->assertEquals( 'New payment instructions', $instructions_setting[0]['value'] );
+		}
+	}
+
+	/**
+	 * Test updating offline payment method with invalid ID.
+	 */
+	public function test_update_offline_payment_method_invalid_id() {
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/invalid' );
+		$request->set_body_params(
+			array(
+				'enabled' => true,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test updating a non-offline payment method returns 404.
+	 */
+	public function test_update_non_offline_payment_method() {
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/stripe' );
+		$request->set_body_params(
+			array(
+				'enabled' => true,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test updating offline payment method without permission.
+	 */
+	public function test_update_offline_payment_method_without_permission() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/bacs' );
+		$request->set_body_params(
+			array(
+				'enabled' => false,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test updating offline payment method with insufficient permission.
+	 */
+	public function test_update_offline_payment_method_with_insufficient_permission() {
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/bacs' );
+		$request->set_body_params(
+			array(
+				'enabled' => false,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test updating payment method order.
+	 */
+	public function test_update_offline_payment_method_order() {
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/payments/offline-methods/bacs' );
+		$request->set_body_params(
+			array(
+				'order' => 5,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 5, $data['order'] );
 	}
 }


### PR DESCRIPTION
## Add GET and UPDATE endpoints for individual offline payment methods to V4 API

### Changes proposed in this Pull Request

This PR extends the V4 REST API offline payment methods endpoint to support fetching and updating individual offline payment gateways (Bank Transfer, Check, and Cash on Delivery).

#### New Endpoints:
- **GET** `/wc/v4/payments/offline-methods/{id}` - Retrieve a single offline payment method
- **PUT/PATCH** `/wc/v4/payments/offline-methods/{id}` - Update a single offline payment method

#### Key Features:
- Full support for updating all gateway settings (enabled status, title, description, custom settings, order)
- Field validation for all setting types (text, textarea, checkbox, select, multiselect)
- Restricted to offline gateways only (`bacs`, `cheque`, `cod`) for security
- Follows V3 API conventions to ensure no breaking changes
- Comprehensive test coverage with 11 new test cases

### Why are we making this change?

The existing V4 endpoint only supported fetching a list of offline payment methods. This PR adds the ability to retrieve and update individual payment methods, completing the CRUD operations needed for managing offline payment gateways through the V4 API. This brings the V4 API to feature parity with the V3 payment gateways endpoint while maintaining V4 architecture patterns.

### How to test this PR

#### Prerequisites
1. Ensure the REST API v4 feature flag is enabled
2. Create REST API keys: Go to **WooCommerce > Settings > Advanced > REST API** and generate API keys with Read/Write permissions
3. Use the generated Consumer Key and Consumer Secret for authentication (OAuth 1.0a)

#### Test GET single offline payment method:

```bash
# Get BACS payment method
curl "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs?consumer_key=ck_xxx&consumer_secret=cs_xxx"

# Expected: 200 OK with full gateway details including id, title, description, enabled status, settings

# Try with invalid ID
curl "http://your-site.test/wp-json/wc/v4/payments/offline-methods/invalid?consumer_key=ck_xxx&consumer_secret=cs_xxx"

# Expected: 404 Not Found

# Try with non-offline gateway (should be restricted)
curl "http://your-site.test/wp-json/wc/v4/payments/offline-methods/stripe?consumer_key=ck_xxx&consumer_secret=cs_xxx"

# Expected: 404 Not Found
```

#### Test UPDATE offline payment method:

```bash
# Update enabled status, title, and description
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs?consumer_key=ck_xxx&consumer_secret=cs_xxx" \
  -H "Content-Type: application/json" \
  -d '{
    "enabled": false,
    "title": "Updated Bank Transfer",
    "description": "New payment instructions"
  }'

# Expected: 200 OK with updated gateway details

# Update gateway-specific settings
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs?consumer_key=ck_xxx&consumer_secret=cs_xxx" \
  -H "Content-Type: application/json" \
  -d '{
    "settings": {
      "instructions": "Please transfer to Account #12345"
    }
  }'

# Expected: 200 OK with updated settings reflected in the response

# Update gateway order/priority
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/cod?consumer_key=ck_xxx&consumer_secret=cs_xxx" \
  -H "Content-Type: application/json" \
  -d '{
    "order": 1
  }'

# Expected: 200 OK with updated order value

# Try to update invalid gateway
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/invalid?consumer_key=ck_xxx&consumer_secret=cs_xxx" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true}'

# Expected: 404 Not Found
```

#### Test permissions:

```bash
# Try GET without authentication
curl "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs"

# Expected: 401 Unauthorized

# Try UPDATE without authentication
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true}'

# Expected: 401 Unauthorized

# Try UPDATE with read-only API keys
# (Generate read-only keys in WooCommerce > Settings > Advanced > REST API)
curl -X PUT "http://your-site.test/wp-json/wc/v4/payments/offline-methods/bacs?consumer_key=ck_readonly&consumer_secret=cs_readonly" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true}'

# Expected: 403 Forbidden
```

### Changelog

```
Significance: minor
Type: add

Add GET and UPDATE endpoints for individual offline payment methods to V4 API.
```
