### PR TITLE
Update OfflinePaymentMethods controller dependency injection to prevent container instantiation errors

### DIFF
--- a/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
@@ -55,7 +55,11 @@ class Controller extends AbstractController {
 	 * @internal
 	 */
 	final public function init( OfflinePaymentMethodSchema $schema ) {
-		$this->payments    = wc_get_container()->get( Payments::class );
+		try {
+			$this->payments = wc_get_container()->get( Payments::class );
+		} catch ( \Throwable $e ) {
+			wc_get_logger()->error( 'Could not get Payments service for offline payment methods controller: ' . $e->getMessage(), array( 'source' => 'offline-payment-methods' ) );
+		}
 		$this->item_schema = $schema;
 	}
 

--- a/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
@@ -59,6 +59,7 @@ class Controller extends AbstractController {
 			$this->payments = wc_get_container()->get( Payments::class );
 		} catch ( \Throwable $e ) {
 			wc_get_logger()->error( 'Could not get Payments service for offline payment methods controller: ' . $e->getMessage(), array( 'source' => 'offline-payment-methods' ) );
+			throw new \RuntimeException( 'Failed to initialize OfflinePaymentMethods controller: Payments service unavailable.', 0, $e );
 		}
 		$this->item_schema = $schema;
 	}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/OfflinePaymentMethods/Controller.php
@@ -51,12 +51,11 @@ class Controller extends AbstractController {
 	/**
 	 * Initialize the controller.
 	 *
-	 * @param Payments                   $payments Payments service.
-	 * @param OfflinePaymentMethodSchema $schema   Schema class.
+	 * @param OfflinePaymentMethodSchema $schema Schema class.
 	 * @internal
 	 */
-	final public function init( Payments $payments, OfflinePaymentMethodSchema $schema ) {
-		$this->payments    = $payments;
+	final public function init( OfflinePaymentMethodSchema $schema ) {
+		$this->payments    = wc_get_container()->get( Payments::class );
 		$this->item_schema = $schema;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
@@ -83,7 +83,7 @@ class WC_REST_Offline_Payment_Methods_V4_Controller_Tests extends WC_REST_Unit_T
 		$schema = new Automattic\WooCommerce\RestApi\Routes\V4\OfflinePaymentMethods\OfflinePaymentMethodSchema();
 
 		$this->endpoint = new OfflinePaymentMethodsController();
-		$this->endpoint->init( $this->payments, $schema );
+		$this->endpoint->init( $schema );
 
 		// Manually register ONLY our controller's routes to avoid triggering global REST API init.
 		$this->endpoint->register_routes();

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OfflinePaymentMethods/class-wc-rest-offline-payment-methods-v4-controller-tests.php
@@ -84,6 +84,12 @@ class WC_REST_Offline_Payment_Methods_V4_Controller_Tests extends WC_REST_Unit_T
 
 		$this->endpoint = new OfflinePaymentMethodsController();
 		$this->endpoint->init( $schema );
+		
+		// Override the payments property with our mock using reflection
+		$reflection = new \ReflectionClass( $this->endpoint );
+		$payments_property = $reflection->getProperty( 'payments' );
+		$payments_property->setAccessible( true );
+		$payments_property->setValue( $this->endpoint, $this->payments );
 
 		// Manually register ONLY our controller's routes to avoid triggering global REST API init.
 		$this->endpoint->register_routes();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR attempts to fix a container instantiation error in the OfflinePaymentMethods V4 REST API controller by adjusting its dependency injection pattern.

The original implementation required both Payments and OfflinePaymentMethodSchema as constructor dependencies via the init() method. Since the container did not know how to provide these dependencies, it resulted in a ContainerException when trying to instantiate the controller:

```
PHP Fatal error: Uncaught Automattic\WooCommerce\Internal\DependencyManagement\ContainerException:
Attempt to get an instance of class 'Automattic\WooCommerce\RestApi\Routes\V4\OfflinePaymentMethods\Controller',
which doesn't exist.
```

Closes WOOPRD-925

### How to test the changes in this Pull Request:
Code changes should make sense.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
