### PR TITLE
Investigate duplicate order meta data creation

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,71 @@
+# Diagnostic Tests for WooCommerce Duplicate Meta Issue
+
+## The Problem
+When using `include('temp.php')` in WP Shell, calling `add_meta_data()` once creates 3 identical meta entries.
+When running the same code directly in WP Shell (without include), it works correctly.
+
+## Tests to Run
+
+### Test 1: Compare execution methods
+
+**Method A - Direct in WP Shell (WORKS):**
+```bash
+wp shell
+>>> $orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+>>> $orders[0]->add_meta_data('_test_direct', 'value');
+>>> $orders[0]->save();
+>>> exit
+```
+
+**Method B - Using include in WP Shell (FAILS - creates 3 entries):**
+```bash
+wp shell
+>>> include('/workspace/temp.php');
+>>> exit
+```
+
+**Method C - Using wp eval-file (Test this):**
+```bash
+wp eval-file /workspace/temp-eval-test.php
+```
+
+### Test 2: Trace database operations
+```bash
+wp shell
+>>> include('/workspace/temp-check-context.php');
+```
+
+Check the output - it will show EVERY time the meta is inserted into the database with a full backtrace.
+
+### Test 3: Simplest single order test
+```bash
+wp shell
+>>> include('/workspace/temp-single-order-test.php');
+```
+
+This uses only 1 order and traces before/after counts.
+
+### Test 4: Full trace with query monitoring
+```bash
+wp shell
+>>> include('/workspace/temp-trace-save.php');
+```
+
+## What to Look For
+
+The key question is: **Why does `include()` cause different behavior than direct execution?**
+
+Possible causes:
+1. The file is being evaluated multiple times somehow
+2. There's output buffering or some WP Shell mechanism that reruns code
+3. There's a shutdown hook or deferred save mechanism
+4. WP Shell's readline/history is somehow re-executing the include
+
+## Next Steps
+
+Please run the tests above and share:
+1. The output from `temp-check-context.php` - especially the backtrace
+2. The count from `temp-single-order-test.php`
+3. Whether `wp eval-file` has the same problem
+
+This will tell us exactly where the duplication is happening.

--- a/temp-check-context.php
+++ b/temp-check-context.php
@@ -1,0 +1,51 @@
+<?php
+// Check if there's something special about the execution context
+
+error_log("=== EXECUTION CONTEXT ===");
+error_log("In shutdown: " . (did_action('shutdown') ? 'yes' : 'no'));
+error_log("In admin: " . (is_admin() ? 'yes' : 'no'));
+error_log("CLI: " . (defined('WP_CLI') && WP_CLI ? 'yes' : 'no'));
+error_log("Doing AJAX: " . (wp_doing_ajax() ? 'yes' : 'no'));
+error_log("Doing CRON: " . (wp_doing_cron() ? 'yes' : 'no'));
+error_log("Current filter: " . current_filter());
+
+// Check how many times save_meta_data is called
+$save_meta_call_count = 0;
+
+// Intercept at a lower level - the actual data store
+add_filter('woocommerce_order_data_store_cpt_get_orders_query', function($query, $query_vars) {
+    error_log("Get orders query called");
+    return $query;
+}, 10, 2);
+
+// Most importantly: trace the actual add_metadata WordPress function
+add_action('added_post_meta', function($meta_id, $object_id, $meta_key, $meta_value) {
+    if ($meta_key === '_debug_log_source_pending_deletion') {
+        static $add_count = 0;
+        $add_count++;
+        $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 15);
+        $trace_str = "ADDED POST META #$add_count (meta_id=$meta_id, object_id=$object_id)\nBacktrace:\n";
+        foreach (array_slice($bt, 0, 10) as $i => $frame) {
+            $trace_str .= "  $i: " . ($frame['file'] ?? 'unknown') . ':' . ($frame['line'] ?? '?') . ' ';
+            $trace_str .= ($frame['class'] ?? '') . ($frame['type'] ?? '') . ($frame['function'] ?? '') . "\n";
+        }
+        error_log($trace_str);
+    }
+}, 10, 4);
+
+error_log("=== RUNNING TEST ===");
+$orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+error_log("Order ID: " . $orders[0]->get_id());
+
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'test-value-' . time());
+error_log("Before save");
+$orders[0]->save();
+error_log("After save");
+
+// Check how many were actually added
+global $wpdb;
+$count = $wpdb->get_var($wpdb->prepare(
+    "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_debug_log_source_pending_deletion'",
+    $orders[0]->get_id()
+));
+error_log("Total meta entries in DB: $count");

--- a/temp-debug.php
+++ b/temp-debug.php
@@ -1,0 +1,31 @@
+<?php
+// Add this at the very top to check if file is included multiple times
+static $include_count = 0;
+$include_count++;
+error_log("temp.php included, count: $include_count");
+
+$orders = wc_get_orders(['limit'=>3,'type'=>'shop_order']);
+error_log("Processing order " . $orders[0]->get_id());
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-1111');
+error_log("About to save order " . $orders[0]->get_id());
+$orders[0]->save();
+error_log("Saved order " . $orders[0]->get_id());
+
+error_log("Processing order " . $orders[1]->get_id());
+$orders[1]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-2222');
+error_log("About to save order " . $orders[1]->get_id());
+$orders[1]->save();
+error_log("Saved order " . $orders[1]->get_id());
+
+error_log("Processing order " . $orders[2]->get_id());
+$orders[2]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-3333');
+error_log("About to save order " . $orders[2]->get_id());
+$orders[2]->save();
+error_log("Saved order " . $orders[2]->get_id());
+
+$l = wc_get_logger();
+$l->debug('Foo!', ['source'=>'place-order-debug-1111']);
+$l->debug('Foo!', ['source'=>'place-order-debug-2222']);
+$l->debug('Foo!', ['source'=>'place-order-debug-3333']);
+
+error_log("Script completed");

--- a/temp-eval-test.php
+++ b/temp-eval-test.php
@@ -1,0 +1,23 @@
+<?php
+// Test file for wp eval-file
+$orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+$orders[0]->delete_meta_data('_debug_log_source_pending_deletion');
+$orders[0]->save();
+
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'eval-file-test');
+$orders[0]->save();
+
+global $wpdb;
+$count = $wpdb->get_var($wpdb->prepare(
+    "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_debug_log_source_pending_deletion'",
+    $orders[0]->get_id()
+));
+
+echo "Order ID: " . $orders[0]->get_id() . "\n";
+echo "Meta entries in database: $count\n";
+
+if ($count == 1) {
+    echo "✓ SUCCESS - Only 1 entry!\n";
+} else {
+    echo "✗ FAIL - Found $count entries (expected 1)\n";
+}

--- a/temp-hook-debug.php
+++ b/temp-hook-debug.php
@@ -1,0 +1,35 @@
+<?php
+// Track hook calls to see if save is being triggered multiple times
+$save_hook_count = 0;
+
+add_action('woocommerce_before_order_object_save', function($order) use (&$save_hook_count) {
+    $save_hook_count++;
+    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
+    $caller = isset($trace[2]) ? $trace[2]['function'] : 'unknown';
+    error_log("woocommerce_before_order_object_save called (count: $save_hook_count) for order " . $order->get_id() . " from $caller");
+}, 1);
+
+add_action('woocommerce_after_order_object_save', function($order) {
+    error_log("woocommerce_after_order_object_save called for order " . $order->get_id());
+}, 1);
+
+add_action('added_order_meta', function($meta_id, $object_id, $meta_key, $meta_value) {
+    static $added_count = 0;
+    $added_count++;
+    error_log("added_order_meta called (count: $added_count): meta_id=$meta_id, order_id=$object_id, key=$meta_key, value=$meta_value");
+}, 10, 4);
+
+$orders = wc_get_orders(['limit'=>3,'type'=>'shop_order']);
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-1111');
+$orders[0]->save();
+$orders[1]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-2222');
+$orders[1]->save();
+$orders[2]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-3333');
+$orders[2]->save();
+
+error_log("Total save hooks called: $save_hook_count");
+
+$l = wc_get_logger();
+$l->debug('Foo!', ['source'=>'place-order-debug-1111']);
+$l->debug('Foo!', ['source'=>'place-order-debug-2222']);
+$l->debug('Foo!', ['source'=>'place-order-debug-3333']);

--- a/temp-no-logger.php
+++ b/temp-no-logger.php
@@ -1,0 +1,22 @@
+<?php
+// Test without the logger to see if that's the cause
+error_log("Starting script without logger");
+
+$orders = wc_get_orders(['limit'=>3,'type'=>'shop_order']);
+error_log("Got " . count($orders) . " orders");
+
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-1111');
+$orders[0]->save();
+error_log("Saved order 0: " . $orders[0]->get_id());
+
+$orders[1]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-2222');
+$orders[1]->save();
+error_log("Saved order 1: " . $orders[1]->get_id());
+
+$orders[2]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-3333');
+$orders[2]->save();
+error_log("Saved order 2: " . $orders[2]->get_id());
+
+// NO LOGGER CALLS HERE - just end the script
+
+error_log("Script completed without logger calls");

--- a/temp-single-order-test.php
+++ b/temp-single-order-test.php
@@ -1,0 +1,56 @@
+<?php
+// Simplest possible test - just ONE order, ONE save
+
+error_log("=== SINGLE ORDER TEST START ===");
+
+// Get just ONE order
+$orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+$order = $orders[0];
+$order_id = $order->get_id();
+
+error_log("Testing with order ID: $order_id");
+
+// Delete any existing test meta first
+error_log("Cleaning existing meta...");
+$order->delete_meta_data('_debug_log_source_pending_deletion');
+$order->save();
+
+// Verify it's clean
+global $wpdb;
+$before_count = $wpdb->get_var($wpdb->prepare(
+    "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_debug_log_source_pending_deletion'",
+    $order_id
+));
+error_log("Meta count before adding: $before_count");
+
+// Now add ONE entry
+error_log("Adding meta data...");
+$order->add_meta_data('_debug_log_source_pending_deletion', 'single-test-value');
+
+// Check count BEFORE save
+$meta_in_object = $order->get_meta('_debug_log_source_pending_deletion', false);
+error_log("Meta in object before save: " . count($meta_in_object));
+
+// Save
+error_log("Calling save...");
+$order->save();
+error_log("Save completed");
+
+// Check count AFTER save
+$after_count = $wpdb->get_var($wpdb->prepare(
+    "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_debug_log_source_pending_deletion'",
+    $order_id
+));
+error_log("Meta count after save: $after_count");
+
+// Get actual values
+$results = $wpdb->get_results($wpdb->prepare(
+    "SELECT meta_id, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_debug_log_source_pending_deletion'",
+    $order_id
+));
+error_log("Actual entries:");
+foreach ($results as $row) {
+    error_log("  meta_id={$row->meta_id}, value={$row->meta_value}");
+}
+
+error_log("=== SINGLE ORDER TEST END ===");

--- a/temp-trace-save.php
+++ b/temp-trace-save.php
@@ -1,0 +1,54 @@
+<?php
+// Comprehensive tracing to see what's happening during save
+
+error_log("=== SCRIPT START ===");
+
+// Track every metadata operation at the database level
+add_filter('query', function($query) {
+    if (strpos($query, '_debug_log_source_pending_deletion') !== false) {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+        $trace_str = '';
+        foreach ($trace as $i => $frame) {
+            $trace_str .= "\n  $i: " . ($frame['class'] ?? '') . ($frame['type'] ?? '') . ($frame['function'] ?? '');
+        }
+        error_log("QUERY with debug meta: " . substr($query, 0, 200) . $trace_str);
+    }
+    return $query;
+}, 1);
+
+// Track save_meta_data calls
+class WC_Order_Tracker {
+    public static function wrap_save_meta() {
+        add_action('woocommerce_before_order_object_save', function($order) {
+            error_log("BEFORE SAVE - Order ID: " . $order->get_id() . ", meta_data count: " . count($order->get_meta_data()));
+        }, 1);
+        
+        add_action('woocommerce_after_order_object_save', function($order) {
+            error_log("AFTER SAVE - Order ID: " . $order->get_id());
+        }, 1);
+    }
+}
+
+WC_Order_Tracker::wrap_save_meta();
+
+error_log("=== GETTING ORDERS ===");
+$orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+error_log("Got order ID: " . $orders[0]->get_id());
+
+error_log("=== ADDING META DATA ===");
+$orders[0]->add_meta_data('_debug_log_source_pending_deletion', 'place-order-debug-TEST');
+
+error_log("=== ABOUT TO CALL SAVE ===");
+$orders[0]->save();
+error_log("=== SAVE RETURNED ===");
+
+// Force any deferred operations to complete
+error_log("=== CHECKING FINAL STATE ===");
+$fresh_order = wc_get_order($orders[0]->get_id());
+$meta_values = $fresh_order->get_meta('_debug_log_source_pending_deletion', false); // Get all values
+error_log("Final meta count: " . count($meta_values));
+foreach ($meta_values as $idx => $val) {
+    error_log("  Meta $idx: " . print_r($val, true));
+}
+
+error_log("=== SCRIPT END ===");

--- a/test-include-count.php
+++ b/test-include-count.php
@@ -1,0 +1,52 @@
+<?php
+// Test if include is being executed multiple times
+static $execution_count = 0;
+$execution_count++;
+
+$unique_id = uniqid('exec_', true);
+echo "Execution #$execution_count at " . microtime(true) . " (ID: $unique_id)\n";
+
+if ($execution_count > 1) {
+    echo "WARNING: File has been executed $execution_count times!\n";
+    echo "Backtrace of second execution:\n";
+    debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+}
+
+$orders = wc_get_orders(['limit'=>1,'type'=>'shop_order']);
+$order = $orders[0];
+
+echo "Working with order ID: " . $order->get_id() . "\n";
+
+// Clean any existing test meta
+$order->delete_meta_data('_test_include_count');
+$order->save();
+
+// Add exactly once
+echo "Adding meta data (execution #$execution_count)...\n";
+$order->add_meta_data('_test_include_count', "execution_$execution_count");
+
+echo "Saving...\n";
+$order->save();
+
+// Check immediately
+global $wpdb;
+$count = $wpdb->get_var($wpdb->prepare(
+    "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_test_include_count'",
+    $order->get_id()
+));
+
+echo "Database shows $count entries\n";
+
+if ($count != 1) {
+    echo "ERROR: Expected 1 entry, found $count!\n";
+    $entries = $wpdb->get_results($wpdb->prepare(
+        "SELECT meta_id, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_test_include_count' ORDER BY meta_id",
+        $order->get_id()
+    ));
+    echo "Entries:\n";
+    foreach ($entries as $entry) {
+        echo "  meta_id={$entry->meta_id}, value={$entry->meta_value}\n";
+    }
+}
+
+echo "Script completed (execution #$execution_count)\n";

--- a/test-minimal.php
+++ b/test-minimal.php
@@ -1,0 +1,9 @@
+<?php
+echo "Script executed at: " . microtime(true) . "\n";
+$order = wc_get_order(wc_get_orders(['limit'=>1])[0]->get_id());
+echo "Order ID: " . $order->get_id() . "\n";
+$order->add_meta_data('_test_minimal', 'value-' . time());
+$order->save();
+global $wpdb;
+$count = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id=%d AND meta_key='_test_minimal'", $order->get_id()));
+echo "Meta count: $count\n";

--- a/test-object-identity.php
+++ b/test-object-identity.php
@@ -1,0 +1,42 @@
+<?php
+echo "=== Testing Object Identity ===\n";
+
+$orders = wc_get_orders(['limit'=>3,'type'=>'shop_order']);
+
+echo "Order IDs: " . $orders[0]->get_id() . ", " . $orders[1]->get_id() . ", " . $orders[2]->get_id() . "\n";
+echo "Object IDs: " . spl_object_id($orders[0]) . ", " . spl_object_id($orders[1]) . ", " . spl_object_id($orders[2]) . "\n";
+echo "Are they the same object? " . (spl_object_id($orders[0]) === spl_object_id($orders[1]) ? "YES - PROBLEM!" : "NO - OK") . "\n\n";
+
+// Clean slate - delete existing test meta
+foreach ($orders as $order) {
+    $order->delete_meta_data('_test_identity');
+}
+foreach ($orders as $order) {
+    $order->save();
+}
+
+echo "=== Adding meta to ONLY first order ===\n";
+$orders[0]->add_meta_data('_test_identity', 'ONLY-FIRST-ORDER');
+echo "Added meta to order " . $orders[0]->get_id() . "\n";
+
+echo "=== Saving ONLY first order ===\n";
+$orders[0]->save();
+echo "Saved order " . $orders[0]->get_id() . "\n\n";
+
+echo "=== Checking database for ALL three orders ===\n";
+global $wpdb;
+foreach ($orders as $idx => $order) {
+    $count = $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_test_identity'",
+        $order->get_id()
+    ));
+    echo "Order $idx (ID " . $order->get_id() . "): $count entries\n";
+    
+    if ($count > 0) {
+        $values = $wpdb->get_col($wpdb->prepare(
+            "SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_test_identity'",
+            $order->get_id()
+        ));
+        echo "  Values: " . implode(", ", $values) . "\n";
+    }
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

These changes introduce three temporary diagnostic PHP scripts (`temp-debug.php`, `temp-hook-debug.php`, `temp-no-logger.php`) to investigate an issue where `WC_Order::add_meta_data()` creates duplicate meta entries when executed via `include()` in WP-CLI, particularly when `wc_get_logger()` is also used. The scripts are designed to:
*   Verify if a file is included multiple times.
*   Track `woocommerce_before_order_object_save`, `woocommerce_after_order_object_save`, and `added_order_meta` hook executions.
*   Isolate the effect of `wc_get_logger()` calls on meta data duplication.

These files are for diagnostic purposes and are not intended for merge into the core.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Save the provided `temp-debug.php`, `temp-hook-debug.php`, and `temp-no-logger.php` files to your WordPress root directory (or a known path).
2.  Open your terminal and navigate to your WordPress root directory.
3.  Execute each script using WP-CLI `shell` and `include`:
    *   `wp shell`
    *   `include('temp-debug.php');`
    *   Observe the `error_log` output for file inclusion count and save events.
4.  Repeat for `temp-hook-debug.php`:
    *   `wp shell`
    *   `include('temp-hook-debug.php');`
    *   Observe the `error_log` output for hook execution counts.
5.  Repeat for `temp-no-logger.php`:
    *   `wp shell`
    *   `include('temp-no-logger.php');`
    *   Check the order meta data in the database for duplication (expecting no duplication if the logger is the cause).

<!-- End testing instructions -->

### Testing that has already taken place:

No testing has taken place yet, these scripts are provided for the user to perform diagnostics.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
These are temporary diagnostic scripts and not intended for merge into the core codebase.
</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-db079492-5b61-43d8-a094-b35618037674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db079492-5b61-43d8-a094-b35618037674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

