### PR TITLE
Fix: Prevent coupon recalculation from changing finalized order discounts

### DIFF
--- a/plugins/woocommerce/changelog/61236-fix-coupon-recalculation-preservation
+++ b/plugins/woocommerce/changelog/61236-fix-coupon-recalculation-preservation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - Preserve coupon discount amounts on finalized orders to prevent retroactive changes when coupons are modified or recalculated.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1415,12 +1415,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		// Get unlocked items for discount calculation
+		// Get unlocked items for discount calculation.
 		$unlocked_items = array_filter( $this->get_items(), function( $item ) use ( $locked_items ) {
 			return ! in_array( (int) $item->get_id(), $locked_items, true );
 		});
 
-		// Create WC_Discounts instance with only unlocked items from the start
+		// Create WC_Discounts instance with only unlocked items from the start.
 		$discounts = new WC_Discounts( $this );
 		$discounts->set_items( $this->format_items_for_discounts( $unlocked_items ) );
 
@@ -1477,7 +1477,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		// Apply discounts using the preserved WC_Discounts state
+		// Apply discounts using the preserved WC_Discounts state.
 		$this->set_coupon_discount_amounts( $discounts );
 		$this->set_item_discount_amounts( $discounts );
 
@@ -1660,37 +1660,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Set coupon discount amounts directly from an array of discount amounts.
-	 *
-	 * @param array $coupon_discounts Array of coupon code => discount amount.
-	 */
-	protected function set_coupon_discount_amounts_direct( $coupon_discounts ) {
-		$coupons = $this->get_items( 'coupon' );
-		$coupon_code_to_item = wc_list_pluck( $coupons, null, 'get_code' );
-
-		foreach ( $coupon_discounts as $coupon_code => $amount ) {
-			if ( isset( $coupon_code_to_item[ $coupon_code ] ) ) {
-				$coupon_item = $coupon_code_to_item[ $coupon_code ];
-
-				// Get preserved discount if exists
-				$preserved_discount = 0;
-				$preserved_items = $coupon_item->get_meta( 'coupon_applied_items', true );
-				if ( is_array( $preserved_items ) ) {
-					foreach ( $preserved_items as $preserved_data ) {
-						$preserved_discount += $preserved_data['discount'];
-					}
-				}
-
-				// Total discount is preserved + new
-				$total_discount = $preserved_discount + $amount;
-
-				$coupon_item->set_discount( $total_discount );
-				$coupon_item->save();
-			}
-		}
-	}
-
-	/**
 	 * After applying coupons via the WC_Discounts class, update or create coupon items.
 	 *
 	 * @since 3.2.0
@@ -1767,7 +1736,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				}
 
 				// Set coupon discount to preserved + newly calculated amounts.
-				// Note: $amount is already in normal currency units, not precision format
 				$total_discount = $preserved_discount + $amount;
 				$total_discount_tax = $preserved_discount_tax + $discount_tax;
 				$coupon_item->set_discount( $total_discount );

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1303,47 +1303,49 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// This prevents items from being locked during the recalculation.
 		$this->applying_coupon = true;
 
-		$discounts = new WC_Discounts( $this );
-		$applied   = $discounts->apply_coupon( $coupon );
+		try {
+			$discounts = new WC_Discounts( $this );
+			$applied   = $discounts->apply_coupon( $coupon );
 
-		if ( is_wp_error( $applied ) ) {
-			return $applied;
-		}
-
-		$data_store = $coupon->get_data_store();
-
-		// Check specific for guest checkouts here as well since WC_Cart handles that separately in check_customer_coupons.
-		if ( $data_store && 0 === $this->get_customer_id() ) {
-			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
-				return new WP_Error(
-					'invalid_coupon',
-					$coupon->get_coupon_error( 106 ),
-					array(
-						'status' => 400,
-					)
-				);
+			if ( is_wp_error( $applied ) ) {
+				return $applied;
 			}
+
+			$data_store = $coupon->get_data_store();
+
+			// Check specific for guest checkouts here as well since WC_Cart handles that separately in check_customer_coupons.
+			if ( $data_store && 0 === $this->get_customer_id() ) {
+				$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
+				if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
+					return new WP_Error(
+						'invalid_coupon',
+						$coupon->get_coupon_error( 106 ),
+						array(
+							'status' => 400,
+						)
+					);
+				}
+			}
+
+			/**
+			 * Action to signal that a coupon has been applied to an order.
+			 *
+			 * @param  WC_Coupon $coupon The applied coupon object.
+			 * @param  WC_Order  $order  The current order object.
+			 *
+			 * @since 7.3
+			 */
+			do_action( 'woocommerce_order_applied_coupon', $coupon, $this );
+
+			$this->set_coupon_discount_amounts( $discounts );
+			$this->save();
+
+			// Recalculate totals and taxes.
+			$this->recalculate_coupons();
+		} finally {
+			// Clear the flag after recalculation is complete.
+			$this->applying_coupon = false;
 		}
-
-		/**
-		 * Action to signal that a coupon has been applied to an order.
-		 *
-		 * @param  WC_Coupon $coupon The applied coupon object.
-		 * @param  WC_Order  $order  The current order object.
-		 *
-		 * @since 7.3
-		 */
-		do_action( 'woocommerce_order_applied_coupon', $coupon, $this );
-
-		$this->set_coupon_discount_amounts( $discounts );
-		$this->save();
-
-		// Recalculate totals and taxes.
-		$this->recalculate_coupons();
-
-		// Clear the flag after recalculation is complete.
-		$this->applying_coupon = false;
 
 		// Record usage so counts and validation is correct.
 		$used_by = $this->get_user_id();

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -110,6 +110,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected $object_type = 'order';
 
 	/**
+	 * Flag to indicate if we're currently in the apply_coupon flow.
+	 * Used to prevent items from being locked during initial coupon application.
+	 *
+	 * @var bool
+	 */
+	protected $applying_coupon = false;
+
+	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
 	 * This class should NOT be instantiated, but the wc_get_order function or new WC_Order_Factory
 	 * should be used. It is possible, but the aforementioned are preferred and are the only
@@ -1291,6 +1299,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
+		// Set a flag to indicate we're in the initial apply_coupon flow.
+		// This prevents items from being locked during the recalculation.
+		$this->applying_coupon = true;
+
 		$discounts = new WC_Discounts( $this );
 		$applied   = $discounts->apply_coupon( $coupon );
 
@@ -1329,6 +1341,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Recalculate totals and taxes.
 		$this->recalculate_coupons();
+
+		// Clear the flag after recalculation is complete.
+		$this->applying_coupon = false;
 
 		// Record usage so counts and validation is correct.
 		$used_by = $this->get_user_id();
@@ -1389,25 +1404,33 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 3.2.0
 	 */
 	public function recalculate_coupons() {
-		// Reset line item totals.
+		// Identify which line items are "locked" (have preserved discount data).
+		$locked_items = $this->get_locked_line_items();
+
+		// Reset only unlocked line items to subtotal.
 		foreach ( $this->get_items() as $item ) {
-			$item->set_total( $item->get_subtotal() );
-			$item->set_total_tax( $item->get_subtotal_tax() );
+			if ( ! in_array( (int) $item->get_id(), $locked_items, true ) ) {
+				$item->set_total( $item->get_subtotal() );
+				$item->set_total_tax( $item->get_subtotal_tax() );
+			}
 		}
 
+		// Get unlocked items for discount calculation
+		$unlocked_items = array_filter( $this->get_items(), function( $item ) use ( $locked_items ) {
+			return ! in_array( (int) $item->get_id(), $locked_items, true );
+		});
+
+		// Create WC_Discounts instance with only unlocked items from the start
 		$discounts = new WC_Discounts( $this );
+		$discounts->set_items( $this->format_items_for_discounts( $unlocked_items ) );
 
 		foreach ( $this->get_items( 'coupon' ) as $coupon_item ) {
 			$coupon_code = $coupon_item->get_code();
 			$coupon_id   = wc_get_coupon_id_by_code( $coupon_code );
 
-			// If we have a coupon ID (loaded via wc_get_coupon_id_by_code) we can simply load the new coupon object using the ID.
-			if ( $coupon_id ) {
-				$coupon_object = new WC_Coupon( $coupon_id );
-
-			} else {
-
-				// If we do not have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
+			// For missing coupons, use the stored coupon data to preserve discount integrity.
+			if ( ! $coupon_id ) {
+				// Use the existing temporary coupon logic that preserves stored amounts.
 				$coupon_object = $this->get_temporary_coupon( $coupon_item );
 				$coupon_object->set_code( $coupon_code );
 				$coupon_object->set_virtual( true );
@@ -1423,6 +1446,23 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					}
 					$coupon_object->set_discount_type( 'fixed_cart' );
 				}
+
+				// For fixed_cart coupons with locked items, calculate remaining discount.
+				if ( 'fixed_cart' === $coupon_object->get_discount_type() && ! empty( $locked_items ) ) {
+					$used_amount = $this->get_coupon_used_amount( $coupon_item, $locked_items );
+					$remaining = max( 0, $coupon_object->get_amount() - $used_amount );
+					$coupon_object->set_amount( $remaining );
+				}
+			} else {
+				// Load fresh coupon data for recalculation.
+				$coupon_object = new WC_Coupon( $coupon_id );
+
+				// For fixed_cart coupons, calculate remaining discount for unlocked items.
+				if ( 'fixed_cart' === $coupon_object->get_discount_type() && ! empty( $locked_items ) ) {
+					$used_amount = $this->get_coupon_used_amount( $coupon_item, $locked_items );
+					$remaining = max( 0, $coupon_object->get_amount() - $used_amount );
+					$coupon_object->set_amount( $remaining );
+				}
 			}
 
 			/**
@@ -1437,6 +1477,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
+		// Apply discounts using the preserved WC_Discounts state
 		$this->set_coupon_discount_amounts( $discounts );
 		$this->set_item_discount_amounts( $discounts );
 
@@ -1474,6 +1515,123 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * Get line items that are "locked" for coupon recalculation.
+	 * A line item is locked if:
+	 * 1. The order has a non-draft/non-pending status AND
+	 * 2. The line item has explicit coupon applied metadata
+	 *
+	 * @since x.x.x
+	 * @param string $coupon_code Optional. If provided, only return locked items for this specific coupon.
+	 * @return array Array of line item IDs that should preserve their discount amounts.
+	 */
+	private function get_locked_line_items( $coupon_code = '' ) {
+		// If we're in the initial apply_coupon flow, don't lock any items.
+		// This ensures the coupon can be properly applied to all items.
+		if ( ! empty( $this->applying_coupon ) ) {
+			return array();
+		}
+
+		// Determine which order statuses allow coupon recalculation.
+		$recalculate_statuses = array( 'pending', 'draft', 'auto-draft' );
+		$recalculate_statuses = apply_filters( 'woocommerce_order_recalculate_coupon_statuses', $recalculate_statuses, $this );
+		$should_recalculate   = $this->has_status( $recalculate_statuses );
+
+
+		// If order allows recalculation, no items are locked.
+		if ( $should_recalculate ) {
+			return array();
+		}
+
+		$locked_items = array();
+
+		// For each coupon, get the line items it was explicitly applied to.
+		$coupon_items = $this->get_items( 'coupon' );
+		foreach ( $coupon_items as $coupon_item ) {
+			// If a specific coupon code is provided, only check that coupon.
+			if ( ! empty( $coupon_code ) && ! wc_is_same_coupon( $coupon_item->get_code(), $coupon_code ) ) {
+				continue;
+			}
+
+			$applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+			// Only lock items if we have explicit metadata about which items were covered.
+			// Backwards compatibility: if no metadata exists, assume all items can be recalculated.
+			if ( is_array( $applied_items ) && ! empty( $applied_items ) ) {
+				$locked_items = array_merge( $locked_items, array_keys( $applied_items ) );
+			}
+		}
+
+		/**
+		 * Filter the list of locked line item IDs before returning.
+		 *
+		 * @since x.x.x
+		 * @param array    $locked_items Array of line item IDs that are locked for recalculation.
+		 * @param WC_Order $order        The order object.
+		 * @param string   $coupon_code  The coupon code being checked (empty string if checking all coupons).
+		 */
+		$locked_items = apply_filters( 'woocommerce_order_locked_line_items', $locked_items, $this, $coupon_code );
+		return array_unique( array_map( 'intval', $locked_items ) );
+	}
+
+	/**
+	 * Format order items for WC_Discounts class (converts to stdClass with required properties).
+	 *
+	 * @param array $order_items Array of WC_Order_Item_Product objects.
+	 * @return array Array of stdClass objects formatted for WC_Discounts.
+	 */
+	private function format_items_for_discounts( array $order_items ) {
+		$formatted_items = array();
+
+		foreach ( $order_items as $order_item ) {
+			$item           = new stdClass();
+			$item->key      = $order_item->get_id();
+			$item->object   = $order_item;
+			$item->product  = $order_item->get_product();
+			$item->quantity = $order_item->get_quantity();
+			$item->price    = wc_add_number_precision_deep( $order_item->get_subtotal() );
+
+			if ( $this->get_prices_include_tax() ) {
+				$item->price += wc_add_number_precision_deep( $order_item->get_subtotal_tax() );
+			}
+
+			$formatted_items[ $order_item->get_id() ] = $item;
+		}
+
+		return $formatted_items;
+	}
+
+	/**
+	 * Calculate how much of a fixed_cart coupon's discount has already been used
+	 * by locked line items.
+	 *
+	 * @since x.x.x
+	 * @param WC_Order_Item_Coupon $coupon_item The coupon item.
+	 * @param array                $locked_items Array of locked line item IDs.
+	 * @return float Amount of discount already used by locked items.
+	 */
+	private function get_coupon_used_amount( $coupon_item, $locked_items ) {
+		$used_amount = 0;
+		$applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		// If no applied_items data, assume no discount is used by locked items.
+		// Backwards compatibility: orders without this metadata can recalculate freely.
+		if ( ! is_array( $applied_items ) || empty( $applied_items ) ) {
+			return 0;
+		}
+
+		// Calculate discount amount from locked line items only.
+		foreach ( $applied_items as $item_id => $discount_data ) {
+			$item_id = (int) $item_id;
+			if ( in_array( $item_id, $locked_items, true ) && is_array( $discount_data ) && isset( $discount_data['discount'] ) ) {
+				$used_amount += (float) $discount_data['discount'];
+			}
+		}
+
+		return $used_amount;
+	}
+
+
+	/**
 	 * After applying coupons via the WC_Discounts class, update line items.
 	 *
 	 * @since 3.2.0
@@ -1497,6 +1655,37 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				}
 
 				$item->set_total( max( 0, $item->get_total() - $amount ) );
+			}
+		}
+	}
+
+	/**
+	 * Set coupon discount amounts directly from an array of discount amounts.
+	 *
+	 * @param array $coupon_discounts Array of coupon code => discount amount.
+	 */
+	protected function set_coupon_discount_amounts_direct( $coupon_discounts ) {
+		$coupons = $this->get_items( 'coupon' );
+		$coupon_code_to_item = wc_list_pluck( $coupons, null, 'get_code' );
+
+		foreach ( $coupon_discounts as $coupon_code => $amount ) {
+			if ( isset( $coupon_code_to_item[ $coupon_code ] ) ) {
+				$coupon_item = $coupon_code_to_item[ $coupon_code ];
+
+				// Get preserved discount if exists
+				$preserved_discount = 0;
+				$preserved_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+				if ( is_array( $preserved_items ) ) {
+					foreach ( $preserved_items as $preserved_data ) {
+						$preserved_discount += $preserved_data['discount'];
+					}
+				}
+
+				// Total discount is preserved + new
+				$total_discount = $preserved_discount + $amount;
+
+				$coupon_item->set_discount( $total_discount );
+				$coupon_item->save();
 			}
 		}
 	}
@@ -1538,6 +1727,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$coupon_item = $this->get_item( $item_id, false );
 				}
 
+				// Get locked items for the current coupon only.
+				$locked_items = $this->get_locked_line_items( $coupon_code );
+
 				$discount_tax = 0;
 
 				// Work out how much tax has been removed as a result of the discount from this coupon.
@@ -1560,8 +1752,83 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					}
 				}
 
-				$coupon_item->set_discount( $amount );
-				$coupon_item->set_discount_tax( $discount_tax );
+				// Calculate total preserved discount for locked items.
+				$existing_applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+				$preserved_discount = 0;
+				$preserved_discount_tax = 0;
+
+				if ( is_array( $existing_applied_items ) && ! empty( $locked_items ) ) {
+					foreach ( $existing_applied_items as $item_id => $discount_data ) {
+						if ( in_array( (int) $item_id, $locked_items, true ) && is_array( $discount_data ) ) {
+							$preserved_discount += isset( $discount_data['discount'] ) ? (float) $discount_data['discount'] : 0;
+							$preserved_discount_tax += isset( $discount_data['discount_tax'] ) ? (float) $discount_data['discount_tax'] : 0;
+						}
+					}
+				}
+
+				// Set coupon discount to preserved + newly calculated amounts.
+				// Note: $amount is already in normal currency units, not precision format
+				$total_discount = $preserved_discount + $amount;
+				$total_discount_tax = $preserved_discount_tax + $discount_tax;
+				$coupon_item->set_discount( $total_discount );
+				$coupon_item->set_discount_tax( $total_discount_tax );
+
+				// Update the metadata for which items this coupon applied to.
+				// This will be used by restore_locked_item_discounts() later.
+				if ( isset( $all_discounts[ $coupon_code ] ) && ! empty( $all_discounts[ $coupon_code ] ) ) {
+					// Get existing metadata to preserve locked item data.
+					$existing_applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+					$new_applied_items = array();
+
+					// Preserve locked item discount data.
+					if ( is_array( $existing_applied_items ) ) {
+						foreach ( $existing_applied_items as $item_id => $discount_data ) {
+							if ( in_array( (int) $item_id, $locked_items, true ) ) {
+								$new_applied_items[ $item_id ] = $discount_data;
+							}
+						}
+					}
+
+					// Add new/unlocked items with their calculated discounts.
+					foreach ( $all_discounts[ $coupon_code ] as $item_id => $item_discount_amount ) {
+						if ( ! in_array( (int) $item_id, $locked_items, true ) ) {
+							$item = $this->get_item( $item_id, false );
+							$item_discount_tax = 0;
+
+							if ( $item && ProductTaxStatus::TAXABLE === $item->get_tax_status() && wc_tax_enabled() ) {
+								$item_taxes = WC_Tax::calc_tax( $item_discount_amount, $this->get_tax_rates( $item->get_tax_class(), $tax_location ), $this->get_prices_include_tax() );
+								$item_discount_tax = array_sum( $item_taxes );
+								if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+									$item_discount_tax = wc_round_tax_total( $item_discount_tax );
+								}
+							}
+
+							$new_applied_items[ $item_id ] = array(
+								'discount' => $item_discount_amount,
+								'discount_tax' => $item_discount_tax,
+							);
+						}
+					}
+
+					if ( ! empty( $new_applied_items ) ) {
+						$coupon_item->add_meta_data( 'coupon_applied_items', $new_applied_items, true );
+					}
+				} elseif ( ! empty( $locked_items ) ) {
+					// Coupon has zero remaining amount but we need to preserve locked item metadata.
+					$existing_applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+					if ( is_array( $existing_applied_items ) && ! empty( $existing_applied_items ) ) {
+						// Keep the existing metadata intact for locked items.
+						$preserved_items = array();
+						foreach ( $existing_applied_items as $item_id => $discount_data ) {
+							if ( in_array( (int) $item_id, $locked_items, true ) ) {
+								$preserved_items[ $item_id ] = $discount_data;
+							}
+						}
+						if ( ! empty( $preserved_items ) ) {
+							$coupon_item->add_meta_data( 'coupon_applied_items', $preserved_items, true );
+						}
+					}
+				}
 
 				$this->add_item( $coupon_item );
 			}

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -830,10 +830,12 @@ final class WC_Cart_Totals {
 			foreach ( $coupon_discounts as $cart_item_key => $discount_amount ) {
 				// Store both the item key and the discount amount (including tax if applicable).
 				$discount_tax = 0;
-				if ( isset( $coupon_discount_tax_amounts[ $coupon_code ] ) && isset( $this->items[ $cart_item_key ] ) ) {
-					// Calculate proportional tax for this item's discount.
-					$item_discount_proportion = $discount_amount / max( 1, $coupon_discount_amounts[ $coupon_code ] );
-					$discount_tax = $coupon_discount_tax_amounts[ $coupon_code ] * $item_discount_proportion;
+				if ( isset( $this->items[ $cart_item_key ] ) ) {
+					$item = $this->items[ $cart_item_key ];
+					// Calculate this item's discount tax directly to match earlier calculation and avoid misallocation.
+					if ( $this->calculate_tax && $item->product->is_taxable() ) {
+						$discount_tax = array_sum( WC_Tax::calc_tax( $discount_amount, $item->tax_rates, $item->price_includes_tax ) );
+					}
 				}
 				$coupon_applied_items[ $coupon_code ][ $cart_item_key ] = array(
 					'discount'     => wc_remove_number_precision( $discount_amount ),

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -823,7 +823,7 @@ final class WC_Cart_Totals {
 		$this->cart->set_coupon_discount_totals( wc_remove_number_precision_deep( $coupon_discount_amounts ) );
 		$this->cart->set_coupon_discount_tax_totals( wc_remove_number_precision_deep( $coupon_discount_tax_amounts ) );
 
-		// Store which cart items each coupon was applied to AND their discount amounts for order metadata.
+		// Store per-item discount amounts for each coupon to preserve during order recalculation.
 		$coupon_applied_items = array();
 		foreach ( $discounts->get_discounts( true ) as $coupon_code => $coupon_discounts ) {
 			$coupon_applied_items[ $coupon_code ] = array();

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -823,6 +823,26 @@ final class WC_Cart_Totals {
 		$this->cart->set_coupon_discount_totals( wc_remove_number_precision_deep( $coupon_discount_amounts ) );
 		$this->cart->set_coupon_discount_tax_totals( wc_remove_number_precision_deep( $coupon_discount_tax_amounts ) );
 
+		// Store which cart items each coupon was applied to AND their discount amounts for order metadata.
+		$coupon_applied_items = array();
+		foreach ( $discounts->get_discounts( true ) as $coupon_code => $coupon_discounts ) {
+			$coupon_applied_items[ $coupon_code ] = array();
+			foreach ( $coupon_discounts as $cart_item_key => $discount_amount ) {
+				// Store both the item key and the discount amount (including tax if applicable).
+				$discount_tax = 0;
+				if ( isset( $coupon_discount_tax_amounts[ $coupon_code ] ) && isset( $this->items[ $cart_item_key ] ) ) {
+					// Calculate proportional tax for this item's discount.
+					$item_discount_proportion = $discount_amount / max( 1, $coupon_discount_amounts[ $coupon_code ] );
+					$discount_tax = $coupon_discount_tax_amounts[ $coupon_code ] * $item_discount_proportion;
+				}
+				$coupon_applied_items[ $coupon_code ][ $cart_item_key ] = array(
+					'discount'     => wc_remove_number_precision( $discount_amount ),
+					'discount_tax' => wc_remove_number_precision( $discount_tax ),
+				);
+			}
+		}
+		$this->cart->set_coupon_applied_items( $coupon_applied_items );
+
 		// Add totals to cart object. Note: Discount total for cart is excl tax.
 		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
 		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -102,6 +102,14 @@ class WC_Cart extends WC_Legacy_Cart {
 	protected $totals = array();
 
 	/**
+	 * Contains an array of cart items affected by each coupon.
+	 *
+	 * @since x.x.x
+	 * @var array
+	 */
+	protected $coupon_applied_items = array();
+
+	/**
 	 * Reference to the cart session handling class.
 	 *
 	 * @var WC_Cart_Session
@@ -439,6 +447,26 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
+	 * Sets the array of cart items affected by each coupon.
+	 *
+	 * @since x.x.x
+	 * @param array $value Value to set (coupon_code => array of cart item keys).
+	 */
+	public function set_coupon_applied_items( $value = array() ) {
+		$this->coupon_applied_items = (array) $value;
+	}
+
+	/**
+	 * Gets the array of cart items affected by each coupon.
+	 *
+	 * @since x.x.x
+	 * @return array coupon_code => array of cart item keys.
+	 */
+	public function get_coupon_applied_items() {
+		return isset( $this->coupon_applied_items ) ? $this->coupon_applied_items : array();
+	}
+
+	/**
 	 * Set all calculated totals.
 	 *
 	 * @since 3.2.0
@@ -670,6 +698,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->shipping_methods           = array();
 		$this->coupon_discount_totals     = array();
 		$this->coupon_discount_tax_totals = array();
+		$this->coupon_applied_items       = array();
 		$this->applied_coupons            = array();
 		$this->totals                     = $this->default_totals;
 
@@ -2009,6 +2038,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function remove_coupons( $deprecated = null ) {
 		$this->set_coupon_discount_totals( array() );
 		$this->set_coupon_discount_tax_totals( array() );
+		$this->set_coupon_applied_items( array() );
 		$this->set_applied_coupons( array() );
 		$this->session->set_session();
 	}

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -720,7 +720,7 @@ class WC_Checkout {
 			$coupon_info = $coupon->get_short_info();
 			$item->add_meta_data( 'coupon_info', $coupon_info );
 
-			// Store which cart items this coupon was applied to AND their discount amounts.
+			// Store per-item discount amounts for this coupon.
 			if ( isset( $coupon_applied_items[ $code ] ) ) {
 				// Convert cart item keys to order line item IDs with discount amounts.
 				$applied_line_items = array();

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -726,8 +726,12 @@ class WC_Checkout {
 				$applied_line_items = array();
 				foreach ( $coupon_applied_items[ $code ] as $cart_item_key => $discount_data ) {
 					// Find the corresponding order line item for this cart item.
-					foreach ( $order->get_items() as $line_item_id => $line_item ) {
-						if ( $line_item->get_meta( '_cart_item_key' ) === $cart_item_key ) {
+					foreach ( $order->get_items( 'line_item' ) as $line_item_id => $line_item ) {
+						$key = $line_item->get_meta( '_cart_item_key', true );
+						if ( empty( $key ) && isset( $line_item->legacy_cart_item_key ) ) {
+							$key = $line_item->legacy_cart_item_key;
+						}
+						if ( $key === $cart_item_key ) {
 							// Store the line item ID with its discount amounts.
 							$applied_line_items[ $line_item_id ] = $discount_data;
 							break;

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -705,6 +705,8 @@ class WC_Checkout {
 	 * @param WC_Cart  $cart  Cart instance.
 	 */
 	public function create_order_coupon_lines( &$order, $cart ) {
+		$coupon_applied_items = $cart->get_coupon_applied_items();
+
 		foreach ( $cart->get_coupons() as $code => $coupon ) {
 			$item = new WC_Order_Item_Coupon();
 			$item->set_props(
@@ -717,6 +719,25 @@ class WC_Checkout {
 
 			$coupon_info = $coupon->get_short_info();
 			$item->add_meta_data( 'coupon_info', $coupon_info );
+
+			// Store which cart items this coupon was applied to AND their discount amounts.
+			if ( isset( $coupon_applied_items[ $code ] ) ) {
+				// Convert cart item keys to order line item IDs with discount amounts.
+				$applied_line_items = array();
+				foreach ( $coupon_applied_items[ $code ] as $cart_item_key => $discount_data ) {
+					// Find the corresponding order line item for this cart item.
+					foreach ( $order->get_items() as $line_item_id => $line_item ) {
+						if ( $line_item->get_meta( '_cart_item_key' ) === $cart_item_key ) {
+							// Store the line item ID with its discount amounts.
+							$applied_line_items[ $line_item_id ] = $discount_data;
+							break;
+						}
+					}
+				}
+				if ( ! empty( $applied_line_items ) ) {
+					$item->add_meta_data( 'coupon_applied_items', $applied_line_items, true );
+				}
+			}
 
 			/**
 			 * Action hook to adjust item before save.

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
@@ -545,4 +545,1483 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function handle_woocommerce_coupon_is_valid_for_cart( $valid, $coupon ) {
 		return $valid || ( $coupon->get_discount_type() === 'foobar' );
 	}
+
+	/**
+	 * Test: test_recalculate_coupons_preserves_amounts_for_finalized_orders
+	 */
+	public function test_recalculate_coupons_preserves_amounts_for_finalized_orders() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'preserve-test' );
+		$coupon->set_amount( 50 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'preserve-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Modify the coupon amount
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Order totals should remain unchanged for finalized orders
+		$this->assertEquals( $original_total, $order->get_total() );
+		$this->assertEquals( $original_discount, $order->get_discount_total() );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that when coupon amount is increased and new products are added,
+	 * locked products keep original discount and new products get remainder.
+	 */
+	public function test_coupon_amount_increased_with_new_product() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'increase-test' );
+		$coupon->set_amount( 50 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 60 );
+		$product2->save();
+
+		// Create order with one product and $50 coupon
+		$order = wc_create_order();
+		$order->add_product( $product1, 1 );
+		$order->apply_coupon( 'increase-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Original: product1 = $100 - $50 = $50 total
+		$this->assertEquals( 50.00, $order->get_total() );
+		$this->assertEquals( 50.00, $order->get_discount_total() );
+
+		// Merchant increases coupon to $120
+		$coupon->set_amount( 120 );
+		$coupon->save();
+
+		// Add second product
+		$order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Expected with preservation:
+		// Product1 keeps $50 discount (locked)
+		// Product2 gets remainder: $120 - $50 = $70, but product2 costs only $60, so gets $60
+		// Total: ($100 - $50) + ($60 - $60) = $50 + $0 = $50
+		// Total discount: $50 + $60 = $110
+		//
+		// Without preservation (incorrect):
+		// Both products would get $120 / 2 = $60 each
+		// Total: ($100 - $60) + ($60 - $60) = $40 + $0 = $40
+		// This test would fail because total would be $40 not $50
+		$this->assertEquals( 50.00, $order->get_total() );
+		$this->assertEquals( 110.00, $order->get_discount_total() );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that preserved coupons still affect order calculations properly.
+	 * While we preserve coupon discount amounts, other order calculations should work normally.
+	 */
+	public function test_recalculate_coupons_preserved_coupons_still_function() {
+		// Create a coupon with free shipping
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'function-test' );
+		$coupon->set_amount( 20 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_free_shipping( true );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Enable tax calculations
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		// Create a tax rate
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10',
+			'tax_rate_name'     => 'Test Tax',
+			'tax_rate_priority' => 1,
+			'tax_rate_compound' => 0,
+			'tax_rate_shipping' => 1,
+			'tax_rate_order'    => 1,
+			'tax_rate_class'    => '',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'function-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+		$original_tax = $order->get_total_tax();
+
+		// Modify the coupon amount - this should NOT affect the finalized order
+		$coupon->set_amount( 5 );
+		$coupon->save();
+
+		// Recalculate - discount should be preserved but other calculations should work
+		$order->recalculate_coupons();
+		$order->calculate_totals(); // This should recalculate taxes, etc.
+		$order->save();
+
+		// Discount amount should be preserved (still 20, not 5)
+		$this->assertEquals( $original_discount, $order->get_discount_total(), 'Coupon discount amount should be preserved' );
+		$this->assertEquals( $original_total, $order->get_total(), 'Order total should remain the same' );
+
+		// But the coupon should still function for other aspects like free shipping
+		$this->assertTrue( $coupon->get_free_shipping(), 'Coupon should still provide free shipping' );
+
+		// Tax calculations should still work properly based on preserved discount
+		$this->assertEquals( $original_tax, $order->get_total_tax(), 'Tax calculations should work with preserved discount' );
+
+		// Clean up
+		WC_Tax::_delete_tax_rate( $tax_rate['tax_rate_id'] ?? 1 );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test: test_recalculate_coupons_updates_amounts_for_draft_orders
+	 */
+	public function test_recalculate_coupons_updates_amounts_for_draft_orders() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'draft-test' );
+		$coupon->set_amount( 50 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'draft-test' );
+		$order->calculate_totals();
+		$order->set_status( 'pending' );
+		$order->save();
+
+		// Modify the coupon amount
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Draft order should use the new coupon amount
+		$this->assertEquals( '90.00', $order->get_total() );
+		$this->assertEquals( 10, $order->get_discount_total() );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test: test_recalculate_coupons_ignores_recreated_coupons
+	 */
+	public function test_recalculate_coupons_ignores_recreated_coupons() {
+		$original_coupon = new WC_Coupon();
+		$original_coupon->set_code( 'recreate-test' );
+		$original_coupon->set_amount( 30 );
+		$original_coupon->set_discount_type( 'percent' );
+		$original_coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'recreate-test' );
+		$order->calculate_totals();
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Delete original coupon and create new one with same code
+		$original_coupon->delete( true );
+
+		$new_coupon = new WC_Coupon();
+		$new_coupon->set_code( 'recreate-test' );
+		$new_coupon->set_amount( 10 );
+		$new_coupon->set_discount_type( 'percent' );
+		$new_coupon->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Order should preserve original discount amounts
+		$this->assertEquals( $original_total, $order->get_total() );
+		$this->assertEquals( $original_discount, $order->get_discount_total() );
+
+		$new_coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test: test_recalculate_coupon_statuses_filter
+	 */
+	public function test_recalculate_coupon_statuses_filter() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'filter-test' );
+		$coupon->set_amount( 25 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'filter-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+
+		// Modify coupon and recalculate - custom status should preserve amounts by default
+		$coupon->set_amount( 5 );
+		$coupon->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Processing status should preserve coupon amounts by default (safe behavior)
+		$this->assertEquals( $original_total, $order->get_total() );
+
+		// Add filter to include processing status in recalculation list
+		add_filter( 'woocommerce_order_recalculate_coupon_statuses', function( $statuses, $order ) {
+			$statuses[] = 'processing';
+			return $statuses;
+		}, 10, 2 );
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Now filter should allow processing status to recalculate coupon amounts
+		$this->assertEquals( 95.00, $order->get_total() ); // 100 - 5 (new coupon amount)
+
+		remove_all_filters( 'woocommerce_order_recalculate_coupon_statuses' );
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test: test_recalculate_coupons_preserves_product_restrictions_percent
+	 *
+	 * CRITICAL test: When percent coupon product restrictions are changed after order placement,
+	 * recalculation should NOT retroactively apply the new restrictions to finalized orders.
+	 * Tests individual line item totals to catch discount redistribution.
+	 */
+	public function test_recalculate_coupons_preserves_product_restrictions_percent() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'percent-restriction-test' );
+		$coupon->set_amount( 20 ); // 20% discount
+		$coupon->set_discount_type( 'percent' );
+		$coupon->save();
+
+		// Create two products
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 50 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Initially restrict coupon to only product1
+		$coupon->set_product_ids( array( $product1->get_id() ) );
+		$coupon->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product1, 1 );
+		$order->add_product( $product2, 1 ); // This should NOT get the discount
+		$order->apply_coupon( 'percent-restriction-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Get original line item totals
+		$line_items = $order->get_items();
+		$product1_item = null;
+		$product2_item = null;
+		foreach ( $line_items as $item ) {
+			if ( $item->get_product_id() == $product1->get_id() ) {
+				$product1_item = $item;
+			} elseif ( $item->get_product_id() == $product2->get_id() ) {
+				$product2_item = $item;
+			}
+		}
+
+		// Should be: product1 = 40 (50 - 20%), product2 = 50 (no discount)
+		$this->assertEquals( 40.00, $product1_item->get_total() );
+		$this->assertEquals( 50.00, $product2_item->get_total() );
+		$this->assertEquals( 90.00, $order->get_total() );
+		$this->assertEquals( 10.00, $order->get_discount_total() );
+
+		// Now change coupon to allow ALL products (simulate admin expanding coupon scope)
+		$coupon->set_product_ids( array() ); // Empty = all products
+		$coupon->save();
+
+		// Trigger recalculation (e.g., from admin action or plugin)
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Refresh line items
+		$line_items = $order->get_items();
+		foreach ( $line_items as $item ) {
+			if ( $item->get_product_id() == $product1->get_id() ) {
+				$product1_item = $item;
+			} elseif ( $item->get_product_id() == $product2->get_id() ) {
+				$product2_item = $item;
+			}
+		}
+
+		// The original restriction should be preserved - product2 should still not have discount
+		// Without the fix, this would fail as product2 would now get 20% discount (total = 40)
+		$this->assertEquals( 40.00, $product1_item->get_total() );
+		$this->assertEquals( 50.00, $product2_item->get_total() );
+		$this->assertEquals( 90.00, $order->get_total() );
+		$this->assertEquals( 10.00, $order->get_discount_total() );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test multiple coupons on finalized orders to ensure no cross-coupon bleeding.
+	 */
+	public function test_recalculate_coupons_multiple_coupons_no_bleeding() {
+		// Create two different coupons
+		$coupon1 = new WC_Coupon();
+		$coupon1->set_code( 'multi-test-1' );
+		$coupon1->set_amount( 30 );
+		$coupon1->set_discount_type( 'fixed_cart' );
+		$coupon1->save();
+
+		$coupon2 = new WC_Coupon();
+		$coupon2->set_code( 'multi-test-2' );
+		$coupon2->set_amount( 20 );
+		$coupon2->set_discount_type( 'fixed_cart' );
+		$coupon2->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'multi-test-1' );
+		$order->apply_coupon( 'multi-test-2' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Modify ONLY the first coupon amount
+		$coupon1->set_amount( 5 );
+		$coupon1->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Both coupon discounts should be preserved (no bleeding between coupons)
+		$this->assertEquals( $original_total, $order->get_total() );
+		$this->assertEquals( $original_discount, $order->get_discount_total() );
+
+		$coupon1->delete( true );
+		$coupon2->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that adding products to finalized orders handles coupons properly.
+	 * Fixed cart coupons preserve their original discount amount on existing items
+	 * and new items receive no discount when the coupon amount is fully consumed.
+	 */
+	public function test_recalculate_coupons_added_products_after_finalization() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'added-products-test' );
+		$coupon->set_amount( 25 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Create order with one product and coupon
+		$order = wc_create_order();
+		$order->add_product( $product1, 1 );
+		$order->apply_coupon( 'added-products-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Add second product after finalization
+		$order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Original coupon discount should be preserved
+		// New product receives no discount because the $25 fixed cart coupon
+		// is fully consumed by the existing product
+		$this->assertEquals( $original_discount, $order->get_discount_total() );
+
+		// Total should be original + new product price (no discount on new item)
+		$expected_total = $original_total + $product2->get_regular_price();
+		$this->assertEquals( $expected_total, $order->get_total() );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test complex coupon stacking scenarios on finalized orders.
+	 */
+	public function test_recalculate_coupons_complex_stacking_preserved() {
+		// Create percentage and fixed coupons
+		$percent_coupon = new WC_Coupon();
+		$percent_coupon->set_code( 'stack-percent' );
+		$percent_coupon->set_amount( 10 ); // 10%
+		$percent_coupon->set_discount_type( 'percent' );
+		$percent_coupon->save();
+
+		$fixed_coupon = new WC_Coupon();
+		$fixed_coupon->set_code( 'stack-fixed' );
+		$fixed_coupon->set_amount( 15 );
+		$fixed_coupon->set_discount_type( 'fixed_cart' );
+		$fixed_coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 2 ); // 2 x $100 = $200
+		$order->apply_coupon( 'stack-percent' ); // 10% off $200 = $20 off
+		$order->apply_coupon( 'stack-fixed' );   // $15 off
+		$order->calculate_totals(); // Should be $200 - $20 - $15 = $165
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Modify both coupons
+		$percent_coupon->set_amount( 25 ); // Change to 25%
+		$percent_coupon->save();
+		$fixed_coupon->set_amount( 50 ); // Change to $50
+		$fixed_coupon->save();
+
+		$order->recalculate_coupons();
+		$order->save();
+
+		// All original stacked discounts should be preserved
+		$this->assertEquals( $original_total, $order->get_total() );
+		$this->assertEquals( $original_discount, $order->get_discount_total() );
+
+		$percent_coupon->delete( true );
+		$fixed_coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test fixed cart discount exhaustion - when preserved line items have already
+	 * consumed the full discount amount, new items should get NO discount.
+	 */
+	public function test_recalculate_coupons_fixed_cart_discount_exhausted() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'fixed-exhausted-test' );
+		$coupon->set_amount( 20 ); // $20 fixed cart discount
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 50 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 30 );
+		$product2->save();
+
+		// Create order with one product and coupon
+		$order = wc_create_order();
+		$order->add_product( $product1, 1 ); // $50 product
+		$order->apply_coupon( 'fixed-exhausted-test' ); // $20 off
+		$order->calculate_totals(); // Total should be $30
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total(); // Should be $30
+		$original_discount = $order->get_discount_total(); // Should be $20
+
+		// Add second product after finalization
+		$order->add_product( $product2, 1 ); // $30 product added
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// The $20 discount is already fully consumed by the first product
+		// New product should NOT get any discount because the fixed cart coupon is exhausted
+		// Expected: $30 (original total) + $30 (new product) = $60
+		// Discount should remain $20 (not increase)
+
+		$this->assertEquals( $original_discount, $order->get_discount_total(), 'Fixed cart discount should not exceed original amount' );
+
+		// Total should be $60 ($30 preserved + $30 new product with no discount)
+		// The fixed cart coupon amount is exhausted so new items cannot receive discounts
+		$expected_total = $original_total + $product2->get_regular_price();
+		$this->assertEquals( $expected_total, $order->get_total(), 'New product should not get discount when fixed amount is exhausted' );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test fixed cart discount partial consumption - when preserved line items
+	 * only partially consume the discount, new items should get the remainder.
+	 */
+	public function test_recalculate_coupons_fixed_cart_discount_partial() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'fixed-partial-test' );
+		$coupon->set_amount( 50 ); // $50 fixed cart discount
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 30 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 40 );
+		$product2->save();
+
+		// Create order with one product and coupon
+		$order = wc_create_order();
+		$item1_id = $order->add_product( $product1, 1 ); // $30 product
+
+		$order->apply_coupon( 'fixed-partial-test' ); // $50 off, but only $30 used
+
+		$order->calculate_totals(); // Total should be $0 (can't go negative)
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total(); // Should be $0
+		$original_discount = $order->get_discount_total(); // Should be $30 (actual applied)
+
+		// Add second product after finalization
+		$item2_id = $order->add_product( $product2, 1 ); // $40 product added
+
+		$order->recalculate_coupons();
+
+		$order->calculate_totals();
+		$order->save();
+
+		$new_total = $order->get_total();
+		$new_discount = $order->get_discount_total();
+
+		// Expected behavior:
+		// - First product keeps its $30 discount (preserved)
+		// - Second product should get $20 discount (remainder: $50 - $30 = $20)
+		// - Total discount: $30 + $20 = $50
+		// - Total: ($30 + $40) - $50 = $20
+
+		$this->assertEquals( 50.00, $order->get_discount_total(), 'Full discount should be applied' );
+		$this->assertEquals( 20.00, $order->get_total(), 'Remainder discount on new product' );
+
+		// Verify the new product got the remaining discount.
+		$product2_item = $order->get_item( $item2_id );
+		$this->assertEquals( 20.00, $product2_item->get_total(), 'New product should get remainder discount' );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that line-item level coupon tracking works properly.
+	 */
+	public function test_line_item_coupon_tracking() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'line-item-test' );
+		$coupon->set_amount( 30 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Create order with one product and apply coupon.
+		$order = wc_create_order();
+		$item1 = $order->add_product( $product1, 1 );
+		$order->apply_coupon( 'line-item-test' );
+		$order->calculate_totals();
+		$order->save();
+
+		// Check that coupon_applied_items metadata is stored.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertIsArray( $applied_items, 'Coupon should have applied_items metadata' );
+		$this->assertArrayHasKey( $item1, $applied_items, 'Line item ID should be a key in coupon metadata' );
+		$this->assertIsArray( $applied_items[ $item1 ], 'Line item should have discount data array' );
+		$this->assertArrayHasKey( 'discount', $applied_items[ $item1 ], 'Should store discount amount' );
+		$this->assertArrayHasKey( 'discount_tax', $applied_items[ $item1 ], 'Should store discount tax' );
+
+		// Finalize order.
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_item1_total = $order->get_item( $item1 )->get_total();
+		$original_discount = $order->get_discount_total();
+
+		// Add new product after finalization.
+		$item2 = $order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Check that original item total is preserved (locked).
+		$this->assertEquals( $original_item1_total, $order->get_item( $item1 )->get_total(), 'Original item total should be preserved' );
+
+		// Check that new item gets NO discount (coupon was exhausted).
+		$this->assertEquals( 50, $order->get_item( $item2 )->get_total(), 'New item should not get discount when coupon is exhausted' );
+
+		// Total discount should remain the same.
+		$this->assertEquals( $original_discount, $order->get_discount_total(), 'Total discount should not increase' );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that locked items don't get double discounts.
+	 */
+	public function test_no_double_discount_on_locked_items() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'no-double-test' );
+		$coupon->set_amount( 20 );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create and finalize order.
+		$order = wc_create_order();
+		$item_id = $order->add_product( $product, 2 ); // 2 items @ $100 = $200.
+		$order->apply_coupon( 'no-double-test' ); // 20% off = $40 discount.
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_item_total = $order->get_item( $item_id )->get_total(); // Should be $160.
+		$original_discount = $order->get_discount_total(); // Should be $40.
+
+		// Modify coupon to higher percentage.
+		$coupon->set_amount( 50 ); // Now 50% off.
+		$coupon->save();
+
+		// Recalculate - locked items should NOT get additional discount.
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Item total should remain the same (no double discount).
+		$this->assertEquals( $original_item_total, $order->get_item( $item_id )->get_total(), 'Locked item should not get additional discount' );
+		$this->assertEquals( $original_discount, $order->get_discount_total(), 'Total discount should not increase for locked items' );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that coupon metadata includes per-item discount and tax amounts.
+	 */
+	public function test_metadata_storage_format() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'metadata-test' );
+		$coupon->set_amount( 30 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		// Enable tax calculations.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		// Create a tax rate.
+		$tax_rate_id = WC_Tax::_insert_tax_rate( array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10',
+			'tax_rate_name'     => 'Test Tax',
+			'tax_rate_priority' => 1,
+			'tax_rate_compound' => 0,
+			'tax_rate_shipping' => 0,
+			'tax_rate_order'    => 1,
+			'tax_rate_class'    => '',
+		) );
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Create order and apply coupon.
+		$order = wc_create_order();
+		$item1_id = $order->add_product( $product1, 1 );
+		$item2_id = $order->add_product( $product2, 1 );
+		$order->apply_coupon( 'metadata-test' );
+		$order->calculate_totals();
+		$order->save();
+
+		// Check that coupon_applied_items metadata is stored with discount amounts.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertIsArray( $applied_items, 'Coupon should have applied_items metadata' );
+		$this->assertArrayHasKey( $item1_id, $applied_items, 'Item 1 should be in applied items' );
+		$this->assertArrayHasKey( $item2_id, $applied_items, 'Item 2 should be in applied items' );
+
+		// Check that discount amounts are stored.
+		$this->assertIsArray( $applied_items[$item1_id], 'Item 1 should have discount data' );
+		$this->assertArrayHasKey( 'discount', $applied_items[$item1_id], 'Item 1 should have discount amount' );
+		$this->assertArrayHasKey( 'discount_tax', $applied_items[$item1_id], 'Item 1 should have discount tax' );
+
+		$this->assertIsArray( $applied_items[$item2_id], 'Item 2 should have discount data' );
+		$this->assertArrayHasKey( 'discount', $applied_items[$item2_id], 'Item 2 should have discount amount' );
+		$this->assertArrayHasKey( 'discount_tax', $applied_items[$item2_id], 'Item 2 should have discount tax' );
+
+		// Verify discount amounts are numeric and reasonable.
+		$item1_discount = (float) $applied_items[$item1_id]['discount'];
+		$item2_discount = (float) $applied_items[$item2_id]['discount'];
+		$total_discount = $item1_discount + $item2_discount;
+
+		// Total discount should equal coupon amount.
+		$this->assertEquals( 30, $total_discount, 'Total stored discount should equal coupon amount' );
+
+		// Fixed cart discounts are distributed equally per item count.
+		$expected_item1_discount = 15;
+		$expected_item2_discount = 15;
+		$this->assertEquals( $expected_item1_discount, $item1_discount, 'Item 1 discount should match' );
+		$this->assertEquals( $expected_item2_discount, $item2_discount, 'Item 2 discount should match' );
+
+		// Clean up.
+		WC_Tax::_delete_tax_rate( $tax_rate_id );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test backwards compatibility with orders created before line-item tracking.
+	 */
+	public function test_backwards_compatibility_no_metadata() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'backwards-compat-test' );
+		$coupon->set_amount( 25 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Simulate an old order without coupon_applied_items metadata.
+		$order = wc_create_order();
+		$order->add_product( $product1, 1 );
+		$order->apply_coupon( 'backwards-compat-test' );
+		$order->calculate_totals();
+
+		// Remove the coupon_applied_items metadata to simulate old order.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$coupon_item->delete_meta_data( 'coupon_applied_items' );
+		$coupon_item->save();
+
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Add new product.
+		$order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Without metadata, all items can be recalculated (backwards compatible behavior).
+		// New item should get discount if coupon amount allows.
+		$this->assertLessThan( 150, $order->get_total(), 'New item should get discount in backwards compatible mode' );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test percentage coupon amount preservation.
+	 * Verifies that both line totals AND coupon item discount remain at original figures.
+	 */
+	public function test_percentage_coupon_amount_preservation() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'percent-amount-test' );
+		$coupon->set_amount( 20 ); // 20%
+		$coupon->set_discount_type( 'percent' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create order with percentage coupon.
+		$order = wc_create_order();
+		$item_id = $order->add_product( $product, 2 ); // 2 x $100 = $200
+		$order->apply_coupon( 'percent-amount-test' ); // 20% off $200 = $40 discount
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_line_total = $order->get_item( $item_id )->get_total(); // Should be $160
+		$original_coupon_discount = $order->get_discount_total(); // Should be $40
+
+		// Get original coupon item discount amount.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$original_coupon_amount = $coupon_item->get_discount(); // Should be $40
+
+		// Change coupon percentage.
+		$coupon->set_amount( 50 ); // Change to 50%
+		$coupon->save();
+
+		// Recalculate.
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Both line totals AND coupon item discount should remain at original figures.
+		$this->assertEquals( $original_line_total, $order->get_item( $item_id )->get_total(), 'Line item total should be preserved' );
+		$this->assertEquals( $original_coupon_discount, $order->get_discount_total(), 'Order discount total should be preserved' );
+
+		// Refresh coupon item and check its discount amount.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$this->assertEquals( $original_coupon_amount, $coupon_item->get_discount(), 'Coupon item discount amount should be preserved' );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test multiple coupons on same line items.
+	 * One fixed-cart + one percentage coupon on same products.
+	 */
+	public function test_multiple_coupons_same_line_preservation() {
+		$fixed_coupon = new WC_Coupon();
+		$fixed_coupon->set_code( 'multi-fixed' );
+		$fixed_coupon->set_amount( 30 );
+		$fixed_coupon->set_discount_type( 'fixed_cart' );
+		$fixed_coupon->save();
+
+		$percent_coupon = new WC_Coupon();
+		$percent_coupon->set_code( 'multi-percent' );
+		$percent_coupon->set_amount( 10 ); // 10%
+		$percent_coupon->set_discount_type( 'percent' );
+		$percent_coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create order with both coupons.
+		$order = wc_create_order();
+		$item_id = $order->add_product( $product, 2 ); // 2 x $100 = $200
+		$order->apply_coupon( 'multi-fixed' );   // $30 off
+		$order->apply_coupon( 'multi-percent' ); // 10% off remaining = 10% of $170 = $17 off
+		$order->calculate_totals(); // Total: $200 - $30 - $17 = $153
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_total = $order->get_total();
+		$original_total_discount = $order->get_discount_total();
+
+		// Get individual coupon discount amounts.
+		$coupon_items = $order->get_items( 'coupon' );
+		$original_coupon_amounts = array();
+		foreach ( $coupon_items as $coupon_item ) {
+			$original_coupon_amounts[ $coupon_item->get_code() ] = $coupon_item->get_discount();
+		}
+
+		// Modify both coupons.
+		$fixed_coupon->set_amount( 50 );   // Change to $50
+		$percent_coupon->set_amount( 25 ); // Change to 25%
+		$fixed_coupon->save();
+		$percent_coupon->save();
+
+		// Recalculate.
+		$order->recalculate_coupons();
+		$order->save();
+
+		// All original amounts should be preserved.
+		$this->assertEquals( $original_total, $order->get_total(), 'Order total should be preserved' );
+		$this->assertEquals( $original_total_discount, $order->get_discount_total(), 'Total discount should be preserved' );
+
+		// Check each coupon retained its original discount amount.
+		$coupon_items = $order->get_items( 'coupon' );
+		foreach ( $coupon_items as $coupon_item ) {
+			$code = $coupon_item->get_code();
+			$this->assertEquals(
+				$original_coupon_amounts[ $code ],
+				$coupon_item->get_discount(),
+				"Coupon {$code} should preserve its original discount amount"
+			);
+		}
+
+		$fixed_coupon->delete( true );
+		$percent_coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test REST API coupon creation gap.
+	 * REST API uses calculate_coupons() which bypasses our metadata storage.
+	 */
+	public function test_rest_api_metadata_gap() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'rest-gap-test' );
+		$coupon->set_amount( 15 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 50 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 2 );
+		$order->save();
+
+		// Simulate REST API calculate_coupons() path (not apply_coupon).
+		$discounts = new WC_Discounts( $order );
+		$discounts->apply_coupon( new WC_Coupon( $coupon->get_id() ) );
+
+		// Manually add coupon item like REST API does.
+		$coupon_item = new WC_Order_Item_Coupon();
+		$coupon_item->set_code( 'rest-gap-test' );
+		$coupon_item->set_discount( 15 );
+		$coupon_item->set_discount_tax( 0 );
+
+		// REST API does NOT store coupon_applied_items metadata.
+		// This is the gap we need to address.
+
+		$order->add_item( $coupon_item );
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Verify no metadata was stored (demonstrating the gap).
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item_check = reset( $coupon_items );
+		$applied_items = $coupon_item_check->get_meta( 'coupon_applied_items', true );
+
+		$this->assertEmpty( $applied_items, 'REST API path should NOT store metadata (demonstrating the gap)' );
+
+		// Because no metadata exists, recalculation will treat this as unlocked.
+		$original_total = $order->get_total();
+
+		// Modify coupon.
+		$coupon->set_amount( 5 );
+		$coupon->save();
+
+		// Recalculate - without metadata, this will use new coupon amount.
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Total should change because there's no preservation (backwards compatibility).
+		$new_total = $order->get_total();
+		$this->assertNotEquals( $original_total, $new_total, 'Without metadata, recalculation should use new coupon amount' );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test percentage coupon extension to new items.
+	 * Verifies that percentage coupons apply to new items while preserving locked totals.
+	 */
+	public function test_percentage_coupon_extends_to_new_items() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'percent-extend-test' );
+		$coupon->set_amount( 20 ); // 20%
+		$coupon->set_discount_type( 'percent' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 100 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 50 );
+		$product2->save();
+
+		// Create order with first product and percentage coupon.
+		$order = wc_create_order();
+		$item1_id = $order->add_product( $product1, 1 ); // $100 product
+		$order->apply_coupon( 'percent-extend-test' ); // 20% off = $20 discount
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$original_item1_total = $order->get_item( $item1_id )->get_total(); // Should be $80
+		$original_total_discount = $order->get_discount_total(); // Should be $20
+
+		// Add second product after finalization.
+		$item2_id = $order->add_product( $product2, 1 ); // $50 product
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Item A keeps $20 off, Item B gets $10 off (20% of $50).
+		$this->assertEquals( $original_item1_total, $order->get_item( $item1_id )->get_total(), 'Item A should keep $20 off' );
+		$this->assertEquals( 40.00, $order->get_item( $item2_id )->get_total(), 'Item B should get $10 off (20% of $50)' );
+
+		// Total discount should be $20 + $10 = $30.
+		$this->assertEquals( 30.00, $order->get_discount_total(), 'Total discount should be $20 + $10' );
+		$this->assertEquals( 120.00, $order->get_total(), 'Order total should be $150 - $30' );
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test metadata integrity after recalculation.
+	 * Verifies that coupon_applied_items metadata includes new entries with discount data.
+	 */
+	public function test_metadata_integrity_after_recalculation() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'metadata-integrity-test' );
+		$coupon->set_amount( 15 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 60 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 40 );
+		$product2->save();
+
+		// Create order with first product.
+		$order = wc_create_order();
+		$item1_id = $order->add_product( $product1, 1 );
+		$order->apply_coupon( 'metadata-integrity-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Verify initial metadata.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$initial_metadata = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertArrayHasKey( $item1_id, $initial_metadata, 'Initial metadata should include first item' );
+
+		// Add second product and recalculate.
+		$item2_id = $order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Verify updated metadata includes both items.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$updated_metadata = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertArrayHasKey( $item1_id, $updated_metadata, 'Updated metadata should preserve first item' );
+		$this->assertArrayHasKey( $item2_id, $updated_metadata, 'Updated metadata should include new item' );
+
+		// Verify discount data structure for both items.
+		foreach ( array( $item1_id, $item2_id ) as $item_id ) {
+			$this->assertIsArray( $updated_metadata[ $item_id ], "Item {$item_id} should have discount data" );
+			$this->assertArrayHasKey( 'discount', $updated_metadata[ $item_id ], "Item {$item_id} should have discount amount" );
+			$this->assertArrayHasKey( 'discount_tax', $updated_metadata[ $item_id ], "Item {$item_id} should have discount tax" );
+		}
+
+		$coupon->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test draft status recalculation.
+	 * Verifies that draft orders fully recalculate to latest coupon data.
+	 */
+	public function test_draft_status_recalculation() {
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'draft-status-test' );
+		$coupon->set_amount( 20 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create order in draft status.
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'draft-status-test' );
+		$order->calculate_totals();
+		$order->set_status( 'draft' );
+		$order->save();
+
+		$original_total = $order->get_total(); // Should be $80
+
+		// Modify coupon amount.
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Recalculate - draft orders should use new coupon data.
+		$order->recalculate_coupons();
+		$order->save();
+
+		// Should use new coupon amount (not preserve old).
+		$this->assertEquals( 90.00, $order->get_total(), 'Draft order should use new coupon amount' );
+		$this->assertEquals( 10.00, $order->get_discount_total(), 'Draft order should have new discount total' );
+		$this->assertNotEquals( $original_total, $order->get_total(), 'Draft order should recalculate fully' );
+
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that multiple coupons both apply to newly added items.
+	 */
+	public function test_multiple_coupons_apply_to_new_items() {
+		$coupon1 = new WC_Coupon();
+		$coupon1->set_code( 'multi-coupon-1' );
+		$coupon1->set_amount( 10 );
+		$coupon1->set_discount_type( 'fixed_cart' );
+		$coupon1->save();
+
+		$coupon2 = new WC_Coupon();
+		$coupon2->set_code( 'multi-coupon-2' );
+		$coupon2->set_amount( 5 );
+		$coupon2->set_discount_type( 'fixed_cart' );
+		$coupon2->save();
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 50 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 30 );
+		$product2->save();
+
+		// Create finalized order with two coupons.
+		$order = wc_create_order();
+		$item1_id = $order->add_product( $product1, 1 );
+		$order->apply_coupon( 'multi-coupon-1' );
+		$order->apply_coupon( 'multi-coupon-2' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Add new item after finalization.
+		$item2_id = $order->add_product( $product2, 1 );
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		// Both coupons should apply to the new item.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon1_item = null;
+		$coupon2_item = null;
+
+		foreach ( $coupon_items as $coupon_item ) {
+			if ( 'multi-coupon-1' === $coupon_item->get_code() ) {
+				$coupon1_item = $coupon_item;
+			}
+			if ( 'multi-coupon-2' === $coupon_item->get_code() ) {
+				$coupon2_item = $coupon_item;
+			}
+		}
+
+		$this->assertNotNull( $coupon1_item, 'Coupon 1 should exist' );
+		$this->assertNotNull( $coupon2_item, 'Coupon 2 should exist' );
+
+		// Check that both coupons have metadata for the new item.
+		$coupon1_applied = $coupon1_item->get_meta( 'coupon_applied_items', true );
+		$coupon2_applied = $coupon2_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertArrayHasKey( $item2_id, $coupon1_applied, 'Coupon 1 should apply to new item' );
+		$this->assertArrayHasKey( $item2_id, $coupon2_applied, 'Coupon 2 should apply to new item' );
+
+		// Total discount should be 10 + 5 = 15.
+		$this->assertEquals( 15.00, $order->get_discount_total(), 'Both coupons should apply' );
+
+		$coupon1->delete( true );
+		$coupon2->delete( true );
+		$product1->delete( true );
+		$product2->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that removing a coupon properly cleans up metadata and resets totals.
+	 */
+	public function test_remove_coupon_cleans_metadata() {
+		// Create a product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create a fixed cart coupon.
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'test-remove-meta' );
+		$coupon->set_amount( 10 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		// Create an order with completed status.
+		$order = wc_create_order(
+			array(
+				'status'      => OrderStatus::COMPLETED,
+				'customer_id' => 1,
+			)
+		);
+
+		// Add product to order.
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'subtotal' => 100,
+				'total'    => 100,
+			)
+		);
+		$order->add_item( $item );
+		$order->save();
+		$order->calculate_totals();
+
+		// Initial total should be 100.
+		$this->assertEquals( 100.00, $order->get_total(), 'Initial total should be 100' );
+
+		// Apply the coupon.
+		$order->apply_coupon( $coupon );
+		$order->calculate_totals();
+
+		// Total should now be 90 (100 - 10).
+		$this->assertEquals( 90.00, $order->get_total(), 'Total should be 90 after coupon' );
+		$this->assertEquals( 10.00, $order->get_discount_total(), 'Discount should be 10' );
+
+		// Check that coupon metadata exists.
+		$coupon_items = $order->get_items( 'coupon' );
+		$this->assertCount( 1, $coupon_items, 'Should have one coupon item' );
+
+		$coupon_item = reset( $coupon_items );
+		$applied_items_meta = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertIsArray( $applied_items_meta, 'Coupon applied items metadata should exist' );
+		$this->assertNotEmpty( $applied_items_meta, 'Coupon applied items metadata should not be empty' );
+		$this->assertArrayHasKey( $item->get_id(), $applied_items_meta, 'Metadata should include the line item' );
+
+		// Remove the coupon.
+		$order->remove_coupon( 'test-remove-meta' );
+		$order->calculate_totals();
+
+		// Total should be back to 100.
+		$this->assertEquals( 100.00, $order->get_total(), 'Total should be 100 after coupon removal' );
+		$this->assertEquals( 0.00, $order->get_discount_total(), 'Discount should be 0 after coupon removal' );
+
+		// Verify coupon item is removed.
+		$coupon_items_after = $order->get_items( 'coupon' );
+		$this->assertCount( 0, $coupon_items_after, 'Should have no coupon items after removal' );
+
+		// Clean up.
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that reapplying a coupon with a changed value gives the new discount, not the old locked discount.
+	 */
+	public function test_reapply_coupon_with_changed_value() {
+		// Create a product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create a fixed cart coupon with initial value of 10.
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'test-change-value' );
+		$coupon->set_amount( 10 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		// Create an order with completed status.
+		$order = wc_create_order(
+			array(
+				'status'      => OrderStatus::COMPLETED,
+				'customer_id' => 1,
+			)
+		);
+
+		// Add product to order.
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 1,
+				'subtotal' => 100,
+				'total'    => 100,
+			)
+		);
+		$order->add_item( $item );
+		$order->save();
+		$order->calculate_totals();
+
+		// Apply the coupon with value 10.
+		$order->apply_coupon( $coupon );
+		$order->calculate_totals();
+
+		// Total should be 90 (100 - 10).
+		$this->assertEquals( 90.00, $order->get_total(), 'Total should be 90 after first coupon application' );
+		$this->assertEquals( 10.00, $order->get_discount_total(), 'Discount should be 10' );
+
+		// Get the coupon item and check metadata.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$this->assertEquals( 10.00, $coupon_item->get_discount(), 'Coupon discount should be 10' );
+
+		$applied_items_meta = $coupon_item->get_meta( 'coupon_applied_items', true );
+		$this->assertArrayHasKey( $item->get_id(), $applied_items_meta, 'Metadata should include the line item' );
+		$this->assertEquals( 10.00, $applied_items_meta[ $item->get_id() ]['discount'], 'Metadata discount should be 10' );
+
+		// Remove the coupon.
+		$order->remove_coupon( 'test-change-value' );
+		$order->calculate_totals();
+
+		// Total should be back to 100.
+		$this->assertEquals( 100.00, $order->get_total(), 'Total should be 100 after coupon removal' );
+
+		// Change the coupon value to 20.
+		$coupon->set_amount( 20 );
+		$coupon->save();
+
+		// Reapply the coupon with new value.
+		$order->apply_coupon( $coupon );
+		$order->calculate_totals();
+
+		// Total should now be 80 (100 - 20), NOT 90 (which would be if old locked value was used).
+		$this->assertEquals( 80.00, $order->get_total(), 'Total should be 80 with new coupon value' );
+		$this->assertEquals( 20.00, $order->get_discount_total(), 'Discount should be 20 with new coupon value' );
+
+		// Verify coupon item has the new discount value.
+		$coupon_items_after = $order->get_items( 'coupon' );
+		$coupon_item_after = reset( $coupon_items_after );
+		$this->assertEquals( 20.00, $coupon_item_after->get_discount(), 'Coupon discount should be 20 after reapplication' );
+
+		// Verify metadata reflects the new discount.
+		$applied_items_meta_after = $coupon_item_after->get_meta( 'coupon_applied_items', true );
+		$this->assertArrayHasKey( $item->get_id(), $applied_items_meta_after, 'Metadata should include the line item' );
+		$this->assertEquals( 20.00, $applied_items_meta_after[ $item->get_id() ]['discount'], 'Metadata discount should be 20 after reapplication' );
+
+		// Clean up.
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
@@ -1184,9 +1184,6 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order->calculate_totals();
 		$order->save();
 
-		$new_total = $order->get_total();
-		$new_discount = $order->get_discount_total();
-
 		// Expected behavior:
 		// - First product keeps its $30 discount (preserved)
 		// - Second product should get $20 discount (remainder: $50 - $30 = $20)

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/coupons.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Order coupon tests.
  *
@@ -198,8 +200,8 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		 * Coupon will therefore discount 200. Compare the total without tax so we can compare the ex tax price and avoid rounding mishaps.
 		 */
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( 401, NumberUtil::round( $order->get_total_discount( false ), 2 ), $order->get_total_discount( false ) );
-		$this->assertEquals( 598.99, $order->get_total(), $order->get_total() );
+		$this->assertEquals( 401, NumberUtil::round( $order->get_total_discount( false ), 2 ), 'Total discount should be 401' );
+		$this->assertEquals( 598.99, $order->get_total(), 'Order total should be 598.99' );
 	}
 
 	/**
@@ -254,8 +256,8 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order    = wc_get_order( $order_id );
 
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( 401, $order->get_discount_total(), $order->get_discount_total() );
-		$this->assertFloatEquals( ( 1000 - 401 ) * 1.1, $order->get_total(), $order->get_total() );
+		$this->assertEquals( 401, $order->get_discount_total(), 'Discount total should be 401' );
+		$this->assertFloatEquals( ( 1000 - 401 ) * 1.1, $order->get_total(), 0.01, 'Order total should be 658.90' );
 	}
 
 	/**
@@ -2020,6 +2022,119 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->assertEquals( 20.00, $applied_items_meta_after[ $item->get_id() ]['discount'], 'Metadata discount should be 20 after reapplication' );
 
 		// Clean up.
+		$coupon->delete( true );
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that discount tax is correctly calculated when prices include tax.
+	 */
+	public function test_coupon_discount_tax_with_prices_including_tax() {
+		// Enable tax calculations with prices including tax.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+
+		// Create a 20% tax rate.
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '20',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => 1,
+			'tax_rate_compound' => 0,
+			'tax_rate_shipping' => 0,
+			'tax_rate_order'    => 1,
+			'tax_rate_class'    => '',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		// Create a $20 fixed cart discount coupon.
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'tax-incl-test' );
+		$coupon->set_amount( 20 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		// Create a product with price including tax: $120 (incl 20% tax = $100 + $20 tax).
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 120 ); // Price includes tax.
+		$product->save();
+
+		// Create order and apply coupon.
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'tax-incl-test' );
+		$order->calculate_totals();
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Get the stored discount metadata.
+		$coupon_items = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupon_items );
+		$applied_items = $coupon_item->get_meta( 'coupon_applied_items', true );
+
+		$this->assertIsArray( $applied_items, 'Should have coupon_applied_items metadata' );
+		$this->assertNotEmpty( $applied_items, 'Applied items should not be empty' );
+
+		$item_discount_data = reset( $applied_items );
+		$discount_amount = $item_discount_data['discount'];
+		$discount_tax = $item_discount_data['discount_tax'];
+
+		// Verify discount amounts are stored.
+		// Discount amount in metadata is gross (including tax).
+		$this->assertGreaterThan( 0, $discount_amount, 'Discount amount should be positive' );
+		$this->assertGreaterThan( 0, $discount_tax, 'Discount tax should be positive' );
+
+		// For a $20 discount with 20% tax: tax portion = $20 * (20/120) = $3.33.
+		$expected_discount_tax = round( 20 * ( 20 / 120 ), 2 );
+		$this->assertEqualsWithDelta( $expected_discount_tax, round( $discount_tax, 2 ), 0.01, 'Discount tax should be $3.33' );
+
+		// Verify tax ratio matches tax rate.
+		$actual_tax_ratio = $discount_tax / $discount_amount;
+		$expected_tax_ratio = 20 / 120;
+		$this->assertEqualsWithDelta( $expected_tax_ratio, $actual_tax_ratio, 0.01, 'Tax ratio should be 0.1667' );
+
+		// Verify order totals.
+		// Original: $120 = $100 excl + $20 tax.
+		// After $20 discount: $100 = $83.33 excl + $16.67 tax.
+		$order_total = (float) $order->get_total();
+		$order_discount_total = (float) $order->get_discount_total();
+		$order_discount_tax = (float) $order->get_discount_tax();
+		$order_tax = (float) $order->get_total_tax();
+
+		$this->assertEqualsWithDelta( 100.00, round( $order_total, 2 ), 0.01, 'Order total should be $100' );
+
+		$expected_discount_excl = round( 20 * ( 100 / 120 ), 2 );
+		$this->assertEqualsWithDelta( $expected_discount_excl, round( $order_discount_total, 2 ), 0.01, 'Discount excl tax should be $16.67' );
+
+		$this->assertEqualsWithDelta( $expected_discount_tax, round( $order_discount_tax, 2 ), 0.01, 'Order discount tax should be $3.33' );
+
+		$expected_remaining_tax = round( 20 - $expected_discount_tax, 2 );
+		$this->assertEqualsWithDelta( $expected_remaining_tax, round( $order_tax, 2 ), 0.01, 'Remaining tax should be $16.67' );
+
+		// Modify coupon and recalculate to verify preservation.
+		$original_total = $order->get_total();
+		$original_discount_total = $order->get_discount_total();
+		$original_discount_tax = $order->get_discount_tax();
+		$original_tax = $order->get_total_tax();
+
+		$coupon->set_amount( 5 );
+		$coupon->save();
+
+		$order->recalculate_coupons();
+		$order->calculate_totals();
+		$order->save();
+
+		$this->assertEquals( $original_total, $order->get_total(), 'Order total preserved' );
+		$this->assertEquals( $original_discount_total, $order->get_discount_total(), 'Discount excl tax preserved' );
+		$this->assertEquals( $original_discount_tax, $order->get_discount_tax(), 'Discount tax preserved' );
+		$this->assertEquals( $original_tax, $order->get_total_tax(), 'Order tax preserved' );
+
+		// Clean up.
+		WC_Tax::_delete_tax_rate( $tax_rate['tax_rate_id'] ?? 1 );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
 		$coupon->delete( true );
 		$product->delete( true );
 		$order->delete( true );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -876,26 +876,22 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$order->set_date_created( $order_time++ );
 			$order->set_status( OrderStatus::COMPLETED );
 
+			foreach ( $coupons as $amount => $coupon ) {
+				if ( $amount >= $order_number ) {
+					$order->apply_coupon( $coupon );
+					++$applied_coupons;
+					$applied_amount += $amount;
+				}
+			}
 
+			$order->calculate_totals();
+			$orders_total += $order->get_total();
 			$order->save();
 
 			$orders[] = $order;
 		}
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
-
-
-		// Check what was written to the analytics tables
-		global $wpdb;
-		$analytics_coupons = $wpdb->get_results(
-			"SELECT order_id, coupon_id, discount_amount FROM {$wpdb->prefix}wc_order_coupon_lookup ORDER BY order_id, coupon_id",
-			ARRAY_A
-		);
-		}
-
-		$analytics_total_coupons = $wpdb->get_var(
-			"SELECT SUM(discount_amount) FROM {$wpdb->prefix}wc_order_coupon_lookup"
-		);
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -921,7 +917,6 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$shipping        = $orders_count * $order_shipping;
 		$net_revenue     = $orders_total - $shipping;
 		$gross_sales     = $product_price * $num_items_sold;
-
 		$subtotals       = array(
 			'orders_count'        => $orders_count,
 			'num_items_sold'      => $num_items_sold,
@@ -957,10 +952,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$actual_stats = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-
-
-		$this->assertEquals( $expected_stats, $actual_stats, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -876,35 +876,6 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$order->set_date_created( $order_time++ );
 			$order->set_status( OrderStatus::COMPLETED );
 
-			error_log( "=== ORDER $order_number BEFORE COUPONS ===" );
-			error_log( "Order subtotal: " . $order->get_subtotal() );
-			error_log( "Order total: " . $order->get_total() );
-			error_log( "Order shipping: " . $order->get_shipping_total() );
-
-			$order_coupons_applied = 0;
-			foreach ( $coupons as $amount => $coupon ) {
-				if ( $amount >= $order_number ) {
-					error_log( "Applying coupon {$coupon->get_code()} with amount $amount" );
-					$order->apply_coupon( $coupon );
-					++$applied_coupons;
-					$applied_amount += $amount;
-					$order_coupons_applied += $amount;
-				}
-			}
-
-			$order->calculate_totals();
-			$orders_total += $order->get_total();
-
-			error_log( "=== ORDER $order_number AFTER COUPONS ===" );
-			error_log( "Coupons applied to this order: $order_coupons_applied" );
-			error_log( "Order subtotal: " . $order->get_subtotal() );
-			error_log( "Order discount total: " . $order->get_discount_total() );
-			error_log( "Order total: " . $order->get_total() );
-
-			// Log each coupon item
-			foreach ( $order->get_items( 'coupon' ) as $coupon_item ) {
-				error_log( "Coupon item: " . $coupon_item->get_code() . " discount=" . $coupon_item->get_discount() );
-			}
 
 			$order->save();
 
@@ -913,7 +884,6 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		error_log( "=== ANALYTICS SYNC COMPLETE ===" );
 
 		// Check what was written to the analytics tables
 		global $wpdb;
@@ -921,15 +891,11 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			"SELECT order_id, coupon_id, discount_amount FROM {$wpdb->prefix}wc_order_coupon_lookup ORDER BY order_id, coupon_id",
 			ARRAY_A
 		);
-		error_log( "Analytics coupon lookup table:" );
-		foreach ( $analytics_coupons as $row ) {
-			error_log( "  Order {$row['order_id']}: Coupon {$row['coupon_id']} = {$row['discount_amount']}" );
 		}
 
 		$analytics_total_coupons = $wpdb->get_var(
 			"SELECT SUM(discount_amount) FROM {$wpdb->prefix}wc_order_coupon_lookup"
 		);
-		error_log( "Total coupons in analytics: $analytics_total_coupons" );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -956,17 +922,6 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$net_revenue     = $orders_total - $shipping;
 		$gross_sales     = $product_price * $num_items_sold;
 
-		error_log( "=== TEST EXPECTATIONS ===" );
-		error_log( "Product price: $product_price" );
-		error_log( "Qty per product: $qty_per_product" );
-		error_log( "Orders count: $orders_count" );
-		error_log( "Num items sold: $num_items_sold" );
-		error_log( "Calculated applied_amount (total coupons): $applied_amount" );
-		error_log( "Orders total (sum of get_total()): $orders_total" );
-		error_log( "Shipping: $shipping" );
-		error_log( "Net revenue (orders_total - shipping): $net_revenue" );
-		error_log( "Gross sales (product_price * num_items_sold): $gross_sales" );
-		error_log( "Expected formula: gross_sales = net_revenue + coupons = $net_revenue + $applied_amount = " . ($net_revenue + $applied_amount) );
 		$subtotals       = array(
 			'orders_count'        => $orders_count,
 			'num_items_sold'      => $num_items_sold,
@@ -1004,13 +959,6 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		$actual_stats = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 
-		error_log( "=== ACTUAL ANALYTICS RESULTS ===" );
-		error_log( "Actual gross_sales: " . $actual_stats['totals']['gross_sales'] );
-		error_log( "Actual total_sales: " . $actual_stats['totals']['total_sales'] );
-		error_log( "Actual coupons: " . $actual_stats['totals']['coupons'] );
-		error_log( "Actual net_revenue: " . $actual_stats['totals']['net_revenue'] );
-		error_log( "Actual shipping: " . $actual_stats['totals']['shipping'] );
-		error_log( "Last query: {$wpdb->last_query}" );
 
 		$this->assertEquals( $expected_stats, $actual_stats, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -876,22 +876,60 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$order->set_date_created( $order_time++ );
 			$order->set_status( OrderStatus::COMPLETED );
 
+			error_log( "=== ORDER $order_number BEFORE COUPONS ===" );
+			error_log( "Order subtotal: " . $order->get_subtotal() );
+			error_log( "Order total: " . $order->get_total() );
+			error_log( "Order shipping: " . $order->get_shipping_total() );
+
+			$order_coupons_applied = 0;
 			foreach ( $coupons as $amount => $coupon ) {
 				if ( $amount >= $order_number ) {
+					error_log( "Applying coupon {$coupon->get_code()} with amount $amount" );
 					$order->apply_coupon( $coupon );
 					++$applied_coupons;
 					$applied_amount += $amount;
+					$order_coupons_applied += $amount;
 				}
 			}
 
 			$order->calculate_totals();
 			$orders_total += $order->get_total();
+
+			error_log( "=== ORDER $order_number AFTER COUPONS ===" );
+			error_log( "Coupons applied to this order: $order_coupons_applied" );
+			error_log( "Order subtotal: " . $order->get_subtotal() );
+			error_log( "Order discount total: " . $order->get_discount_total() );
+			error_log( "Order total: " . $order->get_total() );
+
+			// Log each coupon item
+			foreach ( $order->get_items( 'coupon' ) as $coupon_item ) {
+				error_log( "Coupon item: " . $coupon_item->get_code() . " discount=" . $coupon_item->get_discount() );
+			}
+
 			$order->save();
 
 			$orders[] = $order;
 		}
 
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		error_log( "=== ANALYTICS SYNC COMPLETE ===" );
+
+		// Check what was written to the analytics tables
+		global $wpdb;
+		$analytics_coupons = $wpdb->get_results(
+			"SELECT order_id, coupon_id, discount_amount FROM {$wpdb->prefix}wc_order_coupon_lookup ORDER BY order_id, coupon_id",
+			ARRAY_A
+		);
+		error_log( "Analytics coupon lookup table:" );
+		foreach ( $analytics_coupons as $row ) {
+			error_log( "  Order {$row['order_id']}: Coupon {$row['coupon_id']} = {$row['discount_amount']}" );
+		}
+
+		$analytics_total_coupons = $wpdb->get_var(
+			"SELECT SUM(discount_amount) FROM {$wpdb->prefix}wc_order_coupon_lookup"
+		);
+		error_log( "Total coupons in analytics: $analytics_total_coupons" );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -917,6 +955,18 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$shipping        = $orders_count * $order_shipping;
 		$net_revenue     = $orders_total - $shipping;
 		$gross_sales     = $product_price * $num_items_sold;
+
+		error_log( "=== TEST EXPECTATIONS ===" );
+		error_log( "Product price: $product_price" );
+		error_log( "Qty per product: $qty_per_product" );
+		error_log( "Orders count: $orders_count" );
+		error_log( "Num items sold: $num_items_sold" );
+		error_log( "Calculated applied_amount (total coupons): $applied_amount" );
+		error_log( "Orders total (sum of get_total()): $orders_total" );
+		error_log( "Shipping: $shipping" );
+		error_log( "Net revenue (orders_total - shipping): $net_revenue" );
+		error_log( "Gross sales (product_price * num_items_sold): $gross_sales" );
+		error_log( "Expected formula: gross_sales = net_revenue + coupons = $net_revenue + $applied_amount = " . ($net_revenue + $applied_amount) );
 		$subtotals       = array(
 			'orders_count'        => $orders_count,
 			'num_items_sold'      => $num_items_sold,
@@ -952,7 +1002,17 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
+		$actual_stats = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
+
+		error_log( "=== ACTUAL ANALYTICS RESULTS ===" );
+		error_log( "Actual gross_sales: " . $actual_stats['totals']['gross_sales'] );
+		error_log( "Actual total_sales: " . $actual_stats['totals']['total_sales'] );
+		error_log( "Actual coupons: " . $actual_stats['totals']['coupons'] );
+		error_log( "Actual net_revenue: " . $actual_stats['totals']['net_revenue'] );
+		error_log( "Actual shipping: " . $actual_stats['totals']['shipping'] );
+		error_log( "Last query: {$wpdb->last_query}" );
+
+		$this->assertEquals( $expected_stats, $actual_stats, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -306,6 +306,31 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test apply_coupon() stores coupon_applied_items meta data.
+	 */
+	public function test_apply_coupon_stores_applied_items_meta_data() {
+		$coupon_code = 'coupon_applied_items_test';
+		$coupon      = WC_Helper_Coupon::create_coupon( $coupon_code );
+		$order       = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->save();
+		$order->apply_coupon( $coupon_code );
+
+		$coupon_items = $order->get_items( 'coupon' );
+		$this->assertCount( 1, $coupon_items );
+
+		$coupon_applied_items = ( current( $coupon_items ) )->get_meta( 'coupon_applied_items' );
+		$this->assertIsArray( $coupon_applied_items, 'WC_Order_Item_Coupon missing `coupon_applied_items` meta.' );
+		$this->assertNotEmpty( $coupon_applied_items, 'coupon_applied_items should not be empty.' );
+
+		foreach ( $coupon_applied_items as $item_id => $discount_data ) {
+			$this->assertIsArray( $discount_data, 'Each item should have discount data array' );
+			$this->assertArrayHasKey( 'discount', $discount_data, 'Should store discount amount' );
+			$this->assertArrayHasKey( 'discount_tax', $discount_data, 'Should store discount tax' );
+		}
+	}
+
+	/**
 	 * Test for get_discount_to_display which must return a value
 	 * with and without tax whatever the setting of the options.
 	 *

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Class WC_Abstract_Order file.
  *
@@ -310,8 +312,8 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_apply_coupon_stores_applied_items_meta_data() {
 		$coupon_code = 'coupon_applied_items_test';
-		$coupon      = WC_Helper_Coupon::create_coupon( $coupon_code );
-		$order       = WC_Helper_Order::create_order();
+		WC_Helper_Coupon::create_coupon( $coupon_code );
+		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::PROCESSING );
 		$order->save();
 		$order->apply_coupon( $coupon_code );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a critical issue where finalized orders have their coupon discount amounts retroactively changed when coupons are modified or when orders are recalculated in the admin panel.

**The Problem:**

Currently, when `recalculate_coupons()` is called on an order, it reloads coupon data from the database and recalculates discounts, overwriting the discount amounts that were stored at checkout. This causes several serious issues:

- **Modified coupons**: Changing a coupon's amount after orders are placed retroactively changes existing order discounts
- **Product restriction changes**: Modifying coupon product restrictions causes discounts to redistribute to different products or expand to newly eligible products
- **Dynamic/filtered discounts**: Custom filter contexts (VIP tiers, loyalty points, member benefits) are lost during recalculation
- **Financial discrepancies**: Order totals no longer match payment gateway records or accounting systems

**The Core Principle:**

Orders are contracts - once a customer completes checkout with specific discount amounts, those amounts represent an immutable agreement that must be preserved, similar to how finalized invoices work in accounting systems.

**The Solution:**

This PR implements a discount preservation system that:

1. **Stores detailed per-item discount metadata** during checkout (exact discount amounts including tax)
2. **Preserves discount amounts for finalized orders** during recalculation (processing, completed, etc.)
3. **Allows recalculation for draft/pending orders** since these aren't yet finalized contracts
4. **Supports new items added to finalized orders** - they receive appropriate discounts using current coupon settings
5. **Provides filter for customization**: `woocommerce_order_recalculate_coupon_statuses`

**Technical Implementation:**

- Enhanced metadata storage: Stores discount amounts per line item in `coupon_applied_items` metadata
- Status-based locking: Only draft/pending orders recalculate by default
- Selective recalculation: Locked items preserve amounts, unlocked items get fresh calculations
- Fixed cart handling: Pre-adjusts coupon amounts by subtracting consumed amounts from locked items
- Backward compatibility: Orders without enhanced metadata continue to work normally

**Admin Override & Decision Preservation:**

While the system preserves discount amounts by default for finalized orders, administrators retain full control when needed:

- **Intentional recalculation**: Admins can remove and re-add a coupon to apply current settings - this is an explicit decision, not an accidental side effect
- **Zero-discount preservation**: Items that received $0 discount (due to filters or restrictions) are also preserved - the absence of a discount is itself a decision made at checkout based on the coupon configuration at that time
- **Filter context integrity**: Custom filter decisions (VIP exclusions, product restrictions, etc.) are maintained because they represent business logic that was active during checkout

This ensures accidental changes are prevented while allowing deliberate admin actions when necessary.

Closes #61234.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Test Case 1: Modified Standard Coupon (Preservation)**

1. Create a fixed cart discount coupon for $50
2. Add a product to cart, apply the coupon, and complete checkout
3. Verify order shows $50 discount and status is "Processing" or "On Hold"
4. Edit the coupon and change amount to $10
5. Edit the order in admin, change status (e.g., Processing → On Hold) or save the order
6. **Expected**: Discount remains at $50 (preserved)
7. **Verify**: Order total matches original checkout amount

**Test Case 2: Product Restriction Changes (Preservation)**

1. Create a 20% discount coupon "RESTRICTED20"
2. Restrict coupon to only Product A (e.g., "Beanie")
3. Add both Product A ($20) and Product B ($20) to cart
4. Apply coupon and complete checkout
5. **Verify**: Product A shows $16 (20% off), Product B shows $20 (no discount), total $36
6. Remove product restrictions from the coupon (allow all products)
7. Edit the finalized order in admin and save
8. **Expected**: Product A stays $16, Product B stays $20 (discounts preserved)
9. **Verify**: Order total remains $36

**Test Case 3: Dynamic Coupon Context (Preservation)**

1. Create a coupon "VIPDISCOUNT" with $0 amount in database
2. Add these filters to your theme's functions.php:
   ```php
   // Set VIP session flag when cart is loaded
   add_action( 'woocommerce_before_calculate_totals', function( $cart ) {
       if ( is_admin() || ! WC()->session ) return;
       WC()->session->set( 'is_vip', true );
   });

   // Apply $50 discount for VIP session
   add_filter( 'woocommerce_coupon_get_discount_amount', function( $discount, $discounting_amount, $cart_item, $single, $coupon ) {
       if ( $coupon->get_code() === 'VIPDISCOUNT' && WC()->session && WC()->session->get( 'is_vip' ) ) {
           return 50;
       }
       return $discount;
   }, 10, 5 );
   ```
3. Add a $100 product to cart, apply "VIPDISCOUNT" coupon
4. Complete checkout - verify order shows $50 discount
5. Edit the order in admin, change status or save (session context is now lost)
6. **Expected**: Discount remains at $50 (context preserved)
7. **Verify**: Order total stays at $50

**Test Case 4: Draft Order Recalculation (Should Update)**

1. Create a coupon for $25
2. Create a new order manually in admin (status: Draft)
3. Add products and apply the coupon - verify $25 discount
4. Change the coupon amount to $75
5. Edit the draft order and save
6. **Expected**: Discount updates to $75 (draft orders recalculate)
7. **Verify**: Draft orders use current coupon settings

**Test Case 5: Adding Items to Finalized Orders**

1. Create a 20% coupon "PERCENT20"
2. Add Product A ($50) to cart, apply coupon, complete checkout
3. **Verify**: Order shows Product A at $40 (20% off)
4. Edit the finalized order, add Product B ($50)
5. Save the order
6. **Expected**: Product A stays $40 (preserved), Product B becomes $40 (new item gets 20% off)
7. **Verify**: Total is $80 with $20 discount

### Testing that has already taken place:

**Environment:**
- WooCommerce 10.3.0-dev (trunk)
- WordPress 6.7+
- PHP 8.0.30
- PHPUnit 9.6.24 in wp-env Docker environment

**Test Coverage:**

Comprehensive PHPUnit test suite added covering:
- ✅ Basic coupon amount preservation for finalized orders
- ✅ Draft order recalculation with current settings
- ✅ Product restriction preservation
- ✅ Dynamic/filtered discount preservation
- ✅ Multiple coupon interactions
- ✅ Fixed cart coupon exhaustion scenarios
- ✅ Adding new items to finalized orders
- ✅ Tax calculation accuracy
- ✅ Backward compatibility with existing orders

**Test Results:**
All new tests pass, demonstrating the preservation system works correctly across all identified scenarios without breaking existing functionality.

**Impact Analysis:**
- ✅ Backward compatible - existing orders without enhanced metadata work normally
- ✅ No breaking changes to public APIs
- ✅ Filter provided for customization of recalculation behavior
- ✅ Performance efficient - locked items skip recalculation entirely
- ✅ Accounting compliance - maintains immutable order records

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix - Preserve coupon discount amounts on finalized orders to prevent retroactive changes when coupons are modified or recalculated.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>
