### PR TITLE
Fix CYS flow to work with Template Activation

### DIFF
--- a/bin/patches/@wordpress__edit-site@5.15.0.patch
+++ b/bin/patches/@wordpress__edit-site@5.15.0.patch
@@ -1,5 +1,5 @@
 diff --git a/build-module/lock-unlock.js b/build-module/lock-unlock.js
-index 2265f933ceec19f65ca6776c24c3f88b368d713f..e9e10980bfd1b584ab0a037c3b72edae29a2a26e 100644
+index 2265f933ceec19f65ca6776c24c3f88b368d713f..4b66d79153ceed52ca15b586e5cb38dbb637bf13 100644
 --- a/build-module/lock-unlock.js
 +++ b/build-module/lock-unlock.js
 @@ -1,9 +1,34 @@
@@ -42,8 +42,9 @@ index 2265f933ceec19f65ca6776c24c3f88b368d713f..e9e10980bfd1b584ab0a037c3b72edae
 +
 +export const { lock, unlock } = optInToUnstableAPIs();
  //# sourceMappingURL=lock-unlock.js.map
+\ No newline at end of file
 diff --git a/build-module/store/actions.js b/build-module/store/actions.js
-index a2f9fcd42f..c6bbf6a8c7 100644
+index a2f9fcd42f69fe7f6aa0bac9bd5bde6c6798893a..282249ec83315d7665732e7f211d9dd4589f5e9f 100644
 --- a/build-module/store/actions.js
 +++ b/build-module/store/actions.js
 @@ -240,7 +240,24 @@ export const setPage = page => async ({
@@ -72,3 +73,53 @@ index a2f9fcd42f..c6bbf6a8c7 100644
  
    if (!template) {
      return;
+diff --git a/src/components/layout/hooks.js b/src/components/layout/hooks.js
+index a9bf1b982903a99f3c84fa04660c1a7e3b6ea31a..5f3f4dc554da537e3765c0c4b3917bfe8d2145de 100644
+--- a/src/components/layout/hooks.js
++++ b/src/components/layout/hooks.js
+@@ -5,15 +5,10 @@ import { useEffect, useState } from '@wordpress/element';
+ import { useSelect } from '@wordpress/data';
+ import { store as coreStore } from '@wordpress/core-data';
+ 
+-/**
+- * Internal dependencies
+- */
+-import useEditedEntityRecord from '../use-edited-entity-record';
+ 
+ const MAX_LOADING_TIME = 10000; // 10 seconds
+ 
+ export function useIsSiteEditorLoading() {
+-	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
+ 	const [ loaded, setLoaded ] = useState( false );
+ 	const inLoadingPause = useSelect(
+ 		( select ) => {
+@@ -46,16 +41,17 @@ export function useIsSiteEditorLoading() {
+ 	useEffect( () => {
+ 		if ( inLoadingPause ) {
+ 			/*
+-			 * We're using an arbitrary 1s timeout here to catch brief moments
+-			 * without any resolving selectors that would result in displaying
+-			 * brief flickers of loading state and loaded state.
++			 * We're using an arbitrary 100ms timeout here to catch brief
++			 * moments without any resolving selectors that would result in
++			 * displaying brief flickers of loading state and loaded state.
+ 			 *
+ 			 * It's worth experimenting with different values, since this also
+-			 * adds 1s of artificial delay after loading has finished.
++			 * adds 100ms of artificial delay after loading has finished.
+ 			 */
++			const ARTIFICIAL_DELAY = 100;
+ 			const timeout = setTimeout( () => {
+ 				setLoaded( true );
+-			}, 1000 );
++			}, ARTIFICIAL_DELAY );
+ 
+ 			return () => {
+ 				clearTimeout( timeout );
+@@ -63,5 +59,5 @@ export function useIsSiteEditorLoading() {
+ 		}
+ 	}, [ inLoadingPause ] );
+ 
+-	return ! loaded || ! hasLoadedPost;
++	return ! loaded;
+ }

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -23,7 +23,8 @@
 				".",
 				"https://downloads.wordpress.org/plugin/akismet.zip",
 				"https://github.com/WP-API/Basic-Auth/archive/master.zip",
-				"https://downloads.wordpress.org/plugin/wp-mail-logging.zip"
+				"https://downloads.wordpress.org/plugin/wp-mail-logging.zip",
+				"https://github.com/WordPress/gutenberg/releases/download/v21.8.0-rc.1/gutenberg.zip"
 			],
 			"themes": [],
 			"config": {

--- a/plugins/woocommerce/changelog/fix-assembler-cys
+++ b/plugins/woocommerce/changelog/fix-assembler-cys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Customise Your Store: Adjust the code so it works with Template Activation

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -41,18 +41,8 @@ export const BlockEditorContainer = () => {
 		[]
 	);
 
-	// This is necessary to avoid this issue: https://github.com/woocommerce/woocommerce/issues/45593
-	// Related PR: https://github.com/woocommerce/woocommerce/pull/45600
-	const { templateType } = useSelect( ( select ) => {
-		const { getEditedPostType } = unlock( select( editSiteStore ) );
-
-		return {
-			templateType: getEditedPostType(),
-		};
-	}, [] );
-
 	const [ blocks, , onChange ] = useEditorBlocks(
-		templateType,
+		'wp_template',
 		currentTemplateId || ''
 	);
 

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -9,13 +9,7 @@ import { useContext, useEffect, useMemo } from '@wordpress/element';
 import { BlockInstance, createBlock } from '@wordpress/blocks';
 // @ts-expect-error No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-// @ts-expect-error No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
 import useSiteEditorSettings from '@wordpress/edit-site/build-module/components/block-editor/use-site-editor-settings';
-// @ts-expect-error No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { store as editSiteStore } from '@wordpress/edit-site/build-module/store';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
@@ -107,7 +107,7 @@ export const Layout = () => {
 		useState( false );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
-	const [ templateId, setTemplateId ] = useState< string | undefined >(
+	const [ templateId, setTemplateId ] = useState< number | undefined >(
 		undefined
 	);
 	const [ templateType, setTemplateType ] = useState< string | undefined >(
@@ -117,10 +117,17 @@ export const Layout = () => {
 	useEffect( () => {
 		getHomeTemplate().then( ( template ) => {
 			if ( template ) {
+				if (
+					// @ts-expect-error we won't type it as it most likely will be removed.
+					typeof template.id === 'string' ||
+					// @ts-expect-error we won't type it as it most likely will be removed.
+					typeof template.id === 'number'
+				) {
+					// @ts-expect-error we won't type it as it most likely will be removed.
+					setTemplateId( Number( template.id ) );
+				}
 				// @ts-expect-error we won't type it as it most likely will be removed.
-				setTemplateId( template?.id );
-				// @ts-expect-error we won't type it as it most likely will be removed.
-				setTemplateType( template?.type );
+				setTemplateType( template.type );
 			}
 		} );
 	}, [] );
@@ -129,7 +136,9 @@ export const Layout = () => {
 
 	if (
 		typeof currentState === 'object' &&
-		currentState.transitionalScreen === 'transitional'
+		currentState.transitionalScreen === 'transitional' &&
+		templateType &&
+		templateId
 	) {
 		return (
 			// @ts-expect-error Types are not correct when kind is root and type is site.

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
@@ -167,8 +167,8 @@ export const Layout = () => {
 				<EntityProvider kind="root" type="site">
 					<EntityProvider
 						kind="postType"
-						type={ templateType }
-						id={ templateId }
+						type={ templateType || '' }
+						id={ templateId || 0 }
 					>
 						<div
 							className={ clsx( 'woocommerce-edit-site-layout' ) }

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
@@ -11,7 +11,7 @@ import {
 	useViewportMatch,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useState, useContext } from '@wordpress/element';
+import { useState, useContext, useEffect } from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
 import {
 	// @ts-expect-error No types for this exist yet.
@@ -28,8 +28,8 @@ import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 // @ts-expect-error No types for this exist yet.
 import { NavigableRegion } from '@wordpress/interface';
 import { EntityProvider } from '@wordpress/core-data';
-// @ts-expect-error No types for this exist yet.
-import useEditedEntityRecord from '@wordpress/edit-site/build-module/components/use-edited-entity-record';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -50,6 +50,28 @@ import './gutenberg-styles/layout.scss';
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 const ANIMATION_DURATION = 0.5;
+
+// useEditedEntityRecord hook that we used to use to get the home template does not
+// return the template anymore. So we are using this function to get the home template.
+// It's not ideal but there's no better way to do this in universal way.
+const getHomeTemplate = async () => {
+	let fetchedTemplate;
+	try {
+		// This is NOT calling a REST endpoint but rather ends up with a response from
+		// an Ajax function which has a different shape from a WP_REST_Response.
+		fetchedTemplate = await apiFetch( {
+			url: addQueryArgs( '/', {
+				'_wp-find-template': true,
+			} ),
+			// @ts-expect-error we won't type it as it most likely will be removed.
+		} ).then( ( { data } ) => data );
+	} catch ( e ) {
+		// For non-FSE themes, it is possible that this request returns an error.
+		return null;
+	}
+
+	return fetchedTemplate;
+};
 
 export const Layout = () => {
 	const [ logoBlockIds, setLogoBlockIds ] = useState< Array< string > >( [] );
@@ -85,9 +107,23 @@ export const Layout = () => {
 		useState( false );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
+	const [ templateId, setTemplateId ] = useState< string | undefined >(
+		undefined
+	);
+	const [ templateType, setTemplateType ] = useState< string | undefined >(
+		undefined
+	);
 
-	const { record: template } = useEditedEntityRecord();
-	const { id: templateId, type: templateType } = template;
+	useEffect( () => {
+		getHomeTemplate().then( ( template ) => {
+			if ( template ) {
+				// @ts-expect-error we won't type it as it most likely will be removed.
+				setTemplateId( template?.id );
+				// @ts-expect-error we won't type it as it most likely will be removed.
+				setTemplateType( template?.type );
+			}
+		} );
+	}, [] );
 
 	const editor = <Editor isLoading={ isEditorLoading } />;
 

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -9,7 +9,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { useQuery } from '@woocommerce/navigation';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
 import {
 	__experimentalHStack as HStack,
 	Button,
@@ -110,6 +110,27 @@ export const SaveHub = () => {
 					editEntityRecord( kind, name, key, {
 						status: 'publish',
 					} );
+				}
+
+				// In Gutenberg 21.8, there's a Template Activation mechanism.
+				// It doesn't allow us to use saveEditedEntityRecord to save templates.
+				// So we're using a "workaround" from Gutenberg to do so.
+				if ( kind === 'postType' && name === 'wp_template' ) {
+					const activeTemplates = {
+						// @ts-expect-error No types for this exist yet.
+						...( ( await resolveSelect( coreStore ).getEntityRecord(
+							'root',
+							'site'
+							// @ts-expect-error No types for this exist yet.
+						).active_templates ) ?? {} ),
+					};
+
+					// @ts-expect-error No types for this exist yet.
+					await editEntityRecord( 'root', 'site', undefined, {
+						active_templates: { ...activeTemplates, home: key },
+					} );
+					// @ts-expect-error No types for this exist yet.
+					await saveEditedEntityRecord( 'root', 'site' );
 				}
 
 				await saveEditedEntityRecord( kind, name, key, undefined );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ patchedDependencies:
     path: bin/patches/@wordpress__data@10.0.2.patch
   '@wordpress/edit-site@5.15.0':
     hash: spx7qis6zudgbul6bwdexdeffi
-    path: patches/@wordpress__edit-site@5.15.0.patch
+    path: bin/patches/@wordpress__edit-site@5.15.0.patch
   '@wordpress/env@10.17.0':
     hash: ovltjfwrjswkqlvmxt7r5kywn4
     path: bin/patches/@wordpress__env@10.17.0.patch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ patchedDependencies:
     hash: xjmezqav3jkhcz5453svqnw2p4
     path: bin/patches/@wordpress__data@10.0.2.patch
   '@wordpress/edit-site@5.15.0':
-    hash: u2xn4lpm453vgqpkdgbivlveaa
-    path: bin/patches/@wordpress__edit-site@5.15.0.patch
+    hash: spx7qis6zudgbul6bwdexdeffi
+    path: patches/@wordpress__edit-site@5.15.0.patch
   '@wordpress/env@10.17.0':
     hash: ovltjfwrjswkqlvmxt7r5kywn4
     path: bin/patches/@wordpress__env@10.17.0.patch
@@ -3175,7 +3175,7 @@ importers:
         version: 4.0.1
       '@wordpress/edit-site':
         specifier: 5.15.0
-        version: 5.15.0(patch_hash=u2xn4lpm453vgqpkdgbivlveaa)(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.8.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.15.0(patch_hash=spx7qis6zudgbul6bwdexdeffi)(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.8.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/editor':
         specifier: wp-6.6
         version: 14.0.8(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3663,12 +3663,12 @@ importers:
       '@preact/signals':
         specifier: ^1.3.0
         version: 1.3.1(preact@10.25.1)
+      '@woocommerce/email-editor':
+        specifier: workspace:*
+        version: link:../../../../packages/js/email-editor
       '@woocommerce/sanitize':
         specifier: workspace:*
         version: link:../../../../packages/js/sanitize
-      '@woocommerce/email-editor':
-          specifier: workspace:*
-          version: link:../../../../packages/js/email-editor
       '@woocommerce/tracks':
         specifier: workspace:*
         version: link:../../../../packages/js/tracks
@@ -35862,7 +35862,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/edit-site@5.15.0(patch_hash=u2xn4lpm453vgqpkdgbivlveaa)(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.8.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/edit-site@5.15.0(patch_hash=spx7qis6zudgbul6bwdexdeffi)(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.8.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 3.58.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

CYS flow doesn't work correctly with the Template Activation. Unfortunately, CYS is using some "hardcoded" patched `edit-site` features that are not compatible with newest Gutenberg changes causing the flow to break by freezing on loading screen.

This PR fixes the way we:
- fetch home template in the CYS
- save templates in the CYS
so they're compatible with WP 6.8 and newest changes in GB.

These changes are not ideal and this is pure patching. But the flow is in maintenance mode and given the time constraints it already took us a long time to debug and patch this so consider them satisfactory as may potentially remove the flow completely.

Kudos to @gigitux who coauthored this PR with me.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With GB disabled:

1. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign`
2. Make sure the CYS loads correctly
3. Edit styles
4. Edit header
5. Edit homepage
6. Save
7. Make sure changes are reflected on the frontend

With GB enabled:

1. Enable _newest_ GB
2. Go to Editor > Templates
3. Make sure only one Blog Home template is active
4. Check on the frontend the correct one is active

CYS with GB enabled:

1. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign`
2. Make sure the CYS loads correctly
3. Edit styles
4. Edit header
5. Edit homepage
6. Save
7. Make sure changes are reflected on the frontend

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
