### PR TITLE
Add integration tests to make sure Add to Cart + Options inner blocks are correctly loaded in the editor

### DIFF
--- a/plugins/woocommerce/changelog/update-add-to-cart-with-options-spinner-on-load
+++ b/plugins/woocommerce/changelog/update-add-to-cart-with-options-spinner-on-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: show spinner when grouped product inners blocks are loading in the editor

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -19,8 +19,8 @@ import { useProduct } from '@woocommerce/entities';
 import ToolbarProductTypeGroup from '../components/toolbar-type-product-selector-group';
 import { DowngradeNotice } from '../components/downgrade-notice';
 import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
-import type { Attributes } from '../types';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
+import type { Attributes } from '../types';
 
 const AddToCartOptionsEdit = (
 	props: BlockEditProps< Attributes > & { context?: { postId?: number } }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
@@ -20,6 +20,7 @@ import { resolveSelect, useSelect } from '@wordpress/data';
 import type { ProductResponseItem } from '@woocommerce/types';
 import { productsStore } from '@woocommerce/data';
 import { isProductResponseItem } from '@woocommerce/entities';
+import { Spinner } from '@wordpress/components';
 
 interface Attributes {
 	className?: string;
@@ -151,6 +152,10 @@ export default function ProductItemTemplateEdit(
 
 	const [ selectedProductItem, setSelectedProductItem ] =
 		useState< number >();
+
+	if ( ! products ) {
+		return <Spinner />;
+	}
 
 	return (
 		<div { ...blockProps }>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/edit.tsx
@@ -120,7 +120,10 @@ export default function ProductItemTemplateEdit(
 				resolveSelect( productsStore )
 					.getProducts( { type: 'grouped', per_page: 1 } )
 					.then( ( groupedProduct ) => {
-						if ( groupedProduct.length > 0 ) {
+						if (
+							groupedProduct.length > 0 &&
+							groupedProduct[ 0 ]?.grouped_products?.length > 0
+						) {
 							fetchChildProducts(
 								groupedProduct[ 0 ].grouped_products
 							);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -464,5 +464,3 @@ describe( 'Add to Cart + Options block', () => {
 		} );
 	} );
 } );
-
-// screen.debug( undefined, 300000 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -1,0 +1,468 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+/**
+ * Internal dependencies
+ */
+import {
+	initializeEditor,
+	selectBlock,
+} from '../../../../../tests/integration/helpers/integration-test-editor';
+import '../';
+import '../quantity-selector';
+import '../../../atomic/blocks/product-elements/button';
+import '../../../atomic/blocks/product-elements/stock-indicator';
+import '../../../atomic/blocks/product-elements/price';
+import '../grouped-product-selector';
+import '../grouped-product-selector/product-item';
+import '../grouped-product-selector/product-item-label';
+import '../grouped-product-selector/product-item-selector';
+import '../variation-selector';
+import '../variation-selector/attribute';
+import '../variation-selector/attribute-name';
+import '../variation-selector/attribute-options';
+import '../variation-description';
+
+const mockSimpleTemplatePartHTML = `<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
+<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockExternalTemplatePartHTML = `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockGroupedTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
+<div
+	class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector"
+	role="list"
+>
+	<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
+	<div
+		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-item"
+		role="listitem"
+	>
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
+		<div
+			class="wp-block-group"
+			style="margin-top: 1rem; margin-bottom: 1rem"
+		>
+			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-selector /-->
+
+			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-label {"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
+			<div class="wp-block-group">
+				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
+				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /--></div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
+</div>
+<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockVariableTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-variation-selector -->
+<div
+	class="wp-block-woocommerce-add-to-cart-with-options-variation-selector"
+	role="list"
+>
+	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
+	<div
+		class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute"
+		role="listitem"
+	>
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+		<div
+			class="wp-block-group"
+			style="margin-top: 1rem; margin-bottom: 1rem"
+		>
+			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
+
+			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
+</div>
+<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
+<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group">
+	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+</div>
+<!-- /wp:group -->
+`;
+
+jest.mock( '@woocommerce/settings', () => {
+	return {
+		...jest.requireActual( '@woocommerce/settings' ),
+		getSetting: jest.fn().mockImplementation( ( key, defaultValue ) => {
+			if ( key === 'productTypes' ) {
+				return {
+					simple: 'Simple product',
+					external: 'External/Affiliate product',
+					grouped: 'Grouped product',
+					variable: 'Variable product',
+				};
+			}
+			if ( key === 'addToCartWithOptionsTemplatePartIds' ) {
+				return {
+					simple: 'woocommerce/woocommerce//simple-product-add-to-cart-with-options',
+					external:
+						'woocommerce/woocommerce//external-product-add-to-cart-with-options',
+					grouped:
+						'woocommerce/woocommerce//grouped-product-add-to-cart-with-options',
+					variable:
+						'woocommerce/woocommerce//variable-product-add-to-cart-with-options',
+				};
+			}
+			return defaultValue;
+		} ),
+	};
+} );
+
+const mockProduct = {
+	id: 82,
+	name: 'Beanie with Logo',
+	slug: 'beanie-with-logo',
+	parent: 0,
+	type: 'simple',
+	variation: '',
+	permalink: 'https://202508.local/product/beanie-with-logo/',
+	sku: 'Woo-beanie-logo',
+	short_description: '<p>This is a simple product.</p>',
+	description:
+		'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>',
+	on_sale: true,
+	prices: {
+		price: '1800',
+		regular_price: '2000',
+		sale_price: '1800',
+		price_range: null,
+		currency_code: 'EUR',
+		currency_symbol: '\u20ac',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '',
+		currency_suffix: ' \u20ac',
+	},
+	price_html:
+		'<del aria-hidden="true"><span class="woocommerce-Price-amount amount">20,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></del> <span class="screen-reader-text">Original price was: 20,00&nbsp;&euro;.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount">18,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></ins><span class="screen-reader-text">Current price is: 18,00&nbsp;&euro;.</span>',
+	average_rating: '0',
+	review_count: 0,
+	images: [
+		{
+			id: 105,
+			src: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg',
+			thumbnail:
+				'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg',
+			srcset: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg 800w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg 300w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-100x100.jpg 100w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-600x600.jpg 600w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-150x150.jpg 150w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-768x768.jpg 768w',
+			sizes: '(max-width: 800px) 100vw, 800px',
+			name: 'beanie-with-logo-1.jpg',
+			alt: '',
+		},
+	],
+	categories: [
+		{
+			id: 19,
+			name: 'Accessories',
+			slug: 'accessories',
+			link: 'https://202508.local/product-category/clothing/accessories/',
+		},
+	],
+	tags: [],
+	brands: [],
+	attributes: [
+		{
+			id: 1,
+			name: 'Color',
+			taxonomy: 'pa_color',
+			has_variations: false,
+			terms: [ { id: 24, name: 'Red', slug: 'red' } ],
+		},
+	],
+	variations: [],
+	grouped_products: [],
+	has_options: false,
+	is_purchasable: true,
+	is_in_stock: true,
+	is_on_backorder: false,
+	low_stock_remaining: null,
+	stock_availability: { text: '', class: 'in-stock' },
+	sold_individually: false,
+	add_to_cart: {
+		text: 'Add to cart',
+		description: 'Add to cart: &ldquo;Beanie with Logo&rdquo;',
+		url: '/wp-json/wc/store/v1/products?_locale=user&#038;add-to-cart=82',
+		single_text: 'Add to cart',
+		minimum: 1,
+		maximum: 9999,
+		multiple_of: 1,
+	},
+};
+
+// Setup MSW.
+const handlers = [
+	http.get( '/wp/v2/types', () => {
+		return HttpResponse.json( {
+			wp_template_part: {
+				slug: 'wp_template_part',
+				rest_base: 'template-parts',
+				rest_namespace: 'wp/v2',
+			},
+		} );
+	} ),
+
+	http.get( '/wc/v3/products', () => {
+		return HttpResponse.json( [ mockProduct ] );
+	} ),
+
+	http.get( '/wc/store/v1/products/:id', () => {
+		return HttpResponse.json( mockProduct );
+	} ),
+
+	http.get( '/wc/v3/products/:id', () => {
+		return HttpResponse.json( mockProduct );
+	} ),
+
+	http.get( '/wp/v2/template-parts/*', ( request ) => {
+		if (
+			request.params[ 0 ] ===
+			'woocommerce/woocommerce//simple-product-add-to-cart-with-options'
+		) {
+			return HttpResponse.json( {
+				id: 'woocommerce/woocommerce//simple-product-add-to-cart-with-options',
+				content: {
+					raw: mockSimpleTemplatePartHTML,
+				},
+			} );
+		}
+		if (
+			request.params[ 0 ] ===
+			'woocommerce/woocommerce//external-product-add-to-cart-with-options'
+		) {
+			return HttpResponse.json( {
+				id: 'woocommerce/woocommerce//external-product-add-to-cart-with-options',
+				content: {
+					raw: mockExternalTemplatePartHTML,
+				},
+			} );
+		}
+		if (
+			request.params[ 0 ] ===
+			'woocommerce/woocommerce//grouped-product-add-to-cart-with-options'
+		) {
+			return HttpResponse.json( {
+				id: 'woocommerce/woocommerce//grouped-product-add-to-cart-with-options',
+				content: {
+					raw: mockGroupedTemplatePartHTML,
+				},
+			} );
+		}
+
+		if (
+			request.params[ 0 ] ===
+			'woocommerce/woocommerce//variable-product-add-to-cart-with-options'
+		) {
+			return HttpResponse.json( {
+				id: 'woocommerce/woocommerce//variable-product-add-to-cart-with-options',
+				content: {
+					raw: mockVariableTemplatePartHTML,
+				},
+			} );
+		}
+	} ),
+];
+
+const server = setupServer( ...handlers );
+
+// Start MSW.
+beforeAll( () => server.listen() );
+afterEach( () => server.resetHandlers() );
+afterAll( () => server.close() );
+
+async function setup() {
+	const addToCartWithOptionsBlock = [
+		{
+			name: 'woocommerce/add-to-cart-with-options',
+		},
+	];
+	return await initializeEditor( addToCartWithOptionsBlock );
+}
+
+async function switchProductType( productType: string ) {
+	await selectBlock( 'Block: Add to Cart + Options (Beta)' );
+
+	await act( async () => {
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Switch product type' } )
+		);
+	} );
+
+	await act( async () => {
+		fireEvent.click(
+			screen.getByRole( 'menuitem', { name: productType } )
+		);
+	} );
+}
+
+describe( 'Add to Cart + Options block', () => {
+	it( 'should render inner blocks', async () => {
+		await setup();
+
+		const block = screen.getByRole( 'document', {
+			name: 'Block: Add to Cart + Options (Beta)',
+		} );
+		expect( block ).toBeInTheDocument();
+
+		// Simple products.
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		// External products.
+		await switchProductType( 'External/Affiliate product' );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).not.toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		// Grouped products.
+		await switchProductType( 'Grouped product' );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Grouped Product Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Template (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Label (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Price',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		// Variable products.
+		await switchProductType( 'Variable product' );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Variation Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'list', {
+					name: 'Block: Variation Selector: Template (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen
+					.getAllByRole( 'document', {
+						name: 'Block: Variation Selector: Attribute Name (Beta)',
+					} )
+					.at( 0 )
+			).toBeInTheDocument();
+
+			expect(
+				screen
+					.getAllByRole( 'document', {
+						name: 'Block: Variation Selector: Attribute Options (Beta)',
+					} )
+					.at( 0 )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Variation Description (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+} );
+
+// screen.debug( undefined, 300000 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -245,6 +245,16 @@ async function switchProductType( productType: string ) {
 	} );
 }
 
+const expectBlocksToBeInTheDocument = ( blocks: string[] ) => {
+	blocks.forEach( ( blockName: string ) => {
+		expect(
+			screen.getByRole( 'document', {
+				name: blockName,
+			} )
+		).toBeInTheDocument();
+	} );
+};
+
 describe( 'Add to Cart + Options block', () => {
 	it( 'should render inner blocks', async () => {
 		await setup();
@@ -256,92 +266,51 @@ describe( 'Add to Cart + Options block', () => {
 
 		// Simple products.
 		await waitFor( () => {
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Quantity (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Product Stock Indicator',
+				'Block: Product Quantity (Beta)',
+				'Block: Add to Cart Button',
+			] );
 		} );
 
 		// External products.
 		await switchProductType( 'External/Affiliate product' );
 
 		await waitFor( () => {
+			expectBlocksToBeInTheDocument( [ 'Block: Add to Cart Button' ] );
+
 			expect(
 				screen.queryByRole( 'document', {
 					name: 'Block: Product Stock Indicator',
 				} )
 			).not.toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
-			).toBeInTheDocument();
 		} );
 
 		// Grouped products.
 		await switchProductType( 'Grouped product' );
 
 		await waitFor( () => {
-			expect(
-				screen.queryByRole( 'document', {
-					name: 'Block: Grouped Product Selector (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Template (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Item Selector (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Item Label (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Price',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Grouped Product Selector (Beta)',
+				'Block: Grouped Product: Template (Beta)',
+				'Block: Grouped Product: Item Selector (Beta)',
+				'Block: Grouped Product: Item Label (Beta)',
+				'Block: Product Price',
+				'Block: Product Stock Indicator',
+			] );
 		} );
 
 		// Variable products.
 		await switchProductType( 'Variable product' );
 
 		await waitFor( () => {
-			expect(
-				screen.queryByRole( 'document', {
-					name: 'Block: Variation Selector (Beta)',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Variation Selector (Beta)',
+				'Block: Variation Description (Beta)',
+				'Block: Product Stock Indicator',
+				'Block: Product Quantity (Beta)',
+				'Block: Add to Cart Button',
+			] );
 
 			expect(
 				screen.getByRole( 'list', {
@@ -363,30 +332,6 @@ describe( 'Add to Cart + Options block', () => {
 						name: 'Block: Variation Selector: Attribute Options (Beta)',
 					} )
 					.at( 0 )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Variation Description (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Quantity (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -245,16 +245,6 @@ const switchProductType = async ( productType: string ) => {
 	} );
 };
 
-const expectBlocksToBeInTheDocument = ( blocks: string[] ) => {
-	blocks.forEach( ( blockName: string ) => {
-		expect(
-			screen.getByRole( 'document', {
-				name: blockName,
-			} )
-		).toBeInTheDocument();
-	} );
-};
-
 describe( 'Add to Cart + Options block', () => {
 	it( 'should render inner blocks', async () => {
 		await setup();
@@ -266,51 +256,92 @@ describe( 'Add to Cart + Options block', () => {
 
 		// Simple products.
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Product Stock Indicator',
-				'Block: Product Quantity (Beta)',
-				'Block: Add to Cart Button',
-			] );
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// External products.
 		await switchProductType( 'External/Affiliate product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [ 'Block: Add to Cart Button' ] );
-
 			expect(
 				screen.queryByRole( 'document', {
 					name: 'Block: Product Stock Indicator',
 				} )
 			).not.toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// Grouped products.
 		await switchProductType( 'Grouped product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Grouped Product Selector (Beta)',
-				'Block: Grouped Product: Template (Beta)',
-				'Block: Grouped Product: Item Selector (Beta)',
-				'Block: Grouped Product: Item Label (Beta)',
-				'Block: Product Price',
-				'Block: Product Stock Indicator',
-			] );
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Grouped Product Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Template (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Label (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Price',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// Variable products.
 		await switchProductType( 'Variable product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Variation Selector (Beta)',
-				'Block: Variation Description (Beta)',
-				'Block: Product Stock Indicator',
-				'Block: Product Quantity (Beta)',
-				'Block: Add to Cart Button',
-			] );
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Variation Selector (Beta)',
+				} )
+			).toBeInTheDocument();
 
 			expect(
 				screen.getByRole( 'list', {
@@ -332,6 +363,30 @@ describe( 'Add to Cart + Options block', () => {
 						name: 'Block: Variation Selector: Attribute Options (Beta)',
 					} )
 					.at( 0 )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Variation Description (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -5,8 +5,6 @@ import '@testing-library/jest-dom';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 
 /**
  * Internal dependencies
@@ -30,22 +28,81 @@ import '../variation-selector/attribute-name';
 import '../variation-selector/attribute-options';
 import '../variation-description';
 
-const mockTemplatePartsHTML: Record< string, string > = {
-	simple: '',
-	external: '',
-	grouped: '',
-	variable: '',
-};
+const mockSimpleTemplatePartHTML = `<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
+<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockExternalTemplatePartHTML = `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockGroupedTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
+<div
+	class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector"
+	role="list"
+>
+	<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
+	<div
+		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-item"
+		role="listitem"
+	>
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
+		<div
+			class="wp-block-group"
+			style="margin-top: 1rem; margin-bottom: 1rem"
+		>
+			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-selector /-->
 
-Object.keys( mockTemplatePartsHTML ).forEach( ( key ) => {
-	mockTemplatePartsHTML[ key ] = readFileSync(
-		join(
-			__dirname,
-			`../../../../../../../templates/parts/${ key }-product-add-to-cart-with-options.html`
-		),
-		'utf-8'
-	);
-} );
+			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-label {"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
+			<div class="wp-block-group">
+				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
+				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /--></div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
+</div>
+<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- /wp:group -->`;
+const mockVariableTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-variation-selector -->
+<div
+	class="wp-block-woocommerce-add-to-cart-with-options-variation-selector"
+	role="list"
+>
+	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
+	<div
+		class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute"
+		role="listitem"
+	>
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+		<div
+			class="wp-block-group"
+			style="margin-top: 1rem; margin-bottom: 1rem"
+		>
+			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
+
+			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
+</div>
+<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
+<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group">
+	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
+
+	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+</div>
+<!-- /wp:group -->
+`;
 
 jest.mock( '@woocommerce/settings', () => {
 	return {
@@ -78,9 +135,82 @@ jest.mock( '@woocommerce/settings', () => {
 const mockProduct = {
 	id: 82,
 	name: 'Beanie with Logo',
+	slug: 'beanie-with-logo',
+	parent: 0,
 	type: 'simple',
+	variation: '',
+	permalink: 'https://202508.local/product/beanie-with-logo/',
+	sku: 'Woo-beanie-logo',
+	short_description: '<p>This is a simple product.</p>',
+	description:
+		'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>',
+	on_sale: true,
+	prices: {
+		price: '1800',
+		regular_price: '2000',
+		sale_price: '1800',
+		price_range: null,
+		currency_code: 'EUR',
+		currency_symbol: '\u20ac',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '',
+		currency_suffix: ' \u20ac',
+	},
+	price_html:
+		'<del aria-hidden="true"><span class="woocommerce-Price-amount amount">20,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></del> <span class="screen-reader-text">Original price was: 20,00&nbsp;&euro;.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount">18,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></ins><span class="screen-reader-text">Current price is: 18,00&nbsp;&euro;.</span>',
+	average_rating: '0',
+	review_count: 0,
+	images: [
+		{
+			id: 105,
+			src: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg',
+			thumbnail:
+				'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg',
+			srcset: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg 800w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg 300w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-100x100.jpg 100w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-600x600.jpg 600w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-150x150.jpg 150w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-768x768.jpg 768w',
+			sizes: '(max-width: 800px) 100vw, 800px',
+			name: 'beanie-with-logo-1.jpg',
+			alt: '',
+		},
+	],
+	categories: [
+		{
+			id: 19,
+			name: 'Accessories',
+			slug: 'accessories',
+			link: 'https://202508.local/product-category/clothing/accessories/',
+		},
+	],
+	tags: [],
+	brands: [],
+	attributes: [
+		{
+			id: 1,
+			name: 'Color',
+			taxonomy: 'pa_color',
+			has_variations: false,
+			terms: [ { id: 24, name: 'Red', slug: 'red' } ],
+		},
+	],
+	variations: [],
+	grouped_products: [],
+	has_options: false,
+	is_purchasable: true,
 	is_in_stock: true,
+	is_on_backorder: false,
+	low_stock_remaining: null,
 	stock_availability: { text: '', class: 'in-stock' },
+	sold_individually: false,
+	add_to_cart: {
+		text: 'Add to cart',
+		description: 'Add to cart: &ldquo;Beanie with Logo&rdquo;',
+		url: '/wp-json/wc/store/v1/products?_locale=user&#038;add-to-cart=82',
+		single_text: 'Add to cart',
+		minimum: 1,
+		maximum: 9999,
+		multiple_of: 1,
+	},
 };
 
 // Setup MSW.
@@ -115,7 +245,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//simple-product-add-to-cart-with-options',
 				content: {
-					raw: mockTemplatePartsHTML.simple,
+					raw: mockSimpleTemplatePartHTML,
 				},
 			} );
 		}
@@ -126,7 +256,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//external-product-add-to-cart-with-options',
 				content: {
-					raw: mockTemplatePartsHTML.external,
+					raw: mockExternalTemplatePartHTML,
 				},
 			} );
 		}
@@ -137,7 +267,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//grouped-product-add-to-cart-with-options',
 				content: {
-					raw: mockTemplatePartsHTML.grouped,
+					raw: mockGroupedTemplatePartHTML,
 				},
 			} );
 		}
@@ -149,7 +279,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//variable-product-add-to-cart-with-options',
 				content: {
-					raw: mockTemplatePartsHTML.variable,
+					raw: mockVariableTemplatePartHTML,
 				},
 			} );
 		}
@@ -172,7 +302,7 @@ async function setup() {
 	return await initializeEditor( addToCartWithOptionsBlock );
 }
 
-const switchProductType = async ( productType: string ) => {
+async function switchProductType( productType: string ) {
 	await selectBlock( 'Block: Add to Cart + Options (Beta)' );
 
 	await act( async () => {
@@ -186,17 +316,7 @@ const switchProductType = async ( productType: string ) => {
 			screen.getByRole( 'menuitem', { name: productType } )
 		);
 	} );
-};
-
-const expectBlocksToBeInTheDocument = ( blocks: string[] ) => {
-	blocks.forEach( ( blockName: string ) => {
-		expect(
-			screen.getByRole( 'document', {
-				name: blockName,
-			} )
-		).toBeInTheDocument();
-	} );
-};
+}
 
 describe( 'Add to Cart + Options block', () => {
 	it( 'should render inner blocks', async () => {
@@ -209,51 +329,92 @@ describe( 'Add to Cart + Options block', () => {
 
 		// Simple products.
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Product Stock Indicator',
-				'Block: Product Quantity (Beta)',
-				'Block: Add to Cart Button',
-			] );
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// External products.
 		await switchProductType( 'External/Affiliate product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [ 'Block: Add to Cart Button' ] );
-
 			expect(
 				screen.queryByRole( 'document', {
 					name: 'Block: Product Stock Indicator',
 				} )
 			).not.toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// Grouped products.
 		await switchProductType( 'Grouped product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Grouped Product Selector (Beta)',
-				'Block: Grouped Product: Template (Beta)',
-				'Block: Grouped Product: Item Selector (Beta)',
-				'Block: Grouped Product: Item Label (Beta)',
-				'Block: Product Price',
-				'Block: Product Stock Indicator',
-			] );
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Grouped Product Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Template (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Selector (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Grouped Product: Item Label (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Price',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
 		} );
 
 		// Variable products.
 		await switchProductType( 'Variable product' );
 
 		await waitFor( () => {
-			expectBlocksToBeInTheDocument( [
-				'Block: Variation Selector (Beta)',
-				'Block: Variation Description (Beta)',
-				'Block: Product Stock Indicator',
-				'Block: Product Quantity (Beta)',
-				'Block: Add to Cart Button',
-			] );
+			expect(
+				screen.queryByRole( 'document', {
+					name: 'Block: Variation Selector (Beta)',
+				} )
+			).toBeInTheDocument();
 
 			expect(
 				screen.getByRole( 'list', {
@@ -275,6 +436,30 @@ describe( 'Add to Cart + Options block', () => {
 						name: 'Block: Variation Selector: Attribute Options (Beta)',
 					} )
 					.at( 0 )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Variation Description (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Stock Indicator',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Product Quantity (Beta)',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'document', {
+					name: 'Block: Add to Cart Button',
+				} )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * Internal dependencies
@@ -28,81 +30,22 @@ import '../variation-selector/attribute-name';
 import '../variation-selector/attribute-options';
 import '../variation-description';
 
-const mockSimpleTemplatePartHTML = `<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockExternalTemplatePartHTML = `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockGroupedTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
-<div
-	class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector"
-	role="list"
->
-	<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
-	<div
-		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-item"
-		role="listitem"
-	>
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
-		<div
-			class="wp-block-group"
-			style="margin-top: 1rem; margin-bottom: 1rem"
-		>
-			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-selector /-->
+const mockTemplatePartsHTML: Record< string, string > = {
+	simple: '',
+	external: '',
+	grouped: '',
+	variable: '',
+};
 
-			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-label {"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}}} /-->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
-			<div class="wp-block-group">
-				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
-				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /--></div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
-</div>
-<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockVariableTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-variation-selector -->
-<div
-	class="wp-block-woocommerce-add-to-cart-with-options-variation-selector"
-	role="list"
->
-	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-	<div
-		class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute"
-		role="listitem"
-	>
-		<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-		<div
-			class="wp-block-group"
-			style="margin-top: 1rem; margin-bottom: 1rem"
-		>
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
-
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-</div>
-<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
-<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group">
-	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-
-	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
-</div>
-<!-- /wp:group -->
-`;
+Object.keys( mockTemplatePartsHTML ).forEach( ( key ) => {
+	mockTemplatePartsHTML[ key ] = readFileSync(
+		join(
+			__dirname,
+			`../../../../../../../templates/parts/${ key }-product-add-to-cart-with-options.html`
+		),
+		'utf-8'
+	);
+} );
 
 jest.mock( '@woocommerce/settings', () => {
 	return {
@@ -172,7 +115,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//simple-product-add-to-cart-with-options',
 				content: {
-					raw: mockSimpleTemplatePartHTML,
+					raw: mockTemplatePartsHTML.simple,
 				},
 			} );
 		}
@@ -183,7 +126,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//external-product-add-to-cart-with-options',
 				content: {
-					raw: mockExternalTemplatePartHTML,
+					raw: mockTemplatePartsHTML.external,
 				},
 			} );
 		}
@@ -194,7 +137,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//grouped-product-add-to-cart-with-options',
 				content: {
-					raw: mockGroupedTemplatePartHTML,
+					raw: mockTemplatePartsHTML.grouped,
 				},
 			} );
 		}
@@ -206,7 +149,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//variable-product-add-to-cart-with-options',
 				content: {
-					raw: mockVariableTemplatePartHTML,
+					raw: mockTemplatePartsHTML.variable,
 				},
 			} );
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * Internal dependencies
@@ -28,81 +30,22 @@ import '../variation-selector/attribute-name';
 import '../variation-selector/attribute-options';
 import '../variation-description';
 
-const mockSimpleTemplatePartHTML = `<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockExternalTemplatePartHTML = `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockGroupedTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
-<div
-	class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector"
-	role="list"
->
-	<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
-	<div
-		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-item"
-		role="listitem"
-	>
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
-		<div
-			class="wp-block-group"
-			style="margin-top: 1rem; margin-bottom: 1rem"
-		>
-			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-selector /-->
+const mockTemplatePartsHTML: Record< string, string > = {
+	simple: '',
+	external: '',
+	grouped: '',
+	variable: '',
+};
 
-			<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-item-label {"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}}} /-->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
-			<div class="wp-block-group">
-				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
-				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /--></div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-item -->
-</div>
-<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
-<!-- /wp:group -->`;
-const mockVariableTemplatePartHTML = `<!-- wp:woocommerce/add-to-cart-with-options-variation-selector -->
-<div
-	class="wp-block-woocommerce-add-to-cart-with-options-variation-selector"
-	role="list"
->
-	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-	<div
-		class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute"
-		role="listitem"
-	>
-		<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-		<div
-			class="wp-block-group"
-			style="margin-top: 1rem; margin-bottom: 1rem"
-		>
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
-
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-</div>
-<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
-<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group">
-	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-
-	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
-</div>
-<!-- /wp:group -->
-`;
+Object.keys( mockTemplatePartsHTML ).forEach( ( key ) => {
+	mockTemplatePartsHTML[ key ] = readFileSync(
+		join(
+			__dirname,
+			`../../../../../../../templates/parts/${ key }-product-add-to-cart-with-options.html`
+		),
+		'utf-8'
+	);
+} );
 
 jest.mock( '@woocommerce/settings', () => {
 	return {
@@ -135,82 +78,9 @@ jest.mock( '@woocommerce/settings', () => {
 const mockProduct = {
 	id: 82,
 	name: 'Beanie with Logo',
-	slug: 'beanie-with-logo',
-	parent: 0,
 	type: 'simple',
-	variation: '',
-	permalink: 'https://202508.local/product/beanie-with-logo/',
-	sku: 'Woo-beanie-logo',
-	short_description: '<p>This is a simple product.</p>',
-	description:
-		'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>',
-	on_sale: true,
-	prices: {
-		price: '1800',
-		regular_price: '2000',
-		sale_price: '1800',
-		price_range: null,
-		currency_code: 'EUR',
-		currency_symbol: '\u20ac',
-		currency_minor_unit: 2,
-		currency_decimal_separator: ',',
-		currency_thousand_separator: '.',
-		currency_prefix: '',
-		currency_suffix: ' \u20ac',
-	},
-	price_html:
-		'<del aria-hidden="true"><span class="woocommerce-Price-amount amount">20,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></del> <span class="screen-reader-text">Original price was: 20,00&nbsp;&euro;.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount">18,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></ins><span class="screen-reader-text">Current price is: 18,00&nbsp;&euro;.</span>',
-	average_rating: '0',
-	review_count: 0,
-	images: [
-		{
-			id: 105,
-			src: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg',
-			thumbnail:
-				'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg',
-			srcset: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg 800w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg 300w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-100x100.jpg 100w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-600x600.jpg 600w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-150x150.jpg 150w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-768x768.jpg 768w',
-			sizes: '(max-width: 800px) 100vw, 800px',
-			name: 'beanie-with-logo-1.jpg',
-			alt: '',
-		},
-	],
-	categories: [
-		{
-			id: 19,
-			name: 'Accessories',
-			slug: 'accessories',
-			link: 'https://202508.local/product-category/clothing/accessories/',
-		},
-	],
-	tags: [],
-	brands: [],
-	attributes: [
-		{
-			id: 1,
-			name: 'Color',
-			taxonomy: 'pa_color',
-			has_variations: false,
-			terms: [ { id: 24, name: 'Red', slug: 'red' } ],
-		},
-	],
-	variations: [],
-	grouped_products: [],
-	has_options: false,
-	is_purchasable: true,
 	is_in_stock: true,
-	is_on_backorder: false,
-	low_stock_remaining: null,
 	stock_availability: { text: '', class: 'in-stock' },
-	sold_individually: false,
-	add_to_cart: {
-		text: 'Add to cart',
-		description: 'Add to cart: &ldquo;Beanie with Logo&rdquo;',
-		url: '/wp-json/wc/store/v1/products?_locale=user&#038;add-to-cart=82',
-		single_text: 'Add to cart',
-		minimum: 1,
-		maximum: 9999,
-		multiple_of: 1,
-	},
 };
 
 // Setup MSW.
@@ -245,7 +115,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//simple-product-add-to-cart-with-options',
 				content: {
-					raw: mockSimpleTemplatePartHTML,
+					raw: mockTemplatePartsHTML.simple,
 				},
 			} );
 		}
@@ -256,7 +126,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//external-product-add-to-cart-with-options',
 				content: {
-					raw: mockExternalTemplatePartHTML,
+					raw: mockTemplatePartsHTML.external,
 				},
 			} );
 		}
@@ -267,7 +137,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//grouped-product-add-to-cart-with-options',
 				content: {
-					raw: mockGroupedTemplatePartHTML,
+					raw: mockTemplatePartsHTML.grouped,
 				},
 			} );
 		}
@@ -279,7 +149,7 @@ const handlers = [
 			return HttpResponse.json( {
 				id: 'woocommerce/woocommerce//variable-product-add-to-cart-with-options',
 				content: {
-					raw: mockVariableTemplatePartHTML,
+					raw: mockTemplatePartsHTML.variable,
 				},
 			} );
 		}
@@ -302,7 +172,7 @@ async function setup() {
 	return await initializeEditor( addToCartWithOptionsBlock );
 }
 
-async function switchProductType( productType: string ) {
+const switchProductType = async ( productType: string ) => {
 	await selectBlock( 'Block: Add to Cart + Options (Beta)' );
 
 	await act( async () => {
@@ -316,7 +186,17 @@ async function switchProductType( productType: string ) {
 			screen.getByRole( 'menuitem', { name: productType } )
 		);
 	} );
-}
+};
+
+const expectBlocksToBeInTheDocument = ( blocks: string[] ) => {
+	blocks.forEach( ( blockName: string ) => {
+		expect(
+			screen.getByRole( 'document', {
+				name: blockName,
+			} )
+		).toBeInTheDocument();
+	} );
+};
 
 describe( 'Add to Cart + Options block', () => {
 	it( 'should render inner blocks', async () => {
@@ -329,92 +209,51 @@ describe( 'Add to Cart + Options block', () => {
 
 		// Simple products.
 		await waitFor( () => {
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Quantity (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Product Stock Indicator',
+				'Block: Product Quantity (Beta)',
+				'Block: Add to Cart Button',
+			] );
 		} );
 
 		// External products.
 		await switchProductType( 'External/Affiliate product' );
 
 		await waitFor( () => {
+			expectBlocksToBeInTheDocument( [ 'Block: Add to Cart Button' ] );
+
 			expect(
 				screen.queryByRole( 'document', {
 					name: 'Block: Product Stock Indicator',
 				} )
 			).not.toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
-			).toBeInTheDocument();
 		} );
 
 		// Grouped products.
 		await switchProductType( 'Grouped product' );
 
 		await waitFor( () => {
-			expect(
-				screen.queryByRole( 'document', {
-					name: 'Block: Grouped Product Selector (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Template (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Item Selector (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Grouped Product: Item Label (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Price',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Grouped Product Selector (Beta)',
+				'Block: Grouped Product: Template (Beta)',
+				'Block: Grouped Product: Item Selector (Beta)',
+				'Block: Grouped Product: Item Label (Beta)',
+				'Block: Product Price',
+				'Block: Product Stock Indicator',
+			] );
 		} );
 
 		// Variable products.
 		await switchProductType( 'Variable product' );
 
 		await waitFor( () => {
-			expect(
-				screen.queryByRole( 'document', {
-					name: 'Block: Variation Selector (Beta)',
-				} )
-			).toBeInTheDocument();
+			expectBlocksToBeInTheDocument( [
+				'Block: Variation Selector (Beta)',
+				'Block: Variation Description (Beta)',
+				'Block: Product Stock Indicator',
+				'Block: Product Quantity (Beta)',
+				'Block: Add to Cart Button',
+			] );
 
 			expect(
 				screen.getByRole( 'list', {
@@ -436,30 +275,6 @@ describe( 'Add to Cart + Options block', () => {
 						name: 'Block: Variation Selector: Attribute Options (Beta)',
 					} )
 					.at( 0 )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Variation Description (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Stock Indicator',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Product Quantity (Beta)',
-				} )
-			).toBeInTheDocument();
-
-			expect(
-				screen.getByRole( 'document', {
-					name: 'Block: Add to Cart Button',
-				} )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -135,82 +135,9 @@ jest.mock( '@woocommerce/settings', () => {
 const mockProduct = {
 	id: 82,
 	name: 'Beanie with Logo',
-	slug: 'beanie-with-logo',
-	parent: 0,
 	type: 'simple',
-	variation: '',
-	permalink: 'https://202508.local/product/beanie-with-logo/',
-	sku: 'Woo-beanie-logo',
-	short_description: '<p>This is a simple product.</p>',
-	description:
-		'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>',
-	on_sale: true,
-	prices: {
-		price: '1800',
-		regular_price: '2000',
-		sale_price: '1800',
-		price_range: null,
-		currency_code: 'EUR',
-		currency_symbol: '\u20ac',
-		currency_minor_unit: 2,
-		currency_decimal_separator: ',',
-		currency_thousand_separator: '.',
-		currency_prefix: '',
-		currency_suffix: ' \u20ac',
-	},
-	price_html:
-		'<del aria-hidden="true"><span class="woocommerce-Price-amount amount">20,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></del> <span class="screen-reader-text">Original price was: 20,00&nbsp;&euro;.</span><ins aria-hidden="true"><span class="woocommerce-Price-amount amount">18,00&nbsp;<span class="woocommerce-Price-currencySymbol">&euro;</span></span></ins><span class="screen-reader-text">Current price is: 18,00&nbsp;&euro;.</span>',
-	average_rating: '0',
-	review_count: 0,
-	images: [
-		{
-			id: 105,
-			src: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg',
-			thumbnail:
-				'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg',
-			srcset: 'https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1.jpg 800w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-300x300.jpg 300w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-100x100.jpg 100w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-600x600.jpg 600w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-150x150.jpg 150w, https://202508.local/wp-content/uploads/2025/09/beanie-with-logo-1-768x768.jpg 768w',
-			sizes: '(max-width: 800px) 100vw, 800px',
-			name: 'beanie-with-logo-1.jpg',
-			alt: '',
-		},
-	],
-	categories: [
-		{
-			id: 19,
-			name: 'Accessories',
-			slug: 'accessories',
-			link: 'https://202508.local/product-category/clothing/accessories/',
-		},
-	],
-	tags: [],
-	brands: [],
-	attributes: [
-		{
-			id: 1,
-			name: 'Color',
-			taxonomy: 'pa_color',
-			has_variations: false,
-			terms: [ { id: 24, name: 'Red', slug: 'red' } ],
-		},
-	],
-	variations: [],
-	grouped_products: [],
-	has_options: false,
-	is_purchasable: true,
 	is_in_stock: true,
-	is_on_backorder: false,
-	low_stock_remaining: null,
 	stock_availability: { text: '', class: 'in-stock' },
-	sold_individually: false,
-	add_to_cart: {
-		text: 'Add to cart',
-		description: 'Add to cart: &ldquo;Beanie with Logo&rdquo;',
-		url: '/wp-json/wc/store/v1/products?_locale=user&#038;add-to-cart=82',
-		single_text: 'Add to cart',
-		minimum: 1,
-		maximum: 9999,
-		multiple_of: 1,
-	},
 };
 
 // Setup MSW.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -229,7 +229,7 @@ async function setup() {
 	return await initializeEditor( addToCartWithOptionsBlock );
 }
 
-const switchProductType = async ( productType: string ) => {
+async function switchProductType( productType: string ) {
 	await selectBlock( 'Block: Add to Cart + Options (Beta)' );
 
 	await act( async () => {
@@ -243,7 +243,7 @@ const switchProductType = async ( productType: string ) => {
 			screen.getByRole( 'menuitem', { name: productType } )
 		);
 	} );
-};
+}
 
 describe( 'Add to Cart + Options block', () => {
 	it( 'should render inner blocks', async () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -229,7 +229,7 @@ async function setup() {
 	return await initializeEditor( addToCartWithOptionsBlock );
 }
 
-async function switchProductType( productType: string ) {
+const switchProductType = async ( productType: string ) => {
 	await selectBlock( 'Block: Add to Cart + Options (Beta)' );
 
 	await act( async () => {
@@ -243,7 +243,7 @@ async function switchProductType( productType: string ) {
 			screen.getByRole( 'menuitem', { name: productType } )
 		);
 	} );
-}
+};
 
 const expectBlocksToBeInTheDocument = ( blocks: string[] ) => {
 	blocks.forEach( ( blockName: string ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -3,13 +3,10 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { useProductDataContext } from '@woocommerce/shared-context';
-import { isProductResponseItem } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
  */
-import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import { ATTRIBUTE_ITEM_TEMPLATE } from './attribute/constants';
 
 interface Attributes {
@@ -20,8 +17,6 @@ export default function AddToCartWithOptionsVariationSelectorEdit(
 	props: BlockEditProps< Attributes >
 ) {
 	const { className } = props.attributes;
-	const { current: currentProductType } = useProductTypeSelector();
-	const { product } = useProductDataContext();
 
 	const blockProps = useBlockProps( {
 		className,
@@ -30,14 +25,6 @@ export default function AddToCartWithOptionsVariationSelectorEdit(
 		template: ATTRIBUTE_ITEM_TEMPLATE,
 		templateLock: 'all',
 	} );
-
-	const productType = ! isProductResponseItem( product )
-		? currentProductType?.slug
-		: product.type;
-
-	if ( productType !== 'variable' ) {
-		return null;
-	}
 
 	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the suggestions raised by @gigitux in https://github.com/woocommerce/woocommerce/pull/61219#pullrequestreview-3293013486.

This PR:

* Adds integration tests to make sure Add to Cart + Options inner blocks are correctly loaded in the editor. This would have prevented a regression like the one in https://github.com/woocommerce/woocommerce/pull/61219.
* Makes it so we show a spinner when grouped product inners blocks are loading in the editor.
* Remove the product type check from `variation-selector/edit.tsx`. Hiding the block in the editor might be more confusing than actually showing it (in the future we could explore displaying an error notice instead).
* Strengthened a condition in `grouped-product-selector/product-item/edit.tsx` that might bring us to try to fetch child products from a grouped product without children.

While working on this PR I noticed this other issue: https://github.com/woocommerce/woocommerce/issues/61252.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Switch to the grouped product type.
3. Verify that a spinner is displayed while the inner blocks load.

<img width="1343" height="653" alt="imatge" src="https://github.com/user-attachments/assets/450cbef9-52d9-4943-bd3f-4d90f5e663c7" />
