### PR TITLE
Use Hex for `<` and `>` Inside `<script>` Tags

### DIFF
--- a/packages/php/email-editor/changelog/61245-fix-61186-json-encode-script-tags
+++ b/packages/php/email-editor/changelog/61245-fix-61186-json-encode-script-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Angle brackets are now encoded in hex when rendered in a `<script>` tag via `json_encode()`.

--- a/packages/php/email-editor/src/Engine/class-assets-manager.php
+++ b/packages/php/email-editor/src/Engine/class-assets-manager.php
@@ -191,7 +191,7 @@ class Assets_Manager {
 		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L116-L120.
 		wp_add_inline_script(
 			'wp-blocks',
-			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $context ) ) ),
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $context ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
 			'after'
 		);
 
@@ -199,7 +199,7 @@ class Assets_Manager {
 		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L144C1-L148C3.
 		wp_add_inline_script(
 			'wp-blocks',
-			sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( get_block_editor_server_block_settings() ) )
+			sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( get_block_editor_server_block_settings(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) )
 		);
 
 		$localization_data = array(
@@ -265,7 +265,7 @@ class Assets_Manager {
 			'wp-blocks',
 			sprintf(
 				'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-				wp_json_encode( $preload_data )
+				wp_json_encode( $preload_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);
 	}

--- a/plugins/woocommerce/changelog/61245-fix-61186-json-encode-script-tags
+++ b/plugins/woocommerce/changelog/61245-fix-61186-json-encode-script-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Angle brackets are now encoded in hex when rendered in a `<script>` tag via `json_encode()`.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -553,7 +553,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'wc-admin-order-meta-boxes',
 					'woocommerce_admin_meta_boxes_order',
 					array(
-						'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
+						'countries'              => wp_json_encode(
+							array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ),
+							JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+						),
 						'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
 						'default_country'        => isset( $default_location['country'] ) ? $default_location['country'] : '',
 						'default_state'          => isset( $default_location['state'] ) ? $default_location['state'] : '',
@@ -758,7 +761,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'wc-users',
 					'wc_users_params',
 					array(
-						'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
+						'countries'              => wp_json_encode(
+							array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ),
+							JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+						),
 						'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
 					)
 				);
@@ -806,7 +812,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				wp_add_inline_script(
 					'wc-admin-app',
-					'window.wcMarketplace = ' . wp_json_encode( array( 'promotions' => $promotions ) ),
+					'window.wcMarketplace = ' . wp_json_encode( array( 'promotions' => $promotions ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 					'before'
 				);
 			}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -689,13 +689,14 @@ class WC_Frontend_Scripts {
 							},
 							$providers
 						),
+						JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 					),
 				);
 				break;
 			case 'wc-address-i18n':
 				$params = array(
-					'locale'             => wp_json_encode( WC()->countries->get_country_locale() ),
-					'locale_fields'      => wp_json_encode( WC()->countries->get_country_locale_field_selectors() ),
+					'locale'             => wp_json_encode( WC()->countries->get_country_locale(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+					'locale_fields'      => wp_json_encode( WC()->countries->get_country_locale_field_selectors(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 					'i18n_required_text' => esc_attr__( 'required', 'woocommerce' ),
 					'i18n_optional_text' => esc_html__( 'optional', 'woocommerce' ),
 				);
@@ -742,7 +743,7 @@ class WC_Frontend_Scripts {
 				break;
 			case 'wc-country-select':
 				$params = array(
-					'countries'                 => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
+					'countries'                 => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 					'i18n_select_state_text'    => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
 					'i18n_no_matches'           => _x( 'No matches found', 'enhanced select', 'woocommerce' ),
 					'i18n_ajax_error'           => _x( 'Loading failed', 'enhanced select', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -160,7 +160,7 @@ class WC_Structured_Data {
 		$data  = $this->get_structured_data( $types );
 
 		if ( $data ) {
-			echo '<script type="application/ld+json">' . wc_esc_json( wp_json_encode( $data ), true ) . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<script type="application/ld+json">' . wc_esc_json( wp_json_encode( $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ), true ) . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 

--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -285,7 +285,7 @@ class WC_Shop_Customizer {
 			?>
 			<script type="text/javascript">
 				jQuery( document ).ready( function( $ ) {
-					const message = <?php echo wp_json_encode( $message ); ?>;
+					const message = <?php echo wp_json_encode( $message, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 					$( "#sub-accordion-panel-woocommerce" ).append( "<li class='notice notice-info'>" + message + "</li>" );
 				} );
 			</script>

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -121,7 +121,7 @@ class WC_Site_Tracking {
 
 				const eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				let eventProperties = properties || {};
-				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties ); ?> };
+				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> };
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
 					delete( eventProperties._ui );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -121,7 +121,7 @@ class WC_Site_Tracking {
 
 				const eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				let eventProperties = properties || {};
-				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> };
+				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode ?> };
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
 					delete( eventProperties._ui );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-product-collection-block-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-product-collection-block-tracking.php
@@ -122,7 +122,7 @@ class WC_Product_Collection_Block_Tracking {
 					'in_single_product' => $is_in_single_product ? 'yes' : 'no',
 					'in_template_part'  => $is_in_template_part ? 'yes' : 'no',
 					'in_synced_pattern' => $is_in_synced_pattern ? 'yes' : 'no',
-					'filters'           => wp_json_encode( $this->get_query_filters_usage_data( $block ) ),
+					'filters'           => wp_json_encode( $this->get_query_filters_usage_data( $block ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				);
 			}
 

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -322,7 +322,7 @@ class Features {
 		foreach ( $features as $key ) {
 			$enabled_features[ $key ] = self::is_enabled( $key );
 		}
-		wp_add_inline_script( WC_ADMIN_APP, 'window.wcAdminFeatures = ' . wp_json_encode( $enabled_features ), 'before' );
+		wp_add_inline_script( WC_ADMIN_APP, 'window.wcAdminFeatures = ' . wp_json_encode( $enabled_features, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ), 'before' );
 	}
 
 

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -354,6 +354,6 @@ class LaunchYourStore {
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion, WordPress.WP.EnqueuedResourceParameters.NotInFooter
 		wp_register_script( 'coming-soon-newsletter-mailpoet', '' );
 		wp_enqueue_script( 'coming-soon-newsletter-mailpoet' );
-		wp_add_inline_script( 'coming-soon-newsletter-mailpoet', 'var comingSoonNewsletter = ' . wp_json_encode( $mailpoet ) . ';' );
+		wp_add_inline_script( 'coming-soon-newsletter-mailpoet', 'var comingSoonNewsletter = ' . wp_json_encode( $mailpoet, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ';' );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -204,19 +204,25 @@ class CustomizeStore extends Task {
 			'wp-blocks',
 			sprintf(
 				'window.wcBlockSettings = %s;',
-				wp_json_encode( $editor_settings )
+				wp_json_encode( $editor_settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);
 
 		// Preload server-registered block schemas.
 		wp_add_inline_script(
 			'wp-blocks',
-			'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+			'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');'
 		);
 
 		wp_add_inline_script(
 			'wp-blocks',
-			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( isset( $editor_settings['blockCategories'] ) ? $editor_settings['blockCategories'] : array() ) ),
+			sprintf(
+				'wp.blocks.setCategories( %s );',
+				wp_json_encode(
+					( isset( $editor_settings['blockCategories'] ) ? $editor_settings['blockCategories'] : array() ),
+					JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+				)
+			),
 			'after'
 		);
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -138,12 +138,12 @@ class Init {
 		wp_enqueue_script( $script_handle );
 		wp_add_inline_script(
 			$script_handle,
-			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings ) . ';',
+			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ';',
 			'before'
 		);
 		wp_add_inline_script(
 			$script_handle,
-			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( $editor_settings['blockCategories'] ) ),
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( $editor_settings['blockCategories'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
 			'before'
 		);
 		wp_tinymce_inline_scripts();
@@ -250,7 +250,7 @@ class Init {
 
 			wp_add_inline_script(
 				'wp-blocks',
-				'wp.blocks && wp.blocks.unstable__bootstrapServerSideBlockDefinitions && wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+				'wp.blocks && wp.blocks.unstable__bootstrapServerSideBlockDefinitions && wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');'
 			);
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -372,7 +372,7 @@ class ShippingController {
 			self::LOCAL_PICKUP_ADMIN_JS_HANDLE,
 			sprintf(
 				'var hydratedScreenSettings = %s;',
-				wp_json_encode( $settings )
+				wp_json_encode( $settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			),
 			'before'
 		);

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -288,9 +288,9 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 			'a8c-address-autocomplete-service',
 			sprintf(
 				'var a8cAddressAutocompleteServiceKeys = a8cAddressAutocompleteServiceKeys || {}; a8cAddressAutocompleteServiceKeys[ %1$s ] = { key: %2$s, canTelemetry: %3$s };',
-				wp_json_encode( $this->id ),
-				wp_json_encode( $this->get_jwt() ),
-				wp_json_encode( false !== $this->can_telemetry() && (bool) $this->can_telemetry() )
+				wp_json_encode( $this->id, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+				wp_json_encode( $this->get_jwt(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+				wp_json_encode( false !== $this->can_telemetry() && (bool) $this->can_telemetry(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			),
 			'before'
 		);

--- a/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPConsentAPI.php
@@ -105,7 +105,7 @@ class WPConsentAPI {
 			'wp-consent-api-integration',
 			sprintf(
 				'window.wc_order_attribution.params.consentCategory = %s;',
-				wp_json_encode( self::$consent_category )
+				wp_json_encode( self::$consent_category, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			),
 			'before'
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As described in [WordPress Trac #63851](https://core.trac.wordpress.org/ticket/63851), under certain circumstances, escaping the slashes in `json_encode()` is insufficient and breaks the rendering of the page. The solution employed there [and in Gutenberg](https://github.com/WordPress/gutenberg/issues/71278) is to apply `JSON_HEX_TAG` and `JSON_UNESCAPED_SLASHES` when encoding JSON that is intended to be rendered inside of a `<script>` tag. The browser will then ignore the tag while the JavaScript engine will parse the hex into the expected character.

Closes https://github.com/woocommerce/woocommerce/issues/61186.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To be honest, I'm not _entirely_ sure how to go about testing this? In theory, this should be a harmless change, but those theories don't exactly always pan out! In my audit I didn't really find any places where user input could make its way into a `json_encode()` that prints into a `<script>` tag in the first place. These are generally cases where we are populating an object from properties that we control end-to-end or are otherwise already sanitized to avoid XSS in other places that the properties are rendered.

My _blind hope_ is that our extensive E2E suite would catch any failures.

Let's find out?

<!-- End testing instructions -->

### Testing that has already taken place:

I went on an exploratory adventure through WooCommerce's main features. I didn't notice anything that was out of place, nor did I notice any new console errors.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Angle brackets are now encoded in hex when rendered in a `<script>` tag via `json_encode()`.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
