### PR TITLE
Add v4 Product Settings API

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -225,7 +225,7 @@ class Server {
 			'offline-payment-methods' => OfflinePaymentMethodsController::class,
 			'settings-general'        => 'WC_REST_General_Settings_V4_Controller',
 			'settings-email'          => 'WC_REST_Email_Settings_V4_Controller',
-      'settings-products'       => ProductsController::class,
+			'settings-products'       => ProductsController::class,
 			// This is a wrapper that redirects V4 settings requests to the V3 settings controller.
 			'settings'                => 'WC_REST_Settings_V4_Controller',
 		);

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\RestApi\Routes\V4\OrderNotes\Controller as OrderNotesController;
 use Automattic\WooCommerce\RestApi\Routes\V4\ShippingZones\Controller as ShippingZonesController;
 use Automattic\WooCommerce\RestApi\Routes\V4\Orders\Controller as OrdersController;
+use Automattic\WooCommerce\RestApi\Routes\V4\Settings\Products\Controller as ProductsController;
 
 /**
  * Class responsible for loading the REST API and all REST API namespaces.
@@ -222,6 +223,7 @@ class Server {
 			'orders'           => OrdersController::class,
 			'settings-general' => 'WC_REST_General_Settings_V4_Controller',
 			'settings-email'   => 'WC_REST_Email_Settings_V4_Controller',
+			'settings-products' => ProductsController::class,
 			// This is a wrapper that redirects V4 settings requests to the V3 settings controller.
 			'settings'         => 'WC_REST_Settings_V4_Controller',
 		);

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -215,17 +215,17 @@ class Server {
 	 */
 	protected function get_v4_controllers() {
 		return array(
-			'ping'             => 'WC_REST_Ping_V4_Controller',
-			'fulfillments'     => 'WC_REST_Fulfillments_V4_Controller',
-			'products'         => 'WC_REST_Products_V4_Controller',
-			'order-notes'      => OrderNotesController::class,
-			'shipping-zones'   => ShippingZonesController::class,
-			'orders'           => OrdersController::class,
-			'settings-general' => 'WC_REST_General_Settings_V4_Controller',
-			'settings-email'   => 'WC_REST_Email_Settings_V4_Controller',
+			'ping'              => 'WC_REST_Ping_V4_Controller',
+			'fulfillments'      => 'WC_REST_Fulfillments_V4_Controller',
+			'products'          => 'WC_REST_Products_V4_Controller',
+			'order-notes'       => OrderNotesController::class,
+			'shipping-zones'    => ShippingZonesController::class,
+			'orders'            => OrdersController::class,
+			'settings-general'  => 'WC_REST_General_Settings_V4_Controller',
+			'settings-email'    => 'WC_REST_Email_Settings_V4_Controller',
 			'settings-products' => ProductsController::class,
 			// This is a wrapper that redirects V4 settings requests to the V3 settings controller.
-			'settings'         => 'WC_REST_Settings_V4_Controller',
+			'settings'          => 'WC_REST_Settings_V4_Controller',
 		);
 	}
 

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -314,6 +314,10 @@ class Controller extends AbstractController {
 				return filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE ) ?? floatval( $value );
 
 			case 'checkbox':
+				// Ensure we have a scalar value for checkbox settings
+				if ( is_array( $value ) ) {
+					$value = ! empty( $value ); // Convert array to boolean based on emptiness
+				}
 				return wc_bool_to_string( $value );
 
 			case 'select':

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -244,7 +244,7 @@ class Controller extends AbstractController {
 		// Custom validation rules for specific product settings.
 		switch ( $setting_id ) {
 			case 'woocommerce_weight_unit':
-				$valid_units = array( 'kg', 'g', 'lbs', 'oz' );
+				$valid_units = apply_filters( 'woocommerce_weight_units', array( 'kg', 'g', 'lbs', 'oz' ) );
 				if ( ! in_array( $value, $valid_units, true ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
@@ -255,7 +255,7 @@ class Controller extends AbstractController {
 				break;
 
 			case 'woocommerce_dimension_unit':
-				$valid_units = array( 'm', 'cm', 'mm', 'in', 'yd' );
+				$valid_units = apply_filters( 'woocommerce_dimension_units', array( 'm', 'cm', 'mm', 'in', 'yd' ) );
 				if ( ! in_array( $value, $valid_units, true ) ) {
 					return new WP_Error(
 						'rest_invalid_param',

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * REST API Product Settings controller
+ *
+ * Handles requests to the /settings/products endpoints.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\RestApi\Routes\V4\Settings\Products;
+
+use WP_Error;
+use Automattic\WooCommerce\RestApi\Routes\V4\AbstractController;
+use Automattic\WooCommerce\RestApi\Routes\V4\Settings\Products\Schema\ProductSettingsSchema;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WC_Settings_Products;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product Settings controller class.
+ */
+class Controller extends AbstractController {
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'settings/products';
+
+	/**
+	 * Schema class instance.
+	 *
+	 * @var ProductSettingsSchema
+	 */
+	protected $schema;
+
+	/**
+	 * WC_Settings_Products instance.
+	 *
+	 * @var \WC_Settings_Products
+	 */
+	protected $settings_products_instance;
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @param ProductSettingsSchema $schema Schema class instance.
+	 * @internal
+	 */
+	final public function init( ProductSettingsSchema $schema ) {
+		$this->schema = $schema;
+	}
+
+	/**
+	 * Get the WC_Settings_Products instance.
+	 *
+	 * @return \WC_Settings_Products
+	 */
+	private function get_settings_products_instance() {
+		if ( is_null( $this->settings_products_instance ) ) {
+			$this->settings_products_instance = new WC_Settings_Products();
+		}
+		return $this->settings_products_instance;
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+        return true;
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to access product settings.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to update settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to edit product settings.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Get product settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$settings_instance = $this->get_settings_products_instance();
+		$sections = $settings_instance->get_sections();
+
+		$settings = array();
+
+		// Get settings for each section through WC's filter system
+		foreach ( array_keys( $sections ) as $section ) {
+			$section_settings = $settings_instance->get_settings_for_section( $section );
+			$settings = array_merge( $settings, $section_settings );
+		}
+
+		$response = $this->schema->get_item_response( $settings, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Update product settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$params = $request->get_json_params();
+
+		if ( ! is_array( $params ) || empty( $params ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid or empty request body.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Check if the request contains a 'values' field with the flat key-value mapping.
+		$values_to_update = array();
+		if ( isset( $params['values'] ) && is_array( $params['values'] ) ) {
+			$values_to_update = $params['values'];
+		} else {
+			// Fallback to the old format for backward compatibility.
+			$values_to_update = $params;
+		}
+
+		// Get all product settings definitions.
+		$settings_instance = $this->get_settings_products_instance();
+		$sections = $settings_instance->get_sections();
+		$settings = array();
+
+		// Get settings for each section through WC's filter system
+		foreach ( array_keys( $sections ) as $section ) {
+			$section_settings = $settings_instance->get_settings_for_section( $section );
+			$settings = array_merge( $settings, $section_settings );
+		}
+		$settings_by_id     = array_column( $settings, null, 'id' );
+		$valid_setting_ids  = array_keys( $settings_by_id );
+		$validated_settings = array();
+
+		// Process each setting in the payload.
+		foreach ( $values_to_update as $setting_id => $setting_value ) {
+			// Sanitize the setting ID.
+			$setting_id = sanitize_text_field( $setting_id );
+
+			// Security check: only allow updating valid WooCommerce product settings.
+			if ( ! in_array( $setting_id, $valid_setting_ids, true ) ) {
+				continue;
+			}
+
+			// Sanitize the value based on the setting type.
+			$setting_definition = $settings_by_id[ $setting_id ];
+			$setting_type       = $setting_definition['type'] ?? 'text';
+			$sanitized_value    = $this->sanitize_setting_value( $setting_type, $setting_value );
+
+			// Additional validation for specific settings.
+			$validation_result = $this->validate_setting_value( $setting_id, $sanitized_value );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
+
+			// Store validated values first.
+			$validated_settings[ $setting_id ] = $sanitized_value;
+		}
+
+		// After validation loop, update all settings.
+		$updated_settings = array();
+		foreach ( $validated_settings as $setting_id => $value ) {
+			$update_result = update_option( $setting_id, $value );
+			if ( $update_result ) {
+				$updated_settings[] = $setting_id;
+			}
+		}
+
+		// Log the update if settings were changed.
+		if ( ! empty( $updated_settings ) ) {
+			/**
+			* Fires when WooCommerce product settings are updated.
+			*
+			* @param array $updated_settings Array of updated settings IDs.
+			* @param string $rest_base The REST base of the settings.
+			* @since 4.0.0
+			*/
+			do_action( 'woocommerce_settings_updated', $updated_settings, $this->rest_base );
+		}
+
+		// Get all settings after update
+		$settings_instance = $this->get_settings_products_instance();
+		$sections = $settings_instance->get_sections();
+		$settings = array();
+
+		// Get settings for each section through WC's filter system
+		foreach ( array_keys( $sections ) as $section ) {
+			$section_settings = $settings_instance->get_settings_for_section( $section );
+			$settings = array_merge( $settings, $section_settings );
+		}
+
+		// Return updated settings
+		$response = $this->schema->get_item_response( $settings, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Validate a setting value before updating.
+	 *
+	 * @param string $setting_id Setting ID.
+	 * @param mixed  $value      Setting value.
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 */
+	private function validate_setting_value( string $setting_id, $value ) {
+		// Custom validation rules for specific product settings.
+		switch ( $setting_id ) {
+			case 'woocommerce_weight_unit':
+				$valid_units = array( 'kg', 'g', 'lbs', 'oz' );
+				if ( ! in_array( $value, $valid_units, true ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'Invalid weight unit. Valid units are: kg, g, lbs, oz.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+				break;
+
+			case 'woocommerce_dimension_unit':
+				$valid_units = array( 'm', 'cm', 'mm', 'in', 'yd' );
+				if ( ! in_array( $value, $valid_units, true ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'Invalid dimension unit. Valid units are: m, cm, mm, in, yd.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+				break;
+
+			case 'woocommerce_product_type':
+				$valid_types = array_keys( wc_get_product_types() );
+				if ( ! in_array( $value, $valid_types, true ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'Invalid product type.', 'woocommerce' ),
+						array( 'status' => 400 )
+					);
+				}
+				break;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitize setting value based on its type.
+	 *
+	 * @param string $setting_type Setting type.
+	 * @param mixed  $value        Setting value.
+	 * @return mixed Sanitized value.
+	 */
+	private function sanitize_setting_value( string $setting_type, $value ) {
+		switch ( $setting_type ) {
+			case 'text':
+				return sanitize_text_field( $value );
+
+			case 'number':
+				return is_numeric( $value ) ? floatval( $value ) : 0;
+
+			case 'checkbox':
+				return wc_bool_to_string( $value );
+
+			case 'select':
+				return sanitize_text_field( $value );
+
+			case 'multiselect':
+				if ( is_array( $value ) ) {
+					return array_map( 'sanitize_text_field', $value );
+				}
+				return is_string( $value ) ? array( sanitize_text_field( $value ) ) : array();
+
+			default:
+				return sanitize_text_field( $value );
+		}
+	}
+
+	/**
+	 * Get the schema for the current resource. This use consumed by the AbstractController to generate the item schema
+	 * after running various hooks on the response.
+	 */
+	protected function get_schema(): array {
+		return $this->schema->get_item_schema();
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema(): array {
+		return $this->get_schema();
+	}
+
+	/**
+	 * Prepare a single item for response.
+	 *
+	 * @param mixed            $item    Object to prepare.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Response data.
+	 */
+	protected function get_item_response( $item, WP_REST_Request $request ): array {
+		return $this->schema->get_item_response( $item, $request );
+	}
+}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -310,7 +310,11 @@ class Controller extends AbstractController {
 				return sanitize_text_field( $value );
 
 			case 'number':
-				return is_numeric( $value ) ? floatval( $value ) : 0;
+				if ( ! is_numeric( $value ) ) {
+					return 0;
+				}
+
+				return filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE ) ?? floatval( $value );
 
 			case 'checkbox':
 				return wc_bool_to_string( $value );

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -99,7 +99,6 @@ class Controller extends AbstractController {
 	 * @return bool|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) {
-        return true;
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
 			return new WP_Error(
 				'rest_forbidden',
@@ -135,14 +134,14 @@ class Controller extends AbstractController {
 	 */
 	public function get_item( $request ) {
 		$settings_instance = $this->get_settings_products_instance();
-		$sections = $settings_instance->get_sections();
+		$sections          = $settings_instance->get_sections();
 
 		$settings = array();
 
 		// Get settings for each section through WC's filter system
 		foreach ( array_keys( $sections ) as $section ) {
 			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings = array_merge( $settings, $section_settings );
+			$settings         = array_merge( $settings, $section_settings );
 		}
 
 		$response = $this->schema->get_item_response( $settings, $request );
@@ -177,13 +176,13 @@ class Controller extends AbstractController {
 
 		// Get all product settings definitions.
 		$settings_instance = $this->get_settings_products_instance();
-		$sections = $settings_instance->get_sections();
-		$settings = array();
+		$sections          = $settings_instance->get_sections();
+		$settings          = array();
 
 		// Get settings for each section through WC's filter system
 		foreach ( array_keys( $sections ) as $section ) {
 			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings = array_merge( $settings, $section_settings );
+			$settings         = array_merge( $settings, $section_settings );
 		}
 		$settings_by_id     = array_column( $settings, null, 'id' );
 		$valid_setting_ids  = array_keys( $settings_by_id );
@@ -237,13 +236,13 @@ class Controller extends AbstractController {
 
 		// Get all settings after update
 		$settings_instance = $this->get_settings_products_instance();
-		$sections = $settings_instance->get_sections();
-		$settings = array();
+		$sections          = $settings_instance->get_sections();
+		$settings          = array();
 
 		// Get settings for each section through WC's filter system
 		foreach ( array_keys( $sections ) as $section ) {
 			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings = array_merge( $settings, $section_settings );
+			$settings         = array_merge( $settings, $section_settings );
 		}
 
 		// Return updated settings
@@ -350,7 +349,7 @@ class Controller extends AbstractController {
 	/**
 	 * Prepare a single item for response.
 	 *
-	 * @param mixed            $item    Object to prepare.
+	 * @param mixed           $item    Object to prepare.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array Response data.
 	 */

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -218,15 +218,7 @@ class Controller extends AbstractController {
 		}
 
 		// Get all settings after update.
-		$settings_instance = $this->get_settings_products_instance();
-		$sections          = $settings_instance->get_sections();
-		$settings          = array();
-
-		// Get settings for each section through WC's filter system.
-		foreach ( array_keys( $sections ) as $section ) {
-			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings         = array_merge( $settings, $section_settings );
-		}
+		$settings = $this->get_all_settings();
 
 		// Return updated settings.
 		$response = $this->schema->get_item_response( $settings, $request );

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -314,9 +314,9 @@ class Controller extends AbstractController {
 				return filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE ) ?? floatval( $value );
 
 			case 'checkbox':
-				// Ensure we have a scalar value for checkbox settings
+				// Ensure we have a scalar value for checkbox settings.
 				if ( is_array( $value ) ) {
-					$value = ! empty( $value ); // Convert array to boolean based on emptiness
+					$value = ! empty( $value ); // Convert array to boolean based on emptiness.
 				}
 				return wc_bool_to_string( $value );
 

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -217,18 +217,18 @@ class Controller extends AbstractController {
 			do_action( 'woocommerce_settings_updated', $updated_settings, $this->rest_base );
 		}
 
-		// Get all settings after update
+		// Get all settings after update.
 		$settings_instance = $this->get_settings_products_instance();
 		$sections          = $settings_instance->get_sections();
 		$settings          = array();
 
-		// Get settings for each section through WC's filter system
+		// Get settings for each section through WC's filter system.
 		foreach ( array_keys( $sections ) as $section ) {
 			$section_settings = $settings_instance->get_settings_for_section( $section );
 			$settings         = array_merge( $settings, $section_settings );
 		}
 
-		// Return updated settings
+		// Return updated settings.
 		$response = $this->schema->get_item_response( $settings, $request );
 		return rest_ensure_response( $response );
 	}
@@ -244,6 +244,13 @@ class Controller extends AbstractController {
 		// Custom validation rules for specific product settings.
 		switch ( $setting_id ) {
 			case 'woocommerce_weight_unit':
+				/**
+				 * Filter the available weight units.
+				 *
+				 * @since 10.4.0
+				 *
+				 * @param array $weight_units Array of weight unit strings.
+				 */
 				$valid_units = apply_filters( 'woocommerce_weight_units', array( 'kg', 'g', 'lbs', 'oz' ) );
 				if ( ! in_array( $value, $valid_units, true ) ) {
 					return new WP_Error(
@@ -255,6 +262,13 @@ class Controller extends AbstractController {
 				break;
 
 			case 'woocommerce_dimension_unit':
+				/**
+				 * Filter the available dimension units.
+				 *
+				 * @since 10.4.0
+				 *
+				 * @param array $dimension_units Array of dimension unit strings.
+				 */
 				$valid_units = apply_filters( 'woocommerce_dimension_units', array( 'm', 'cm', 'mm', 'in', 'yd' ) );
 				if ( ! in_array( $value, $valid_units, true ) ) {
 					return new WP_Error(

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -309,8 +309,16 @@ class Controller extends AbstractController {
 				if ( is_array( $value ) ) {
 					return array_map( 'sanitize_text_field', $value );
 				}
-				return is_string( $value ) ? array( sanitize_text_field( $value ) ) : array();
 
+				if ( is_string( $value ) ) {
+					return array( sanitize_text_field( $value ) );
+				}
+
+				if ( is_scalar( $value ) ) {
+					return array( sanitize_text_field( (string) $value ) );
+				}
+
+				return array();
 			default:
 				return sanitize_text_field( $value );
 		}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Controller.php
@@ -133,16 +133,7 @@ class Controller extends AbstractController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
-		$settings_instance = $this->get_settings_products_instance();
-		$sections          = $settings_instance->get_sections();
-
-		$settings = array();
-
-		// Get settings for each section through WC's filter system
-		foreach ( array_keys( $sections ) as $section ) {
-			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings         = array_merge( $settings, $section_settings );
-		}
+		$settings = $this->get_all_settings();
 
 		$response = $this->schema->get_item_response( $settings, $request );
 		return rest_ensure_response( $response );
@@ -175,15 +166,7 @@ class Controller extends AbstractController {
 		}
 
 		// Get all product settings definitions.
-		$settings_instance = $this->get_settings_products_instance();
-		$sections          = $settings_instance->get_sections();
-		$settings          = array();
-
-		// Get settings for each section through WC's filter system
-		foreach ( array_keys( $sections ) as $section ) {
-			$section_settings = $settings_instance->get_settings_for_section( $section );
-			$settings         = array_merge( $settings, $section_settings );
-		}
+		$settings           = $this->get_all_settings();
 		$settings_by_id     = array_column( $settings, null, 'id' );
 		$valid_setting_ids  = array_keys( $settings_by_id );
 		$validated_settings = array();
@@ -359,5 +342,23 @@ class Controller extends AbstractController {
 	 */
 	protected function get_item_response( $item, WP_REST_Request $request ): array {
 		return $this->schema->get_item_response( $item, $request );
+	}
+
+	/**
+	 * Get all product settings definitions.
+	 *
+	 * @return array Array of setting definitions.
+	 */
+	private function get_all_settings(): array {
+		$settings_instance = $this->get_settings_products_instance();
+		$sections          = $settings_instance->get_sections();
+		$settings          = array();
+
+		foreach ( array_keys( $sections ) as $section ) {
+			$section_settings = $settings_instance->get_settings_for_section( $section );
+			$settings         = array_merge( $settings, $section_settings );
+		}
+
+		return $settings;
 	}
 }

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -31,13 +31,13 @@ class ProductSettingsSchema extends AbstractSchema {
 	 */
 	public function get_item_schema_properties(): array {
 		return array(
-			'id' => array(
+			'id'          => array(
 				'description' => __( 'Unique identifier for the settings group.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'title' => array(
+			'title'       => array(
 				'description' => __( 'Settings title.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
@@ -49,7 +49,7 @@ class ProductSettingsSchema extends AbstractSchema {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'values' => array(
+			'values'      => array(
 				'description'          => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
 				'type'                 => 'object',
 				'context'              => array( 'view', 'edit' ),
@@ -58,7 +58,7 @@ class ProductSettingsSchema extends AbstractSchema {
 					'type'        => array( 'string', 'number', 'array', 'boolean' ),
 				),
 			),
-			'groups' => array(
+			'groups'      => array(
 				'description'          => __( 'Collection of setting groups.', 'woocommerce' ),
 				'type'                 => 'object',
 				'context'              => array( 'view', 'edit' ),
@@ -66,7 +66,7 @@ class ProductSettingsSchema extends AbstractSchema {
 					'type'        => 'object',
 					'description' => __( 'Settings group.', 'woocommerce' ),
 					'properties'  => array(
-						'title' => array(
+						'title'       => array(
 							'description' => __( 'Group title.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
@@ -76,13 +76,13 @@ class ProductSettingsSchema extends AbstractSchema {
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
-						'order' => array(
+						'order'       => array(
 							'description' => __( 'Display order for the group.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
-						'fields' => array(
+						'fields'      => array(
 							'description' => __( 'Settings fields.', 'woocommerce' ),
 							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
@@ -136,7 +136,7 @@ class ProductSettingsSchema extends AbstractSchema {
 	/**
 	 * Get product settings data by transforming WC_Settings_Products data into REST API format.
 	 *
-	 * @param mixed            $item             Settings products instance.
+	 * @param mixed           $item             Settings products instance.
 	 * @param WP_REST_Request $request          Request object.
 	 * @param array           $include_fields   Fields to include.
 	 * @return array
@@ -145,9 +145,9 @@ class ProductSettingsSchema extends AbstractSchema {
 		$raw_settings = $item;
 
 		// Transform raw settings into grouped format based on title/sectionend markers
-		$groups = array();
-		$values = array();
-		$current_group = null;
+		$groups           = array();
+		$values           = array();
+		$current_group    = null;
 		$current_group_id = null;
 
 		foreach ( $raw_settings as $setting ) {
@@ -156,7 +156,7 @@ class ProductSettingsSchema extends AbstractSchema {
 			// Handle section titles - start of a new group
 			if ( 'title' === $setting_type ) {
 				$current_group_id = $setting['id'] ?? '';
-				$current_group = array(
+				$current_group    = array(
 					'title'       => $setting['title'] ?? '',
 					'description' => $setting['desc'] ?? '',
 					'order'       => isset( $setting['order'] ) ? (int) $setting['order'] : 999,
@@ -168,9 +168,9 @@ class ProductSettingsSchema extends AbstractSchema {
 			// Handle section ends - save the current group
 			if ( 'sectionend' === $setting_type ) {
 				if ( $current_group && $current_group_id ) {
-					$groups[$current_group_id] = $current_group;
+					$groups[ $current_group_id ] = $current_group;
 				}
-				$current_group = null;
+				$current_group    = null;
 				$current_group_id = null;
 				continue;
 			}
@@ -192,11 +192,14 @@ class ProductSettingsSchema extends AbstractSchema {
 		}
 
 		// Sort groups by their order if available
-		uasort( $groups, function( $a, $b ) {
-			$a_order = $a['order'] ?? 999;
-			$b_order = $b['order'] ?? 999;
-			return $a_order - $b_order;
-		});
+		uasort(
+			$groups,
+			function ( $a, $b ) {
+				$a_order = $a['order'] ?? 999;
+				$b_order = $b['order'] ?? 999;
+				return $a_order - $b_order;
+			}
+		);
 
 		return array(
 			'id'          => 'products',
@@ -277,7 +280,7 @@ class ProductSettingsSchema extends AbstractSchema {
 	private function normalize_field_type( string $wc_type ): string {
 		$type_map = array(
 			'single_select_product' => 'select',
-			'multi_select_product' => 'multiselect',
+			'multi_select_product'  => 'multiselect',
 		);
 
 		return $type_map[ $wc_type ] ?? $wc_type;

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -188,8 +188,8 @@ class ProductSettingsSchema extends AbstractSchema {
 				$field = $this->transform_setting_to_field( $setting );
 				if ( $field ) {
 					$current_group['fields'][] = $field;
-					// Add field value to the flat values array
-					$raw_value = get_option( $field['id'], $setting['default'] ?? '' );
+					// Add field value to the flat values array.
+					$raw_value              = get_option( $field['id'], $setting['default'] ?? '' );
 					$values[ $field['id'] ] = $this->validate_field_value( $raw_value, $field['type'] );
 				}
 			}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -189,7 +189,8 @@ class ProductSettingsSchema extends AbstractSchema {
 				if ( $field ) {
 					$current_group['fields'][] = $field;
 					// Add field value to the flat values array
-					$values[ $field['id'] ] = get_option( $field['id'], $setting['default'] ?? '' );
+					$raw_value = get_option( $field['id'], $setting['default'] ?? '' );
+					$values[ $field['id'] ] = $this->validate_field_value( $raw_value, $field['type'] );
 				}
 			}
 		}
@@ -288,5 +289,27 @@ class ProductSettingsSchema extends AbstractSchema {
 		);
 
 		return $type_map[ $wc_type ] ?? $wc_type;
+	}
+
+	/**
+	 * Validate and sanitize field value based on its type.
+	 *
+	 * @param mixed  $value Field value.
+	 * @param string $type  Field type.
+	 * @return mixed Validated value.
+	 */
+	private function validate_field_value( $value, string $type ) {
+		switch ( $type ) {
+			case 'number':
+				return is_numeric( $value ) ? (float) $value : 0;
+			case 'checkbox':
+				return (bool) $value;
+			case 'multiselect':
+				return is_array( $value ) ? $value : array();
+			case 'text':
+			case 'select':
+			default:
+				return is_string( $value ) ? $value : (string) $value;
+		}
 	}
 }

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * REST API Product Settings Schema
+ *
+ * Handles schema definition for product settings.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\RestApi\Routes\V4\Settings\Products\Schema;
+
+use Automattic\WooCommerce\RestApi\Routes\V4\AbstractSchema;
+
+/**
+ * Product Settings Schema Class.
+ */
+class ProductSettingsSchema extends AbstractSchema {
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product_settings';
+
+	/**
+	 * Return all properties for the item schema.
+	 *
+	 * @return array The schema properties.
+	 */
+	public function get_item_schema_properties(): array {
+		return array(
+			'id' => array(
+				'description' => __( 'Unique identifier for the settings group.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'title' => array(
+				'description' => __( 'Settings title.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'description' => array(
+				'description' => __( 'Settings description.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'values' => array(
+				'description'          => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
+				'type'                 => 'object',
+				'context'              => array( 'view', 'edit' ),
+				'additionalProperties' => array(
+					'description' => __( 'Setting field value.', 'woocommerce' ),
+					'type'        => array( 'string', 'number', 'array', 'boolean' ),
+				),
+			),
+			'groups' => array(
+				'description'          => __( 'Collection of setting groups.', 'woocommerce' ),
+				'type'                 => 'object',
+				'context'              => array( 'view', 'edit' ),
+				'additionalProperties' => array(
+					'type'        => 'object',
+					'description' => __( 'Settings group.', 'woocommerce' ),
+					'properties'  => array(
+						'title' => array(
+							'description' => __( 'Group title.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'description' => array(
+							'description' => __( 'Group description.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'order' => array(
+							'description' => __( 'Display order for the group.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'fields' => array(
+							'description' => __( 'Settings fields.', 'woocommerce' ),
+							'type'        => 'array',
+							'context'     => array( 'view', 'edit' ),
+							'items'       => $this->get_field_schema(),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the schema for individual setting fields.
+	 *
+	 * @return array
+	 */
+	private function get_field_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'      => array(
+					'description' => __( 'Setting field ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'label'   => array(
+					'description' => __( 'Setting field label.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'type'    => array(
+					'description' => __( 'Setting field type.', 'woocommerce' ),
+					'type'        => 'string',
+					'enum'        => array( 'text', 'number', 'select', 'multiselect', 'checkbox' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'options' => array(
+					'description' => __( 'Available options for select/multiselect fields.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'desc'    => array(
+					'description' => __( 'Description for the setting field.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get product settings data by transforming WC_Settings_Products data into REST API format.
+	 *
+	 * @param mixed            $item             Settings products instance.
+	 * @param WP_REST_Request $request          Request object.
+	 * @param array           $include_fields   Fields to include.
+	 * @return array
+	 */
+	public function get_item_response( $item, \WP_REST_Request $request, array $include_fields = array() ): array {
+		$raw_settings = $item;
+
+		// Transform raw settings into grouped format based on title/sectionend markers
+		$groups = array();
+		$values = array();
+		$current_group = null;
+		$current_group_id = null;
+
+		foreach ( $raw_settings as $setting ) {
+			$setting_type = $setting['type'] ?? '';
+
+			// Handle section titles - start of a new group
+			if ( 'title' === $setting_type ) {
+				$current_group_id = $setting['id'] ?? '';
+				$current_group = array(
+					'title'       => $setting['title'] ?? '',
+					'description' => $setting['desc'] ?? '',
+					'order'       => isset( $setting['order'] ) ? (int) $setting['order'] : 999,
+					'fields'      => array(),
+				);
+				continue;
+			}
+
+			// Handle section ends - save the current group
+			if ( 'sectionend' === $setting_type ) {
+				if ( $current_group && $current_group_id ) {
+					$groups[$current_group_id] = $current_group;
+				}
+				$current_group = null;
+				$current_group_id = null;
+				continue;
+			}
+
+			// Skip title and sectionend types
+			if ( in_array( $setting_type, array( 'title', 'sectionend' ), true ) ) {
+				continue;
+			}
+
+			// Convert setting to field format
+			if ( isset( $setting['id'] ) && $current_group ) {
+				$field = $this->transform_setting_to_field( $setting );
+				if ( $field ) {
+					$current_group['fields'][] = $field;
+					// Add field value to the flat values array
+					$values[ $field['id'] ] = get_option( $field['id'], $setting['default'] ?? '' );
+				}
+			}
+		}
+
+		// Sort groups by their order if available
+		uasort( $groups, function( $a, $b ) {
+			$a_order = $a['order'] ?? 999;
+			$b_order = $b['order'] ?? 999;
+			return $a_order - $b_order;
+		});
+
+		return array(
+			'id'          => 'products',
+			'title'       => __( 'Products', 'woocommerce' ),
+			'description' => __( 'Manage product settings including dimensions, weight units, and display options.', 'woocommerce' ),
+			'values'      => $values,
+			'groups'      => $groups,
+		);
+	}
+
+	/**
+	 * Transform a WooCommerce setting into REST API field format.
+	 *
+	 * @param array $setting WooCommerce setting array.
+	 * @return array|null Transformed field or null if should be skipped.
+	 */
+	private function transform_setting_to_field( array $setting ): ?array {
+		$setting_id   = $setting['id'] ?? '';
+		$setting_type = $setting['type'] ?? 'text';
+
+		$field = array(
+			'id'    => $setting_id,
+			'label' => $setting['title'] ?? $setting_id,
+			'type'  => $this->normalize_field_type( $setting_type ),
+			'desc'  => $setting['desc'] ?? '',
+		);
+
+		// Add options for select fields.
+		if ( isset( $setting['options'] ) && is_array( $setting['options'] ) ) {
+			$field['options'] = $setting['options'];
+		} else {
+			// Generate options for special field types.
+			$field['options'] = $this->get_field_options( $setting_type, $setting_id );
+		}
+
+		return $field;
+	}
+
+	/**
+	 * Get options for specific field types.
+	 *
+	 * @param string $field_type Field type.
+	 * @param string $field_id Field ID.
+	 * @return array Field options.
+	 */
+	private function get_field_options( string $field_type, string $field_id ): array {
+		switch ( $field_id ) {
+			case 'woocommerce_weight_unit':
+				return array(
+					'kg'  => __( 'kg', 'woocommerce' ),
+					'g'   => __( 'g', 'woocommerce' ),
+					'lbs' => __( 'lbs', 'woocommerce' ),
+					'oz'  => __( 'oz', 'woocommerce' ),
+				);
+
+			case 'woocommerce_dimension_unit':
+				return array(
+					'm'  => __( 'm', 'woocommerce' ),
+					'cm' => __( 'cm', 'woocommerce' ),
+					'mm' => __( 'mm', 'woocommerce' ),
+					'in' => __( 'in', 'woocommerce' ),
+					'yd' => __( 'yd', 'woocommerce' ),
+				);
+
+			case 'woocommerce_product_type':
+				return wc_get_product_types();
+		}
+
+		return array();
+	}
+
+	/**
+	 * Normalize WooCommerce field types to REST API field types.
+	 *
+	 * @param string $wc_type WooCommerce field type.
+	 * @return string Normalized field type.
+	 */
+	private function normalize_field_type( string $wc_type ): string {
+		$type_map = array(
+			'single_select_product' => 'select',
+			'multi_select_product' => 'multiselect',
+		);
+
+		return $type_map[ $wc_type ] ?? $wc_type;
+	}
+}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -265,7 +265,8 @@ class ProductSettingsSchema extends AbstractSchema {
 				);
 
 			case 'woocommerce_product_type':
-				return wc_get_product_types();
+				$product_types = function_exists( 'wc_get_product_types' ) ? wc_get_product_types() : array();
+				return is_array( $product_types ) ? $product_types : array();
 		}
 
 		return array();

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -306,7 +306,13 @@ class ProductSettingsSchema extends AbstractSchema {
 			case 'number':
 				return is_numeric( $value ) ? (float) $value : 0;
 			case 'checkbox':
-				return (bool) $value;
+				if ( function_exists( 'wc_string_to_bool' ) ) {
+					return wc_string_to_bool( $value );
+				}
+				if ( is_bool( $value ) ) {
+					return $value;
+				}
+				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 			case 'multiselect':
 				return is_array( $value ) ? $value : array();
 			case 'text':

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -236,7 +236,7 @@ class ProductSettingsSchema extends AbstractSchema {
 			$field['options'] = $setting['options'];
 		} else {
 			// Generate options for special field types.
-			$field['options'] = $this->get_field_options( $setting_type, $setting_id );
+			$field['options'] = $this->get_field_options( $setting_id );
 		}
 
 		return $field;
@@ -245,11 +245,10 @@ class ProductSettingsSchema extends AbstractSchema {
 	/**
 	 * Get options for specific field types.
 	 *
-	 * @param string $field_type Field type.
 	 * @param string $field_id Field ID.
 	 * @return array Field options.
 	 */
-	private function get_field_options( string $field_type, string $field_id ): array {
+	private function get_field_options( string $field_id ): array {
 		switch ( $field_id ) {
 			case 'woocommerce_weight_unit':
 				return array(
@@ -269,7 +268,11 @@ class ProductSettingsSchema extends AbstractSchema {
 				);
 
 			case 'woocommerce_product_type':
-				$product_types = function_exists( 'wc_get_product_types' ) ? wc_get_product_types() : array();
+				if ( ! function_exists( 'wc_get_product_types' ) ) {
+					return array();
+				}
+
+				$product_types = wc_get_product_types();
 				return is_array( $product_types ) ? $product_types : array();
 		}
 

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/Products/Schema/ProductSettingsSchema.php
@@ -11,7 +11,10 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\RestApi\Routes\V4\Settings\Products\Schema;
 
+defined( 'ABSPATH' ) || exit;
+
 use Automattic\WooCommerce\RestApi\Routes\V4\AbstractSchema;
+use WP_REST_Request;
 
 /**
  * Product Settings Schema Class.
@@ -141,10 +144,10 @@ class ProductSettingsSchema extends AbstractSchema {
 	 * @param array           $include_fields   Fields to include.
 	 * @return array
 	 */
-	public function get_item_response( $item, \WP_REST_Request $request, array $include_fields = array() ): array {
+	public function get_item_response( $item, WP_REST_Request $request, array $include_fields = array() ): array {
 		$raw_settings = $item;
 
-		// Transform raw settings into grouped format based on title/sectionend markers
+		// Transform raw settings into grouped format based on title/sectionend markers.
 		$groups           = array();
 		$values           = array();
 		$current_group    = null;
@@ -153,7 +156,7 @@ class ProductSettingsSchema extends AbstractSchema {
 		foreach ( $raw_settings as $setting ) {
 			$setting_type = $setting['type'] ?? '';
 
-			// Handle section titles - start of a new group
+			// Handle section titles - start of a new group.
 			if ( 'title' === $setting_type ) {
 				$current_group_id = $setting['id'] ?? '';
 				$current_group    = array(
@@ -165,7 +168,7 @@ class ProductSettingsSchema extends AbstractSchema {
 				continue;
 			}
 
-			// Handle section ends - save the current group
+			// Handle section ends - save the current group.
 			if ( 'sectionend' === $setting_type ) {
 				if ( $current_group && $current_group_id ) {
 					$groups[ $current_group_id ] = $current_group;
@@ -175,12 +178,12 @@ class ProductSettingsSchema extends AbstractSchema {
 				continue;
 			}
 
-			// Skip title and sectionend types
+			// Skip title and sectionend types.
 			if ( in_array( $setting_type, array( 'title', 'sectionend' ), true ) ) {
 				continue;
 			}
 
-			// Convert setting to field format
+			// Convert setting to field format.
 			if ( isset( $setting['id'] ) && $current_group ) {
 				$field = $this->transform_setting_to_field( $setting );
 				if ( $field ) {
@@ -191,7 +194,7 @@ class ProductSettingsSchema extends AbstractSchema {
 			}
 		}
 
-		// Sort groups by their order if available
+		// Sort groups by their order if available.
 		uasort(
 			$groups,
 			function ( $a, $b ) {

--- a/plugins/woocommerce/src/RestApi/Routes/V4/Settings/README.md
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/Settings/README.md
@@ -1,0 +1,36 @@
+# WooCommerce Settings REST API - v4
+
+> This is an internal API only. Do not use it in production.
+
+The WooCommerce Settings REST API provides a consistent interface for managing various WooCommerce settings. All settings endpoints share a common response schema that organizes settings into logical groups with standardized field types.
+
+## Response Schema
+
+Each settings endpoint returns data in the following structure:
+
+```json
+{
+  "id": "string",          // Unique identifier for the settings group
+  "title": "string",       // Settings title
+  "description": "string", // Settings description
+  "values": {             // Flat key-value mapping of all setting field values
+    "field_id": "value"   // Values can be string, number, array, boolean...
+  },
+  "groups": {             // Collection of setting groups
+    "group_id": {
+      "title": "string",       // Group title
+      "description": "string", // Group description
+      "order": 0,             // Display order for the group
+      "fields": [             // Array of setting fields
+        {
+          "id": "string",     // Setting field ID
+          "label": "string",  // Setting field label
+          "type": "string",   // Field type (text, number, select, multiselect, checkbox)
+          "options": {},      // Available options for select/multiselect fields
+          "desc": "string"    // Field description
+        }
+      ]
+    }
+  }
+}
+```


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds support for a v4 Products Settings API and matches the schema for General and Notifications settings.

It is also creates the new API controller in the new folder (others will be migrated into the new folder)

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is for internal use and doesn't need a changelog

</details>