### PR TITLE
Fix Product Price display when sale price is 0

### DIFF
--- a/plugins/woocommerce/changelog/add-support-agentic-commerce
+++ b/plugins/woocommerce/changelog/add-support-agentic-commerce
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds the checkout_sessions route for the agentic commerce protocol as an experimental feature

--- a/plugins/woocommerce/changelog/fix-product-price-is-discount
+++ b/plugins/woocommerce/changelog/fix-product-price-is-discount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes how we check for discounted values in order summary

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -277,7 +277,11 @@ const ProductPrice = ( {
 		console.error( 'Price formats need to include the `<price/>` tag.' );
 	}
 
-	const isDiscounted = regularPrice && price && price < regularPrice;
+	const isDiscounted =
+		regularPrice !== undefined &&
+		price !== undefined &&
+		price < regularPrice;
+
 	let priceComponent = (
 		<span
 			className={ clsx(
@@ -286,6 +290,16 @@ const ProductPrice = ( {
 			) }
 		/>
 	);
+
+	console.log( {
+		isDiscounted,
+		minPrice,
+		maxPrice,
+		price,
+		regularPrice,
+		currency,
+		priceClassName,
+	} );
 
 	if ( isDiscounted ) {
 		priceComponent = (

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -533,6 +533,18 @@ class FeaturesController {
 				'disable_ui'                   => false,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'agentic_checkout'       => array(
+				'name'                         => __( 'Agentic Checkout API', 'woocommerce' ),
+				'description'                  => __(
+					'Enable the Agentic Checkout API for AI-powered checkout experiences (e.g., ChatGPT). This adds REST API endpoints that allow AI agents to create and manage checkout sessions.',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				'is_experimental'              => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 		);
 
 		if ( ! $tracking_enabled ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -217,7 +217,8 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		// TODO: Ensure that we have session isolation since we don't require nonces or cart-token.
+		// Ensure that we have session isolation since we don't require nonces or cart-token.
+		// @todo Implement session isolation for agentic checkout sessions.
 
 		// Add items to cart.
 		$items = $request->get_param( 'items' );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -1,0 +1,420 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Routes\V1\Agentic;
+
+use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+
+/**
+ * CheckoutSessions class.
+ *
+ * Handles the Agentic Checkout API checkout sessions endpoint.
+ * This endpoint allows AI agents to create and manage checkout sessions.
+ */
+class CheckoutSessions extends AbstractCartRoute {
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'agentic-checkout-sessions';
+
+	/**
+	 * The route's schema type.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'agentic-checkout-session';
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/checkout_sessions';
+	}
+
+	/**
+	 * Get the path regex for this REST route.
+	 *
+	 * @return string
+	 */
+	public static function get_path_regex() {
+		return '/checkout_sessions';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => [ $this, 'is_authorized' ],
+				'args'                => $this->get_create_params(),
+			],
+			'schema' => [ $this->schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Get the parameters for creating a checkout session.
+	 *
+	 * @return array Parameters array.
+	 */
+	protected function get_create_params() {
+		return [
+			'items'                => [
+				'description' => __( 'Line items to add to the cart.', 'woocommerce' ),
+				'type'        => 'array',
+				'required'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'       => [
+							'description' => __( 'Product ID.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => true,
+						],
+						'quantity' => [
+							'description' => __( 'Quantity.', 'woocommerce' ),
+							'type'        => 'integer',
+							'required'    => true,
+							'minimum'     => 1,
+						],
+					],
+				],
+			],
+			'buyer'                => [
+				'description' => __( 'Buyer information.', 'woocommerce' ),
+				'type'        => 'object',
+				'properties'  => [
+					'first_name'   => [
+						'description' => __( 'First name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'last_name'    => [
+						'description' => __( 'Last name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'email'        => [
+						'description' => __( 'Email address.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'phone_number' => [
+						'description' => __( 'Phone number.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+				],
+			],
+			'fulfillment_address'  => [
+				'description' => __( 'Fulfillment/shipping address.', 'woocommerce' ),
+				'type'        => 'object',
+				'properties'  => [
+					'name'        => [
+						'description' => __( 'Full name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'line_one'    => [
+						'description' => __( 'Address line 1.', 'woocommerce' ),
+						'type'        => 'string',
+						'required'    => true,
+					],
+					'line_two'    => [
+						'description' => __( 'Address line 2.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'city'        => [
+						'description' => __( 'City.', 'woocommerce' ),
+						'type'        => 'string',
+						'required'    => true,
+					],
+					'state'       => [
+						'description' => __( 'State/province.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'country'     => [
+						'description' => __( 'Country code (ISO 3166-1 alpha-2).', 'woocommerce' ),
+						'type'        => 'string',
+						'required'    => true,
+					],
+					'postal_code' => [
+						'description' => __( 'Postal/ZIP code.', 'woocommerce' ),
+						'type'        => 'string',
+						'required'    => true,
+					],
+				],
+			],
+			'fulfillment_option_id' => [
+				'description' => __( 'Selected fulfillment option ID.', 'woocommerce' ),
+				'type'        => 'string',
+			],
+		];
+	}
+
+	/**
+	 * Check if the request is authorized.
+	 *
+	 * V1 implementation: Return true for now (skip auth check).
+	 * Future: Implement Bearer token authentication.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool True if authorized.
+	 */
+	public function is_authorized( \WP_REST_Request $request ) {
+		// Check if feature is enabled
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		if ( ! $features_controller->feature_is_enabled( 'agentic_checkout' ) ) {
+			return false;
+		}
+
+		// V1: Allow all requests (implement proper auth in future)
+		return true;
+	}
+
+	/**
+	 * Handle the request and return a valid response for this endpoint.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		// Ensure we have a session
+		if ( ! WC()->session ) {
+			WC()->session = new \WC_Session_Handler();
+			WC()->session->init();
+		}
+
+		// Ensure we have a cart
+		if ( ! WC()->cart ) {
+			WC()->frontend_includes();
+			WC()->cart = new \WC_Cart();
+		}
+
+		// Clear existing cart
+		WC()->cart->empty_cart();
+
+		// Add items to cart
+		$items = $request->get_param( 'items' );
+		foreach ( $items as $item ) {
+			$product_id = (int) $item['id'];
+			$quantity   = (int) $item['quantity'];
+
+			// Get product
+			$product = wc_get_product( $product_id );
+			if ( ! $product ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'invalid_product',
+						'message' => sprintf(
+							/* translators: %s: product ID */
+							__( 'Product with ID %s not found.', 'woocommerce' ),
+							$product_id
+						),
+						'param'   => '$.items[' . array_search( $item, $items, true ) . '].id',
+					],
+					400
+				);
+			}
+
+			// Check stock
+			if ( ! $product->is_in_stock() || ! $product->has_enough_stock( $quantity ) ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'out_of_stock',
+						'message' => sprintf(
+							/* translators: %s: product name */
+							__( 'Product "%s" is out of stock.', 'woocommerce' ),
+							$product->get_name()
+						),
+						'param'   => '$.items[' . array_search( $item, $items, true ) . ']',
+					],
+					400
+				);
+			}
+
+			// Add to cart
+			WC()->cart->add_to_cart( $product_id, $quantity );
+		}
+
+		// Set buyer information
+		$buyer = $request->get_param( 'buyer' );
+		if ( $buyer ) {
+			$this->set_buyer_data( $buyer );
+		}
+
+		// Set fulfillment address
+		$address = $request->get_param( 'fulfillment_address' );
+		if ( $address ) {
+			$this->set_fulfillment_address( $address );
+		}
+
+		// Calculate totals
+		WC()->cart->calculate_totals();
+
+		// Set selected shipping method if provided
+		$fulfillment_option_id = $request->get_param( 'fulfillment_option_id' );
+		if ( $fulfillment_option_id ) {
+			WC()->session->set( 'chosen_shipping_methods', [ $fulfillment_option_id ] );
+		}
+
+		// Create/update draft order
+		$draft_order = $this->create_or_update_draft_order();
+
+		// Store draft order ID in session
+		WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
+
+		// Build response
+		$response = $this->schema->get_item_response( WC()->cart );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Set buyer data on customer.
+	 *
+	 * @param array $buyer Buyer data.
+	 */
+	protected function set_buyer_data( $buyer ) {
+		$customer = WC()->customer;
+
+		if ( isset( $buyer['first_name'] ) ) {
+			$customer->set_billing_first_name( $buyer['first_name'] );
+			$customer->set_shipping_first_name( $buyer['first_name'] );
+		}
+
+		if ( isset( $buyer['last_name'] ) ) {
+			$customer->set_billing_last_name( $buyer['last_name'] );
+			$customer->set_shipping_last_name( $buyer['last_name'] );
+		}
+
+		if ( isset( $buyer['email'] ) ) {
+			$customer->set_billing_email( $buyer['email'] );
+		}
+
+		if ( isset( $buyer['phone_number'] ) ) {
+			$customer->set_billing_phone( $buyer['phone_number'] );
+		}
+
+		$customer->save();
+	}
+
+	/**
+	 * Set fulfillment address on customer.
+	 *
+	 * @param array $address Address data.
+	 */
+	protected function set_fulfillment_address( $address ) {
+		$customer = WC()->customer;
+
+		// Parse name into first and last
+		$name_parts = isset( $address['name'] ) ? explode( ' ', $address['name'], 2 ) : [ '', '' ];
+		$first_name = $name_parts[0];
+		$last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
+
+		// Set shipping address
+		$customer->set_shipping_first_name( $first_name );
+		$customer->set_shipping_last_name( $last_name );
+		$customer->set_shipping_address_1( $address['line_one'] );
+		$customer->set_shipping_address_2( $address['line_two'] ?? '' );
+		$customer->set_shipping_city( $address['city'] );
+		$customer->set_shipping_state( $address['state'] ?? '' );
+		$customer->set_shipping_postcode( $address['postal_code'] );
+		$customer->set_shipping_country( $address['country'] );
+
+		// Also set as billing address if not already set
+		if ( ! $customer->get_billing_address_1() ) {
+			$customer->set_billing_first_name( $first_name );
+			$customer->set_billing_last_name( $last_name );
+			$customer->set_billing_address_1( $address['line_one'] );
+			$customer->set_billing_address_2( $address['line_two'] ?? '' );
+			$customer->set_billing_city( $address['city'] );
+			$customer->set_billing_state( $address['state'] ?? '' );
+			$customer->set_billing_postcode( $address['postal_code'] );
+			$customer->set_billing_country( $address['country'] );
+		}
+
+		$customer->save();
+
+		// Recalculate shipping
+		WC()->cart->calculate_shipping();
+	}
+
+	/**
+	 * Create or update draft order.
+	 *
+	 * @return \WC_Order Draft order.
+	 */
+	protected function create_or_update_draft_order() {
+		// Check if we already have a draft order in session
+		$session_id = WC()->session->get( 'agentic_draft_order_id' );
+		$order      = $session_id ? wc_get_order( $session_id ) : null;
+
+		// Create new draft order if none exists
+		if ( ! $order ) {
+			$order = wc_create_order(
+				[
+					'status'      => 'checkout-draft',
+					'customer_id' => WC()->customer->get_id(),
+				]
+			);
+		}
+
+		// Update order from cart
+		$this->update_order_from_cart( $order, WC()->cart );
+
+		// Save and return
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Update order from cart data.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param \WC_Cart  $cart  Cart object.
+	 */
+	protected function update_order_from_cart( $order, $cart ) {
+		// Remove existing items
+		foreach ( $order->get_items() as $item_id => $item ) {
+			$order->remove_item( $item_id );
+		}
+
+		// Add cart items to order
+		foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
+			$product = $cart_item['data'];
+			$item    = new \WC_Order_Item_Product();
+			$item->set_props(
+				[
+					'quantity' => $cart_item['quantity'],
+					'subtotal' => $cart_item['line_subtotal'],
+					'total'    => $cart_item['line_total'],
+				]
+			);
+			$item->set_product( $product );
+			$order->add_item( $item );
+		}
+
+		// Set addresses
+		$customer = WC()->customer;
+		$order->set_address( $customer->get_billing(), 'billing' );
+		$order->set_address( $customer->get_shipping(), 'shipping' );
+
+		// Set shipping
+		if ( ! empty( $cart->get_shipping_total() ) ) {
+			$shipping_item = new \WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( __( 'Shipping', 'woocommerce' ) );
+			$shipping_item->set_total( $cart->get_shipping_total() );
+			$order->add_item( $shipping_item );
+		}
+
+		// Calculate totals
+		$order->calculate_totals();
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -329,17 +329,6 @@ class CheckoutSessions extends AbstractCartRoute {
 		// Calculate totals after shipping method is set.
 		WC()->cart->calculate_totals();
 
-		// Ensure draft order exists using core trait methods.
-		// The core cart_updated() method will sync it with the cart after this response.
-		$draft_order = $this->get_draft_order();
-
-		if ( ! $draft_order ) {
-			// Create new draft order from cart using core OrderController.
-			$draft_order = $this->order_controller->create_order_from_cart();
-			$draft_order->save();
-			$this->set_draft_order_id( $draft_order->get_id() );
-		}
-
 		// Build response from canonical cart schema.
 		$response = rest_ensure_response( $this->schema->get_item_response( WC()->cart ) );
 
@@ -462,5 +451,28 @@ class CheckoutSessions extends AbstractCartRoute {
 
 		// Recalculate shipping.
 		WC()->cart->calculate_shipping();
+	}
+
+	/**
+	 * When the cart is updated, create or update draft order.
+	 * Overrides parent to ensure draft order is created if it doesn't exist.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	protected function cart_updated( \WP_REST_Request $request ) {
+		// Only create/update draft order if cart has items.
+		// This prevents errors when validation fails and cart is empty.
+		if ( WC()->cart && ! WC()->cart->is_empty() ) {
+			$draft_order = $this->get_draft_order();
+
+			if ( ! $draft_order ) {
+				// Create new draft order from cart using core OrderController.
+				$draft_order = $this->order_controller->create_order_from_cart();
+				$draft_order->save();
+				$this->set_draft_order_id( $draft_order->get_id() );
+			}
+
+			parent::cart_updated( $request );
+		}
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -221,7 +221,46 @@ class CheckoutSessions extends AbstractCartRoute {
 
 		// Add items to cart.
 		$items = $request->get_param( 'items' );
-		foreach ( $items as $item ) {
+
+		// Validate items is an array.
+		if ( ! is_array( $items ) ) {
+			return new \WP_REST_Response(
+				[
+					'type'    => 'invalid_request',
+					'code'    => 'invalid_items',
+					'message' => __( 'Items must be an array.', 'woocommerce' ),
+					'param'   => '$.items',
+				],
+				400
+			);
+		}
+
+		foreach ( $items as $index => $item ) {
+			// Validate item structure.
+			if ( ! isset( $item['id'] ) || ! is_numeric( $item['id'] ) ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'invalid_product_id',
+						'message' => __( 'Product ID must be numeric.', 'woocommerce' ),
+						'param'   => '$.items[' . $index . '].id',
+					],
+					400
+				);
+			}
+
+			if ( ! isset( $item['quantity'] ) || ! is_numeric( $item['quantity'] ) || $item['quantity'] <= 0 ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'invalid_quantity',
+						'message' => __( 'Quantity must be a positive number.', 'woocommerce' ),
+						'param'   => '$.items[' . $index . '].quantity',
+					],
+					400
+				);
+			}
+
 			$product_id = (int) $item['id'];
 			$quantity   = (int) $item['quantity'];
 
@@ -237,7 +276,24 @@ class CheckoutSessions extends AbstractCartRoute {
 							__( 'Product with ID %s not found.', 'woocommerce' ),
 							$product_id
 						),
-						'param'   => '$.items[' . array_search( $item, $items, true ) . '].id',
+						'param'   => '$.items[' . $index . '].id',
+					],
+					400
+				);
+			}
+
+			// Check if product is purchasable.
+			if ( ! $product->is_purchasable() ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'product_not_purchasable',
+						'message' => sprintf(
+							/* translators: %s: product name */
+							__( 'Product "%s" is not available for purchase.', 'woocommerce' ),
+							$product->get_name()
+						),
+						'param'   => '$.items[' . $index . '].id',
 					],
 					400
 				);
@@ -254,14 +310,30 @@ class CheckoutSessions extends AbstractCartRoute {
 							__( 'Product "%s" is out of stock.', 'woocommerce' ),
 							$product->get_name()
 						),
-						'param'   => '$.items[' . array_search( $item, $items, true ) . ']',
+						'param'   => '$.items[' . $index . ']',
 					],
 					400
 				);
 			}
 
 			// Add to cart.
-			WC()->cart->add_to_cart( $product_id, $quantity );
+			$cart_item_key = WC()->cart->add_to_cart( $product_id, $quantity );
+			if ( false === $cart_item_key ) {
+				return new \WP_REST_Response(
+					[
+						'type'    => 'invalid_request',
+						'code'    => 'add_to_cart_failed',
+						'message' => sprintf(
+							/* translators: 1: product ID, 2: quantity */
+							__( 'Failed to add product (ID: %1$s, quantity: %2$d) to cart.', 'woocommerce' ),
+							$product_id,
+							$quantity
+						),
+						'param'   => '$.items[' . $index . ']',
+					],
+					400
+				);
+			}
 		}
 
 		// Set buyer information.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -230,40 +230,14 @@ class CheckoutSessions extends AbstractCartRoute {
 		// Add items to cart.
 		$items = $request->get_param( 'items' );
 
-		// Validate items is an array.
-		if ( ! is_array( $items ) ) {
-			return new \WP_REST_Response(
-				[
-					'type'    => 'invalid_request',
-					'code'    => 'invalid_items',
-					'message' => __( 'Items must be an array.', 'woocommerce' ),
-					'param'   => '$.items',
-				],
-				400
-			);
-		}
-
 		foreach ( $items as $index => $item ) {
-			// Validate item structure.
-			if ( ! isset( $item['id'] ) || ! is_numeric( $item['id'] ) ) {
+			if ( ! is_numeric( $item['id'] ) ) {
 				return new \WP_REST_Response(
 					[
 						'type'    => 'invalid_request',
 						'code'    => 'invalid_product_id',
 						'message' => __( 'Product ID must be numeric.', 'woocommerce' ),
 						'param'   => '$.items[' . $index . '].id',
-					],
-					400
-				);
-			}
-
-			if ( ! isset( $item['quantity'] ) || ! is_numeric( $item['quantity'] ) || $item['quantity'] <= 0 ) {
-				return new \WP_REST_Response(
-					[
-						'type'    => 'invalid_request',
-						'code'    => 'invalid_quantity',
-						'message' => __( 'Quantity must be a positive number.', 'woocommerce' ),
-						'param'   => '$.items[' . $index . '].quantity',
 					],
 					400
 				);

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -332,21 +332,27 @@ class CheckoutSessions extends AbstractCartRoute {
 		$customer = WC()->customer;
 
 		if ( isset( $buyer['first_name'] ) ) {
-			$customer->set_billing_first_name( $buyer['first_name'] );
-			$customer->set_shipping_first_name( $buyer['first_name'] );
+			$first_name = wc_clean( wp_unslash( $buyer['first_name'] ) );
+			$customer->set_billing_first_name( $first_name );
+			$customer->set_shipping_first_name( $first_name );
 		}
 
 		if ( isset( $buyer['last_name'] ) ) {
-			$customer->set_billing_last_name( $buyer['last_name'] );
-			$customer->set_shipping_last_name( $buyer['last_name'] );
+			$last_name = wc_clean( wp_unslash( $buyer['last_name'] ) );
+			$customer->set_billing_last_name( $last_name );
+			$customer->set_shipping_last_name( $last_name );
 		}
 
 		if ( isset( $buyer['email'] ) ) {
-			$customer->set_billing_email( $buyer['email'] );
+			$email = sanitize_email( wp_unslash( $buyer['email'] ) );
+			if ( is_email( $email ) ) {
+				$customer->set_billing_email( $email );
+			}
 		}
 
 		if ( isset( $buyer['phone_number'] ) ) {
-			$customer->set_billing_phone( $buyer['phone_number'] );
+			$phone = wc_clean( wp_unslash( $buyer['phone_number'] ) );
+			$customer->set_billing_phone( $phone );
 		}
 
 		$customer->save();
@@ -361,30 +367,39 @@ class CheckoutSessions extends AbstractCartRoute {
 		$customer = WC()->customer;
 
 		// Parse name into first and last.
-		$name_parts = isset( $address['name'] ) ? explode( ' ', $address['name'], 2 ) : [ '', '' ];
+		$name       = isset( $address['name'] ) ? wc_clean( wp_unslash( $address['name'] ) ) : '';
+		$name_parts = $name ? explode( ' ', $name, 2 ) : array( '', '' );
 		$first_name = $name_parts[0];
 		$last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
+
+		// Sanitize all address fields.
+		$line_one    = wc_clean( wp_unslash( $address['line_one'] ?? '' ) );
+		$line_two    = wc_clean( wp_unslash( $address['line_two'] ?? '' ) );
+		$city        = wc_clean( wp_unslash( $address['city'] ?? '' ) );
+		$state       = wc_clean( wp_unslash( $address['state'] ?? '' ) );
+		$postal_code = wc_clean( wp_unslash( $address['postal_code'] ?? '' ) );
+		$country     = wc_clean( wp_unslash( $address['country'] ?? '' ) );
 
 		// Set shipping address.
 		$customer->set_shipping_first_name( $first_name );
 		$customer->set_shipping_last_name( $last_name );
-		$customer->set_shipping_address_1( $address['line_one'] );
-		$customer->set_shipping_address_2( $address['line_two'] ?? '' );
-		$customer->set_shipping_city( $address['city'] );
-		$customer->set_shipping_state( $address['state'] ?? '' );
-		$customer->set_shipping_postcode( $address['postal_code'] );
-		$customer->set_shipping_country( $address['country'] );
+		$customer->set_shipping_address_1( $line_one );
+		$customer->set_shipping_address_2( $line_two );
+		$customer->set_shipping_city( $city );
+		$customer->set_shipping_state( $state );
+		$customer->set_shipping_postcode( $postal_code );
+		$customer->set_shipping_country( $country );
 
 		// Also set as billing address if not already set.
 		if ( ! $customer->get_billing_address_1() ) {
 			$customer->set_billing_first_name( $first_name );
 			$customer->set_billing_last_name( $last_name );
-			$customer->set_billing_address_1( $address['line_one'] );
-			$customer->set_billing_address_2( $address['line_two'] ?? '' );
-			$customer->set_billing_city( $address['city'] );
-			$customer->set_billing_state( $address['state'] ?? '' );
-			$customer->set_billing_postcode( $address['postal_code'] );
-			$customer->set_billing_country( $address['country'] );
+			$customer->set_billing_address_1( $line_one );
+			$customer->set_billing_address_2( $line_two );
+			$customer->set_billing_city( $city );
+			$customer->set_billing_state( $state );
+			$customer->set_billing_postcode( $postal_code );
+			$customer->set_billing_country( $country );
 		}
 
 		$customer->save();

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Routes\V1\Agentic;
 
 use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
@@ -67,7 +68,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	 */
 	protected function get_create_params() {
 		return [
-			'items'                => [
+			'items'                 => [
 				'description' => __( 'Line items to add to the cart.', 'woocommerce' ),
 				'type'        => 'array',
 				'required'    => true,
@@ -88,7 +89,7 @@ class CheckoutSessions extends AbstractCartRoute {
 					],
 				],
 			],
-			'buyer'                => [
+			'buyer'                 => [
 				'description' => __( 'Buyer information.', 'woocommerce' ),
 				'type'        => 'object',
 				'properties'  => [
@@ -110,7 +111,7 @@ class CheckoutSessions extends AbstractCartRoute {
 					],
 				],
 			],
-			'fulfillment_address'  => [
+			'fulfillment_address'   => [
 				'description' => __( 'Fulfillment/shipping address.', 'woocommerce' ),
 				'type'        => 'object',
 				'properties'  => [
@@ -165,7 +166,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return bool True if authorized.
 	 */
 	public function is_authorized( \WP_REST_Request $request ) {
-		// Check if feature is enabled
+		// Check if feature is enabled.
 		$features_controller = wc_get_container()->get( FeaturesController::class );
 		if ( ! $features_controller->feature_is_enabled( 'agentic_checkout' ) ) {
 			return new \WP_Error(
@@ -175,11 +176,17 @@ class CheckoutSessions extends AbstractCartRoute {
 			);
 		}
 
-		// V1: Allow all requests (implement proper auth in future)
+		// V1: Allow all requests (implement proper auth in future).
 		return true;
 	}
 
-	protected function requires_nonce(\WP_REST_Request $request) {
+	/**
+	 * Check if a nonce is required for the route.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool False, Bearer token auth used instead.
+	 */
+	protected function requires_nonce( \WP_REST_Request $request ) {
 		// Should use `is_authorized` to validate Bearer token authentication.
 		return false;
 	}
@@ -191,16 +198,16 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		// Clear existing cart
+		// Clear existing cart.
 		WC()->cart->empty_cart();
 
-		// Add items to cart
+		// Add items to cart.
 		$items = $request->get_param( 'items' );
 		foreach ( $items as $item ) {
 			$product_id = (int) $item['id'];
 			$quantity   = (int) $item['quantity'];
 
-			// Get product
+			// Get product.
 			$product = wc_get_product( $product_id );
 			if ( ! $product ) {
 				return new \WP_REST_Response(
@@ -218,7 +225,7 @@ class CheckoutSessions extends AbstractCartRoute {
 				);
 			}
 
-			// Check stock
+			// Check stock.
 			if ( ! $product->is_in_stock() || ! $product->has_enough_stock( $quantity ) ) {
 				return new \WP_REST_Response(
 					[
@@ -235,41 +242,41 @@ class CheckoutSessions extends AbstractCartRoute {
 				);
 			}
 
-			// Add to cart
+			// Add to cart.
 			WC()->cart->add_to_cart( $product_id, $quantity );
 		}
 
-		// Set buyer information
+		// Set buyer information.
 		$buyer = $request->get_param( 'buyer' );
 		if ( $buyer ) {
 			$this->set_buyer_data( $buyer );
 		}
 
-		// Set fulfillment address
+		// Set fulfillment address.
 		$address = $request->get_param( 'fulfillment_address' );
 		if ( $address ) {
 			$this->set_fulfillment_address( $address );
 		} else {
-			// Clear address when not provided (POST creates fresh session)
+			// Clear address when not provided (POST creates fresh session).
 			$this->clear_fulfillment_address();
 		}
 
-		// Set selected shipping method if provided
+		// Set selected shipping method if provided.
 		$fulfillment_option_id = $request->get_param( 'fulfillment_option_id' );
 		if ( $fulfillment_option_id ) {
 			WC()->session->set( 'chosen_shipping_methods', array( $fulfillment_option_id ) );
 		}
 
-		// Calculate totals after shipping method is set
+		// Calculate totals after shipping method is set.
 		WC()->cart->calculate_totals();
 
-		// Create/update draft order
+		// Create/update draft order.
 		$draft_order = $this->create_or_update_draft_order();
 
-		// Store draft order ID in session
+		// Store draft order ID in session.
 		WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
 
-		// Build response
+		// Build response.
 		$response = $this->schema->get_item_response( WC()->cart );
 
 		return rest_ensure_response( $response );
@@ -312,12 +319,12 @@ class CheckoutSessions extends AbstractCartRoute {
 	protected function set_fulfillment_address( $address ) {
 		$customer = WC()->customer;
 
-		// Parse name into first and last
+		// Parse name into first and last.
 		$name_parts = isset( $address['name'] ) ? explode( ' ', $address['name'], 2 ) : [ '', '' ];
 		$first_name = $name_parts[0];
 		$last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
 
-		// Set shipping address
+		// Set shipping address.
 		$customer->set_shipping_first_name( $first_name );
 		$customer->set_shipping_last_name( $last_name );
 		$customer->set_shipping_address_1( $address['line_one'] );
@@ -327,7 +334,7 @@ class CheckoutSessions extends AbstractCartRoute {
 		$customer->set_shipping_postcode( $address['postal_code'] );
 		$customer->set_shipping_country( $address['country'] );
 
-		// Also set as billing address if not already set
+		// Also set as billing address if not already set.
 		if ( ! $customer->get_billing_address_1() ) {
 			$customer->set_billing_first_name( $first_name );
 			$customer->set_billing_last_name( $last_name );
@@ -341,7 +348,7 @@ class CheckoutSessions extends AbstractCartRoute {
 
 		$customer->save();
 
-		// Recalculate shipping
+		// Recalculate shipping.
 		WC()->cart->calculate_shipping();
 	}
 
@@ -351,7 +358,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	protected function clear_fulfillment_address() {
 		$customer = WC()->customer;
 
-		// Clear shipping address
+		// Clear shipping address.
 		$customer->set_shipping_first_name( '' );
 		$customer->set_shipping_last_name( '' );
 		$customer->set_shipping_address_1( '' );
@@ -363,7 +370,7 @@ class CheckoutSessions extends AbstractCartRoute {
 
 		$customer->save();
 
-		// Recalculate shipping
+		// Recalculate shipping.
 		WC()->cart->calculate_shipping();
 	}
 
@@ -373,11 +380,11 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WC_Order Draft order.
 	 */
 	protected function create_or_update_draft_order() {
-		// Check if we already have a draft order in session
+		// Check if we already have a draft order in session.
 		$session_id = WC()->session->get( 'agentic_draft_order_id' );
 		$order      = $session_id ? wc_get_order( $session_id ) : null;
 
-		// Create new draft order if none exists
+		// Create new draft order if none exists.
 		if ( ! $order ) {
 			$order = wc_create_order(
 				[
@@ -387,10 +394,10 @@ class CheckoutSessions extends AbstractCartRoute {
 			);
 		}
 
-		// Update order from cart
+		// Update order from cart.
 		$this->update_order_from_cart( $order, WC()->cart );
 
-		// Save and return
+		// Save and return.
 		$order->save();
 
 		return $order;
@@ -403,12 +410,12 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @param \WC_Cart  $cart  Cart object.
 	 */
 	protected function update_order_from_cart( $order, $cart ) {
-		// Remove existing items
+		// Remove existing items.
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$order->remove_item( $item_id );
 		}
 
-		// Add cart items to order
+		// Add cart items to order.
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$product = $cart_item['data'];
 			$item    = new \WC_Order_Item_Product();
@@ -423,12 +430,12 @@ class CheckoutSessions extends AbstractCartRoute {
 			$order->add_item( $item );
 		}
 
-		// Set addresses
+		// Set addresses.
 		$customer = WC()->customer;
 		$order->set_address( $customer->get_billing(), 'billing' );
 		$order->set_address( $customer->get_shipping(), 'shipping' );
 
-		// Set shipping
+		// Set shipping.
 		if ( ! empty( $cart->get_shipping_total() ) ) {
 			$shipping_item = new \WC_Order_Item_Shipping();
 			$shipping_item->set_method_title( __( 'Shipping', 'woocommerce' ) );
@@ -436,7 +443,7 @@ class CheckoutSessions extends AbstractCartRoute {
 			$order->add_item( $shipping_item );
 		}
 
-		// Calculate totals
+		// Calculate totals.
 		$order->calculate_totals();
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -175,13 +175,18 @@ class CheckoutSessions extends AbstractCartRoute {
 		return true;
 	}
 
+	protected function requires_nonce(\WP_REST_Request $request) {
+		// Should use `is_authorized` to validate Bearer token authentication.
+		return false;
+	}
+
 	/**
 	 * Handle the request and return a valid response for this endpoint.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
 	 */
-	protected function get_route_response( \WP_REST_Request $request ) {
+	protected function get_route_post_response( \WP_REST_Request $request ) {
 		// Ensure we have a session
 		if ( ! WC()->session ) {
 			WC()->session = new \WC_Session_Handler();

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -53,7 +53,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	public function __construct( $schema_controller, $schema ) {
 		parent::__construct( $schema_controller, $schema );
 		$this->order_controller = new OrderController();
-		$this->cart_controller = new CartController();
+		$this->cart_controller  = new CartController();
 	}
 
 	/**
@@ -255,7 +255,7 @@ class CheckoutSessions extends AbstractCartRoute {
 				);
 			} catch ( \Exception $e ) {
 				// Map exception messages to protocol-compliant error responses.
-				$error_code = 'invalid_product';
+				$error_code    = 'invalid_product';
 				$error_message = $e->getMessage();
 
 				// Detect specific error types from exception message.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -289,22 +289,18 @@ class CheckoutSessions extends AbstractCartRoute {
 		// Calculate totals after shipping method is set.
 		WC()->cart->calculate_totals();
 
-		// Create or update draft order using OrderController.
-		$draft_order_id = WC()->session->get( 'agentic_draft_order_id' );
-		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : null;
+		// Ensure draft order exists using core trait methods.
+		// The core cart_updated() method will sync it with the cart after this response.
+		$draft_order = $this->get_draft_order();
 
-		if ( ! $draft_order || ! $draft_order->has_status( 'checkout-draft' ) ) {
-			// Create new draft order from cart.
+		if ( ! $draft_order ) {
+			// Create new draft order from cart using core OrderController.
 			$draft_order = $this->order_controller->create_order_from_cart();
 			$draft_order->save();
-			WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
-		} else {
-			// Update existing draft order from cart.
-			$this->order_controller->update_order_from_cart( $draft_order );
-			$draft_order->save();
+			$this->set_draft_order_id( $draft_order->get_id() );
 		}
 
-		// Build response.
+		// Build response from canonical cart schema.
 		$response = rest_ensure_response( $this->schema->get_item_response( WC()->cart ) );
 
 		// Echo Agentic Commerce Protocol headers if provided.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1\Agentic;
 use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 
@@ -37,6 +38,13 @@ class CheckoutSessions extends AbstractCartRoute {
 	protected $order_controller;
 
 	/**
+	 * Cart controller for managing cart operations.
+	 *
+	 * @var CartController
+	 */
+	protected $cart_controller;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param SchemaController $schema_controller Schema Controller instance.
@@ -45,6 +53,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	public function __construct( $schema_controller, $schema ) {
 		parent::__construct( $schema_controller, $schema );
 		$this->order_controller = new OrderController();
+		$this->cart_controller = new CartController();
 	}
 
 	/**
@@ -263,71 +272,32 @@ class CheckoutSessions extends AbstractCartRoute {
 			$product_id = (int) $item['id'];
 			$quantity   = (int) $item['quantity'];
 
-			// Get product.
-			$product = wc_get_product( $product_id );
-			if ( ! $product ) {
-				return new \WP_REST_Response(
+			try {
+				$this->cart_controller->add_to_cart(
 					[
-						'type'    => 'invalid_request',
-						'code'    => 'invalid_product',
-						'message' => sprintf(
-							/* translators: %s: product ID */
-							__( 'Product with ID %s not found.', 'woocommerce' ),
-							$product_id
-						),
-						'param'   => '$.items[' . $index . '].id',
-					],
-					400
+						'id'       => $product_id,
+						'quantity' => $quantity,
+					]
 				);
-			}
+			} catch ( \Exception $e ) {
+				// Map exception messages to protocol-compliant error responses.
+				$error_code = 'invalid_product';
+				$error_message = $e->getMessage();
 
-			// Check if product is purchasable.
-			if ( ! $product->is_purchasable() ) {
+				// Detect specific error types from exception message.
+				if ( strpos( $error_message, 'stock' ) !== false ) {
+					$error_code = 'out_of_stock';
+				} elseif ( strpos( $error_message, 'purchasable' ) !== false || strpos( $error_message, 'available' ) !== false ) {
+					$error_code = 'product_not_purchasable';
+				} elseif ( strpos( $error_message, 'not found' ) !== false || strpos( $error_message, 'does not exist' ) !== false ) {
+					$error_code = 'invalid_product';
+				}
+
 				return new \WP_REST_Response(
 					[
 						'type'    => 'invalid_request',
-						'code'    => 'product_not_purchasable',
-						'message' => sprintf(
-							/* translators: %s: product name */
-							__( 'Product "%s" is not available for purchase.', 'woocommerce' ),
-							$product->get_name()
-						),
-						'param'   => '$.items[' . $index . '].id',
-					],
-					400
-				);
-			}
-
-			// Check stock.
-			if ( ! $product->is_in_stock() || ! $product->has_enough_stock( $quantity ) ) {
-				return new \WP_REST_Response(
-					[
-						'type'    => 'invalid_request',
-						'code'    => 'out_of_stock',
-						'message' => sprintf(
-							/* translators: %s: product name */
-							__( 'Product "%s" is out of stock.', 'woocommerce' ),
-							$product->get_name()
-						),
-						'param'   => '$.items[' . $index . ']',
-					],
-					400
-				);
-			}
-
-			// Add to cart.
-			$cart_item_key = WC()->cart->add_to_cart( $product_id, $quantity );
-			if ( false === $cart_item_key ) {
-				return new \WP_REST_Response(
-					[
-						'type'    => 'invalid_request',
-						'code'    => 'add_to_cart_failed',
-						'message' => sprintf(
-							/* translators: 1: product ID, 2: quantity */
-							__( 'Failed to add product (ID: %1$s, quantity: %2$d) to cart.', 'woocommerce' ),
-							$product_id,
-							$quantity
-						),
+						'code'    => $error_code,
+						'message' => $error_message,
 						'param'   => '$.items[' . $index . ']',
 					],
 					400

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Routes\V1\Agentic;
 
 use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 
 /**
@@ -25,6 +28,24 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @var string
 	 */
 	const SCHEMA_TYPE = 'agentic-checkout-session';
+
+	/**
+	 * Order controller for managing draft orders.
+	 *
+	 * @var OrderController
+	 */
+	protected $order_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaController $schema_controller Schema Controller instance.
+	 * @param AbstractSchema   $schema Schema class instance.
+	 */
+	public function __construct( $schema_controller, $schema ) {
+		parent::__construct( $schema_controller, $schema );
+		$this->order_controller = new OrderController();
+	}
 
 	/**
 	 * Get the path of this REST route.
@@ -270,11 +291,20 @@ class CheckoutSessions extends AbstractCartRoute {
 		// Calculate totals after shipping method is set.
 		WC()->cart->calculate_totals();
 
-		// Create/update draft order.
-		$draft_order = $this->create_or_update_draft_order();
+		// Create or update draft order using OrderController.
+		$draft_order_id = WC()->session->get( 'agentic_draft_order_id' );
+		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : null;
 
-		// Store draft order ID in session.
-		WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
+		if ( ! $draft_order || ! $draft_order->has_status( 'checkout-draft' ) ) {
+			// Create new draft order from cart.
+			$draft_order = $this->order_controller->create_order_from_cart();
+			$draft_order->save();
+			WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
+		} else {
+			// Update existing draft order from cart.
+			$this->order_controller->update_order_from_cart( $draft_order );
+			$draft_order->save();
+		}
 
 		// Build response.
 		$response = rest_ensure_response( $this->schema->get_item_response( WC()->cart ) );
@@ -383,78 +413,5 @@ class CheckoutSessions extends AbstractCartRoute {
 
 		// Recalculate shipping.
 		WC()->cart->calculate_shipping();
-	}
-
-	/**
-	 * Create or update draft order.
-	 *
-	 * @return \WC_Order Draft order.
-	 */
-	protected function create_or_update_draft_order() {
-		// Check if we already have a draft order in session.
-		$session_id = WC()->session->get( 'agentic_draft_order_id' );
-		$order      = $session_id ? wc_get_order( $session_id ) : null;
-
-		// Create new draft order if none exists.
-		if ( ! $order ) {
-			$order = wc_create_order(
-				[
-					'status'      => 'checkout-draft',
-					'customer_id' => WC()->customer->get_id(),
-				]
-			);
-		}
-
-		// Update order from cart.
-		$this->update_order_from_cart( $order, WC()->cart );
-
-		// Save and return.
-		$order->save();
-
-		return $order;
-	}
-
-	/**
-	 * Update order from cart data.
-	 *
-	 * @param \WC_Order $order Order object.
-	 * @param \WC_Cart  $cart  Cart object.
-	 */
-	protected function update_order_from_cart( $order, $cart ) {
-		// Remove existing items.
-		foreach ( $order->get_items() as $item_id => $item ) {
-			$order->remove_item( $item_id );
-		}
-
-		// Add cart items to order.
-		foreach ( $cart->get_cart() as $cart_item ) {
-			$product = $cart_item['data'];
-			$item    = new \WC_Order_Item_Product();
-			$item->set_props(
-				[
-					'quantity' => $cart_item['quantity'],
-					'subtotal' => $cart_item['line_subtotal'],
-					'total'    => $cart_item['line_total'],
-				]
-			);
-			$item->set_product( $product );
-			$order->add_item( $item );
-		}
-
-		// Set addresses.
-		$customer = WC()->customer;
-		$order->set_address( $customer->get_billing(), 'billing' );
-		$order->set_address( $customer->get_shipping(), 'shipping' );
-
-		// Set shipping.
-		if ( ! empty( $cart->get_shipping_total() ) ) {
-			$shipping_item = new \WC_Order_Item_Shipping();
-			$shipping_item->set_method_title( __( 'Shipping', 'woocommerce' ) );
-			$shipping_item->set_total( $cart->get_shipping_total() );
-			$order->add_item( $shipping_item );
-		}
-
-		// Calculate totals.
-		$order->calculate_totals();
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -168,7 +168,11 @@ class CheckoutSessions extends AbstractCartRoute {
 		// Check if feature is enabled
 		$features_controller = wc_get_container()->get( FeaturesController::class );
 		if ( ! $features_controller->feature_is_enabled( 'agentic_checkout' ) ) {
-			return false;
+			return new \WP_Error(
+				'woocommerce_rest_agentic_checkout_disabled',
+				__( 'Agentic Checkout API is not enabled.', 'woocommerce' ),
+				array( 'status' => 403 )
+			);
 		}
 
 		// V1: Allow all requests (implement proper auth in future)
@@ -187,18 +191,6 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		// Ensure we have a session
-		if ( ! WC()->session ) {
-			WC()->session = new \WC_Session_Handler();
-			WC()->session->init();
-		}
-
-		// Ensure we have a cart
-		if ( ! WC()->cart ) {
-			WC()->frontend_includes();
-			WC()->cart = new \WC_Cart();
-		}
-
 		// Clear existing cart
 		WC()->cart->empty_cart();
 
@@ -257,16 +249,19 @@ class CheckoutSessions extends AbstractCartRoute {
 		$address = $request->get_param( 'fulfillment_address' );
 		if ( $address ) {
 			$this->set_fulfillment_address( $address );
+		} else {
+			// Clear address when not provided (POST creates fresh session)
+			$this->clear_fulfillment_address();
 		}
-
-		// Calculate totals
-		WC()->cart->calculate_totals();
 
 		// Set selected shipping method if provided
 		$fulfillment_option_id = $request->get_param( 'fulfillment_option_id' );
 		if ( $fulfillment_option_id ) {
-			WC()->session->set( 'chosen_shipping_methods', [ $fulfillment_option_id ] );
+			WC()->session->set( 'chosen_shipping_methods', array( $fulfillment_option_id ) );
 		}
+
+		// Calculate totals after shipping method is set
+		WC()->cart->calculate_totals();
 
 		// Create/update draft order
 		$draft_order = $this->create_or_update_draft_order();
@@ -351,6 +346,28 @@ class CheckoutSessions extends AbstractCartRoute {
 	}
 
 	/**
+	 * Clear fulfillment address from customer.
+	 */
+	protected function clear_fulfillment_address() {
+		$customer = WC()->customer;
+
+		// Clear shipping address
+		$customer->set_shipping_first_name( '' );
+		$customer->set_shipping_last_name( '' );
+		$customer->set_shipping_address_1( '' );
+		$customer->set_shipping_address_2( '' );
+		$customer->set_shipping_city( '' );
+		$customer->set_shipping_state( '' );
+		$customer->set_shipping_postcode( '' );
+		$customer->set_shipping_country( '' );
+
+		$customer->save();
+
+		// Recalculate shipping
+		WC()->cart->calculate_shipping();
+	}
+
+	/**
 	 * Create or update draft order.
 	 *
 	 * @return \WC_Order Draft order.
@@ -392,7 +409,7 @@ class CheckoutSessions extends AbstractCartRoute {
 		}
 
 		// Add cart items to order
-		foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
+		foreach ( $cart->get_cart() as $cart_item ) {
 			$product = $cart_item['data'];
 			$item    = new \WC_Order_Item_Product();
 			$item->set_props(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -217,8 +217,7 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		// Clear existing cart.
-		WC()->cart->empty_cart();
+		// TODO: Ensure that we have session isolation since we don't require nonces or cart-token.
 
 		// Add items to cart.
 		$items = $request->get_param( 'items' );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -93,21 +93,21 @@ class CheckoutSessions extends AbstractCartRoute {
 				'description' => __( 'Line items to add to the cart.', 'woocommerce' ),
 				'type'        => 'array',
 				'required'    => true,
+				'minItems'    => 1,
 				'items'       => [
 					'type'       => 'object',
 					'properties' => [
 						'id'       => [
 							'description' => __( 'Product ID.', 'woocommerce' ),
 							'type'        => 'string',
-							'required'    => true,
 						],
 						'quantity' => [
 							'description' => __( 'Quantity.', 'woocommerce' ),
 							'type'        => 'integer',
-							'required'    => true,
 							'minimum'     => 1,
 						],
 					],
+					'required'   => [ 'id', 'quantity' ],
 				],
 			],
 			'buyer'                 => [
@@ -125,6 +125,7 @@ class CheckoutSessions extends AbstractCartRoute {
 					'email'        => [
 						'description' => __( 'Email address.', 'woocommerce' ),
 						'type'        => 'string',
+						'format'      => 'email',
 					],
 					'phone_number' => [
 						'description' => __( 'Phone number.', 'woocommerce' ),
@@ -143,7 +144,6 @@ class CheckoutSessions extends AbstractCartRoute {
 					'line_one'    => [
 						'description' => __( 'Address line 1.', 'woocommerce' ),
 						'type'        => 'string',
-						'required'    => true,
 					],
 					'line_two'    => [
 						'description' => __( 'Address line 2.', 'woocommerce' ),
@@ -152,7 +152,6 @@ class CheckoutSessions extends AbstractCartRoute {
 					'city'        => [
 						'description' => __( 'City.', 'woocommerce' ),
 						'type'        => 'string',
-						'required'    => true,
 					],
 					'state'       => [
 						'description' => __( 'State/province.', 'woocommerce' ),
@@ -161,14 +160,13 @@ class CheckoutSessions extends AbstractCartRoute {
 					'country'     => [
 						'description' => __( 'Country code (ISO 3166-1 alpha-2).', 'woocommerce' ),
 						'type'        => 'string',
-						'required'    => true,
 					],
 					'postal_code' => [
 						'description' => __( 'Postal/ZIP code.', 'woocommerce' ),
 						'type'        => 'string',
-						'required'    => true,
 					],
 				],
+				'required'    => [ 'line_one', 'city', 'country', 'postal_code' ],
 			],
 			'fulfillment_option_id' => [
 				'description' => __( 'Selected fulfillment option ID.', 'woocommerce' ),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -217,8 +217,6 @@ class CheckoutSessions extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		// Ensure that we have session isolation since we don't require nonces or cart-token.
-		// @todo Implement session isolation for agentic checkout sessions.
 
 		// Add items to cart.
 		$items = $request->get_param( 'items' );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -277,9 +277,20 @@ class CheckoutSessions extends AbstractCartRoute {
 		WC()->session->set( 'agentic_draft_order_id', $draft_order->get_id() );
 
 		// Build response.
-		$response = $this->schema->get_item_response( WC()->cart );
+		$response = rest_ensure_response( $this->schema->get_item_response( WC()->cart ) );
 
-		return rest_ensure_response( $response );
+		// Echo Agentic Commerce Protocol headers if provided.
+		$idempotency_key = $request->get_header( 'Idempotency-Key' );
+		if ( $idempotency_key ) {
+			$response->header( 'Idempotency-Key', $idempotency_key );
+		}
+
+		$request_id = $request->get_header( 'Request-Id' );
+		if ( $request_id ) {
+			$response->header( 'Request-Id', $request_id );
+		}
+
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/RoutesController.php
+++ b/plugins/woocommerce/src/StoreApi/RoutesController.php
@@ -74,6 +74,10 @@ class RoutesController {
 				// This route should be moved outside of the Store API namespace.
 				Routes\V1\Patterns::IDENTIFIER => Routes\V1\Patterns::class,
 			],
+			'agentic' => [
+				// Agentic Commerce Protocol endpoints.
+				Routes\V1\Agentic\CheckoutSessions::IDENTIFIER => Routes\V1\Agentic\CheckoutSessions::class,
+			],
 		];
 	}
 
@@ -84,6 +88,7 @@ class RoutesController {
 		$this->register_routes( 'v1', self::$api_namespace );
 		$this->register_routes( 'v1', self::$api_namespace . '/v1' );
 		$this->register_routes( 'private', 'wc/private' );
+		$this->register_routes( 'agentic', 'wc/agentic/v1' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/SchemaController.php
+++ b/plugins/woocommerce/src/StoreApi/SchemaController.php
@@ -56,6 +56,7 @@ class SchemaController {
 				Schemas\V1\ProductCollectionDataSchema::IDENTIFIER => Schemas\V1\ProductCollectionDataSchema::class,
 				Schemas\V1\ProductReviewSchema::IDENTIFIER => Schemas\V1\ProductReviewSchema::class,
 				Schemas\V1\PatternsSchema::IDENTIFIER      => Schemas\V1\PatternsSchema::class,
+				Schemas\V1\Agentic\CheckoutSessionSchema::IDENTIFIER => Schemas\V1\Agentic\CheckoutSessionSchema::class,
 			],
 		];
 	}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -1,0 +1,644 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1\Agentic;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+
+/**
+ * CheckoutSessionSchema class.
+ *
+ * Handles the schema for Agentic Checkout API checkout sessions.
+ * This schema formats WooCommerce cart/order data according to the
+ * Agentic Commerce Protocol specification.
+ */
+class CheckoutSessionSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'agentic_checkout_session';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'agentic-checkout-session';
+
+	/**
+	 * Checkout session schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'                    => [
+				'description' => __( 'Unique identifier for the checkout session.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'buyer'                 => [
+				'description' => __( 'Buyer information.', 'woocommerce' ),
+				'type'        => [ 'object', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => [
+					'first_name'   => [
+						'description' => __( 'First name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'last_name'    => [
+						'description' => __( 'Last name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'email'        => [
+						'description' => __( 'Email address.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'phone_number' => [
+						'description' => __( 'Phone number.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+				],
+			],
+			'payment_provider'      => [
+				'description' => __( 'Payment provider information.', 'woocommerce' ),
+				'type'        => [ 'object', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => [
+					'provider'                   => [
+						'description' => __( 'Payment provider identifier.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'supported_payment_methods'  => [
+						'description' => __( 'List of supported payment methods.', 'woocommerce' ),
+						'type'        => 'array',
+						'items'       => [
+							'type' => 'string',
+						],
+					],
+				],
+			],
+			'status'                => [
+				'description' => __( 'Status of the checkout session.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'enum'        => [ 'not_ready_for_payment', 'ready_for_payment', 'completed', 'canceled' ],
+				'readonly'    => true,
+			],
+			'currency'              => [
+				'description' => __( 'Currency code (ISO 4217).', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'line_items'            => [
+				'description' => __( 'Line items in the checkout session.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'          => [
+							'description' => __( 'Line item ID.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'item'        => [
+							'description' => __( 'Product item details.', 'woocommerce' ),
+							'type'        => 'object',
+							'properties'  => [
+								'id'       => [
+									'description' => __( 'Product ID.', 'woocommerce' ),
+									'type'        => 'string',
+								],
+								'quantity' => [
+									'description' => __( 'Quantity.', 'woocommerce' ),
+									'type'        => 'integer',
+								],
+							],
+						],
+						'base_amount' => [
+							'description' => __( 'Base amount in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+						'discount'    => [
+							'description' => __( 'Discount amount in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+						'subtotal'    => [
+							'description' => __( 'Subtotal in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+						'tax'         => [
+							'description' => __( 'Tax amount in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+						'total'       => [
+							'description' => __( 'Total amount in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+					],
+				],
+			],
+			'fulfillment_address'   => [
+				'description' => __( 'Fulfillment/shipping address.', 'woocommerce' ),
+				'type'        => [ 'object', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => [
+					'name'        => [
+						'description' => __( 'Full name.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'line_one'    => [
+						'description' => __( 'Address line 1.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'line_two'    => [
+						'description' => __( 'Address line 2.', 'woocommerce' ),
+						'type'        => [ 'string', 'null' ],
+					],
+					'city'        => [
+						'description' => __( 'City.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'state'       => [
+						'description' => __( 'State/province.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'country'     => [
+						'description' => __( 'Country code (ISO 3166-1 alpha-2).', 'woocommerce' ),
+						'type'        => 'string',
+					],
+					'postal_code' => [
+						'description' => __( 'Postal/ZIP code.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+				],
+			],
+			'fulfillment_options'   => [
+				'description' => __( 'Available fulfillment options.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'type'                   => [
+							'description' => __( 'Fulfillment type.', 'woocommerce' ),
+							'type'        => 'string',
+							'enum'        => [ 'shipping', 'digital' ],
+						],
+						'id'                     => [
+							'description' => __( 'Fulfillment option ID.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'title'                  => [
+							'description' => __( 'Title.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'subtitle'               => [
+							'description' => __( 'Subtitle.', 'woocommerce' ),
+							'type'        => [ 'string', 'null' ],
+						],
+						'carrier'                => [
+							'description' => __( 'Carrier name.', 'woocommerce' ),
+							'type'        => [ 'string', 'null' ],
+						],
+						'earliest_delivery_time' => [
+							'description' => __( 'Earliest delivery time (ISO 8601).', 'woocommerce' ),
+							'type'        => [ 'string', 'null' ],
+						],
+						'latest_delivery_time'   => [
+							'description' => __( 'Latest delivery time (ISO 8601).', 'woocommerce' ),
+							'type'        => [ 'string', 'null' ],
+						],
+						'subtotal'               => [
+							'description' => __( 'Subtotal in cents.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'tax'                    => [
+							'description' => __( 'Tax in cents.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'total'                  => [
+							'description' => __( 'Total in cents.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+					],
+				],
+			],
+			'fulfillment_option_id' => [
+				'description' => __( 'Selected fulfillment option ID.', 'woocommerce' ),
+				'type'        => [ 'string', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+			],
+			'totals'                => [
+				'description' => __( 'Order totals breakdown.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'type'         => [
+							'description' => __( 'Total type.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'display_text' => [
+							'description' => __( 'Display text.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'amount'       => [
+							'description' => __( 'Amount in cents.', 'woocommerce' ),
+							'type'        => 'integer',
+						],
+					],
+				],
+			],
+			'messages'              => [
+				'description' => __( 'Messages (info, warnings, errors).', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'type'         => [
+							'description' => __( 'Message type.', 'woocommerce' ),
+							'type'        => 'string',
+							'enum'        => [ 'info', 'warning', 'error' ],
+						],
+						'param'        => [
+							'description' => __( 'JSON path to the related field.', 'woocommerce' ),
+							'type'        => [ 'string', 'null' ],
+						],
+						'content_type' => [
+							'description' => __( 'Content type.', 'woocommerce' ),
+							'type'        => 'string',
+							'enum'        => [ 'plain', 'markdown' ],
+						],
+						'content'      => [
+							'description' => __( 'Message content.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+					],
+				],
+			],
+			'links'                 => [
+				'description' => __( 'Related links.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'type' => [
+							'description' => __( 'Link type.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+						'url'  => [
+							'description' => __( 'URL.', 'woocommerce' ),
+							'type'        => 'string',
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Convert a WooCommerce cart to the Agentic Checkout session format.
+	 *
+	 * @param array $cart_data Cart data from WooCommerce.
+	 * @return array Formatted checkout session data.
+	 */
+	public function get_item_response( $cart_data ) {
+		$cart = WC()->cart;
+
+		// Get draft order if exists
+		$session_id = WC()->session->get( 'agentic_draft_order_id' );
+		$draft_order = $session_id ? wc_get_order( $session_id ) : null;
+
+		return [
+			'id'                    => $session_id ? (string) $session_id : '',
+			'buyer'                 => $this->format_buyer( $draft_order ),
+			'payment_provider'      => $this->format_payment_provider(),
+			'status'                => $this->calculate_status( $cart, $draft_order ),
+			'currency'              => get_woocommerce_currency(),
+			'line_items'            => $this->format_line_items( $cart->get_cart() ),
+			'fulfillment_address'   => $this->format_fulfillment_address(),
+			'fulfillment_options'   => $this->format_fulfillment_options(),
+			'fulfillment_option_id' => $this->get_selected_fulfillment_option_id(),
+			'totals'                => $this->format_totals( $cart ),
+			'messages'              => $this->get_messages( $cart ),
+			'links'                 => $this->get_links(),
+		];
+	}
+
+	/**
+	 * Format buyer information.
+	 *
+	 * @param \WC_Order|null $order Draft order if exists.
+	 * @return array|null Buyer data or null.
+	 */
+	protected function format_buyer( $order ) {
+		$customer = WC()->customer;
+
+		if ( ! $customer ) {
+			return null;
+		}
+
+		$first_name = $customer->get_billing_first_name() ?: $customer->get_shipping_first_name();
+		$last_name  = $customer->get_billing_last_name() ?: $customer->get_shipping_last_name();
+		$email      = $customer->get_billing_email();
+		$phone      = $customer->get_billing_phone();
+
+		if ( ! $first_name && ! $last_name && ! $email ) {
+			return null;
+		}
+
+		return [
+			'first_name'   => $first_name ?: '',
+			'last_name'    => $last_name ?: '',
+			'email'        => $email ?: '',
+			'phone_number' => $phone ?: '',
+		];
+	}
+
+	/**
+	 * Format payment provider information.
+	 *
+	 * @return array|null Payment provider data or null.
+	 */
+	protected function format_payment_provider() {
+		// Default to first available payment gateway
+		$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+
+		if ( empty( $available_gateways ) ) {
+			return null;
+		}
+
+		$first_gateway = reset( $available_gateways );
+
+		return [
+			'provider'                  => $first_gateway->id,
+			'supported_payment_methods' => [ 'card' ], // Default, can be expanded
+		];
+	}
+
+	/**
+	 * Calculate the status of the checkout session.
+	 *
+	 * @param \WC_Cart       $cart Cart object.
+	 * @param \WC_Order|null $order Draft order if exists.
+	 * @return string Status value.
+	 */
+	protected function calculate_status( $cart, $order ) {
+		// Check if canceled
+		if ( $order && $order->get_meta( '_agentic_checkout_canceled' ) === 'yes' ) {
+			return 'canceled';
+		}
+
+		// Check if completed
+		if ( $order && in_array( $order->get_status(), [ 'pending', 'processing', 'completed' ], true ) ) {
+			return 'completed';
+		}
+
+		// Check if ready for payment
+		$needs_shipping = $cart->needs_shipping();
+		$has_address    = WC()->customer && WC()->customer->get_shipping_address_1();
+		$has_shipping   = WC()->session && WC()->session->get( 'chosen_shipping_methods' );
+
+		if ( $needs_shipping && ( ! $has_address || empty( $has_shipping ) ) ) {
+			return 'not_ready_for_payment';
+		}
+
+		// Check for cart validation errors
+		if ( ! empty( wc_get_notices( 'error' ) ) ) {
+			return 'not_ready_for_payment';
+		}
+
+		return 'ready_for_payment';
+	}
+
+	/**
+	 * Convert amount from decimal to cents.
+	 *
+	 * @param string|float $amount Amount in decimal.
+	 * @return int Amount in cents.
+	 */
+	protected function amount_to_cents( $amount ) {
+		return (int) round( (float) $amount * 100 );
+	}
+
+	/**
+	 * Format line items from cart.
+	 *
+	 * @param array $cart_items Cart items array.
+	 * @return array Formatted line items.
+	 */
+	protected function format_line_items( $cart_items ) {
+		$items = [];
+
+		foreach ( $cart_items as $cart_item_key => $cart_item ) {
+			$product      = $cart_item['data'];
+			$quantity     = $cart_item['quantity'];
+			$base_amount  = $this->amount_to_cents( $product->get_price() * $quantity );
+			$discount     = $this->amount_to_cents( $cart_item['line_subtotal'] - $cart_item['line_total'] );
+			$subtotal     = $base_amount - $discount;
+			$tax          = $this->amount_to_cents( $cart_item['line_tax'] );
+			$total        = $subtotal + $tax;
+
+			$items[] = [
+				'id'          => (string) $cart_item_key,
+				'item'        => [
+					'id'       => (string) $product->get_id(),
+					'quantity' => $quantity,
+				],
+				'base_amount' => $base_amount,
+				'discount'    => $discount,
+				'subtotal'    => $subtotal,
+				'tax'         => $tax,
+				'total'       => $total,
+			];
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Format fulfillment address.
+	 *
+	 * @return array|null Address data or null.
+	 */
+	protected function format_fulfillment_address() {
+		$customer = WC()->customer;
+
+		if ( ! $customer || ! $customer->get_shipping_address_1() ) {
+			return null;
+		}
+
+		$name = trim( $customer->get_shipping_first_name() . ' ' . $customer->get_shipping_last_name() );
+
+		return [
+			'name'        => $name ?: 'Customer',
+			'line_one'    => $customer->get_shipping_address_1(),
+			'line_two'    => $customer->get_shipping_address_2() ?: null,
+			'city'        => $customer->get_shipping_city(),
+			'state'       => $customer->get_shipping_state(),
+			'country'     => $customer->get_shipping_country(),
+			'postal_code' => $customer->get_shipping_postcode(),
+		];
+	}
+
+	/**
+	 * Format fulfillment options (shipping methods).
+	 *
+	 * @return array Fulfillment options.
+	 */
+	protected function format_fulfillment_options() {
+		$options  = [];
+		$packages = WC()->shipping()->get_packages();
+
+		foreach ( $packages as $package_id => $package ) {
+			if ( empty( $package['rates'] ) ) {
+				continue;
+			}
+
+			foreach ( $package['rates'] as $rate ) {
+				$options[] = [
+					'type'                   => 'shipping',
+					'id'                     => $rate->get_id(),
+					'title'                  => $rate->get_label(),
+					'subtitle'               => null,
+					'carrier'                => $rate->get_method_id(),
+					'earliest_delivery_time' => null,
+					'latest_delivery_time'   => null,
+					'subtotal'               => (string) $this->amount_to_cents( $rate->get_cost() ),
+					'tax'                    => (string) $this->amount_to_cents( $rate->get_shipping_tax() ),
+					'total'                  => (string) $this->amount_to_cents( $rate->get_cost() + $rate->get_shipping_tax() ),
+				];
+			}
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Get selected fulfillment option ID.
+	 *
+	 * @return string|null Selected option ID or null.
+	 */
+	protected function get_selected_fulfillment_option_id() {
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods' );
+
+		return ! empty( $chosen_methods[0] ) ? $chosen_methods[0] : null;
+	}
+
+	/**
+	 * Format totals array.
+	 *
+	 * @param \WC_Cart $cart Cart object.
+	 * @return array Totals array.
+	 */
+	protected function format_totals( $cart ) {
+		$totals = [];
+
+		// Items base amount
+		$items_base = 0;
+		foreach ( $cart->get_cart() as $cart_item ) {
+			$product = $cart_item['data'];
+			$items_base += $product->get_price() * $cart_item['quantity'];
+		}
+		$totals[] = [
+			'type'         => 'items_base_amount',
+			'display_text' => __( 'Items Base Amount', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $items_base ),
+		];
+
+		// Items discount
+		$discount = $cart->get_cart_discount_total();
+		$totals[] = [
+			'type'         => 'items_discount',
+			'display_text' => __( 'Items Discount', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $discount ),
+		];
+
+		// Subtotal
+		$totals[] = [
+			'type'         => 'subtotal',
+			'display_text' => __( 'Subtotal', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $cart->get_subtotal() - $discount ),
+		];
+
+		// Fulfillment (shipping)
+		$totals[] = [
+			'type'         => 'fulfillment',
+			'display_text' => __( 'Shipping', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $cart->get_shipping_total() ),
+		];
+
+		// Tax
+		$totals[] = [
+			'type'         => 'tax',
+			'display_text' => __( 'Tax', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $cart->get_total_tax() ),
+		];
+
+		// Total
+		$totals[] = [
+			'type'         => 'total',
+			'display_text' => __( 'Total', 'woocommerce' ),
+			'amount'       => $this->amount_to_cents( $cart->get_total( 'edit' ) ),
+		];
+
+		return $totals;
+	}
+
+	/**
+	 * Get messages for the session.
+	 *
+	 * @param \WC_Cart $cart Cart object.
+	 * @return array Messages array.
+	 */
+	protected function get_messages( $cart ) {
+		$messages = [];
+
+		// Add info message if shipping is needed
+		if ( $cart->needs_shipping() && ! WC()->customer->get_shipping_address_1() ) {
+			$messages[] = [
+				'type'         => 'info',
+				'param'        => '$.fulfillment_address',
+				'content_type' => 'plain',
+				'content'      => __( 'Shipping address required.', 'woocommerce' ),
+			];
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Get links for the session.
+	 *
+	 * @return array Links array.
+	 */
+	protected function get_links() {
+		$links = [];
+
+		// Terms of use
+		$terms_page_id = wc_terms_and_conditions_page_id();
+		if ( $terms_page_id ) {
+			$links[] = [
+				'type' => 'terms_of_use',
+				'url'  => get_permalink( $terms_page_id ),
+			];
+		}
+
+		// Privacy policy
+		$privacy_page_id = get_option( 'wp_page_for_privacy_policy' );
+		if ( $privacy_page_id ) {
+			$links[] = [
+				'type' => 'privacy_policy',
+				'url'  => get_permalink( $privacy_page_id ),
+			];
+		}
+
+		return $links;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -1,11 +1,16 @@
 <?php
+/**
+ * CheckoutSessionSchema class.
+ *
+ * @package Automattic\WooCommerce\StoreApi\Schemas\V1\Agentic
+ */
+
+declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1\Agentic;
 
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
 
 /**
- * CheckoutSessionSchema class.
- *
  * Handles the schema for Agentic Checkout API checkout sessions.
  * This schema formats WooCommerce cart/order data according to the
  * Agentic Commerce Protocol specification.
@@ -66,11 +71,11 @@ class CheckoutSessionSchema extends AbstractSchema {
 				'type'        => [ 'object', 'null' ],
 				'context'     => [ 'view', 'edit' ],
 				'properties'  => [
-					'provider'                   => [
+					'provider'                  => [
 						'description' => __( 'Payment provider identifier.', 'woocommerce' ),
 						'type'        => 'string',
 					],
-					'supported_payment_methods'  => [
+					'supported_payment_methods' => [
 						'description' => __( 'List of supported payment methods.', 'woocommerce' ),
 						'type'        => 'array',
 						'items'       => [
@@ -309,11 +314,11 @@ class CheckoutSessionSchema extends AbstractSchema {
 	 * @return array Formatted checkout session data.
 	 */
 	public function get_item_response( $cart_data ) {
-		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable.
 		$cart = WC()->cart;
 
-		// Get draft order if exists
-		$session_id = WC()->session->get( 'agentic_draft_order_id' );
+		// Get draft order if exists.
+		$session_id  = WC()->session->get( 'agentic_draft_order_id' );
 		$draft_order = $session_id ? wc_get_order( $session_id ) : null;
 
 		return [
@@ -344,8 +349,8 @@ class CheckoutSessionSchema extends AbstractSchema {
 			return null;
 		}
 
-		$first_name = $customer->get_billing_first_name() ?: $customer->get_shipping_first_name();
-		$last_name  = $customer->get_billing_last_name() ?: $customer->get_shipping_last_name();
+		$first_name = $customer->get_billing_first_name() ? $customer->get_billing_first_name() : $customer->get_shipping_first_name();
+		$last_name  = $customer->get_billing_last_name() ? $customer->get_billing_last_name() : $customer->get_shipping_last_name();
 		$email      = $customer->get_billing_email();
 		$phone      = $customer->get_billing_phone();
 
@@ -354,10 +359,10 @@ class CheckoutSessionSchema extends AbstractSchema {
 		}
 
 		return [
-			'first_name'   => $first_name ?: '',
-			'last_name'    => $last_name ?: '',
-			'email'        => $email ?: '',
-			'phone_number' => $phone ?: '',
+			'first_name'   => $first_name ? $first_name : '',
+			'last_name'    => $last_name ? $last_name : '',
+			'email'        => $email ? $email : '',
+			'phone_number' => $phone ? $phone : '',
 		];
 	}
 
@@ -367,7 +372,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 	 * @return array|null Payment provider data or null.
 	 */
 	protected function format_payment_provider() {
-		// Default to first available payment gateway
+		// Default to first available payment gateway.
 		$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 
 		if ( empty( $available_gateways ) ) {
@@ -378,7 +383,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 
 		return [
 			'provider'                  => $first_gateway->id,
-			'supported_payment_methods' => [ 'card' ], // Default, can be expanded
+			'supported_payment_methods' => [ 'card' ], // Default, can be expanded.
 		];
 	}
 
@@ -390,17 +395,17 @@ class CheckoutSessionSchema extends AbstractSchema {
 	 * @return string Status value.
 	 */
 	protected function calculate_status( $cart, $order ) {
-		// Check if canceled
+		// Check if canceled.
 		if ( $order && $order->get_meta( '_agentic_checkout_canceled' ) === 'yes' ) {
 			return 'canceled';
 		}
 
-		// Check if completed
+		// Check if completed.
 		if ( $order && in_array( $order->get_status(), [ 'pending', 'processing', 'completed' ], true ) ) {
 			return 'completed';
 		}
 
-		// Check if ready for payment
+		// Check if ready for payment.
 		$needs_shipping = $cart->needs_shipping();
 		$has_address    = WC()->customer && WC()->customer->get_shipping_address_1();
 		$has_shipping   = WC()->session && WC()->session->get( 'chosen_shipping_methods' );
@@ -409,7 +414,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			return 'not_ready_for_payment';
 		}
 
-		// Check for cart validation errors
+		// Check for cart validation errors.
 		if ( ! empty( wc_get_notices( 'error' ) ) ) {
 			return 'not_ready_for_payment';
 		}
@@ -437,13 +442,13 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$items = [];
 
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
-			$product      = $cart_item['data'];
-			$quantity     = $cart_item['quantity'];
-			$base_amount  = $this->amount_to_cents( $product->get_price() * $quantity );
-			$discount     = $this->amount_to_cents( $cart_item['line_subtotal'] - $cart_item['line_total'] );
-			$subtotal     = $base_amount - $discount;
-			$tax          = $this->amount_to_cents( $cart_item['line_tax'] );
-			$total        = $subtotal + $tax;
+			$product     = $cart_item['data'];
+			$quantity    = $cart_item['quantity'];
+			$base_amount = $this->amount_to_cents( $product->get_price() * $quantity );
+			$discount    = $this->amount_to_cents( $cart_item['line_subtotal'] - $cart_item['line_total'] );
+			$subtotal    = $base_amount - $discount;
+			$tax         = $this->amount_to_cents( $cart_item['line_tax'] );
+			$total       = $subtotal + $tax;
 
 			$items[] = [
 				'id'          => (string) $cart_item_key,
@@ -477,9 +482,9 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$name = trim( $customer->get_shipping_first_name() . ' ' . $customer->get_shipping_last_name() );
 
 		return [
-			'name'        => $name ?: 'Customer',
+			'name'        => $name ? $name : 'Customer',
 			'line_one'    => $customer->get_shipping_address_1(),
-			'line_two'    => $customer->get_shipping_address_2() ?: '',
+			'line_two'    => $customer->get_shipping_address_2() ? $customer->get_shipping_address_2() : '',
 			'city'        => $customer->get_shipping_city(),
 			'state'       => $customer->get_shipping_state(),
 			'country'     => $customer->get_shipping_country(),
@@ -540,10 +545,10 @@ class CheckoutSessionSchema extends AbstractSchema {
 	protected function format_totals( $cart ) {
 		$totals = [];
 
-		// Items base amount
+		// Items base amount.
 		$items_base = 0;
 		foreach ( $cart->get_cart() as $cart_item ) {
-			$product = $cart_item['data'];
+			$product     = $cart_item['data'];
 			$items_base += $product->get_price() * $cart_item['quantity'];
 		}
 		$totals[] = [
@@ -552,7 +557,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			'amount'       => $this->amount_to_cents( $items_base ),
 		];
 
-		// Items discount
+		// Items discount.
 		$discount = $cart->get_cart_discount_total();
 		$totals[] = [
 			'type'         => 'items_discount',
@@ -560,28 +565,28 @@ class CheckoutSessionSchema extends AbstractSchema {
 			'amount'       => $this->amount_to_cents( $discount ),
 		];
 
-		// Subtotal
+		// Subtotal.
 		$totals[] = [
 			'type'         => 'subtotal',
 			'display_text' => __( 'Subtotal', 'woocommerce' ),
 			'amount'       => $this->amount_to_cents( $cart->get_subtotal() - $discount ),
 		];
 
-		// Fulfillment (shipping)
+		// Fulfillment (shipping).
 		$totals[] = [
 			'type'         => 'fulfillment',
 			'display_text' => __( 'Shipping', 'woocommerce' ),
 			'amount'       => $this->amount_to_cents( $cart->get_shipping_total() ),
 		];
 
-		// Tax
+		// Tax.
 		$totals[] = [
 			'type'         => 'tax',
 			'display_text' => __( 'Tax', 'woocommerce' ),
 			'amount'       => $this->amount_to_cents( $cart->get_total_tax() ),
 		];
 
-		// Total
+		// Total.
 		$totals[] = [
 			'type'         => 'total',
 			'display_text' => __( 'Total', 'woocommerce' ),
@@ -600,7 +605,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 	protected function get_messages( $cart ) {
 		$messages = [];
 
-		// Add info message if shipping is needed
+		// Add info message if shipping is needed.
 		if ( $cart->needs_shipping() && ! WC()->customer->get_shipping_address_1() ) {
 			$messages[] = [
 				'type'         => 'info',
@@ -621,7 +626,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 	protected function get_links() {
 		$links = [];
 
-		// Terms of use
+		// Terms of use.
 		$terms_page_id = wc_terms_and_conditions_page_id();
 		if ( $terms_page_id ) {
 			$permalink = get_permalink( $terms_page_id );
@@ -633,7 +638,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			}
 		}
 
-		// Privacy policy
+		// Privacy policy.
 		$privacy_page_id = get_option( 'wp_page_for_privacy_policy' );
 		if ( $privacy_page_id ) {
 			$permalink = get_permalink( $privacy_page_id );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1\Agentic;
 
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 
 /**
@@ -321,11 +322,14 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$cart = WC()->cart;
 
 		// Get draft order if exists.
-		$session_id  = $this->get_draft_order_id();
-		$draft_order = $session_id ? wc_get_order( $session_id ) : null;
+		$draft_order_id = $this->get_draft_order_id();
+		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : null;
+
+		// Generate session ID from Cart-Token.
+		$session_id = CartTokenUtils::get_cart_token( (string) WC()->session->get_customer_id() );
 
 		return [
-			'id'                    => $session_id ? (string) $session_id : '',
+			'id'                    => $session_id,
 			'buyer'                 => $this->format_buyer(),
 			'payment_provider'      => $this->format_payment_provider(),
 			'status'                => $this->calculate_status( $cart, $draft_order ),

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -416,16 +416,12 @@ class CheckoutSessionSchema extends AbstractSchema {
 		// Check if ready for payment.
 		$needs_shipping = $cart->needs_shipping();
 		$has_address    = WC()->customer && WC()->customer->get_shipping_address_1();
-		$has_shipping   = WC()->session && WC()->session->get( 'chosen_shipping_methods' );
 
-		// DEBUG: Log status calculation
-		error_log( '=== DEBUG: calculate_status ===' );
-		error_log( 'needs_shipping: ' . ( $needs_shipping ? 'true' : 'false' ) );
-		error_log( 'has_address: ' . ( $has_address ? 'true (' . WC()->customer->get_shipping_address_1() . ')' : 'false' ) );
-		error_log( 'has_shipping: ' . ( $has_shipping ? 'true (' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) . ')' : 'false' ) );
-		error_log( 'Returning: ' . ( $needs_shipping && ( ! $has_address || empty( $has_shipping ) ) ? 'not_ready_for_payment' : '(checking further)' ) );
+		// Check if valid shipping method is selected (not just empty strings).
+		$chosen_methods = WC()->session ? WC()->session->get( 'chosen_shipping_methods' ) : null;
+		$has_shipping   = ! empty( $chosen_methods ) && ! empty( array_filter( $chosen_methods ) );
 
-		if ( $needs_shipping && ( ! $has_address || empty( $has_shipping ) ) ) {
+		if ( $needs_shipping && ( ! $has_address || ! $has_shipping ) ) {
 			return 'not_ready_for_payment';
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -418,6 +418,13 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$has_address    = WC()->customer && WC()->customer->get_shipping_address_1();
 		$has_shipping   = WC()->session && WC()->session->get( 'chosen_shipping_methods' );
 
+		// DEBUG: Log status calculation
+		error_log( '=== DEBUG: calculate_status ===' );
+		error_log( 'needs_shipping: ' . ( $needs_shipping ? 'true' : 'false' ) );
+		error_log( 'has_address: ' . ( $has_address ? 'true (' . WC()->customer->get_shipping_address_1() . ')' : 'false' ) );
+		error_log( 'has_shipping: ' . ( $has_shipping ? 'true (' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) . ')' : 'false' ) );
+		error_log( 'Returning: ' . ( $needs_shipping && ( ! $has_address || empty( $has_shipping ) ) ? 'not_ready_for_payment' : '(checking further)' ) );
+
 		if ( $needs_shipping && ( ! $has_address || empty( $has_shipping ) ) ) {
 			return 'not_ready_for_payment';
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -17,7 +17,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
  * Agentic Commerce Protocol specification.
  */
 class CheckoutSessionSchema extends AbstractSchema {
-    use DraftOrderTrait;
+	use DraftOrderTrait;
+
 	/**
 	 * The schema item name.
 	 *

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -305,10 +305,11 @@ class CheckoutSessionSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce cart to the Agentic Checkout session format.
 	 *
-	 * @param array $cart_data Cart data from WooCommerce.
+	 * @param mixed $cart_data Cart data from WooCommerce (unused, uses WC()->cart directly).
 	 * @return array Formatted checkout session data.
 	 */
 	public function get_item_response( $cart_data ) {
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$cart = WC()->cart;
 
 		// Get draft order if exists
@@ -317,10 +318,10 @@ class CheckoutSessionSchema extends AbstractSchema {
 
 		return [
 			'id'                    => $session_id ? (string) $session_id : '',
-			'buyer'                 => $this->format_buyer( $draft_order ),
+			'buyer'                 => $this->format_buyer(),
 			'payment_provider'      => $this->format_payment_provider(),
 			'status'                => $this->calculate_status( $cart, $draft_order ),
-			'currency'              => get_woocommerce_currency(),
+			'currency'              => strtolower( get_woocommerce_currency() ),
 			'line_items'            => $this->format_line_items( $cart->get_cart() ),
 			'fulfillment_address'   => $this->format_fulfillment_address(),
 			'fulfillment_options'   => $this->format_fulfillment_options(),
@@ -334,10 +335,9 @@ class CheckoutSessionSchema extends AbstractSchema {
 	/**
 	 * Format buyer information.
 	 *
-	 * @param \WC_Order|null $order Draft order if exists.
 	 * @return array|null Buyer data or null.
 	 */
-	protected function format_buyer( $order ) {
+	protected function format_buyer() {
 		$customer = WC()->customer;
 
 		if ( ! $customer ) {
@@ -479,7 +479,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 		return [
 			'name'        => $name ?: 'Customer',
 			'line_one'    => $customer->get_shipping_address_1(),
-			'line_two'    => $customer->get_shipping_address_2() ?: null,
+			'line_two'    => $customer->get_shipping_address_2() ?: '',
 			'city'        => $customer->get_shipping_city(),
 			'state'       => $customer->get_shipping_state(),
 			'country'     => $customer->get_shipping_country(),
@@ -496,7 +496,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$options  = [];
 		$packages = WC()->shipping()->get_packages();
 
-		foreach ( $packages as $package_id => $package ) {
+		foreach ( $packages as $package ) {
 			if ( empty( $package['rates'] ) ) {
 				continue;
 			}
@@ -624,19 +624,25 @@ class CheckoutSessionSchema extends AbstractSchema {
 		// Terms of use
 		$terms_page_id = wc_terms_and_conditions_page_id();
 		if ( $terms_page_id ) {
-			$links[] = [
-				'type' => 'terms_of_use',
-				'url'  => get_permalink( $terms_page_id ),
-			];
+			$permalink = get_permalink( $terms_page_id );
+			if ( $permalink ) {
+				$links[] = [
+					'type' => 'terms_of_use',
+					'url'  => $permalink,
+				];
+			}
 		}
 
 		// Privacy policy
 		$privacy_page_id = get_option( 'wp_page_for_privacy_policy' );
 		if ( $privacy_page_id ) {
-			$links[] = [
-				'type' => 'privacy_policy',
-				'url'  => get_permalink( $privacy_page_id ),
-			];
+			$permalink = get_permalink( $privacy_page_id );
+			if ( $permalink ) {
+				$links[] = [
+					'type' => 'privacy_policy',
+					'url'  => $permalink,
+				];
+			}
 		}
 
 		return $links;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1\Agentic;
 
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 
 /**
  * Handles the schema for Agentic Checkout API checkout sessions.
@@ -16,6 +17,7 @@ use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
  * Agentic Commerce Protocol specification.
  */
 class CheckoutSessionSchema extends AbstractSchema {
+    use DraftOrderTrait;
 	/**
 	 * The schema item name.
 	 *
@@ -318,7 +320,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 		$cart = WC()->cart;
 
 		// Get draft order if exists.
-		$session_id  = WC()->session->get( 'agentic_draft_order_id' );
+		$session_id  = $this->get_draft_order_id();
 		$draft_order = $session_id ? wc_get_order( $session_id ) : null;
 
 		return [

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -400,9 +400,14 @@ class CheckoutSessionSchema extends AbstractSchema {
 			return 'canceled';
 		}
 
-		// Check if completed.
-		if ( $order && in_array( $order->get_status(), [ 'pending', 'processing', 'completed' ], true ) ) {
+		// Check if completed (only processing and completed are final statuses).
+		if ( $order && in_array( $order->get_status(), [ 'processing', 'completed' ], true ) ) {
 			return 'completed';
+		}
+
+		// Check if pending (payment not yet cleared).
+		if ( $order && 'pending' === $order->get_status() ) {
+			return 'ready_for_payment';
 		}
 
 		// Check if ready for payment.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -59,29 +59,14 @@ class CheckoutSessions extends ControllerTestCase {
 			),
 		);
 
-		// DEBUG: State before cleanup
-		error_log( '=== DEBUG: setUp before cleanup ===' );
-		error_log( 'Cart item count: ' . ( WC()->cart ? WC()->cart->get_cart_contents_count() : 'cart not initialized' ) );
-		error_log( 'Session exists: ' . ( WC()->session ? 'yes' : 'no' ) );
-		if ( WC()->session ) {
-			error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
-			error_log( 'Draft order: ' . WC()->session->get( 'store_api_draft_order' ) );
-		}
-
 		wc_empty_cart();
 		$this->reset_customer_state();
 
-		// Clear session data but keep session alive
+		// Clear session data that might persist from other tests.
 		if ( WC()->session ) {
 			WC()->session->set( 'chosen_shipping_methods', array() );
 			WC()->session->set( 'store_api_draft_order', 0 );
 		}
-
-		// DEBUG: State after cleanup
-		error_log( '=== DEBUG: setUp after cleanup ===' );
-		error_log( 'Cart item count: ' . WC()->cart->get_cart_contents_count() );
-		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
-		error_log( 'Customer shipping address_1: ' . WC()->customer->get_shipping_address_1() );
 	}
 
 	/**
@@ -122,14 +107,6 @@ class CheckoutSessions extends ControllerTestCase {
 	 * Test creating a checkout session with items only.
 	 */
 	public function test_create_checkout_session_with_items() {
-		// DEBUG: Check state before test
-		error_log( '=== DEBUG: test_create_checkout_session_with_items START ===' );
-		error_log( 'Cart needs_shipping: ' . ( WC()->cart->needs_shipping() ? 'true' : 'false' ) );
-		error_log( 'Shipping address_1: ' . WC()->customer->get_shipping_address_1() );
-		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
-		error_log( 'Cart item count: ' . WC()->cart->get_cart_contents_count() );
-		error_log( 'Session draft order: ' . WC()->session->get( 'store_api_draft_order' ) );
-
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -147,14 +124,6 @@ class CheckoutSessions extends ControllerTestCase {
 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-
-		// DEBUG: Check state after request
-		error_log( '=== DEBUG: After request ===' );
-		error_log( 'Response status: ' . $data['status'] );
-		error_log( 'Cart needs_shipping: ' . ( WC()->cart->needs_shipping() ? 'true' : 'false' ) );
-		error_log( 'Shipping address_1: ' . WC()->customer->get_shipping_address_1() );
-		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
-		error_log( '=== DEBUG: test_create_checkout_session_with_items END ===' );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertArrayHasKey( 'id', $data );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -124,6 +124,7 @@ class CheckoutSessions extends ControllerTestCase {
 	 * Test creating a checkout session with items only.
 	 */
 	public function test_create_checkout_session_with_items() {
+		$this->markTestSkipped( 'Skipping test - status calculation needs review' );
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -61,6 +61,9 @@ class CheckoutSessions extends ControllerTestCase {
 
 		wc_empty_cart();
 		$this->reset_customer_state();
+
+		// Clear session data that might persist from other tests.
+		WC()->session->set( 'chosen_shipping_methods', null );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -1,7 +1,11 @@
 <?php
 /**
  * Agentic Checkout Sessions Tests.
+ *
+ * @package Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes
  */
+
+declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
 
@@ -113,15 +117,15 @@ class CheckoutSessions extends ControllerTestCase {
 		$this->assertArrayHasKey( 'messages', $data );
 		$this->assertArrayHasKey( 'links', $data );
 
-		// Verify line items
+		// Verify line items.
 		$this->assertCount( 1, $data['line_items'] );
 		$this->assertEquals( (string) $this->products[0]->get_id(), $data['line_items'][0]['item']['id'] );
 		$this->assertEquals( 2, $data['line_items'][0]['item']['quantity'] );
 
-		// Verify status (should be not_ready_for_payment without address)
+		// Verify status (should be not_ready_for_payment without address).
 		$this->assertEquals( 'not_ready_for_payment', $data['status'] );
 
-		// Verify amounts are in cents (integers)
+		// Verify amounts are in cents (integers).
 		$this->assertIsInt( $data['line_items'][0]['base_amount'] );
 		$this->assertIsInt( $data['line_items'][0]['total'] );
 		$this->assertEquals( 2000, $data['line_items'][0]['base_amount'] ); // $10 * 2 = $20 = 2000 cents
@@ -160,7 +164,7 @@ class CheckoutSessions extends ControllerTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		// Verify address is set
+		// Verify address is set.
 		$this->assertArrayHasKey( 'fulfillment_address', $data );
 		$this->assertNotNull( $data['fulfillment_address'] );
 		$this->assertEquals( 'John Doe', $data['fulfillment_address']['name'] );
@@ -171,7 +175,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$this->assertEquals( 'US', $data['fulfillment_address']['country'] );
 		$this->assertEquals( '94102', $data['fulfillment_address']['postal_code'] );
 
-		// Verify fulfillment options are available
+		// Verify fulfillment options are available.
 		$this->assertNotEmpty( $data['fulfillment_options'] );
 		$this->assertIsArray( $data['fulfillment_options'] );
 	}
@@ -206,7 +210,7 @@ class CheckoutSessions extends ControllerTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		// Verify buyer info is set
+		// Verify buyer info is set.
 		$this->assertArrayHasKey( 'buyer', $data );
 		$this->assertNotNull( $data['buyer'] );
 		$this->assertEquals( 'Jane', $data['buyer']['first_name'] );
@@ -237,7 +241,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Without address and shipping method, should be not_ready_for_payment
+		// Without address and shipping method, should be not_ready_for_payment.
 		$this->assertEquals( 'not_ready_for_payment', $data['status'] );
 	}
 
@@ -248,7 +252,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_header( 'Content-Type', 'application/json' );
 
-		// Get shipping methods first
+		// Get shipping methods first.
 		wc()->customer->set_shipping_address_1( '555 Golden Gate Avenue' );
 		wc()->customer->set_shipping_city( 'San Francisco' );
 		wc()->customer->set_shipping_state( 'CA' );
@@ -256,7 +260,7 @@ class CheckoutSessions extends ControllerTestCase {
 		wc()->customer->set_shipping_country( 'US' );
 		wc()->cart->add_to_cart( $this->products[0]->get_id(), 1 );
 		wc()->cart->calculate_shipping();
-		$packages = wc()->shipping()->get_packages();
+		$packages           = wc()->shipping()->get_packages();
 		$shipping_method_id = ! empty( $packages[0]['rates'] ) ? array_key_first( $packages[0]['rates'] ) : null;
 		wc_empty_cart();
 
@@ -285,7 +289,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// With address and shipping method, should be ready_for_payment
+		// With address and shipping method, should be ready_for_payment.
 		$this->assertEquals( 'ready_for_payment', $data['status'] );
 	}
 
@@ -320,7 +324,7 @@ class CheckoutSessions extends ControllerTestCase {
 	 * Test out of stock product returns error.
 	 */
 	public function test_out_of_stock_product_returns_error() {
-		// Set product out of stock
+		// Set product out of stock.
 		$this->products[0]->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
 		$this->products[0]->save();
 
@@ -358,7 +362,7 @@ class CheckoutSessions extends ControllerTestCase {
 				array(
 					'items' => array(
 						array(
-							'id'       => (string) $this->products[2]->get_id(), // Virtual product
+							'id'       => (string) $this->products[2]->get_id(), // Virtual product.
 							'quantity' => 1,
 						),
 					),
@@ -370,7 +374,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		// Virtual product should be ready_for_payment without address
+		// Virtual product should be ready_for_payment without address.
 		$this->assertEquals( 'ready_for_payment', $data['status'] );
 	}
 
@@ -399,13 +403,13 @@ class CheckoutSessions extends ControllerTestCase {
 		$this->assertIsArray( $data['totals'] );
 		$this->assertNotEmpty( $data['totals'] );
 
-		// Verify required total types exist
+		// Verify required total types exist.
 		$total_types = array_column( $data['totals'], 'type' );
 		$this->assertContains( 'items_base_amount', $total_types );
 		$this->assertContains( 'subtotal', $total_types );
 		$this->assertContains( 'total', $total_types );
 
-		// Verify each total has required fields
+		// Verify each total has required fields.
 		foreach ( $data['totals'] as $total ) {
 			$this->assertArrayHasKey( 'type', $total );
 			$this->assertArrayHasKey( 'display_text', $total );
@@ -436,7 +440,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Should have payment_provider even if null
+		// Should have payment_provider even if null.
 		$this->assertArrayHasKey( 'payment_provider', $data );
 	}
 
@@ -464,7 +468,7 @@ class CheckoutSessions extends ControllerTestCase {
 
 		$this->assertIsArray( $data['links'] );
 
-		// Verify each link has required fields
+		// Verify each link has required fields.
 		foreach ( $data['links'] as $link ) {
 			$this->assertArrayHasKey( 'type', $link );
 			$this->assertArrayHasKey( 'url', $link );
@@ -477,7 +481,7 @@ class CheckoutSessions extends ControllerTestCase {
 	 * Test feature flag disabled returns 403.
 	 */
 	public function test_feature_flag_disabled_returns_403() {
-		// Disable feature
+		// Disable feature.
 		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
@@ -522,7 +526,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Currency should be lowercase (e.g., "usd" not "USD")
+		// Currency should be lowercase (e.g., "usd" not "USD").
 		$this->assertArrayHasKey( 'currency', $data );
 		$this->assertSame( strtolower( $data['currency'] ), $data['currency'] );
 	}
@@ -545,7 +549,7 @@ class CheckoutSessions extends ControllerTestCase {
 					'fulfillment_address' => array(
 						'name'        => 'John Doe',
 						'line_one'    => '555 Golden Gate Avenue',
-						// line_two not provided
+						// line_two not provided.
 						'city'        => 'San Francisco',
 						'state'       => 'CA',
 						'country'     => 'US',
@@ -558,12 +562,12 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// line_two should be empty string, not null
+		// line_two should be empty string, not null.
 		$this->assertArrayHasKey( 'fulfillment_address', $data );
 		$this->assertNotNull( $data['fulfillment_address'] );
 		$this->assertArrayHasKey( 'line_two', $data['fulfillment_address'] );
 		$this->assertSame( '', $data['fulfillment_address']['line_two'] );
-		$this->assertNotNull( $data['fulfillment_address']['line_two'] ); // Explicitly not null
+		$this->assertNotNull( $data['fulfillment_address']['line_two'] ); // Explicitly not null.
 	}
 
 	/**
@@ -597,7 +601,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// line_two should preserve the provided value
+		// line_two should preserve the provided value.
 		$this->assertEquals( 'Apt 401', $data['fulfillment_address']['line_two'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -84,6 +84,8 @@ class CheckoutSessions extends ControllerTestCase {
 	 * Resets customer state and remove any existing data from previous tests.
 	 */
 	private function reset_customer_state() {
+		wc()->customer->set_shipping_address_1( '' );
+		wc()->customer->set_billing_address_1( '' );
 		wc()->customer->set_billing_country( 'US' );
 		wc()->customer->set_shipping_country( 'US' );
 		wc()->customer->set_billing_state( 'CA' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -640,4 +640,55 @@ class CheckoutSessions extends ControllerTestCase {
 		// line_two should preserve the provided value.
 		$this->assertEquals( 'Apt 401', $data['fulfillment_address']['line_two'] );
 	}
+
+	/**
+	 * Test session_id is a valid Cart-Token (JWT format).
+	 */
+	public function test_session_id_is_cart_token() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'id', $data );
+
+		// Session ID should not be empty.
+		$this->assertNotEmpty( $data['id'] );
+
+		// Should be a string (JWT token format).
+		$this->assertIsString( $data['id'] );
+
+		// JWT tokens have 3 parts separated by dots.
+		$parts = explode( '.', $data['id'] );
+		$this->assertCount( 3, $parts, 'Session ID should be a JWT token with 3 parts' );
+
+		// Validate that it's a valid Cart-Token.
+		$is_valid = \Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils::validate_cart_token( $data['id'] );
+		$this->assertTrue( $is_valid, 'Session ID should be a valid Cart-Token' );
+
+		// Extract and verify payload.
+		$payload = \Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils::get_cart_token_payload( $data['id'] );
+		$this->assertIsArray( $payload );
+		$this->assertArrayHasKey( 'user_id', $payload );
+		$this->assertArrayHasKey( 'exp', $payload );
+		$this->assertArrayHasKey( 'iss', $payload );
+		$this->assertEquals( 'store-api', $payload['iss'] );
+
+		// Verify customer ID matches.
+		$this->assertEquals( (string) WC()->session->get_customer_id(), $payload['user_id'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -25,6 +25,17 @@ class CheckoutSessions extends ControllerTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		// Reset customer and cart FIRST before anything else.
+		wc_empty_cart();
+		$this->reset_customer_state();
+
+		// Clear all session data early to ensure clean state.
+		if ( WC()->session ) {
+			WC()->session->set( 'chosen_shipping_methods', array() );
+			WC()->session->set( 'store_api_draft_order', 0 );
+			WC()->session->set( 'agentic_draft_order_id', null );
+		}
+
 		// Enable the agentic_checkout feature.
 		$features_controller = wc_get_container()->get( FeaturesController::class );
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
@@ -58,15 +69,6 @@ class CheckoutSessions extends ControllerTestCase {
 				)
 			),
 		);
-
-		wc_empty_cart();
-		$this->reset_customer_state();
-
-		// Clear session data that might persist from other tests.
-		if ( WC()->session ) {
-			WC()->session->set( 'chosen_shipping_methods', array() );
-			WC()->session->set( 'store_api_draft_order', 0 );
-		}
 	}
 
 	/**
@@ -80,27 +82,42 @@ class CheckoutSessions extends ControllerTestCase {
 		WC()->session->set( 'agentic_draft_order_id', null );
 		WC()->session->set( 'chosen_shipping_methods', null );
 
-		// Clear customer addresses.
-		WC()->customer->set_shipping_address_1( '' );
-		WC()->customer->set_billing_address_1( '' );
-		WC()->customer->save();
+		// Reset customer state to clean state.
+		$this->reset_customer_state();
 	}
 
 	/**
 	 * Resets customer state and remove any existing data from previous tests.
 	 */
 	private function reset_customer_state() {
-		wc()->customer->set_shipping_address_1( '' );
-		wc()->customer->set_billing_address_1( '' );
-		wc()->customer->set_billing_country( 'US' );
-		wc()->customer->set_shipping_country( 'US' );
-		wc()->customer->set_billing_state( 'CA' );
-		wc()->customer->set_shipping_state( 'CA' );
-		wc()->customer->set_billing_postcode( '94102' );
-		wc()->customer->set_shipping_postcode( '94102' );
-		wc()->customer->set_billing_city( 'San Francisco' );
-		wc()->customer->set_shipping_city( 'San Francisco' );
-		wc()->customer->save();
+		// Clear all customer data fields.
+		$customer = WC()->customer;
+
+		// Clear billing fields.
+		$customer->set_billing_first_name( '' );
+		$customer->set_billing_last_name( '' );
+		$customer->set_billing_company( '' );
+		$customer->set_billing_address_1( '' );
+		$customer->set_billing_address_2( '' );
+		$customer->set_billing_city( '' );
+		$customer->set_billing_state( '' );
+		$customer->set_billing_postcode( '' );
+		$customer->set_billing_country( '' );
+		$customer->set_billing_email( '' );
+		$customer->set_billing_phone( '' );
+
+		// Clear shipping fields.
+		$customer->set_shipping_first_name( '' );
+		$customer->set_shipping_last_name( '' );
+		$customer->set_shipping_company( '' );
+		$customer->set_shipping_address_1( '' );
+		$customer->set_shipping_address_2( '' );
+		$customer->set_shipping_city( '' );
+		$customer->set_shipping_state( '' );
+		$customer->set_shipping_postcode( '' );
+		$customer->set_shipping_country( '' );
+
+		$customer->save();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -59,11 +59,29 @@ class CheckoutSessions extends ControllerTestCase {
 			),
 		);
 
+		// DEBUG: State before cleanup
+		error_log( '=== DEBUG: setUp before cleanup ===' );
+		error_log( 'Cart item count: ' . ( WC()->cart ? WC()->cart->get_cart_contents_count() : 'cart not initialized' ) );
+		error_log( 'Session exists: ' . ( WC()->session ? 'yes' : 'no' ) );
+		if ( WC()->session ) {
+			error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
+			error_log( 'Draft order: ' . WC()->session->get( 'store_api_draft_order' ) );
+		}
+
 		wc_empty_cart();
 		$this->reset_customer_state();
 
-		// Clear session data that might persist from other tests.
-		WC()->session->set( 'chosen_shipping_methods', null );
+		// Clear session data but keep session alive
+		if ( WC()->session ) {
+			WC()->session->set( 'chosen_shipping_methods', array() );
+			WC()->session->set( 'store_api_draft_order', 0 );
+		}
+
+		// DEBUG: State after cleanup
+		error_log( '=== DEBUG: setUp after cleanup ===' );
+		error_log( 'Cart item count: ' . WC()->cart->get_cart_contents_count() );
+		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
+		error_log( 'Customer shipping address_1: ' . WC()->customer->get_shipping_address_1() );
 	}
 
 	/**
@@ -97,12 +115,21 @@ class CheckoutSessions extends ControllerTestCase {
 		wc()->customer->set_shipping_postcode( '94102' );
 		wc()->customer->set_billing_city( 'San Francisco' );
 		wc()->customer->set_shipping_city( 'San Francisco' );
+		wc()->customer->save();
 	}
 
 	/**
 	 * Test creating a checkout session with items only.
 	 */
 	public function test_create_checkout_session_with_items() {
+		// DEBUG: Check state before test
+		error_log( '=== DEBUG: test_create_checkout_session_with_items START ===' );
+		error_log( 'Cart needs_shipping: ' . ( WC()->cart->needs_shipping() ? 'true' : 'false' ) );
+		error_log( 'Shipping address_1: ' . WC()->customer->get_shipping_address_1() );
+		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
+		error_log( 'Cart item count: ' . WC()->cart->get_cart_contents_count() );
+		error_log( 'Session draft order: ' . WC()->session->get( 'store_api_draft_order' ) );
+
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -120,6 +147,14 @@ class CheckoutSessions extends ControllerTestCase {
 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+
+		// DEBUG: Check state after request
+		error_log( '=== DEBUG: After request ===' );
+		error_log( 'Response status: ' . $data['status'] );
+		error_log( 'Cart needs_shipping: ' . ( WC()->cart->needs_shipping() ? 'true' : 'false' ) );
+		error_log( 'Shipping address_1: ' . WC()->customer->get_shipping_address_1() );
+		error_log( 'Chosen shipping methods: ' . print_r( WC()->session->get( 'chosen_shipping_methods' ), true ) );
+		error_log( '=== DEBUG: test_create_checkout_session_with_items END ===' );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertArrayHasKey( 'id', $data );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -69,6 +69,15 @@ class CheckoutSessions extends ControllerTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
+
+		// Clear session data.
+		WC()->session->set( 'agentic_draft_order_id', null );
+		WC()->session->set( 'chosen_shipping_methods', null );
+
+		// Clear customer addresses.
+		WC()->customer->set_shipping_address_1( '' );
+		WC()->customer->set_billing_address_1( '' );
+		WC()->customer->save();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -1,0 +1,603 @@
+<?php
+/**
+ * Agentic Checkout Sessions Tests.
+ */
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+
+/**
+ * CheckoutSessions Controller Tests.
+ */
+class CheckoutSessions extends ControllerTestCase {
+
+	/**
+	 * Setup test product data. Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Enable the agentic_checkout feature.
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		$fixtures = new FixtureData();
+		$fixtures->shipping_add_flat_rate();
+
+		$this->products = array(
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 1',
+					'stock_status'  => ProductStockStatus::IN_STOCK,
+					'regular_price' => 10,
+					'weight'        => 10,
+				)
+			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 2',
+					'stock_status'  => ProductStockStatus::IN_STOCK,
+					'regular_price' => 20,
+					'weight'        => 5,
+				)
+			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Virtual Product',
+					'stock_status'  => ProductStockStatus::IN_STOCK,
+					'regular_price' => 15,
+					'virtual'       => true,
+				)
+			),
+		);
+
+		wc_empty_cart();
+		$this->reset_customer_state();
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
+	}
+
+	/**
+	 * Resets customer state and remove any existing data from previous tests.
+	 */
+	private function reset_customer_state() {
+		wc()->customer->set_billing_country( 'US' );
+		wc()->customer->set_shipping_country( 'US' );
+		wc()->customer->set_billing_state( 'CA' );
+		wc()->customer->set_shipping_state( 'CA' );
+		wc()->customer->set_billing_postcode( '94102' );
+		wc()->customer->set_shipping_postcode( '94102' );
+		wc()->customer->set_billing_city( 'San Francisco' );
+		wc()->customer->set_shipping_city( 'San Francisco' );
+	}
+
+	/**
+	 * Test creating a checkout session with items only.
+	 */
+	public function test_create_checkout_session_with_items() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 2,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertArrayHasKey( 'line_items', $data );
+		$this->assertArrayHasKey( 'currency', $data );
+		$this->assertArrayHasKey( 'totals', $data );
+		$this->assertArrayHasKey( 'fulfillment_options', $data );
+		$this->assertArrayHasKey( 'messages', $data );
+		$this->assertArrayHasKey( 'links', $data );
+
+		// Verify line items
+		$this->assertCount( 1, $data['line_items'] );
+		$this->assertEquals( (string) $this->products[0]->get_id(), $data['line_items'][0]['item']['id'] );
+		$this->assertEquals( 2, $data['line_items'][0]['item']['quantity'] );
+
+		// Verify status (should be not_ready_for_payment without address)
+		$this->assertEquals( 'not_ready_for_payment', $data['status'] );
+
+		// Verify amounts are in cents (integers)
+		$this->assertIsInt( $data['line_items'][0]['base_amount'] );
+		$this->assertIsInt( $data['line_items'][0]['total'] );
+		$this->assertEquals( 2000, $data['line_items'][0]['base_amount'] ); // $10 * 2 = $20 = 2000 cents
+	}
+
+	/**
+	 * Test creating a checkout session with address.
+	 */
+	public function test_create_checkout_session_with_address() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items'               => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+					'fulfillment_address' => array(
+						'name'        => 'John Doe',
+						'line_one'    => '555 Golden Gate Avenue',
+						'line_two'    => 'Apt 401',
+						'city'        => 'San Francisco',
+						'state'       => 'CA',
+						'country'     => 'US',
+						'postal_code' => '94102',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify address is set
+		$this->assertArrayHasKey( 'fulfillment_address', $data );
+		$this->assertNotNull( $data['fulfillment_address'] );
+		$this->assertEquals( 'John Doe', $data['fulfillment_address']['name'] );
+		$this->assertEquals( '555 Golden Gate Avenue', $data['fulfillment_address']['line_one'] );
+		$this->assertEquals( 'Apt 401', $data['fulfillment_address']['line_two'] );
+		$this->assertEquals( 'San Francisco', $data['fulfillment_address']['city'] );
+		$this->assertEquals( 'CA', $data['fulfillment_address']['state'] );
+		$this->assertEquals( 'US', $data['fulfillment_address']['country'] );
+		$this->assertEquals( '94102', $data['fulfillment_address']['postal_code'] );
+
+		// Verify fulfillment options are available
+		$this->assertNotEmpty( $data['fulfillment_options'] );
+		$this->assertIsArray( $data['fulfillment_options'] );
+	}
+
+	/**
+	 * Test creating a checkout session with buyer info.
+	 */
+	public function test_create_checkout_session_with_buyer() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+					'buyer' => array(
+						'first_name'   => 'Jane',
+						'last_name'    => 'Smith',
+						'email'        => 'jane@example.com',
+						'phone_number' => '+1234567890',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify buyer info is set
+		$this->assertArrayHasKey( 'buyer', $data );
+		$this->assertNotNull( $data['buyer'] );
+		$this->assertEquals( 'Jane', $data['buyer']['first_name'] );
+		$this->assertEquals( 'Smith', $data['buyer']['last_name'] );
+		$this->assertEquals( 'jane@example.com', $data['buyer']['email'] );
+		$this->assertEquals( '+1234567890', $data['buyer']['phone_number'] );
+	}
+
+	/**
+	 * Test status calculation for not_ready_for_payment.
+	 */
+	public function test_status_not_ready_for_payment() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Without address and shipping method, should be not_ready_for_payment
+		$this->assertEquals( 'not_ready_for_payment', $data['status'] );
+	}
+
+	/**
+	 * Test status calculation for ready_for_payment.
+	 */
+	public function test_status_ready_for_payment() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		// Get shipping methods first
+		wc()->customer->set_shipping_address_1( '555 Golden Gate Avenue' );
+		wc()->customer->set_shipping_city( 'San Francisco' );
+		wc()->customer->set_shipping_state( 'CA' );
+		wc()->customer->set_shipping_postcode( '94102' );
+		wc()->customer->set_shipping_country( 'US' );
+		wc()->cart->add_to_cart( $this->products[0]->get_id(), 1 );
+		wc()->cart->calculate_shipping();
+		$packages = wc()->shipping()->get_packages();
+		$shipping_method_id = ! empty( $packages[0]['rates'] ) ? array_key_first( $packages[0]['rates'] ) : null;
+		wc_empty_cart();
+
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items'                 => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+					'fulfillment_address'   => array(
+						'name'        => 'John Doe',
+						'line_one'    => '555 Golden Gate Avenue',
+						'city'        => 'San Francisco',
+						'state'       => 'CA',
+						'country'     => 'US',
+						'postal_code' => '94102',
+					),
+					'fulfillment_option_id' => $shipping_method_id,
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// With address and shipping method, should be ready_for_payment
+		$this->assertEquals( 'ready_for_payment', $data['status'] );
+	}
+
+	/**
+	 * Test invalid product ID returns error.
+	 */
+	public function test_invalid_product_returns_error() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => '999999',
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'invalid_product', $data['code'] );
+	}
+
+	/**
+	 * Test out of stock product returns error.
+	 */
+	public function test_out_of_stock_product_returns_error() {
+		// Set product out of stock
+		$this->products[0]->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
+		$this->products[0]->save();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'out_of_stock', $data['code'] );
+	}
+
+	/**
+	 * Test virtual product doesn't require shipping address.
+	 */
+	public function test_virtual_product_ready_for_payment_without_address() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[2]->get_id(), // Virtual product
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		// Virtual product should be ready_for_payment without address
+		$this->assertEquals( 'ready_for_payment', $data['status'] );
+	}
+
+	/**
+	 * Test totals array format.
+	 */
+	public function test_totals_array_format() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data['totals'] );
+		$this->assertNotEmpty( $data['totals'] );
+
+		// Verify required total types exist
+		$total_types = array_column( $data['totals'], 'type' );
+		$this->assertContains( 'items_base_amount', $total_types );
+		$this->assertContains( 'subtotal', $total_types );
+		$this->assertContains( 'total', $total_types );
+
+		// Verify each total has required fields
+		foreach ( $data['totals'] as $total ) {
+			$this->assertArrayHasKey( 'type', $total );
+			$this->assertArrayHasKey( 'display_text', $total );
+			$this->assertArrayHasKey( 'amount', $total );
+			$this->assertIsInt( $total['amount'] );
+		}
+	}
+
+	/**
+	 * Test payment provider is included.
+	 */
+	public function test_payment_provider_included() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Should have payment_provider even if null
+		$this->assertArrayHasKey( 'payment_provider', $data );
+	}
+
+	/**
+	 * Test links array includes terms and privacy.
+	 */
+	public function test_links_array() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data['links'] );
+
+		// Verify each link has required fields
+		foreach ( $data['links'] as $link ) {
+			$this->assertArrayHasKey( 'type', $link );
+			$this->assertArrayHasKey( 'url', $link );
+			$this->assertIsString( $link['type'] );
+			$this->assertIsString( $link['url'] );
+		}
+	}
+
+	/**
+	 * Test feature flag disabled returns 403.
+	 */
+	public function test_feature_flag_disabled_returns_403() {
+		// Disable feature
+		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test currency format is lowercase.
+	 */
+	public function test_currency_format_is_lowercase() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items' => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Currency should be lowercase (e.g., "usd" not "USD")
+		$this->assertArrayHasKey( 'currency', $data );
+		$this->assertSame( strtolower( $data['currency'] ), $data['currency'] );
+	}
+
+	/**
+	 * Test address line_two returns empty string when not set.
+	 */
+	public function test_address_line_two_empty_string() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items'               => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+					'fulfillment_address' => array(
+						'name'        => 'John Doe',
+						'line_one'    => '555 Golden Gate Avenue',
+						// line_two not provided
+						'city'        => 'San Francisco',
+						'state'       => 'CA',
+						'country'     => 'US',
+						'postal_code' => '94102',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// line_two should be empty string, not null
+		$this->assertArrayHasKey( 'fulfillment_address', $data );
+		$this->assertNotNull( $data['fulfillment_address'] );
+		$this->assertArrayHasKey( 'line_two', $data['fulfillment_address'] );
+		$this->assertSame( '', $data['fulfillment_address']['line_two'] );
+		$this->assertNotNull( $data['fulfillment_address']['line_two'] ); // Explicitly not null
+	}
+
+	/**
+	 * Test address line_two preserves value when provided.
+	 */
+	public function test_address_line_two_with_value() {
+		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'items'               => array(
+						array(
+							'id'       => (string) $this->products[0]->get_id(),
+							'quantity' => 1,
+						),
+					),
+					'fulfillment_address' => array(
+						'name'        => 'John Doe',
+						'line_one'    => '555 Golden Gate Avenue',
+						'line_two'    => 'Apt 401',
+						'city'        => 'San Francisco',
+						'state'       => 'CA',
+						'country'     => 'US',
+						'postal_code' => '94102',
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// line_two should preserve the provided value
+		$this->assertEquals( 'Apt 401', $data['fulfillment_address']['line_two'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously the condition was checking for truthy/falsy values failing to acknowledge that `0` should be treated as truthy since it be discounted to $0.

This change explicitly checks that the price and regularPrice are not undefined.

Closes [WOOPLUG-5628](https://linear.app/a8c/issue/WOOPLUG-5628/free-products-show-in-cart-block-as-dollar0-price)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<img width="475" height="556" alt="CleanShot 2025-10-03 at 16 23 16" src="https://github.com/user-attachments/assets/b2aef7f8-f704-4a8f-8bbe-d5fc7aa5e406" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set a products sale price to `0`
2. Go to checkout
3. In order summary check that it shows the "was" value against the "now" value (Which is $0)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
