### PR TITLE
Fix Product Price display when sale price is 0

### DIFF
--- a/plugins/woocommerce/changelog/fix-isdiscount-check
+++ b/plugins/woocommerce/changelog/fix-isdiscount-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix isDiscount check for order summary to fix display issues when product is discounted to 0

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -277,7 +277,12 @@ const ProductPrice = ( {
 		console.error( 'Price formats need to include the `<price/>` tag.' );
 	}
 
-	const isDiscounted = regularPrice && price && price < regularPrice;
+	// Explicitly check for undefined values because 0 is a valid price.
+	const isDiscounted =
+		regularPrice !== undefined &&
+		price !== undefined &&
+		price < regularPrice;
+
 	let priceComponent = (
 		<span
 			className={ clsx(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously the condition was checking for truthy/falsy values failing to acknowledge that `0` should be treated as truthy since it be discounted to $0.

This change explicitly checks that the price and regularPrice are not undefined.

Closes [WOOPLUG-5628](https://linear.app/a8c/issue/WOOPLUG-5628/free-products-show-in-cart-block-as-dollar0-price)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<img width="475" height="556" alt="CleanShot 2025-10-03 at 16 23 16" src="https://github.com/user-attachments/assets/b2aef7f8-f704-4a8f-8bbe-d5fc7aa5e406" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set a products sale price to `0`
2. Go to checkout
3. In order summary check that it shows the "was" value against the "now" value (Which is $0)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
