### PR TITLE
Coerce order total into float when empty string is provided in setter

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-total-empty-string
+++ b/plugins/woocommerce/changelog/fix-order-total-empty-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Coerce order total into float when empty string is provided in setter

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -813,7 +813,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			wc_deprecated_argument( 'total_type', '3.0', 'Use dedicated total setter methods instead.' );
 			return $this->legacy_set_total( $value, $deprecated );
 		}
-		$this->set_prop( 'total', wc_format_decimal( $value, wc_get_price_decimals() ) );
+
+		$this->set_prop( 'total', wc_format_decimal( (float) $value, wc_get_price_decimals() ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -201,6 +201,15 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: get_total_empty
+	 */
+	public function test_get_total_empty() {
+		$object = new WC_Order();
+		$object->set_total( '' );
+		$this->assertEquals( 0, $object->get_total() );
+	}
+
+	/**
 	 * Test: get_total_tax
 	 */
 	public function test_get_total_tax() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Originally discovered by @jorgeatorres 🙌  - in the legacy order data store, we set the total to an empty string [here](https://github.com/woocommerce/woocommerce/blob/ac4f4426cc9bf32ed6ac18348923c843e6d9c954/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php#L439).  This causes the new updates introduced in https://github.com/woocommerce/woocommerce/pull/59368 to format this as an empty string.

To provide better data consistency, this PR coerces any passed values to floats in the order `set_total` setter.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the legacy order data storage at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Navigate to the Orders -> Add New page
3. Verify that you can create an order
4. Test for other regressions across the order creation/update flows

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
