### PR TITLE
Performance improvements to analytics reports endpoints.

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-3100-optimize-analytics-performance-indicator-endpoints
+++ b/plugins/woocommerce/changelog/WOOPLUG-3100-optimize-analytics-performance-indicator-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improved performance of Analytics Reports endpoints.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -304,8 +304,8 @@ class WC_Install {
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
 		'10.4.0' => array(
-			'wc_update_1040_add_idx_date_paid_status_parent'
-		)
+			'wc_update_1040_add_idx_date_paid_status_parent',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -303,6 +303,9 @@ class WC_Install {
 		'10.2.0' => array(
 			'wc_update_1020_add_old_refunded_order_items_to_product_lookup_table',
 		),
+		'10.4.0' => array(
+			'wc_update_1040_add_idx_date_paid_status_parent'
+		)
 	);
 
 	/**
@@ -1952,7 +1955,8 @@ CREATE TABLE {$wpdb->prefix}wc_order_stats (
 	PRIMARY KEY (order_id),
 	KEY date_created (date_created),
 	KEY customer_id (customer_id),
-	KEY status (status)
+	KEY status (status),
+	KEY idx_date_paid_status_parent (date_paid, status, parent_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 	order_item_id bigint(20) unsigned NOT NULL,

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -289,7 +289,7 @@ function wc_update_670_delete_deprecated_remote_inbox_notifications_option() {
  */
 function wc_update_1040_add_idx_date_paid_status_parent() {
 	global $wpdb;
-	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_order_stats WHERE key_name = 'woo_idx_comment_type'" );
+	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_order_stats WHERE key_name = 'idx_date_paid_status_parent'" );
 
 	if ( is_null( $index_exists ) ) {
 		$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_order_stats ADD INDEX idx_date_paid_status_parent (date_paid, status, parent_id)" );

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -292,6 +292,6 @@ function wc_update_1040_add_idx_date_paid_status_parent() {
 	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_order_stats WHERE key_name = 'woo_idx_comment_type'" );
 
 	if ( is_null( $index_exists ) ) {
-		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX idx_date_paid_status_parent (date_paid, status, parent_id)" );
+		$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_order_stats ADD INDEX idx_date_paid_status_parent (date_paid, status, parent_id)" );
 	}
 }

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -283,3 +283,15 @@ function wc_admin_update_340_remove_is_primary_from_note_action() {
 function wc_update_670_delete_deprecated_remote_inbox_notifications_option() {
 	delete_option( 'wc_remote_inbox_notifications_specs' );
 }
+
+/**
+ * Add an index to the wc_order_stats table for (date_paid, status, parent) to improve report performance.
+ */
+function wc_update_1040_add_idx_date_paid_status_parent() {
+	global $wpdb;
+	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_order_stats WHERE key_name = 'woo_idx_comment_type'" );
+
+	if ( is_null( $index_exists ) ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX idx_date_paid_status_parent (date_paid, status, parent_id)" );
+	}
+}

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -327,6 +327,11 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 			$this->debug_cache_data['query_args'] = $params;
 		}
 
+		// Normalize the $params to reduce cache misses.
+		$params = array_filter( $params, function ( $param ) {
+			return ! empty( $param );
+		} );
+		ksort( $params );
 		return implode(
 			'_',
 			array(

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -328,9 +328,12 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 		}
 
 		// Normalize the $params to reduce cache misses.
-		$params = array_filter( $params, function ( $param ) {
-			return ! empty( $param );
-		} );
+		$params = array_filter(
+			$params,
+			function ( $param ) {
+				return ! empty( $param );
+			}
+		);
 		ksort( $params );
 		return implode(
 			'_',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This improves the performance of the `/wp-json/wc-analytics/reports/performance-indicators endpoints` with the following changes:

#### Improve query performance through an added index:

Adds an index to  `wc_order_stats` covering `(date_paid, status, parent_id)` cutting the query time for the order stats by ~50%.

#### Improve cache hit rate for queries:

The same query ends up running multiple times, however, the caching is based on the $query_args being used.  Because different endpoints may fill in extra default empty values for request args or put them in different orders, they produced unique cache keys causing a cache miss.  This removes keys where the value evaluates to empty (default) and sorts the array by key to produce a consistent key.

This cut the controller time spent building the response by an additional 50% for endpoint such as `/wp-json/wc-analytics/reports/performance-indicators?after=2025-01-01T00%3A00%3A00&before=2025-10-02T23%3A59%3A59&stats=revenue%2Ftotal_sales%2Crevenue%2Fnet_revenue%2Corders%2Forders_count%2Cproducts%2Fitems_sold%2Cvariations%2Fitems_sold&_locale=user`.

In testing a sit with ~1.2M orders within the year to date range, running the above request for the year to date values changed by the following:
Initial TTFB: `6.8s`
After Fixing query caching: `4.05s`
After index added: `2.88s`

Overall a 58% performance improvement when including the other overhead of the request.

Closes [WOOPLUG-3100](https://linear.app/a8c/issue/WOOPLUG-3100/performance-optimize-wp-jsonwc-analyticsreportsperformance-indicators) / #55026 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable analytics under WooCommerce -> Settings -> Advanced -> Features.
2. Create orders on the site. The orders must be complete/paid.
3. Check each of the reports under the Analytics submenu.
4. Confirm that filters work as expected in respective reports.

<!-- End testing instructions -->

### Testing that has already taken place:

In my own testing environment, I opened all of the reports while reviewing trunk and then switched to the new branch and opened all of the reports again, in new tabs.  I then compared the views from each to confirm there were no differences introduced.
