### PR TITLE
Disable CYS tests with Gutenberg nightly

### DIFF
--- a/plugins/woocommerce/changelog/disable-cys-tests-with-gb-nightly
+++ b/plugins/woocommerce/changelog/disable-cys-tests-with-gb-nightly
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Disable CYS E2E tests
+
+

--- a/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-nightly/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-nightly/playwright.config.js
@@ -1,3 +1,19 @@
-const config = require( '../gutenberg-stable/playwright.config.js' );
+let config = require( '../gutenberg-stable/playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
+
+config = {
+	...config,
+	projects: [
+		...config.projects,
+		{
+			name: 'Gutenberg',
+			grep: new RegExp( tags.GUTENBERG ),
+			// Customise Your Store tests are failing with Gutenberg nightly, since 21.7RC.
+			// We're disabling them as we're considering sunsetting CYS in 10.3.
+			testIgnore: [ '**/customize-store/**' ],
+			dependencies: [ 'site setup' ],
+		},
+	],
+};
 
 module.exports = config;

--- a/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-nightly/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-nightly/playwright.config.js
@@ -1,19 +1,3 @@
-let config = require( '../gutenberg-stable/playwright.config.js' );
-const { tags } = require( '../../fixtures/fixtures' );
-
-config = {
-	...config,
-	projects: [
-		...config.projects,
-		{
-			name: 'Gutenberg',
-			grep: new RegExp( tags.GUTENBERG ),
-			// Customise Your Store tests are failing with Gutenberg nightly, since 21.7RC.
-			// We're disabling them as we're considering sunsetting CYS in 10.3.
-			testIgnore: [ '**/customize-store/**' ],
-			dependencies: [ 'site setup' ],
-		},
-	],
-};
+const config = require( '../gutenberg-stable/playwright.config.js' );
 
 module.exports = config;

--- a/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-stable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-stable/playwright.config.js
@@ -10,6 +10,10 @@ config = {
 		{
 			name: 'Gutenberg',
 			grep: new RegExp( tags.GUTENBERG ),
+			// Customise Your Store tests are failing with Gutenberg nightly, since 21.7RC
+			// and change causing the fail will most likely land in 21.8 stable.
+			// We're disabling them as we're considering sunsetting CYS in 10.3.
+			testIgnore: [ '**/customize-store/**' ],
 			dependencies: [ 'site setup' ],
 		},
 	],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

CYS flow doesn't work correctly with the Template Activation Gutenberg feature since GB 21.7RC version.

We made an attempt to fix these tests (https://github.com/woocommerce/woocommerce/pull/61240) but unsuccessful:

1. Even though the flows passed locally they were still failing on CI
2. Some of these issues will be most likely addressed in Gutenberg
3. We're considering sunsetting CYS flow.

And fot that reason we're disabling the CYS tests with GB nightly so there is less noise.

Context: p1759376678038519-slack-C03CPM3UXDJ

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check Core E2E - Gutenberg stable tests suite
2. **Expected:** Make sure `**/customise-store/**` tests are not running there
3. Core E2E - Gutenberg nightly config inherits from the stable one so they won't run as well 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>