### PR TITLE
e2e tests: skip block-based product editor tests

### DIFF
--- a/plugins/woocommerce/changelog/qao-113-woocommerce-core-e2e-disable-block-based-product-editor
+++ b/plugins/woocommerce/changelog/qao-113-woocommerce-core-e2e-disable-block-based-product-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+e2e tests: skip block-based product editor tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-grouped-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-grouped-product-block-editor.spec.js
@@ -10,6 +10,9 @@ import { test } from '../../../fixtures/block-editor-fixtures';
 import { tags, expect } from '../../../fixtures/fixtures';
 import { clickOnTab } from '../../../utils/simple-products';
 import { getFakeProduct } from '../../../utils/data';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-simple-product-block-editor.spec.js
@@ -10,6 +10,9 @@ import { test } from '../../../fixtures/block-editor-fixtures';
 import { clickOnTab } from '../../../utils/simple-products';
 import { tags, expect } from '../../../fixtures/fixtures';
 import { checkCartContent } from '../../../utils/cart';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/create-variable-product-block-editor.spec.js
@@ -9,6 +9,9 @@ import attributes from './fixtures/attributes';
 import tabs from './data/tabs';
 import { waitForGlobalAttributesLoaded } from './helpers/wait-for-global-attributes-loaded';
 import { expect, tags } from '../../../fixtures/fixtures';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const {
 	createVariableProduct,

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/disable-block-product-editor.spec.js
@@ -8,6 +8,9 @@ const { toggleBlockProductTour } = require( '../../../utils/tours' );
 const { tags } = require( '../../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../../playwright.config' );
 const { wpCLI } = require( '../../../utils/cli' );
+const { skipTestsForDeprecatedFeature } = require( './helpers/skip-tests' );
+
+skipTestsForDeprecatedFeature();
 
 async function dismissFeedbackModalIfShown( page ) {
 	try {

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/helpers/skip-tests.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/helpers/skip-tests.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../../../fixtures/block-editor-fixtures';
+
+// eslint-disable-next-line jest/no-export
+export const skipTestsForDeprecatedFeature = () =>
+	test.skip(
+		() => true,
+		'Experimental block-based product editor is officially deprecated since 10.2. See: https://developer.woocommerce.com/2025/07/23/10-1-pre-release-updates/#:~:text=%F0%9F%8C%85%20Say%20sayonara,the%20near%20future'
+	);

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -10,6 +10,9 @@ import { test } from '../../../fixtures/block-editor-fixtures';
 import { helpers } from '../../../utils';
 import { tags, expect } from '../../../fixtures/fixtures';
 import { clickOnTab } from '../../../utils/simple-products';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/organization-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/organization-tab-product-block-editor.spec.js
@@ -10,6 +10,9 @@ import { test } from '../../../fixtures/block-editor-fixtures';
 import { expect, tags } from '../../../fixtures/fixtures';
 import { clickOnTab } from '../../../utils/simple-products';
 import { getFakeCategory } from '../../../utils/data';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-attributes-block-editor.spec.js
@@ -12,6 +12,9 @@ import { updateProduct } from '../../../utils/product-block-editor';
 import { clickOnTab } from '../../../utils/simple-products';
 import attributesData from './fixtures/attributes';
 import { waitForGlobalAttributesLoaded } from './helpers/wait-for-global-attributes-loaded';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 async function waitForAttributeList( page ) {
 	// The list child is different in case there are no results versus when there already are some attributes, so we need to wait for either one to be visible.

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-edit-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-edit-block-editor.spec.js
@@ -8,6 +8,9 @@ import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
  */
 import { test as baseTest } from '../../../fixtures/block-editor-fixtures';
 import { expect, tags } from '../../../fixtures/fixtures';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const test = baseTest.extend( {
 	product: async ( { restApi }, use ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-images-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-images-block-editor.spec.js
@@ -8,6 +8,9 @@ import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
  */
 import { test as baseTest } from '../../../fixtures/block-editor-fixtures';
 import { expect, tags } from '../../../fixtures/fixtures';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 async function selectImagesInLibrary( page, imagesNames ) {
 	const dataIds = [];

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-inventory-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/product-inventory-block-editor.spec.js
@@ -8,6 +8,9 @@ import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
  */
 import { test as baseTest } from '../../../fixtures/block-editor-fixtures';
 import { expect, tags } from '../../../fixtures/fixtures';
+import { skipTestsForDeprecatedFeature } from './helpers/skip-tests';
+
+skipTestsForDeprecatedFeature();
 
 const test = baseTest.extend( {
 	product: async ( { restApi }, use ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes QAO-113

Skips the tests for block-based product editor. The feature has been [deprecated since 10.1](https://developer.woocommerce.com/2025/07/23/10-1-pre-release-updates/#:~:text=%F0%9F%8C%85%20Say%20sayonara,the%20near%20future).
Once the feature is completely removed we'll also delete the tests.

More context: p1759743304831439/1759376678.038519-slack-C03CPM3UXDJ

### How to test the changes in this Pull Request:

Checks the tests that ran in CI in the `Core e2e tests` jobs. The `product/block-editor` tests should be skipped. See https://github.com/woocommerce/woocommerce/actions/runs/18279528686/job/52039162574?pr=61276#step:9:116