### PR TITLE
dev: Update sharding arguments for e2e tests to improve distribution

### DIFF
--- a/plugins/woocommerce/changelog/dev-re-balance-ci-jobs-shards
+++ b/plugins/woocommerce/changelog/dev-re-balance-ci-jobs-shards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: Update sharding arguments for e2e tests to improve distribution

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -253,12 +253,11 @@
 					"testType": "e2e",
 					"command": "test:e2e",
 					"shardingArguments": [
-						"--shard=1/6",
-						"--shard=2/6",
-						"--shard=3/6",
-						"--shard=4/6",
-						"--shard=5/6",
-						"--shard=6/6"
+						"--shard=1/5",
+						"--shard=2/5",
+						"--shard=3/5",
+						"--shard=4/5",
+						"--shard=5/5"
 					],
 					"changes": [
 						"client/admin/config/*.json",
@@ -328,10 +327,8 @@
 					"testType": "e2e",
 					"command": "test:e2e:gb-stable",
 					"shardingArguments": [
-						"--shard=1/4",
-						"--shard=2/4",
-						"--shard=3/4",
-						"--shard=4/4"
+						"--shard=1/2",
+						"--shard=2/2"
 					],
 					"changes": [
 						"tests/e2e-pw/**"
@@ -359,10 +356,8 @@
 					"testType": "e2e",
 					"command": "test:e2e:gb-nightly",
 					"shardingArguments": [
-						"--shard=1/4",
-						"--shard=2/4",
-						"--shard=3/4",
-						"--shard=4/4"
+						"--shard=1/2",
+						"--shard=2/2"
 					],
 					"changes": [
 						"tests/e2e-pw/**"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -253,11 +253,12 @@
 					"testType": "e2e",
 					"command": "test:e2e",
 					"shardingArguments": [
-						"--shard=1/5",
-						"--shard=2/5",
-						"--shard=3/5",
-						"--shard=4/5",
-						"--shard=5/5"
+						"--shard=1/6",
+						"--shard=2/6",
+						"--shard=3/6",
+						"--shard=4/6",
+						"--shard=5/6",
+						"--shard=6/6"
 					],
 					"changes": [
 						"client/admin/config/*.json",
@@ -292,9 +293,7 @@
 					"name": "Core e2e tests - Legacy MiniCart",
 					"testType": "e2e",
 					"command": "test:e2e:legacy-mini-cart",
-					"shardingArguments": [
-						"--shard=1/1"
-					],
+					"shardingArguments": [],
 					"changes": [
 						"client/admin/config/*.json",
 						"composer.json",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With some e2e tests being disabled we need to re-balance the shards, e.g. runs with Gutenberg don't need 4 shards.

### How to test the changes in this Pull Request:

Check the running times for e2e tests jobs in CI.

