### PR TITLE
Moving the PayPal buttons endpoint to the src folder

### DIFF
--- a/plugins/woocommerce/changelog/61281-dev-moving-paypal-buttons-endpoint-to-src
+++ b/plugins/woocommerce/changelog/61281-dev-moving-paypal-buttons-endpoint-to-src
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Moves the new PayPal Standard `paypal-buttons/create-order` and `paypal-buttons/cancel-payment` endpoints to the src folder, under the v4 group, to be autoloaded using namespaces

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/payment-methods/paypal/buttons.js
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/payment-methods/paypal/buttons.js
@@ -167,7 +167,7 @@ const PayPalButtonsContainer = ( {
 			// Create a PayPal order.
 			const paypalResponseData = await apiFetch( {
 				method: 'POST',
-				path: '/wc/v3/paypal-buttons/create-order',
+				path: '/wc/v4/paypal-buttons/create-order',
 				headers: {
 					Nonce: payPalData.create_order_nonce,
 				},
@@ -217,7 +217,7 @@ const PayPalButtonsContainer = ( {
 		try {
 			await apiFetch( {
 				method: 'POST',
-				path: '/wc/v3/paypal-buttons/cancel-payment',
+				path: '/wc/v4/paypal-buttons/cancel-payment',
 				headers: {
 					Nonce: payPalData.cancel_payment_nonce,
 				},

--- a/plugins/woocommerce/client/legacy/js/gateways/paypal.js
+++ b/plugins/woocommerce/client/legacy/js/gateways/paypal.js
@@ -118,7 +118,7 @@ jQuery(function ($) {
 					// Create a PayPal order.
 					const paypalResponseData = await window.wp.apiFetch( {
 						method: 'POST',
-						path: '/wc/v3/paypal-buttons/create-order',
+						path: '/wc/v4/paypal-buttons/create-order',
 						headers: {
 							Nonce: paypal_standard.create_order_nonce,
 						},
@@ -162,7 +162,7 @@ jQuery(function ($) {
 				try {
 					await window.wp.apiFetch( {
 						method: 'POST',
-						path: '/wc/v3/paypal-buttons/cancel-payment',
+						path: '/wc/v4/paypal-buttons/cancel-payment',
 						headers: {
 							Nonce: paypal_standard.cancel_payment_nonce,
 						},

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\RestApi\Utilities\SingletonTrait;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\RestApi\Routes\V4\OrderNotes\Controller as OrderNotesController;
+use Automattic\WooCommerce\RestApi\Routes\V4\PayPalButtons\Controller as PayPalButtonsController;
 use Automattic\WooCommerce\RestApi\Routes\V4\ShippingZones\Controller as ShippingZonesController;
 use Automattic\WooCommerce\RestApi\Routes\V4\Orders\Controller as OrdersController;
 use Automattic\WooCommerce\RestApi\Routes\V4\OfflinePaymentMethods\Controller as OfflinePaymentMethodsController;
@@ -204,7 +205,6 @@ class Server {
 			'data-currencies'          => 'WC_REST_Data_Currencies_Controller',
 			'paypal-standard'          => 'WC_REST_Paypal_Standard_Controller',
 			'paypal-webhooks'          => 'WC_REST_Paypal_Webhooks_Controller',
-			'paypal-buttons'           => 'WC_REST_Paypal_Buttons_Controller',
 		);
 	}
 
@@ -221,6 +221,7 @@ class Server {
 			'order-notes'             => OrderNotesController::class,
 			'shipping-zones'          => ShippingZonesController::class,
 			'orders'                  => OrdersController::class,
+			'paypal-buttons'          => PayPalButtonsController::class,
 			'offline-payment-methods' => OfflinePaymentMethodsController::class,
 			'settings-general'        => 'WC_REST_General_Settings_V4_Controller',
 			'settings-email'          => 'WC_REST_Email_Settings_V4_Controller',

--- a/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/Controller.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/Controller.php
@@ -9,9 +9,12 @@
 
 declare(strict_types=1);
 
+namespace Automattic\WooCommerce\RestApi\Routes\V4\PayPalButtons;
+
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\RestApi\Routes\V4\AbstractController;
 
 if ( ! class_exists( 'WC_Gateway_Paypal_Constants' ) ) {
 	require_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-constants.php';
@@ -21,28 +24,26 @@ if ( ! class_exists( 'WC_Gateway_Paypal_Request' ) ) {
 	require_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php';
 }
 
-
 /**
  * REST API PayPal buttons controller class.
  *
  * @package WooCommerce\RestApi
- * @extends WC_REST_Controller
+ * @extends AbstractController
  */
-class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc/v3';
-
+class Controller extends AbstractController {
 	/**
 	 * Route base.
 	 *
 	 * @var string
 	 */
 	protected $rest_base = 'paypal-buttons';
+
+	/**
+	 * Schema instance.
+	 *
+	 * @var PayPalButtonsOrderSchema
+	 */
+	protected $item_schema;
 
 	/**
 	 * Register the routes for the PayPal buttons functionality handler.
@@ -54,19 +55,25 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/create-order',
 			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'create_order' ),
-				'permission_callback' => array( $this, 'validate_create_order_request' ),
-			)
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_order' ),
+					'permission_callback' => array( $this, 'validate_create_order_request' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
 		);
 
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/cancel-payment',
 			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'cancel_payment' ),
-				'permission_callback' => array( $this, 'validate_cancel_payment_request' ),
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'cancel_payment' ),
+					'permission_callback' => array( $this, 'validate_cancel_payment_request' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 	}
@@ -74,10 +81,10 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 	/**
 	 * Validate the create order request.
 	 *
-	 * @param WP_REST_Request $request The request object.
+	 * @param \WP_REST_Request $request The request object.
 	 * @return bool True if the create order request is valid, false otherwise.
 	 */
-	public function validate_create_order_request( WP_REST_Request $request ) {
+	public function validate_create_order_request( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'Nonce' ) ) {
 			$nonce = $request->get_header( 'Nonce' );
 			return wp_verify_nonce( $nonce, 'wc_gateway_paypal_standard_create_order' );
@@ -88,10 +95,10 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 	/**
 	 * Validate the cancel payment request.
 	 *
-	 * @param WP_REST_Request $request The request object.
+	 * @param \WP_REST_Request $request The request object.
 	 * @return bool True if the cancel payment request is valid, false otherwise.
 	 */
-	public function validate_cancel_payment_request( WP_REST_Request $request ) {
+	public function validate_cancel_payment_request( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'Nonce' ) ) {
 			$nonce = $request->get_header( 'Nonce' );
 			return wp_verify_nonce( $nonce, 'wc_gateway_paypal_standard_cancel_payment' );
@@ -102,44 +109,44 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 	/**
 	 * Create a PayPal order.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response The response object.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response The response object.
 	 */
-	public function create_order( WP_REST_Request $request ) {
+	public function create_order( \WP_REST_Request $request ) {
 		$data = $request->get_json_params();
 
 		if ( empty( $data['order_id'] ) || empty( $data['order_key'] ) ) {
-			return new WP_REST_Response( array( 'error' => 'Invalid request' ), 400 );
+			return new \WP_REST_Response( array( 'error' => 'Invalid request' ), 400 );
 		}
 
 		$payment_source = isset( $data['payment_source'] ) ? sanitize_text_field( $data['payment_source'] ) : '';
-		if ( empty( $payment_source ) || ! in_array( $payment_source, WC_Gateway_Paypal_Constants::SUPPORTED_PAYMENT_SOURCES, true ) ) {
-			return new WP_REST_Response( array( 'error' => 'Missing/Invalid payment source: ' . esc_html( $payment_source ) ), 400 );
+		if ( empty( $payment_source ) || ! in_array( $payment_source, \WC_Gateway_Paypal_Constants::SUPPORTED_PAYMENT_SOURCES, true ) ) {
+			return new \WP_REST_Response( array( 'error' => 'Missing/Invalid payment source: ' . esc_html( $payment_source ) ), 400 );
 		}
 
 		$order_id = $data['order_id'];
 		$order    = wc_get_order( $order_id );
 
 		if ( ! $order ) {
-			return new WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
+			return new \WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
 		}
 
 		$order_key = $data['order_key'];
 		if ( ! $order_key || ! hash_equals( $order->get_order_key(), $order_key ) ) {
-			return new WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
+			return new \WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
 		}
 
 		if ( ! in_array( $order->get_status(), array( OrderStatus::CHECKOUT_DRAFT, OrderStatus::PENDING ), true ) ) {
-			return new WP_REST_Response( array( 'error' => 'Invalid order status' ), 409 );
+			return new \WP_REST_Response( array( 'error' => 'Invalid order status' ), 409 );
 		}
 
-		$gateway = WC_Gateway_Paypal::get_instance();
+		$gateway = \WC_Gateway_Paypal::get_instance();
 
 		// For Buttons requests, we need to explicitly set the payment method to PayPal.
 		$order->set_payment_method( $gateway->id );
 		$order->save();
 
-		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+		$paypal_request = new \WC_Gateway_Paypal_Request( $gateway );
 		$paypal_order   = $paypal_request->create_paypal_order(
 			$order,
 			$payment_source,
@@ -150,14 +157,14 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 		);
 
 		if ( ! $paypal_order || empty( $paypal_order['id'] ) ) {
-			return new WP_REST_Response( array( 'error' => 'Failed to create PayPal order' ), 400 );
+			return new \WP_REST_Response( array( 'error' => 'Failed to create PayPal order' ), 400 );
 		}
 
 		$order->update_meta_data( '_paypal_order_id', $paypal_order['id'] );
 		$order->update_status( OrderStatus::PENDING );
 		$order->save();
 
-		return new WP_REST_Response(
+		return new \WP_REST_Response(
 			array(
 				'paypal_order_id' => $paypal_order['id'] ?? null,
 				'order_id'        => $order_id,
@@ -170,42 +177,61 @@ class WC_REST_Paypal_Buttons_Controller extends WC_REST_Controller {
 	/**
 	 * Cancel a PayPal payment. This is used to move the woocommerce order back to a draft status.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response The response object.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response The response object.
 	 */
-	public function cancel_payment( WP_REST_Request $request ) {
+	public function cancel_payment( \WP_REST_Request $request ) {
 		$data = $request->get_json_params();
 
 		$order_id        = isset( $data['order_id'] ) ? absint( $data['order_id'] ) : 0;
 		$paypal_order_id = isset( $data['paypal_order_id'] ) ? wc_clean( $data['paypal_order_id'] ) : '';
 		if ( ! $order_id || '' === $paypal_order_id ) {
-			return new WP_REST_Response( array( 'error' => 'Invalid request' ), 400 );
+			return new \WP_REST_Response( array( 'error' => 'Invalid request' ), 400 );
 		}
 
 		$order = wc_get_order( $order_id );
 		if ( ! $order ) {
-			return new WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
+			return new \WP_REST_Response( array( 'error' => 'Order not found' ), 404 );
 		}
 
 		// Verify order by checking the PayPal order ID.
 		$paypal_order_id_from_meta = $order->get_meta( '_paypal_order_id' );
 		if ( $paypal_order_id_from_meta !== $paypal_order_id ) {
-			return new WP_REST_Response( array( 'error' => 'Invalid PayPal order' ), 404 );
+			return new \WP_REST_Response( array( 'error' => 'Invalid PayPal order' ), 404 );
 		}
 
 		// If order is already in draft status, do nothing and return success.
 		if ( $order->has_status( OrderStatus::CHECKOUT_DRAFT ) ) {
-			return new WP_REST_Response( array( 'success' => true ), 200 );
+			return new \WP_REST_Response( array( 'success' => true ), 200 );
 		}
 
 		// If order is not pending, return an error.
 		if ( ! $order->has_status( OrderStatus::PENDING ) ) {
-			return new WP_REST_Response( array( 'error' => 'Order is not pending' ), 409 );
+			return new \WP_REST_Response( array( 'error' => 'Order is not pending' ), 409 );
 		}
 
 		$order->update_status( OrderStatus::CHECKOUT_DRAFT );
 		$order->save();
 
-		return new WP_REST_Response( array( 'success' => true ), 200 );
+		return new \WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Get the schema for the current resource. This use consumed by the AbstractController to generate the item schema
+	 * after running various hooks on the response.
+	 */
+	protected function get_schema(): array {
+		return $this->item_schema->get_item_schema();
+	}
+
+	/**
+	 * Prepare a single order object for response.
+	 *
+	 * @param array            $item Order data.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	protected function get_item_response( $item, \WP_REST_Request $request ): array {
+		return $this->item_schema->get_item_response( $item, $request, $this->get_fields_for_response( $request ) );
 	}
 }

--- a/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PayPalButtonsOrderSchema class.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\RestApi\Routes\V4\PayPalButtons;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\RestApi\Routes\V4\AbstractSchema;
+
+/**
+ * ShippingZoneSchema class.
+ */
+class PayPalButtonsOrderSchema extends AbstractSchema {
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'paypal-buttons-order';
+
+	/**
+	 * Return all properties for the item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema_properties(): array {
+		$schema = array(
+			'paypal_order_id'        => array(
+				'description' => __( 'Unique identifier for the PayPal order (on the PayPal side).', 'woocommerce' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			),
+			'order_id'      => array(
+				'description' => __( 'Unique identifier for the order (WooCommerce side).', 'woocommerce' ),
+				'type'        => 'integer',
+				'readonly'    => true,
+			),
+			'return_url'     => array(
+				'description' => __( 'The order return URL.', 'woocommerce' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Get the item response.
+	 *
+	 * @param array            $order_data The order data.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param array            $include_fields Fields to include in the response.
+	 * @return array The item response.
+	 */
+	public function get_item_response( $order_data, \WP_REST_Request $request, array $include_fields = array() ): array {
+		return array(
+			'paypal_order_id' => $order_data['paypal_order_id'],
+			'order_id'        => $order_data['order_id'],
+			'return_url'      => $order_data['return_url'],
+		);
+	}
+}

--- a/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
@@ -31,17 +31,17 @@ class PayPalButtonsOrderSchema extends AbstractSchema {
 	 */
 	public function get_item_schema_properties(): array {
 		$schema = array(
-			'paypal_order_id'        => array(
+			'paypal_order_id' => array(
 				'description' => __( 'Unique identifier for the PayPal order (on the PayPal side).', 'woocommerce' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			),
-			'order_id'      => array(
+			'order_id'        => array(
 				'description' => __( 'Unique identifier for the order (WooCommerce side).', 'woocommerce' ),
 				'type'        => 'integer',
 				'readonly'    => true,
 			),
-			'return_url'     => array(
+			'return_url'      => array(
 				'description' => __( 'The order return URL.', 'woocommerce' ),
 				'type'        => 'string',
 				'readonly'    => true,

--- a/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
+++ b/plugins/woocommerce/src/RestApi/Routes/V4/PayPalButtons/PayPalButtonsOrderSchema.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\RestApi\Routes\V4\AbstractSchema;
 
 /**
- * ShippingZoneSchema class.
+ * PayPalButtonsOrderSchema class.
  */
 class PayPalButtonsOrderSchema extends AbstractSchema {
 	/**

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -65,12 +65,3 @@ $GLOBALS['woocommerce'] = WC();
 if ( class_exists( \Automattic\Jetpack\Connection\Rest_Authentication::class ) ) {
 	\Automattic\Jetpack\Connection\Rest_Authentication::init();
 }
-
-add_filter( 'woocommerce_paypal_use_orders_v2', '__return_true' );
-
-$woocommerce_paypal_settings = get_option( 'woocommerce_paypal_settings' );
-if ( ! is_array( $woocommerce_paypal_settings ) ) {
-	$woocommerce_paypal_settings = array();
-}
-$woocommerce_paypal_settings['_should_load'] = 'yes';
-update_option( 'woocommerce_paypal_settings', $woocommerce_paypal_settings );

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -65,3 +65,12 @@ $GLOBALS['woocommerce'] = WC();
 if ( class_exists( \Automattic\Jetpack\Connection\Rest_Authentication::class ) ) {
 	\Automattic\Jetpack\Connection\Rest_Authentication::init();
 }
+
+add_filter( 'woocommerce_paypal_use_orders_v2', '__return_true' );
+
+$woocommerce_paypal_settings = get_option( 'woocommerce_paypal_settings' );
+if ( ! is_array( $woocommerce_paypal_settings ) ) {
+	$woocommerce_paypal_settings = array();
+}
+$woocommerce_paypal_settings['_should_load'] = 'yes';
+update_option( 'woocommerce_paypal_settings', $woocommerce_paypal_settings );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Towards PAYPAL-92
Original PR https://github.com/woocommerce/woocommerce/pull/61034
Related: https://github.com/woocommerce/woocommerce/pull/61261 https://github.com/woocommerce/woocommerce/pull/61204

In this PR, I am moving the new `paypal-buttons/create-order` and `paypal-buttons/cancel-payment` endpoints introduced in https://github.com/woocommerce/woocommerce/pull/61034 to the src folder so it can be autoloaded using namespaces, following the request from pcShBQ-3Aw-p2. It also changes the version of the endpoint from v3 to v4, to keep it under the new standard. These files are all related to the PayPal Standard project.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/61034. No feature behavior should change as a result of this PR.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Moves the new PayPal Standard `paypal-buttons/create-order` and `paypal-buttons/cancel-payment` endpoints to the src folder, under the v4 group, to be autoloaded using namespaces

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
