### PR TITLE
Optimize caching of price data for variations

### DIFF
--- a/plugins/woocommerce/changelog/pr-61286
+++ b/plugins/woocommerce/changelog/pr-61286
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Optimize caching of price data for variations

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -266,15 +266,22 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since  3.0.0
 	 */
 	public function read_price_data( &$product, $for_display = false ) {
+		static $has_variation_prices_array_filters = null;
+
+		if ( is_null( $has_variation_prices_array_filters ) ) {
+			global $wp_filter;
+			$has_variation_prices_array_filters = ! empty( $wp_filter['woocommerce_variation_prices_array'] );
+		}
 
 		/**
 		 * Transient name for storing prices for this product (note: Max transient length is 45)
 		 *
 		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
 		 */
-		$transient_name    = 'wc_var_prices_' . $product->get_id();
-		$transient_version = WC_Cache_Helper::get_transient_version( 'product' );
-		$price_hash        = $this->get_price_hash( $product, $for_display );
+		$transient_name      = 'wc_var_prices_' . $product->get_id();
+		$transient_version   = WC_Cache_Helper::get_transient_version( 'product' );
+		$price_hash          = $this->get_price_hash( $product, $for_display );
+		$opposite_price_hash = $this->taxes_influence_price( $product ) ? null : $this->get_price_hash( $product, ! $for_display );
 
 		/**
 		 * $this->prices_array is an array of values which may have been modified from what is stored in transients - this may not match $transient_cached_prices_array.
@@ -373,13 +380,43 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 						$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
 						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price, wc_get_price_decimals() );
 
-						$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
+						if ( $has_variation_prices_array_filters ) {
+							/**
+							 * Filter the variation prices array before storing in transient cache.
+							 *
+							 * This filter allows developers to modify the variation prices array for each variation
+							 * during the price calculation process. It's called for each variation individually
+							 * and can be used to add custom pricing data or modify existing prices.
+							 *
+							 * @since 3.6.0
+							 *
+							 * @param array        $prices_array The prices array being built. Contains 'price', 'regular_price', and 'sale_price' keys.
+							 * @param WC_Product   $variation    The variation product object.
+							 * @param bool         $for_display  Whether prices are for display (with tax adjustments) or for calculations.
+							 */
+							$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
+							if ( $opposite_price_hash ) {
+								// In principle, we know that prices for display and not for display are the same ones,
+								// but code hooking on woocommerce_variation_prices_array could make this different
+								// so we need to check.
+								$prices_array_hash = md5( wp_json_encode( $prices_array ) );
+								// phpcs:ignore WooCommerce.Commenting.CommentHooks
+								$opposite_prices_array      = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, ! $for_display );
+								$opposite_prices_array_hash = md5( wp_json_encode( $opposite_prices_array ) );
+								if ( $opposite_prices_array_hash !== $prices_array_hash ) {
+									$opposite_price_hash = null;
+								}
+							}
+						}
 					}
 				}
 
 				// Add all pricing data to the transient array.
 				foreach ( $prices_array as $key => $values ) {
 					$transient_cached_prices_array[ $price_hash ][ $key ] = $values;
+					if ( $opposite_price_hash !== $price_hash ) {
+						$transient_cached_prices_array[ $opposite_price_hash ][ $key ] = $values;
+					}
 				}
 
 				// Validate the prices data before storing it in the transient.
@@ -393,8 +430,37 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			 * This value may differ from the transient cache. It is filtered once before storing locally.
 			 */
 			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $for_display );
+			if ( $opposite_price_hash ) {
+				$this->prices_array[ $opposite_price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $opposite_price_hash ], $product, ! $for_display );
+			}
 		}
 		return $this->prices_array[ $price_hash ];
+	}
+
+	/**
+	 * Check if the prices for a product will be different with or without taxes.
+	 *
+	 * @param WC_Product $product Product to check.
+	 * @return bool True if the prices will be different with or without taxes.
+	 */
+	private function taxes_influence_price( $product ): bool {
+		if ( ! wc_tax_enabled() ) {
+			return false;
+		}
+
+		if ( ! $product->is_taxable() ) {
+			return false;
+		}
+
+		if ( empty( WC_Tax::get_rates( $product->get_tax_class() ) ) ) {
+			return false;
+		}
+
+		if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -266,9 +266,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since  3.0.0
 	 */
 	public function read_price_data( &$product, $for_display = false ) {
-		global $wp_filter;
-		$has_variation_prices_array_filters = ! empty( $wp_filter['woocommerce_variation_prices_array'] );
-
 		/**
 		 * Transient name for storing prices for this product (note: Max transient length is 45)
 		 *
@@ -376,7 +373,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 						$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
 						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price, wc_get_price_decimals() );
 
-						if ( $has_variation_prices_array_filters ) {
+						if ( has_filter( 'woocommerce_variation_prices_array' ) ) {
 							/**
 							 * Filter the variation prices array before storing in transient cache.
 							 *

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -453,8 +453,10 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 *
 	 * @param WC_Product $product Product to check.
 	 * @return bool True if the prices will be different with or without taxes.
+	 *
+	 * @since 10.4.0
 	 */
-	private function taxes_influence_price( $product ): bool {
+	protected function taxes_influence_price( $product ): bool {
 		if ( ! $product->is_taxable() ) {
 			return false;
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -441,7 +441,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			 * @param bool       $for_display  Whether prices are being retrieved for display.
 			 */
 			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $for_display );
-			if ( $opposite_price_hash ) {
+			if ( ! is_null( $opposite_price_hash ) && $opposite_price_hash !== $price_hash ) {
 				// phpcs:ignore WooCommerce.Commenting.CommentHooks
 				$this->prices_array[ $opposite_price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $opposite_price_hash ], $product, ! $for_display );
 			}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -374,6 +374,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price, wc_get_price_decimals() );
 
 						if ( has_filter( 'woocommerce_variation_prices_array' ) ) {
+							$original_prices_array = $prices_array;
+
 							/**
 							 * Filter the variation prices array before storing in transient cache.
 							 *
@@ -394,7 +396,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 								// so we need to check.
 								$prices_array_hash = md5( wp_json_encode( $prices_array ) );
 								// phpcs:ignore WooCommerce.Commenting.CommentHooks
-								$opposite_prices_array      = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, ! $for_display );
+								$opposite_prices_array      = apply_filters( 'woocommerce_variation_prices_array', $original_prices_array, $variation, ! $for_display );
 								$opposite_prices_array_hash = md5( wp_json_encode( $opposite_prices_array ) );
 								if ( $opposite_prices_array_hash !== $prices_array_hash ) {
 									$opposite_price_hash = null;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -414,7 +414,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				// Add all pricing data to the transient array.
 				foreach ( $prices_array as $key => $values ) {
 					$transient_cached_prices_array[ $price_hash ][ $key ] = $values;
-					if ( $opposite_price_hash !== $price_hash ) {
+					if ( ! is_null( $opposite_price_hash ) && $opposite_price_hash !== $price_hash ) {
 						$transient_cached_prices_array[ $opposite_price_hash ][ $key ] = $values;
 					}
 				}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -422,11 +422,27 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			}
 
 			/**
-			 * Give plugins one last chance to filter the variation prices array which has been generated and store locally to the class.
-			 * This value may differ from the transient cache. It is filtered once before storing locally.
+			 * Filters the variation prices array for a variable product.
+			 *
+			 * This filter gives plugins one last chance to modify the variation prices array which has been
+			 * generated and will be stored locally to the class. This value may differ from the transient cache.
+			 * It is filtered once before storing locally.
+			 *
+			 * @since 3.0.0
+			 *
+			 * @param array      $prices_array {
+			 *     Associative array of variation prices indexed by variation ID.
+			 *
+			 *     @type array $price         Array of active prices (variation_id => price).
+			 *     @type array $regular_price Array of regular prices (variation_id => price).
+			 *     @type array $sale_price    Array of sale prices (variation_id => price).
+			 * }
+			 * @param WC_Product $product      The variable product object.
+			 * @param bool       $for_display  Whether prices are being retrieved for display.
 			 */
 			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $for_display );
 			if ( $opposite_price_hash ) {
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks
 				$this->prices_array[ $opposite_price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $opposite_price_hash ], $product, ! $for_display );
 			}
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -440,10 +440,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @return bool True if the prices will be different with or without taxes.
 	 */
 	private function taxes_influence_price( $product ): bool {
-		if ( ! wc_tax_enabled() ) {
-			return false;
-		}
-
 		if ( ! $product->is_taxable() ) {
 			return false;
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -266,12 +266,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since  3.0.0
 	 */
 	public function read_price_data( &$product, $for_display = false ) {
-		static $has_variation_prices_array_filters = null;
-
-		if ( is_null( $has_variation_prices_array_filters ) ) {
-			global $wp_filter;
-			$has_variation_prices_array_filters = ! empty( $wp_filter['woocommerce_variation_prices_array'] );
-		}
+		global $wp_filter;
+		$has_variation_prices_array_filters = ! empty( $wp_filter['woocommerce_variation_prices_array'] );
 
 		/**
 		 * Transient name for storing prices for this product (note: Max transient length is 45)

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -475,7 +475,7 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @param bool $tax_has_rates Product tax has defined rates or not.
 	 * @param bool $user_vat_exempt User is VAT exempt or not.
 	 */
-	public function test_read_prices_data_when_taxes_dont_influence_price( bool $tax_enabled, bool $taxable_product, bool $tax_has_rates, bool $user_vat_exempt ) {
+	public function test_read_prices_cache_when_taxes_dont_influence_price( bool $tax_enabled, bool $taxable_product, bool $tax_has_rates, bool $user_vat_exempt ) {
 		add_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
 		add_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
 		add_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
@@ -486,33 +486,71 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$transient_name = 'wc_var_prices_' . $product->get_id();
 		delete_transient( $transient_name );
 
-		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
-		$extended_data_store = new class() extends WC_Product_Variable_Data_Store_CPT {
-			public function get_price_hash( &$product, $for_display = false ) {
-				return parent::get_price_hash( $product, $for_display );
-			}
-		};
-		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+		$extended_data_store = $this->get_data_store_with_public_get_price_hash();
 
 		$expected_hashes = array_unique( array( $extended_data_store->get_price_hash( $product, true ), $extended_data_store->get_price_hash( $product, false ) ) );
 		sort( $expected_hashes );
 
 		delete_transient( $transient_name );
 		$data_store->read_price_data( $product, false );
-		$actual_hashes = array_unique( array_keys( (array) json_decode( get_transient( $transient_name ) ) ) );
+		$actual_hashes = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
 		sort( $actual_hashes );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
 
 		$data_store = new WC_Product_Variable_Data_Store_CPT();
 		delete_transient( $transient_name );
 		$data_store->read_price_data( $product, false );
-		$actual_hashes = array_unique( array_keys( (array) json_decode( get_transient( $transient_name ) ) ) );
+		$actual_hashes = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
 		sort( $actual_hashes );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
 
 		remove_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
 		remove_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+	}
+
+	/**
+	 * @testdox read_prices does separate caching for prices for display and not for display when they are different.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $for_display Test getting prices for display or not for display.
+	 */
+	public function test_read_prices_cache_when_taxes_influence_price( bool $for_display ) {
+		add_filter( 'wc_tax_enabled', '__return_true' );
+		add_filter( 'woocommerce_product_is_taxable', '__return_true' );
+		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
+		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
+		WC()->customer->set_is_vat_exempt( false );
+
+		$data_store     = new WC_Product_Variable_Data_Store_CPT();
+		$product        = WC_Helper_Product::create_variation_product();
+		$transient_name = 'wc_var_prices_' . $product->get_id();
+		delete_transient( $transient_name );
+
+		$extended_data_store = $this->get_data_store_with_public_get_price_hash();
+
+		delete_transient( $transient_name );
+		$data_store->read_price_data( $product, $for_display );
+		$expected_hashes = array( $extended_data_store->get_price_hash( $product, $for_display ) );
+		$actual_hashes   = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
+		$this->assertEquals( $expected_hashes, $actual_hashes );
+	}
+
+	/**
+	 * Get an instance of WC_Product_Variable_Data_Store_CPT whose get_price_hash method is public.
+	 *
+	 * @return WC_Product_Variable_Data_Store_CPT
+	 */
+	private function get_data_store_with_public_get_price_hash(): object {
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
+		return new class() extends WC_Product_Variable_Data_Store_CPT {
+			public function get_price_hash( &$product, $for_display = false ) {
+				return parent::get_price_hash( $product, $for_display );
+			}
+		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -463,6 +463,73 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox read_prices caches both prices for display and not for display when prices are the same in both cases.
+	 *
+	 * @testWith [false, true, true, false]
+	 *           [false, false, true, false]
+	 *           [true, true, false, false]
+	 *           [true, true, true, true]
+	 *
+	 * @param bool $tax_enabled Taxes enabled shop-wide or not.
+	 * @param bool $taxable_product Product is taxable or not.
+	 * @param bool $tax_has_rates Product tax has defined rates or not.
+	 * @param bool $user_vat_exempt User is VAT exempt or not.
+	 */
+	public function test_read_prices_data_when_taxes_dont_influence_price( bool $tax_enabled, bool $taxable_product, bool $tax_has_rates, bool $user_vat_exempt ) {
+		add_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
+		add_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
+		add_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+		WC()->customer->set_is_vat_exempt( $user_vat_exempt );
+
+		$data_store     = new WC_Product_Variable_Data_Store_CPT();
+		$product        = WC_Helper_Product::create_variation_product();
+		$transient_name = 'wc_var_prices_' . $product->get_id();
+		delete_transient( $transient_name );
+
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
+		$extended_data_store = new class() extends WC_Product_Variable_Data_Store_CPT {
+			public function get_price_hash( &$product, $for_display = false ) {
+				return parent::get_price_hash( $product, $for_display );
+			}
+		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+
+		$expected_hashes = array_unique( array( $extended_data_store->get_price_hash( $product, true ), $extended_data_store->get_price_hash( $product, false ) ) );
+		sort( $expected_hashes );
+
+		delete_transient( $transient_name );
+		$data_store->read_price_data( $product, false );
+		$actual_hashes = array_unique( array_keys( (array) json_decode( get_transient( $transient_name ) ) ) );
+		sort( $actual_hashes );
+		$this->assertEquals( $expected_hashes, $actual_hashes );
+
+		$data_store = new WC_Product_Variable_Data_Store_CPT();
+		delete_transient( $transient_name );
+		$data_store->read_price_data( $product, false );
+		$actual_hashes = array_unique( array_keys( (array) json_decode( get_transient( $transient_name ) ) ) );
+		sort( $actual_hashes );
+		$this->assertEquals( $expected_hashes, $actual_hashes );
+
+		remove_filter( 'wc_tax_enabled', $tax_enabled ? '__return_true' : '__return_false' );
+		remove_filter( 'woocommerce_product_is_taxable', $taxable_product ? '__return_true' : '__return_false' );
+		remove_filter( 'woocommerce_matched_rates', $tax_has_rates ? array( $this, '__return_rates' ) : '__return_empty_array' );
+	}
+
+	/**
+	 * Return dummy tax rates.
+	 *
+	 * @return array
+	 */
+	public function __return_rates() {
+		return array(
+			'rate'     => 10,
+			'label'    => 'rate',
+			'shipping' => 'no',
+			'compund'  => 'no',
+		);
+	}
+
+	/**
 	 * @testdox Test read_price_data method works even when price validation fails
 	 */
 	public function test_read_price_data_with_validation_failure() {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -493,14 +493,14 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		delete_transient( $transient_name );
 		$data_store->read_price_data( $product, false );
-		$actual_hashes = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
+		$actual_hashes = array_unique( $this->get_keys_for_json_encoded_transient( $transient_name ) );
 		sort( $actual_hashes );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
 
 		$data_store = new WC_Product_Variable_Data_Store_CPT();
 		delete_transient( $transient_name );
 		$data_store->read_price_data( $product, false );
-		$actual_hashes = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
+		$actual_hashes = array_unique( $this->get_keys_for_json_encoded_transient( $transient_name ) );
 		sort( $actual_hashes );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
 
@@ -521,7 +521,6 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		add_filter( 'wc_tax_enabled', '__return_true' );
 		add_filter( 'woocommerce_product_is_taxable', '__return_true' );
 		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
-		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
 		WC()->customer->set_is_vat_exempt( false );
 
 		$data_store     = new WC_Product_Variable_Data_Store_CPT();
@@ -534,8 +533,60 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		delete_transient( $transient_name );
 		$data_store->read_price_data( $product, $for_display );
 		$expected_hashes = array( $extended_data_store->get_price_hash( $product, $for_display ) );
-		$actual_hashes   = array_unique( array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) ) );
+		$actual_hashes   = array_unique( $this->get_keys_for_json_encoded_transient( $transient_name ) );
 		$this->assertEquals( $expected_hashes, $actual_hashes );
+
+		remove_filter( 'wc_tax_enabled', '__return_true' );
+		remove_filter( 'woocommerce_product_is_taxable', '__return_true' );
+		remove_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
+	}
+
+	/**
+	 * @testdox read_prices skips unified caching if code hooked to woocommerce_variation_prices_array modifies the prices array.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $hook_modifies_prices The hooked code modifies the prices array or not.
+	 * @return void
+	 */
+	public function test_read_prices_cache_when_taxes_dont_influence_price_plus_hook( bool $hook_modifies_prices ) {
+		add_filter( 'wc_tax_enabled', '__return_true' );
+		add_filter( 'woocommerce_product_is_taxable', '__return_false' );
+		add_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
+		WC()->customer->set_is_vat_exempt( false );
+
+		add_filter(
+			'woocommerce_variation_prices_array',
+			function ( $prices_array, $variation, $for_display ) use ( $hook_modifies_prices ) {
+				if ( $hook_modifies_prices ) {
+					$prices_array['foobar'] = $for_display;
+				}
+				return $prices_array;
+			},
+			10,
+			3
+		);
+
+		$data_store     = new WC_Product_Variable_Data_Store_CPT();
+		$product        = WC_Helper_Product::create_variation_product();
+		$transient_name = 'wc_var_prices_' . $product->get_id();
+		delete_transient( $transient_name );
+
+		$extended_data_store = $this->get_data_store_with_public_get_price_hash();
+
+		$data_store->read_price_data( $product, true );
+		$actual_hashes   = array_unique( $this->get_keys_for_json_encoded_transient( $transient_name ) );
+		$expected_hashes =
+			$hook_modifies_prices ?
+			array( $extended_data_store->get_price_hash( $product, true ) ) :
+			array( $extended_data_store->get_price_hash( $product, true ), $extended_data_store->get_price_hash( $product, false ) );
+		$this->assertEquals( $expected_hashes, $actual_hashes );
+
+		remove_all_filters( 'woocommerce_variation_prices_array' );
+		remove_filter( 'wc_tax_enabled', '__return_true' );
+		remove_filter( 'woocommerce_product_is_taxable', '__return_false' );
+		remove_filter( 'woocommerce_matched_rates', array( $this, '__return_rates' ) );
 	}
 
 	/**
@@ -551,6 +602,16 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			}
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+	}
+
+	/**
+	 * Parse a variable product prices transient and return the hashes only.
+	 *
+	 * @param string $transient_name Name of the transient to parse.
+	 * @return array
+	 */
+	private function get_keys_for_json_encoded_transient( string $transient_name ): array {
+		return array_keys( array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As pointed out in https://github.com/woocommerce/woocommerce/issues/61222, there are cases where `WC_Product_Variable_Data_Store_CPT::read_price_data` returns the same values for both `$for_display` being true and being false. With the changes in this pull request such case is checked for, and if detected, the generated prices data is cached twice, one using the hash for `$for_display` being true for the cache key, and one using the hash for it being false. Care is taken to detect the cases where code hooked to `woocommerce_variation_prices_array` makes the prices different where they would otherwise have been equal.

Before fully closing https://github.com/woocommerce/woocommerce/issues/61222 it would be convenient to do some research on the first part of the issue (are there opportunities to make the transient deletions less "aggressive"?)

### How to test the changes in this Pull Request:

For testing these changes you'll need a variable product with a lot of variations. One way to create it is by creating a variable product with one variation, exporting it to CSV, editing it to add additional variation lines, and importing it.

Also you need to create the following file (adjust the product id in the first line):

```php
<?php
$p=wc_get_product(<variable product id>);
wc_delete_product_transients($p->get_id());
if(!function_exists('run')) {
    function run($msg, $callback) {
        $start=microtime(true);
        $result = $callback();
        $ms = absint((microtime(true)-$start)*1000);
        echo "$msg: $ms ms";
        if($result !== null) {
            echo ", result: $result";
        }
        echo "\n";
    };
}
run("for display:    ", fn()=>$p->get_variation_prices(true));
run("not for display:", fn()=>$p->get_variation_prices(false));
run("for display again:    ", fn()=>$p->get_variation_prices(true));
run("not for display again:", fn()=>$p->get_variation_prices(false));

$v=wc_get_product($p->get_children()[0]);
run("price with tax:    ", fn()=>wc_get_price_including_tax($v));
run("price without tax: ", fn()=>wc_get_price_excluding_tax($v));
```

Also add the following snippet to your store in order to make sure that we start out with a taxable product, we'll modify it as we test:

```php
add_filter('woocommerce_prices_include_tax', fn() => true);
add_filter( 'woocommerce_product_is_taxable', fn() => true);
add_filter( 'woocommerce_matched_rates', fn() => ['the_rate' => ['rate' => 10, 'label' => 'rate', 'shipping' => 'no', 'compund'  => 'no']]);
WC()->initialize_cart();
WC()->customer->set_is_vat_exempt( false );
```

1. Run the following: `wp eval 'wp_set_current_user(1); include("temp.php");'`. You'll see that the first calculation takes a considerable amount of time both for the "for display" and "not for display" cases, while the second run is instantaneous. Also the prices with and without taxes are different as expected. This is the behavior that's always seen without the changes of this pull request.

2. Now repeat 1 making the following changes to the snippet one by one (make one change, test, revert it):

- Have the `woocommerce_product_is_taxable` filter return false
- Have the `woocommerce_matched_rates` filter return an empty array
- Set the customer as VAT exempt

Now what you'll see is that the first calculation of the "for display" case takes a lot of time, but for the "not for display" case it's instantaneous even the first time: that's the double caching in action. Also both prices, with and without taxes, should be identical.

3. Now add the following additional snippet:

```php
add_filter('woocommerce_variation_prices_array', function($prices_array, $variation, $for_display) {
    return $prices_array;
}, 10, 3);
```

then repeat 1, you should still get the double caching.

4. Repeat modifying the snippet as follows:

```php
add_filter('woocommerce_variation_prices_array', function($prices_array, $variation, $for_display) {
    $prices_array['foobar']=$for_display;
    return $prices_array;
}, 10, 3);
```

and repeat 1, the double caching should have disappeared (but prices with and without taxes are the same since we aren't actually modifying them in our hook).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
