### PR TITLE
Handle legacy → HPOS sync when order was deleted while sync was off

### DIFF
--- a/plugins/woocommerce/changelog/fix-52837
+++ b/plugins/woocommerce/changelog/fix-52837
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure legacy > HPOS sync correctly handles deleted orders deleted while sync was off.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1373,8 +1373,10 @@ WHERE
 			global $wpdb;
 
 			// Exclude orders that do not exist in the posts table.
-			$order_ids_placeholder = implode( ', ', array_fill( 0, count( $load_posts_for ), '%d' ) );
-			$load_posts_for        = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( $order_ids_placeholder )", ...$load_posts_for ) ) ); // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( $load_posts_for ) {
+				$order_ids_placeholder = implode( ', ', array_fill( 0, count( $load_posts_for ), '%d' ) );
+				$load_posts_for        = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( $order_ids_placeholder )", ...$load_posts_for ) ) ); // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 
 			$post_orders = $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1367,7 +1367,17 @@ WHERE
 		}
 
 		$load_posts_for = array_diff( $order_ids, array_merge( self::$reading_order_ids, self::$backfilling_order_ids ) );
-		$post_orders    = $data_sync_enabled ? $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) ) : array();
+
+		$post_orders = array();
+		if ( $data_sync_enabled ) {
+			global $wpdb;
+
+			// Exclude orders that do not exist in the posts table.
+			$order_ids_placeholder = implode( ', ', array_fill( 0, count( $load_posts_for ), '%d' ) );
+			$load_posts_for        = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( $order_ids_placeholder )", ...$load_posts_for ) ) );
+
+			$post_orders = $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) );
+		}
 
 		$cogs_is_enabled = $this->cogs_is_enabled();
 
@@ -1534,8 +1544,13 @@ WHERE
 		$cpt_stores       = array();
 		$cpt_store_orders = array();
 		foreach ( $orders as $order_id => $order ) {
-			$table_data_store     = $order->get_data_store();
-			$cpt_data_store       = $table_data_store->get_cpt_data_store_instance();
+			$table_data_store = $order->get_data_store();
+			$cpt_data_store   = $table_data_store->get_cpt_data_store_instance();
+
+			if ( ! $cpt_data_store ) {
+				throw new \Exception( 'No CPT data store found for order ' . $order_id );
+			}
+
 			$cpt_store_class_name = get_class( $cpt_data_store );
 			if ( ! isset( $cpt_stores[ $cpt_store_class_name ] ) ) {
 				$cpt_stores[ $cpt_store_class_name ]       = $cpt_data_store;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1374,7 +1374,7 @@ WHERE
 
 			// Exclude orders that do not exist in the posts table.
 			$order_ids_placeholder = implode( ', ', array_fill( 0, count( $load_posts_for ), '%d' ) );
-			$load_posts_for        = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( $order_ids_placeholder )", ...$load_posts_for ) ) );
+			$load_posts_for        = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( $order_ids_placeholder )", ...$load_posts_for ) ) ); // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			$post_orders = $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) );
 		}
@@ -1533,6 +1533,8 @@ WHERE
 	 * @param array $orders    List of orders mapped by $order_id.
 	 *
 	 * @return array List of posts.
+	 *
+	 * @throws \Exception If no CPT data store is found for an order.
 	 */
 	private function get_post_orders_for_ids( array $orders ): array {
 		$order_ids = array_keys( $orders );
@@ -1548,7 +1550,7 @@ WHERE
 			$cpt_data_store   = $table_data_store->get_cpt_data_store_instance();
 
 			if ( ! $cpt_data_store ) {
-				throw new \Exception( 'No CPT data store found for order ' . $order_id );
+				throw new \Exception( sprintf( 'No CPT data store found for order %d.', absint( $order_id ) ) );
 			}
 
 			$cpt_store_class_name = get_class( $cpt_data_store );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#52837 describes an edge case where an order deleted from the legacy datastore while sync was off (thus not immediately propagated) will make further syncs (with compatibility mode enabled) fail with a fatal error, thus preventing completion of the sync.

The fatal error happens because we attempt to read the order **from the HPOS datastore** while processing deleted orders, which in turn triggers sync-on-fly from legacy for an order that no longer exists, resulting in a fatal.

This PR makes sure that a failure to load the legacy datastore for an order that was deleted doesn't produce a fatal error.

Closes #52837.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start with HPOS disabled and sync enabled:
   ```
   wp wc hpos disable
   wp wc hpos compatibility-mode enable
   ```

   If necessary, run `wp wc hpos sync` to ensure the commands can be executed.
1. Go to **WC > Orders** in the admin and create a new order with any details you like.
1. Ensure orders are synced up:
   ```
   wp wc hpos sync
   ```
1. Disable sync temporarily:
   ```
   wp wc hpos compatibility-mode disable
   ```
1. Go to **WC > Orders** and then trash and permanently delete the order you created. Alternatively, use the CLI to do this:

   ```
   wp post delete ORDER_ID --force
   ```
1. Enable sync again and run a sync:
   ```
   wp wc hpos compatibility-mode enable
   wp wc hpos sync
   ```

   No errors should occur.
1. (Optional) Check out `trunk` and repeat steps 2-6. Confirm that an error prevents the sync from completing.

<!-- End testing instructions -->