### PR TITLE
Fully read orders from the CPT datastore (including meta) for sync-on-read

### DIFF
--- a/plugins/woocommerce/changelog/fix-43126
+++ b/plugins/woocommerce/changelog/fix-43126
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+For HPOS sync-on-read, ensure metadata is fully read from the CPT datastore.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\Utilities\PostMetaUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
@@ -778,23 +779,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					}
 				}
 			}
-			if ( is_object( $meta_data->value ) && '__PHP_Incomplete_Class' === get_class( $meta_data->value ) ) {
-				$meta_value = maybe_serialize( $meta_data->value );
-				$result     = $wpdb->insert(
-					_get_meta_table( 'post' ),
-					array(
-						'post_id'    => $order->get_id(),
-						'meta_key'   => $meta_data->key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-						'meta_value' => $meta_value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-					),
-					array( '%d', '%s', '%s' )
-				);
-				wp_cache_delete( $order->get_id(), 'post_meta' );
-				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID %d: "%s"', $order->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
-			} else {
-				add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
-			}
+
+			PostMetaUtil::add_post_meta_safe( $order->get_id(), $meta_data->key, $meta_data->value, false );
 		}
 
 		// Find remaining meta that was deleted from the order but still present in the associated post.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1649,8 +1649,8 @@ WHERE
 	 *
 	 * Also provides an option to sync the metadata as well, since we are already computing the diff.
 	 *
-	 * @param \WC_Abstract_Order $order1 Order object read from posts.
-	 * @param \WC_Abstract_Order $order2 Order object read from COT.
+	 * @param \WC_Abstract_Order $order1 Order object read from COT.
+	 * @param \WC_Abstract_Order $order2 Order object read from posts.
 	 * @param bool               $sync   Whether to also sync the meta data.
 	 *
 	 * @return array Difference between post and COT meta data.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1540,6 +1540,8 @@ WHERE
 	 * @throws \Exception If no CPT data store is found for an order.
 	 */
 	private function get_post_orders_for_ids( array $orders ): array {
+		$legacy_handler = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\LegacyDataHandler::class );
+
 		$order_ids = array_keys( $orders );
 		foreach ( $order_ids as $order_id ) {
 			// Exclude orders where the CPT version is a placeholder post.
@@ -1584,7 +1586,7 @@ WHERE
 
 				try {
 					$cpt_order->set_id( $order_id );
-					$cpt_store->read( $cpt_order );
+					$legacy_handler->read_order_from_datastore( $cpt_order, $cpt_store );
 					$cpt_orders[ $order_id ] = $cpt_order;
 				} catch ( Exception $e ) {
 					// If the post record has been deleted (for instance, by direct query) then an exception may be thrown.
@@ -1674,7 +1676,7 @@ WHERE
 
 			$order2_values = ArrayUtil::select( $order2_meta_by_key[ $key ], 'value', ArrayUtil::SELECT_BY_ARRAY_KEY );
 			$new_diff      = ArrayUtil::deep_assoc_array_diff( $order1_values, $order2_values );
-			if ( ! empty( $new_diff ) && $sync ) {
+			if ( ! empty( $new_diff ) ) {
 				if ( count( $order2_values ) > 1 ) {
 					$sync && $order1->delete_meta_data( $key );
 					foreach ( $order2_values as $post_order_value ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1655,8 +1655,18 @@ WHERE
 	 * @return array Difference between post and COT meta data.
 	 */
 	private function get_diff_meta_data_between_orders( \WC_Abstract_Order &$order1, \WC_Abstract_Order $order2, $sync = false ): array {
-		$order1_meta        = ArrayUtil::select( $order1->get_meta_data(), 'get_data', ArrayUtil::SELECT_BY_OBJECT_METHOD );
-		$order2_meta        = ArrayUtil::select( $order2->get_meta_data(), 'get_data', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+		$order1_meta = ArrayUtil::select( $order1->get_meta_data(), 'get_data', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+		$order2_meta = ArrayUtil::select( $order2->get_meta_data(), 'get_data', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+
+		// Canonicalize metadata by converting scalar to string for comparison purposes.
+		if ( ! $sync ) {
+			$maybe_convert_to_string = function ( &$m ) {
+				$m['value'] = is_scalar( $m['value'] ) ? (string) $m['value'] : $m['value'];
+			};
+			array_walk( $order1_meta, $maybe_convert_to_string );
+			array_walk( $order2_meta, $maybe_convert_to_string );
+		}
+
 		$order1_meta_by_key = ArrayUtil::select_as_assoc( $order1_meta, 'key', ArrayUtil::SELECT_BY_ARRAY_KEY );
 		$order2_meta_by_key = ArrayUtil::select_as_assoc( $order2_meta, 'key', ArrayUtil::SELECT_BY_ARRAY_KEY );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -20,6 +20,7 @@ use WC_Abstract_Order;
 use WC_Data;
 use WC_Order;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
+use Automattic\WooCommerce\Internal\Utilities\PostMetaUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -3298,8 +3299,6 @@ CREATE TABLE $meta_table (
 	 * @return bool
 	 */
 	public function delete_meta( &$object, $meta ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
-		global $wpdb;
-
 		if ( $this->should_backfill_post_record() && isset( $meta->id ) ) {
 			// Let's get the actual meta key before its deleted for backfilling. We cannot delete just by ID because meta IDs are different in HPOS and posts tables.
 			$db_meta = $this->data_store_meta->get_metadata_by_id( $meta->id );
@@ -3314,23 +3313,7 @@ CREATE TABLE $meta_table (
 
 		if ( ! $changes_applied && $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() && isset( $meta->key ) ) {
 			self::$backfilling_order_ids[] = $object->get_id();
-			if ( is_object( $meta->value ) && '__PHP_Incomplete_Class' === get_class( $meta->value ) ) {
-				$meta_value = maybe_serialize( $meta->value );
-				$wpdb->delete(
-					_get_meta_table( 'post' ),
-					array(
-						'post_id'    => $object->get_id(),
-						'meta_key'   => $meta->key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-						'meta_value' => $meta_value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-					),
-					array( '%d', '%s', '%s' )
-				);
-				wp_cache_delete( $object->get_id(), 'post_meta' );
-				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID %d: "%s"', $object->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
-			} else {
-				delete_post_meta( $object->get_id(), $meta->key, $meta->value );
-			}
+			PostMetaUtil::delete_post_meta_safe( $object->get_id(), $meta->key, $meta->value );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $object->get_id() ) );
 		}
 
@@ -3373,7 +3356,7 @@ CREATE TABLE $meta_table (
 
 		if ( ! $changes_applied && $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
 			self::$backfilling_order_ids[] = $object->get_id();
-			update_post_meta( $object->get_id(), $meta->key, $meta->value );
+			PostMetaUtil::update_post_meta_safe( $object->get_id(), $meta->key, $meta->value );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $object->get_id() ) );
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/PostMetaUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PostMetaUtil.php
@@ -1,0 +1,129 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+
+/**
+ * A class of utilities for dealing with post meta.
+ *
+ * @since 10.4.0
+ */
+class PostMetaUtil {
+
+	/**
+	 * Check if a value is an incomplete object.
+	 *
+	 * @param mixed $value The value to check.
+	 * @return bool TRUE if the value is an incomplete object, FALSE otherwise.
+	 */
+	private static function is_incomplete_object( $value ): bool {
+		return is_object( $value ) && '__PHP_Incomplete_Class' === get_class( $value );
+	}
+
+	/**
+	 * Add a post meta value safely, ensuring incomplete objects are handled gracefully.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $key     The meta key.
+	 * @param mixed  $value   The meta value.
+	 * @param bool   $unique  Whether the meta value should be unique.
+	 * @return bool
+	 */
+	public static function add_post_meta_safe( int $post_id, string $key, $value, bool $unique = false ): bool {
+		global $wpdb;
+
+		if ( ! self::is_incomplete_object( $value ) ) {
+			return (bool) add_post_meta( $post_id, $key, $value, $unique );
+		}
+
+		$value  = maybe_serialize( $value );
+		$result = $wpdb->insert(
+			_get_meta_table( 'post' ),
+			array(
+				'post_id'    => $post_id,
+				'meta_key'   => $key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			),
+			array( '%d', '%s', '%s' )
+		);
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+		$logger->warning( sprintf( 'encountered a post meta value of type __PHP_Incomplete_Class during `add_post_meta_safe` in post with ID %d and key %s: "%s"', $post_id, $key, var_export( $value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		return (bool) $result;
+	}
+
+	/**
+	 * Delete a post meta value safely, ensuring incomplete objects are handled gracefully.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $key     The meta key.
+	 * @param mixed  $value   The meta value.
+	 * @return bool
+	 */
+	public static function delete_post_meta_safe( int $post_id, string $key, $value ): bool {
+		global $wpdb;
+
+		if ( ! self::is_incomplete_object( $value ) ) {
+			return delete_post_meta( $post_id, $key, $value );
+		}
+
+		$value = maybe_serialize( $value );
+
+		$result = $wpdb->delete(
+			_get_meta_table( 'post' ),
+			array(
+				'post_id'    => $post_id,
+				'meta_key'   => $key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			),
+			array( '%d', '%s', '%s' )
+		);
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+		$logger->warning( sprintf( 'encountered a post meta value of type __PHP_Incomplete_Class during `delete_post_meta_safe` in post with ID %d and key %s: "%s"', $post_id, $key, var_export( $value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		return (bool) $result;
+	}
+
+	/**
+	 * Update a post meta value safely, ensuring incomplete objects are handled gracefully.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $key     The meta key.
+	 * @param mixed  $value   The meta value.
+	 * @return bool
+	 */
+	public static function update_post_meta_safe( int $post_id, string $key, $value ): bool {
+		global $wpdb;
+
+		if ( ! self::is_incomplete_object( $value ) ) {
+			return (bool) update_post_meta( $post_id, $key, $value );
+		}
+
+		$value = maybe_serialize( $value );
+
+		$result = $wpdb->update(
+			_get_meta_table( 'post' ),
+			array(
+				'meta_value' => $value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			),
+			array(
+				'post_id'  => $post_id,
+				'meta_key' => $key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+		$logger->warning( sprintf( 'encountered a post meta value of type __PHP_Incomplete_Class during `update_post_meta_safe` in post with ID %d and key %s: "%s"', $post_id, $key, var_export( $value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		return (bool) $result;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Utilities/PostMetaUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PostMetaUtil.php
@@ -38,6 +38,10 @@ class PostMetaUtil {
 			return (bool) add_post_meta( $post_id, $key, $value, $unique );
 		}
 
+		if ( $unique && metadata_exists( 'post', $post_id, $key ) ) {
+			return false;
+		}
+
 		$value  = maybe_serialize( $value );
 		$result = $wpdb->insert(
 			_get_meta_table( 'post' ),

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -13,11 +13,14 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStoreMeta;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
+use Automattic\WooCommerce\Internal\DependencyManagement\ContainerException;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use WC_Data_Exception;
 use WC_Helper_Order;
 use WC_Helper_Payment_Token;
 use WC_Helper_Product;
@@ -3786,6 +3789,26 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$order->add_meta_data( $meta_key, $meta_value, false );
 		$order->save_meta_data();
 		$this->assertEquals( $wpdb->get_var( $query ), 2 ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query has already been prepared.
+	}
+
+	/**
+	 * @testdox Sync-on-read should update metadata as well.
+	 */
+	public function test_sync_on_read_updates_metadata() {
+		$this->toggle_cot_feature_and_usage( true );
+		$this->enable_cot_sync();
+
+		$order = OrderHelper::create_order();
+		$order->add_meta_data( 'foo', 'bar' );
+		$order->save();
+
+		// Update the meta data on the post.
+		update_post_meta( $order->get_id(), 'foo', 'baz' );
+
+		$fresh_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'baz', get_post_meta( $order->get_id(), 'foo', true ) );
+		$this->assertEquals( 'baz', $fresh_order->get_meta( 'foo', true, 'edit' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -13,14 +13,11 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStoreMeta;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
-use Automattic\WooCommerce\Internal\DependencyManagement\ContainerException;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use DateTime;
 use DateTimeZone;
-use Exception;
-use WC_Data_Exception;
 use WC_Helper_Order;
 use WC_Helper_Payment_Token;
 use WC_Helper_Product;
@@ -3411,7 +3408,11 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( 'Europe/Brussels', $meta_object_vars['timezone'] );
 
 		// Check that the log entry was created.
-		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID ' . $order->get_id() . ': "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
+		$serialized_meta_value = '"\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"';
+
+		$log_message = end( $fake_logger->warnings )['message'];
+		$this->assertStringContainsString( 'encountered a post meta value of type __PHP_Incomplete_Class during', $log_message );
+		$this->assertStringContainsString( $serialized_meta_value, $log_message );
 
 		// Test deleting meta data containing an object of a non-existent class.
 		$meta_data = $this->sut->read_meta( $order );
@@ -3424,7 +3425,9 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( '', get_post_meta( $order->get_id(), $meta_key, true ) );
 
 		// Check that the log entry was created.
-		$this->assertEquals( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID ' . $order->get_id() . ': "\'O:11:"geoiprecord":14:{s:12:"country_code";s:2:"BE";s:13:"country_code3";s:3:"BEL";s:12:"country_name";s:7:"Belgium";s:6:"region";s:3:"BRU";s:4:"city";s:8:"Brussels";s:11:"postal_code";s:4:"1000";s:8:"latitude";d:50.8333;s:9:"longitude";d:4.3333;s:9:"area_code";N;s:8:"dma_code";N;s:10:"metro_code";N;s:14:"continent_code";s:2:"EU";s:11:"region_name";s:16:"Brussels Capital";s:8:"timezone";s:15:"Europe/Brussels";}\'"', end( $fake_logger->warnings )['message'] );
+		$log_message = end( $fake_logger->warnings )['message'];
+		$this->assertStringContainsString( 'encountered a post meta value of type __PHP_Incomplete_Class during', $log_message );
+		$this->assertStringContainsString( $serialized_meta_value, $log_message );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When HPOS is enabled and compatibility mode are enabled, reading an order performs a comparison between the HPOS and posts version of the order and if the post seems to be newer, the order is updated to reflect those changes. This assumes the post was updated directly via `(add|update|delete)_post_meta()` or by manipulating the database.

The comparison we were using didn't fully compare the objects and was relying on priming the metadata cache instead of actually using the correct datastore to load the metadata.

This PR ensures that for sync on read, order and post are fully compared and the metadata is read from the datastore. Additionally, the updated methods handle incomplete objects (meta values that correspond to classes that can't be loaded at the moment) better by using new class `PostMetaUtil`.

Closes #43126.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start with HPOS and compatibility mode enabled:
   ```
   wp wc hpos enable
   wp wc hpos compatibility-mode enable
   ```

   You might need to run `wp wc hpos sync` first if the commands above fail.
1. Go to **WC > Orders** on the admin and create a new order with any data you want. Make sure to include a `foo` meta key with any value:
   <img width="1039" height="194" alt="Screenshot 2025-10-07 at 18 13 06" src="https://github.com/user-attachments/assets/b8be0401-e402-4f80-8539-e2d978134fca" />
   Keep the order edit screen open and take note of the order ID.
1. Use the command line to update the `foo` meta key:
   ```
   wp post meta update ORDER_ID foo baz
   ```
1. Refresh the order edit screen you were on and confirm that the new meta values appear (indicating the HPOS version of the order was updated to match those):
   <img width="1027" height="255" alt="Screenshot 2025-10-07 at 18 26 36" src="https://github.com/user-attachments/assets/c0383719-c719-4acf-84c9-f648dd7be831" />
1. Use the command line to add a new meta key `othermeta` meta key:
   ```
   wp post meta add ORDER_ID othermeta yes
   ```
1. Refresh the order edit screen and confirm that the new meta key/value appears.
1. (Optional) Check out `trunk` and repeat steps 2-6. Notice that when updating the `foo` meta key nothing happens and then suddenly both values are updated when adding the `othermeta` key.

<!-- End testing instructions -->