### PR TITLE
Fix block styles missing in email editor's iframe

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-933-some-styles-are-missing-in-editor-iframe
+++ b/packages/php/email-editor/changelog/wooprd-933-some-styles-are-missing-in-editor-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow fetching core blocks' styles in the editor's iframe for blocks that support emails

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -208,10 +208,6 @@ class Settings_Controller {
 				continue;
 			}
 
-			if ( strpos( $block->name, 'core/' ) !== false ) {
-				continue;
-			}
-
 			foreach ( $block->style_handles as $handle ) {
 				$allowed_iframe_style_handles[] = $handle . '-css';
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses the issue that occurs when the editor is used in an SPA, which fetches block styles per block, compared to a single CSS file in the classic admin. The styles were not added to the iframe because they are removed by the filtering mechanism introduced in https://github.com/woocommerce/woocommerce/pull/60354.

I tested the change with the theme Twenty Twenty-One and didn't experience any issues when editing the notification emails in classic Woo settings.

I'm not sure why the core blocks were skipped. I might be missing some issues.

Closes WOOPRD-933.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="884" height="1228" alt="Screenshot 2025-10-07 at 16 04 02" src="https://github.com/user-attachments/assets/5aff084d-04e6-45ce-bd10-51f581f0b4fb" /> |<img width="896" height="1252" alt="Screenshot 2025-10-07 at 16 04 24" src="https://github.com/user-attachments/assets/b557b783-14fe-40cd-8adc-ba09807b1365" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate the email block editor
2. Activate a classic theme
3. Open the editor and check that there are no unwanted styles present

For testing with a SPA, you can try adding two columns side by side. Without the styles, they render below each other.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
