### PR TITLE
Update data store to allow setting status when creating or editing coupons

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-944-implement-duplicate-and-activatedeactivate-actions
+++ b/plugins/woocommerce/changelog/wooprd-944-implement-duplicate-and-activatedeactivate-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update data store to allow setting status when creating or editing coupons

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -78,7 +78,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 				'woocommerce_new_coupon_data',
 				array(
 					'post_type'     => 'shop_coupon',
-					'post_status'   => 'publish',
+					'post_status'   => $coupon->get_status( 'edit' ) ? $coupon->get_status( 'edit' ) : 'publish',
 					'post_author'   => get_current_user_id(),
 					'post_title'    => $coupon->get_code( 'edit' ),
 					'post_content'  => '',

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -180,10 +180,11 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$coupon->save_meta_data();
 		$changes = $coupon->get_changes();
 
-		if ( array_intersect( array( 'code', 'description', 'date_created', 'date_modified' ), array_keys( $changes ) ) ) {
+		if ( array_intersect( array( 'code', 'description', 'date_created', 'date_modified', 'status' ), array_keys( $changes ) ) ) {
 			$post_data = array(
 				'post_title'        => $coupon->get_code( 'edit' ),
 				'post_excerpt'      => $coupon->get_description( 'edit' ),
+				'post_status'       => $coupon->get_status( 'edit' ),
 				'post_date'         => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getOffsetTimestamp() ),
 				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getTimestamp() ),
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $coupon->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
@@ -166,4 +166,38 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( array( 1 ), $coupon->get_used_by() );
 	}
 
+	/**
+	 * Test coupon status update from publish to draft.
+	 * @since 10.4.0
+	 */
+	public function test_coupon_status_update_to_draft() {
+		$coupon = WC_Helper_Coupon::create_coupon( 'update-test-coupon' );
+		$coupon->save();
+		$this->assertEquals( 'publish', $coupon->get_status() );
+
+		$coupon->set_status( 'draft' );
+		$coupon->save();
+
+		$updated_coupon = new WC_Coupon( $coupon->get_id() );
+		$this->assertEquals( 'draft', $updated_coupon->get_status() );
+	}
+
+	/**
+	 * Test coupon creation with specific status.
+	 * @since 10.4.0
+	 */
+	public function test_coupon_create_with_status() {
+		$code   = 'create-test-coupon-' . time();
+		$coupon = new WC_Coupon();
+		$coupon->set_code( $code );
+		$coupon->set_status( 'draft' );
+		$coupon->save();
+
+		$this->assertEquals( 'draft', $coupon->get_status() );
+		$this->assertNotEquals( 0, $coupon->get_id() );
+
+		$read_coupon = new WC_Coupon( $coupon->get_id() );
+		$this->assertEquals( 'draft', $read_coupon->get_status() );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-status-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-status-tests.php
@@ -1,0 +1,144 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * class WC_REST_Coupons_Controller_Status_Tests.
+ * Additional tests for coupon status changes in V3 REST API.
+ */
+class WC_REST_Coupons_Controller_Status_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Coupons_Controller();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that coupon status can be updated via PATCH request.
+	 */
+	public function test_patch_coupon_status() {
+		wp_set_current_user( $this->user );
+		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon', 'draft' );
+		$coupon->save();
+
+		$request = new WP_REST_Request( 'PATCH', '/wc/v3/coupons/' . $coupon->get_id() );
+		$request->set_body_params( array( 'status' => 'publish' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'publish', $data['status'] );
+
+		$updated_coupon = new WC_Coupon( $coupon->get_id() );
+		$this->assertEquals( 'publish', $updated_coupon->get_status() );
+	}
+
+	/**
+	 * Test that valid status values are accepted.
+	 */
+	public function test_coupon_status_change() {
+		wp_set_current_user( $this->user );
+		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon', 'draft' );
+		$coupon->save();
+
+		$statuses = array( 'publish', 'draft' );
+
+		foreach ( $statuses as $status ) {
+			$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/' . $coupon->get_id() );
+			$request->set_body_params( array( 'status' => $status ) );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status(), "Status '{$status}' should be accepted" );
+			$data = $response->get_data();
+			$this->assertEquals( $status, $data['status'] );
+		}
+	}
+
+	/**
+	 * Test that status update works with other coupon properties.
+	 */
+	public function test_coupon_status_update_with_other_properties() {
+		wp_set_current_user( $this->user );
+		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon', 'draft' );
+		$coupon->save();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/' . $coupon->get_id() );
+		$request->set_body_params(
+			array(
+				'status'      => 'publish',
+				'description' => 'Updated description',
+				'amount'      => '15.00',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'publish', $data['status'] );
+		$this->assertEquals( 'Updated description', $data['description'] );
+		$this->assertEquals( '15.00', $data['amount'] );
+	}
+
+	/**
+	 * Test that non-admin users cannot update coupon status.
+	 */
+	public function test_coupon_status_update_permissions() {
+		$subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon', 'draft' );
+		$coupon->save();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/' . $coupon->get_id() );
+		$request->set_body_params( array( 'status' => 'publish' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test that status update works with batch operations.
+	 */
+	public function test_batch_coupon_status_updates() {
+		wp_set_current_user( $this->user );
+		$coupon1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon-1', 'draft' );
+		$coupon2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'test-coupon-2', 'publish' );
+		$coupon1->save();
+		$coupon2->save();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons/batch' );
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'     => $coupon1->get_id(),
+						'status' => 'publish',
+					),
+					array(
+						'id'     => $coupon2->get_id(),
+						'status' => 'draft',
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount( 2, $data['update'] );
+		$this->assertEquals( 'publish', $data['update'][0]['status'] );
+		$this->assertEquals( 'draft', $data['update'][1]['status'] );
+
+		$updated_coupon1 = new WC_Coupon( $coupon1->get_id() );
+		$updated_coupon2 = new WC_Coupon( $coupon2->get_id() );
+		$this->assertEquals( 'publish', $updated_coupon1->get_status() );
+		$this->assertEquals( 'draft', $updated_coupon2->get_status() );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When managing coupons via REST API v3, there is no way to create the coupon with specific status or to change the status, as the data store has hardcoded values. This PR adds the option to set the coupon status.

Related to WOOPRD-944.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Call POST `/wp-json/wc/v3/coupons/{$id}` with `{id: "{$id}", status: "draft"}` and check that the status is changed accordingly. 
2. Call POST `/wp-json/wc/v3/coupons/{$id}` without specifying `id` but with specific (non-`publish`) status and check that the coupon is created with specified status.
```
{
    "amount": "0.00",
    "discount_type": "fixed_cart",
    "code": "testing",
    "status": "draft"
}
```
