### PR TITLE
Use WooCommerce Bot for generating release-related PRs

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -53,7 +53,7 @@ jobs:
 
           # Must run from trunk.
           if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
-              echo "::error::This workflow must be run from the `trunk` branch. Enter the release branch as input."
+              echo "::error::This workflow must be run from the 'trunk' branch. Enter the release branch as input."
               exit 1
           fi
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -150,13 +150,13 @@ jobs:
 
       - name: Open PR with changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           branch_name="bump-wc-version-to-${{ steps.compute-new-version.outputs.nextVersion }}/${{ github.run_id }}"
 
           # Configure Git.
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "woocommercebot"
+          git config --global user.email "woocommercebot@users.noreply.github.com"
 
           # Push changes.
           git checkout -b ${branch_name}

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -23,10 +23,10 @@ concurrency:
   group: release-compile-changelog-${{ inputs.version }}
 
 env:
-    GIT_COMMITTER_NAME: 'WooCommerce Bot'
-    GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-    GIT_AUTHOR_NAME: 'WooCommerce Bot'
-    GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+  GIT_COMMITTER_NAME: 'woocommercebot'
+  GIT_COMMITTER_EMAIL: 'woocommercebot@users.noreply.github.com'
+  GIT_AUTHOR_NAME: 'woocommercebot'
+  GIT_AUTHOR_EMAIL: 'woocommercebot@users.noreply.github.com'
 
 jobs:
   build-prep:
@@ -165,7 +165,7 @@ jobs:
         env:
           VERSION: ${{ steps.validate-selected-branch-version.outputs.current_version }}
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           echo "Using branch: $SELECTED_BRANCH"
           echo "Generating changelog for version: $VERSION"

--- a/.linear/release-kickoff-patch.md
+++ b/.linear/release-kickoff-patch.md
@@ -76,6 +76,10 @@ The following details are copied from the official [Building and Publishing guid
     - If the version was marked as stable in Step 1 above, check "Set as the latest release."
     - If the version was not marked as stable in Step 1 above, do not set as the latest release.
 
+### Step 3: Merge follow-up PRs
+
+- [ ] **Action:** Merge the "Update changelog.txt after {RELEASE_VERSION}.{PATCH_VERSION}" PR that is automatically created once the release tag is published on GitHub.
+
 ## Post Release Monitoring
 
 For all RC and stable releases, the release lead should continue to monitor for any bugs directly related to the latest version. Monitoring should continue for 3 days after a major release and 1 day for a point release.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR ensures that the bump version and changelog release workflows make use of the token for the WooCommerce Bot account, allowing CI to run on those automatically.

A minor release documentation update is also included.

Closes #61095.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repo including at least `trunk` and branch `release/10.3`.
1. Go to **Settings > Developer Settings** for your GitHub account and create a fine-grained token with access to your fork and at least the following permissions:
   - Actions (read/write)
   - Contents (read/write)
   - Issues (read/write)
   - Pull requests (read/write)
   Take note of the generated token.
1. Ensure actions are enabled in your fork and that the **CI** workflow is also enabled.
1. In your fork, go to **Settings > Secrets and variables > Actions** and create a secret named `WC_BOT_PR_CREATE_TOKEN` with the token in step 2 as value.
1. **Ensure bump version workflow uses WooCommerce Bot account:**
   1. In your fork, go to **Actions > Release: Bump version number** and run the workflow using `release/10.3` as branch and bump type `beta`.
   1. Wait until the workflow finishes.
   1. Confirm that a PR ("Bump WooCommerce version to ...") has been created, with your account as author and WooCommerce Bot as committer, like in the following screenshot.
      <img width="588" height="323" alt="Screenshot 2025-10-07 at 19 51 56" src="https://github.com/user-attachments/assets/6dcf0831-b3bc-407e-a68b-cadfd70da6c1" />
   1. Confirm that CI checks start running automatically on this PR:
      <img width="152" height="53" alt="Screenshot 2025-10-07 at 19 52 03" src="https://github.com/user-attachments/assets/f48cec96-a57f-4098-b28c-a868822a6839" />
1. **Ensure changelog workflow uses WooCommerce Bot account:**
   1. In your fork, go to **Actions > Release: Compile changelog** and run the workflow using `10.3` as version. 
   1. Wait until the workflow finishes.
   1. Similar to step 5, confirm that the generated PRs are associated with your account and WooCommerce Bot as committer, and that CI runs automatically.

<!-- End testing instructions -->