### PR TITLE
Move has_session and get_session_data from WC_Session_Handler to parent abstract WC_Session

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
@@ -139,4 +139,22 @@ abstract class WC_Session {
 	public function get_customer_id() {
 		return $this->_customer_id ?? '';
 	}
+
+	/**
+	 * Return true if the current user has an active session, i.e. a cookie to retrieve values.
+	 *
+	 * @return bool
+	 */
+	public function has_session() {
+		return isset( $_COOKIE[ $this->_cookie ] ) || $this->_has_cookie || is_user_logged_in();
+	}
+
+	/**
+	 * Get session data.
+	 *
+	 * @return array
+	 */
+	public function get_session_data() {
+		return $this->has_session() ? (array) $this->get_session( $this->get_customer_id(), array() ) : array();
+	}
 }

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -373,15 +373,6 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Return true if the current user has an active session, i.e. a cookie to retrieve values.
-	 *
-	 * @return bool
-	 */
-	public function has_session() {
-		return isset( $_COOKIE[ $this->_cookie ] ) || $this->_has_cookie || is_user_logged_in();
-	}
-
-	/**
 	 * Checks if the session is expiring.
 	 *
 	 * @return bool Whether session is expiring.
@@ -525,14 +516,6 @@ class WC_Session_Handler extends WC_Session {
 		return array( $customer_id, $session_expiration, $session_expiring, $cookie_hash );
 	}
 
-	/**
-	 * Get session data.
-	 *
-	 * @return array
-	 */
-	public function get_session_data() {
-		return $this->has_session() ? (array) $this->get_session( $this->get_customer_id(), array() ) : array();
-	}
 
 	/**
 	 * Gets a cache prefix. This is used in session names so the entire cache can be invalidated with 1 function call.

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -114,12 +114,4 @@ final class SessionHandler extends WC_Session {
 		}
 	}
 
-	/**
-	 * Return the current session data.
-	 *
-	 * @return array
-	 */
-	public function get_session_data() {
-		return $this->_data ?? [];
-	}
 }


### PR DESCRIPTION
It looks like that `get_session_data` is being used here  https://github.com/woocommerce/woocommerce/pull/60800, which will be released in 10.3. 

However, it seems that not all child classes of `abstract WC_Session` has this method. Only `WC_Session_Handler` has it. 

After reviewing `get_session_data`, I think it makes sense to move it to `abstract WC_Session` so all child classes can have it without any additional code. 

Reference: 
- https://github.com/Automattic/woocommerce-payments/pull/11080#discussion_r2412467417
- https://github.com/woocommerce/woocommerce/pull/61216#discussion_r2406559357 - this is where I found out specific code by PR #60800 causing the error:


> PHP Fatal error: Uncaught Error: Call to undefined method Automattic\WooCommerce\StoreApi\SessionHandler::get_session_data() in /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-cart-session.php on line 689

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the following query to enable `agentic_checkout`.
```cli
wp db query "insert into wp_options (option_name, option_value) values('woocommerce_feature_agentic_checkout_enabled', 'yes');”
```
2. In `trunk`, temporarily remove the `get_session_data` method from `plugins/woocommerce/src/StoreApi/SessionHandler.php` (this is a fix that was recently implemented [here](https://github.com/woocommerce/woocommerce/commit/188d238a08545fa9fe8bea5591fe91745432b834#diff-bf91cb081722593ea0b747ea1d4468c67c5bb3a7f32ffdc811fbfbdf188a0750R122-R124).

3. Make the following request using the `PRODUCT_ID` and note the `id` from the result:

```bash
  curl -X POST http://your-site.com/wp-json/wc/agentic/v1/checkout_sessions \
    -H "Content-Type: application/json" \
    -d '{
      "items": [{"id": PRODUCT_ID, "quantity": 2}],
      "buyer": {
        "first_name": "John",
        "last_name": "Doe",
        "email": "john@example.com"
      }
    }'
```

4. Make the following request using the `id` from the previous step as the `{session_id}`:

```bash
  curl -X POST http://your-site.com/wp-json/wc/agentic/v1/checkout_sessions/{session_id} \
    -H "Content-Type: application/json" \
    -d '{
      "items": [{"id": PRODUCT_ID, "quantity": 3}],
      "fulfillment_address": {
        "name": "John Doe",
        "line_one": "123 Main St",
        "city": "San Francisco",
        "state": "CA",
        "country": "US",
        "postal_code": "94105"
      }
    }'
```

5. You should see an `internal_server_error` in the response and an error similar to this one in the logs: 
```
PHP **Fatal** **error:**  Uncaught **Error**: Call to undefined method Automattic\WooCommerce\StoreApi\SessionHandler::get_session_data() in plugins/woocommerce/plugins/woocommerce/includes/class-wc-cart-session.php:689
```

6. Now switch to this PR branch `fix/add-get_session_data`.
7. Repeat the request from step 4 and ensure you don’t get the fatal error anymore.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
