### PR TITLE
Fix: Preserve anchor tags in email editor image blocks

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-5646-block-email-editor-links-are-removed-from-the-image-block
+++ b/packages/php/email-editor/changelog/wooplug-5646-block-email-editor-links-are-removed-from-the-image-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed image block link removal.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -332,7 +332,7 @@ class Image extends Abstract_Block_Renderer {
 	 * Parse block content to get image URL, image HTML and caption HTML.
 	 *
 	 * @param string $block_content Block content.
-	 * @return array{imageUrl: string, image: string, caption: string, class: string}|null
+	 * @return array{imageUrl: string, image: string, caption: string, class: string, anchor_tag_href: string}|null
 	 */
 	private function parse_block_content( string $block_content ): ?array {
 		// If block's image is not set, we don't need to parse the content.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -32,10 +32,11 @@ class Image extends Abstract_Block_Renderer {
 			return '';
 		}
 
-		$image_url = $parsed_html['imageUrl'];
-		$image     = $parsed_html['image'];
-		$caption   = $parsed_html['caption'];
-		$class     = $parsed_html['class'];
+		$image_url       = $parsed_html['imageUrl'];
+		$image           = $parsed_html['image'];
+		$caption         = $parsed_html['caption'];
+		$class           = $parsed_html['class'];
+		$anchor_tag_href = $parsed_html['anchor_tag_href'];
 
 		$parsed_block = $this->add_image_size_when_missing( $parsed_block, $image_url );
 		$image        = $this->add_image_dimensions( $image, $parsed_block );
@@ -43,7 +44,7 @@ class Image extends Abstract_Block_Renderer {
 		$image_with_wrapper = str_replace(
 			array( '{image_content}', '{caption_content}' ),
 			array( $image, $caption ),
-			$this->get_block_wrapper( $parsed_block, $rendering_context, $caption )
+			$this->get_block_wrapper( $parsed_block, $rendering_context, $caption, $anchor_tag_href )
 		);
 
 		$image_with_wrapper = $this->apply_rounded_style( $image_with_wrapper, $parsed_block );
@@ -211,8 +212,9 @@ class Image extends Abstract_Block_Renderer {
 	 * @param array             $parsed_block Parsed block.
 	 * @param Rendering_Context $rendering_context Rendering context.
 	 * @param string|null       $caption Caption.
+	 * @param string|null       $anchor_tag_href Anchor tag href.
 	 */
-	private function get_block_wrapper( array $parsed_block, Rendering_Context $rendering_context, ?string $caption ): string {
+	private function get_block_wrapper( array $parsed_block, Rendering_Context $rendering_context, ?string $caption, ?string $anchor_tag_href ): string {
 		$styles = array(
 			'border-collapse' => 'collapse',
 			'border-spacing'  => '0px',
@@ -271,7 +273,15 @@ class Image extends Abstract_Block_Renderer {
 			'style' => 'overflow: hidden;',
 		);
 
-		$image_html    = Table_Wrapper_Helper::render_table_wrapper( '{image_content}', $image_table_attrs, $image_cell_attrs );
+		$image_content = '{image_content}';
+		if ( $anchor_tag_href ) {
+			$image_content = sprintf(
+				'<a href="%s" rel="noopener nofollow" target="_blank">%s</a>',
+				esc_url( $anchor_tag_href ),
+				'{image_content}'
+			);
+		}
+		$image_html    = Table_Wrapper_Helper::render_table_wrapper( $image_content, $image_table_attrs, $image_cell_attrs );
 		$inner_content = $image_html . $caption_html;
 
 		return Table_Wrapper_Helper::render_table_wrapper( $inner_content, $table_attrs, $cell_attrs );
@@ -349,11 +359,15 @@ class Image extends Abstract_Block_Renderer {
 		$figcaption_html = $figcaption ? $dom_helper->get_outer_html( $figcaption ) : '';
 		$figcaption_html = str_replace( array( '<figcaption', '</figcaption>' ), array( '<span', '</span>' ), $figcaption_html );
 
+		$anchor_tag      = $dom_helper->find_element( 'a' );
+		$anchor_tag_href = $anchor_tag ? $dom_helper->get_attribute_value( $anchor_tag, 'href' ) : '';
+
 		return array(
-			'imageUrl' => $image_src ? $image_src : '',
-			'image'    => $this->cleanup_image_html( $image_html ),
-			'caption'  => $figcaption_html ? $figcaption_html : '',
-			'class'    => $image_class ? $image_class : '',
+			'imageUrl'        => $image_src ? $image_src : '',
+			'image'           => $this->cleanup_image_html( $image_html ),
+			'caption'         => $figcaption_html ? $figcaption_html : '',
+			'class'           => $image_class ? $image_class : '',
+			'anchor_tag_href' => $anchor_tag_href ? $anchor_tag_href : '',
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #61287 https://linear.app/a8c/issue/WOOPLUG-5646/block-email-editor-links-are-removed-from-the-image-block

(For Bug Fixes) Bug introduced in PR # .

This PR fixes a bug in the WooCommerce Email Editor where anchor tags (links) were being stripped from image blocks during email rendering. When users added links to images in the email editor, these links would not appear in the final rendered email output.

**Why this change is needed:**
- Users expect images with links to remain clickable in rendered emails
- The current implementation was only extracting image data but ignoring anchor tag information
- This creates a poor user experience where configured links are silently removed



### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Block email editor
2. Add an image block and add a link to it
3. Click on Save and Preview
4. On the Preview, try to click the image
5. Notice the image is clickable

Example block
```html
<!-- wp:image {"lightbox":{"enabled":false},"id":2426,"sizeSlug":"full","linkDestination":"custom"} -->
<figure class="wp-block-image size-full"><a href="https://oluwaseun.com.ng" target="_blank" rel=" noreferrer noopener"><img src="http://wordpress.mailpoet.orb.local/wp-content/uploads/2025/08/generated-image-1.png" alt="" class="wp-image-2426"/></a></figure>
<!-- /wp:image -->
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
