### PR TITLE
[Woo POS] Products catalog API: endpoint with mock response behind a feature flag

### DIFF
--- a/plugins/woocommerce/changelog/WOOMOB-1455-pos-catalog-api-skeleton
+++ b/plugins/woocommerce/changelog/WOOMOB-1455-pos-catalog-api-skeleton
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `/products/catalog` endpoints to v3 API with mock response behind a local feature flag.

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -25,6 +25,7 @@
 		"pattern-toolkit-full-composability": true,
 		"product-pre-publish-modal": false,
 		"product-custom-fields": true,
+		"products-catalog-api": false,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -26,6 +26,7 @@
 		"payment-gateway-suggestions": true,
 		"product-pre-publish-modal": false,
 		"product-custom-fields": true,
+		"products-catalog-api": true,
 		"printful": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -47,9 +47,14 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 					'callback'            => array( $this, 'generate_catalog' ),
 					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
 					'args'                => array(
-						'fields' => array(
+						'fields'         => array(
 							'description' => __( 'Product/variation fields to include in the catalog.', 'woocommerce' ),
 							'type'        => 'array',
+						),
+						'force_generate' => array(
+							'description' => __( 'Force generation of a new catalog file.', 'woocommerce' ),
+							'type'        => 'boolean',
+							'default'     => false,
 						),
 					),
 				),
@@ -87,10 +92,25 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function generate_catalog( $request ) {
-		// Mock job ID.
-		$response_data = array(
-			'job_id' => '134aec',
-		);
+		$fields         = $request->get_param( 'fields' ) ?? array();
+		$force_generate = $request->get_param( 'force_generate' ) ?? false;
+		$file_info      = $this->get_catalog_file_info( $fields );
+
+		// Check if file exists and force_generate is false.
+		if ( ! $force_generate && file_exists( $file_info['filepath'] ) ) {
+			$response_data = array(
+				'download_url' => $file_info['url'],
+			);
+		} else {
+			// Temporarily return job_id with base64-encoded fields for use in status endpoint.
+			// TODO: WOOMOB-1455 - Replace with proper async job tracking once we have a job tracking system.
+			$job_id = base64_encode( wp_json_encode( $fields ) );
+
+			$response_data = array(
+				'job_id' => $job_id,
+			);
+		}
+
 		return rest_ensure_response( $response_data );
 	}
 
@@ -108,11 +128,44 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 		$job_id = sanitize_text_field( $job_id );
-		// Mock response to make it look like the generation is complete.
+
+		// Decode fields from job_id (base64-encoded JSON).
+		$fields_json = base64_decode( $job_id, true );
+		if ( false === $fields_json ) {
+			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$fields = json_decode( $fields_json, true );
+		if ( null === $fields ) {
+			$fields = array();
+		}
+
+		// Get file info based on decoded fields.
+		$file_info = $this->get_catalog_file_info( $fields );
+
+		// Create directory if it doesn't exist.
+		if ( ! file_exists( $file_info['directory'] ) ) {
+			wp_mkdir_p( $file_info['directory'] );
+		}
+
+		// Generate empty catalog file.
+		$catalog_data = array(
+			'products'   => array(),
+			'variations' => array(),
+		);
+
+		// Write to file.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$result = file_put_contents( $file_info['filepath'], wp_json_encode( $catalog_data ) );
+
+		if ( false === $result ) {
+			return new WP_Error( 'catalog_generation_failed', __( 'Failed to generate catalog file.', 'woocommerce' ), array( 'status' => 500 ) );
+		}
+
 		$response_data = array(
 			'job_id'       => $job_id,
 			'status'       => 'complete',
-			'download_url' => rest_url( $this->namespace . '/' . $this->rest_base . '/download?filename=products_catalog.json' ),
+			'download_url' => $file_info['url'],
 		);
 		return rest_ensure_response( $response_data );
 	}
@@ -143,12 +196,15 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			'title'      => 'generate_products_catalog',
 			'type'       => 'object',
 			'properties' => array(
-				'job_id' => array(
-					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
+				'job_id'       => array(
+					'description' => __( 'Products catalog generation job ID. Returned when catalog needs to be generated.', 'woocommerce' ),
+					'type'        => 'string',
+				),
+				'download_url' => array(
+					'description' => __( 'Products catalog download URL. Returned when catalog file already exists.', 'woocommerce' ),
 					'type'        => 'string',
 				),
 			),
-			'required'   => array( 'job_id' ),
 		);
 	}
 
@@ -178,6 +234,28 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				),
 			),
 			'required'   => array( 'job_id', 'status' ),
+		);
+	}
+
+	/**
+	 * Get catalog file information based on fields.
+	 *
+	 * @param array $fields Product/variation fields to include in the catalog.
+	 * @return array Array with 'filepath', 'url', and 'directory' keys.
+	 */
+	private function get_catalog_file_info( $fields ) {
+		$upload_dir  = wp_upload_dir();
+		$catalog_dir = trailingslashit( $upload_dir['basedir'] ) . 'wc-catalog/';
+		$catalog_url = trailingslashit( $upload_dir['baseurl'] ) . 'wc-catalog/';
+
+		$today        = gmdate( 'Y-m-d' );
+		$catalog_hash = wp_hash( $today . wp_json_encode( $fields ) );
+		$filename     = "products-{$today}-{$catalog_hash}.json";
+
+		return array(
+			'filepath'  => $catalog_dir . $filename,
+			'url'       => $catalog_url . $filename,
+			'directory' => $catalog_dir,
 		);
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -45,9 +45,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_catalog' ),
-					'permission_callback' => array( $this, 'get_catalog_permissions_check' ),
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'request_catalog' ),
+					'permission_callback' => array( $this, 'request_catalog_permissions_check' ),
 					'args'                => array(
 						'fields'         => array(
 							'description'       => __( 'Product/variation fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
@@ -71,14 +71,14 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Get products catalog.
+	 * Request products catalog.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 *
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	public function get_catalog( $request ) {
+	public function request_catalog( $request ) {
 		$fields         = $this->sanitize_fields_arg( $request->get_param( 'fields' ) ?? array() );
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
 		$file_info      = $this->get_catalog_file_info( $fields );
@@ -101,14 +101,14 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Checks if a given request has permission to get products catalog.
+	 * Checks if a given request has permission to request products catalog.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
 	 *
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	public function get_catalog_permissions_check( $request ) {
+	public function request_catalog_permissions_check( $request ) {
 		if ( ! ( wc_rest_check_post_permissions( 'product', 'read' ) && wc_rest_check_post_permissions( 'product_variation', 'read' ) ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -101,6 +101,10 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
 		$file_info      = $this->get_catalog_file_info( $fields );
 
+		if ( is_wp_error( $file_info ) ) {
+			return $file_info;
+		}
+
 		// Check if file exists and force_generate is false.
 		if ( ! $force_generate && file_exists( $file_info['filepath'] ) ) {
 			$response_data = array(
@@ -108,6 +112,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			);
 		} else {
 			// Temporarily return job_id with base64-encoded fields for use in status endpoint.
+			// Base64 encoding ensures the job_id is URL-safe when passed as a query parameter.
 			// TODO: WOOMOB-1455 - Replace with proper async job tracking once we have a job tracking system.
 			$job_id = base64_encode( wp_json_encode( $fields ) );
 
@@ -145,8 +150,15 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			$fields = array();
 		}
 
+		// Sanitize and canonicalize fields.
+		$fields = $this->sanitize_fields_arg( $fields );
+
 		// Get file info based on decoded fields.
 		$file_info = $this->get_catalog_file_info( $fields );
+
+		if ( is_wp_error( $file_info ) ) {
+			return $file_info;
+		}
 
 		// Create directory if it doesn't exist.
 		if ( ! file_exists( $file_info['directory'] ) ) {
@@ -273,10 +285,15 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * Get catalog file information based on fields.
 	 *
 	 * @param array $fields Product/variation fields to include in the catalog.
-	 * @return array Array with 'filepath', 'url', and 'directory' keys.
+	 * @return array|WP_Error Array with 'filepath', 'url', and 'directory' keys, or WP_Error on failure.
 	 */
 	private function get_catalog_file_info( $fields ) {
-		$upload_dir  = wp_upload_dir();
+		$upload_dir = wp_upload_dir();
+
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new WP_Error( 'upload_dir_error', $upload_dir['error'], array( 'status' => 500 ) );
+		}
+
 		$catalog_dir = trailingslashit( $upload_dir['basedir'] ) . 'wc-catalog/';
 		$catalog_url = trailingslashit( $upload_dir['baseurl'] ) . 'wc-catalog/';
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -48,13 +48,18 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
 					'args'                => array(
 						'fields'         => array(
-							'description' => __( 'Product/variation fields to include in the catalog.', 'woocommerce' ),
-							'type'        => 'array',
+							'description'       => __( 'Product/variation fields to include in the catalog.', 'woocommerce' ),
+							'type'              => 'array',
+							'items'             => array( 'type' => 'string' ),
+							'default'           => array(),
+							'validate_callback' => array( $this, 'validate_fields_arg' ),
+							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
 						),
 						'force_generate' => array(
-							'description' => __( 'Force generation of a new catalog file.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
+							'description'       => __( 'Force generation of a new catalog file.', 'woocommerce' ),
+							'type'              => 'boolean',
+							'default'           => false,
+							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
 					),
 				),
@@ -92,7 +97,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function generate_catalog( $request ) {
-		$fields         = $request->get_param( 'fields' ) ?? array();
+		$fields         = $this->sanitize_fields_arg( $request->get_param( 'fields' ) ?? array() );
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
 		$file_info      = $this->get_catalog_file_info( $fields );
 
@@ -186,6 +191,33 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	}
 
 	/**
+	 * Validate fields argument.
+	 *
+	 * @param mixed $value The value to validate.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+	 */
+	public function validate_fields_arg( $value ) {
+		if ( ! is_array( $value ) ) {
+			return new WP_Error( 'invalid_fields', __( 'fields must be an array of strings.', 'woocommerce' ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Sanitize fields argument.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 * @return array Sanitized and canonicalized fields array.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+	 */
+	public function sanitize_fields_arg( $value ) {
+		return $this->canonicalize_fields( is_array( $value ) ? $value : array() );
+	}
+
+	/**
 	 * Products catalog generation schema.
 	 *
 	 * @return array Products catalog generation schema data.
@@ -257,5 +289,17 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			'url'       => $catalog_url . $filename,
 			'directory' => $catalog_dir,
 		);
+	}
+
+	/**
+	 * Canonicalize fields array for stable hashing.
+	 *
+	 * @param array $fields Product/variation fields.
+	 * @return array Canonicalized fields array.
+	 */
+	private function canonicalize_fields( array $fields ) {
+		$fields = array_values( array_unique( array_map( 'strval', $fields ) ) );
+		sort( $fields, SORT_STRING );
+		return $fields;
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -58,7 +58,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
 						),
 						'force_generate' => array(
-							'description'       => __( 'Whether to generate of a new catalog file regardless of whether a catalog file already exists.', 'woocommerce' ),
+							'description'       => __( 'Whether to generate a new catalog file regardless of whether a catalog file already exists.', 'woocommerce' ),
 							'type'              => 'boolean',
 							'default'           => false,
 							'sanitize_callback' => 'rest_sanitize_boolean',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * REST API Products Catalog controller
+ *
+ * Handles requests to the products/catalog endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   10.4.0
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Enums\ProductType;
+
+/**
+ * REST API Products Catalog controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'products/catalog';
+
+	/**
+	 * Register the routes for products catalog.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/generate',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'generate_catalog' ),
+					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
+					'args'                => array(
+						'fields' => array(
+							'description' => __( 'Product/variation fields to include in the catalog.', 'woocommerce' ),
+							'type'        => 'array',
+						),
+					),
+				),
+				'schema' => array( $this, 'generate_products_catalog_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/status',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_catalog_generation_status' ),
+					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
+					'args'                => array(
+						'job_id' => array(
+							'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+				'schema' => array( $this, 'catalog_generation_status_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/download',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'download_catalog' ),
+					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
+					'args'                => array(
+						'filename' => array(
+							'description' => __( 'Products catalog filename to download.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+				'schema' => array( $this, 'catalog_download_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Generate products catalog.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function generate_catalog( $request ) {
+		// Mock job ID.
+		$response_data = array(
+			'job_id' => '134aec',
+		);
+		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Get products catalog generation job status.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_catalog_generation_status( $request ) {
+		$job_id = $request->get_param( 'job_id' );
+		// Mock response to make it look like the generation is complete.
+		$response_data = array(
+			'job_id'       => $job_id,
+			'status'       => 'complete',
+			'download_url' => rest_url( $this->namespace . '/' . $this->rest_base . '/download?filename=products_catalog.json' ),
+		);
+		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Download export file.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function download_catalog( $request ) {
+		// Mock empty catalog.
+		$response_data = array(
+			'products'   => array(),
+			'variations' => array(),
+		);
+		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Checks if a given request has permission to generate products catalog.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
+	 */
+	public function generate_products_catalog_permissions_check( $request ) {
+		if ( ! ( wc_rest_check_post_permissions( 'product', 'read' ) && wc_rest_check_post_permissions( 'product_variation', 'read' ) ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Products catalog generation schema.
+	 *
+	 * @return array Products catalog generation schema data.
+	 */
+	private function catalog_generation_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'generate_products_catalog',
+			'type'       => 'object',
+			'properties' => array(
+				'job_id' => array(
+					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Products catalog generation status schema.
+	 *
+	 * @return array Products catalog generation status schema data.
+	 */
+	private function catalog_generation_status_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'products_catalog_generation_status',
+			'type'       => 'object',
+			'properties' => array(
+				'job_id'       => array(
+					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+				'status'       => array(
+					'description' => __( 'Products catalog generation status. Possible values: pending, processing, complete, failed.', 'woocommerce' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+				'download_url' => array(
+					'description' => __( 'Products catalog download URL when the generation is complete.', 'woocommerce' ),
+					'type'        => 'string',
+					'required'    => false,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Products catalog download schema.
+	 *
+	 * @return array Products catalog download schema data.
+	 */
+	private function catalog_download_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'products_catalog_download',
+			'type'       => 'object',
+			'properties' => array(
+				'products'   => array(
+					'description' => __( 'Products catalog products.', 'woocommerce' ),
+					'type'        => 'array',
+					'required'    => true,
+				),
+				'variations' => array(
+					'description' => __( 'Products catalog variations.', 'woocommerce' ),
+					'type'        => 'array',
+					'required'    => true,
+				),
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -105,6 +105,8 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function generate_catalog( $request ) {
 		// Mock job ID.
@@ -119,6 +121,8 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function get_catalog_generation_status( $request ) {
 		$job_id = $request->get_param( 'job_id' );
@@ -132,10 +136,12 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Download export file.
+	 * Download catalog file.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function download_catalog( $request ) {
 		// Mock empty catalog.
@@ -151,6 +157,8 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
 	public function generate_products_catalog_permissions_check( $request ) {
 		if ( ! ( wc_rest_check_post_permissions( 'product', 'read' ) && wc_rest_check_post_permissions( 'product_variation', 'read' ) ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -343,7 +343,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 */
 	private function base64url_encode( $data ) {
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		return str_replace( array( '+', '/', '=' ), array( '-', '_', '' ), base64_encode( $data ) );
+		$b64 = base64_encode( $data );
+		$b64 = strtr( $b64, '+/', '-_' );
+		return rtrim( $b64, '=' );
 	}
 
 	/**
@@ -353,7 +355,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @return string|false Decoded data or false on failure.
 	 */
 	private function base64url_decode( $data ) {
+		$b64  = strtr( $data, '-_', '+/' );
+		$b64 .= str_repeat( '=', ( 4 - strlen( $b64 ) % 4 ) % 4 );
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		return base64_decode( str_replace( array( '-', '_' ), array( '+', '/' ), $data ), true );
+		return base64_decode( $b64, true );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -183,9 +183,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'job_id' => array(
 					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
 					'type'        => 'string',
-					'required'    => true,
 				),
 			),
+			'required'   => array( 'job_id' ),
 		);
 	}
 
@@ -203,20 +203,18 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'job_id'       => array(
 					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
 					'type'        => 'string',
-					'required'    => true,
 				),
 				'status'       => array(
 					'description' => __( 'Products catalog generation status. Possible values: pending, processing, complete, failed.', 'woocommerce' ),
 					'type'        => 'string',
 					'enum'        => array( 'pending', 'processing', 'complete', 'failed' ),
-					'required'    => true,
 				),
 				'download_url' => array(
 					'description' => __( 'Products catalog download URL when the generation is complete.', 'woocommerce' ),
 					'type'        => 'string',
-					'required'    => false,
 				),
 			),
+			'required'   => array( 'job_id', 'status' ),
 		);
 	}
 
@@ -234,14 +232,13 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'products'   => array(
 					'description' => __( 'Products catalog products.', 'woocommerce' ),
 					'type'        => 'array',
-					'required'    => true,
 				),
 				'variations' => array(
 					'description' => __( 'Products catalog variations.', 'woocommerce' ),
 					'type'        => 'array',
-					'required'    => true,
 				),
 			),
+			'required'   => array( 'products', 'variations' ),
 		);
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -124,6 +124,10 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 */
 	public function get_catalog_generation_status( $request ) {
 		$job_id = $request->get_param( 'job_id' );
+		if ( empty( $job_id ) || ! is_string( $job_id ) ) {
+			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+		$job_id = sanitize_text_field( $job_id );
 		// Mock response to make it look like the generation is complete.
 		$response_data = array(
 			'job_id'       => $job_id,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -183,8 +183,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		);
 
 		// Write to file.
+		$json = wp_json_encode( $catalog_data );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		$result = file_put_contents( $file_info['filepath'], wp_json_encode( $catalog_data ) );
+		$result = file_put_contents( $file_info['filepath'], $json, LOCK_EX );
 
 		if ( false === $result ) {
 			return new WP_Error( 'catalog_generation_failed', __( 'Failed to generate catalog file.', 'woocommerce' ), array( 'status' => 500 ) );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -53,7 +53,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 							'description'       => __( 'Product/variation fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
 							'type'              => array( 'array', 'string' ),
 							'items'             => array( 'type' => 'string' ),
-							'default'           => array(),
+							'required'          => true,
 							'validate_callback' => array( $this, 'validate_fields_arg' ),
 							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
 						),
@@ -127,6 +127,11 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		if ( ! is_array( $value ) && ! is_string( $value ) ) {
 			return new WP_Error( 'invalid_fields', __( 'fields must be an array of strings or a comma-separated string.', 'woocommerce' ) );
 		}
+
+		if ( ( is_array( $value ) && empty( $value ) ) || ( is_string( $value ) && '' === trim( $value ) ) ) {
+			return new WP_Error( 'invalid_fields', __( 'fields cannot be empty.', 'woocommerce' ) );
+		}
+
 		return true;
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -12,6 +12,8 @@ declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
+
 /**
  * REST API Products Catalog controller class.
  *
@@ -203,17 +205,11 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @return true|WP_Error True on success, WP_Error on failure.
 	 */
 	private function generate_catalog_file( $file_info ) {
-		// Ensure directory exists.
-		if ( ! wp_mkdir_p( $file_info['directory'] ) ) {
-			return new WP_Error( 'catalog_dir_creation_failed', __( 'Unable to create catalog directory.', 'woocommerce' ), array( 'status' => 500 ) );
-		}
-
-		// Prevent directory listing.
-		$index_file = trailingslashit( $file_info['directory'] ) . 'index.html';
-		if ( ! file_exists( $index_file ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			$result = file_put_contents( $index_file, '' );
-			// Non-critical: ignore if index.html creation fails.
+		// Ensure directory exists and is not indexable.
+		try {
+			FilesystemUtil::mkdir_p_not_indexable( $file_info['directory'] );
+		} catch ( \Exception $exception ) {
+			return new WP_Error( 'catalog_dir_creation_failed', $exception->getMessage(), array( 'status' => 500 ) );
 		}
 
 		// Generate empty catalog file.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -207,7 +207,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	private function generate_catalog_file( $file_info ) {
 		// Ensure directory exists and is not indexable.
 		try {
-			FilesystemUtil::mkdir_p_not_indexable( $file_info['directory'] );
+			FilesystemUtil::mkdir_p_not_indexable( $file_info['directory'], true );
 		} catch ( \Exception $exception ) {
 			return new WP_Error( 'catalog_dir_creation_failed', $exception->getMessage(), array( 'status' => 500 ) );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -40,63 +40,43 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/generate',
+			'/' . $this->rest_base,
 			array(
 				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'generate_catalog' ),
-					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_catalog' ),
+					'permission_callback' => array( $this, 'get_catalog_permissions_check' ),
 					'args'                => array(
 						'fields'         => array(
-							'description'       => __( 'Product/variation fields to include in the catalog.', 'woocommerce' ),
-							'type'              => 'array',
+							'description'       => __( 'Product/variation fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
+							'type'              => array( 'array', 'string' ),
 							'items'             => array( 'type' => 'string' ),
 							'default'           => array(),
 							'validate_callback' => array( $this, 'validate_fields_arg' ),
 							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
 						),
 						'force_generate' => array(
-							'description'       => __( 'Force generation of a new catalog file.', 'woocommerce' ),
+							'description'       => __( 'Whether to generate of a new catalog file regardless of whether a catalog file already exists.', 'woocommerce' ),
 							'type'              => 'boolean',
 							'default'           => false,
 							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
 					),
 				),
-				'schema' => array( $this, 'catalog_generation_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/status',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_catalog_generation_status' ),
-					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
-					'args'                => array(
-						'job_id' => array(
-							'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
-							'type'        => 'string',
-							'required'    => true,
-						),
-					),
-				),
-				'schema' => array( $this, 'catalog_generation_status_schema' ),
+				'schema' => array( $this, 'catalog_schema' ),
 			)
 		);
 	}
 
 	/**
-	 * Generate products catalog.
+	 * Get products catalog.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 *
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	public function generate_catalog( $request ) {
+	public function get_catalog( $request ) {
 		$fields         = $this->sanitize_fields_arg( $request->get_param( 'fields' ) ?? array() );
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
 		$file_info      = $this->get_catalog_file_info( $fields );
@@ -108,61 +88,121 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		// Check if file exists and force_generate is false.
 		if ( ! $force_generate && file_exists( $file_info['filepath'] ) ) {
 			$response_data = array(
+				'status'       => 'complete',
 				'download_url' => $file_info['url'],
 			);
-		} else {
-			// Temporarily return job_id with URL-safe base64-encoded fields for use in status endpoint.
-			// WOOMOB-1455 - Replace base64 fields job ID with proper async job tracking once we have a job tracking system.
-			$job_id = $this->base64url_encode( wp_json_encode( $fields ) );
-
-			$response_data = array(
-				'job_id' => $job_id,
-			);
+			return rest_ensure_response( $response_data );
 		}
 
-		return rest_ensure_response( $response_data );
+		// Generate catalog and return response.
+		return $this->catalog_generation_response( $file_info );
 	}
 
 	/**
-	 * Get products catalog generation job status.
+	 * Checks if a given request has permission to get products catalog.
 	 *
-	 * @param WP_REST_Request $request Request data.
-	 * @return WP_Error|WP_REST_Response
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool
 	 *
 	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	public function get_catalog_generation_status( $request ) {
-		$job_id = $request->get_param( 'job_id' );
-		if ( empty( $job_id ) || ! is_string( $job_id ) ) {
-			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
+	public function get_catalog_permissions_check( $request ) {
+		if ( ! ( wc_rest_check_post_permissions( 'product', 'read' ) && wc_rest_check_post_permissions( 'product_variation', 'read' ) ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Validate fields argument.
+	 *
+	 * @param mixed $value The value to validate.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+	 */
+	public function validate_fields_arg( $value ) {
+		if ( ! is_array( $value ) && ! is_string( $value ) ) {
+			return new WP_Error( 'invalid_fields', __( 'fields must be an array of strings or a comma-separated string.', 'woocommerce' ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Sanitize fields argument.
+	 *
+	 * @param mixed $value The value to sanitize. Can be an array or comma-separated string.
+	 * @return array Sanitized and canonicalized fields array.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+	 */
+	public function sanitize_fields_arg( $value ) {
+		if ( is_string( $value ) ) {
+			$value = array_map( 'trim', explode( ',', $value ) );
+		}
+		return $this->canonicalize_fields( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Products catalog schema.
+	 *
+	 * @return array Products catalog schema data.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+	 */
+	public function catalog_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'products_catalog',
+			'type'       => 'object',
+			'properties' => array(
+				'status'       => array(
+					'description' => __( 'Products catalog generation status.', 'woocommerce' ),
+					'type'        => 'string',
+					'enum'        => array( 'pending', 'processing', 'complete', 'failed' ),
+				),
+				'download_url' => array(
+					'description' => __( 'Products catalog file URL. Null when catalog is not ready.', 'woocommerce' ),
+					'type'        => array( 'string', 'null' ),
+					'format'      => 'uri',
+				),
+			),
+			'required'   => array( 'status', 'download_url' ),
+		);
+	}
+
+	/**
+	 * Generate catalog and return REST response.
+	 *
+	 * This function orchestrates catalog generation and returns the appropriate response.
+	 * In the future, it will check if a generation based on the file_info is in progress.
+	 *
+	 * @param array $file_info File information with 'filepath', 'url', and 'directory' keys.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error on failure.
+	 */
+	private function catalog_generation_response( $file_info ) {
+		// In the future, check if generation is in progress and return appropriate status.
+		// For now, generate synchronously.
+		$result = $this->generate_catalog_file( $file_info );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		// Enforce size and URL-safe base64 charset.
-		if ( strlen( $job_id ) > 4096 || ! preg_match( '/^[A-Za-z0-9\-_]+$/', $job_id ) ) {
-			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
+		return rest_ensure_response(
+			array(
+				'status'       => 'complete',
+				'download_url' => $file_info['url'],
+			)
+		);
+	}
 
-		// Decode fields from job_id (URL-safe base64-encoded JSON).
-		$fields_json = $this->base64url_decode( $job_id );
-		if ( false === $fields_json ) {
-			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID encoding.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
-
-		$fields = json_decode( $fields_json, true );
-		if ( ! is_array( $fields ) ) {
-			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID format.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
-
-		// Sanitize and canonicalize fields.
-		$fields = $this->sanitize_fields_arg( $fields );
-
-		// Get file info based on decoded fields.
-		$file_info = $this->get_catalog_file_info( $fields );
-
-		if ( is_wp_error( $file_info ) ) {
-			return $file_info;
-		}
-
+	/**
+	 * Generate catalog file and save it to the specified file path.
+	 *
+	 * @param array $file_info File information with 'filepath', 'url', and 'directory' keys.
+	 * @return true|WP_Error True on success, WP_Error on failure.
+	 */
+	private function generate_catalog_file( $file_info ) {
 		// Ensure directory exists.
 		if ( ! wp_mkdir_p( $file_info['directory'] ) ) {
 			return new WP_Error( 'catalog_dir_creation_failed', __( 'Unable to create catalog directory.', 'woocommerce' ), array( 'status' => 500 ) );
@@ -191,116 +231,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			return new WP_Error( 'catalog_generation_failed', __( 'Failed to generate catalog file.', 'woocommerce' ), array( 'status' => 500 ) );
 		}
 
-		$response_data = array(
-			'job_id'       => $job_id,
-			'status'       => 'complete',
-			'download_url' => $file_info['url'],
-		);
-		return rest_ensure_response( $response_data );
-	}
-
-	/**
-	 * Checks if a given request has permission to generate products catalog.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|bool
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function generate_products_catalog_permissions_check( $request ) {
-		if ( ! ( wc_rest_check_post_permissions( 'product', 'read' ) && wc_rest_check_post_permissions( 'product_variation', 'read' ) ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
-		}
 		return true;
-	}
-
-	/**
-	 * Validate fields argument.
-	 *
-	 * @param mixed $value The value to validate.
-	 * @return true|WP_Error True if valid, WP_Error otherwise.
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function validate_fields_arg( $value ) {
-		if ( ! is_array( $value ) ) {
-			return new WP_Error( 'invalid_fields', __( 'fields must be an array of strings.', 'woocommerce' ) );
-		}
-		return true;
-	}
-
-	/**
-	 * Sanitize fields argument.
-	 *
-	 * @param mixed $value The value to sanitize.
-	 * @return array Sanitized and canonicalized fields array.
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function sanitize_fields_arg( $value ) {
-		return $this->canonicalize_fields( is_array( $value ) ? $value : array() );
-	}
-
-	/**
-	 * Products catalog generation schema.
-	 *
-	 * @return array Products catalog generation schema data.
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function catalog_generation_schema() {
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'generate_products_catalog',
-			'type'       => 'object',
-			'properties' => array(
-				'job_id'       => array(
-					'description' => __( 'Products catalog generation job ID. Returned when catalog needs to be generated.', 'woocommerce' ),
-					'type'        => 'string',
-				),
-				'download_url' => array(
-					'description' => __( 'Products catalog download URL. Returned when catalog file already exists.', 'woocommerce' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-			),
-			'anyOf'      => array(
-				array( 'required' => array( 'job_id' ) ),
-				array( 'required' => array( 'download_url' ) ),
-			),
-		);
-	}
-
-	/**
-	 * Products catalog generation status schema.
-	 *
-	 * @return array Products catalog generation status schema data.
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function catalog_generation_status_schema() {
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'products_catalog_generation_status',
-			'type'       => 'object',
-			'properties' => array(
-				'job_id'       => array(
-					'description' => __( 'Products catalog generation job ID.', 'woocommerce' ),
-					'type'        => 'string',
-				),
-				'status'       => array(
-					'description' => __( 'Products catalog generation status. Possible values: pending, processing, complete, failed.', 'woocommerce' ),
-					'type'        => 'string',
-					'enum'        => array( 'pending', 'processing', 'complete', 'failed' ),
-				),
-				'download_url' => array(
-					'description' => __( 'Products catalog download URL when the generation is complete.', 'woocommerce' ),
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-			),
-			'required'   => array( 'job_id', 'status' ),
-		);
 	}
 
 	/**
@@ -340,31 +271,5 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$fields = array_values( array_unique( array_map( 'strval', $fields ) ) );
 		sort( $fields, SORT_STRING );
 		return $fields;
-	}
-
-	/**
-	 * Encode data using URL-safe base64.
-	 *
-	 * @param string $data Data to encode.
-	 * @return string URL-safe base64-encoded string.
-	 */
-	private function base64url_encode( $data ) {
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$b64 = base64_encode( $data );
-		$b64 = strtr( $b64, '+/', '-_' );
-		return rtrim( $b64, '=' );
-	}
-
-	/**
-	 * Decode URL-safe base64 data.
-	 *
-	 * @param string $data URL-safe base64-encoded string.
-	 * @return string|false Decoded data or false on failure.
-	 */
-	private function base64url_decode( $data ) {
-		$b64  = strtr( $data, '-_', '+/' );
-		$b64 .= str_repeat( '=', ( 4 - strlen( $b64 ) % 4 ) % 4 );
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		return base64_decode( $b64, true );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -112,7 +112,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			);
 		} else {
 			// Temporarily return job_id with URL-safe base64-encoded fields for use in status endpoint.
-			// TODO: WOOMOB-1455 - Replace with proper async job tracking once we have a job tracking system.
+			// WOOMOB-1455 - Replace base64 fields job ID with proper async job tracking once we have a job tracking system.
 			$job_id = $this->base64url_encode( wp_json_encode( $fields ) );
 
 			$response_data = array(
@@ -172,7 +172,8 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$index_file = trailingslashit( $file_info['directory'] ) . 'index.html';
 		if ( ! file_exists( $index_file ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			@file_put_contents( $index_file, '' );
+			$result = file_put_contents( $index_file, '' );
+			// Non-critical: ignore if index.html creation fails.
 		}
 
 		// Generate empty catalog file.
@@ -243,8 +244,10 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * Products catalog generation schema.
 	 *
 	 * @return array Products catalog generation schema data.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	function catalog_generation_schema() {
+	public function catalog_generation_schema() {
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'generate_products_catalog',
@@ -266,8 +269,10 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * Products catalog generation status schema.
 	 *
 	 * @return array Products catalog generation status schema data.
+	 *
+	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
 	 */
-	function catalog_generation_status_schema() {
+	public function catalog_generation_status_schema() {
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'products_catalog_generation_status',
@@ -337,6 +342,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @return string URL-safe base64-encoded string.
 	 */
 	private function base64url_encode( $data ) {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return str_replace( array( '+', '/', '=' ), array( '-', '_', '' ), base64_encode( $data ) );
 	}
 
@@ -347,6 +353,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @return string|false Decoded data or false on failure.
 	 */
 	private function base64url_decode( $data ) {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		return base64_decode( str_replace( array( '-', '_' ), array( '+', '/' ), $data ), true );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -137,7 +137,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 *
 	 * @return array Products catalog generation schema data.
 	 */
-	private function catalog_generation_schema() {
+	function catalog_generation_schema() {
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'generate_products_catalog',
@@ -157,7 +157,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 *
 	 * @return array Products catalog generation status schema data.
 	 */
-	private function catalog_generation_status_schema() {
+	function catalog_generation_status_schema() {
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'products_catalog_generation_status',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -261,7 +261,12 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'download_url' => array(
 					'description' => __( 'Products catalog download URL. Returned when catalog file already exists.', 'woocommerce' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 				),
+			),
+			'anyOf'      => array(
+				array( 'required' => array( 'job_id' ) ),
+				array( 'required' => array( 'download_url' ) ),
 			),
 		);
 	}
@@ -291,6 +296,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'download_url' => array(
 					'description' => __( 'Products catalog download URL when the generation is complete.', 'woocommerce' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 				),
 			),
 			'required'   => array( 'job_id', 'status' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -12,8 +12,6 @@ declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Enums\ProductType;
-
 /**
  * REST API Products Catalog controller class.
  *
@@ -206,6 +204,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'status'       => array(
 					'description' => __( 'Products catalog generation status. Possible values: pending, processing, complete, failed.', 'woocommerce' ),
 					'type'        => 'string',
+					'enum'        => array( 'pending', 'processing', 'complete', 'failed' ),
 					'required'    => true,
 				),
 				'download_url' => array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -163,9 +163,16 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			return $file_info;
 		}
 
-		// Create directory if it doesn't exist.
-		if ( ! file_exists( $file_info['directory'] ) ) {
-			wp_mkdir_p( $file_info['directory'] );
+		// Ensure directory exists.
+		if ( ! wp_mkdir_p( $file_info['directory'] ) ) {
+			return new WP_Error( 'catalog_dir_creation_failed', __( 'Unable to create catalog directory.', 'woocommerce' ), array( 'status' => 500 ) );
+		}
+
+		// Prevent directory listing.
+		$index_file = trailingslashit( $file_info['directory'] ) . 'index.html';
+		if ( ! file_exists( $index_file ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			@file_put_contents( $index_file, '' );
 		}
 
 		// Generate empty catalog file.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -218,10 +218,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		}
 
 		// Generate empty catalog file.
-		$catalog_data = array(
-			'products'   => array(),
-			'variations' => array(),
-		);
+		$catalog_data = array();
 
 		// Write to file.
 		$json = wp_json_encode( $catalog_data );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -111,10 +111,9 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'download_url' => $file_info['url'],
 			);
 		} else {
-			// Temporarily return job_id with base64-encoded fields for use in status endpoint.
-			// Base64 encoding ensures the job_id is URL-safe when passed as a query parameter.
+			// Temporarily return job_id with URL-safe base64-encoded fields for use in status endpoint.
 			// TODO: WOOMOB-1455 - Replace with proper async job tracking once we have a job tracking system.
-			$job_id = base64_encode( wp_json_encode( $fields ) );
+			$job_id = $this->base64url_encode( wp_json_encode( $fields ) );
 
 			$response_data = array(
 				'job_id' => $job_id,
@@ -137,17 +136,21 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		if ( empty( $job_id ) || ! is_string( $job_id ) ) {
 			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
-		$job_id = sanitize_text_field( $job_id );
 
-		// Decode fields from job_id (base64-encoded JSON).
-		$fields_json = base64_decode( $job_id, true );
-		if ( false === $fields_json ) {
+		// Enforce size and URL-safe base64 charset.
+		if ( strlen( $job_id ) > 4096 || ! preg_match( '/^[A-Za-z0-9\-_]+$/', $job_id ) ) {
 			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
+		// Decode fields from job_id (URL-safe base64-encoded JSON).
+		$fields_json = $this->base64url_decode( $job_id );
+		if ( false === $fields_json ) {
+			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID encoding.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
 		$fields = json_decode( $fields_json, true );
-		if ( null === $fields ) {
-			$fields = array();
+		if ( ! is_array( $fields ) ) {
+			return new WP_Error( 'invalid_job_id', __( 'Invalid products catalog generation job ID format.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		// Sanitize and canonicalize fields.
@@ -318,5 +321,25 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$fields = array_values( array_unique( array_map( 'strval', $fields ) ) );
 		sort( $fields, SORT_STRING );
 		return $fields;
+	}
+
+	/**
+	 * Encode data using URL-safe base64.
+	 *
+	 * @param string $data Data to encode.
+	 * @return string URL-safe base64-encoded string.
+	 */
+	private function base64url_encode( $data ) {
+		return str_replace( array( '+', '/', '=' ), array( '-', '_', '' ), base64_encode( $data ) );
+	}
+
+	/**
+	 * Decode URL-safe base64 data.
+	 *
+	 * @param string $data URL-safe base64-encoded string.
+	 * @return string|false Decoded data or false on failure.
+	 */
+	private function base64url_decode( $data ) {
+		return base64_decode( str_replace( array( '-', '_' ), array( '+', '/' ), $data ), true );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -76,26 +76,6 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'schema' => array( $this, 'catalog_generation_status_schema' ),
 			)
 		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/download',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'download_catalog' ),
-					'permission_callback' => array( $this, 'generate_products_catalog_permissions_check' ),
-					'args'                => array(
-						'filename' => array(
-							'description' => __( 'Products catalog filename to download.', 'woocommerce' ),
-							'type'        => 'string',
-							'required'    => true,
-						),
-					),
-				),
-				'schema' => array( $this, 'catalog_download_schema' ),
-			)
-		);
 	}
 
 	/**
@@ -133,23 +113,6 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 			'job_id'       => $job_id,
 			'status'       => 'complete',
 			'download_url' => rest_url( $this->namespace . '/' . $this->rest_base . '/download?filename=products_catalog.json' ),
-		);
-		return rest_ensure_response( $response_data );
-	}
-
-	/**
-	 * Download catalog file.
-	 *
-	 * @param WP_REST_Request $request Request data.
-	 * @return WP_Error|WP_REST_Response
-	 *
-	 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-	 */
-	public function download_catalog( $request ) {
-		// Mock empty catalog.
-		$response_data = array(
-			'products'   => array(),
-			'variations' => array(),
 		);
 		return rest_ensure_response( $response_data );
 	}
@@ -215,30 +178,6 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				),
 			),
 			'required'   => array( 'job_id', 'status' ),
-		);
-	}
-
-	/**
-	 * Products catalog download schema.
-	 *
-	 * @return array Products catalog download schema data.
-	 */
-	private function catalog_download_schema() {
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'products_catalog_download',
-			'type'       => 'object',
-			'properties' => array(
-				'products'   => array(
-					'description' => __( 'Products catalog products.', 'woocommerce' ),
-					'type'        => 'array',
-				),
-				'variations' => array(
-					'description' => __( 'Products catalog variations.', 'woocommerce' ),
-					'type'        => 'array',
-				),
-			),
-			'required'   => array( 'products', 'variations' ),
 		);
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -53,7 +53,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 						),
 					),
 				),
-				'schema' => array( $this, 'generate_products_catalog_schema' ),
+				'schema' => array( $this, 'catalog_generation_schema' ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -164,7 +164,7 @@ class Server {
 	 * @return array
 	 */
 	protected function get_v3_controllers() {
-		return array(
+		$controllers = array(
 			'coupons'                  => 'WC_REST_Coupons_Controller',
 			'customer-downloads'       => 'WC_REST_Customer_Downloads_Controller',
 			'customers'                => 'WC_REST_Customers_Controller',
@@ -212,6 +212,12 @@ class Server {
 			'paypal-webhooks'          => 'WC_REST_Paypal_Webhooks_Controller',
 			'paypal-buttons'           => 'WC_REST_Paypal_Buttons_Controller',
 		);
+
+		if ( Features::is_enabled( 'products-catalog-api' ) ) {
+			$controllers['products-catalog'] = 'WC_REST_Products_Catalog_Controller';
+		}
+
+		return $controllers;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -68,9 +68,10 @@ class FilesystemUtil {
 	 * @since 9.3.0
 	 *
 	 * @param string $path Directory to create.
+	 * @param bool   $allow_file_access Whether to allow file access while preventing directory listing. Default false (deny all access).
 	 * @throws \Exception In case of error.
 	 */
-	public static function mkdir_p_not_indexable( string $path ): void {
+	public static function mkdir_p_not_indexable( string $path, bool $allow_file_access = false ): void {
 		$wp_fs = self::get_wp_filesystem();
 
 		if ( $wp_fs->is_dir( $path ) ) {
@@ -81,8 +82,10 @@ class FilesystemUtil {
 			throw new \Exception( esc_html( sprintf( 'Could not create directory: %s.', wp_basename( $path ) ) ) );
 		}
 
+		$htaccess_content = $allow_file_access ? 'Options -Indexes' : 'deny from all';
+
 		$files = array(
-			'.htaccess'  => 'deny from all',
+			'.htaccess'  => $htaccess_content,
 			'index.html' => '',
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of WOOMOB-1455

This pull request introduces a new products catalog API to core, which is currently available as a mock implementation behind a feature flag. The main change is the addition of a new `/products/catalog` endpoint in the v3 REST API, allowing for catalog generation/retrieval, with response currently mocked. The endpoint is only enabled when the `products-catalog-api` feature flag is active, which is set to `true` in development and `false` in production by default.

**API Feature Addition**

* Added a new `WC_REST_Products_Catalog_Controller` class implementing one endpoint `/products/catalog` in the v3 REST API that returns mock data for catalog file and status.
* Registered the new controller conditionally in `Server.php` so it is only available when the `products-catalog-api` feature flag is enabled.
* The endpoint has the following spec:


`POST /products/catalog`

- Parameters:
  - (Required) `fields: [string] or string of comma separated values`: product/variation fields to include in the catalog.
  - (Optional) `force_generate: bool`: whether to generate of a new catalog file regardless of whether a catalog file already exists. Default to `false`.
- Response:
  - `download_url: string?`: non-null when the file is ready for download.
  - `status: string`: catalog generation status.

**Feature Flag Configuration**

* Introduced a new `products-catalog-api` feature flag, set to `false` in `core.json` (production) and `true` in `development.json`, controlling the availability of the products catalog API endpoints. [[1]](diffhunk://#diff-5464cd600798d5152459c15cfb474ab5e51d4e9af8e89198407c7f497fc04787R28) [[2]](diffhunk://#diff-3b1658fe0d52d421be55a61c013dc63400fa1331c34da2cfda789c595ac103e3R29)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**1. WC V3 API routes**

- Check the V3 API routes by `GET /wp-json/wc/v3` --> in development, it should include 3 `/wc/v3/products/catalog/*` endpoints. In non-development build (e.g. live branch in a JN site), these 3 endpoints should not be included

**2. Catalog API**

1. Catalog generation: make a request `POST /products/catalog` with a `fields=id,name,...` parameter --> it should return `status: complete` and a non-null `download_url` with the format of `$domain/wp-content/uploads/wc-catalog/products-{date}-{hash}.json`
2. Access the `download_url` --> it should contain an empty array. If you have access to the WP uploads directory, there should be a `wc-catalog` directory with the JSON as in the response, along with an empty `index.html` file and a hidden `.htaccess` file
3. Make the same catalog request as in the first step --> it should return exactly the same response. The JSON file from the URL should be last modified as in the first step (file not regenerated)
4. Make the same catalog request as in the first step, but with the values in the `fields` parameter in a different order --> it should return exactly the same response. The JSON file from the URL should be last modified as in the first step (file not regenerated)
5. Make the same catalog request as in the first step, adding `force_generate=true` to the request --> it should return exactly the same response. But the JSON file from the URL should have the last modified date as the current time (file regenerated)
6. Make the same catalog request as in the first step, but with different unique values in the `fields` parameter --> it should return `status: complete` and a non-null `download_url`. The URL should have a different hash from before

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I tested:

- [x] Catalog endpoints do not appear in V3 API routes in a JN site on this branch
- [x] All the scenarios for the catalog endpoints in a local site

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
