### PR TITLE
Email Editor: Prevent callback replacement attacks via __unserialize()

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-946-check-for-classes-that-hold-a-callable-add-protection
+++ b/packages/php/email-editor/changelog/wooprd-946-check-for-classes-that-hold-a-callable-add-protection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent callback replacement attacks via __unserialize()

--- a/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
+++ b/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
@@ -117,6 +117,17 @@ class Personalization_Tag {
 	}
 
 	/**
+	 * Prevents deserialization of this class to avoid callback replacement attacks.
+	 *
+	 * @param array $data The serialized data.
+	 * @return void
+	 * @throws \Exception Always throws an exception to prevent deserialization.
+	 */
+	public function __unserialize( array $data ): void {
+		throw new \Exception( 'Deserialization of Personalization_Tag is not allowed for security reasons.' );
+	}
+
+	/**
 	 * Returns the name of the personalization tag.
 	 *
 	 * @return string

--- a/packages/php/email-editor/src/class-container.php
+++ b/packages/php/email-editor/src/class-container.php
@@ -29,6 +29,17 @@ class Container {
 	protected array $instances = array();
 
 	/**
+	 * Prevents deserialization of this class to avoid callback replacement attacks.
+	 *
+	 * @param array $data The serialized data.
+	 * @return void
+	 * @throws \Exception Always throws an exception to prevent deserialization.
+	 */
+	public function __unserialize( array $data ): void {
+		throw new \Exception( 'Deserialization of Container is not allowed for security reasons.' );
+	}
+
+	/**
 	 * The method for registering a new service.
 	 *
 	 * @param string   $name     The name of the service.

--- a/packages/php/email-editor/tests/unit/Container_Test.php
+++ b/packages/php/email-editor/tests/unit/Container_Test.php
@@ -72,4 +72,17 @@ class Container_Test extends TestCase { // phpcs:ignore
 
 		$container->get( Simple_Service::class );
 	}
+
+	/**
+	 * Test that deserialization is prevented for security reasons.
+	 */
+	public function testUnserializeThrowsException(): void {
+		$container = new Container();
+
+		// Attempt to deserialize should throw an exception.
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Deserialization of Container is not allowed for security reasons.' );
+
+		$container->__unserialize( array() );
+	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tag_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tag_Test.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package.
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types = 1);
+
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test cases for the Personalization_Tag class.
+ */
+class Personalization_Tag_Test extends TestCase {
+	/**
+	 * Test that the tag can be created and used normally.
+	 */
+	public function testTagCreationAndUsage(): void {
+		$callback = function () {
+			return 'test value';
+		};
+
+		$tag = new Personalization_Tag(
+			'Test Tag',
+			'test_token',
+			'Test Category',
+			$callback,
+			array( 'default' => 'fallback' ),
+			'[test_token default="fallback"]'
+		);
+
+		$this->assertSame( 'Test Tag', $tag->get_name() );
+		$this->assertSame( '[test_token]', $tag->get_token() );
+		$this->assertSame( 'Test Category', $tag->get_category() );
+		$this->assertSame( array( 'default' => 'fallback' ), $tag->get_attributes() );
+		$this->assertSame( '[test_token default="fallback"]', $tag->get_value_to_insert() );
+		$this->assertSame( 'test value', $tag->execute_callback( array(), array() ) );
+	}
+
+	/**
+	 * Test that deserialization is prevented for security reasons.
+	 */
+	public function testUnserializeThrowsException(): void {
+		$callback = function () {
+			return 'test value';
+		};
+
+		$tag = new Personalization_Tag(
+			'Test Tag',
+			'test_token',
+			'Test Category',
+			$callback
+		);
+
+		// Attempt to deserialize should throw an exception.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Deserialization of Personalization_Tag is not allowed for security reasons.' );
+
+		$tag->__unserialize( array() );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add __unserialize() protection to classes with callable properties to prevent callback replacement attacks during deserialization.

Closes [WOOPRD-946: Check for classes that hold a callable add protection against injecting code via deserialization](https://linear.app/a8c/issue/WOOPRD-946/check-for-classes-that-hold-a-callable-add-protection-against).

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Code review.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Prevent callback replacement attacks via __unserialize()
</details>
