### PR TITLE
Avoid a call to load missing Category Title and Category Description stylesheets

### DIFF
--- a/plugins/woocommerce/changelog/fix-category-title-description-style
+++ b/plugins/woocommerce/changelog/fix-category-title-description-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Avoid a call to load missing Category Title and Category Description stylesheets
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
@@ -68,4 +68,13 @@ class CategoryDescription extends AbstractBlock {
 	protected function get_block_type_uses_context() {
 		return [ 'termId', 'termTaxonomy' ];
 	}
+
+	/**
+	 * Disable the style handle for this block.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
@@ -81,4 +81,13 @@ class CategoryTitle extends AbstractBlock {
 	protected function get_block_type_uses_context() {
 		return [ 'termId', 'termTaxonomy' ];
 	}
+
+	/**
+	 * Disable the style handle for this block.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/60779 we introduced the _Category Title_ and _Category Description_ blocks, but forgot to set their style handles to `null`. That causes that every time you open the _Site Editor_, there are two 404 calls trying to load the missing stylesheets. This PR fixes that.

### How to test the changes in this Pull Request:

1. Open the _Site Editor_.
2. Verify there are no 404 requests to `/wp-content/plugins/woocommerce/assets/client/blocks/category-description.css` and `/wp-content/plugins/woocommerce/assets/client/blocks/category-title.css`.