### PR TITLE
Add support for reply-to to transactional emails

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-942-make-sure-reply-to-address-and-name-are-used
+++ b/plugins/woocommerce/changelog/wooprd-942-make-sure-reply-to-address-and-name-are-used
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support for reply-to address in transactional emails


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We plan to allow users to configure the reply-to name and address. This PR adds support for these options to the sending code.

Closes WOOPRD-942 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The settings will be saved in the `wp_options` table:

- `woocommerce_email_reply_to_enabled`  - 'yes' | 'no'
- `woocommerce_email_reply_to_name` - string
- `woocommerce_email_reply_to_address` - email address

There is a unit test for the functionality.

For manual testing:

1) Add these options to `wp_options` table
2) Test with various values
3) `woocommerce_email_reply_to_enabled` has to be set to 'yes', `woocommerce_email_reply_to_name` must not be empty and `woocommerce_email_reply_to_address` must contain a valid email address; otherwise, we use the from address and name
4) For admin notifications, we use the customer's address

<!-- End testing instructions -->
