### PR TITLE
Fix PHP notice for indirect modification of overloaded property in WC_Tracks

### DIFF
--- a/plugins/woocommerce/changelog/61362-fix-WOOPLUG-5667-fix-php-notice-for-indirect-modification-of-overloaded-property-in-wc-tracks
+++ b/plugins/woocommerce/changelog/61362-fix-WOOPLUG-5667-fix-php-notice-for-indirect-modification-of-overloaded-property-in-wc-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP notice for indirect modification of overloaded property in WC_Tracks

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -81,7 +81,7 @@ class WC_Tracks {
 	 */
 	public static function get_role_details( $user ) {
 		return array(
-			'role'                   => ! empty( $user->roles ) ? reset( $user->roles ) : '',
+			'role'                   => ! empty( $user->roles ) ? array_values( $user->roles )[0] : '',
 			'can_install_plugins'    => $user->has_cap( 'install_plugins' ),
 			'can_activate_plugins'   => $user->has_cap( 'activate_plugins' ),
 			'can_manage_woocommerce' => $user->has_cap( 'manage_woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a PHP notice that occurs when WooCommerce tracks events in WordPress 6.9+ installations. The notice is caused by WordPress core changes where the `WP_User::$roles` property was changed from public to protected with lazy loading.

**Root Cause:** The `WC_Tracks::get_role_details()` method uses `reset($user->roles)` which triggers a PHP notice in PHP 8+ due to indirect modification of the overloaded property.

**Solution:** Don't modify the `WP_User::roles` property.

**Files Changed:**
- `plugins/woocommerce/includes/tracks/class-wc-tracks.php` (line 84)

Closes WOOPLUG-5667.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a WordPress 6.9+ installation with PHP 8+ and WooCommerce
2. Enable WordPress debug logging (`WP_DEBUG_LOG = true`)
3. Perform actions that trigger WooCommerce tracking events (e.g., add products to cart, complete checkout)
4. Check the debug log to verify no PHP notices are generated for "Indirect modification of overloaded property WP_User::$roles"
5. Verify that user role detection still works correctly in tracking events
6. Test with users having single roles, multiple roles, and no roles

### Testing that has already taken place:

- Verified no PHP notices are generated when tracking events for users
- Confirmed role detection still works correctly with the new implementation
- Tested with users having single and multiple roles
- Tested with users having no roles (returns empty string as expected)
- Confirmed the fix maintains the same functionality as the original code
- Reviewed the codebase to ensure no other instances of this pattern exist

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-  [x] Patch
-  [ ] Minor
-  [ ] Major

#### Type

<!-- Choose only one -->

-  [x] Fix - Fixes an existing bug
-  [ ] Add - Adds functionality
-  [ ] Update - Update existing functionality
-  [ ] Dev - Development related task
-  [ ] Tweak - A minor adjustment to the codebase
-  [ ] Performance - Address performance issues
-  [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix PHP notice for indirect modification of overloaded property in WC_Tracks

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>