### PR TITLE
Change tracking url when provider select changes

### DIFF
--- a/plugins/woocommerce/changelog/61368-WOOPLUG-5483-dynamic-tracking-url-on-provider-change
+++ b/plugins/woocommerce/changelog/61368-WOOPLUG-5483-dynamic-tracking-url-on-provider-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Auto fill tracking url with the tracking number and the selected shipping provider.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
@@ -86,6 +86,13 @@ export default function ShipmentManualEntryForm() {
 						value={ shipmentProvider }
 						options={ ShipmentProviders }
 						onChange={ ( value ) => {
+							if ( typeof value !== 'string' ) {
+								return;
+							}
+							if ( ! value ) {
+								setTrackingUrl( '' );
+								return;
+							}
 							setShipmentProvider( value as string );
 							setTrackingUrl(
 								(
@@ -94,7 +101,7 @@ export default function ShipmentManualEntryForm() {
 									]?.url ?? ''
 								).replace(
 									/__placeholder__/i,
-									trackingNumber ?? ''
+									encodeURIComponent( trackingNumber ?? '' )
 								)
 							);
 						} }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
@@ -92,7 +92,10 @@ export default function ShipmentManualEntryForm() {
 									window.wcFulfillmentSettings.providers[
 										value as string
 									]?.url ?? ''
-								).replace( /__placeholder__/i, trackingNumber )
+								).replace(
+									/__placeholder__/i,
+									trackingNumber ?? ''
+								)
 							);
 						} }
 						__nextHasNoMarginBottom

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/shipment-manual-entry-form.tsx
@@ -87,6 +87,13 @@ export default function ShipmentManualEntryForm() {
 						options={ ShipmentProviders }
 						onChange={ ( value ) => {
 							setShipmentProvider( value as string );
+							setTrackingUrl(
+								(
+									window.wcFulfillmentSettings.providers[
+										value as string
+									]?.url ?? ''
+								).replace( /__placeholder__/i, trackingNumber )
+							);
 						} }
 						__nextHasNoMarginBottom
 					/>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/test/shipment-manual-entry-form.test.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/test/shipment-manual-entry-form.test.js
@@ -113,4 +113,31 @@ describe( 'ShipmentManualEntryForm', () => {
 			'http://example.com'
 		);
 	} );
+
+	it( 'updates tracking URL when provider changes without tracking number', () => {
+		render( <ShipmentManualEntryForm /> );
+		const combobox = screen.getByRole( 'combobox' );
+		fireEvent.change( combobox, { target: { value: 'ups' } } );
+		expect( mockContext.setTrackingUrl ).toHaveBeenCalledWith(
+			'https://www.ups.com/track?loc=en_US&tracknum='
+		);
+	} );
+
+	it( 'updates tracking URL with tracking number when provider changes', () => {
+		mockContext.trackingNumber = '123456789';
+		render( <ShipmentManualEntryForm /> );
+		const combobox = screen.getByRole( 'combobox' );
+		fireEvent.change( combobox, { target: { value: 'dhl' } } );
+		expect( mockContext.setTrackingUrl ).toHaveBeenCalledWith(
+			'https://www.dhl.com/en/express/tracking.html?AWB=123456789'
+		);
+	} );
+
+	it( 'sets empty tracking URL when provider does not exist in settings', () => {
+		mockContext.trackingNumber = '123456789';
+		render( <ShipmentManualEntryForm /> );
+		const combobox = screen.getByRole( 'combobox' );
+		fireEvent.change( combobox, { target: { value: 'unknown-provider' } } );
+		expect( mockContext.setTrackingUrl ).toHaveBeenCalledWith( '' );
+	} );
 } );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/shipment-providers.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/shipment-providers.tsx
@@ -9,6 +9,7 @@ const ShipmentProviders: ShipmentProvider[] = [
 		label: __( 'Other', 'woocommerce' ),
 		icon: null,
 		value: 'other',
+		url: '',
 	},
 ];
 export default ShipmentProviders;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/global.d.ts
@@ -5,6 +5,7 @@ declare global {
 		label: string;
 		icon: string | null;
 		value: string;
+		url: string;
 	}
 
 	interface FulfillmentStatusProps {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/test-helper/global-mock.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/test-helper/global-mock.ts
@@ -16,13 +16,13 @@ global.window.wcFulfillmentSettings = {
 			label: 'UPS',
 			icon: '',
 			value: 'ups',
-			url: 'https://www.ups.com/track?loc=en_US&tracknum=%25placeholder%25',
+			url: 'https://www.ups.com/track?loc=en_US&tracknum=__placeholder__',
 		},
 		dhl: {
 			label: 'DHL',
 			icon: '',
 			value: 'dhl',
-			url: 'https://www.dhl.com/en/express/tracking.html?AWB=%25placeholder%25',
+			url: 'https://www.dhl.com/en/express/tracking.html?AWB=__placeholder__',
 		},
 	},
 	currency_symbols: {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/test-helper/global-mock.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/test-helper/global-mock.ts
@@ -16,11 +16,13 @@ global.window.wcFulfillmentSettings = {
 			label: 'UPS',
 			icon: '',
 			value: 'ups',
+			url: 'https://www.ups.com/track?loc=en_US&tracknum=%25placeholder%25',
 		},
 		dhl: {
 			label: 'DHL',
 			icon: '',
 			value: 'dhl',
+			url: 'https://www.dhl.com/en/express/tracking.html?AWB=%25placeholder%25',
 		},
 	},
 	currency_symbols: {

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
@@ -453,6 +453,7 @@ class FulfillmentUtils {
 					'label' => $shipping_provider_instance->get_name(),
 					'icon'  => $shipping_provider_instance->get_icon(),
 					'value' => $shipping_provider_instance->get_key(),
+					'url'   => $shipping_provider_instance->get_tracking_url( '__PLACEHOLDER__' ),
 				);
 			}
 			if ( is_object( $shipping_provider ) && $shipping_provider instanceof AbstractShippingProvider ) {
@@ -460,6 +461,7 @@ class FulfillmentUtils {
 					'label' => $shipping_provider->get_name(),
 					'icon'  => $shipping_provider->get_icon(),
 					'value' => $shipping_provider->get_key(),
+					'url'   => $shipping_provider->get_tracking_url( '__PLACEHOLDER__' ),
 				);
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR exposes shipping provider tracking url patterns with a `__placeholder__` set as the tracking number to frontend, so when an user changes the shipping provider on the manual entry form, the url gets autopopulated with the tracking number.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5483

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Build the assets with `pnpm run watch:build` in `plugins/woocommerce` folder.
3. Go to orders list screen on WP admin
4. Open the fulfillments drawer for an existing order
5. Select manual entry mode in the tracking information form
6. Enter a tracking number to the input
7. Select a shipping provider from the list
8. See that the URL gets automatically filled with the correct tracking URL for the given provider and tracking number.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Auto fill tracking url with the tracking number and the selected shipping provider.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
