### PR TITLE
Fix Featured Product deprecation logic

### DIFF
--- a/plugins/woocommerce/changelog/fix-feature-product-deprecation
+++ b/plugins/woocommerce/changelog/fix-feature-product-deprecation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Featured Product deprecation logic
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.json
@@ -26,8 +26,7 @@
 		"color": {
 			"text": true,
 			"background": true,
-			"link": false,
-			"__experimentalSkipSerialization": true
+			"link": false
 		},
 		"typography": {
 			"fontSize": true,
@@ -35,7 +34,6 @@
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
-			"__experimentalSkipSerialization": true,
 			"__experimentalLetterSpacing": true
 		},
 		"__experimentalSelector": ".wp-block-woocommerce-product-price .wc-block-components-product-price",

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -75,7 +75,6 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		isExperimentalWcRestApiV4Enabled,
 	} = props;
 
-	const styleProps = useStyleProps( props );
 	const { parentName, parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext(
 		/**
@@ -95,6 +94,17 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	const isDescendentOfAddToCartGroupedProductSelectorBlock =
 		parentName ===
 		'woocommerce/add-to-cart-with-options-grouped-product-item';
+
+	// If the block is not a descendant of the All Products block, we are
+	// already printing the styles from the PHP side (in the frontend) and the
+	// `edit.tsx` file (in the editor).
+	let styleProps = useStyleProps( props );
+	if ( ! isDescendentOfAllProductsBlock ) {
+		styleProps = {
+			className: '',
+			style: {},
+		};
+	}
 
 	const showPricePreview =
 		( isDescendentOfSingleProductTemplate &&

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -98,12 +98,13 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	// If the block is not a descendant of the All Products block, we are
 	// already printing the styles from the PHP side (in the frontend) and the
 	// `edit.tsx` file (in the editor).
-	let styleProps = useStyleProps( props );
-	if ( ! isDescendentOfAllProductsBlock ) {
-		styleProps = {
-			className: '',
-			style: {},
-		};
+	const computedStyles = useStyleProps( props );
+	let styleProps = {
+		className: '',
+		style: {},
+	};
+	if ( isDescendentOfAllProductsBlock ) {
+		styleProps = computedStyles;
 	}
 
 	const showPricePreview =

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -58,7 +58,6 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],
-	[ 'woocommerce/product-price', { textAlign: 'center' } ],
 	[
 		'woocommerce/product-summary',
 		{
@@ -71,6 +70,7 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 			summaryLength: 80,
 		},
 	],
+	[ 'woocommerce/product-price', { textAlign: 'center' } ],
 	[
 		'core/buttons',
 		{

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -70,7 +70,19 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 			summaryLength: 80,
 		},
 	],
-	[ 'woocommerce/product-price', { textAlign: 'center' } ],
+	[
+		'woocommerce/product-price',
+		{
+			style: {
+				spacing: {
+					padding: {
+						bottom: '16px',
+					},
+				},
+			},
+			textAlign: 'center',
+		},
+	],
 	[
 		'core/buttons',
 		{

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -80,7 +80,7 @@ const v1 = {
 				isLink: false,
 				style: {
 					padding: {
-						bottom: OLD_PADDING_BOTTOM,
+						bottom: V1_PADDING_BOTTOM,
 					},
 				},
 				textAlign: 'center',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -42,31 +42,16 @@ const v1 = {
 		// Now that they are inner blocks, we are porting this padding to their attributes.
 		const V1_PADDING_BOTTOM = '16px';
 
-		if ( showDesc !== false ) {
-			innerBlocks.unshift(
-				createBlock( 'woocommerce/product-summary', {
-					showDescriptionIfEmpty: true,
-					summaryLength: 80,
-					style: {
-						padding: {
-							bottom: V1_PADDING_BOTTOM,
-						},
-						typography: {
-							textAlign: 'center',
-						},
-					},
-				} )
-			);
-		}
-
 		// We check if these legacy attributes are explicitly set to false, because
 		// the default value is true (i.e. `undefined` meant `true`).
 		if ( showPrice !== false ) {
 			innerBlocks.unshift(
 				createBlock( 'woocommerce/product-price', {
 					style: {
-						padding: {
-							bottom: V1_PADDING_BOTTOM,
+						spacing: {
+							padding: {
+								bottom: V1_PADDING_BOTTOM,
+							},
 						},
 					},
 					textAlign: 'center',
@@ -74,15 +59,23 @@ const v1 = {
 			);
 		}
 
+		if ( showDesc !== false ) {
+			innerBlocks.unshift(
+				createBlock( 'woocommerce/product-summary', {
+					showDescriptionIfEmpty: true,
+					summaryLength: 80,
+					style: {
+						typography: {
+							textAlign: 'center',
+						},
+					},
+				} )
+			);
+		}
 		innerBlocks.unshift(
 			createBlock( 'core/post-title', {
 				level: 2,
 				isLink: false,
-				style: {
-					padding: {
-						bottom: V1_PADDING_BOTTOM,
-					},
-				},
 				textAlign: 'center',
 				__woocommerceNamespace:
 					'woocommerce/product-collection/product-title',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -67,14 +67,16 @@ class ProductPrice extends AbstractBlock {
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
-			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-			$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
+			$styles_and_classes = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 			$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
 			$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
 			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( ProductType::VARIABLE );
 
-			$wrapper_attributes     = array();
+			$wrapper_attributes     = array(
+				'style' => $styles_and_classes['styles'] ?? '',
+				'class' => $styles_and_classes['classes'] ?? '',
+			);
 			$interactive_attributes = '';
 			$context_directive      = '';
 
@@ -125,14 +127,11 @@ class ProductPrice extends AbstractBlock {
 			}
 
 			return sprintf(
-				'<div %1$s %2$s><div class="wc-block-components-product-price wc-block-grid__product-price %3$s %4$s" style="%5$s" %6$s>
-					%7$s
+				'<div %1$s %2$s><div class="wc-block-components-product-price wc-block-grid__product-price" %3$s>
+					%4$s
 				</div></div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
 				$context_directive,
-				esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
-				esc_attr( $styles_and_classes['classes'] ),
-				esc_attr( $styles_and_classes['styles'] ?? '' ),
 				$interactive_attributes,
 				$product->get_price_html()
 			);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Something I noticed when creating https://github.com/woocommerce/woocommerce/issues/61370. The _Featured Product_ block deprecation logic was causing a JS error.

While fixing this, I also noticed something weird with the _Product Price_ styles. Things like the padding was applied twice in the editor and the frontend. I fixed that too, but it requires doing some smoke testing on the _All Products_ block and other blocks to make sure I didn't introduce any regressions. :crossed_fingers: 

### How to test the changes in this Pull Request:

**Test _Featured Product_ block migration:**

1. In WC 10.3, add the _Featured Product_ block to a post.
2. Switch to this branch.
3. Reload that post in the editor.
4. Verify there are no JS errors.
5. Add a new _Featured Product_ block.
6. In both _Featured Product_ blocks, verify the _Product Description_ is above the _Product Price_ by default.

Before | After
--- | ---
<img width="1237" height="232" alt="imatge" src="https://github.com/user-attachments/assets/6b01b3d2-d61a-4949-a531-4cb2ef947d22" /> | <img width="975" height="795" alt="imatge" src="https://github.com/user-attachments/assets/175585c3-7390-4254-ad73-137e3a0621da" />

**Test _Product Price_ styles:**

1. Add the _All Products_ block to a post or page. You can use this code:

```HTML
<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image",{"imageSizing":"cropped"}],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;,{&quot;imageSizing&quot;:&quot;cropped&quot;}],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div>
<!-- /wp:woocommerce/all-products -->
```

2. Edit the _Product Price_ styles and verify they are applied correctly in the editor.
3. Load the post or page in the frontend and verify the styles are applied correctly in the frontend too.
4. Repeat the previous steps with the _Product Collection_ block just in case.

Note: when editing the _All Products_ block, you will notice the _Product Price_ block is not visible. That's a bug in `trunk` too, but we will deprecate the edit view of the _All Products_ block soon, so I don't think it's worth fixing it.