### PR TITLE
Fix floating-point precision bug in price conversion

### DIFF
--- a/plugins/woocommerce/changelog/61377-fix-price-floating-point-precision
+++ b/plugins/woocommerce/changelog/61377-fix-price-floating-point-precision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix floating-point precision bug in price conversion where prices like 10.04 would display as 10.03.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -54,13 +54,13 @@ interface PriceProps {
  * @param fallback    The fallback value if priceString is null/undefined (defaults to "0")
  * @return The price converted to minor units as a string (e.g., "1299")
  */
-const convertAdminPriceToStoreApiFormat = (
+export const convertAdminPriceToStoreApiFormat = (
 	priceString: string | null | undefined,
 	currency: Currency,
 	fallback = '0'
 ) => {
 	const multiplier = 10 ** currency.minorUnit;
-	return (
+	return Math.round(
 		Number.parseFloat( priceString ?? fallback ) * multiplier
 	).toString();
 };

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/test/block.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/test/block.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import type { Currency } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { convertAdminPriceToStoreApiFormat } from '../block';
+
+const createMockCurrency = ( minorUnit: number ): Currency => ( {
+	code: 'USD',
+	decimalSeparator: '.',
+	minorUnit,
+	prefix: '$',
+	suffix: '',
+	symbol: '$',
+	thousandSeparator: ',',
+} );
+
+describe( 'convertAdminPriceToStoreApiFormat', () => {
+	const currencyWithTwoDecimals = createMockCurrency( 2 );
+	const currencyWithThreeDecimals = createMockCurrency( 3 );
+
+	describe( 'basic conversion', () => {
+		test( 'should convert decimal price to minor units', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'12.99',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1299' );
+		} );
+
+		test( 'should handle whole numbers', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'10',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1000' );
+		} );
+
+		test( 'should handle zero', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'0',
+					currencyWithTwoDecimals
+				)
+			).toBe( '0' );
+		} );
+	} );
+
+	describe( 'floating-point precision', () => {
+		test( 'should correctly round 10.04 to 1004 (not 1003)', () => {
+			// This is the bug fix - without Math.round, floating point errors
+			// cause 10.04 * 100 = 1003.9999999999999 -> "1003"
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'10.04',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1004' );
+		} );
+
+		test( 'should correctly handle 0.01', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'0.01',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1' );
+		} );
+
+		test( 'should correctly handle 9.99', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'9.99',
+					currencyWithTwoDecimals
+				)
+			).toBe( '999' );
+		} );
+
+		test( 'should correctly handle 19.95', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'19.95',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1995' );
+		} );
+	} );
+
+	describe( 'null and undefined handling', () => {
+		test( 'should use fallback for null', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					null,
+					currencyWithTwoDecimals
+				)
+			).toBe( '0' );
+		} );
+
+		test( 'should use fallback for undefined', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					undefined,
+					currencyWithTwoDecimals
+				)
+			).toBe( '0' );
+		} );
+
+		test( 'should use custom fallback', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					null,
+					currencyWithTwoDecimals,
+					'100'
+				)
+			).toBe( '10000' );
+		} );
+	} );
+
+	describe( 'different currency minor units', () => {
+		test( 'should handle 3 decimal places (e.g., Kuwaiti Dinar)', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'12.345',
+					currencyWithThreeDecimals
+				)
+			).toBe( '12345' );
+		} );
+
+		test( 'should handle 0 decimal places (e.g., Japanese Yen)', () => {
+			const currencyWithNoDecimals = createMockCurrency( 0 );
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'1000',
+					currencyWithNoDecimals
+				)
+			).toBe( '1000' );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		test( 'should handle very small decimals', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'0.001',
+					currencyWithTwoDecimals
+				)
+			).toBe( '0' ); // Rounds to 0
+		} );
+
+		test( 'should handle large numbers', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'9999999.99',
+					currencyWithTwoDecimals
+				)
+			).toBe( '999999999' );
+		} );
+
+		test( 'should handle trailing zeros', () => {
+			expect(
+				convertAdminPriceToStoreApiFormat(
+					'10.00',
+					currencyWithTwoDecimals
+				)
+			).toBe( '1000' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes an issue where in price block the prices like 10.04 would display as 10.03 due to floating-point arithmetic errors.

**Problem**: The `convertAdminPriceToStoreApiFormat` function multiplies decimal prices by 100 (or other multipliers) to convert to minor currency units. Due to floating-point precision issues, `10.04 * 100` equals `1003.9999999999999`, which when converted to string becomes `"1003"` instead of `"1004"`.

**Solution**: Use `Math.round()` to ensure accurate integer conversion.

## Changes

- Add `Math.round()` to price conversion in `convertAdminPriceToStoreApiFormat`
- Export the function for testing
- Add comprehensive test suite with 15 tests covering:
  - Basic price conversions
  - Floating-point precision cases (10.04, 9.99, 19.95, 0.01)
  - Null/undefined handling
  - Different currency decimal places (0, 2, 3)
  - Edge cases

## Testing

All tests pass:
```bash
pnpm test:js assets/js/atomic/blocks/product-elements/price/test/block.test.tsx
```

## Files changed

- `client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx` - Added Math.round() and exported function
- `client/blocks/assets/js/atomic/blocks/product-elements/price/test/block.test.tsx` - New test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)