### PR TITLE
Add link to jump to the add note section of the WooCommerce order.

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3626,6 +3626,10 @@ ul.order_notes {
 	}
 }
 
+.add_note_jump_to {
+	padding: 0 10px 0;
+}
+
 .add_note {
 	border-top: 1px solid #ddd;
 	padding: 10px 10px 0;

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -33,10 +33,15 @@ class WC_Meta_Box_Order_Notes {
 		} else {
 			$notes = array();
 		}
+		if ( count( $notes ) > 4 ) {
+			?>
+			<p class="add_note_jump_to"><a href="#woocommerce-order-notes-add-note"><?php esc_html_e( 'Add note', 'woocommerce' ); ?></a></p>
+			<?php
+		}
 
 		include __DIR__ . '/views/html-order-notes.php';
 		?>
-		<div class="add_note">
+		<div class="add_note" id="woocommerce-order-notes-add-note">
 			<p>
 				<label for="add_order_note"><?php esc_html_e( 'Add note', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Add a note for your reference, or add a customer note (the user will be notified).', 'woocommerce' ) ); ?></label>
 				<textarea type="text" name="order_note" id="add_order_note" class="input-text" cols="20" rows="5"></textarea>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This is an alternative solution to https://github.com/woocommerce/woocommerce/pull/61375 if we don't want to actually move the Add note form if it is believed that that would break existing workflows. I believe that the other solution is better for UX, but this one is a simpler change to help with the goal but without changing existing behavior.

The notes display with the newest first, so when adding a note you would usually be looking a the newest note which is also at the top. This adds an Add note link if there are more than 4 notes to be able to quickly jump to the bottom of the list. If you have a long list of notes you would be looking at the most recent note at the top and then have to scroll all the way to the bottom to add the new note.
With the note count, if the note list is short the link would not be needed or helpful so it does not show.

Closes #34648 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="280" height="834" alt="image" src="https://github.com/user-attachments/assets/6eca12d4-b5e2-40d5-88b2-1d0216cec620" />     |    <img width="280" height="866" alt="image" src="https://github.com/user-attachments/assets/df7b2b43-2011-4f7d-9232-32266387b187" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the order view of any order.
2. View the order notes on the right.
3. Test with more than 4 and less than 4 notes.
4. Make sure that the link takes you to the Add note section.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Add link to jump to the add note section of the WooCommerce order.
</details>
