### PR TITLE
Prevent accidental syncing of placeholder to order during sync-on-read

### DIFF
--- a/plugins/woocommerce/changelog/fix-53307
+++ b/plugins/woocommerce/changelog/fix-53307
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent accidental syncing of order with placeholder post when HPOS compat mode is enabled.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
When HPOS is authoritative and sync is enabled at some point, sync-on-read might end up overwriting order data with placeholder information, effectively turning a valid order into a "blank" pending order with items but no metadata or status information.

This PR ensures that we don't attempt to sync-on-read from placeholder posts.

Closes #53307.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start with HPOS enabled and sync disabled:
   ```
   wp wc hpos enable
   wp wc hpos compatibility-mode disable
   ```
   If necessary, perform a sync via `wp wc hpos sync` to ensure you can switch settings.
1. Go to **WC > Orders** and create a new order, ensuring that it **is not** in "Pending" status and that it has some billing or shipping information associated.
   Take note of the order ID and keep the order edit screen open.
1. Enable compatibility mode:
   ```
    wp wc hpos compatibility-mode enable
   ```
1. For the bug to occur, we need to quickly refresh the order edit page (or read an order via code) before any update makes the HPOS version more recent (based on modified timestamp) than the post version. This has to happen so fast that is not easy to do, so instead, we're going to adjust the placeholder modified date so it appears newer:
   ```
   wp post update ORDER_ID --post_modified_gmt=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   ```
1. Refresh the order edit page.
1. Confirm that the order data remains intact.
1. (Optional) Repeat 1-5 on `trunk` and confirm that refreshing the page overwrites order data, setting it back to "Pending" status and removing billing/shipping info.


<!-- End testing instructions -->