### PR TITLE
Don't trigger block hooks manually in WooCommerce templates on WordPress 6.9 or higher

### DIFF
--- a/plugins/woocommerce/changelog/fix-BlockTemplatesController-conditionally-call-run_hooks_on_block_templates
+++ b/plugins/woocommerce/changelog/fix-BlockTemplatesController-conditionally-call-run_hooks_on_block_templates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Don't trigger block hooks manually in WooCommerce templates on WordPress 6.9 or higher
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
+use Automattic\WooCommerce\Blocks\Utils\Utils;
 
 /**
  * BlockTemplatesController class.
@@ -25,13 +26,19 @@ class BlockTemplatesController {
 	public function init() {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
-		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_db_templates_with_woo_slug' ), 10, 3 );
 		add_filter( 'rest_pre_insert_wp_template', array( $this, 'dont_load_templates_for_suggestions' ), 10, 1 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'hide_template_selector_in_cart_checkout_pages' ), 10 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'dequeue_legacy_scripts' ], 20 );
+
+		// Fix a bug in WordPress 6.8 and lower that caused block hooks no to
+		// run in templates registered via the Template Registration API.
+		// @see https://github.com/WordPress/gutenberg/issues/71139
+		if ( Utils::wp_version_compare( '6.8', '<=' ) ) {
+			add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
+		}
 	}
 
 	/**
@@ -219,9 +226,6 @@ class BlockTemplatesController {
 	 * @return array The block templates.
 	 */
 	public function run_hooks_on_block_templates( $templates ) {
-		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
-		// via the Template Registration API. Because of this, we run them manually.
-		// https://github.com/WordPress/gutenberg/issues/71139.
 		foreach ( $templates as $template ) {
 			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
 				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -35,7 +35,7 @@ class BlockTemplatesController {
 
 		// Fix a bug in WordPress 6.8 and lower that caused block hooks no to
 		// run in templates registered via the Template Registration API.
-		// @see https://github.com/WordPress/gutenberg/issues/71139
+		// @see https://github.com/WordPress/gutenberg/issues/71139.
 		if ( Utils::wp_version_compare( '6.8', '<=' ) ) {
 			add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -33,7 +33,7 @@ class BlockTemplatesController {
 		add_action( 'current_screen', array( $this, 'hide_template_selector_in_cart_checkout_pages' ), 10 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'dequeue_legacy_scripts' ], 20 );
 
-		// Fix a bug in WordPress 6.8 and lower that caused block hooks no to
+		// Fix a bug in WordPress 6.8 and lower that caused block hooks not to
 		// run in templates registered via the Template Registration API.
 		// @see https://github.com/WordPress/gutenberg/issues/71139.
 		if ( Utils::wp_version_compare( '6.8', '<=' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When we migrated to the Template registration API (https://github.com/woocommerce/woocommerce/pull/60234), we had to  manually call block hooks in templates registered via the Template registration API because of an upstream bug: https://github.com/WordPress/gutenberg/issues/71139. The bug has now been fixed in WP 6.9, so there is no need to call it anymore!

### How to test the changes in this Pull Request:

1. Go to _WooCommerce_ > _Settings_ > _Accounts & Privacy_.
2. Enable the options _Enable guest checkout (recommended)_ and _After checkout (recommended)_.
3. With a non-logged in user, make a purchase.
4. Verify you see the _Create an account_ banner in the order confirmation page.
5. Now, using the WordPress Beta Tester plugin, update to WordPress 6.9 nightly.
6. Repeat steps 1-4.

<img width="1410" height="1277" alt="imatge" src="https://github.com/user-attachments/assets/59f5be3c-332d-487e-99eb-71b5591a1a7d" />
