### PR TITLE
Fix issue with duplicate tax rows, by matching tax rate id

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5669-analytics-taxes-shows-duplicate-tax-rows-when-multiple-tax
+++ b/plugins/woocommerce/changelog/wooplug-5669-analytics-taxes-shows-duplicate-tax-rows-when-multiple-tax
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where tax reports where showing duplicate rows for orders with multiple tax rates.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -85,7 +85,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->report_columns = array(
 			'tax_rate_id'  => "{$table_name}.tax_rate_id",
 			'name'         => "SUBSTRING_INDEX(SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-2), '-', 1) as name",
-			'tax_rate'     => "CAST({$wpdb->prefix}woocommerce_order_itemmeta.meta_value AS DECIMAL(7,4)) as tax_rate",
+			'tax_rate'     => "CAST(itemmeta_rate_percent.meta_value AS DECIMAL(7,4)) as tax_rate",
 			'country'      => "SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',1) as country",
 			'state'        => "SUBSTRING_INDEX(SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-3), '-', 1) as state",
 			'priority'     => "SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-1) as priority",
@@ -118,7 +118,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$this->subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}woocommerce_order_items ON {$table_name}.order_id = {$wpdb->prefix}woocommerce_order_items.order_id AND {$wpdb->prefix}woocommerce_order_items.order_item_type = 'tax'" );
-		$this->subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}woocommerce_order_itemmeta ON {$wpdb->prefix}woocommerce_order_itemmeta.order_item_id = {$wpdb->prefix}woocommerce_order_items.order_item_id AND {$wpdb->prefix}woocommerce_order_itemmeta.meta_key = 'rate_percent'" );
+		$this->subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}woocommerce_order_itemmeta itemmeta_rate_id ON itemmeta_rate_id.order_item_id = {$wpdb->prefix}woocommerce_order_items.order_item_id AND itemmeta_rate_id.meta_key = 'rate_id'" );
+		$this->subquery->add_sql_clause( 'join', "JOIN {$wpdb->prefix}woocommerce_order_itemmeta itemmeta_rate_percent ON itemmeta_rate_percent.order_item_id = {$wpdb->prefix}woocommerce_order_items.order_item_id AND itemmeta_rate_percent.meta_key = 'rate_percent'" );
 	}
 
 	/**
@@ -138,6 +139,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$order_status_filter = $this->get_status_subquery( $query_args );
 		$this->add_from_sql_params( $query_args, $order_status_filter );
 
+		$this->subquery->add_sql_clause( 'where', "AND itemmeta_rate_id.meta_value = {$order_tax_lookup_table}.tax_rate_id" );
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
 			$allowed_taxes = self::get_filtered_ids( $query_args, 'taxes' );
 			$this->subquery->add_sql_clause( 'where', "AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})" );
@@ -343,6 +345,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->subquery->add_sql_clause( 'select', self::get_db_table_name() . '.tax_rate_id' );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
 		$this->subquery->add_sql_clause( 'group_by', self::get_db_table_name() . '.tax_rate_id' );
-		$this->subquery->add_sql_clause( 'group_by', ", {$wpdb->prefix}woocommerce_order_items.order_item_name, {$wpdb->prefix}woocommerce_order_itemmeta.meta_value" );
+		$this->subquery->add_sql_clause( 'group_by', ", {$wpdb->prefix}woocommerce_order_items.order_item_name, itemmeta_rate_percent.meta_value, itemmeta_rate_id.meta_value" );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -345,6 +345,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->subquery->add_sql_clause( 'select', self::get_db_table_name() . '.tax_rate_id' );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
 		$this->subquery->add_sql_clause( 'group_by', self::get_db_table_name() . '.tax_rate_id' );
-		$this->subquery->add_sql_clause( 'group_by', ", {$wpdb->prefix}woocommerce_order_items.order_item_name, itemmeta_rate_percent.meta_value, itemmeta_rate_id.meta_value" );
+		$this->subquery->add_sql_clause( 'group_by', ", {$wpdb->prefix}woocommerce_order_items.order_item_name, itemmeta_rate_percent.meta_value" );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -85,7 +85,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->report_columns = array(
 			'tax_rate_id'  => "{$table_name}.tax_rate_id",
 			'name'         => "SUBSTRING_INDEX(SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-2), '-', 1) as name",
-			'tax_rate'     => "CAST(itemmeta_rate_percent.meta_value AS DECIMAL(7,4)) as tax_rate",
+			'tax_rate'     => 'CAST(itemmeta_rate_percent.meta_value AS DECIMAL(7,4)) as tax_rate',
 			'country'      => "SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',1) as country",
 			'state'        => "SUBSTRING_INDEX(SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-3), '-', 1) as state",
 			'priority'     => "SUBSTRING_INDEX({$wpdb->prefix}woocommerce_order_items.order_item_name,'-',-1) as priority",

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
@@ -234,7 +234,7 @@ class WC_Admin_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 	 * Ensures that the report returns the correct number of unique tax rates
 	 * when an order has multiple different taxes applied.
 	 *
-	 * @since 3.5.0
+	 * @since 10.4.0
 	 */
 	public function test_get_reports_with_multiple_tax_line_items() {
 		global $wpdb;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
@@ -315,6 +315,41 @@ class WC_Admin_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 		$order->set_total( 109.75 ); // Product + all taxes.
 		$order->save();
 
+		// @todo Remove this once order data is synced to wc_order_tax_lookup
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => $order->get_id(),
+				'tax_rate_id'  => 1,
+				'date_created' => gmdate( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 1,
+				'order_tax'    => 5,
+				'total_tax'    => 6,
+			)
+		);
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => $order->get_id(),
+				'tax_rate_id'  => 2,
+				'date_created' => gmdate( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 0.5,
+				'order_tax'    => 2.5,
+				'total_tax'    => 3,
+			)
+		);
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => $order->get_id(),
+				'tax_rate_id'  => 3,
+				'date_created' => gmdate( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 0.25,
+				'order_tax'    => 1,
+				'total_tax'    => 1.25,
+			)
+		);
+
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Make the API request.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
@@ -230,6 +230,148 @@ class WC_Admin_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 
 
 	/**
+	 * Test getting reports with multiple tax line items on a single order.
+	 * Ensures that the report returns the correct number of unique tax rates
+	 * when an order has multiple different taxes applied.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_with_multiple_tax_line_items() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a test product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create multiple tax rates.
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 1,
+				'tax_rate'          => '5',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'CA',
+				'tax_rate_name'     => 'State Tax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 2,
+				'tax_rate'          => '2.5',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'CA',
+				'tax_rate_name'     => 'City Tax',
+				'tax_rate_priority' => 2,
+				'tax_rate_order'    => 2,
+			)
+		);
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 3,
+				'tax_rate'          => '1',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'CA',
+				'tax_rate_name'     => 'County Tax',
+				'tax_rate_priority' => 3,
+				'tax_rate_order'    => 3,
+			)
+		);
+
+		// Create an order with multiple tax line items.
+		$order = WC_Helper_Order::create_order( 1, $product );
+
+		// Add first tax item (State Tax).
+		$tax_item_1 = new WC_Order_Item_Tax();
+		$tax_item_1->set_rate( 1 );
+		$tax_item_1->set_tax_total( 5 );
+		$tax_item_1->set_shipping_tax_total( 1 );
+		$order->add_item( $tax_item_1 );
+
+		// Add second tax item (City Tax).
+		$tax_item_2 = new WC_Order_Item_Tax();
+		$tax_item_2->set_rate( 2 );
+		$tax_item_2->set_tax_total( 2.5 );
+		$tax_item_2->set_shipping_tax_total( 0.5 );
+		$order->add_item( $tax_item_2 );
+
+		// Add third tax item (County Tax).
+		$tax_item_3 = new WC_Order_Item_Tax();
+		$tax_item_3->set_rate( 3 );
+		$tax_item_3->set_tax_total( 1 );
+		$tax_item_3->set_shipping_tax_total( 0.25 );
+		$order->add_item( $tax_item_3 );
+
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->set_total( 109.75 ); // Product + all taxes.
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		// Make the API request.
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		// Assert response is successful.
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Assert we get exactly 3 unique tax rates in the report.
+		$this->assertEquals( 3, count( $reports ), 'Should return 3 unique tax rates' );
+
+		// Organize reports by tax_rate_id for easier assertions.
+		$reports_by_id = array();
+		foreach ( $reports as $report ) {
+			$reports_by_id[ $report['tax_rate_id'] ] = $report;
+		}
+
+		// Assert each tax rate has correct data.
+		// Tax Rate 1 - State Tax.
+		$this->assertArrayHasKey( 1, $reports_by_id );
+		$this->assertEquals( 1, $reports_by_id[1]['tax_rate_id'] );
+		$this->assertEquals( 5.0, $reports_by_id[1]['tax_rate'] );
+		$this->assertEquals( 'US', $reports_by_id[1]['country'] );
+		$this->assertEquals( 'CA', $reports_by_id[1]['state'] );
+		$this->assertEquals( 'STATE TAX', $reports_by_id[1]['name'] );
+		$this->assertEquals( 6, $reports_by_id[1]['total_tax'] );
+		$this->assertEquals( 5, $reports_by_id[1]['order_tax'] );
+		$this->assertEquals( 1, $reports_by_id[1]['shipping_tax'] );
+		$this->assertEquals( 1, $reports_by_id[1]['orders_count'] );
+
+		// Tax Rate 2 - City Tax.
+		$this->assertArrayHasKey( 2, $reports_by_id );
+		$this->assertEquals( 2, $reports_by_id[2]['tax_rate_id'] );
+		$this->assertEquals( 2.5, $reports_by_id[2]['tax_rate'] );
+		$this->assertEquals( 'US', $reports_by_id[2]['country'] );
+		$this->assertEquals( 'CA', $reports_by_id[2]['state'] );
+		$this->assertEquals( 'CITY TAX', $reports_by_id[2]['name'] );
+		$this->assertEquals( 3, $reports_by_id[2]['total_tax'] );
+		$this->assertEquals( 2.5, $reports_by_id[2]['order_tax'] );
+		$this->assertEquals( 0.5, $reports_by_id[2]['shipping_tax'] );
+		$this->assertEquals( 1, $reports_by_id[2]['orders_count'] );
+
+		// Tax Rate 3 - County Tax.
+		$this->assertArrayHasKey( 3, $reports_by_id );
+		$this->assertEquals( 3, $reports_by_id[3]['tax_rate_id'] );
+		$this->assertEquals( 1.0, $reports_by_id[3]['tax_rate'] );
+		$this->assertEquals( 'US', $reports_by_id[3]['country'] );
+		$this->assertEquals( 'CA', $reports_by_id[3]['state'] );
+		$this->assertEquals( 'COUNTY TAX', $reports_by_id[3]['name'] );
+		$this->assertEquals( 1.25, $reports_by_id[3]['total_tax'] );
+		$this->assertEquals( 1, $reports_by_id[3]['order_tax'] );
+		$this->assertEquals( 0.25, $reports_by_id[3]['shipping_tax'] );
+		$this->assertEquals( 1, $reports_by_id[3]['orders_count'] );
+	}
+
+	/**
 	 * Test getting reports without valid permissions.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Context of the issue:**
Because of the way the `wc_order_tax_lookup` table is structured, we don't have direct access to the `order_item_id` and thus have to do a join on the `order_id`. This means if multiple taxes were included on a single order it would generate two rows for each tax lookup item, with each order tax line item ( see screenshot where tax rate id matches two different order items ).
<img width="507" height="227" alt="Screenshot 2025-10-13 at 11 03 32" src="https://github.com/user-attachments/assets/e92e1e25-9c6a-4732-97d2-0ce498181e3c" />
`group_by` would fix this if we only group by `tax_rate_id`, but unfortunately that is not possible because of the additional information we need.

**The fix:**
We were already doing a join to the `order_itemmeta` table to get the correct `rate_percent`. The item meta also contains the tax rate id.
This PR adds an additional JOIN to get the tax rate id and includes a where condition to match the tax rate id from the order tax lookup to that of the `order_itemmeta` table.

**Alternative:**
Ideally we did update the `wc_order_tax_lookup` table to include the `order_line_item_id` as part of the table, but given this will include having to back fill a bunch of data, this solution seems like a better approach.

Closes #WOOPLUG-5669

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1332" height="648" alt="Screenshot 2025-10-13 at 10 50 17" src="https://github.com/user-attachments/assets/d12f8167-8a38-40d0-974d-cb8fa68d82dc" /> | <img width="1330" height="426" alt="Screenshot 2025-10-13 at 10 49 38" src="https://github.com/user-attachments/assets/483dd7d3-561c-4889-909c-b40346e9b4bd" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce (current stable) or load the `trunk` branch.
2. Enabled taxes under **WooCommerce → Settings** and then go to **WooCommerce → Settings → Tax → Standard rates**, and import the attached tax CSV (contains QC GST 5% Priority 1 and QC PST 9.975% Priority 2; other provinces may also be present from the export).
[tax_rates (1).csv](https://github.com/user-attachments/files/22879881/tax_rates.1.csv)
3. Add some products ( you can add the default products through the Task List )
4. Place one order (frontend or manual) shipping to a Quebec address; mark it Completed.
5. Open **Analytics → Taxes**
6. Observe duplicate rows for QC GST/PST with differing amounts (only two rows are “correct” and match the order; the others are spurious).
7. Load this branch and refresh the **Analytics → Taxes** page, you may need to clear the Analytics cache under **WooCommerce > Status > Tools > Clear analytics cache**
8. It should now correctly show two rows and no duplication.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
