### PR TITLE
Product Collection: show 'Preview' label when editing the Products by Brand template

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-collection-brand-taxonomy
+++ b/plugins/woocommerce/changelog/fix-product-collection-brand-taxonomy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: show 'Preview' label when editing the Products by Brand template

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -390,9 +390,10 @@ export const useSetPreviewState = ( {
 	 * For all Product Collection blocks that inherit query from the template,
 	 * we want to show a preview message in the editor if the block is in
 	 * generic archive template i.e.
-	 * - Products by category
-	 * - Products by tag
-	 * - Products by attribute
+	 * - Products by Category
+	 * - Products by Tag
+	 * - Products by Attribute
+	 * - Products by Brand
 	 */
 	const termId =
 		location.type === LocationType.Archive

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -78,6 +78,7 @@ const isInProductArchive = () => {
 		// That includes:
 		// - taxonomy-product_cat
 		// - taxonomy-product_tag
+		// - taxonomy-product_brand
 		'taxonomy-product_cat',
 		'taxonomy-product_tag',
 		'taxonomy-product_brand',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -246,30 +246,30 @@ const productGallery = {
 		},
 		onSelectedLargeImageKeyDown: ( event: KeyboardEvent ) => {
 			if (
-				event.code === 'Enter' ||
-				event.code === 'Space' ||
-				event.code === 'NumpadEnter'
+				event.key === 'Enter' ||
+				event.key === 'Space' ||
+				event.key === 'NumpadEnter'
 			) {
-				if ( event.code === 'Space' ) {
+				if ( event.key === 'Space' ) {
 					event.preventDefault();
 				}
 				actions.openDialog();
 			}
 
-			if ( event.code === 'ArrowRight' ) {
+			if ( event.key === 'ArrowRight' ) {
 				actions.selectNextImage();
 			}
 
-			if ( event.code === 'ArrowLeft' ) {
+			if ( event.key === 'ArrowLeft' ) {
 				actions.selectPreviousImage();
 			}
 		},
 		onDialogKeyDown: ( event: KeyboardEvent ) => {
-			if ( event.code === 'Escape' ) {
+			if ( event.key === 'Escape' ) {
 				actions.closeDialog();
 			}
 
-			if ( event.code === 'Tab' ) {
+			if ( event.key === 'Tab' ) {
 				const focusableElementsSelectors =
 					'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
@@ -383,12 +383,12 @@ const productGallery = {
 			context.thumbnailsOverflow = overflowState;
 		},
 		onArrowsKeyDown: ( event: KeyboardEvent ) => {
-			if ( event.code === 'ArrowRight' ) {
+			if ( event.key === 'ArrowRight' ) {
 				event.preventDefault();
 				actions.selectNextImage();
 			}
 
-			if ( event.code === 'ArrowLeft' ) {
+			if ( event.key === 'ArrowLeft' ) {
 				event.preventDefault();
 				actions.selectPreviousImage();
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -245,12 +245,8 @@ const productGallery = {
 			actions.selectImage( newImageIndex );
 		},
 		onSelectedLargeImageKeyDown: ( event: KeyboardEvent ) => {
-			if (
-				event.key === 'Enter' ||
-				event.key === 'Space' ||
-				event.key === 'NumpadEnter'
-			) {
-				if ( event.key === 'Space' ) {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				if ( event.key === ' ' ) {
 					event.preventDefault();
 				}
 				actions.openDialog();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/utils.tsx
@@ -19,7 +19,7 @@ type Context< T > = T & {
 };
 type SetEntityId = (
 	kind: 'postType' | 'taxonomy',
-	name: 'product' | 'product_cat' | 'product_tag',
+	name: 'product' | 'product_cat' | 'product_tag' | 'product_brand',
 	slug: string,
 	stateSetter: ( entityId: number | null ) => void
 ) => void;
@@ -28,6 +28,7 @@ const templateSlugs = {
 	singleProduct: 'single-product',
 	productCategory: 'taxonomy-product_cat',
 	productTag: 'taxonomy-product_tag',
+	productBrand: 'taxonomy-product_brand',
 	productAttribute: 'taxonomy-product_attribute',
 	orderConfirmation: 'order-confirmation',
 	cart: 'page-cart',
@@ -148,10 +149,14 @@ export const useGetLocation = < T, >(
 	const isInSpecificTagTemplate = isInSpecificTemplate(
 		templateSlugs.productTag
 	);
+	const isInSpecificBrandTemplate = isInSpecificTemplate(
+		templateSlugs.productBrand
+	);
 
 	const [ productId, setProductId ] = useState< number | null >( null );
 	const [ categoryId, setCategoryId ] = useState< number | null >( null );
 	const [ tagId, setTagId ] = useState< number | null >( null );
+	const [ brandId, setBrandId ] = useState< number | null >( null );
 
 	useEffect( () => {
 		if ( isInSpecificProductTemplate ) {
@@ -168,10 +173,16 @@ export const useGetLocation = < T, >(
 			const slug = getEntitySlug( templateSlugs.productTag );
 			setEntityId( 'taxonomy', 'product_tag', slug, setTagId );
 		}
+
+		if ( isInSpecificBrandTemplate ) {
+			const slug = getEntitySlug( templateSlugs.productBrand );
+			setEntityId( 'taxonomy', 'product_brand', slug, setBrandId );
+		}
 	}, [
 		isInSpecificProductTemplate,
 		isInSpecificCategoryTemplate,
 		isInSpecificTagTemplate,
+		isInSpecificBrandTemplate,
 		getEntitySlug,
 	] );
 
@@ -269,7 +280,19 @@ export const useGetLocation = < T, >(
 	}
 
 	/**
-	 * Case 2.5: TEMPLATES: GENERIC TAXONOMY
+	 * Case 2.5: TEMPLATES: SPECIFIC TAXONOMY
+	 * Specific Brand template
+	 */
+
+	if ( isInSpecificBrandTemplate ) {
+		return createLocationObject( LocationType.Archive, {
+			taxonomy: 'product_brand',
+			termId: brandId,
+		} );
+	}
+
+	/**
+	 * Case 2.6: TEMPLATES: GENERIC TAXONOMY
 	 * Generic Taxonomy template
 	 */
 
@@ -295,6 +318,17 @@ export const useGetLocation = < T, >(
 		} );
 	}
 
+	const isInProductsByBrandTemplate = isInGenericTemplate(
+		templateSlugs.productBrand
+	);
+
+	if ( isInProductsByBrandTemplate ) {
+		return createLocationObject( LocationType.Archive, {
+			taxonomy: 'product_brand',
+			termId: null,
+		} );
+	}
+
 	const isInProductsByAttributeTemplate = isInGenericTemplate(
 		templateSlugs.productAttribute
 	);
@@ -307,7 +341,7 @@ export const useGetLocation = < T, >(
 	}
 
 	/**
-	 * Case 2.6: TEMPLATES: GENERIC CART
+	 * Case 2.7: TEMPLATES: GENERIC CART
 	 * Cart/Checkout templates
 	 */
 
@@ -320,7 +354,7 @@ export const useGetLocation = < T, >(
 	}
 
 	/**
-	 * Case 2.7: TEMPLATES: GENERIC ORDER
+	 * Case 2.8: TEMPLATES: GENERIC ORDER
 	 * Order Confirmation template
 	 */
 
@@ -419,6 +453,7 @@ export const parseTemplateSlug = ( rawTemplateSlug = '' ) => {
 	const categoryPrefix = 'category-';
 	const productCategoryPrefix = 'taxonomy-product_cat-';
 	const productTagPrefix = 'taxonomy-product_tag-';
+	const productBrandPrefix = 'taxonomy-product_brand-';
 
 	if ( rawTemplateSlug.startsWith( categoryPrefix ) ) {
 		return {
@@ -438,6 +473,13 @@ export const parseTemplateSlug = ( rawTemplateSlug = '' ) => {
 		return {
 			taxonomy: 'product_tag',
 			slug: rawTemplateSlug.replace( productTagPrefix, '' ),
+		};
+	}
+
+	if ( rawTemplateSlug.startsWith( productBrandPrefix ) ) {
+		return {
+			taxonomy: 'product_brand',
+			slug: rawTemplateSlug.replace( productBrandPrefix, '' ),
 		};
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements two small fixes:

* https://github.com/woocommerce/woocommerce/commit/8b557540d303d75a5b76bedbc588fbea4d7c5b8d: switches from using [`event.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) to [`event.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) to detect keyboard events on the _Product Gallery_ block. `event.key` has better browser support and from my understanding, is what should be used when we care about what key was pressed, instead of in which position the key is in a physical keyboard.
* https://github.com/woocommerce/woocommerce/commit/ac146c33b1efcfafc01eb77ea97310c7468dcd1e: updates the _Product Collection_ block so it handles brands like other taxonomies such as categories or tags. I think eventually we might want this to be dynamic, so any taxonomy associated with products is considered. But for now, I fixed it for brands.

### How to test the changes in this Pull Request:

**Product Gallery input:**

1. Go to the product page in the frontend, making sure the _Product Gallery_ block is in the template.
2. Interact with the gallery using the keyboard: switching images, opening and closing the modal, etc.
3. Verify there are no regressions.

**Product Collection on brand templates:**

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Add Template_ > _Products by Brand_ and create a generic template for all brands.
2. When creating the template, select the _Product Collection_ block.
3. Verify there is a _Preview_ label on the top right of the block.

Before | After
--- | ---
<img width="812" height="532" alt="imatge" src="https://github.com/user-attachments/assets/f51dfda2-60d6-4760-a953-d0339134ecbf" /> | <img width="812" height="532" alt="imatge" src="https://github.com/user-attachments/assets/1177759d-32c9-45ea-974b-538ee6b879b7" />

4. Now create a new brand, assign some products to it.
5. Go to _Appearance_ > _Editor_ > _Templates_ > _Add Template_ > _Products by Brand_ and create a specific template for one brand.
6. In the editor, verify the products assigned to that brands are correctly displayed (instead of all products available in the store).

Before | After
--- | ---
<img width="812" height="532" alt="imatge" src="https://github.com/user-attachments/assets/a3efb2e0-d0ad-4e2c-a1b5-a548e3ad8c82" /> | <img width="812" height="532" alt="imatge" src="https://github.com/user-attachments/assets/4d7d2a98-c842-4ee0-ae2f-a38264d5a910" />