### PR TITLE
Improve 'can add custom product attributes' flaky test (II)

### DIFF
--- a/plugins/woocommerce/changelog/fix-53449-flaky-test-ii
+++ b/plugins/woocommerce/changelog/fix-53449-flaky-test-ii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'can add custom product attributes' flaky test
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.js
@@ -66,6 +66,16 @@ const test = baseTest.extend( {
  * @param {import('@playwright/test').Page} page
  */
 async function goToAttributesTab( page ) {
+	// There is the chance we might click on the 'Attributes' tab too early. To
+	// prevent that, we wait until the 'Variations' tab is hidden, which means
+	// the tabs have been updated.
+	// @see https://github.com/woocommerce/woocommerce/issues/53449.
+	await expect(
+		page
+			.locator( '.attribute_tab' )
+			.getByRole( 'link', { name: 'Variations' } )
+	).toBeHidden();
+
 	await test.step( 'Go to the "Attributes" tab.', async () => {
 		const attributesTab = page
 			.locator( '.attribute_tab' )
@@ -174,15 +184,6 @@ test( 'can add custom product attributes', async ( { page, product } ) => {
 			page.locator( '.notice-success', { name: 'Product updated' } )
 		).toBeVisible();
 	} );
-
-	// There is the chance we might click on the 'Attributes' tab too early. To
-	// prevent that, we wait until the 'Variations' tab is hidden, which means
-	// the tabs have been updated.
-	await expect(
-		page
-			.locator( '.attribute_tab' )
-			.getByRole( 'link', { name: 'Variations' } )
-	).toBeHidden();
 
 	await goToAttributesTab( page );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53449.

As mentioned in #59762, the test was flaky because we were clicking on the _Attributes_ button before it was interactive. In #59762, we implemented a fix so the test waits for the tabs to update before clicking on it.

This PR uses the fix from https://github.com/woocommerce/woocommerce/pull/59762, but moves it inside the `goToAttributesTab()` util. This way, we fix the flakiness every time the function is called instead of on a case-by-case basis.

### How to test the changes in this Pull Request:

1. Make sure the 'can add custom product attributes' test passes and is not flaky (run [Core e2e tests 5/6](https://github.com/woocommerce/woocommerce/actions/runs/18462833734/job/52598154976?pr=61404#logs)).