### PR TITLE
Fix broken pagination on wc analytics variations endpoint

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5677-broken-pagination-on-wc-analyticsvariations-endpoint
+++ b/plugins/woocommerce/changelog/wooplug-5677-broken-pagination-on-wc-analyticsvariations-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix issue in variations endpoint where pagination with the modified orderby was causing duplicates.
+Fix issue in where pagination with the modified orderby was causing duplicates in Variation and Product endpoints.

--- a/plugins/woocommerce/changelog/wooplug-5677-broken-pagination-on-wc-analyticsvariations-endpoint
+++ b/plugins/woocommerce/changelog/wooplug-5677-broken-pagination-on-wc-analyticsvariations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue in variations endpoint where pagination with the modified orderby was causing duplicates.

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -612,7 +612,7 @@ class WC_Query {
 		}
 
 		// Convert to correct format.
-		$orderby = strtolower( is_array( $orderby ) ? (string) current( $orderby ) : (string) $orderby );
+		$orderby = is_array( $orderby ) ? (string) current( $orderby ) : (string) $orderby;
 		$order   = strtoupper( is_array( $order ) ? (string) current( $order ) : (string) $order );
 		$args    = array(
 			'orderby'  => $orderby,
@@ -620,6 +620,7 @@ class WC_Query {
 			'meta_key' => '', // @codingStandardsIgnoreLine
 		);
 
+		$orderby = strtolower( $orderby );
 		switch ( $orderby ) {
 			case 'id':
 				$args['orderby'] = 'ID';
@@ -638,8 +639,9 @@ class WC_Query {
 			case 'rand':
 				$args['orderby'] = 'rand'; // @codingStandardsIgnoreLine
 				break;
+			case 'modified':
 			case 'date':
-				$args['orderby'] = 'date ID';
+				$args['orderby'] = $orderby . ' ID';
 				$args['order']   = ( 'ASC' === $order ) ? 'ASC' : 'DESC';
 				break;
 			case 'price':

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -612,15 +612,17 @@ class WC_Query {
 		}
 
 		// Convert to correct format.
-		$orderby = is_array( $orderby ) ? (string) current( $orderby ) : (string) $orderby;
+		$orderby = strtolower( is_array( $orderby ) ? (string) current( $orderby ) : (string) $orderby );
+		// ID can already be added and requires to be capitalized.
+		$orderby = str_replace( ' id', ' ID', $orderby );
 		$order   = strtoupper( is_array( $order ) ? (string) current( $order ) : (string) $order );
-		$args    = array(
+
+		$args = array(
 			'orderby'  => $orderby,
 			'order'    => ( 'DESC' === $order ) ? 'DESC' : 'ASC',
 			'meta_key' => '', // @codingStandardsIgnoreLine
 		);
 
-		$orderby = strtolower( $orderby );
 		switch ( $orderby ) {
 			case 'id':
 				$args['orderby'] = 'ID';

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -299,8 +299,9 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		$args['s']                   = $request['search'];
 		$args['fields']              = $this->get_fields_for_response( $request );
 
-		if ( 'date' === $args['orderby'] ) {
-			$args['orderby'] = 'date ID';
+		// Add ID to orderby for consistency with pagination.
+		if ( in_array( $args['orderby'], array( 'date', 'modified' ), true ) ) {
+			$args['orderby'] = $args['orderby'] . ' ID';
 		}
 
 		$date_query = array();

--- a/plugins/woocommerce/src/Admin/API/ProductVariations.php
+++ b/plugins/woocommerce/src/Admin/API/ProductVariations.php
@@ -140,6 +140,19 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 	}
 
 	/**
+	 * Optionally add the ID to the orderby clause if the orderby is modified.
+	 *
+	 * @param WP_Query $wp_query The WP_Query object.
+	 * @return WP_Query
+	 */
+	public static function optionally_add_wp_query_orderby_id( $wp_query ) {
+		if ( 'modified' === $wp_query->get( 'orderby' ) ) {
+			$wp_query->set( 'orderby', 'modified ID' );
+		}
+		return;
+	}
+
+	/**
 	 * Get a collection of posts and add the post title filter option to WP_Query.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -149,10 +162,12 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10, 2 );
+		add_action( 'pre_get_posts', array( __CLASS__, 'optionally_add_wp_query_orderby_id' ), 10, 2 );
 		$response = parent::get_items( $request );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
 		remove_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10 );
+		remove_action( 'pre_get_posts', array( __CLASS__, 'optionally_add_wp_query_orderby_id' ), 10 );
 		return $response;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/ProductVariations.php
+++ b/plugins/woocommerce/src/Admin/API/ProductVariations.php
@@ -140,19 +140,6 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 	}
 
 	/**
-	 * Optionally add the ID to the orderby clause if the orderby is modified.
-	 *
-	 * @param WP_Query $wp_query The WP_Query object.
-	 * @return WP_Query
-	 */
-	public static function optionally_add_wp_query_orderby_id( $wp_query ) {
-		if ( 'modified' === $wp_query->get( 'orderby' ) ) {
-			$wp_query->set( 'orderby', 'modified ID' );
-		}
-		return;
-	}
-
-	/**
 	 * Get a collection of posts and add the post title filter option to WP_Query.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -162,12 +149,10 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10, 2 );
-		add_action( 'pre_get_posts', array( __CLASS__, 'optionally_add_wp_query_orderby_id' ), 10, 2 );
 		$response = parent::get_items( $request );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
 		remove_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10 );
-		remove_action( 'pre_get_posts', array( __CLASS__, 'optionally_add_wp_query_orderby_id' ), 10 );
 		return $response;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This solves an issue where sorting by `modified` was causing issues with pagination as the modified date can be the same for a large set of variations and thus provide inconsistent pagination results and may even skip certain records. This issue was also present in some of the core REST API work for the product and variation endpoints.

Closes #WOOPLUG-5677, and https://github.com/woocommerce/woocommerce/issues/33386

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load `trunk` or the latest WooCommerce release
2. Create a bunch of products and products with a bunch of variations > 100 ( check if the products/variations have a large set where the modified_date is the same, you can also trigger this by doing a bulk update ).
3. In your admin, open your console and something like this and see if any duplicate variations are returned ( Note: I was not able to reproduce this )
```
window.test = {};
for ( let i = 1; i < 10; i++ ) {
wp.apiFetch({
  path: wp.url.addQueryArgs('/wc-analytics/variations', {
      'orderby': 'modified',
      'order': 'asc',
      'per_page': 10,
      'page': i,
      '_fields': 'id,parent_id,description,sku,global_unique_id,status,price,regular_price,sale_price,date_modified,stock_quantity,stock_status,manage_stock,backordered,attributes,image,downloadable,name'
  })
}).then( function( data ) {
    data.forEach( ( item ) => {
        const count = window.test[item.id] ? window.test[item.id] : 0;
        if ( count > 0 ) {
            console.log( 'duplicate ID: ' + item.id + 'Request Page: ' + i );
        }
        window.test[item.id] = count + 1;
    });
});
};
```
5. If you can reproduce it, load this branch and check if it doesn't happen anymore.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
