### PR TITLE
Fix PHP CodeSniffer memory exhaustion and improve linting performance

### DIFF
--- a/plugins/woocommerce/.eslintignore
+++ b/plugins/woocommerce/.eslintignore
@@ -1,9 +1,12 @@
 *.min.js
 
 /.wireit/**
+**/.wireit/**
 /assets/**
 /bin/composer/**
 /client/legacy/build/**
+/client/admin/build/**
+/client/blocks/build/**
 /client/legacy/js/accounting/**
 /client/legacy/js/flexslider/**
 /client/legacy/js/jquery-blockui/**

--- a/plugins/woocommerce/changelog/dev-lint-fixes
+++ b/plugins/woocommerce/changelog/dev-lint-fixes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Efficiency improvements to linter config

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -17,14 +17,8 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>lib/</exclude-pattern>
 
-	<!-- Exclude JavaScript/TypeScript files which are covered by ESLint. -->
-	<exclude-pattern>*.js</exclude-pattern>
-	<exclude-pattern>*.jsx</exclude-pattern>
-	<exclude-pattern>*.ts</exclude-pattern>
-	<exclude-pattern>*.tsx</exclude-pattern>
-	<exclude-pattern>*.json</exclude-pattern>
-	<exclude-pattern>*.scss</exclude-pattern>
-	<exclude-pattern>*.css</exclude-pattern>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php" />
 
 	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="ps" />

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -17,6 +17,15 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>lib/</exclude-pattern>
 
+	<!-- Exclude JavaScript/TypeScript files which are covered by ESLint. -->
+	<exclude-pattern>*.js</exclude-pattern>
+	<exclude-pattern>*.jsx</exclude-pattern>
+	<exclude-pattern>*.ts</exclude-pattern>
+	<exclude-pattern>*.tsx</exclude-pattern>
+	<exclude-pattern>*.json</exclude-pattern>
+	<exclude-pattern>*.scss</exclude-pattern>
+	<exclude-pattern>*.css</exclude-pattern>
+
 	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="ps" />
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/61413.

This PR fixes issues preventing the PHP linting command from running successfully. The main problem was PHP CodeSniffer attempting to tokenize JavaScript/TypeScript files, causing memory exhaustion and timeouts.

## Changes

### phpcs.xml
Added exclusions for non-PHP file types that don't need to be linted by phpcs:

```xml
<!-- Only check PHP files. -->
<arg name="extensions" value="php" />
```

**Impact:**

Benchmarks from my machine:

Time:
- Reduced from 223.46 seconds to 105.24 seconds
- 53% faster (or 2.1x speedup)
- Saved 118 seconds

Memory:
- Reduced from 889.03 MB to 64.03 MB
- 93% reduction (or 13.9x less memory)
- Saved 825 MB

### .eslintignore
Added exclusions to prevent ESLint from scanning build artifacts and cache directories:
- `**/.wireit/**` - Excludes all wireit cache directories (398MB+ of generated files)
- `/client/admin/build/**` - Excludes admin build artifacts
- `/client/blocks/build/**` - Excludes blocks build artifacts

**Impact:** Reduces unnecessary file scanning and improves ESLint performance.

## Testing Instructions

0. Checkout `develop` and run `cd plugins/woocommerce && pnpm run lint:php` - take note of the time it takes and the memory usage.
1. Checkout this branch
2. Run PHP linting:
   ```bash
   cd plugins/woocommerce && pnpm run lint:php
   ```
3. Verify the command completes successfully (note that you will get some lint errors from some legacy files). The time taken and memory usage should be lower.
## Changelog Entry

> Dev - Fix PHP CodeSniffer memory exhaustion by excluding non-PHP files from phpcs scanning