### PR TITLE
Add to Cart + Options: add up quantities when the same product is in the cart multiple times as different cart items

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-multiple-products-quantity
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-multiple-products-quantity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: add up quantities when the same product is in the cart multiple times as different cart items

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -73,16 +73,22 @@ const productButtonStore = {
 
 			// Return the product quantity when the item is a non-variable product.
 			if ( products[ 0 ]?.type !== 'variation' ) {
-				return products[ 0 ]?.quantity || 0;
+				return products.reduce(
+					( acc, item ) => acc + item.quantity,
+					0
+				);
 			}
 
 			const selectedAttributes =
 				addToCartWithOptionsState?.selectedAttributes;
-			const selectedVariableProduct = products.find( ( item ) =>
+			const selectedVariableProducts = products.filter( ( item ) =>
 				doesCartItemMatchAttributes( item, selectedAttributes )
 			);
 
-			return selectedVariableProduct?.quantity || 0;
+			return selectedVariableProducts.reduce(
+				( acc, item ) => acc + item.quantity,
+				0
+			);
 		},
 		get slideInAnimation() {
 			const { animationStatus } = getContext< Context >();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is the chance that the same product might be in two different cart item entries. For example, when using the Product Add-Ons plugin, you can add the same product with and without add-ons.

Until now, the _Add to Cart Button_ block would only display the quantity of the item that was first added to the cart. With these changes, it will add-up the quantities of all items, making the values more intuitive.

### How to test the changes in this Pull Request:

Verify the quantities are correct when two cart items have the same id:

1. See steps in 4070-gh-woocommerce/woocommerce-bookings.

Make sure there are no regressions in the quantity shown in the _X in cart_ text of the _Add to Cart Button_ block:

1. Update the _Single Product_ template and switch to the blockified _Add to Cart + Options_ block.
2. In the frontend of a simple product, add the product several times. Make sure the button updates properly.
3. Repeat the process in a variable product, making sure the button shows the number of that specific variation in cart.