### PR TITLE
dev: Update Evaluate Project Job Statuses to run for all trigger types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,8 +316,9 @@ jobs:
     # on the results of the other jobs in the workflow.
     name: 'Evaluate Project Job Statuses'
     runs-on: ubuntu-latest
-    needs: [ 'identify-jobs-to-run', 'project-jobs', 'project-lint-jobs', 'project-test-jobs', 'validate-changelog', 'validate-markdown', 'validate-syncpack' ]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    needs: [ 'project-jobs', 'project-lint-jobs', 'project-test-jobs', 'validate-changelog', 'validate-markdown', 'validate-syncpack' ]
+    # This job must run for all trigger types (not just PRs) so that alert-on-failure can access its outputs
+    if: ${{ !cancelled() }}
     outputs:
       non_successful_jobs: ${{ steps.evaluation.outputs.non_successful_jobs }}
     steps:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Evaluate Project Job Statuses job is needed to always run, because it outputs a list of failed jobs, which is needed by the subsequent alert job.
Always running it doesn't hurt, it's fast enough.

Fixes QAO-117


### How to test the changes in this Pull Request:

- Check CI runs after merge. The Evaluate Project Job Statuses should not be skipped.
