### PR TITLE
e2e tests: Add JUnit reporter configuration for Playwright test results

### DIFF
--- a/plugins/woocommerce/changelog/qao-127-output-junit-style-report
+++ b/plugins/woocommerce/changelog/qao-127-output-junit-style-report
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add JUnit report configuration

--- a/plugins/woocommerce/client/blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/playwright.config.ts
@@ -31,6 +31,12 @@ const config: PlaywrightTestConfig = {
 					},
 				],
 				[ 'buildkite-test-collector/playwright/reporter' ],
+				[
+					'junit',
+					{
+						outputFile: `${ __dirname }/artifacts/test-results/results.xml`,
+					},
+				],
 		  ]
 		: 'list',
 	use: {

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -52,10 +52,8 @@ if ( process.env.CI ) {
 	reporter.push( [ 'buildkite-test-collector/playwright/reporter' ] );
 	reporter.push( [ `${ TESTS_ROOT_PATH }/reporters/skipped-tests.js` ] );
 	reporter.push( [
-		[
-			'junit',
-			{ outputFile: `${ TESTS_ROOT_PATH }/test-results/results.xml` },
-		],
+		'junit',
+		{ outputFile: `${ TESTS_ROOT_PATH }/test-results/results.xml` },
 	] );
 } else {
 	reporter.push( [

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -51,6 +51,12 @@ const reporter = [
 if ( process.env.CI ) {
 	reporter.push( [ 'buildkite-test-collector/playwright/reporter' ] );
 	reporter.push( [ `${ TESTS_ROOT_PATH }/reporters/skipped-tests.js` ] );
+	reporter.push( [
+		[
+			'junit',
+			{ outputFile: `${ TESTS_ROOT_PATH }/test-results/results.xml` },
+		],
+	] );
 } else {
 	reporter.push( [
 		'html',


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Part of QAO-127

Configure JUnit reporter for e2e tests.

### How to test the changes in this Pull Request:

See the artefacts in CI. A `results.xml` file should exist.
