### PR TITLE
Switch to using the elvis operator for current ternary operators that call functions for truthy checks.

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-fee.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<td class="name">
 		<div class="view">
-			<?php echo esc_html( $item->get_name() ? $item->get_name() : __( 'Fee', 'woocommerce' ) ); ?>
+			<?php echo esc_html( $item->get_name() ?: __( 'Fee', 'woocommerce' ) ); ?>
 		</div>
 		<div class="edit" style="display: none;">
 			<input type="text" placeholder="<?php esc_attr_e( 'Fee name', 'woocommerce' ); ?>" name="order_item_name[<?php echo absint( $item_id ); ?>]" value="<?php echo ( $item->get_name() ) ? esc_attr( $item->get_name() ) : ''; ?>" />

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<td class="name">
 		<div class="view">
-			<?php echo esc_html( $item->get_name() ? $item->get_name() : __( 'Shipping', 'woocommerce' ) ); ?>
+			<?php echo esc_html( $item->get_name() ?: __( 'Shipping', 'woocommerce' ) ); ?>
 		</div>
 		<div class="edit" style="display: none;">
 			<input type="hidden" name="shipping_method_id[]" value="<?php echo esc_attr( $item_id ); ?>" />

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 
-<?php wc_back_header( $zone->get_zone_name() ? $zone->get_zone_name() : __( 'Add zone', 'woocommerce' ), __( 'Return to shipping', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>
+<?php wc_back_header( $zone->get_zone_name() ?: __( 'Add zone', 'woocommerce' ), __( 'Return to shipping', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>
 
 <?php
 // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -372,7 +372,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 
 		return $order ? add_query_arg(
 			array(
-				'download_file' => $this->get_variation_id() ? $this->get_variation_id() : $this->get_product_id(),
+				'download_file' => $this->get_variation_id() ?: $this->get_product_id(),
 				'order'         => $order->get_order_key(),
 				'email'         => rawurlencode( $order->get_billing_email() ),
 				'key'           => $download_id,
@@ -390,7 +390,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 		$files      = array();
 		$product    = $this->get_product();
 		$order      = $this->get_order();
-		$product_id = $this->get_variation_id() ? $this->get_variation_id() : $this->get_product_id();
+		$product_id = $this->get_variation_id() ?: $this->get_product_id();
 
 		if ( $product && $order && $product->is_downloadable() && $order->is_download_permitted() ) {
 			$email_hash         = function_exists( 'hash' ) ? hash( 'sha256', $order->get_billing_email() ) : sha1( $order->get_billing_email() );

--- a/plugins/woocommerce/includes/class-wc-product-external.php
+++ b/plugins/woocommerce/includes/class-wc-product-external.php
@@ -171,7 +171,7 @@ class WC_Product_External extends WC_Product {
 	 * @return string
 	 */
 	public function single_add_to_cart_text() {
-		return apply_filters( 'woocommerce_product_single_add_to_cart_text', $this->get_button_text() ? $this->get_button_text() : _x( 'Buy product', 'placeholder', 'woocommerce' ), $this );
+		return apply_filters( 'woocommerce_product_single_add_to_cart_text', $this->get_button_text() ?: _x( 'Buy product', 'placeholder', 'woocommerce' ), $this );
 	}
 
 	/**
@@ -181,7 +181,7 @@ class WC_Product_External extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_text() {
-		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->get_button_text() ? $this->get_button_text() : _x( 'Buy product', 'placeholder', 'woocommerce' ), $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->get_button_text() ?: _x( 'Buy product', 'placeholder', 'woocommerce' ), $this );
 	}
 
 	/**
@@ -192,6 +192,6 @@ class WC_Product_External extends WC_Product {
 	 */
 	public function add_to_cart_description() {
 		/* translators: %s: Product title */
-		return apply_filters( 'woocommerce_product_add_to_cart_description', $this->get_button_text() ? $this->get_button_text() : sprintf( __( 'Buy &ldquo;%s&rdquo;', 'woocommerce' ), $this->get_name() ), $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_description', $this->get_button_text() ?: sprintf( __( 'Buy &ldquo;%s&rdquo;', 'woocommerce' ), $this->get_name() ), $this );
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -397,7 +397,7 @@ class WC_Product_Variable extends WC_Product {
 		}
 		// See if prices should be shown for each variation after selection.
 		$show_variation_price = apply_filters( 'woocommerce_show_variation_price', $variation->get_price() === '' || $this->get_variation_sale_price( 'min' ) !== $this->get_variation_sale_price( 'max' ) || $this->get_variation_regular_price( 'min' ) !== $this->get_variation_regular_price( 'max' ), $this, $variation );
-
+		$max_purchase_quantity = $variation->get_max_purchase_quantity();
 		return apply_filters(
 			'woocommerce_available_variation',
 			array(
@@ -415,7 +415,7 @@ class WC_Product_Variable extends WC_Product {
 				'is_purchasable'        => $variation->is_purchasable(),
 				'is_sold_individually'  => $variation->is_sold_individually() ? 'yes' : 'no',
 				'is_virtual'            => $variation->is_virtual(),
-				'max_qty'               => 0 < $variation->get_max_purchase_quantity() ? $variation->get_max_purchase_quantity() : '',
+				'max_qty'               => 0 < $max_purchase_quantity ? $max_purchase_quantity : '',
 				'min_qty'               => $variation->get_min_purchase_quantity(),
 				'price_html'            => $show_variation_price ? '<span class="price">' . $variation->get_price_html() . '</span>' : '',
 				'sku'                   => $variation->get_sku(),

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -209,7 +209,7 @@ class WC_Structured_Data {
 			'@id'         => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
 			'name'        => wp_kses_post( $product->get_name() ),
 			'url'         => $permalink,
-			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) ),
+			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ?: $product->get_description() ) ),
 		);
 
 		if ( $image ) {

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -78,7 +78,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function create( &$order ) {
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
-		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
+		$order->set_currency( $order->get_currency() ?: get_woocommerce_currency() );
 		if ( ! $order->get_date_created( 'edit' ) ) {
 			$order->set_date_created( time() );
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
@@ -90,7 +90,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 				"SELECT download_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE user_email = %s AND order_key = %s AND product_id = %d ORDER BY permission_id",
 				$order->get_billing_email(),
 				$order->get_order_key(),
-				$item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id()
+				$item->get_variation_id() ?: $item->get_product_id()
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -206,9 +206,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'woocommerce_new_product_data',
 				array(
 					'post_type'      => 'product',
-					'post_status'    => $product->get_status() ? $product->get_status() : ProductStatus::PUBLISH,
+					'post_status'    => $product->get_status() ?: ProductStatus::PUBLISH,
 					'post_author'    => get_current_user_id(),
-					'post_title'     => $product->get_name() ? $product->get_name() : __( 'Product', 'woocommerce' ),
+					'post_title'     => $product->get_name() ?: __( 'Product', 'woocommerce' ),
 					'post_content'   => $product->get_description(),
 					'post_excerpt'   => $product->get_short_description(),
 					'post_parent'    => $product->get_parent_id(),

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -137,7 +137,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				'woocommerce_new_product_variation_data',
 				array(
 					'post_type'      => 'product_variation',
-					'post_status'    => $product->get_status() ? $product->get_status() : ProductStatus::PUBLISH,
+					'post_status'    => $product->get_status() ?: ProductStatus::PUBLISH,
 					'post_author'    => get_current_user_id(),
 					'post_title'     => $product->get_name( 'edit' ),
 					'post_excerpt'   => $product->get_attribute_summary( 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -265,7 +265,7 @@ class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {
 				switch ( $key ) {
 					case 'code' :
 						$coupon_code  = wc_format_coupon_code( $value );
-						$id           = $coupon->get_id() ? $coupon->get_id() : 0;
+						$id           = $coupon->get_id() ?: 0;
 						$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 						if ( $id_from_code ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -337,7 +337,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 		foreach ( $order->get_refunds() as $refund ) {
 			$data['refunds'][] = array(
 				'id'     => $refund->get_id(),
-				'refund' => $refund->get_reason() ? $refund->get_reason() : '',
+				'refund' => $refund->get_reason() ?: '',
 				'total'  => '-' . wc_format_decimal( $refund->get_amount(), $dp ),
 			);
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -481,7 +481,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 			'sku'                   => $product->get_sku(),
 			'price'                 => $product->get_price(),
 			'regular_price'         => $product->get_regular_price(),
-			'sale_price'            => $product->get_sale_price() ? $product->get_sale_price() : '',
+			'sale_price'            => $product->get_sale_price() ?: '',
 			'date_on_sale_from'     => $product->get_date_on_sale_from() ? date( 'Y-m-d', $product->get_date_on_sale_from()->getTimestamp() ) : '',
 			'date_on_sale_to'       => $product->get_date_on_sale_to() ? date( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() ) : '',
 			'price_html'            => $product->get_price_html(),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -299,7 +299,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 				switch ( $key ) {
 					case 'code':
 						$coupon_code  = wc_format_coupon_code( $value );
-						$id           = $coupon->get_id() ? $coupon->get_id() : 0;
+						$id           = $coupon->get_id() ?: 0;
 						$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 						if ( $id_from_code ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -438,7 +438,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					foreach ( $order->get_refunds() as $refund ) {
 						$data['refunds'][] = array(
 							'id'     => $refund->get_id(),
-							'reason' => $refund->get_reason() ? $refund->get_reason() : '',
+							'reason' => $refund->get_reason() ?: '',
 							'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
 						);
 					}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -188,9 +188,9 @@ class WC_Shortcode_Checkout {
 
 				WC()->customer->set_props(
 					array(
-						'billing_country'  => $order->get_billing_country() ? $order->get_billing_country() : null,
-						'billing_state'    => $order->get_billing_state() ? $order->get_billing_state() : null,
-						'billing_postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+						'billing_country'  => $order->get_billing_country() ?: null,
+						'billing_state'    => $order->get_billing_state() ?: null,
+						'billing_postcode' => $order->get_billing_postcode() ?: null,
 					)
 				);
 				WC()->customer->save();

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -586,7 +586,7 @@ function wc_create_refund( $args = array() ) {
 		$refund->set_currency( $order->get_currency() );
 		$refund->set_amount( $args['amount'] );
 		$refund->set_parent_id( absint( $args['order_id'] ) );
-		$refund->set_refunded_by( get_current_user_id() ? get_current_user_id() : 1 );
+		$refund->set_refunded_by( get_current_user_id() ?: 1 );
 		$refund->set_prices_include_tax( $order->get_prices_include_tax() );
 
 		if ( ! is_null( $args['reason'] ) ) {

--- a/plugins/woocommerce/src/Admin/API/Orders.php
+++ b/plugins/woocommerce/src/Admin/API/Orders.php
@@ -260,7 +260,7 @@ class Orders extends \WC_REST_Orders_Controller {
 		foreach ( $object->get_refunds() as $refund ) {
 			$data['refunds'][] = array(
 				'id'     => $refund->get_id(),
-				'reason' => $refund->get_reason() ? $refund->get_reason() : '',
+				'reason' => $refund->get_reason() ?: '',
 				'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -96,7 +96,7 @@ class FeaturedProduct extends FeaturedItem {
 			) {
 				$desc_str = sprintf(
 					'<div class="wc-block-featured-product__description">%s</div>',
-					wc_format_content( wp_kses_post( $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ) )
+					wc_format_content( wp_kses_post( $product->get_short_description() ?: wc_trim_string( $product->get_description(), 400 ) ) )
 				);
 				$output  .= $desc_str;
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2826,7 +2826,7 @@ FROM $order_meta_table
 	 */
 	protected function persist_save( &$order, bool $force_all_fields = false, $backfill = true ) {
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
-		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
+		$order->set_currency( $order->get_currency() ?: get_woocommerce_currency() );
 
 		if ( ! $order->get_date_created( 'edit' ) ) {
 			$order->set_date_created( time() );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderItemSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderItemSchema.php
@@ -157,7 +157,7 @@ class OrderItemSchema extends AbstractLineItemSchema {
 			'id'           => $order_item->get_id(),
 			'name'         => $order_item->get_name(),
 			'image'        => $this->get_image( $order_item ),
-			'product_id'   => $order_item->get_variation_id() ? $order_item->get_variation_id() : $order_item->get_product_id(),
+			'product_id'   => $order_item->get_variation_id() ?: $order_item->get_product_id(),
 			'product_data' => $this->get_product_data( $order_item ),
 			'quantity'     => $order_item->get_quantity(),
 			'price'        => $quantity_amount ? $order_item->get_total() / $quantity_amount : 0,
@@ -292,7 +292,7 @@ class OrderItemSchema extends AbstractLineItemSchema {
 			return '';
 		}
 
-		$image_id = $product->get_image_id() ? $product->get_image_id() : 0;
+		$image_id = $product->get_image_id() ?: 0;
 		return $image_id ? wp_get_attachment_image_url( $image_id, 'full' ) : '';
 	}
 }

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/Templates/html-product-data-admin.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/Templates/html-product-data-admin.php
@@ -29,7 +29,7 @@ if ( ! empty( $product->get_sku() ) ) {
 		<span>
 			<?php printf( '(%s)', esc_html( $identifier ) ); ?>
 		</span>
-		<a target="_blank" href="<?php echo esc_url( admin_url( sprintf( 'post.php?post=%d&action=edit', $product->get_parent_id() ? $product->get_parent_id() : $product->get_id() ) ) ); ?>"><span class="dashicons dashicons-external"></span></a>
+		<a target="_blank" href="<?php echo esc_url( admin_url( sprintf( 'post.php?post=%d&action=edit', $product->get_parent_id() ?: $product->get_id() ) ) ); ?>"><span class="dashicons dashicons-external"></span></a>
 	</p>
 
 	<span class="product-details__price">

--- a/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Frontend/ProductPageIntegration.php
@@ -211,7 +211,7 @@ class ProductPageIntegration {
 		wc_get_template(
 			'single-product/back-in-stock-form.php',
 			array(
-				'product_id'       => $product->get_parent_id() ? $product->get_parent_id() : $product->get_id(),
+				'product_id'       => $product->get_parent_id() ?: $product->get_id(),
 				'show_checkbox'    => ! is_user_logged_in() && Config::creates_account_on_signup() && ! Config::requires_account(),
 				'show_email_field' => ! is_user_logged_in() && ! Config::requires_account(),
 				'button_class'     => $button_class,

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/Agentic/CheckoutSessionSchema.php
@@ -405,8 +405,8 @@ class CheckoutSessionSchema extends AbstractSchema {
 			return null;
 		}
 
-		$first_name = $customer->get_billing_first_name() ? $customer->get_billing_first_name() : $customer->get_shipping_first_name();
-		$last_name  = $customer->get_billing_last_name() ? $customer->get_billing_last_name() : $customer->get_shipping_last_name();
+		$first_name = $customer->get_billing_first_name() ?: $customer->get_shipping_first_name();
+		$last_name  = $customer->get_billing_last_name() ?: $customer->get_shipping_last_name();
 		$email      = $customer->get_billing_email();
 
 		if ( ! $first_name && ! $last_name && ! $email ) {
@@ -417,7 +417,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			'first_name'   => $first_name ? $first_name : '',
 			'last_name'    => $last_name ? $last_name : '',
 			'email'        => $email ? $email : '',
-			'phone_number' => $customer->get_billing_phone() ? $customer->get_billing_phone() : '',
+			'phone_number' => $customer->get_billing_phone() ?: '',
 		];
 	}
 
@@ -428,8 +428,8 @@ class CheckoutSessionSchema extends AbstractSchema {
 	 * @return array|null Buyer data or null.
 	 */
 	protected function format_buyer_from_order( $order ) {
-		$first_name = $order->get_billing_first_name() ? $order->get_billing_first_name() : $order->get_shipping_first_name();
-		$last_name  = $order->get_billing_last_name() ? $order->get_billing_last_name() : $order->get_shipping_last_name();
+		$first_name = $order->get_billing_first_name() ?: $order->get_shipping_first_name();
+		$last_name  = $order->get_billing_last_name() ?: $order->get_shipping_last_name();
 		$email      = $order->get_billing_email();
 
 		if ( ! $first_name && ! $last_name && ! $email ) {
@@ -440,7 +440,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			'first_name'   => $first_name ? $first_name : '',
 			'last_name'    => $last_name ? $last_name : '',
 			'email'        => $email ? $email : '',
-			'phone_number' => $order->get_billing_phone() ? $order->get_billing_phone() : '',
+			'phone_number' => $order->get_billing_phone() ?: '',
 		];
 	}
 
@@ -537,7 +537,7 @@ class CheckoutSessionSchema extends AbstractSchema {
 			$total       = $subtotal + $tax;
 
 			// Use product_id from the order item, with variation_id as fallback.
-			$item_product_id = $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id();
+			$item_product_id = $item->get_variation_id() ?: $item->get_product_id();
 
 			$items[] = [
 				'id'          => (string) $item_id,


### PR DESCRIPTION
ON HOLD - The `Universal.Operators.DisallowShortTernary` phpcs rule prevents this from being applied.  

Saving to go back and evaluate which of these may be worth adding additional lines of code to prevent the duplicate function calls at a later point.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
