### PR TITLE
Only update term counts when product visibility changes

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-5693-only-update-term-counts-when-product-visibility-changes
+++ b/plugins/woocommerce/changelog/WOOPLUG-5693-only-update-term-counts-when-product-visibility-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Trigger term recounts for products after visibility terms change instead of after product saving.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -592,7 +592,7 @@ class WC_Post_Data {
 	 * @since 10.4.0
 	 */
 	public static function recount_terms_for_product_visibility_change( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
-		if ( $taxonomy !== 'product_visibility' ) {
+		if ( 'product_visibility' !== $taxonomy ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -39,6 +39,7 @@ class WC_Post_Data {
 		add_action( 'shutdown', array( __CLASS__, 'do_deferred_product_sync' ), 10 );
 		add_action( 'set_object_terms', array( __CLASS__, 'force_default_term' ), 10, 5 );
 		add_action( 'set_object_terms', array( __CLASS__, 'delete_product_query_transients' ) );
+		add_action( 'set_object_terms', array( __CLASS__, 'recount_terms_for_product_visibility_change' ), 10, 6 );
 		add_action( 'deleted_term_relationships', array( __CLASS__, 'delete_product_query_transients' ) );
 		add_action( 'woocommerce_product_set_stock_status', array( __CLASS__, 'delete_product_query_transients' ) );
 		add_action( 'woocommerce_product_set_visibility', array( __CLASS__, 'delete_product_query_transients' ) );
@@ -575,6 +576,49 @@ class WC_Post_Data {
 			if ( $default_term && ! in_array( $default_term, $tt_ids, true ) ) {
 				wp_set_post_terms( $object_id, array( $default_term ), 'product_cat', true );
 			}
+		}
+	}
+
+	/**
+	 * Recounts product terms when product visibility changes affect catalog display.
+	 *
+	 * @param int    $object_id   The object ID.
+	 * @param array  $terms       An array of object terms.
+	 * @param array  $tt_ids      An array of term taxonomy IDs.
+	 * @param string $taxonomy    Taxonomy slug.
+	 * @param bool   $append      Whether to append new terms to the old terms.
+	 * @param array  $old_tt_ids  The old array of term taxonomy IDs.
+	 *
+	 * @since 10.4.0
+	 */
+	public static function recount_terms_for_product_visibility_change( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+		if ( $taxonomy !== 'product_visibility' ) {
+			return;
+		}
+
+		if ( $append ) {
+			$modified_tt_ids = $tt_ids;
+		} else {
+			$modified_tt_ids = array_merge( array_diff( $tt_ids, $old_tt_ids ), array_diff( $old_tt_ids, $tt_ids ) );
+		}
+
+		if ( empty( $modified_tt_ids ) ) {
+			return;
+		}
+
+		// Despite the name, wc_get_product_visibility_term_ids() actually returns an associative array with term_taxonomy_ids.
+		$visibility_tt_ids = wc_get_product_visibility_term_ids();
+
+		$tt_ids_modifying_term_counts = array();
+		if ( ! empty( $visibility_tt_ids['exclude-from-catalog'] ) ) {
+			$tt_ids_modifying_term_counts[] = $visibility_tt_ids['exclude-from-catalog'];
+		}
+
+		if ( ! empty( $visibility_tt_ids['outofstock'] ) && 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+			$tt_ids_modifying_term_counts[] = $visibility_tt_ids['outofstock'];
+		}
+		if ( ! empty( array_intersect( $modified_tt_ids, $tt_ids_modifying_term_counts ) ) ) {
+			_wc_recount_terms_by_product( $object_id );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -617,6 +617,7 @@ class WC_Post_Data {
 		if ( ! empty( $visibility_tt_ids['outofstock'] ) && 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$tt_ids_modifying_term_counts[] = $visibility_tt_ids['outofstock'];
 		}
+
 		if ( ! empty( array_intersect( $modified_tt_ids, $tt_ids_modifying_term_counts ) ) ) {
 			_wc_recount_terms_by_product( $object_id );
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -926,8 +926,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $force || array_key_exists( 'shipping_class_id', $changes ) ) {
 			wp_set_post_terms( $product->get_id(), array( $product->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
 		}
-
-		_wc_recount_terms_by_product( $product->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/AssignDefaultCategoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AssignDefaultCategoryTest.php
@@ -34,16 +34,20 @@ class AssignDefaultCategoryTest extends \WC_Unit_Test_Case {
 
 		$products = array( $product1, $product2, $product3 );
 
-		// Remove all categories from products.
+		// Remove all categories from products. A direct query is used to get around WC_Post_Data::delete_product_query_transients().
 		foreach ( $products as $product ) {
-			$result = $wpdb->query(
+			$wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->term_relationships} WHERE object_id = %d AND term_taxonomy_id = %d",
 					$product->get_id(),
 					$default_category
 				)
 			);
+
 		}
+
+		wp_cache_flush();
+		delete_transient( 'wc_term_counts' );
 
 		// Ensure all categories are removed from products.
 		foreach ( $products as $product ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [WOOPLUG-5693](https://linear.app/a8c/issue/WOOPLUG-5693/unneeded-term-recounts-for-products) / #61416.

This removes the direct call to `_wc_recount_terms_by_product()` from `WC_Product_Data_Store_CPT::update_terms()` that is run on every product save and instead triggers `_wc_recount_terms_by_product()` when the visibility terms are modified on a product.  This provides around a ~10% performance improvement when writing to products and fixes a bug where the term counts aren't updated if the visibility terms for a product are modified without saving the product itself.

### Screenshots or screen recordings:

The following are the test results running 5 iterations of both CREATE and UPDATE batched requests for 100 products comparing this patch vs trunk.

| Metric | Patch | Trunk | Time Difference | Improvement |
|--------|-------|-------|-----------------|-------------|
| **CREATE - Average Time (sec)** | 20.68 | 22.43 | **-1.75s** | **7.8%** |
| **CREATE - P50 Median (sec)** | 20.73 | 22.43 | **-1.70s** | **7.6%** |
| **CREATE - P75 (sec)** | 20.74 | 22.84 | **-2.10s** | **9.2%** |
| **CREATE - Min Time (sec)** | 20.52 | 21.45 | **-0.93s** | **4.3%** |
| **CREATE - Max Time (sec)** | 20.77 | 23.38 | **-2.61s** | **11.2%** |
| **CREATE - Throughput (products/sec)** | 4.8 | 4.5 | **+0.3** | **6.7%** |
| **UPDATE - Average Time (sec)** | 13.78 | 15.34 | **-1.56s** | **10.2%** |
| **UPDATE - P50 Median (sec)** | 13.76 | 15.04 | **-1.28s** | **8.5%** |
| **UPDATE - P75 (sec)** | 13.78 | 15.37 | **-1.59s** | **10.3%** |
| **UPDATE - Min Time (sec)** | 13.67 | 14.91 | **-1.24s** | **8.3%** |
| **UPDATE - Max Time (sec)** | 13.98 | 16.42 | **-2.44s** | **14.9%** |
| **UPDATE - Throughput (products/sec)** | 7.3 | 6.5 | **+0.8** | **12.3%** |
| **Total Execution Time (sec)** | 177.52 | 193.32 | **-15.80s** | **8.2%** |

The script I used for testing is below. Note, it was AI generated for this. It requires that the test site already has some existing product tags and categories to work from. To use:

1. Configure the credentials at the top of the file.
2 . Run: `php test-batch.php`
https://gist.github.com/prettyboymp/6999924cb865f060d5b374efe5ec9e33

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Setup:
Before testing, do one of the following to make sure you can see the product counts for a given category:
1. Within Customizer, go to WooCommerce -> Product Catalog.
2. Change the Shop page to Show Categories and Category Display to Show Subcategories
OR
1. Add the Product Categories List widget to the site and set it to Show product count.

Testing:

1. Go to Admin -> WooCommerce -> Settings -> Products -> Inventory.
2. Enable stock management
3. Enable Hide out of stock items.
4. Go to Admin -> Products and filter by a specific category.
5. Compare the number of in-stock products in the category to the numbers shown on the front-end and make sure they match.
6. Use quick edit to modify an in-stock item and change it's visibility to "Search" or "Hidden" - one of the options that doesn't include catalog.
7. Check that the count was updated on the category on the front end to have one less item.
