### PR TITLE
Filter product class in REST API like in `WC_Product_Factory::get_product_classname()`

### DIFF
--- a/plugins/woocommerce/changelog/add-rest-product-class-filter
+++ b/plugins/woocommerce/changelog/add-rest-product-class-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Filter product class in REST API like in `WC_Product_Factory::get_product_classname()`

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -203,6 +203,11 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			 * @since 10.3.0
 			 */
 			$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_Variation', ProductType::VARIATION, 'product_variation', 0 );
+
+			if ( ! class_exists( $classname ) ) {
+				$classname = 'WC_Product_Variation';
+			}
+
 			$variation = new $classname();
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
+use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareRestControllerTrait;
@@ -196,7 +197,13 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		if ( isset( $request['id'] ) ) {
 			$variation = wc_get_product( absint( $request['id'] ) );
 		} else {
-			$variation = new WC_Product_Variation();
+			/**
+			 * This filter is documented in includes/class-wc-product-factory.php
+			 *
+			 * @since 10.3.0
+			 */
+			$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_Variation', ProductType::VARIATION, 'product_variation', 0 );
+			$variation = new $classname();
 		}
 
 		$variation->set_parent_id( absint( $request['product_id'] ) );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -728,17 +728,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Type is the most important part here because we need to be using the correct class and methods.
 		if ( isset( $request['type'] ) ) {
-			$classname = WC_Product_Factory::get_classname_from_product_type( $request['type'] );
-
-			if ( ! class_exists( $classname ) ) {
-				$classname = 'WC_Product_Simple';
-			}
+			$classname = WC_Product_Factory::get_product_classname( $id, $request['type'] );
 
 			$product = new $classname( $id );
 		} elseif ( isset( $request['id'] ) ) {
 			$product = wc_get_product( $id );
 		} else {
-			$product = new WC_Product_Simple();
+			/**
+			 * This filter is documented in includes/class-wc-product-factory.php
+			 *
+			 * @since 10.3.0
+			 */
+			$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_Simple', ProductType::SIMPLE, 'product', 0 );
+			$product   = new $classname();
 		}
 
 		if ( ProductType::VARIATION === $product->get_type() ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -740,7 +740,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			 * @since 10.3.0
 			 */
 			$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_Simple', ProductType::SIMPLE, 'product', 0 );
-			$product   = new $classname();
+
+			if ( ! class_exists( $classname ) ) {
+				$classname = 'WC_Product_Simple';
+			}
+
+			$product = new $classname();
 		}
 
 		if ( ProductType::VARIATION === $product->get_type() ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -2114,4 +2114,79 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertContains( $visible_product->get_id(), $product_ids );
 		$this->assertContains( $hidden_product->get_id(), $product_ids );
 	}
+
+	/**
+	 * Test that REST Controllers allow overriding product classes.
+	 *
+	 * Verifies that the `woocommerce_product_class` filter hook, used to override
+	 * product classes in `WC_Product_Factory::get_product_classname()`, is also
+	 * used by REST Controllers when interacting with products.
+	 */
+	public function test_custom_product_classes() {
+		/* Add filters for custom product classes */
+
+		$simple_class    = new class() extends WC_Product_Simple {};
+		$variation_class = new class() extends WC_Product_Variation {};
+
+		$woocommerce_product_class_filter_callback = function ( $classname, $product_type ) use ( $simple_class, $variation_class ) {
+			if ( 'simple' === $product_type ) {
+				return $simple_class::class;
+			} elseif ( 'variation' === $product_type ) {
+				return $variation_class::class;
+			}
+			return $classname;
+		};
+		add_filter( 'woocommerce_product_class', $woocommerce_product_class_filter_callback, 10, 2 );
+
+		$woocommerce_rest_prepare_object_filter_callback = function ( $response, $object ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
+			$response->data['classname'] = get_class( $object );
+			return $response;
+		};
+		add_filter( 'woocommerce_rest_prepare_product_object', $woocommerce_rest_prepare_object_filter_callback, 10, 2 );
+		add_filter( 'woocommerce_rest_prepare_product_variation_object', $woocommerce_rest_prepare_object_filter_callback, 10, 2 );
+
+		/* Define and run tests */
+
+		$simple_product    = WC_Helper_Product::create_simple_product();
+		$variable_product  = WC_Helper_Product::create_variation_product();
+		$variation_product = $variable_product->get_available_variations()[0];
+		$variation_product = wc_get_product( $variation_product['variation_id'] );
+
+		$test_cases = array(
+			array(
+				'product'        => $simple_product,
+				'expected_class' => $simple_class::class,
+				'api_endpoint'   => "/wc/v3/products/{$simple_product->get_id()}",
+			),
+			array(
+				'product'        => $variation_product,
+				'expected_class' => $variation_class::class,
+				'api_endpoint'   => "/wc/v3/products/{$variable_product->get_id()}/variations/{$variation_product->get_id()}",
+			),
+			array(
+				'product'        => $variable_product,
+				'expected_class' => 'WC_Product_Variable',
+				'api_endpoint'   => "/wc/v3/products/{$variable_product->get_id()}",
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$request  = new WP_REST_Request( 'GET', $case['api_endpoint'] );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( $case['expected_class'], $response->data['classname'] );
+
+			$request = new WP_REST_Request( 'PUT', $case['api_endpoint'] );
+			$request->set_body_params( array( 'name' => "{$case['product']->get_name()} - Test Update" ) );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( $case['expected_class'], $response->data['classname'] );
+		}
+
+		/* Remove filters */
+
+		remove_filter( 'woocommerce_product_class', $woocommerce_product_class_filter_callback, 10 );
+		remove_filter( 'woocommerce_rest_prepare_product_object', $woocommerce_rest_prepare_object_filter_callback, 10 );
+		remove_filter( 'woocommerce_rest_prepare_product_variation_object', $woocommerce_rest_prepare_object_filter_callback, 10 );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

 - [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 - [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
 - [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

[`WC_Product_Factory::get_product_classname()`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-factory.php#L62) is used to determine which product class ([`WC_Product_Simple`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-simple.php),  [`WC_Product_Variable`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-variable.php), [`WC_Product_External`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-external.php), etc) to instantiate when retrieving a product (with [`wc_get_product()`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/wc-product-functions.php#L69), for example). The method allows overriding WC's product classes through the `woocommerce_product_class` filter hook ([see here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-factory.php#L73)). This PR ensures that the same hook is used when interacting with products in the REST API.

I personally use this hook to instantiate my own product classes, which extend WC's classes. Currently, the REST API is not working correctly for me because I need products to be instantiated with my classes when I call API endpoints.

Three notes:
* From what I read in WC's documentation, adding new code in `includes` should be rare, as it is considered legacy code (read [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/README.md#writing-unit-tests) and [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/README.md#interacting-with-legacy-code)). But the legacy REST product controllers (like [`WC_REST_Products_Controller`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php)) are being used in [`AbilitiesRestBridge`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php) ([see here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php#L31)). This is my first contribution to WC, I'm still getting familiar with the code, so I'm not sure if my approach is correct.
* I added `@since 10.3.0` above the two new `apply_filters()` calls in the REST API. I don't know if that's the right version to use.
* In [`WC_Product_Factory::get_product_classname()`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-factory.php#L62), the classname falls back to `WC_Product_Simple` in case no class exists with the derived classname (see code snippet below). I decided to not include this fallback in the REST API because, there, we're defining the filterable classname directly instead of using [`WC_Product_Factory::get_classname_from_product_type()`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-product-factory.php#L105).
  ```php
  $classname = apply_filters( 'woocommerce_product_class', self::get_classname_from_product_type( $product_type ), ... )

  if ( ! $classname || ! class_exists( $classname ) ) {
	  $classname = 'WC_Product_Simple';
  }
  ```

### How to test the changes in this Pull Request:

Unit test included in PR.

### Testing that has already taken place:

Unit test included in PR.

### Changelog entry

Changelog included in PR.