### PR TITLE
Prevent unnecessary query in clearing admin notices

### DIFF
--- a/plugins/woocommerce/changelog/fix-30823
+++ b/plugins/woocommerce/changelog/fix-30823
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Prevent unnecessary queries in admin notices.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -214,12 +214,12 @@ class WC_Admin_Notices {
 	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
 	public static function remove_notice( $name, $force_save = false ) {
-		self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
-
-		$option_name = 'woocommerce_admin_notice_' . $name;
-		if ( false !== get_option( $option_name, false ) ) {
-			delete_option( $option_name );
+		// Don't proceed if the notice doesn't exist.
+		if ( ! self::has_notice( $name ) ) {
+			return;
 		}
+
+		self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
 
 		if ( $force_save ) {
 			// Adding early save to prevent more race conditions with notices.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -473,7 +473,7 @@ class WC_Admin_Notices {
 		if ( $enabled ) {
 			include __DIR__ . '/views/html-notice-legacy-shipping.php';
 		} else {
-			self::remove_notice( 'template_files' );
+			self::remove_notice( 'legacy_shipping' );
 		}
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -96,7 +96,20 @@ class WC_Admin_Notices {
 	 * Store the locally cached notices to DB.
 	 */
 	public static function store_notices() {
-		update_option( 'woocommerce_admin_notices', self::get_notices() );
+		$current_notices = self::get_notices();
+		$prev_notices    = get_option( 'woocommerce_admin_notices', array() );
+
+		// Store notices.
+		update_option( 'woocommerce_admin_notices', $current_notices );
+
+		// Clean up removed notices.
+		foreach ( array_diff( $prev_notices, $current_notices ) as $notice ) {
+			if ( isset( self::$core_notices[ $notice ] ) ) {
+				continue;
+			}
+
+			delete_option( 'woocommerce_admin_notice_' . $notice );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -9,7 +9,6 @@
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -227,12 +227,9 @@ class WC_Admin_Notices {
 	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
 	public static function remove_notice( $name, $force_save = false ) {
-		// Don't proceed if the notice doesn't exist.
-		if ( ! self::has_notice( $name ) ) {
-			return;
+		if ( self::has_notice( $name ) ) {
+			self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
 		}
-
-		self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
 
 		if ( $force_save ) {
 			// Adding early save to prevent more race conditions with notices.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -216,7 +216,11 @@ class WC_Admin_Notices {
 	 */
 	public static function remove_notice( $name, $force_save = false ) {
 		self::set_notices( array_diff( self::get_notices(), array( $name ) ) );
-		delete_option( 'woocommerce_admin_notice_' . $name );
+
+		$option_name = 'woocommerce_admin_notice_' . $name;
+		if ( false !== get_option( $option_name, false ) ) {
+			delete_option( $option_name );
+		}
 
 		if ( $force_save ) {
 			// Adding early save to prevent more race conditions with notices.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR optimizes the `WC_Admin_Notices::remove_notice()` method to prevent redundant database queries on every WordPress admin screen load, leveraging WP's internal caching for options.

Even though all of the queries involved are very fast, reducing unnecessary queries seems like good form.

Closes #30823.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Confirm the issue on `trunk`:
   1. Install Query Monitor or similar on your test site.
   1. Check out `trunk`.
   1. Go to _any_ admin page.
   1. Confirm that the following queries are always executed:
      <img width="1337" height="163" alt="Screenshot 2025-10-22 at 17 44 09" src="https://github.com/user-attachments/assets/f978bedb-397b-4733-b2b9-52d3db0ec3a3" />
1. Check out this branch (`fix/30823`).
1. Visit any admin page.
1. Confirm the queries are no longer executed.
1. Confirm that the notices functionality remains intact:
   1. Go to WC > Settings > Products > Downloadable products.
   1. Change **File download method** to **Redirect only** and save the settings.
   1. Confirm you see a warning about it:
      <img width="1203" height="100" alt="Screenshot 2025-10-22 at 18 08 46" src="https://github.com/user-attachments/assets/9193f00d-b6ea-4ca8-8cae-4c363c8b6052" />
   1. Change back the setting to another download method.
   1. Confirm the notice goes away.
1. Use `wp shell` to register a custom notice:
   ```
   wp> \WC_Admin_Notices::add_custom_notice( 'my_test_notice', 'Life is suffering.' );
   wp> \WC_Admin_Notices::store_notices();
   ```
1. Confirm that the notice is visible on the admin.
1. Remove the notice with `wp shell`:
   ```
   wp> \WC_Admin_Notices::remove_notice( 'my_test_notice', true );
   ```
1. Confirm that the notice is no longer visible on the admin and there's no option with name `woocommerce_admin_notice_my_test_notice` in the `wp_options` table.

<!-- End testing instructions -->