### PR TITLE
Apply consistent font sizes and spacing in cart and checkout (order summary)

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -23,15 +23,9 @@
 	}
 
 	.wc-block-components-order-summary-item {
-		@include font-size(small);
 		display: flex;
 		padding-bottom: 1px;
-		padding-top: $gap;
 		width: 100%;
-
-		&:first-child {
-			padding-top: 0;
-		}
 
 		&:last-child {
 			border-bottom: 0;
@@ -46,7 +40,7 @@
 		}
 
 		.wc-block-components-product-metadata {
-			@include font-size(regular);
+			font-size: 12px;
 		}
 	}
 
@@ -93,13 +87,17 @@
 	.wc-block-components-order-summary-item__description {
 		padding-left: $gap-large;
 		padding-right: $gap-small;
-		padding-bottom: $gap;
+		padding-bottom: $gap-small;
 		word-break: break-word;
 
 		p,
 		.wc-block-components-product-metadata {
 			line-height: 1.375;
 			margin-top: $gap-smaller;
+		}
+
+		p:first-child {
+			margin-top: 0;
 		}
 	}
 
@@ -110,10 +108,5 @@
 	}
 	.wc-block-components-totals-item__description.wc-block-components-totals-shipping__via {
 		padding-top: $gap-smallest;
-	}
-
-	.wc-block-components-order-summary-item__individual-prices {
-		display: block;
-		padding-top: $gap-smaller;
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -53,7 +53,7 @@
 	.wc-block-components-order-summary-item__image {
 		width: #{$gap-large * 2};
 		padding-bottom: $gap;
-		margin-top: 10px;
+		margin-top: $gap-smaller;
 		position: relative;
 
 		> img {
@@ -85,6 +85,7 @@
 	}
 
 	.wc-block-components-order-summary-item__description {
+		padding-top: $gap-smallest;
 		padding-left: $gap-large;
 		padding-right: $gap-small;
 		padding-bottom: $gap-small;
@@ -105,6 +106,7 @@
 		font-weight: bold;
 		margin-left: auto;
 		text-align: right;
+		padding-top: $gap-smallest;
 	}
 	.wc-block-components-totals-item__description.wc-block-components-totals-shipping__via {
 		padding-top: $gap-smallest;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -93,7 +93,7 @@
 		p,
 		.wc-block-components-product-metadata {
 			line-height: 1.375;
-			margin-top: $gap-smaller;
+			margin-top: $gap-smallest;
 		}
 
 		p:first-child {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -40,7 +40,7 @@
 		}
 
 		.wc-block-components-product-metadata {
-			font-size: 12px;
+			@include font-small-locked;
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -96,10 +96,6 @@
 			line-height: 1.375;
 			margin-top: $gap-smallest;
 		}
-
-		p:first-child {
-			margin-top: 0;
-		}
 	}
 
 	.wc-block-components-order-summary-item__total-price {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-totals-footer-item {
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
-		@include font-large-locked;
+		@include font-size(large);
 	}
 
 	.wc-block-components-totals-item__label {
@@ -29,5 +29,12 @@
 
 	.wc-block-components-totals-item__value {
 		font-weight: 700;
+	}
+}
+
+.wp-block-woocommerce-checkout .wc-block-components-totals-footer-item {
+	.wc-block-components-totals-item__value,
+	.wc-block-components-totals-item__label {
+		@include font-large-locked;
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-totals-footer-item {
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
-		font-size: 21px;
+		@include font-large-locked;
 	}
 
 	.wc-block-components-totals-item__label {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -30,9 +30,7 @@
 	.wc-block-components-totals-item__value {
 		font-weight: 700;
 	}
-}
 
-.wp-block-woocommerce-checkout .wc-block-components-totals-footer-item {
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
 		@include font-large-locked;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-totals-footer-item {
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
-		@include font-size(large);
+		font-size: 21px;
 	}
 
 	.wc-block-components-totals-item__label {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -31,6 +31,7 @@
 	.wp-block-woocommerce-cart-order-summary-block {
 		border-bottom: 1px solid $universal-border-light;
 		margin-bottom: $gap;
+		@include font-regular-locked;
 
 		.wc-block-components-totals-item,
 		.wc-block-components-panel,
@@ -139,7 +140,7 @@
 
 		.wc-block-cart__totals-title {
 			@include text-heading();
-			@include font-size(smaller);
+			@include font-small-locked;
 			display: block;
 			font-weight: 700;
 			padding: $gap-smaller $gap $gap-smaller 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -143,7 +143,7 @@
 			@include font-small-locked;
 			display: block;
 			font-weight: 700;
-			padding: $gap-smaller $gap $gap-smaller 0;
+			padding: $gap-smaller $gap $gap 0;
 			text-align: left;
 			text-transform: uppercase;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -2,7 +2,7 @@
 	border: 1px solid $universal-border-light;
 	border-radius: 5px;
 	box-sizing: border-box;
-	font-size: 14px;
+	@include font-regular-locked;
 
 	&.checkout-order-summary-block-fill-wrapper {
 		.wc-block-components-order-summary {
@@ -33,7 +33,7 @@
 			margin: 0 0 0 $gap;
 			flex-grow: 1;
 			font-weight: 500;
-			font-size: 21px;
+			@include font-large-locked;
 		}
 
 		.wc-block-components-checkout-order-summary__title-open-close {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -30,7 +30,7 @@
 		align-items: center;
 
 		.wc-block-components-checkout-order-summary__title-text {
-			margin: 0 0 0 $gap;
+			margin: 0 0 $gap-smaller $gap;
 			flex-grow: 1;
 			font-weight: 500;
 			@include font-large-locked;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -2,10 +2,15 @@
 	border: 1px solid $universal-border-light;
 	border-radius: 5px;
 	box-sizing: border-box;
+	font-size: 14px;
 
 	&.checkout-order-summary-block-fill-wrapper {
 		.wc-block-components-order-summary {
 			padding: 0 $gap;
+		}
+
+		.wc-block-components-title {
+			margin-bottom: $gap;
 		}
 	}
 
@@ -13,8 +18,9 @@
 		font-weight: 600;
 	}
 
-	.wc-block-components-totals-wrapper:first-of-type {
+	.wp-block-woocommerce-checkout-order-summary-cart-items-block.wc-block-components-totals-wrapper {
 		border-top: 0;
+		padding-top: $gap-smaller;
 	}
 
 	.wc-block-components-checkout-order-summary__title {
@@ -24,9 +30,10 @@
 		align-items: center;
 
 		.wc-block-components-checkout-order-summary__title-text {
-			margin: 0 0 $gap $gap;
+			margin: 0 0 0 $gap;
 			flex-grow: 1;
 			font-weight: 500;
+			font-size: 21px;
 		}
 
 		.wc-block-components-checkout-order-summary__title-open-close {
@@ -52,11 +59,21 @@
 			padding-right: $gap;
 		}
 	}
+
+	.wc-block-components-product-name {
+		margin: 0;
+	}
 }
 
 .has-dark-controls {
 	.wp-block-woocommerce-checkout-order-summary-block {
 		border: 1px solid $input-border-dark;
+	}
+}
+
+.wc-block-checkout__main {
+	.wc-block-components-order-summary {
+		margin-top: $gap-smaller;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the checkout block order summary spacing and font sizes to match the ones in the new design.

Closes WOOPLUG-5062.

Continuation of work tracked in https://github.com/woocommerce/woocommerce/pull/59787 ("long" lived branch synced with trunk)
Intro post: pfHfG4-1iC-p2
Designs: fpl1YUEIW7suBFO09qymA2-fi-1212_50897

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
|-|-|
| <img width="325" height="679" alt="Screenshot 2025-10-16 at 10 38 50 PM" src="https://github.com/user-attachments/assets/1e6dc119-c415-4c9e-a98c-12e3cb5f3965" /> | <img width="308" height="469" alt="Screenshot 2025-10-17 at 10 14 56 AM" src="https://github.com/user-attachments/assets/eadcca3d-3a92-45de-b070-b635bef889ad" /> |
| <img width="398" height="679" alt="Screenshot 2025-10-16 at 10 39 15 PM" src="https://github.com/user-attachments/assets/9852b808-5b57-4220-95e9-f4279e2e0879" /> | <img width="386" height="504" alt="Screenshot 2025-10-17 at 10 15 10 AM" src="https://github.com/user-attachments/assets/64d10d67-3643-4dc0-b1d6-078b5ae983c8" /> |
| <img width="313" height="797" alt="Screenshot 2025-10-21 at 12 50 52 AM" src="https://github.com/user-attachments/assets/4d3b860e-0b03-4cb2-a6a2-742b09320976" /> | <img width="313" height="689" alt="Screenshot 2025-10-21 at 12 54 27 AM" src="https://github.com/user-attachments/assets/8eceb185-36c5-45cb-8ae4-002d19ccc4d9" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add some different types of products to the cart, including variable products.
2. Access the blocks checkout page.
3. The order summary should match Figma design.
4. Make sure there are no design regressions on other components.
5. Access the blocks cart page.
6. The order summary should match Figma design.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR doesn't target `trunk`. Changelog will be added when the main branch will be merged to `trunk`.

</details>