### PR TITLE
Fix missing data in certain WooCommerce blocks inside the Product block when editing as an author

### DIFF
--- a/plugins/woocommerce/changelog/fix-61369-wc-blocks-in-product-author
+++ b/plugins/woocommerce/changelog/fix-61369-wc-blocks-in-product-author
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing data in certain WooCommerce blocks inside the Product block when editing as an author

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -135,12 +135,14 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		return productPriceComponent;
 	}
 
-	let prices: PriceProps = product?.prices ?? {};
+	let prices: Partial< PriceProps > = product?.prices ?? {};
 	const currency = showPricePreview
 		? getCurrencyFromPriceResponse()
 		: getCurrencyFromPriceResponse( prices );
 
-	if ( isExperimentalWcRestApiV4Enabled ) {
+	// In the v4 API, the prices are in the root `product` object instead of a
+	// `prices` attribute.
+	if ( ! product?.prices && product.price ) {
 		prices = {
 			price: convertAdminPriceToStoreApiFormat(
 				product?.price,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+/**
+ * Internal dependencies
+ */
+import { initializeEditor } from '../../../../../tests/integration/helpers/integration-test-editor';
+import '../';
+import '../../../atomic/blocks/product-elements/price';
+import '../../../atomic/blocks/product-elements/summary';
+
+const mockProduct = {
+	id: 82,
+	name: 'Beanie with Logo',
+	short_description: 'This is a short description',
+	prices: {
+		price: '2000',
+		regular_price: '2000',
+		sale_price: '',
+		price_range: null,
+		currency_code: 'EUR',
+		currency_symbol: '€',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '',
+		currency_suffix: ' €',
+	},
+	images: [
+		{
+			id: 1,
+			src: 'test-image-1.jpg',
+			thumbnail: 'test-thumb-1.jpg',
+			alt: 'Test 1',
+		},
+		{
+			id: 2,
+			src: 'test-image-2.jpg',
+			thumbnail: 'test-thumb-2.jpg',
+			alt: 'Test 2',
+		},
+		{
+			id: 3,
+			src: 'test-image-3.jpg',
+			thumbnail: 'test-thumb-3.jpg',
+			alt: 'Test 3',
+		},
+	],
+};
+
+// Setup MSW.
+const handlers = [
+	http.get( '/wp/v2/types', () => {
+		return HttpResponse.json( {} );
+	} ),
+
+	http.get( '/wc/store/v1/products/:id', () => {
+		return HttpResponse.json( mockProduct );
+	} ),
+];
+
+const server = setupServer( ...handlers );
+
+// Start MSW.
+beforeAll( () => server.listen() );
+afterEach( () => server.resetHandlers() );
+afterAll( () => server.close() );
+
+async function setup() {
+	const singleProductBlock = [
+		{
+			name: 'woocommerce/single-product',
+			attributes: {
+				productId: '82',
+			},
+		},
+	];
+	return initializeEditor( singleProductBlock );
+}
+
+describe( 'Product block', () => {
+	it( 'should render inner blocks for users without edit permissions', async () => {
+		server.use(
+			http.get( '/wc/v3/products/:id', () => {
+				return HttpResponse.json( '', { status: 403 } );
+			} )
+		);
+
+		await setup();
+
+		const block = await screen.findAllByLabelText( `Block: Product` );
+		expect( block.length ).toBeGreaterThan( 0 );
+
+		const productDescription = await screen.findByText(
+			'This is a short description'
+		);
+		expect( productDescription ).toBeInTheDocument();
+
+		const productPrice = await screen.findByText( '20,00 €' );
+		expect( productPrice ).toBeInTheDocument();
+	} );
+
+	it( 'should render inner blocks for admins', async () => {
+		server.use(
+			http.get( '/wc/v3/products/:id', () => {
+				return HttpResponse.json( mockProduct );
+			} )
+		);
+
+		await setup();
+
+		const block = await screen.findAllByLabelText( `Block: Product` );
+		expect( block.length ).toBeGreaterThan( 0 );
+
+		const productDescription = await screen.findByText(
+			'This is a short description'
+		);
+		expect( productDescription ).toBeInTheDocument();
+
+		const productPrice = await screen.findByText( '20,00 €' );
+		expect( productPrice ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/entities/product/hooks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/product/hooks.ts
@@ -22,19 +22,6 @@ export const useProduct = ( postId: number | string | undefined ) => {
 			const parsedPostId =
 				typeof postId === 'string' ? parseInt( postId, 10 ) : postId;
 
-			const userCanEdit = select( coreStore ).canUser( 'update', {
-				kind: 'root',
-				name: 'product',
-				id: parsedPostId,
-			} );
-
-			if ( ! userCanEdit ) {
-				return {
-					product: undefined,
-					isResolving: false,
-				};
-			}
-
 			const product = select( coreStore ).getEditedEntityRecord(
 				'root',
 				'product',

--- a/plugins/woocommerce/client/blocks/assets/js/entities/product/hooks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/entities/product/hooks.ts
@@ -22,6 +22,19 @@ export const useProduct = ( postId: number | string | undefined ) => {
 			const parsedPostId =
 				typeof postId === 'string' ? parseInt( postId, 10 ) : postId;
 
+			const userCanEdit = select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'product',
+				id: parsedPostId,
+			} );
+
+			if ( ! userCanEdit ) {
+				return {
+					product: undefined,
+					isResolving: false,
+				};
+			}
+
 			const product = select( coreStore ).getEditedEntityRecord(
 				'root',
 				'product',

--- a/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
@@ -80,7 +80,7 @@ const ProductDataContext = createContext< {
 
 type UseProductDataContextProps = {
 	isAdmin?: boolean | undefined;
-	product?: ProductResponseItem | ProductEntityResponse | undefined;
+	product?: ProductResponseItem | ProductEntityResponse | null | undefined;
 	isResolving?: boolean | undefined;
 };
 
@@ -108,7 +108,7 @@ export const useProductDataContext = (
 	const context = useContext( ProductDataContext );
 	const { isAdmin, product, isResolving } = props;
 
-	if ( ! isAdmin ) {
+	if ( ! isAdmin || ! product ) {
 		return context;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/61369.

This PR adds fallbacks inside and around the `useProduct()` hook for cases where the user doesn't have permission to access the `/wc/v4/products/` endpoint.

### How to test the changes in this Pull Request:

1. Create a user with *Author* role.
2. Create a post and add the *Product* block.
3. Select a product and verify the _Product Image Gallery_, _Product Rating_, _Product Summary_ and _Product Price_ blocks render the correct data. (Note: _Product Title_ is expected to be empty, that's a known issue)
4. Install WooCommerce Beta Tester, go to _Tools_ > _WCA Test Helper_ > _Features_ and enable _rest-api-v4_.
5. Repeat steps 1-3.

Before | After
--- | ---
<img width="867" height="712" alt="imatge" src="https://github.com/user-attachments/assets/e196d0d6-1766-4ce4-b026-7a3be8cc302e" /> | <img width="867" height="712" alt="imatge" src="https://github.com/user-attachments/assets/f37f9aed-9060-43f7-accf-494a34c45d8d" />

6. Now, repeat steps 1-5 with an admin user.