### PR TITLE
Fix undefined array key warning when firing woocommerce_variation_prices

### DIFF
--- a/plugins/woocommerce/changelog/pr-61472
+++ b/plugins/woocommerce/changelog/pr-61472
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined array key warning when firing woocommerce_variation_prices

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -289,7 +289,9 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			}
 
 			// If the prices are not stored for this hash, generate them and add to the transient.
-			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
+			// Check also the opposite price hash as it may have changed (see get_price_hash).
+			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ||
+				( ( $opposite_price_hash !== $price_hash ) && empty( $transient_cached_prices_array[ $opposite_price_hash ] ) ) ) {
 				$prices_array = array(
 					'price'         => array(),
 					'regular_price' => array(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/61286 we introduced a double caching of variation prices for the cases in which prices with and without taxes were the same. However this introduced a bug: the `woocommerce_variation_prices` filter is fired a second time with the opposite price hash, but the transient that caches the prices is assumed to contain a key with the current value of the opposite price hash, but this will not be the case when the calculation of the hash changes (because configuration has changed or the applied hooks are different). This causes an "undefined array key" PHP warning.

The fix is to recalculate all the cached prices not only when the normal price hash is missing in the cached prices array, but also when the opposite hash is missing.

Bug introduced in PR #61286.

### How to test the changes in this Pull Request:

1. Create a variable product. Either make the product non-taxable, or disable taxes globally in the entire store. Take note of the product id.
2. Run this in command line: ` wp eval 'delete_transient("wc_var_prices_<product_id>");'`
3. Go to the shop and load the product page.
4. Go to WooCommerce settings - Tax - Tax options and invert the value of the "Display prices in the shop" setting.
5. Reload the product page.

Without this fix this would have produced a "PHP Notice:  Undefined index: <price hash> in class-wc-product-variable-data-store-cpt.php" warning, with this fix this won't happen.

6. Repeat the testing instructions of https://github.com/woocommerce/woocommerce/pull/61286 to ensure that nothing broke.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
