### PR TITLE
Implement cache control headers for REST API responses

### DIFF
--- a/plugins/woocommerce/changelog/pr-61476
+++ b/plugins/woocommerce/changelog/pr-61476
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Implement cache control headers for REST API responses

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -18,7 +18,7 @@ use WP_REST_Response;
  *   headers (like Set-Cookie) and optionally others specified via configuration
  *   (per-controller or per-endpoint).
  * - For the purposes of caching, a request is uniquely identified by its route,
- *   HTTP method, query string, and user ID.
+ *   query string, and user ID.
  * - The VersionStringGenerator class is used to track versions of entities included
  *   in the responses (an "entity" is any object that is uniquely identified by type and id
  *   and contributes with information to be included in the response),
@@ -32,6 +32,11 @@ use WP_REST_Response;
  *   to the query string.
  * - A X-WC-Cache HTTP header is added to responses to indicate cache status:
  *   HIT, MISS, or SKIP.
+ *
+ * Additionally to caching, this trait also handles the sending of appropriate
+ * Cache-Control and ETag headers to instruct clients and proxies on how to cache responses.
+ * The ETag is generated based on the cached response data and cache key, and a request
+ * containing an If-None-Match header with a matching ETag will receive a 304 Not Modified response.
  *
  * Usage: Wrap endpoint callbacks with the `with_cache()` method when registering routes.
  *
@@ -98,7 +103,7 @@ use WP_REST_Response;
  * (checked via call to VersionStringGenerator::can_use()), so the cache is persistent
  * across requests and not just for the current request.
  *
- * @since   10.5.0
+ * @since 10.5.0
  */
 trait RestApiCache {
 	/**
@@ -133,12 +138,21 @@ trait RestApiCache {
 	private ?VersionStringGenerator $version_string_generator = null;
 
 	/**
+	 * Whether we are currently handling a cached endpoint.
+	 *
+	 * @var bool
+	 */
+	private $is_handling_cached_endpoint = false;
+
+	/**
 	 * Initialize the trait.
 	 * This MUST be called from the controller's constructor.
 	 */
 	protected function initialize_rest_api_cache(): void {
 		$generator                      = wc_get_container()->get( VersionStringGenerator::class );
 		$this->version_string_generator = $generator->can_use() ? $generator : null;
+
+		add_filter( 'rest_send_nocache_headers', array( $this, 'handle_rest_send_nocache_headers' ), 10, 1 );
 	}
 
 	/**
@@ -185,14 +199,15 @@ trait RestApiCache {
 
 		if ( $should_skip_cache ) {
 			$response = call_user_func( $callback, $request );
-			if ( ! is_wp_error( $response ) ) {
-				$response = rest_ensure_response( $response );
+			if ( $response instanceof WP_REST_Response ) {
 				$response->header( 'X-WC-Cache', 'SKIP' );
 			}
 			return $response;
 		}
 
-		$cached_response = $this->get_cached_response( $cached_config );
+		$this->is_handling_cached_endpoint = true;
+
+		$cached_response = $this->get_cached_response( $request, $cached_config );
 
 		if ( $cached_response ) {
 			$cached_response->header( 'X-WC-Cache', 'HIT' );
@@ -312,6 +327,9 @@ trait RestApiCache {
 				$cached_config['endpoint_id']
 			);
 
+			$etag_data = is_array( $data ) ? $this->get_data_for_etag( $data, $request, $cached_config['endpoint_id'] ) : $data;
+			$etag      = '"' . md5( $cached_config['cache_key'] . wp_json_encode( $etag_data ) ) . '"';
+
 			$this->store_cached_response(
 				$cached_config['cache_key'],
 				$data,
@@ -320,10 +338,16 @@ trait RestApiCache {
 				$entity_ids,
 				$cached_config['cache_ttl'],
 				$cached_config['relevant_hooks'],
-				$cacheable_headers
+				$cacheable_headers,
+				$etag
 			);
 
 			$cached = true;
+
+			$is_user_logged_in = wc_get_container()->get( LegacyProxy::class )->call_function( 'is_user_logged_in' );
+			$cache_visibility  = $cached_config['vary_by_user'] && $is_user_logged_in ? 'private' : 'public';
+			$response->header( 'ETag', $etag );
+			$response->header( 'Cache-Control', $cache_visibility . ', must-revalidate, max-age=' . $cached_config['cache_ttl'] );
 		}
 
 		$response->header( 'X-WC-Cache', $cached ? 'MISS' : 'SKIP' );
@@ -340,6 +364,21 @@ trait RestApiCache {
 	 */
 	protected function get_default_response_entity_type(): ?string {
 		return null;
+	}
+
+	/**
+	 * Get data for ETag generation.
+	 *
+	 * Override in classes to exclude fields that change on each request
+	 * (e.g., random recommendations, timestamps).
+	 *
+	 * @param array           $data        Response data.
+	 * @param WP_REST_Request $request     The request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array Cleaned data for ETag generation.
+	 */
+	protected function get_data_for_etag( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $data;
 	}
 
 	/**
@@ -474,9 +513,7 @@ trait RestApiCache {
 	 * 3. The woocommerce_rest_api_cached_headers filter is applied, receiving both the candidate
 	 *    headers list and all available headers. This allows filters to both add and remove
 	 *    headers from the caching list.
-	 * 4. Always-excluded headers are enforced again post-filter to prevent filters from
-	 *    re-introducing dangerous headers like Set-Cookie.
-	 * 5. Only headers from the response that are in the filtered list are returned.
+	 * 4. Only headers from the response that are in the filtered list are returned.
 	 *
 	 * @param array            $nominal_headers Response headers.
 	 * @param array|false      $include_headers Header names to include (false to use exclusion logic).
@@ -539,32 +576,8 @@ trait RestApiCache {
 			$this
 		);
 
-		// Step 4: Enforce always-excluded headers post-filter.
+		// Step 4: Return only the headers that are in the filtered list.
 		$filtered_header_names_lowercase = array_map( 'strtolower', $filtered_header_names );
-		$reintroduced_headers            = array_filter(
-			$filtered_header_names,
-			fn( $name ) => in_array( strtolower( $name ), $always_exclude_lowercase, true )
-		);
-
-		if ( ! empty( $reintroduced_headers ) ) {
-			wc_get_container()->get( LegacyProxy::class )->call_function(
-				'wc_doing_it_wrong',
-				__METHOD__,
-				sprintf(
-					/* translators: %s: comma-separated list of header names */
-					'The woocommerce_rest_api_cached_headers filter attempted to cache always-excluded headers: %s. These headers have been removed for security reasons.',
-					implode( ', ', $reintroduced_headers )
-				),
-				'10.5.0'
-			);
-
-			$filtered_header_names_lowercase = array_filter(
-				$filtered_header_names_lowercase,
-				fn( $name ) => ! in_array( $name, $always_exclude_lowercase, true )
-			);
-		}
-
-		// Step 5: Return only the headers that are in the filtered list.
 		return array_filter(
 			$nominal_headers,
 			fn( $name ) => in_array( strtolower( $name ), $filtered_header_names_lowercase, true ),
@@ -588,7 +601,6 @@ trait RestApiCache {
 
 		$cache_key_parts = array(
 			$request->get_route(),
-			$request->get_method(),
 			wp_json_encode( $request_query_params ),
 		);
 
@@ -622,7 +634,7 @@ trait RestApiCache {
 		 * @param array           $cache_key_parts Array of cache key information parts.
 		 * @param WP_REST_Request $request         The request object.
 		 * @param bool            $vary_by_user    Whether user ID is included in cache key.
-		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint (passed to with_cache).
+		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint.
 		 * @param object          $controller      The controller instance.
 		 * @return array Filtered cache key information parts.
 		 */
@@ -681,10 +693,11 @@ trait RestApiCache {
 	/**
 	 * Get a cached response, but only if it's valid (otherwise the cached response will be invalidated).
 	 *
-	 * @param array $cached_config Built caching configuration from build_cache_config().
+	 * @param WP_REST_Request $request       The request object.
+	 * @param array           $cached_config Built caching configuration from build_cache_config().
 	 * @return WP_REST_Response|null Cached response, or null if not available or has been invalidated.
 	 */
-	private function get_cached_response( array $cached_config ): ?WP_REST_Response {
+	private function get_cached_response( WP_REST_Request $request, array $cached_config ): ?WP_REST_Response {
 		$cache_key      = $cached_config['cache_key'];
 		$entity_type    = $cached_config['entity_type'];
 		$cache_ttl      = $cached_config['cache_ttl'];
@@ -724,7 +737,34 @@ trait RestApiCache {
 		}
 
 		// At this point the cached response is valid.
+
+		// Check if client sent an ETag and it matches - if so, return 304 Not Modified.
+		$cached_etag  = $cached['etag'] ?? '';
+		$request_etag = $request->get_header( 'if_none_match' );
+
+		$is_user_logged_in = wc_get_container()->get( LegacyProxy::class )->call_function( 'is_user_logged_in' );
+		$cache_visibility  = $cached_config['vary_by_user'] && $is_user_logged_in ? 'private' : 'public';
+		$response_headers  = array();
+
+		if ( ! empty( $cached_etag ) ) {
+			$response_headers['ETag'] = $cached_etag;
+		}
+		$response_headers['Cache-Control'] = $cache_visibility . ', must-revalidate, max-age=' . $cache_ttl;
+
+		// If the server adds a 'Date' header by itself there will be two such headers in the response.
+		// To help disambiguate them, we add also an 'X-WC-Date' header with the proper value.
+		$created_at                    = gmdate( 'D, d M Y H:i:s', $cached['created_at'] ) . ' GMT';
+		$response_headers['Date']      = $created_at;
+		$response_headers['X-WC-Date'] = $created_at;
+
+		if ( ! empty( $cached_etag ) && $request_etag === $cached_etag ) {
+			return new WP_REST_Response( null, 304, $response_headers );
+		}
 		$response = new WP_REST_Response( $cached['data'], $cached['status_code'] ?? 200 );
+
+		foreach ( $response_headers as $name => $value ) {
+			$response->header( $name, $value );
+		}
 
 		if ( ! empty( $cached['headers'] ) ) {
 			foreach ( $cached['headers'] as $name => $value ) {
@@ -746,8 +786,9 @@ trait RestApiCache {
 	 * @param int    $cache_ttl      Cache TTL in seconds.
 	 * @param array  $relevant_hooks Hook names to track for invalidation.
 	 * @param array  $headers        Response headers to cache.
+	 * @param string $etag           ETag for the response.
 	 */
-	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl, array $relevant_hooks, array $headers = array() ): void {
+	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl, array $relevant_hooks, array $headers = array(), string $etag = '' ): void {
 		$entity_versions = array();
 		foreach ( $entity_ids as $entity_id ) {
 			$version_id = "{$entity_type}_{$entity_id}";
@@ -775,6 +816,27 @@ trait RestApiCache {
 			$cache_data['headers'] = $headers;
 		}
 
+		if ( ! empty( $etag ) ) {
+			$cache_data['etag'] = $etag;
+		}
+
 		wp_cache_set( $cache_key, $cache_data, self::$cache_group, $cache_ttl );
+	}
+
+	/**
+	 * Handle rest_send_nocache_headers filter to prevent WordPress from overriding our cache headers.
+	 *
+	 * @internal
+	 *
+	 * @param bool $send_no_cache_headers Whether to send no-cache headers.
+	 * @return bool False if we're handling caching for this request, original value otherwise.
+	 */
+	public function handle_rest_send_nocache_headers( bool $send_no_cache_headers ): bool {
+		if ( ! $this->is_handling_cached_endpoint ) {
+			return $send_no_cache_headers;
+		}
+
+		$this->is_handling_cached_endpoint = false;
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -18,7 +18,7 @@ use WP_REST_Response;
  *   headers (like Set-Cookie) and optionally others specified via configuration
  *   (per-controller or per-endpoint).
  * - For the purposes of caching, a request is uniquely identified by its route,
- *   query string, and user ID.
+ *   HTTP method, query string, and user ID.
  * - The VersionStringGenerator class is used to track versions of entities included
  *   in the responses (an "entity" is any object that is uniquely identified by type and id
  *   and contributes with information to be included in the response),
@@ -199,7 +199,8 @@ trait RestApiCache {
 
 		if ( $should_skip_cache ) {
 			$response = call_user_func( $callback, $request );
-			if ( $response instanceof WP_REST_Response ) {
+			if ( ! is_wp_error( $response ) ) {
+				$response = rest_ensure_response( $response );
 				$response->header( 'X-WC-Cache', 'SKIP' );
 			}
 			return $response;
@@ -513,7 +514,9 @@ trait RestApiCache {
 	 * 3. The woocommerce_rest_api_cached_headers filter is applied, receiving both the candidate
 	 *    headers list and all available headers. This allows filters to both add and remove
 	 *    headers from the caching list.
-	 * 4. Only headers from the response that are in the filtered list are returned.
+	 * 4. Always-excluded headers are enforced again post-filter to prevent filters from
+	 *    re-introducing dangerous headers like Set-Cookie.
+	 * 5. Only headers from the response that are in the filtered list are returned.
 	 *
 	 * @param array            $nominal_headers Response headers.
 	 * @param array|false      $include_headers Header names to include (false to use exclusion logic).
@@ -576,8 +579,32 @@ trait RestApiCache {
 			$this
 		);
 
-		// Step 4: Return only the headers that are in the filtered list.
+		// Step 4: Enforce always-excluded headers post-filter.
 		$filtered_header_names_lowercase = array_map( 'strtolower', $filtered_header_names );
+		$reintroduced_headers            = array_filter(
+			$filtered_header_names,
+			fn( $name ) => in_array( strtolower( $name ), $always_exclude_lowercase, true )
+		);
+
+		if ( ! empty( $reintroduced_headers ) ) {
+			wc_get_container()->get( LegacyProxy::class )->call_function(
+				'wc_doing_it_wrong',
+				__METHOD__,
+				sprintf(
+					/* translators: %s: comma-separated list of header names */
+					'The woocommerce_rest_api_cached_headers filter attempted to cache always-excluded headers: %s. These headers have been removed for security reasons.',
+					implode( ', ', $reintroduced_headers )
+				),
+				'10.5.0'
+			);
+
+			$filtered_header_names_lowercase = array_filter(
+				$filtered_header_names_lowercase,
+				fn( $name ) => ! in_array( $name, $always_exclude_lowercase, true )
+			);
+		}
+
+		// Step 5: Return only the headers that are in the filtered list.
 		return array_filter(
 			$nominal_headers,
 			fn( $name ) => in_array( strtolower( $name ), $filtered_header_names_lowercase, true ),
@@ -601,6 +628,7 @@ trait RestApiCache {
 
 		$cache_key_parts = array(
 			$request->get_route(),
+			$request->get_method(),
 			wp_json_encode( $request_query_params ),
 		);
 
@@ -634,7 +662,7 @@ trait RestApiCache {
 		 * @param array           $cache_key_parts Array of cache key information parts.
 		 * @param WP_REST_Request $request         The request object.
 		 * @param bool            $vary_by_user    Whether user ID is included in cache key.
-		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint.
+		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint (passed to with_cache).
 		 * @param object          $controller      The controller instance.
 		 * @return array Filtered cache key information parts.
 		 */

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -213,6 +213,25 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Cache keys differ based on HTTP method.
+	 */
+	public function test_cache_key_depends_on_http_method() {
+		$response1 = $this->query_endpoint( 'multi_method', null, 'GET' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+		$this->assertCount( 1, $this->get_all_cache_keys() );
+
+		$response2 = $this->query_endpoint( 'multi_method', null, 'POST' );
+		$this->assertCacheHeader( $response2, 'MISS' );
+		$this->assertCount( 2, $this->get_all_cache_keys() );
+
+		$response3 = $this->query_endpoint( 'multi_method', null, 'GET' );
+		$this->assertCacheHeader( $response3, 'HIT' );
+
+		$response4 = $this->query_endpoint( 'multi_method', null, 'POST' );
+		$this->assertCacheHeader( $response4, 'HIT' );
+	}
+
+	/**
 	 * @testdox Caching is skipped when _skip_cache parameter is set.
 	 * @testWith ["1"]
 	 *           ["true"]
@@ -468,6 +487,19 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox SKIP header is added to raw array responses when cache is skipped.
+	 */
+	public function test_skip_header_added_for_raw_array_responses() {
+		$response = $this->query_endpoint( 'raw_array_response', array( '_skip_cache' => 'true' ) );
+		$this->assertCacheHeader( $response, 'SKIP' );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertIsArray( $response->get_data() );
+		$this->assertArrayHasKey( 'id', $response->get_data() );
+		$this->assertSame( 42, $response->get_data()['id'] );
+		$this->assertCount( 0, $this->get_all_cache_keys() );
+	}
+
+	/**
 	 * @testdox Response headers are cached and restored on cache hit.
 	 */
 	public function test_response_headers_are_cached() {
@@ -689,6 +721,67 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The woocommerce_rest_api_cached_headers filter cannot re-introduce always-excluded headers.
+	 */
+	public function test_filter_cannot_reintroduce_always_excluded_headers() {
+		$this->sut->response_headers['standard'] = array(
+			'Set-Cookie'      => 'session=abc123',
+			'Cache-Control'   => 'no-cache',
+			'X-Custom-Header' => 'custom-value',
+		);
+
+		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
+
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys   = $this->get_all_cache_keys();
+		$cache_key    = $cache_keys[0];
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'Set-Cookie', $cached_entry['headers'], 'Set-Cookie should not be cached even when filter returns it' );
+		$this->assertArrayNotHasKey( 'Cache-Control', $cached_entry['headers'], 'Cache-Control should not be cached even when filter returns it' );
+		$this->assertArrayHasKey( 'X-Custom-Header', $cached_entry['headers'], 'Non-excluded headers should still be cached' );
+		$this->assertEquals( 'custom-value', $cached_entry['headers']['X-Custom-Header'] );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie should not be in cached response' );
+		// Cache-Control IS present because we add our own cache control headers, but it should NOT contain the original "no-cache" value.
+		$this->assertArrayHasKey( 'Cache-Control', $headers, 'Cache-Control should be present with our generated cache headers' );
+		$this->assertStringNotContainsString( 'no-cache', $headers['Cache-Control'], 'Original no-cache value should not be in Cache-Control' );
+		$this->assertStringContainsString( 'max-age', $headers['Cache-Control'], 'Our generated Cache-Control should contain max-age' );
+		$this->assertArrayHasKey( 'X-Custom-Header', $headers );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
+	}
+
+	/**
+	 * @testdox A doing_it_wrong notice is emitted when filter tries to re-introduce always-excluded headers.
+	 */
+	public function test_doing_it_wrong_notice_when_filter_reintroduces_excluded_headers() {
+		$this->sut->response_headers['standard'] = array(
+			'Set-Cookie'      => 'session=abc123',
+			'X-Custom-Header' => 'custom-value',
+		);
+
+		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
+
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
+
+		$this->query_endpoint( 'standard' );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
+	}
+
+	/**
 	 * @testdox Setting include_headers to false in endpoint config forces exclusion mode even when controller has default inclusion list.
 	 */
 	public function test_false_include_headers_forces_exclusion_mode() {
@@ -749,15 +842,15 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->query_endpoint( 'invalid_headers' );
 	}
 
-
 	/**
 	 * Query an endpoint and return the response.
 	 *
-	 * @param string     $endpoint_name Endpoint name.
-	 * @param array|null $query_params  Optional query parameters.
+	 * @param string      $endpoint_name Endpoint name.
+	 * @param array|null  $query_params  Optional query parameters.
+	 * @param string|null $method        Optional HTTP method (default: GET).
 	 */
-	private function query_endpoint( $endpoint_name, $query_params = null ) {
-		$request = new WP_REST_Request( 'GET', "/wc/v3/rest_api_cache_test/{$endpoint_name}" );
+	private function query_endpoint( $endpoint_name, $query_params = null, $method = null ) {
+		$request = new WP_REST_Request( $method ?? 'GET', "/wc/v3/rest_api_cache_test/{$endpoint_name}" );
 		if ( ! is_null( $query_params ) ) {
 			$request->set_query_params( $query_params );
 		}
@@ -894,6 +987,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				$this->register_cached_route( 'no_vary_by_user', array( 'vary_by_user' => false ) );
 				$this->register_cached_route( 'with_endpoint_id', array( 'endpoint_id' => 'test_endpoint' ) );
 				$this->register_cached_route( 'custom_ttl', array( 'cache_ttl' => 10 ) );
+				$this->register_multi_method_route();
 				$this->register_cached_route( 'with_endpoint_hooks', array( 'relevant_hooks' => array( 'test_endpoint_hook_for_caching' ) ) );
 				$this->register_cached_route( 'with_controller_hooks' );
 				$this->register_cached_route( 'standard' );
@@ -918,6 +1012,29 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 									$this->handle_request( $endpoint, $request );
 							},
 							$cache_args
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+
+			private function register_multi_method_route() {
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/multi_method',
+					array(
+						'methods'             => array( 'GET', 'POST' ),
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								$method = $request->get_method();
+								return new WP_REST_Response(
+									array(
+										'id'     => 'GET' === $method ? 10 : 20,
+										'method' => $method,
+									),
+									200
+								);
+							}
 						),
 						'permission_callback' => '__return_true',
 					)

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -213,25 +213,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Cache keys differ based on HTTP method.
-	 */
-	public function test_cache_key_depends_on_http_method() {
-		$response1 = $this->query_endpoint( 'multi_method', null, 'GET' );
-		$this->assertCacheHeader( $response1, 'MISS' );
-		$this->assertCount( 1, $this->get_all_cache_keys() );
-
-		$response2 = $this->query_endpoint( 'multi_method', null, 'POST' );
-		$this->assertCacheHeader( $response2, 'MISS' );
-		$this->assertCount( 2, $this->get_all_cache_keys() );
-
-		$response3 = $this->query_endpoint( 'multi_method', null, 'GET' );
-		$this->assertCacheHeader( $response3, 'HIT' );
-
-		$response4 = $this->query_endpoint( 'multi_method', null, 'POST' );
-		$this->assertCacheHeader( $response4, 'HIT' );
-	}
-
-	/**
 	 * @testdox Caching is skipped when _skip_cache parameter is set.
 	 * @testWith ["1"]
 	 *           ["true"]
@@ -487,19 +468,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox SKIP header is added to raw array responses when cache is skipped.
-	 */
-	public function test_skip_header_added_for_raw_array_responses() {
-		$response = $this->query_endpoint( 'raw_array_response', array( '_skip_cache' => 'true' ) );
-		$this->assertCacheHeader( $response, 'SKIP' );
-		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertIsArray( $response->get_data() );
-		$this->assertArrayHasKey( 'id', $response->get_data() );
-		$this->assertSame( 42, $response->get_data()['id'] );
-		$this->assertCount( 0, $this->get_all_cache_keys() );
-	}
-
-	/**
 	 * @testdox Response headers are cached and restored on cache hit.
 	 */
 	public function test_response_headers_are_cached() {
@@ -562,7 +530,10 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$headers = $response2->get_headers();
 
 		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie header should not be cached' );
-		$this->assertArrayNotHasKey( 'Date', $headers, 'Date header should not be cached' );
+		$this->assertArrayHasKey( 'Date', $headers, 'Date header should be present with cache timestamp' );
+		$this->assertNotEquals( 'Mon, 01 Jan 2024 00:00:00 GMT', $headers['Date'], 'Date should be cache timestamp, not original' );
+		$this->assertArrayHasKey( 'X-WC-Date', $headers, 'X-WC-Date header should be present' );
+		$this->assertEquals( $headers['Date'], $headers['X-WC-Date'], 'X-WC-Date should match Date' );
 
 		$this->assertArrayHasKey( 'X-Custom-Valid', $headers );
 		$this->assertEquals( 'should-be-present', $headers['X-Custom-Valid'] );
@@ -718,64 +689,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The woocommerce_rest_api_cached_headers filter cannot re-introduce always-excluded headers.
-	 */
-	public function test_filter_cannot_reintroduce_always_excluded_headers() {
-		$this->sut->response_headers['standard'] = array(
-			'Set-Cookie'      => 'session=abc123',
-			'Cache-Control'   => 'no-cache',
-			'X-Custom-Header' => 'custom-value',
-		);
-
-		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
-		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
-
-		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
-
-		$response1 = $this->query_endpoint( 'standard' );
-		$this->assertCacheHeader( $response1, 'MISS' );
-
-		$cache_keys   = $this->get_all_cache_keys();
-		$cache_key    = $cache_keys[0];
-		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
-
-		$this->assertArrayHasKey( 'headers', $cached_entry );
-		$this->assertArrayNotHasKey( 'Set-Cookie', $cached_entry['headers'], 'Set-Cookie should not be cached even when filter returns it' );
-		$this->assertArrayNotHasKey( 'Cache-Control', $cached_entry['headers'], 'Cache-Control should not be cached even when filter returns it' );
-		$this->assertArrayHasKey( 'X-Custom-Header', $cached_entry['headers'], 'Non-excluded headers should still be cached' );
-		$this->assertEquals( 'custom-value', $cached_entry['headers']['X-Custom-Header'] );
-
-		$response2 = $this->query_endpoint( 'standard' );
-		$this->assertCacheHeader( $response2, 'HIT' );
-
-		$headers = $response2->get_headers();
-		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie should not be in cached response' );
-		$this->assertArrayNotHasKey( 'Cache-Control', $headers, 'Cache-Control should not be in cached response' );
-		$this->assertArrayHasKey( 'X-Custom-Header', $headers );
-
-		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
-	}
-
-	/**
-	 * @testdox A doing_it_wrong notice is emitted when filter tries to re-introduce always-excluded headers.
-	 */
-	public function test_doing_it_wrong_notice_when_filter_reintroduces_excluded_headers() {
-		$this->sut->response_headers['standard'] = array(
-			'Set-Cookie'      => 'session=abc123',
-			'X-Custom-Header' => 'custom-value',
-		);
-
-		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
-		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
-
-		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
-
-		$this->query_endpoint( 'standard' );
-
-		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
-	}
-
-	/**
 	 * @testdox Setting include_headers to false in endpoint config forces exclusion mode even when controller has default inclusion list.
 	 */
 	public function test_false_include_headers_forces_exclusion_mode() {
@@ -836,15 +749,15 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->query_endpoint( 'invalid_headers' );
 	}
 
+
 	/**
 	 * Query an endpoint and return the response.
 	 *
-	 * @param string      $endpoint_name Endpoint name.
-	 * @param array|null  $query_params  Optional query parameters.
-	 * @param string|null $method        Optional HTTP method (default: GET).
+	 * @param string     $endpoint_name Endpoint name.
+	 * @param array|null $query_params  Optional query parameters.
 	 */
-	private function query_endpoint( $endpoint_name, $query_params = null, $method = null ) {
-		$request = new WP_REST_Request( $method ?? 'GET', "/wc/v3/rest_api_cache_test/{$endpoint_name}" );
+	private function query_endpoint( $endpoint_name, $query_params = null ) {
+		$request = new WP_REST_Request( 'GET', "/wc/v3/rest_api_cache_test/{$endpoint_name}" );
 		if ( ! is_null( $query_params ) ) {
 			$request->set_query_params( $query_params );
 		}
@@ -981,7 +894,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				$this->register_cached_route( 'no_vary_by_user', array( 'vary_by_user' => false ) );
 				$this->register_cached_route( 'with_endpoint_id', array( 'endpoint_id' => 'test_endpoint' ) );
 				$this->register_cached_route( 'custom_ttl', array( 'cache_ttl' => 10 ) );
-				$this->register_multi_method_route();
 				$this->register_cached_route( 'with_endpoint_hooks', array( 'relevant_hooks' => array( 'test_endpoint_hook_for_caching' ) ) );
 				$this->register_cached_route( 'with_controller_hooks' );
 				$this->register_cached_route( 'standard' );
@@ -1012,29 +924,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				);
 			}
 
-			private function register_multi_method_route() {
-				register_rest_route(
-					$this->namespace,
-					'/' . $this->rest_base . '/multi_method',
-					array(
-						'methods'             => array( 'GET', 'POST' ),
-						'callback'            => $this->with_cache(
-							function ( $request ) {
-								$method = $request->get_method();
-								return new WP_REST_Response(
-									array(
-										'id'     => 'GET' === $method ? 10 : 20,
-										'method' => $method,
-									),
-									200
-								);
-							}
-						),
-						'permission_callback' => '__return_true',
-					)
-				);
-			}
-
 			private function register_custom_config_route( string $endpoint ) {
 				$cache_args = isset( $this->endpoint_cache_config[ $endpoint ]['config'] ) ?
 					$this->endpoint_cache_config[ $endpoint ]['config'] :
@@ -1059,7 +948,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			protected function get_default_response_entity_type(): ?string {
 				return $this->default_entity_type;
 			}
-
 
 			protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool {
 				if ( ! is_null( $endpoint_id ) && isset( $this->endpoint_vary_by_user[ $endpoint_id ] ) ) {
@@ -1118,5 +1006,181 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 
 			// phpcs:enable Squiz.Commenting
 		};
+	}
+
+	/**
+	 * @testdox Response includes ETag header on cache MISS.
+	 */
+	public function test_etag_header_on_cache_miss() {
+		$response = $this->query_endpoint( 'single_entity' );
+
+		$this->assertCacheHeader( $response, 'MISS' );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'ETag', $headers );
+		$this->assertMatchesRegularExpression( '/^"[a-f0-9]{32}"$/', $headers['ETag'] );
+	}
+
+	/**
+	 * @testdox Response includes ETag header on cache HIT.
+	 */
+	public function test_etag_header_on_cache_hit() {
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$etag1     = $response1->get_headers()['ETag'];
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+
+		$this->assertCacheHeader( $response2, 'HIT' );
+		$headers = $response2->get_headers();
+		$this->assertArrayHasKey( 'ETag', $headers );
+		$this->assertSame( $etag1, $headers['ETag'] );
+	}
+
+	/**
+	 * @testdox 304 Not Modified is returned when If-None-Match header matches ETag.
+	 */
+	public function test_304_response_when_etag_matches() {
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$etag      = $response1->get_headers()['ETag'];
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/rest_api_cache_test/single_entity' );
+		$request->set_header( 'If-None-Match', $etag );
+		$response2 = $this->server->dispatch( $request );
+
+		$this->assertSame( 304, $response2->get_status() );
+		$this->assertNull( $response2->get_data() );
+		$headers = $response2->get_headers();
+		$this->assertArrayHasKey( 'ETag', $headers );
+		$this->assertSame( $etag, $headers['ETag'] );
+	}
+
+	/**
+	 * @testdox 200 response with full data when If-None-Match header does not match.
+	 */
+	public function test_200_response_when_etag_does_not_match() {
+		$this->query_endpoint( 'single_entity' );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/rest_api_cache_test/single_entity' );
+		$request->set_header( 'If-None-Match', '"wrong-etag"' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotNull( $response->get_data() );
+		$this->assertCacheHeader( $response, 'HIT' );
+	}
+
+	/**
+	 * @testdox Cache-Control header is "private" when user is logged in and vary_by_user is true.
+	 */
+	public function test_cache_control_private_when_user_logged_in() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'is_user_logged_in' => fn() => true )
+		);
+
+		$response = $this->query_endpoint( 'single_entity' );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 'private', $headers['Cache-Control'] );
+		$this->assertStringContainsString( 'must-revalidate', $headers['Cache-Control'] );
+		$this->assertStringContainsString( 'max-age=', $headers['Cache-Control'] );
+	}
+
+	/**
+	 * @testdox Cache-Control header is "public" when no user is logged in even with vary_by_user true.
+	 */
+	public function test_cache_control_public_when_no_user() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'is_user_logged_in' => fn() => false )
+		);
+
+		$response = $this->query_endpoint( 'single_entity' );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 'public', $headers['Cache-Control'] );
+		$this->assertStringContainsString( 'must-revalidate', $headers['Cache-Control'] );
+		$this->assertStringContainsString( 'max-age=', $headers['Cache-Control'] );
+	}
+
+	/**
+	 * @testdox Cache-Control header is "public" when vary_by_user is false regardless of login status.
+	 */
+	public function test_cache_control_public_when_vary_by_user_false() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'is_user_logged_in' => fn() => true )
+		);
+
+		$response = $this->query_endpoint( 'no_vary_by_user' );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 'public', $headers['Cache-Control'] );
+	}
+
+	/**
+	 * @testdox Date and X-WC-Date headers are present and correctly formatted on cache HIT.
+	 */
+	public function test_date_header_present() {
+		$this->query_endpoint( 'single_entity' );
+		$response = $this->query_endpoint( 'single_entity' );
+
+		$this->assertCacheHeader( $response, 'HIT' );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Date', $headers );
+		$this->assertMatchesRegularExpression( '/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/', $headers['Date'] );
+		$this->assertArrayHasKey( 'X-WC-Date', $headers );
+		$this->assertEquals( $headers['Date'], $headers['X-WC-Date'], 'X-WC-Date should match Date' );
+	}
+
+	/**
+	 * @testdox ETags are different for different users when vary_by_user is true.
+	 */
+	public function test_etags_differ_per_user() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 1 )
+		);
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$etag1     = $response1->get_headers()['ETag'];
+
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 2 )
+		);
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$etag2     = $response2->get_headers()['ETag'];
+
+		$this->assertNotSame( $etag1, $etag2 );
+	}
+
+	/**
+	 * @testdox User cannot get 304 with another user's ETag.
+	 */
+	public function test_304_not_returned_with_different_user_etag() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 1 )
+		);
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$etag1     = $response1->get_headers()['ETag'];
+
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 2 )
+		);
+		$request = new WP_REST_Request( 'GET', '/wc/v3/rest_api_cache_test/single_entity' );
+		$request->set_header( 'If-None-Match', $etag1 );
+		$response2 = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response2->get_status() );
+		$this->assertNotNull( $response2->get_data() );
+	}
+
+	/**
+	 * @testdox WordPress no-cache headers are suppressed for cached endpoints.
+	 */
+	public function test_nocache_headers_suppressed() {
+		$response = $this->query_endpoint( 'single_entity' );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringNotContainsString( 'no-cache', $headers['Cache-Control'] );
+		$this->assertStringNotContainsString( 'no-store', $headers['Cache-Control'] );
 	}
 }


### PR DESCRIPTION
_This is the sixth of a series of pull requests to implement output caching for the WooCommerce REST API endpoints. Previous: https://github.com/woocommerce/woocommerce/pull/61931, next: https://github.com/woocommerce/woocommerce/pull/61986_

### Changes proposed in this Pull Request:

This pull request extends the `RestApiCache` trait implemented starting with https://github.com/woocommerce/woocommerce/pull/61798 by implementing support for cache control headers for REST API responses:

- Includes `Cache-Control`, `ETag`, `Date` and `X-WC-Date` headers in REST API responses:
  * `Cache-Control` will be `private` for endpoints that vary by user when the request is authenticated, in all other cases it will be `public`.
  * `max-age` in `Cache-Control` will be equal to the TTL of the corresponding cached response.
  * For cached responses, `Date` will hold the date in which the response was cached. Clients can use this value together with `max-age` to determine if a locally cached response is still usable.
    * Some servers will add their own `Date` header, resulting in the response having two such headers. To help disambiguate, and to make extra clear that a `Date` header was added by WooCommerce, `X-WC-Date` containing the same value is also sent.
  * `ETag` will be generated from the response data *and* the key used to identify the cached response. This implies that for endpoints that vary by user, different users will get different ETags even when the output is identical for both.
- Handles `If-None-Match` headers in requests, sending a "304 Not Modified" response when appropriate.

### How to test the changes in this Pull Request:

> **⚠️ Testing Prerequisite:** A persistent object cache must be installed in your WordPress instance. If you are testing locally you can use [this simple file-based drop-in plugin](https://gist.github.com/Konamiman/96aeacc7933b5b89cb735c46f02adf89).

1. Add the following snippet to your site, this will create a simple "thing" controller:

```php
// To easily test the per-user variance
add_filter( 'rest_pre_dispatch', function( $result, $server, $request ) {
	$user_id = $request->get_header( 'X-User-Id' );
	if ( ! is_null( $user_id ) ) {
		wp_set_current_user( (int) $user_id );
	}
	return $result;
}, 10, 3 );

add_action(
	'rest_api_init',
	function() {
		$controller = new class() extends WC_REST_Controller {
			use Automattic\WooCommerce\Internal\Traits\RestApiCache;

			public function __construct() {
				$this->initialize_rest_api_cache();
			}

			protected function get_default_response_entity_type(): ?string {
				return 'thing';
			}

			public function register_routes() {
				register_rest_route(
					'wc',
					'/things/(?P<id>[\d]+)',
					array(
						array(
							'methods'             => WP_REST_Server::READABLE,
							'callback'            => $this->with_cache( array( $this, 'get_item' ) ),
							'permission_callback' => '__return_true',
						),
					)
				);
			}

			public function get_item( $request ) {
				$id = $request->get_param( 'id' );

				return array(
					'id'          => $id,
					'name'        => 'Test Thing #' . $id,
					'description' => 'This is a test thing for cache control testing',
					'timestamp'   => time(),
				);
			}

			protected function get_data_for_etag( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array {
				// Exclude timestamp from ETag to allow proper 304 responses.
				$etag_data = $data;
				unset( $etag_data['timestamp'] );
				return $etag_data;
			}
		};

		$controller->register_routes();
	}
);
```

2. Test the endpoint as an anonymous user:

```
curl -i "http://localhost/wp-json/wc/things/1"
```

The response should:
- Be a cache miss
- Include an `ETag` header
- Include a `Date` header with the current date
- Include a `Cache-Control: public, must-revalidate, max-age=3600` header

3. Repeat the same request. This time the response should:

- Be a cache hit
- Have the same values for the `ETag`, `Date` and `Cache-Control` headers
- Have the same value for the `timestamp` field in the response is the same as in the previous case.

6. Repeat the same request but this time including an `If-None-Match` header with the value of the ETag from the response you got earlier:

```
curl -i -H "If-None-Match: \"<ETag value>\"" "http://localhost/wp-json/wc/things/1"
```

This time the response should have a `304 Not Modified` status line, and the body should be empty.

7. Now let's simulate an authenticated request:

```
curl -i -H "X-User-Id: <valid user id>" "http://localhost/wp-json/wc/things/1"
```

You should get the same result as in step 2, except that the visibility in the `Cache-Control` header is now `private` (and the `Date` and `ETag` are different of course).

8. Repeat the authenticated request, you should get the same `Date` and `ETag` as in step 3.

9. Repeat the authenticated request including an `If-None-Match` header with the ETag value received, you should get a 304 response.

10. Repeat the authenticated request with a different user id. The value of the received ETag should be different.

11. Repeat the authenticated request with the second user id and an `If-None-Match` header that holds the value that you got for `ETag` for the first user. You should get a 200 response (NOT a 304 response).

12. Add the following to the test controller:

```php
	protected function get_ttl_for_cached_response( WP_REST_Request $request, ?string $endpoint_id = null ): int {
		return MINUTE_IN_SECONDS;
	}
```

then repeat any of the requests, this time you should get `max-age=60` inside the `Cache-Control` header in the response.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
