### PR TITLE
Agentic Commerce Settings: Reorganize for better clarity

### DIFF
--- a/plugins/woocommerce/changelog/update-acp-settings-v2
+++ b/plugins/woocommerce/changelog/update-acp-settings-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Group agentic commerce settings for better comprehension.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR improves the Agentic Commerce settings page based on design feedback, reorganizing sections for  better clarity and usability.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="4412" height="3200" alt="CleanShot 2025-10-16 at 17 20 42@2x" src="https://github.com/user-attachments/assets/0a92b093-908f-458b-9ca5-10ba70347d61" />     |   <img width="3852" height="2690" alt="CleanShot 2025-10-17 at 09 23 25@2x" src="https://github.com/user-attachments/assets/fbc5186e-4db5-4254-a8a3-ff39ec29b988" />    |

Note: The after screenshot here contains the product feed url and return window, which are added via filter. They will not ship as part of Woo core.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable the `agentic_checkout` feature flag. Either modify the feature to show the UI or update `woocommerce_feature_agentic_checkout_enabled` to `yes`.
2. Navigate to **WooCommerce > Settings > Integrations**
3. Click on **Agentic Commerce**
4. Verify you see:
   - General Settings section with product visibility checkbox and read-only privacy/terms URLs
   - ChatGPT section with bearer token, webhook URL, and webhook secret fields
5. Fill in the ChatGPT credentials:
   - Authorization Token: `test_bearer_token_123`
   - Webhook URL: `https://example.com/webhook`
   - Webhook Secret: `test_secret_456`
6. Check "Enable products by default"
7. Click "Save changes"
8. Verify settings are saved by refreshing the page
9. Check the database - the `woocommerce_agentic_agent_registry` option should contain your saved data
10. Verify the option is not autoloaded: `SELECT autoload FROM wp_options WHERE option_name = 'woocommerce_agentic_agent_registry'` should return `'no'`
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Manual testing as mentioned above.
