### PR TITLE
Align pickup location with shipping options styling

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -32,7 +32,6 @@
 		.wc-block-components-radio-control__option-checked {
 			.wc-block-components-radio-control__description-group {
 				.read-more-content {
-					margin-left: $gap-small * 0.25;
 					position: initial;
 					visibility: visible;
 					z-index: initial;
@@ -48,14 +47,9 @@
 			display: flex;
 			flex-direction: column;
 			gap: $gap-smallest;
+			margin-top: $gap-smallest;
 
 			box-sizing: border-box;
-			padding: 0 $gap;
-
-			// Go to plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
-			// and inspect $content-padding-left to learn more about this "magic" value
-			margin-left: -#{calc($gap + 24px + $gap-smaller)};
-			margin-top: $gap-small;
 
 			.read-more-content {
 				position: absolute;
@@ -88,6 +82,7 @@
 				// Pixel perfect alignement needed as internal padding of the SVG
 				// is inconsistent (top one bigger that the bottom one).
 				margin-top: -2px;
+				margin-left: -3px;
 			}
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -27,6 +27,7 @@ import type {
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
 import type { ReactElement } from 'react';
 import { useMemo } from '@wordpress/element';
+import ReadMore from '@woocommerce/base-components/read-more';
 
 /**
  * Renders a shipping rate control option.
@@ -39,6 +40,7 @@ const renderShippingRatesControlOption = (
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
 		: parseInt( option.price, 10 );
+	const isSelected = option?.selected;
 
 	const secondaryLabel =
 		priceWithTaxes === 0 ? (
@@ -57,7 +59,12 @@ const renderShippingRatesControlOption = (
 		value: option.rate_id,
 		description: decodeEntities( option.delivery_time ),
 		secondaryLabel,
-		secondaryDescription: decodeEntities( option.description ),
+		secondaryDescription:
+			isSelected && option.description ? (
+				<ReadMore maxLines={ 2 }>
+					{ decodeEntities( option.description ) }
+				</ReadMore>
+			) : undefined,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
@@ -16,6 +16,14 @@
 		&:last-child {
 			margin-bottom: 0;
 		}
+
+		.wc-block-components-radio-control
+			.wc-block-components-radio-control__input {
+			// We want it to stick to the top, since it has position: absolute we
+			// can position it to be aligned with the top padding value.
+			top: $gap;
+			transform: none;
+		}
 	}
 	.wc-block-checkout__login-prompt {
 		float: right;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

* Update the styling of pickup locations to better match the shipping methods.
* Shows the shipping method description only for the selected method.
* Add the `Read more` button when the shipping method description is too long (that already happens on pickup locations).

Closes WOOPLUG-4945.

Continuation of work tracked in https://github.com/woocommerce/woocommerce/pull/59787 ("long" lived branch synced with trunk)
Intro post: pfHfG4-1iC-p2
Designs: fpl1YUEIW7suBFO09qymA2-fi-1212_50897

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| trunk | #59787 | This PR |
|-|-|-|
| <img width="567" height="407" alt="Screenshot 2025-10-17 at 2 32 25 PM" src="https://github.com/user-attachments/assets/a54fec57-fd28-4c41-b448-ec56ff8d7536" /> | <img width="564" height="242" alt="Screenshot 2025-10-17 at 2 32 59 PM" src="https://github.com/user-attachments/assets/2bcc9870-b48c-448c-9325-fc5a8d979915" /> | <img width="567" height="237" alt="Screenshot 2025-10-17 at 2 22 10 PM" src="https://github.com/user-attachments/assets/a75e04eb-d614-4896-8443-54ff21b3d541" /> |
| <img width="567" height="407" alt="Screenshot 2025-10-17 at 2 32 35 PM" src="https://github.com/user-attachments/assets/d862f87c-bb9c-46e9-a022-33e38e111023" /> | <img width="564" height="348" alt="Screenshot 2025-10-17 at 2 32 49 PM" src="https://github.com/user-attachments/assets/36f69dfa-fc4d-4aee-a6fb-4683adee3742" /> | <img width="564" height="247" alt="Screenshot 2025-10-20 at 10 38 08 AM" src="https://github.com/user-attachments/assets/04ae0f95-76c0-495e-a919-cfc002d69f27" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create shipping zones and pickup locations with description.
2. Load the following snippet to load extra shipping information on shipping methods:

```
function custom_shipping_description( $rates, $package ) {
    foreach ( $rates as $rate_id => $rate ) {
		if ( 'pickup_location' === $rate->method_id ) {
			continue;
		}
		$rate->description = 'This is a custom description for ' . $rate->label . '. It is quite a long, descriptive description that should flow onto multiple lines, for testing purposes. Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat.';
		$rate->delivery_time = 'This will be delivered in ' . rand( 1, 5 ) . ' days.';
	}
    return $rates;
}
add_filter( 'woocommerce_package_rates', 'custom_shipping_description', 10, 2 );
```

3. Add products to the cart.
4. Access the blocks checkout page.
5. Shipping methods should now show the description only for the selected one, and show `Read more` when the description is too long.
6. Pickup location methods should match the Figma spacing and font sizes.

<!-- End testing instructions -->
### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR doesn't target `trunk`. Changelog will be added when the main branch will be merged to `trunk`.

</details>
