### PR TITLE
Featured Product block: add support for duotone filter

### DIFF
--- a/plugins/woocommerce/changelog/61485-wooplug-5668-fpb-add-support-for-duotone-filter
+++ b/plugins/woocommerce/changelog/61485-wooplug-5668-fpb-add-support-for-duotone-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for the duotone filter to the Featured Product block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -11,6 +11,9 @@
 		"align": [ "wide", "full" ],
 		"ariaLabel": true,
 		"html": false,
+		"filter": {
+			"duotone": true
+		},
 		"color": {
 			"background": true,
 			"text": true
@@ -98,6 +101,11 @@
 		"previewProduct": {
 			"type": "object",
 			"default": null
+		}
+	},
+	"selectors": {
+		"filter": {
+			"duotone": ".wp-block-woocommerce-featured-product .wc-block-featured-product__background-image"
 		}
 	},
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/featured-product/featured-product.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/featured-product/featured-product.block_theme.spec.ts
@@ -37,7 +37,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await blockLocator.getByText( 'Done' ).click();
 		await editor.clickBlockToolbarButton( 'Edit product image' );
 		await editor.clickBlockToolbarButton( 'Rotate' );
-		await editor.page.getByRole( 'button', { name: 'Apply' } ).click();
+		await editor.page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 		await expect(
 			editor.canvas.locator( 'img[alt="Album"][src*="-edited"]' )
 		).toBeVisible();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds support for the duotone filter to the Featured Category block background image.

Closes #61363 .

### Screenshots or screen recordings:

<img width="682" height="546" alt="Screenshot 2025-10-19 at 20 47 11" src="https://github.com/user-attachments/assets/d303ac50-7314-4af7-9ba5-f418be853ba3" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a Featured Product block to a page.
2. Go to the style tab and confirm that the duotone filter is available and it works both in the editor and on the front-end. (It should only apply to the background image).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add support for the duotone filter to the Featured Product block.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
