### PR TITLE
Featured Items: show border UI by default

### DIFF
--- a/plugins/woocommerce/changelog/61486-wooplug-5433-fcb-show-border-by-default
+++ b/plugins/woocommerce/changelog/61486-wooplug-5433-fcb-show-border-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Featured Product and Featured Category blocks show border UI by default.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
@@ -29,6 +29,11 @@
 			"color": true,
 			"radius": true,
 			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true
+			},
 			"__experimentalSkipSerialization": true
 		}
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -26,6 +26,11 @@
 			"color": true,
 			"radius": true,
 			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true
+			},
 			"__experimentalSkipSerialization": true
 		},
 		"multiple": true


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In order to be in line with the controls coming from the Cover block, this PR adds the border UI by default in the Featured Category and Featured Product blocks.

Closes #60624.

### Screenshots or screen recordings:

<img width="266" height="188" alt="Screenshot 2025-10-19 at 21 00 37" src="https://github.com/user-attachments/assets/e0aa42d0-8695-4d87-a066-0164e52519bf" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a Featured Category block to the page.
2. Open the Inspector Controls → Style tab.
3. Scroll down and verify that the controls are visible by default.
4. Repeat for the Featured Product block.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Featured Product and Featured Category blocks show border UI by default.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
