### PR TITLE
Use reload page util in Cart/Checkout block error boundaries

### DIFF
--- a/plugins/woocommerce/changelog/issues-53248-javascript-url-event-handler
+++ b/plugins/woocommerce/changelog/issues-53248-javascript-url-event-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use event handler to reload page, eliminates deprecated warning in checkout block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/block.js
@@ -14,14 +14,13 @@ import {
 } from '@woocommerce/base-context';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
+import { reloadPage } from '@woocommerce/blocks/checkout/utils';
 
 /**
  * Internal dependencies
  */
 import { CartBlockContext } from './context';
 import './style.scss';
-
-const reloadPage = () => void window.location.reload( true );
 
 const Cart = ( { children, attributes = {} } ) => {
 	const { hasDarkControls } = attributes;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
@@ -21,6 +21,8 @@ import {
 	GENERIC_CART_ITEM_ERROR,
 } from './constants';
 
+const reloadPage = () => void window.location.reload( true );
+
 // Type definitions
 interface ErrorData {
 	code: string;
@@ -114,7 +116,7 @@ const ErrorButton = ( { errorData }: ErrorComponentProps ) => {
 			) : (
 				<button
 					className="wp-block-button__link"
-					onClick={ () => window.location.reload() }
+					onClick={ reloadPage }
 				>
 					{ buttonText }
 				</button>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 import { CheckoutResponse } from '@woocommerce/types';
+import { reloadPage } from '@woocommerce/blocks/checkout/utils';
 
 /**
  * Internal dependencies
@@ -20,8 +21,6 @@ import {
 	PRODUCT_SOLD_INDIVIDUALLY,
 	GENERIC_CART_ITEM_ERROR,
 } from './constants';
-
-const reloadPage = () => void window.location.reload( true );
 
 // Type definitions
 interface ErrorData {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/utils.ts
@@ -124,4 +124,4 @@ export const formatAddress = (
 	return { name: parsedName, address: addressParts };
 };
 
-export const reloadPage = (): void => void window.location.reload( true );
+export const reloadPage = (): void => void window.location.reload();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use event handler to reload page, eliminates deprecated warning in checkout block. Closes #53248.

[Matches fix already in use](https://github.com/woocommerce/woocommerce/blob/ed292453a9424aa5474c6d5566a947466f1ae479/plugins/woocommerce-blocks/assets/js/blocks/cart/block.js#L81)

### Testing instructions

1. put product in cart and proceed to checkout block, see warning:
`Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed "javascript:window.location.reload(true)".`
2. Apply patch, rebuild block scripts, warning should be gone
