### PR TITLE
Apply consistent font sizes and spacing in cart

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -13,11 +13,11 @@ table.wc-block-cart-items {
 	width: 100%;
 
 	.wc-block-cart-items__header {
-		@include font-size(smaller);
+		@include font-small-locked;
 		text-transform: uppercase;
 
 		.wc-block-cart-items__header-image {
-			width: 100px;
+			width: 80px;
 		}
 		.wc-block-cart-items__header-product {
 			visibility: hidden;
@@ -33,7 +33,7 @@ table.wc-block-cart-items {
 	.wc-block-cart-items__row {
 		.wc-block-cart-item__wrap > *,
 		.wc-block-components-quantity-selector {
-			margin-bottom: $gap-small;
+			margin-bottom: $gap-smaller * 1.25;
 		}
 
 		.wc-block-cart-item__wrap > *:last-child {
@@ -45,10 +45,14 @@ table.wc-block-cart-items {
 			margin: 0;
 		}
 		.wc-block-cart-item__prices {
-			line-height: 1.2;
+			@include font-button-locked;
 		}
 
 		.wc-block-cart-item__quantity {
+			display: flex;
+			flex-direction: column;
+			align-items: start;
+
 			.wc-block-cart-item__remove-link {
 				@include link-button();
 				@include hover-effect();
@@ -62,6 +66,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-components-product-name {
+			@include font-button-locked;
 			display: block;
 			max-width: max-content;
 			line-height: 1.4;
@@ -70,7 +75,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-cart-item__total {
-			@include font-size(regular);
+			@include font-button-locked;
 			text-align: right;
 			line-height: 1.8;
 		}
@@ -158,12 +163,12 @@ table.wc-block-cart-items {
 			border-bottom: 1px solid $universal-border-light;
 
 			th {
-				padding: $gap-smaller $gap $gap-smaller 0;
+				padding: $gap-smaller $gap $gap 0;
 				white-space: nowrap;
 			}
 			td {
 				border-top: 1px solid $universal-border-light;
-				padding: $gap-large 0 $gap-large $gap;
+				padding: $gap * 1.25 0 $gap * 1.25 $gap;
 				vertical-align: top;
 			}
 			th:last-child {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,8 +1,8 @@
 .wc-block-components-product-metadata {
-	@include font-size(smaller);
+	@include font-regular-locked;
 
 	.wc-block-components-product-metadata__description > p,
 	.wc-block-components-product-metadata__variation-data {
-		margin: 0.25em 0;
+		margin: 0;
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -22,12 +22,6 @@
 		margin: 0;
 	}
 
-	table.wc-block-cart-items,
-	table.wc-block-cart-items th,
-	table.wc-block-cart-items td {
-		margin: 0 0 $gap * 2.5;
-	}
-
 	.wp-block-woocommerce-cart-order-summary-block {
 		border-bottom: 1px solid $universal-border-light;
 		margin-bottom: $gap;
@@ -115,9 +109,6 @@
 		.wc-block-components-sale-badge {
 			display: none;
 		}
-	}
-	table.wc-block-cart-items {
-		margin: 0;
 	}
 
 	.wc-block-cart {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -1,6 +1,12 @@
 .wp-block-woocommerce-product-collection {
+	margin-bottom: $gap-large * 1.25;
+
 	.wc-block-components-product-stock-indicator {
 		text-align: center;
+	}
+
+	h2.wp-block-heading {
+		@include font-button-locked;
 	}
 
 	&:has(.is-product-collection-layout-carousel) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the cart block spacing and font sizes to match the ones in the new design.

Closes WOOPLUG-5713.

Continuation of work tracked in https://github.com/woocommerce/woocommerce/pull/59787 ("long" lived branch synced with trunk)
Intro post: pfHfG4-1iC-p2
Designs: fpl1YUEIW7suBFO09qymA2-fi-1212_50897

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="574" height="906" alt="Screenshot 2025-10-21 at 12 29 32 AM" src="https://github.com/user-attachments/assets/3912996d-1092-46b9-aa14-d0ee23cf9f1d" /> | <img width="576" height="831" alt="Screenshot 2025-10-21 at 12 22 14 AM" src="https://github.com/user-attachments/assets/95a3ad80-7ec7-47ff-b271-271aca7652f5" /> |
| <img width="416" height="822" alt="Screenshot 2025-10-21 at 12 29 53 AM" src="https://github.com/user-attachments/assets/75a85393-6f36-478b-9568-25effe305f17" /> | <img width="393" height="818" alt="Screenshot 2025-10-21 at 12 24 46 AM" src="https://github.com/user-attachments/assets/3d42af2b-4801-4e5e-8e4d-11e3ae57ce7a" /> |
| <img width="415" height="903" alt="Screenshot 2025-10-22 at 10 59 10 AM" src="https://github.com/user-attachments/assets/6e6353c9-ab58-4806-974e-833a7ea2eede" /> | <img width="415" height="903" alt="Screenshot 2025-10-22 at 10 58 10 AM" src="https://github.com/user-attachments/assets/12b5118b-dcd6-4d84-955b-6b7ae3e84286" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add some different types of products to the cart, including variable products.
2. Access the blocks cart page.
3. The spacing and font sizes should match Figma design.
4. Make sure there are no design regressions on other components.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR doesn't target `trunk`. Changelog will be added when the main branch will be merged to `trunk`.

</details>
