### PR TITLE
Revert global event handler for anchors with role buttons and add specific event listeners to places that require it

### DIFF
--- a/plugins/woocommerce/changelog/fix-61444-too-aggressive-event-listener
+++ b/plugins/woocommerce/changelog/fix-61444-too-aggressive-event-listener
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove glboal event handler for a['role=button'] and assign specific ones to elements that needs it

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -17,6 +17,7 @@ jQuery( function( $ ) {
 		$( document.body )
 			.on( 'click', '.add_to_cart_button:not(.wc-interactive)', { addToCartHandler: this }, this.onAddToCart )
 			.on( 'click', '.remove_from_cart_button', { addToCartHandler: this }, this.onRemoveFromCart )
+			.on( 'keydown', '.remove_from_cart_button', this.onKeydownRemoveFromCart )
 			.on( 'added_to_cart', { addToCartHandler: this }, this.onAddedToCart )
 			.on( 'removed_from_cart', { addToCartHandler: this }, this.onRemovedFromCart )
 			.on( 'ajax_request_not_sent.adding_to_cart', this.updateButton );
@@ -167,6 +168,18 @@ jQuery( function( $ ) {
 			},
 			dataType: 'json'
 		});
+	};
+
+	/**
+	 * Handle when pressing the Space key on the remove item link.
+	 * This is necessary because the link got the role="button" attribute
+	 * and needs to act like a button.
+	 */
+	AddToCartHandler.prototype.onKeydownRemoveFromCart = function( event ) {
+		if ( event.key === ' ' ) {
+			event.preventDefault();
+			$( this ).trigger( 'click' );
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -16,6 +16,10 @@ jQuery( function( $ ) {
 
 		$( document.body )
 			.on( 'click', '.add_to_cart_button:not(.wc-interactive)', { addToCartHandler: this }, this.onAddToCart )
+			// Handle when pressing the Space key on the add to cart anchor with role="button" attribute.
+			.on( 'keydown', '.add_to_cart_button:not(.wc-interactive)', { addToCartHandler: this },
+				( e ) => { if ( e.key === ' ' ) { e.preventDefault(); e.target.click(); } }
+			)
 			.on( 'click', '.remove_from_cart_button', { addToCartHandler: this }, this.onRemoveFromCart )
 			.on( 'keydown', '.remove_from_cart_button', this.onKeydownRemoveFromCart )
 			.on( 'added_to_cart', { addToCartHandler: this }, this.onAddedToCart )

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -122,19 +122,19 @@ jQuery( function( $ ) {
 					'<p class="stars">\
 						<span role="group" aria-labelledby="comment-form-rating-label">\
 							<a role="radio" tabindex="0" aria-checked="false" class="star-1" href="#">' +
-								wc_single_product_params.i18n_rating_options[0] + 
+								wc_single_product_params.i18n_rating_options[0] +
 							'</a>\
-							<a role="radio" tabindex="-1" aria-checked="false" class="star-2" href="#">' + 
-								wc_single_product_params.i18n_rating_options[1] + 
+							<a role="radio" tabindex="-1" aria-checked="false" class="star-2" href="#">' +
+								wc_single_product_params.i18n_rating_options[1] +
 							'</a>\
-							<a role="radio" tabindex="-1" aria-checked="false" class="star-3" href="#">' + 
-								wc_single_product_params.i18n_rating_options[2] + 
+							<a role="radio" tabindex="-1" aria-checked="false" class="star-3" href="#">' +
+								wc_single_product_params.i18n_rating_options[2] +
 							'</a>\
-							<a role="radio" tabindex="-1" aria-checked="false" class="star-4" href="#">' + 
-								wc_single_product_params.i18n_rating_options[3] + 
+							<a role="radio" tabindex="-1" aria-checked="false" class="star-4" href="#">' +
+								wc_single_product_params.i18n_rating_options[3] +
 							'</a>\
-							<a role="radio" tabindex="-1" aria-checked="false" class="star-5" href="#">' + 
-								wc_single_product_params.i18n_rating_options[4] + 
+							<a role="radio" tabindex="-1" aria-checked="false" class="star-5" href="#">' +
+								wc_single_product_params.i18n_rating_options[4] +
 							'</a>\
 						</span>\
 					</p>'
@@ -182,7 +182,7 @@ jQuery( function( $ ) {
 			if ( ! allDirections.includes( direction ) ) {
 				return;
 			}
-			
+
 			e.preventDefault();
 			e.stopPropagation();
 
@@ -340,7 +340,7 @@ jQuery( function( $ ) {
 				touch: false,
 				callback: function() {
 					var zoomImg = this;
-					
+
 					setTimeout( function() {
 						zoomImg.removeAttribute( 'role' );
 						zoomImg.setAttribute( 'alt', '' );
@@ -377,6 +377,11 @@ jQuery( function( $ ) {
 				'</a>'
 			);
 			this.$target.on( 'click', '.woocommerce-product-gallery__trigger', this.openPhotoswipe );
+			this.$target.on( 'keydown', '.woocommerce-product-gallery__trigger', ( e ) => {
+				if ( e.key === ' ' ) {
+					this.openPhotoswipe( e );
+				}
+			} );
 			this.$target.on( 'click', '.woocommerce-product-gallery__image a', function( e ) {
 				e.preventDefault();
 			});
@@ -477,7 +482,7 @@ jQuery( function( $ ) {
 
 	/**
 	 * Control focus in photoswipe modal.
-	 * 
+	 *
 	 * @param {boolean} trapFocus - Whether to trap focus or not.
 	 */
 	ProductGallery.prototype.trapFocusPhotoswipe = function( trapFocus ) {
@@ -493,7 +498,7 @@ jQuery( function( $ ) {
 			pswp.removeEventListener( 'keydown', this.handlePswpTrapFocus );
 		}
 	};
-	
+
 	/**
 	 * Handle keydown event in photoswipe modal.
 	 */

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -23,8 +23,8 @@ jQuery( function ( $ ) {
 	} else {
 		$( '.woocommerce-store-notice' ).show();
 		/**
-		 * After adding the role="button" attribute to the 
-		 * .woocommerce-store-notice__dismiss-link element, 
+		 * After adding the role="button" attribute to the
+		 * .woocommerce-store-notice__dismiss-link element,
 		 * we need to add the keydown event listener to it.
 		 */
 		function store_notice_keydown_handler( event ) {
@@ -43,7 +43,7 @@ jQuery( function ( $ ) {
 				.off( 'click', store_notice_click_handler )
 				.off( 'keydown', store_notice_keydown_handler );
 		}
-		
+
 		$( '.woocommerce-store-notice__dismiss-link' )
 			.on( 'click', store_notice_click_handler )
 			.on( 'keydown', store_notice_keydown_handler );
@@ -249,7 +249,7 @@ function refresh_sorted_by_live_region() {
 	if ( sorted_by_live_region ) {
 		var text = sorted_by_live_region.innerHTML;
 		sorted_by_live_region.setAttribute('aria-hidden', 'true');
-		
+
 		var sorted_by_live_region_id = setTimeout( function () {
 			sorted_by_live_region.setAttribute('aria-hidden', 'false');
 			sorted_by_live_region.innerHTML = '';

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -14,19 +14,6 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	// Global accessibility handler for all links with role="button"
-	// This ensures both spacebar and enter keypresses trigger click events, as per ARIA specification
-	document.body.addEventListener( 'keydown', function ( event ) {
-		if ( ! event.target.matches( 'a[role="button"]' ) ) {
-			return;
-		}
-
-		if ( event.key === ' ' || event.key === 'Enter' ) {
-			event.preventDefault();
-			event.target.click();
-		}
-	} );
-
 	var noticeID = $( '.woocommerce-store-notice' ).data( 'noticeId' ) || '',
 		cookieName = 'store_notice' + noticeID;
 
@@ -35,22 +22,31 @@ jQuery( function ( $ ) {
 		$( '.woocommerce-store-notice' ).hide();
 	} else {
 		$( '.woocommerce-store-notice' ).show();
+		/**
+		 * After adding the role="button" attribute to the 
+		 * .woocommerce-store-notice__dismiss-link element, 
+		 * we need to add the keydown event listener to it.
+		 */
+		function store_notice_keydown_handler( event ) {
+			if ( ['Enter', ' '].includes( event.key ) ) {
+				event.preventDefault();
+				$( '.woocommerce-store-notice__dismiss-link' ).click();
+			}
+		}
 
 		// Set a cookie and hide the store notice when the dismiss button is clicked
 		function store_notice_click_handler( event ) {
 			Cookies.set( cookieName, 'hidden', { path: '/' } );
 			$( '.woocommerce-store-notice' ).hide();
 			event.preventDefault();
-			$( '.woocommerce-store-notice__dismiss-link' ).off(
-				'click',
-				store_notice_click_handler
-			);
+			$( '.woocommerce-store-notice__dismiss-link' )
+				.off( 'click', store_notice_click_handler )
+				.off( 'keydown', store_notice_keydown_handler );
 		}
-
-		$( '.woocommerce-store-notice__dismiss-link' ).on(
-			'click',
-			store_notice_click_handler
-		);
+		
+		$( '.woocommerce-store-notice__dismiss-link' )
+			.on( 'click', store_notice_click_handler )
+			.on( 'keydown', store_notice_keydown_handler );
 	}
 
 	// Make form field descriptions toggle on focus.
@@ -186,11 +182,26 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	$( document.body ).on(
-		'item_removed_from_classic_cart updated_wc_div',
-		focus_populate_live_region
-	);
+	// If the "Enable AJAX add to cart buttons on archives" setting is disabled
+	// the add-to-cart.js file won't be loaded, so we need to add the event listener here.
+	if ( typeof wc_add_to_cart_params === 'undefined') {
+		$( document.body ).on( 'keydown', '.remove_from_cart_button', on_keydown_remove_from_cart );
+	}
+
+	$( document.body ).on( 'item_removed_from_classic_cart updated_wc_div', focus_populate_live_region );
 } );
+
+/**
+ * Handle when pressing the Space key on the remove item link.
+ * This is necessary because the link has the role="button" attribute
+ * and needs to act like a button.
+ */
+function on_keydown_remove_from_cart( event ) {
+	if ( event.key === ' ' ) {
+		event.preventDefault();
+		event.currentTarget.click();
+	}
+}
 
 /**
  * Focus on the first notice element on the page.
@@ -237,10 +248,10 @@ function refresh_sorted_by_live_region() {
 
 	if ( sorted_by_live_region ) {
 		var text = sorted_by_live_region.innerHTML;
-		sorted_by_live_region.setAttribute( 'aria-hidden', 'true' );
-
+		sorted_by_live_region.setAttribute('aria-hidden', 'true');
+		
 		var sorted_by_live_region_id = setTimeout( function () {
-			sorted_by_live_region.setAttribute( 'aria-hidden', 'false' );
+			sorted_by_live_region.setAttribute('aria-hidden', 'false');
 			sorted_by_live_region.innerHTML = '';
 			sorted_by_live_region.innerHTML = text;
 			clearTimeout( sorted_by_live_region_id );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


#### Background
In PR https://github.com/woocommerce/woocommerce/pull/59578, we added a global accessibility event handler to ensure that links with role="button" respond to both spacebar and enter key presses, as required by ARIA specifications. This was implemented as a single global event listener on document.body that handled all a[role="button"] elements.

#### Problem
A third-party developer reported in issue https://github.com/woocommerce/woocommerce/issues/61444 that our global event handler was too aggressive and caused conflicts with their Max Mega Menu plugin. The global approach was interfering with other plugins' keyboard navigation implementations, breaking their functionality. Other extensions could've been impacted as well.

#### Solution
This PR addresses the issue by:
- Reverting the global event handler - Removes the document.body event listener that was affecting all a[role="button"] elements site-wide
- Adding targeted manual handlers - Implements specific event handlers for individual WooCommerce components.

cc: @PanosSynetos, letting you know that Composite Products would have to add their own event handler for anchor with button role (a['role=button']) that we were addressing in this PR: https://github.com/woocommerce/woocommerce/pull/59578.

Closes https://github.com/woocommerce/woocommerce/issues/61444.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use classic theme like Storefront
2. Go to /shop
3. Use tab to focus on Add to Cart button and press spacebar
5. **Expected:** Product is added to cart
6. Go to single product
7. Use tab to focus on maginifying glass in gallery and press spacebar
8. **Expected:** Full page gallery is opened

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
