### PR TITLE
[Backport to release/10.3] Fixes CSV import failure with brands

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-5666-csv-import-failure-due-to-newly-introduced-brands-setter
+++ b/plugins/woocommerce/changelog/fix-wooplug-5666-csv-import-failure-due-to-newly-introduced-brands-setter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix fatal error when importing products with brands.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -693,7 +693,7 @@ class WC_Brands_Admin {
 	/**
 	 * Add formatting callback for brand_ids during CSV import.
 	 *
-	 * @param  array                $callbacks Formatting callbacks.
+	 * @param  array               $callbacks Formatting callbacks.
 	 * @param  WC_Product_Importer $importer  Importer instance.
 	 * @return array $callbacks
 	 */
@@ -718,11 +718,11 @@ class WC_Brands_Admin {
 	 * @param array      $data    Raw CSV data.
 	 */
 	public function process_import( $product, $data ) {
-		if ( empty( $data[ 'brand_ids' ] ) || ! is_array( $data[ 'brand_ids' ] ) ) {
+		if ( empty( $data['brand_ids'] ) || ! is_array( $data['brand_ids'] ) ) {
 			return;
 		}
 
-		$brand_ids = array_map( 'intval', $data[ 'brand_ids' ] );
+		$brand_ids = array_map( 'intval', $data['brand_ids'] );
 		wp_set_object_terms( $product->get_id(), $brand_ids, 'product_brand' );
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -99,6 +99,7 @@ class WC_Brands_Admin {
 		// Import.
 		add_filter( 'woocommerce_csv_product_import_mapping_options', array( $this, 'add_column_to_importer_exporter' ), 10 );
 		add_filter( 'woocommerce_csv_product_import_mapping_default_columns', array( $this, 'add_default_column_mapping' ), 10 );
+		add_filter( 'woocommerce_product_importer_formatting_callbacks', array( $this, 'add_formatting_callback' ), 10, 2 );
 		add_filter( 'woocommerce_product_import_inserted_product_object', array( $this, 'process_import' ), 10, 2 );
 
 		// Export.
@@ -690,18 +691,38 @@ class WC_Brands_Admin {
 	}
 
 	/**
+	 * Add formatting callback for brand_ids during CSV import.
+	 *
+	 * @param  array                $callbacks Formatting callbacks.
+	 * @param  WC_Product_Importer $importer  Importer instance.
+	 * @return array $callbacks
+	 */
+	public function add_formatting_callback( $callbacks, $importer ) {
+		$mapped_keys = $importer->get_mapped_keys();
+
+		// Find the index of brand_ids in the mapped keys.
+		$brand_ids_index = array_search( 'brand_ids', $mapped_keys, true );
+
+		// If brand_ids exists in the mapping, add our custom parser.
+		if ( false !== $brand_ids_index ) {
+			$callbacks[ $brand_ids_index ] = array( $this, 'parse_brands_field' );
+		}
+
+		return $callbacks;
+	}
+
+	/**
 	 * Add brands to newly imported product.
 	 *
 	 * @param WC_Product $product Product being imported.
 	 * @param array      $data    Raw CSV data.
 	 */
 	public function process_import( $product, $data ) {
-		if ( empty( $data['brand_ids'] ) ) {
+		if ( empty( $data[ 'brand_ids' ] ) || ! is_array( $data[ 'brand_ids' ] ) ) {
 			return;
 		}
 
-		$brand_ids = array_map( 'intval', $this->parse_brands_field( $data['brand_ids'] ) );
-
+		$brand_ids = array_map( 'intval', $data[ 'brand_ids' ] );
 		wp_set_object_terms( $product->get_id(), $brand_ids, 'product_brand' );
 	}
 


### PR DESCRIPTION
This PR is a cherry-pick of #61366 to `trunk`.

## Original PR Description

Addresses a fatal error encountered during CSV product imports when brands are involved.

This issue arose due to the newly introduced brands setter. The fix ensures that the brand IDs are correctly processed during the import process.

Adds formatting callback to correctly parse the brand ids.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I introduced a formatting callback to the `brand_ids` , as there was no formatter callback, and it defaulted to `wc_clean` - See https://github.com/woocommerce/woocommerce/blob/e95fa134cb2386f85cb7f9b05f42e50eb1e3f162/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php#L839

I've also updated `process_import` not to call `parse_brands_field` as it's now called in `add_formatting_callback`


Closes #61357 
Closes WOOPLUG-5666

(For Bug Fixes) Bug introduced in PR #60512 
- #60512  .

### Screenshots or screen recordings:

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Trunk
[wc-product-export-9-10-2025-1760027349010.csv](https://github.com/user-attachments/files/22801311/wc-product-export-9-10-2025-1760027349010.csv)

- Go to `wp-admin/edit.php?post_type=product&page=product_importer`
- Upload the CSV and `Continue` (no other settings)
- On the next screen, leave the default mapping and `Run the importer`
- On the next screen the import progress bar won't move and a fatal error is triggered

#### This Branch

- Go to `wp-admin/edit.php?post_type=product&page=product_importer`
- Upload the CSV and `Continue` (no other settings)
- On the next screen, leave the default mapping and `Run the importer`
- On the next screen the import progress bar finishes
- Check that the product was imported and Brands have been set.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
