### PR TITLE
[Rest API v4] Add `refund_total` and `refund_tax` in response

### DIFF
--- a/plugins/woocommerce/changelog/add-order-v4-api-refund-total
+++ b/plugins/woocommerce/changelog/add-order-v4-api-refund-total
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add refund total to experimental v4 orders route
+
+

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
@@ -220,6 +220,18 @@ class OrderSchema extends AbstractSchema {
 				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
+			'refund_total'         => array(
+				'description' => __( 'Total refund amount for the order.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'refund_tax'           => array(
+				'description' => __( 'Total refund tax amount for the order.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
 			'prices_include_tax'   => array(
 				'description' => __( 'True the prices included tax during checkout.', 'woocommerce' ),
 				'type'        => 'boolean',
@@ -630,6 +642,14 @@ class OrderSchema extends AbstractSchema {
 			'needs_processing'     => $order->needs_processing(),
 			'fulfillment_status'   => FulfillmentUtils::get_order_fulfillment_status( $order ),
 		);
+
+		if ( in_array( 'refund_total', $include_fields, true ) ) {
+			$data['refund_total'] = wc_format_decimal( $order->get_total_refunded(), $dp );
+		}
+
+		if ( in_array( 'refund_tax', $include_fields, true ) ) {
+			$data['refund_tax'] = wc_format_decimal( $order->get_total_tax_refunded(), $dp );
+		}
 
 		if ( in_array( 'line_items', $include_fields, true ) ) {
 			$line_items         = $order->get_items( 'line_item' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds `refund_total` and `refund_tax` to the orders route. 

Closes WOOPRD-984

### How to test the changes in this Pull Request:

You need to enable experimental orders API v4.

1. Request GET `http://localhost:9001/wp-json/wc/v4/orders/123?_fields=refund_total,refund_tax` replacing `123` with a valid order ID.
2. Confirm totals are correct
3. Refund something in that order
4. GET again and check the response is correct

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing. There is a unit test for this.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
