### PR TITLE
Move HPOS Datastore caching out of experimental features.

### DIFF
--- a/plugins/woocommerce/changelog/update-move-hpos-datastore-caching-out-of-experimental
+++ b/plugins/woocommerce/changelog/update-move-hpos-datastore-caching-out-of-experimental
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Move HPOS Datastore Caching out of experimental phase.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -375,10 +375,10 @@ class FeaturesController {
 			'hpos_datastore_caching' => array(
 				'name'                         => __( 'HPOS Data Caching', 'woocommerce' ),
 				'description'                  => __(
-					'Enable order data caching in the datastore. This feature only works with high-performance order storage.',
+					'Enable order data caching in the datastore. This feature only works with high-performance order storage and is recommended for stores using object caching.',
 					'woocommerce'
 				),
-				'is_experimental'              => true,
+				'is_experimental'              => false,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the HPOS Datastore caching feature out of experimental features.  We'll look at making it enabled by default in a future release.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> Advanced -> Fetures
2. Check that "HPOS Data Caching" is listed among the features and no longer within the Experimental Features section.

<!-- End testing instructions -->

