### PR TITLE
Remove link to product page when already viewing the product in missing variation ID error message

### DIFF
--- a/plugins/woocommerce/changelog/fix-missing-variation-adding-variable-product-to-cart
+++ b/plugins/woocommerce/changelog/fix-missing-variation-adding-variable-product-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove link to product page when already viewing the product in missing variation ID error message

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -959,7 +959,7 @@ class WC_Form_Handler {
 
 		// Prevent parent variable product from being added to cart.
 		if ( empty( $variation_id ) && $product && $product->is_type( ProductType::VARIABLE ) ) {
-			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . sanitize_text_field( wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) ) : '';
+			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ) : '';
 			$product_url        = str_replace( array( 'https://', 'http://' ), '', get_permalink( $product_id ) );
 			$is_in_product_page = rtrim( $current_url, '/' ) === rtrim( $product_url, '/' );
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -959,9 +959,9 @@ class WC_Form_Handler {
 
 		// Prevent parent variable product from being added to cart.
 		if ( empty( $variation_id ) && $product && $product->is_type( ProductType::VARIABLE ) ) {
-			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ) : '';
-			$product_url        = str_replace( array( 'https://', 'http://' ), '', get_permalink( $product_id ) );
-			$is_in_product_page = rtrim( $current_url, '/' ) === rtrim( $product_url, '/' );
+			$current_url        = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ) : '';
+			$product_url        = wp_parse_url( get_permalink( $product_id ), PHP_URL_PATH );
+			$is_in_product_page = $current_url && $product_url && untrailingslashit( $current_url ) === untrailingslashit( $product_url );
 
 			if ( $is_in_product_page ) {
 				/* translators: 1: product name */

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -959,8 +959,19 @@ class WC_Form_Handler {
 
 		// Prevent parent variable product from being added to cart.
 		if ( empty( $variation_id ) && $product && $product->is_type( ProductType::VARIABLE ) ) {
-			/* translators: 1: product link, 2: product name */
-			wc_add_notice( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( get_permalink( $product_id ) ), esc_html( $product->get_name() ) ), 'error' );
+			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
+			$product_url        = str_replace( array( 'https://', 'http://' ), '', get_permalink( $product_id ) );
+			$is_in_product_page = rtrim( $current_url, '/' ) === rtrim( $product_url, '/' );
+
+			if ( $is_in_product_page ) {
+				/* translators: 1: product name */
+				$error_message = sprintf( __( 'Please choose product options for %1$s.', 'woocommerce' ), esc_html( $product->get_name() ) );
+			} else {
+				/* translators: 1: product link, 2: product name */
+				$error_message = sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( get_permalink( $product_id ) ), esc_html( $product->get_name() ) );
+			}
+
+			wc_add_notice( $error_message, 'error' );
 
 			return false;
 		}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -959,7 +959,7 @@ class WC_Form_Handler {
 
 		// Prevent parent variable product from being added to cart.
 		if ( empty( $variation_id ) && $product && $product->is_type( ProductType::VARIABLE ) ) {
-			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
+			$current_url        = isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . sanitize_text_field( wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) ) : '';
 			$product_url        = str_replace( array( 'https://', 'http://' ), '', get_permalink( $product_id ) );
 			$is_in_product_page = rtrim( $current_url, '/' ) === rtrim( $product_url, '/' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Something that was mentioned in https://github.com/woocommerce/woocommerce/issues/61378 was that the error displayed when trying to add a variable product to cart without having selected a variation was confusing. It was suggesting the shopper go to the product page even though it was likely the user was already on the product page!

This PR fixes that by checking the current URL. If it matches the product URL, we don't include the link in the error message.

I tried to keep the error message copy as consistent as possible with the existing one.

### How to test the changes in this Pull Request:

1. Set your browser devtools throttling to "Slow 3G".
2. Go to the frontend of a variable product.
3. Before the scripts finish loading, click on "Add to cart".
4. Verify the error that appears doesn't contain a link to the product page.

Before | After
--- | ---
<img width="1696" height="1106" alt="image" src="https://github.com/user-attachments/assets/8a5bc43a-a341-43dd-b9e8-9dd2df9ffb0d" /> | <img width="1696" height="1106" alt="Captura de pantalla de 2025-10-22 11-18-47" src="https://github.com/user-attachments/assets/879e8ad4-12cd-4180-b964-f7d78a72d4ac" />

5. Now, go to any other page (ie: _Shop_) and append this to the URL: `?add-to-cart=62&product_id=62&variation_id=`. You will need to change the id with a variable product id.
6. Verify the error now includes the link to the product page.