### PR TITLE
dev: Update CI configuration for Blocks e2e tests to remove unnecessary paths

### DIFF
--- a/plugins/woocommerce/changelog/dev-update-blocks-e2e-wp-prerelease-changes-config
+++ b/plugins/woocommerce/changelog/dev-update-blocks-e2e-wp-prerelease-changes-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: update CI config for Blocks e2e tests - WP pre-release job

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -781,9 +781,6 @@
 						"--shard=10/10"
 					],
 					"changes": [
-						"src/Blocks/**",
-						"templates/**",
-						"patterns/**",
 						"client/blocks/tests/e2e/**"
 					],
 					"testEnv": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixed [QAO-135](https://linear.app/a8c/issue/QAO-135/remove-unnecessary-paths-from-ci-configuration-for-blocks-e2e-tests)

Cleans up CI configuration for Blocks e2e tests by removing unnecessary path filters from package.json scripts. The WP pre-release job should only run on changes e2e tests changes in case of PRs.

Context: p1761139400042999/1761105532.305359-slack-C03CPM3UXDJ