### PR TITLE
Easy support for user-specific rules to Claude Code

### DIFF
--- a/plugins/woocommerce/CLAUDE.md
+++ b/plugins/woocommerce/CLAUDE.md
@@ -107,3 +107,7 @@ Key directories for testing:
 - Test failures provide detailed output showing expected vs actual values
 - The test environment handles WordPress/WooCommerce setup automatically
 - Extension counts in payment tests must match the actual implementation exactly
+
+# User-specific rules
+
+@~/.claude/woocommerce.md

--- a/plugins/woocommerce/CLAUDE.md
+++ b/plugins/woocommerce/CLAUDE.md
@@ -108,6 +108,6 @@ Key directories for testing:
 - The test environment handles WordPress/WooCommerce setup automatically
 - Extension counts in payment tests must match the actual implementation exactly
 
-# User-specific rules
+## User-specific rules
 
 @~/.claude/woocommerce.md


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Allow individual developers to add their own Claude Code rules without editing the main ruleset. 

### How to test the changes in this Pull Request:

Try adding `~/.claude/woocommerce.md` and see if the rules there are picked up by Claude Code.