### PR TITLE
dev: update CI configuration for PHP tests with WP pre-release

### DIFF
--- a/plugins/woocommerce/changelog/dev-update-ci-config-php-tests-with-wp-prerelease
+++ b/plugins/woocommerce/changelog/dev-update-ci-config-php-tests-with-wp-prerelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: update CI configuration

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -215,11 +215,9 @@
 					],
 					"onlyForDependencies": [],
 					"changes": [
-						"client/admin/config/*.json",
-						"composer.json",
-						"composer.lock",
-						"**/*.php",
-						".wp-env.json",
+						"tests/legacy/**",
+						"tests/php/**",
+						"tests/unit-tests/**",
 						"phpunit.xml"
 					],
 					"testEnv": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the CI configuration for PHP: 7.4 WP: prerelease job to only run on changes to php tests on PRs.

Context: p1761140444215419/1761105532.305359-slack-C03CPM3UXDJ