### PR TITLE
Disable orders v2 for authorization intent

### DIFF
--- a/plugins/woocommerce/changelog/61551-task-disable-pp-v2-for-authorization
+++ b/plugins/woocommerce/changelog/61551-task-disable-pp-v2-for-authorization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Disable PayPal orders v2 API when the payment intent is `authorize`.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
@@ -39,6 +39,14 @@ class WC_Gateway_Paypal_Helper {
 	public static function is_orders_v2_migration_eligible() {
 		$settings = get_option( 'woocommerce_paypal_settings', array() );
 
+		// If the intent is 'authorization' store is not eligible for migration.
+		// ToDo: Support authorization payments.
+		$intent = $settings['paymentaction'] ?? 'sale';
+
+		if ( 'authorization' === $intent ) {
+			return false;
+		}
+
 		// If API keys are set, the merchant is not eligible for migration
 		// as they may be using features that cannot be seamlessly migrated.
 		$is_test_mode  = isset( $settings['testmode'] ) && 'yes' === $settings['testmode'];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Disabling PayPal orders v2 API when the intent is `authorize`.

### How to test the changes in this Pull Request:
- Enable PayPal Standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`
- Go to **WooCommerce > Settings > Payments > PayPal Standard**. Enable the gateway and keep the API credentials empty. 
- Select `Authorize` as Payment action. Save the settings.
- Verify that you still have the API credentials section in the settings.
- As a shopper, place an order with PayPal. Confirm that the order is placed with legacy API.
- Select `Capture` as Payment action. Save the settings.
- Verify that the API credentials section in the settings is hidden.
- As a shopper, place an order with PayPal. Confirm that the order is placed with new API.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Disable PayPal orders v2 API when the payment intent is `authorize`.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
