### PR TITLE
Check if it is a paypal order before capturing

### DIFF
--- a/plugins/woocommerce/changelog/61555-fix-paypal-authorized-capture
+++ b/plugins/woocommerce/changelog/61555-fix-paypal-authorized-capture
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Check the payment method ID before sending a request to capture a PayPal payment.

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -701,6 +701,11 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	public function capture_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
+		// Bail if the order is not a PayPal order.
+		if ( self::ID !== $order->get_payment_method() ) {
+			return;
+		}
+
 		// If the order is authorized via legacy API, the '_paypal_status' meta will be 'pending'.
 		$is_authorized_via_legacy_api = 'pending' === $order->get_meta( '_paypal_status', true );
 
@@ -712,7 +717,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			return;
 		}
 
-		if ( self::ID === $order->get_payment_method() && 'pending' === $order->get_meta( '_paypal_status', true ) && $order->get_transaction_id() ) {
+		if ( 'pending' === $order->get_meta( '_paypal_status', true ) && $order->get_transaction_id() ) {
 			$this->init_api();
 			$result = WC_Gateway_Paypal_API_Handler::do_capture( $order );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Check the payment method of the corresponding order before trying to capture it. Without this check, it tries to capture a payment when it's paid via other payment methods (i,e. Stripe)

### How to test the changes in this Pull Request:
- Checkout to `trunk` branch.
- Enable PayPal Standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`.
- Enable the PayPal Standard gateway in **WooCommerce > Settings > Payments > PayPal Standard**
- Enable the [Stripe plugin](https://wordpress.org/plugins/woocommerce-gateway-stripe/) and enable the gateway.
- As a shopper, place an order using one of the Stripe payment methods.
- As an admin, go to the order edit page and notice that there is a `PayPal capture authorized payment failed` order note.
- Checkout to this branch `fix/paypal-authorized-capture`.
- As a shopper, place another order using one of the Stripe payment methods.
- As an admin, go to the order edit page and confirm that there is no PayPal related order note.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Check the payment method ID before sending a request to capture a PayPal payment.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
