### PR TITLE
Fix Abilities API tests for WordPress 6.9+

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-latest.zip",
+	"core": "https://wordpress.org/wordpress-6.9-beta1.zip",
 	"phpVersion": "8.1",
 	"plugins": [ "." ],
 	"config": {

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.9-beta1.zip",
+	"core": "https://wordpress.org/wordpress-latest.zip",
 	"phpVersion": "8.1",
 	"plugins": [ "." ],
 	"config": {

--- a/plugins/woocommerce/changelog/fix-abilities-api-wp69-tests
+++ b/plugins/woocommerce/changelog/fix-abilities-api-wp69-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Abilities API integration tests for WordPress 6.9+ compatibility with backward compatibility for earlier versions.

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -76,8 +76,11 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 			}
 		}
 
-		// Ensure REST API routes are registered (hook may be cleared by parent tear_down).
-		if ( class_exists( 'WP_REST_Abilities_Init' ) ) {
+		/*
+		 * Ensure REST API routes are registered (hook may be cleared by parent tear_down).
+		 * WordPress 6.9+ handles REST API registration in core, so only do this for vendor package.
+		 */
+		if ( ! $is_wp_69_plus && class_exists( 'WP_REST_Abilities_Init' ) ) {
 			add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
 		}
 
@@ -377,8 +380,14 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	 * @group abilities-api
 	 */
 	public function test_rest_endpoints_are_registered() {
-		// Ensure the bootstrap file has been loaded by checking for the class.
-		$this->assertTrue( class_exists( 'WP_REST_Abilities_Init' ), 'Bootstrap should load WP_REST_Abilities_Init class' );
+		// Ensure REST API classes are loaded.
+		// WordPress 6.9+ uses core controllers, earlier versions use vendor package's init class.
+		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		if ( $is_wp_69_plus ) {
+			$this->assertTrue( class_exists( 'WP_REST_Abilities_V1_List_Controller' ), 'WordPress 6.9+ should have WP_REST_Abilities_V1_List_Controller class' );
+		} else {
+			$this->assertTrue( class_exists( 'WP_REST_Abilities_Init' ), 'Bootstrap should load WP_REST_Abilities_Init class' );
+		}
 
 		$routes = $this->server->get_routes();
 

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -18,10 +18,45 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	private $registered_abilities = array();
 
 	/**
+	 * Action name for abilities API initialization.
+	 *
+	 * @var string
+	 */
+	private $abilities_init_action;
+
+	/**
+	 * Action name for abilities API categories initialization.
+	 *
+	 * @var string
+	 */
+	private $abilities_categories_init_action;
+
+	/**
+	 * Category registry class name.
+	 *
+	 * @var string
+	 */
+	private $category_registry_class;
+
+	/**
 	 * Set up before each test
 	 */
 	public function set_up() {
 		global $wp_actions;
+
+		// Detect WordPress 6.9+ by checking for the core class name (plural "Categories").
+		// WP 6.9+ uses different action names and class names than the vendor package.
+		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+
+		if ( $is_wp_69_plus ) {
+			$this->abilities_init_action            = 'wp_abilities_api_init';
+			$this->abilities_categories_init_action = 'wp_abilities_api_categories_init';
+			$this->category_registry_class          = 'WP_Ability_Categories_Registry';
+		} else {
+			$this->abilities_init_action            = 'abilities_api_init';
+			$this->abilities_categories_init_action = 'abilities_api_categories_init';
+			$this->category_registry_class          = 'WP_Abilities_Category_Registry';
+		}
 
 		/*
 		 * Explicitly ensure the abilities API bootstrap file is loaded for tests.
@@ -42,7 +77,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		parent::set_up();
 
 		// WordPress 6.9+ requires did_action('init') to return truthy before abilities API can be used.
-		// Fake this by setting the action counter directly.
+		// Fake this by setting the action counter directly. Doesn't hurt pre-6.9 versions.
 		$wp_actions['init'] = 1;
 	}
 
@@ -70,19 +105,19 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		}
 
 		// Reset category registry singleton to allow fresh category registration in next test.
-		if ( class_exists( 'WP_Ability_Categories_Registry' ) ) {
-			$reflection        = new \ReflectionClass( 'WP_Ability_Categories_Registry' );
+		if ( class_exists( $this->category_registry_class ) ) {
+			$reflection        = new \ReflectionClass( $this->category_registry_class );
 			$instance_property = $reflection->getProperty( 'instance' );
 			$instance_property->setAccessible( true );
 			$instance_property->setValue( null );
 		}
 
 		// Reset action counters to allow init actions to fire again.
-		if ( isset( $wp_actions['wp_abilities_api_init'] ) ) {
-			unset( $wp_actions['wp_abilities_api_init'] );
+		if ( isset( $wp_actions[ $this->abilities_init_action ] ) ) {
+			unset( $wp_actions[ $this->abilities_init_action ] );
 		}
-		if ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
-			unset( $wp_actions['wp_abilities_api_categories_init'] );
+		if ( isset( $wp_actions[ $this->abilities_categories_init_action ] ) ) {
+			unset( $wp_actions[ $this->abilities_categories_init_action ] );
 		}
 
 		// Reset user.
@@ -150,7 +185,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -164,7 +199,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration without permission_callback.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -204,7 +239,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -218,7 +253,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -263,7 +298,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -277,7 +312,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -357,7 +392,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -371,7 +406,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id_1, $ability_id_2 ) {
 				wp_register_ability(
 					$ability_id_1,
@@ -454,7 +489,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -468,7 +503,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -550,7 +585,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'wp_abilities_api_categories_init',
+			$this->abilities_categories_init_action,
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -564,7 +599,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'wp_abilities_api_init',
+			$this->abilities_init_action,
 			function () use ( $ability_id_1, $ability_id_2 ) {
 				wp_register_ability(
 					$ability_id_1,

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -39,6 +39,13 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	private $category_registry_class;
 
 	/**
+	 * Original value of $wp_actions['init'] to restore in tear_down.
+	 *
+	 * @var int|null
+	 */
+	private $original_init_action_count;
+
+	/**
 	 * Set up before each test
 	 */
 	public function set_up() {
@@ -77,8 +84,9 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		parent::set_up();
 
 		// WordPress 6.9+ requires did_action('init') to return truthy before abilities API can be used.
-		// Fake this by setting the action counter directly. Doesn't hurt pre-6.9 versions.
-		$wp_actions['init'] = 1;
+		// Save the original value and set to 1. Doesn't hurt pre-6.9 versions.
+		$this->original_init_action_count = $wp_actions['init'] ?? null;
+		$wp_actions['init']               = 1; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/**
@@ -125,9 +133,12 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		parent::tear_down();
 
-		// Restore 'init' action counter after parent::tear_down() resets it.
-		// WordPress 6.9+ requires did_action('init') to return truthy.
-		$wp_actions['init'] = 1;
+		// Restore 'init' action counter to its original value.
+		if ( null !== $this->original_init_action_count ) {
+			$wp_actions['init'] = $this->original_init_action_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $wp_actions['init'] ) ) {
+			unset( $wp_actions['init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -381,21 +381,24 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	 */
 	public function test_rest_endpoints_are_registered() {
 		// Ensure REST API classes are loaded.
-		// WordPress 6.9+ uses core controllers, earlier versions use vendor package's init class.
+		// WordPress 6.9+ uses core controllers with different namespace, earlier versions use vendor package.
 		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
 		if ( $is_wp_69_plus ) {
 			$this->assertTrue( class_exists( 'WP_REST_Abilities_V1_List_Controller' ), 'WordPress 6.9+ should have WP_REST_Abilities_V1_List_Controller class' );
+			$list_endpoint = '/wp-abilities/v1/abilities';
+			$run_endpoint  = '/wp-abilities/v1/abilities/(?P<name>[a-zA-Z0-9\\-\\/]+?)/run';
 		} else {
 			$this->assertTrue( class_exists( 'WP_REST_Abilities_Init' ), 'Bootstrap should load WP_REST_Abilities_Init class' );
+			$list_endpoint = '/wp/v2/abilities';
+			$run_endpoint  = '/wp/v2/abilities/(?P<name>[a-zA-Z0-9\\-\\/]+?)/run';
 		}
 
 		$routes = $this->server->get_routes();
 
 		// Check for abilities list endpoint.
-		$this->assertArrayHasKey( '/wp/v2/abilities', $routes, 'Abilities list endpoint should be registered' );
+		$this->assertArrayHasKey( $list_endpoint, $routes, 'Abilities list endpoint should be registered' );
 
 		// Check for ability run endpoint - look for the exact pattern from the controller.
-		$run_endpoint = '/wp/v2/abilities/(?P<name>[a-zA-Z0-9\\-\\/]+?)/run';
 		$this->assertArrayHasKey( $run_endpoint, $routes, 'Ability run endpoint should be registered' );
 	}
 
@@ -470,8 +473,10 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 			}
 		);
 
-		// Create REST request.
-		$request = new \WP_REST_Request( 'GET', '/wp/v2/abilities' );
+		// Create REST request - use version-appropriate namespace.
+		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$list_endpoint = $is_wp_69_plus ? '/wp-abilities/v1/abilities' : '/wp/v2/abilities';
+		$request       = new \WP_REST_Request( 'GET', $list_endpoint );
 		// Set up authentication for admin user.
 		wp_set_current_user( 1 );
 		$response = $this->server->dispatch( $request );
@@ -565,8 +570,10 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 			}
 		);
 
-		// Create REST request for execution.
-		$request = new \WP_REST_Request( 'POST', '/wp/v2/abilities/' . $ability_id . '/run' );
+		// Create REST request for execution - use version-appropriate namespace.
+		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$namespace     = $is_wp_69_plus ? '/wp-abilities/v1' : '/wp/v2';
+		$request       = new \WP_REST_Request( 'POST', $namespace . '/abilities/' . $ability_id . '/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -46,14 +46,14 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	private $original_init_action_count;
 
 	/**
-	 * Check if WordPress 6.9+ is being used.
+	 * Check if Abilities API is in WordPress core.
 	 *
 	 * WordPress 6.9+ has the Abilities API in core with different class names than the vendor package.
 	 * We detect this by checking for the core class name (plural "Categories" instead of singular "Category").
 	 *
-	 * @return bool True if WordPress 6.9+, false otherwise.
+	 * @return bool True if Abilities API is in core, false if using vendor package.
 	 */
-	private function is_wp_69_plus(): bool {
+	private function are_abilities_in_wp_core(): bool {
 		return class_exists( 'WP_Ability_Categories_Registry' );
 	}
 
@@ -65,9 +65,9 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Detect WordPress 6.9+ by checking for the core class name (plural "Categories").
 		// WP 6.9+ uses different action names and class names than the vendor package.
-		$is_wp_69_plus = $this->is_wp_69_plus();
+		$are_abilities_in_wp_core = $this->are_abilities_in_wp_core();
 
-		if ( $is_wp_69_plus ) {
+		if ( $are_abilities_in_wp_core ) {
 			$this->abilities_init_action            = 'wp_abilities_api_init';
 			$this->abilities_categories_init_action = 'wp_abilities_api_categories_init';
 			$this->category_registry_class          = 'WP_Ability_Categories_Registry';
@@ -92,7 +92,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		 * Ensure REST API routes are registered (hook may be cleared by parent tear_down).
 		 * WordPress 6.9+ handles REST API registration in core, so only do this for vendor package.
 		 */
-		if ( ! $is_wp_69_plus && class_exists( 'WP_REST_Abilities_Init' ) ) {
+		if ( ! $are_abilities_in_wp_core && class_exists( 'WP_REST_Abilities_Init' ) ) {
 			add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
 		}
 
@@ -394,8 +394,8 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	public function test_rest_endpoints_are_registered() {
 		// Ensure REST API classes are loaded.
 		// WordPress 6.9+ uses core controllers with different namespace, earlier versions use vendor package.
-		$is_wp_69_plus = $this->is_wp_69_plus();
-		if ( $is_wp_69_plus ) {
+		$are_abilities_in_wp_core = $this->are_abilities_in_wp_core();
+		if ( $are_abilities_in_wp_core ) {
 			$this->assertTrue( class_exists( 'WP_REST_Abilities_V1_List_Controller' ), 'WordPress 6.9+ should have WP_REST_Abilities_V1_List_Controller class' );
 			$list_endpoint = '/wp-abilities/v1/abilities';
 			$run_endpoint  = '/wp-abilities/v1/abilities/(?P<name>[a-zA-Z0-9\\-\\/]+?)/run';
@@ -486,9 +486,9 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		);
 
 		// Create REST request - use version-appropriate namespace.
-		$is_wp_69_plus = $this->is_wp_69_plus();
-		$list_endpoint = $is_wp_69_plus ? '/wp-abilities/v1/abilities' : '/wp/v2/abilities';
-		$request       = new \WP_REST_Request( 'GET', $list_endpoint );
+		$are_abilities_in_wp_core = $this->are_abilities_in_wp_core();
+		$list_endpoint            = $are_abilities_in_wp_core ? '/wp-abilities/v1/abilities' : '/wp/v2/abilities';
+		$request                  = new \WP_REST_Request( 'GET', $list_endpoint );
 		// Set up authentication for admin user.
 		wp_set_current_user( 1 );
 		$response = $this->server->dispatch( $request );
@@ -583,9 +583,9 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		);
 
 		// Create REST request for execution - use version-appropriate namespace.
-		$is_wp_69_plus = $this->is_wp_69_plus();
-		$namespace     = $is_wp_69_plus ? '/wp-abilities/v1' : '/wp/v2';
-		$request       = new \WP_REST_Request( 'POST', $namespace . '/abilities/' . $ability_id . '/run' );
+		$are_abilities_in_wp_core = $this->are_abilities_in_wp_core();
+		$namespace                = $are_abilities_in_wp_core ? '/wp-abilities/v1' : '/wp/v2';
+		$request                  = new \WP_REST_Request( 'POST', $namespace . '/abilities/' . $ability_id . '/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -46,6 +46,18 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	private $original_init_action_count;
 
 	/**
+	 * Check if WordPress 6.9+ is being used.
+	 *
+	 * WordPress 6.9+ has the Abilities API in core with different class names than the vendor package.
+	 * We detect this by checking for the core class name (plural "Categories" instead of singular "Category").
+	 *
+	 * @return bool True if WordPress 6.9+, false otherwise.
+	 */
+	private function is_wp_69_plus(): bool {
+		return class_exists( 'WP_Ability_Categories_Registry' );
+	}
+
+	/**
 	 * Set up before each test
 	 */
 	public function set_up() {
@@ -53,7 +65,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Detect WordPress 6.9+ by checking for the core class name (plural "Categories").
 		// WP 6.9+ uses different action names and class names than the vendor package.
-		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$is_wp_69_plus = $this->is_wp_69_plus();
 
 		if ( $is_wp_69_plus ) {
 			$this->abilities_init_action            = 'wp_abilities_api_init';
@@ -382,7 +394,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	public function test_rest_endpoints_are_registered() {
 		// Ensure REST API classes are loaded.
 		// WordPress 6.9+ uses core controllers with different namespace, earlier versions use vendor package.
-		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$is_wp_69_plus = $this->is_wp_69_plus();
 		if ( $is_wp_69_plus ) {
 			$this->assertTrue( class_exists( 'WP_REST_Abilities_V1_List_Controller' ), 'WordPress 6.9+ should have WP_REST_Abilities_V1_List_Controller class' );
 			$list_endpoint = '/wp-abilities/v1/abilities';
@@ -474,7 +486,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		);
 
 		// Create REST request - use version-appropriate namespace.
-		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$is_wp_69_plus = $this->is_wp_69_plus();
 		$list_endpoint = $is_wp_69_plus ? '/wp-abilities/v1/abilities' : '/wp/v2/abilities';
 		$request       = new \WP_REST_Request( 'GET', $list_endpoint );
 		// Set up authentication for admin user.
@@ -571,7 +583,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		);
 
 		// Create REST request for execution - use version-appropriate namespace.
-		$is_wp_69_plus = class_exists( 'WP_Ability_Categories_Registry' );
+		$is_wp_69_plus = $this->is_wp_69_plus();
 		$namespace     = $is_wp_69_plus ? '/wp-abilities/v1' : '/wp/v2';
 		$request       = new \WP_REST_Request( 'POST', $namespace . '/abilities/' . $ability_id . '/run' );
 		$request->set_header( 'Content-Type', 'application/json' );

--- a/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AbilitiesApi/AbilitiesApiIntegrationTest.php
@@ -21,10 +21,11 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 	 * Set up before each test
 	 */
 	public function set_up() {
+		global $wp_actions;
+
 		/*
 		 * Explicitly ensure the abilities API bootstrap file is loaded for tests.
-		 * The bootstrap file has an ABSPATH check that ensures it only loads in a proper
-		 * WordPress context, which may require manual loading in test environments.
+		 * WordPress 6.9+ has abilities API in core, so we don't need to load the vendor version.
 		 */
 		if ( ! function_exists( 'wp_register_ability' ) ) {
 			$bootstrap_file = WP_PLUGIN_DIR . '/woocommerce/vendor/wordpress/abilities-api/includes/bootstrap.php';
@@ -39,12 +40,18 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		}
 
 		parent::set_up();
+
+		// WordPress 6.9+ requires did_action('init') to return truthy before abilities API can be used.
+		// Fake this by setting the action counter directly.
+		$wp_actions['init'] = 1;
 	}
 
 	/**
 	 * Tear down the test environment.
 	 */
 	public function tear_down() {
+		global $wp_actions;
+
 		// Clean up any abilities registered during tests.
 		foreach ( $this->registered_abilities as $ability_id ) {
 			$this->cleanup_ability( $ability_id );
@@ -63,26 +70,29 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 		}
 
 		// Reset category registry singleton to allow fresh category registration in next test.
-		if ( class_exists( 'WP_Abilities_Category_Registry' ) ) {
-			$reflection        = new \ReflectionClass( 'WP_Abilities_Category_Registry' );
+		if ( class_exists( 'WP_Ability_Categories_Registry' ) ) {
+			$reflection        = new \ReflectionClass( 'WP_Ability_Categories_Registry' );
 			$instance_property = $reflection->getProperty( 'instance' );
 			$instance_property->setAccessible( true );
 			$instance_property->setValue( null );
 		}
 
 		// Reset action counters to allow init actions to fire again.
-		global $wp_actions;
-		if ( isset( $wp_actions['abilities_api_init'] ) ) {
-			unset( $wp_actions['abilities_api_init'] );
+		if ( isset( $wp_actions['wp_abilities_api_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_init'] );
 		}
-		if ( isset( $wp_actions['abilities_api_categories_init'] ) ) {
-			unset( $wp_actions['abilities_api_categories_init'] );
+		if ( isset( $wp_actions['wp_abilities_api_categories_init'] ) ) {
+			unset( $wp_actions['wp_abilities_api_categories_init'] );
 		}
 
 		// Reset user.
 		wp_set_current_user( 0 );
 
 		parent::tear_down();
+
+		// Restore 'init' action counter after parent::tear_down() resets it.
+		// WordPress 6.9+ requires did_action('init') to return truthy.
+		$wp_actions['init'] = 1;
 	}
 
 	/**
@@ -140,7 +150,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -154,7 +164,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration without permission_callback.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -194,7 +204,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -208,7 +218,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -253,7 +263,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -267,7 +277,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -347,7 +357,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -361,7 +371,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id_1, $ability_id_2 ) {
 				wp_register_ability(
 					$ability_id_1,
@@ -444,7 +454,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -458,7 +468,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id ) {
 				wp_register_ability(
 					$ability_id,
@@ -540,7 +550,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Register test category for abilities used in tests.
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			function () {
 				wp_register_ability_category(
 					'test',
@@ -554,7 +564,7 @@ class AbilitiesApiIntegrationTest extends \WC_REST_Unit_Test_Case {
 
 		// Hook ability registration to the init action.
 		add_action(
-			'abilities_api_init',
+			'wp_abilities_api_init',
 			function () use ( $ability_id_1, $ability_id_2 ) {
 				wp_register_ability(
 					$ability_id_1,


### PR DESCRIPTION
Fixes Abilities API integration tests for WordPress 6.9+ with backward compatibility.

Fixes WOOAI-112  

Changes:
- Detect WP version by checking for `WP_Ability_Categories_Registry` class
- Use correct action names (`wp_abilities_api_*` for 6.9+, `abilities_api_*` for earlier)
- Set `$wp_actions['init'] = 1` to satisfy WP 6.9's `did_action('init')` check

All 9 tests pass on WP 6.9-beta1.