### PR TITLE
[Backport to release/10.3] Check the `get_session_data` method exists on the session object

### DIFF
--- a/plugins/woocommerce/changelog/61352-fix-get-session-data-fatal-error
+++ b/plugins/woocommerce/changelog/61352-fix-get-session-data-fatal-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Check the get_session_data method exists on the session object

--- a/plugins/woocommerce/changelog/61561-cherry-pick-PR61352-to-release-10.3
+++ b/plugins/woocommerce/changelog/61561-cherry-pick-PR61352-to-release-10.3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Check the get_session_data method exists on the session object

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -686,9 +686,11 @@ final class WC_Cart_Session {
 	private function remove_shipping_for_package_from_session() {
 		$wc_session = WC()->session;
 
-		foreach ( array_keys( $wc_session->get_session_data() ) as $key ) {
-			if ( 0 === strpos( $key, 'shipping_for_package_' ) ) {
-				$wc_session->set( $key, null );
+		if ( method_exists( $wc_session, 'get_session_data' ) ) {
+			foreach ( array_keys( $wc_session->get_session_data() ) as $key ) {
+				if ( 0 === strpos( $key, 'shipping_for_package_' ) ) {
+					$wc_session->set( $key, null );
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -686,11 +686,13 @@ final class WC_Cart_Session {
 	private function remove_shipping_for_package_from_session() {
 		$wc_session = WC()->session;
 
-		if ( method_exists( $wc_session, 'get_session_data' ) ) {
-			foreach ( array_keys( $wc_session->get_session_data() ) as $key ) {
-				if ( 0 === strpos( $key, 'shipping_for_package_' ) ) {
-					$wc_session->set( $key, null );
-				}
+		if ( ! method_exists( $wc_session, 'get_session_data' ) ) {
+			return;
+		}
+
+		foreach ( array_keys( $wc_session->get_session_data() ) as $key ) {
+			if ( 0 === strpos( $key, 'shipping_for_package_' ) ) {
+				$wc_session->set( $key, null );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -686,7 +686,7 @@ final class WC_Cart_Session {
 	private function remove_shipping_for_package_from_session() {
 		$wc_session = WC()->session;
 
-		if ( ! method_exists( $wc_session, 'get_session_data' ) ) {
+		if ( ! is_a( $wc_session, 'WC_Session_Handler' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR is a cherry-pick of #61352 to `release/10.3`.

## Original PR Description

This PR introduces a condition in the `remove_shipping_for_package_from_session` in `WC_Cart_Session` to check if the session is of type `WC_Session_Handler` so we can call the `get_session_data` since not all classes extending `WC_Session` implement it.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Follow-up of https://github.com/woocommerce/woocommerce/pull/61326 (this PR proposed a solution that was discarded).

Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/60800

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
1. Run the following command to enable `agentic_checkout`.
```cli
wp option add woocommerce_feature_agentic_checkout_enabled yes
```
2. In `trunk`, temporarily remove the `get_session_data` method from `plugins/woocommerce/src/StoreApi/SessionHandler.php` (this is just to simulate a class extending the `WC_Session` without the `get_session_data` method; it's actually where the issue was discovered).

3. Make the following request using the `PRODUCT_ID` and note the `id` from the result:

```bash
  curl -X POST http://your-site.com/wp-json/wc/agentic/v1/checkout_sessions \
    -H "Content-Type: application/json" \
    -d '{
      "items": [{"id": PRODUCT_ID, "quantity": 2}],
      "buyer": {
        "first_name": "John",
        "last_name": "Doe",
        "email": "john@example.com"
      }
    }'
```

4. Make the following request using the `id` from the previous step as the `{session_id}`:

```bash
  curl -X POST http://your-site.com/wp-json/wc/agentic/v1/checkout_sessions/{session_id} \
    -H "Content-Type: application/json" \
    -d '{
      "items": [{"id": PRODUCT_ID, "quantity": 3}],
      "fulfillment_address": {
        "name": "John Doe",
        "line_one": "123 Main St",
        "city": "San Francisco",
        "state": "CA",
        "country": "US",
        "postal_code": "94105"
      }
    }'
```

5. You should see an `internal_server_error` in the response and an error similar to this one in the logs: 
```
PHP **Fatal** **error:**  Uncaught **Error**: Call to undefined method Automattic\WooCommerce\StoreApi\SessionHandler::get_session_data() in plugins/woocommerce/plugins/woocommerce/includes/class-wc-cart-session.php:689
```

6. Now switch to this PR branch `fix-get-session-data-fatal-error`.
7. Repeat the request from step 4 and ensure you don’t get the fatal error anymore.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Check the get_session_data method exists on the session object

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
