### PR TITLE
Support WordPress 6.9+ action names in abilities registration

### DIFF
--- a/plugins/woocommerce/changelog/fix-abilities-api-wp69-hooks
+++ b/plugins/woocommerce/changelog/fix-abilities-api-wp69-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support both WordPress 6.9+ and pre-6.9 action hook names for Abilities API registration to ensure compatibility across WordPress versions.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesCategories.php
@@ -23,8 +23,12 @@ class AbilitiesCategories {
 	 * @internal
 	 */
 	final public static function init(): void {
-		// Register categories when Abilities API categories are ready.
+		/*
+		 * Register categories when Abilities API categories are ready.
+		 * Support both old (pre-6.9) and new (6.9+) action names.
+		 */
 		add_action( 'abilities_api_categories_init', array( __CLASS__, 'register_categories' ) );
+		add_action( 'wp_abilities_api_categories_init', array( __CLASS__, 'register_categories' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -102,8 +102,12 @@ class AbilitiesRestBridge {
 	 * @internal
 	 */
 	final public static function init(): void {
-		// Register abilities when Abilities API is ready.
+		/*
+		 * Register abilities when Abilities API is ready.
+		 * Support both old (pre-6.9) and new (6.9+) action names.
+		 */
 		add_action( 'abilities_api_init', array( __CLASS__, 'register_abilities' ) );
+		add_action( 'wp_abilities_api_init', array( __CLASS__, 'register_abilities' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOAI-113

Updates WooCommerce abilities registration to support both WordPress 6.9+ and pre-6.9 action hook names.

## Changes

- Register for both `abilities_api_init` and `wp_abilities_api_init`
- Register for both `abilities_api_categories_init` and `wp_abilities_api_categories_init`
- Updated `AbilitiesRestBridge.php` and `AbilitiesCategories.php`

## Why

WordPress 6.9+ renamed the Abilities API action hooks with `wp_` prefix. WooCommerce needs to support both old and new hook names for backward compatibility.

Only one action will fire depending on the WordPress version, ensuring abilities are registered exactly once.

## INFO
This change is most likely temporary. When a new abilities-api version will be released we will be able to use the same action names. 

## Related

- Related to PR #61560 (test fixes for WP 6.9 compatibility)