### PR TITLE
e2e tests: update screenshot mode for blocks e2e tests to capture full page

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-screenshot-mode-blocks-e2e
+++ b/plugins/woocommerce/changelog/e2e-update-screenshot-mode-blocks-e2e
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: e2e tests: updated screenshot mode configuration
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/playwright.config.ts
@@ -43,7 +43,7 @@ const config: PlaywrightTestConfig = {
 		: 'list',
 	use: {
 		baseURL: BASE_URL,
-		screenshot: 'only-on-failure',
+		screenshot: { mode: 'only-on-failure', fullPage: true },
 		trace:
 			/^https?:\/\/localhost/.test( BASE_URL ) || ! CI
 				? 'retain-on-first-failure'


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Update Playwright screenshot configuration to capture full page instead of only the visible part of the viewport.


