### PR TITLE
Update copy on Autocomplete setting tooltip

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5724-autocomplete-settings-doesnt-match-the-design-requirement
+++ b/plugins/woocommerce/changelog/wooplug-5724-autocomplete-settings-doesnt-match-the-design-requirement
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Fixes a typo
+
+

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -50,7 +50,7 @@ class WC_Settings_General extends WC_Settings_Page {
 		}
 
 		$address_autocomplete_preferred_provider_setting = array();
-		$address_autocomplete_setting_desc_tip           = __( 'Suggest full addresses for customer as they type.', 'woocommerce' );
+		$address_autocomplete_setting_desc_tip           = __( 'Suggest full addresses to customers as they type.', 'woocommerce' );
 
 		// This is in a try because getting the class from the container may fail if the class is not available.
 		// If it fails, these settings should not be shown as the feature is not available.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates copy on the address autocomplete setting tooltip.

Closes WOOPLUG-5724

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="565" height="84" alt="image" src="https://github.com/user-attachments/assets/26a4c181-159b-4294-b20e-d554dafc7294" /> | <img width="563" height="77" alt="image" src="https://github.com/user-attachments/assets/a3a28da8-a636-4d22-93cc-d360ac9def55" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable all address autocomplete providers (any test ones installed, and WooPayments)
2. Go to WC -> Settings and view the address autocomplete setting.
3. Ensure the tooltip is grammatically correct and reads: `Suggest full addresses to customers as they type.`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
