### PR TITLE
dev: Make CI jobs testing with a pre-release WP version optional

### DIFF
--- a/plugins/woocommerce/changelog/dev-make-all-wp-pre-release-jobs-optional
+++ b/plugins/woocommerce/changelog/dev-make-all-wp-pre-release-jobs-optional
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: dev: make all CI jobs testing with a pre-release WP version optional
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -206,7 +206,8 @@
 					]
 				},
 				{
-					"name": "PHP: 7.4 WP: prerelease",
+					"name": "PHP: 7.4 WP: pre-release",
+					"optional": true,
 					"testType": "unit:php",
 					"command": "test:php:env",
 					"shardingArguments": [
@@ -474,6 +475,7 @@
 				},
 				{
 					"name": "Core e2e tests - WP pre-release",
+					"optional": true,
 					"testType": "e2e",
 					"command": "test:e2e",
 					"shardingArguments": [
@@ -764,6 +766,7 @@
 				},
 				{
 					"name": "Blocks e2e tests - WP pre-release",
+					"optional": true,
 					"testType": "e2e",
 					"command": "test:e2e:blocks",
 					"shardingArguments": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the CI configuration for all jobs that are testing with a pre-released version of WordPress to make them optional. This helps unblocking PRs that have unrelated test failures.

### How to test the changes in this Pull Request:

See the PR checks of this PR. Some `Blocks e2e tests - WP pre-release` are failing, but they're marked as optional, and the PR can be merged. Basically the [CI / Evaluate Project Job Statuses (pull_request)](https://github.com/woocommerce/woocommerce/actions/runs/18751070560/job/53494768880?pr=61572) needs to be green.