### PR TITLE
Add some instructions to try to harden around order/data deletion

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -15,3 +15,7 @@ reviews:
         - Is backwards compatible.
         - Is readable and intuitive.
         - Has unit or E2E tests where applicable.
+        When making any changes to code that deletes or modifies orders/products/customer data, make sure that there are
+        sufficient checks in place to prevent accidental data loss. As an example, if deleting a draft order, check that
+        the order status is indeed `draft` or `checkout-draft`. Also think about whether race conditions could occur and
+        delete orders that don't belong to the current customer. When in doubt, ask for clarification in the PR comments.

--- a/plugins/woocommerce/.claude/CLAUDE.md
+++ b/plugins/woocommerce/.claude/CLAUDE.md
@@ -20,6 +20,7 @@ This document provides Claude Code with essential information about working with
     - **To determine the next WooCommerce version number for `@since` annotations**: Read the `$version` property in `includes/class-woocommerce.php` and remove the `-dev` suffix if present.
 - When an `@internal` annotation is added, it must be placed after the method description and before the arguments list, with a blank comment line before and after.
 - When modifying existing code, if the git diff shows changes to a line that fires a hook without a docblock, add a docblock for that hook. Use `git log` to determine which version introduced the hook, and add the appropriate `@since` annotation with that version number.
+- When making any changes to code that deletes or modifies orders/products/customer data, make sure that there are sufficient checks in place to prevent accidental data loss. As an example, if deleting a draft order, check that the order status is indeed `draft` or `checkout-draft`. Also think about whether race conditions could occur and delete orders that don't belong to the current customer. When in doubt, ask for clarification from the user.
 
 **Unit test file conventions:**
 

--- a/plugins/woocommerce/changelog/add-additional-coderabbit-instructions
+++ b/plugins/woocommerce/changelog/add-additional-coderabbit-instructions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Change to build tooling only
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Try to add some more instructions for coderabbit to guard against accidental/poorly checked data deletion.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The way I tested this was to merge this branch into trunk locally, add some code that deletes an order with no good checks, then run `coderabbit` (https://www.coderabbit.ai/cli) and see what the suggestions are. Interestingly, without this change it still makes the suggestions, but I'm wondering if that's because of the size of the change and if coderabbit's internals had 'remembered' that it should be careful about deleting orders. In any case, I think adding more specific instructions to these agents is not a bad thing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Change to internal tooling.

</details>
