### PR TITLE
PayPal Standard: Include fees with order items

### DIFF
--- a/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
+++ b/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Resolve PayPal order creation failures caused by a mismatch between the total and breakdown amounts.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -550,7 +550,7 @@ class WC_Gateway_Paypal_Request {
 	private function get_paypal_order_items( $order ) {
 		$items = array();
 
-		foreach ( $order->get_items() as $item ) {
+		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item ) {
 			$items[] = array(
 				'name'        => $this->limit_length( $item->get_name(), WC_Gateway_Paypal_Constants::PAYPAL_ORDER_ITEM_NAME_MAX_LENGTH ),
 				'quantity'    => $item->get_quantity(),
@@ -558,7 +558,7 @@ class WC_Gateway_Paypal_Request {
 					'currency_code' => $order->get_currency(),
 					// Use the subtotal before discounts.
 					'value'         => wc_format_decimal(
-						$order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
+						'fee' === $item['type'] ? $item->get_amount() : $order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
 						wc_get_price_decimals()
 					),
 				),
@@ -578,6 +578,11 @@ class WC_Gateway_Paypal_Request {
 		$total = 0;
 		foreach ( $order->get_items() as $item ) {
 			$total += (float) $item->get_subtotal();
+		}
+
+
+		foreach ( $order->get_items( 'fee' ) as $fee ) {
+			$total += (float) $fee->get_amount();
 		}
 
 		return $total;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -580,7 +580,6 @@ class WC_Gateway_Paypal_Request {
 			$total += (float) $item->get_subtotal();
 		}
 
-
 		foreach ( $order->get_items( 'fee' ) as $fee ) {
 			$total += (float) $fee->get_amount();
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -558,7 +558,7 @@ class WC_Gateway_Paypal_Request {
 					'currency_code' => $order->get_currency(),
 					// Use the subtotal before discounts.
 					'value'         => wc_format_decimal(
-						'fee' === $item['type'] ? $item->get_amount() : $order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
+						'fee' === $item->get_type() ? $item->get_amount() : $order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
 						wc_get_price_decimals()
 					),
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The fees were missing from the purchase unit. This is one of the possible reasons for order creation failures due to a mismatched total. 
`fee` is included with the line items in the [legacy implementation](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php#L1113).

In this PR, I have included the order `fee` with line items similar to the legacy implementation.


### How to test the changes in this Pull Request:
- Checkout to trunk branch.
- Enable PayPal Standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'.`
- Add this snippet to include fee in your orders.

```
add_action( 'woocommerce_cart_calculate_fees', 'add_custom_fee_to_cart' );
function add_custom_fee_to_cart( $cart ) {
	if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
		return;
	}

	$fee = 5.00;
	$cart->add_fee( __( 'Handling Fee', 'your-textdomain' ), $fee, true );
}
```
- As a shopper, try to place an order with PayPal.
- Checkout should fail and you should see and error in the logs similar to the following-

```
{
                "field": "\/purchase_units\/@reference_id=='default'\/amount\/value",
                "value": "62.01",
                "issue": "AMOUNT_MISMATCH",
                "description": "Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount."
            }
```
- Checkout to this branch `update/include-fee-in-purchase-unit`.
- Try to place an order with PayPal again as a shopper.
- Verify that, you can place the order successfully.

Towards PAYPAL-104

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Resolve PayPal order creation failures caused by a mismatch between the total and breakdown amounts.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
