### PR TITLE
[Backport to release/10.3] Fix deleted orders bug by adding a check for draft orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-deleted-orders-bug
+++ b/plugins/woocommerce/changelog/fix-deleted-orders-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Race condition where orders may be deleted from the database

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -422,6 +422,9 @@ final class WC_Cart_Session {
 			$wc_session->set( 'chosen_shipping_methods', null );
 			$this->remove_shipping_for_package_from_session();
 		}
+		if ( empty( $cart ) ) {
+			$wc_session->set( 'store_api_draft_order', null );
+		}
 
 		/**
 		 * Fires when cart is updated.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -671,7 +671,17 @@ final class WC_Cart_Session {
 		}
 
 		$order = wc_get_order( $draft_order );
-		if ( $order ) {
+		if ( ! $order ) {
+			// Clear session if order doesn't exist.
+			WC()->session->set( 'store_api_draft_order', null );
+			return;
+		}
+
+		// Only delete orders that are actually drafts.
+		// This prevents deletion of completed/processing orders due to race conditions
+		// or stale session data.
+		$order_status = $order->get_status();
+		if ( in_array( $order_status, array( 'checkout-draft', 'draft' ), true ) ) {
 			$order->delete( true );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -416,9 +416,6 @@ final class WC_Cart_Session {
 		$wc_session->set( 'coupon_discount_totals', empty( $coupon_discount_totals ) ? null : $coupon_discount_totals );
 		$wc_session->set( 'coupon_discount_tax_totals', empty( $coupon_discount_tax_totals ) ? null : $coupon_discount_tax_totals );
 		$wc_session->set( 'removed_cart_contents', empty( $removed_cart_contents ) ? null : $removed_cart_contents );
-		if ( empty( $cart ) ) {
-			$this->remove_draft_order();
-		}
 		if ( ! $this->cart_has_shippable_products() ) {
 			$wc_session->set( 'shipping_method_counts', null );
 			$wc_session->set( 'previous_shipping_methods', null );
@@ -657,35 +654,6 @@ final class WC_Cart_Session {
 		}
 
 		return $cart;
-	}
-
-	/**
-	 * Remove the draft order from the session and delete it.
-	 */
-	private function remove_draft_order() {
-		$wc_session = WC()->session;
-
-		$draft_order = $wc_session->get( 'store_api_draft_order' );
-		if ( ! $draft_order ) {
-			return;
-		}
-
-		$order = wc_get_order( $draft_order );
-		if ( ! $order ) {
-			// Clear session if order doesn't exist.
-			WC()->session->set( 'store_api_draft_order', null );
-			return;
-		}
-
-		// Only delete orders that are actually drafts.
-		// This prevents deletion of completed/processing orders due to race conditions
-		// or stale session data.
-		$order_status = $order->get_status();
-		if ( in_array( $order_status, array( 'checkout-draft', 'draft' ), true ) ) {
-			$order->delete( true );
-		}
-
-		WC()->session->set( 'store_api_draft_order', null );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -592,13 +592,17 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	 * @testdox should clear store_api_draft_order from session when cart is empty
 	 */
 	public function test_setting_session_should_clear_store_api_draft_order_when_cart_is_empty() {
-		$cart     = WC()->cart;
-		$order_id = WC_Helper_Order::create_order()->save();
+		$cart  = WC()->cart;
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order_id = $order->save();
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
 		$cart->set_session();
 
 		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		// Verify the draft order was actually deleted.
+		$this->assertFalse( wc_get_order( $order_id ) );
 	}
 
 	/**
@@ -609,7 +613,9 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$cart->add_to_cart( $product->get_id() );
-		$order_id = WC_Helper_Order::create_order()->save();
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order_id = $order->save();
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
 		$this->assertEquals( $order_id, WC()->session->get( 'store_api_draft_order' ) );
@@ -627,7 +633,9 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	public function test_emptying_the_cart_should_clear_store_api_draft_order() {
 		$cart = WC()->cart;
 
-		$order_id = WC_Helper_Order::create_order()->save();
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order_id = $order->save();
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
 		$this->assertEquals( $order_id, WC()->session->get( 'store_api_draft_order' ) );
@@ -635,6 +643,36 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$cart->empty_cart();
 
 		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		// Verify the draft order was actually deleted.
+		$this->assertFalse( wc_get_order( $order_id ) );
+	}
+
+	/**
+	 * @testdox should NOT delete non-draft orders when clearing store_api_draft_order from session
+	 */
+	public function test_emptying_cart_should_not_delete_non_draft_orders() {
+		$cart = WC()->cart;
+
+		// Create a processing order (simulating a completed checkout).
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'processing' );
+		$order_id = $order->save();
+
+		// Simulate stale session data where order ID still exists in session.
+		WC()->session->set( 'store_api_draft_order', $order_id );
+
+		$cart->empty_cart();
+
+		// Session should be cleared.
+		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+
+		// BUT the order should NOT be deleted.
+		$order = wc_get_order( $order_id );
+		$this->assertNotFalse( $order, 'Non-draft order should not be deleted' );
+		$this->assertEquals( 'processing', $order->get_status(), 'Order status should remain unchanged' );
+
+		// Clean up.
+		$order->delete( true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -588,22 +588,6 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$coupon->delete( true );
 	}
 
-	/**
-	 * @testdox should clear store_api_draft_order from session when cart is empty
-	 */
-	public function test_setting_session_should_clear_store_api_draft_order_when_cart_is_empty() {
-		$cart  = WC()->cart;
-		$order = WC_Helper_Order::create_order();
-		$order->set_status( 'checkout-draft' );
-		$order_id = $order->save();
-		WC()->session->set( 'store_api_draft_order', $order_id );
-
-		$cart->set_session();
-
-		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
-		// Verify the draft order was actually deleted.
-		$this->assertFalse( wc_get_order( $order_id ) );
-	}
 
 	/**
 	 * @testdox should not clear store_api_draft_order from session when cart is not empty
@@ -627,25 +611,6 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( $order_id, WC()->session->get( 'store_api_draft_order' ) );
 	}
 
-	/**
-	 * @testdox should clear store_api_draft_order from session and db when the cart is emptied
-	 */
-	public function test_emptying_the_cart_should_clear_store_api_draft_order() {
-		$cart = WC()->cart;
-
-		$order = WC_Helper_Order::create_order();
-		$order->set_status( 'checkout-draft' );
-		$order_id = $order->save();
-		WC()->session->set( 'store_api_draft_order', $order_id );
-
-		$this->assertEquals( $order_id, WC()->session->get( 'store_api_draft_order' ) );
-
-		$cart->empty_cart();
-
-		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
-		// Verify the draft order was actually deleted.
-		$this->assertFalse( wc_get_order( $order_id ) );
-	}
 
 	/**
 	 * @testdox should NOT delete non-draft orders when clearing store_api_draft_order from session


### PR DESCRIPTION
This PR is a cherry-pick of #61575 to `release/10.3`.

## Original PR Description

### Changes proposed in this Pull Request:

Fix issue caused by https://github.com/woocommerce/woocommerce/pull/60739

### How to test the changes in this Pull Request:

A customer starts checkout (creating a draft order), completes payment (order becomes processing), but their session still contains the old draft order ID (assumed race condition/replication lag here). When they later empty their cart, the system should NOT delete their completed order.

1. Add this to `wp-content/mu-plugins/test-stale-session.php`:

```php
<?php
add_action('init', function() {
    if (!isset($_GET['set_stale_session'])) {
        return;
    }

    $order_id = intval($_GET['order_id']);

    // Set stale session data
    WC()->session->set('store_api_draft_order', $order_id);

    echo "Session set with order ID: $order_id<br>";
    echo '<a href="' . wc_get_cart_url() . '">Go to Cart (will trigger cleanup)</a>';
    exit;
});
```

2. Choose an existing order with status processing, or create a new one

3. Visit `http://localhost:8080/?set_stale_session&order_id=<ORDER_ID>`

4. Trigger cleanup by clicking on that href.

    - In 10.2.2: it should NOT delete the order
    - In 10.3.0: it will delete the order (bug)
    - On this branch: it should NOT delete the order


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
