### PR TITLE
Add in deprecated script warnings and backwards compatibility for 3PDs

### DIFF
--- a/plugins/woocommerce/changelog/fix-61584
+++ b/plugins/woocommerce/changelog/fix-61584
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add in deprecated script warnings and backwards compatibility for 3PDs

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -22,6 +22,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 	/**
 	 * WC_Admin_Assets Class.
+	 *
+	 * These scripts are enqueued in the admin of the store.  The registered script handles in this class
+	 * can be used to enqueue the scripts in the admin by third party plugins and the handles will follow
+	 * WooCommerce's L-1 support policy.  Scripts registered outside of this class do not guarantee support
+	 * and can be removed in future versions of WooCommerce.
 	 */
 	class WC_Admin_Assets {
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -361,10 +361,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				if ( isset( $script['legacy_handle'] ) ) {
 					wp_register_script(
 						$script['legacy_handle'],
-						$script['path'],
-						$script['dependencies'] ?? array(),
+						false,
+						array( $script['handle'] ),
 						$script['version'] ?? null,
-						$script['args'] ?? array( 'in_footer' => false )
+						true
 					);
 				}
 			}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -412,7 +412,7 @@ class WC_Frontend_Scripts {
 			self::register_script( $name, $props['src'], $props['deps'], $props['version'] );
 
 			if ( isset( $props['legacy_handle'] ) ) {
-				self::register_script( $props['legacy_handle'], $props['src'], $props['deps'], $props['version'] );
+				self::register_script( $props['legacy_handle'], false, array( $name ), $props['version'], true );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -307,9 +307,10 @@ class WC_Frontend_Scripts {
 				'legacy_handle' => 'jquery-cookie',
 			),
 			'wc-jquery-payment'          => array(
-				'src'     => self::get_asset_url( 'assets/js/jquery-payment/jquery.payment' . $suffix . '.js' ),
-				'deps'    => array( 'jquery' ),
-				'version' => '3.0.0-wc.' . $version,
+				'src'           => self::get_asset_url( 'assets/js/jquery-payment/jquery.payment' . $suffix . '.js' ),
+				'deps'          => array( 'jquery' ),
+				'version'       => '3.0.0-wc.' . $version,
+				'legacy_handle' => 'jquery-payment',
 			),
 			'wc-jquery-tiptip'           => array(
 				'src'           => self::get_asset_url( 'assets/js/jquery-tiptip/jquery.tipTip' . $suffix . '.js' ),

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Frontend scripts class.
+ *
+ * These scripts are enqueued in the frontend of the store.  The registered script handles in this class
+ * can be used to enqueue the scripts in the frontend by third party plugins and the handles will follow
+ * WooCommerce's L-1 support policy.  Scripts registered outside of this class do not guarantee support
+ * and can be removed in future versions of WooCommerce.
  */
 class WC_Frontend_Scripts {
 

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
@@ -35,6 +35,9 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		$suffix                   = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 		$version                  = Constants::get_constant( 'WC_VERSION' );
 		wp_register_script( 'wc-accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2', true );
+		// This script is deprecated, but we need to register it for backwards compatibility.
+		// This can be removed in WooCommerce 10.5.0.
+		wp_register_script( 'accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2', true );
 		wp_register_script( 'wc-jquery-ui-touchpunch', WC()->plugin_url() . '/assets/js/jquery-ui-touch-punch/jquery-ui-touch-punch' . $suffix . '.js', array( 'jquery-ui-slider' ), $version, true );
 		wp_register_script( 'wc-price-slider', WC()->plugin_url() . '/assets/js/frontend/price-slider' . $suffix . '.js', array( 'jquery-ui-slider', 'wc-jquery-ui-touchpunch', 'wc-accounting' ), $version, true );
 		wp_localize_script(
@@ -53,7 +56,24 @@ class WC_Widget_Price_Filter extends WC_Widget {
 			wp_enqueue_script( 'wc-price-slider' );
 		}
 
+		add_action( 'shutdown', array( $this, 'add_legacy_script_warnings' ) );
+
 		parent::__construct();
+	}
+
+	/**
+	 * Add warnings for deprecated script handles.
+	 */
+	public function add_legacy_script_warnings() {
+		$exists = wp_script_is( 'accounting' );
+		if ( $exists ) {
+			wc_deprecated_argument(
+				'wp_enqueue_script',
+				'10.3.0',
+				/* translators: %1$s: new script handle, %2$s: previous script handle */
+				sprintf( __( 'Please use the new handle %1$s in place of the previous handle %2$s.', 'woocommerce' ), 'wc-accounting', 'accounting' )
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
@@ -37,7 +37,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		wp_register_script( 'wc-accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2', true );
 		// This script is deprecated, but we need to register it for backwards compatibility.
 		// This can be removed in WooCommerce 10.5.0.
-		wp_register_script( 'accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2', true );
+		wp_register_script( 'accounting', false, array( 'wc-accounting' ), '0.4.2', true );
 		wp_register_script( 'wc-jquery-ui-touchpunch', WC()->plugin_url() . '/assets/js/jquery-ui-touch-punch/jquery-ui-touch-punch' . $suffix . '.js', array( 'jquery-ui-slider' ), $version, true );
 		wp_register_script( 'wc-price-slider', WC()->plugin_url() . '/assets/js/frontend/price-slider' . $suffix . '.js', array( 'jquery-ui-slider', 'wc-jquery-ui-touchpunch', 'wc-accounting' ), $version, true );
 		wp_localize_script(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/60648 and https://github.com/woocommerce/woocommerce/pull/60536 scripts that weren't properly prefixed were updated to prefixed names.  A number of third party plugins enqueue those script handles directly and were impacted by this change.

While script handles are not public API and we cannot guarantee support for script handles in general, we have decided to implement an explicit L-1 support policy for script handles in frontend and admin assets classes.  Plugins can take advantage of those script handles, but in doing so should take care to check for deprecation notices between versions.

Script handles or assets outside of these classes are not guaranteed between versions and dependencies should be copied to respective plugins if they are part of critical flows.

Closes #61584 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following snippet to your site:
```php
add_action( 'init', function() {
	wp_enqueue_script( 'wc-accounting' );
        wp_enqueue_script( 'accounting' );
	wp_enqueue_script( 'jquery-payment' );
} );
add_action( 'admin_init', function() {
	wp_enqueue_script( 'jquery-blockui' );
        wp_enqueue_script( 'wc-jquery-blockui' );
} );
```
2. Check that your debug log shows deprecation warnings for both scripts
3. Check that no other legacy scripts updated in https://github.com/woocommerce/woocommerce/pull/60648 and https://github.com/woocommerce/woocommerce/pull/60536 can be enqueued without re-registering the scripts
4. Make sure that scripts load the `wc-` prefixed script and no scripts are double loaded
5. Test with other various scripts in the frontend or admin assets

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
