### PR TITLE
Agentic Checkout: Add authorization

### DIFF
--- a/plugins/woocommerce/changelog/update-agentic-checkout-auth
+++ b/plugins/woocommerce/changelog/update-agentic-checkout-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Adds authorization for agentic checkout

--- a/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
@@ -58,7 +58,7 @@ class AgenticSettingsPage {
 					__( 'To get started, <a href="%s" target="_blank">apply to ChatGPT</a>. Once approved, ChatGPT will provide the credentials below.', 'woocommerce' ),
 					'https://chatgpt.com/merchants'
 				),
-				'fields'      => $this->get_openai_fields( $registry['openai'] ?? array() ),
+				'fields'      => $this->get_openai_fields(),
 			),
 		);
 
@@ -194,10 +194,9 @@ class AgenticSettingsPage {
 	/**
 	 * Get OpenAI provider fields.
 	 *
-	 * @param array $config Current OpenAI configuration.
 	 * @return array Fields configuration.
 	 */
-	private function get_openai_fields( $config ) {
+	private function get_openai_fields() {
 		return array(
 			array(
 				'title'   => __( 'Authorization Token', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
@@ -267,7 +267,6 @@ class AgenticSettingsPage {
 		$registry = $this->get_registry();
 
 		// Update general settings.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above with check_admin_referer.
 		$registry['general'] = array(
 			'enable_products_default' => isset( $_POST['woocommerce_agentic_enable_products_default'] ) && '1' === $_POST['woocommerce_agentic_enable_products_default']
 				? 'yes'
@@ -275,10 +274,9 @@ class AgenticSettingsPage {
 		);
 
 		// Update OpenAI settings.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above with check_admin_referer.
 		$registry['openai'] = array(
-			'bearer_token' => isset( $_POST['woocommerce_agentic_openai_bearer_token'] )
-				? sanitize_text_field( wp_unslash( $_POST['woocommerce_agentic_openai_bearer_token'] ) )
+			'bearer_token' => ! empty( $_POST['woocommerce_agentic_openai_bearer_token'] )
+				? wp_hash_password( sanitize_text_field( wp_unslash( $_POST['woocommerce_agentic_openai_bearer_token'] ) ) )
 				: '',
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/Agentic/AgenticSettingsPage.php
@@ -204,7 +204,7 @@ class AgenticSettingsPage {
 				'desc'    => __( 'The bearer token that ChatGPT uses to authenticate checkout requests.', 'woocommerce' ),
 				'id'      => 'woocommerce_agentic_openai_bearer_token',
 				'type'    => 'password',
-				'default' => esc_attr( $config['bearer_token'] ?? '' ),
+				'default' => '',
 			),
 		);
 	}
@@ -260,10 +260,8 @@ class AgenticSettingsPage {
 	 * Save settings to registry structure.
 	 */
 	public function save_settings() {
-		// Verify nonce for security.
 		check_admin_referer( 'woocommerce-settings' );
 
-		// Get current registry.
 		$registry = $this->get_registry();
 
 		// Update general settings.
@@ -274,11 +272,16 @@ class AgenticSettingsPage {
 		);
 
 		// Update OpenAI settings.
-		$registry['openai'] = array(
-			'bearer_token' => ! empty( $_POST['woocommerce_agentic_openai_bearer_token'] )
-				? wp_hash_password( sanitize_text_field( wp_unslash( $_POST['woocommerce_agentic_openai_bearer_token'] ) ) )
-				: '',
-		);
+		$new_token = isset( $_POST['woocommerce_agentic_openai_bearer_token'] )
+			? sanitize_text_field( wp_unslash( $_POST['woocommerce_agentic_openai_bearer_token'] ) )
+			: '';
+
+		// Only update if a new token was provided; otherwise keep existing.
+		if ( ! empty( $new_token ) ) {
+			$registry['openai']['bearer_token'] = wp_hash_password( $new_token );
+		} elseif ( ! isset( $registry['openai']['bearer_token'] ) ) {
+			$registry['openai']['bearer_token'] = '';
+		}
 
 		/**
 		 * Filter registry before saving.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/Enums/SessionKey.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/Enums/SessionKey.php
@@ -25,4 +25,9 @@ class SessionKey {
 	 * Whether payment is in progress.
 	 */
 	const AGENTIC_CHECKOUT_PAYMENT_IN_PROGRESS = 'agentic_checkout_payment_in_progress';
+
+	/**
+	 * Provider ID that authenticated the request.
+	 */
+	const AGENTIC_CHECKOUT_PROVIDER_ID = 'agentic_checkout_provider_id';
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -340,17 +340,6 @@ class AgenticCheckoutUtils {
 	 * @return bool|\WP_Error True if authorized, WP_Error otherwise.
 	 */
 	public static function is_authorized( $request = null ) {
-		// Check if feature is enabled.
-		$features_controller = wc_get_container()->get( FeaturesController::class );
-		if ( ! $features_controller->feature_is_enabled( 'agentic_checkout' ) ) {
-			return new \WP_Error(
-				'woocommerce_rest_agentic_checkout_disabled',
-				__( 'Agentic Checkout API is not enabled.', 'woocommerce' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		// If no request provided, cannot validate (should not happen in normal flow).
 		if ( null === $request ) {
 			return new \WP_Error(
 				'woocommerce_rest_agentic_checkout_invalid_request',

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -353,7 +353,7 @@ class AgenticCheckoutUtils {
 		if ( empty( $auth_header ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_agentic_checkout_missing_auth',
-				__( 'Missing authorization header.', 'woocommerce' ),
+				__( 'Invalid authorization.', 'woocommerce' ),
 				array( 'status' => 401 )
 			);
 		}
@@ -362,7 +362,7 @@ class AgenticCheckoutUtils {
 		if ( ! preg_match( '/^Bearer\s+(.+)$/i', $auth_header, $matches ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_agentic_checkout_invalid_auth_format',
-				__( 'Invalid authorization header format. Expected: Bearer <token>', 'woocommerce' ),
+				__( 'Invalid authorization.', 'woocommerce' ),
 				array( 'status' => 401 )
 			);
 		}

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -342,51 +342,52 @@ class AgenticCheckoutUtils {
 	public static function is_authorized( $request = null ) {
 		if ( null === $request ) {
 			return new \WP_Error(
-				'woocommerce_rest_agentic_checkout_invalid_request',
+				'invalid_request',
 				__( 'Invalid request object.', 'woocommerce' ),
-				array( 'status' => 500 )
+				array(
+					'status' => 400,
+					'type'   => 'invalid_request',
+					'code'   => 'invalid_request',
+				)
 			);
 		}
 
-		// Extract Authorization header.
 		$auth_header = $request->get_header( 'Authorization' );
-		if ( empty( $auth_header ) ) {
+		if ( empty( $auth_header ) || 0 !== stripos( $auth_header, 'Bearer ' ) ) {
 			return new \WP_Error(
-				'woocommerce_rest_agentic_checkout_missing_auth',
+				'invalid_request',
 				__( 'Invalid authorization.', 'woocommerce' ),
-				array( 'status' => 401 )
+				array(
+					'status' => 400,
+					'type'   => 'invalid_request',
+					'code'   => 'invalid_authorization_format',
+				)
 			);
 		}
 
-		// Parse bearer token from header.
-		if ( ! preg_match( '/^Bearer\s+(.+)$/i', $auth_header, $matches ) ) {
+		$provided_token = trim( substr( $auth_header, 7 ) ); // "Bearer " is 7 characters
+		if ( empty( $provided_token ) ) {
 			return new \WP_Error(
-				'woocommerce_rest_agentic_checkout_invalid_auth_format',
+				'invalid_request',
 				__( 'Invalid authorization.', 'woocommerce' ),
-				array( 'status' => 401 )
+				array(
+					'status' => 400,
+					'type'   => 'invalid_request',
+					'code'   => 'invalid_authorization_format',
+				)
 			);
 		}
-
-		$provided_token = $matches[1];
 
 		// Load agent registry.
 		$registry = get_option( \Automattic\WooCommerce\Internal\Admin\Agentic\AgenticSettingsPage::REGISTRY_OPTION, array() );
 
 		// Check each provider's bearer token.
 		foreach ( $registry as $provider_id => $provider_config ) {
-			// Skip non-array configs and special keys like 'general'.
-			if ( ! is_array( $provider_config ) ) {
+			if ( ! is_array( $provider_config ) || empty( $provider_config['bearer_token'] ) ) {
 				continue;
 			}
 
-			// Skip if no bearer token configured.
-			if ( empty( $provider_config['bearer_token'] ) ) {
-				continue;
-			}
-
-			// Use hash_equals for constant-time comparison to prevent timing attacks.
 			if ( hash_equals( $provider_config['bearer_token'], $provided_token ) ) {
-				// Store provider ID in session for tracking.
 				if ( WC()->session ) {
 					WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $provider_id );
 				}
@@ -394,11 +395,14 @@ class AgenticCheckoutUtils {
 			}
 		}
 
-		// No matching token found.
 		return new \WP_Error(
-			'woocommerce_rest_agentic_checkout_invalid_token',
-			__( 'Invalid authorization token.', 'woocommerce' ),
-			array( 'status' => 401 )
+			'invalid_request',
+			__( 'Invalid authorization.', 'woocommerce' ),
+			array(
+				'status' => 400,
+				'type'   => 'invalid_request',
+				'code'   => 'authentication_failed',
+			)
 		);
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -332,14 +332,14 @@ class AgenticCheckoutUtils {
 	}
 
 	/**
-	 * Check if the Agentic Checkout feature is enabled.
+	 * Check if the Agentic Checkout feature is enabled and request is authorized.
 	 *
-	 * V1 implementation: Returns true if feature is enabled (no auth check).
-	 * Future: Implement Bearer token authentication.
+	 * Validates bearer token against registered agents in the agent registry.
 	 *
+	 * @param \WP_REST_Request $request Request object.
 	 * @return bool|\WP_Error True if authorized, WP_Error otherwise.
 	 */
-	public static function is_authorized() {
+	public static function is_authorized( $request = null ) {
 		// Check if feature is enabled.
 		$features_controller = wc_get_container()->get( FeaturesController::class );
 		if ( ! $features_controller->feature_is_enabled( 'agentic_checkout' ) ) {
@@ -350,8 +350,67 @@ class AgenticCheckoutUtils {
 			);
 		}
 
-		// V1: Allow all requests (implement proper auth in future).
-		return true;
+		// If no request provided, cannot validate (should not happen in normal flow).
+		if ( null === $request ) {
+			return new \WP_Error(
+				'woocommerce_rest_agentic_checkout_invalid_request',
+				__( 'Invalid request object.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		// Extract Authorization header.
+		$auth_header = $request->get_header( 'Authorization' );
+		if ( empty( $auth_header ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_agentic_checkout_missing_auth',
+				__( 'Missing authorization header.', 'woocommerce' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		// Parse bearer token from header.
+		if ( ! preg_match( '/^Bearer\s+(.+)$/i', $auth_header, $matches ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_agentic_checkout_invalid_auth_format',
+				__( 'Invalid authorization header format. Expected: Bearer <token>', 'woocommerce' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$provided_token = $matches[1];
+
+		// Load agent registry.
+		$registry = get_option( \Automattic\WooCommerce\Internal\Admin\Agentic\AgenticSettingsPage::REGISTRY_OPTION, array() );
+
+		// Check each provider's bearer token.
+		foreach ( $registry as $provider_id => $provider_config ) {
+			// Skip non-array configs and special keys like 'general'.
+			if ( ! is_array( $provider_config ) ) {
+				continue;
+			}
+
+			// Skip if no bearer token configured.
+			if ( empty( $provider_config['bearer_token'] ) ) {
+				continue;
+			}
+
+			// Use hash_equals for constant-time comparison to prevent timing attacks.
+			if ( hash_equals( $provider_config['bearer_token'], $provided_token ) ) {
+				// Store provider ID in session for tracking.
+				if ( WC()->session ) {
+					WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $provider_id );
+				}
+				return true;
+			}
+		}
+
+		// No matching token found.
+		return new \WP_Error(
+			'woocommerce_rest_agentic_checkout_invalid_token',
+			__( 'Invalid authorization token.', 'woocommerce' ),
+			array( 'status' => 401 )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -378,7 +378,6 @@ class AgenticCheckoutUtils {
 			);
 		}
 
-		// Load agent registry.
 		$registry = get_option( \Automattic\WooCommerce\Internal\Admin\Agentic\AgenticSettingsPage::REGISTRY_OPTION, array() );
 
 		// Check each provider's bearer token.
@@ -387,7 +386,6 @@ class AgenticCheckoutUtils {
 				continue;
 			}
 
-			// Use wp_check_password for hashed token verification.
 			if ( wp_check_password( $provided_token, $provider_config['bearer_token'] ) ) {
 				if ( WC()->session ) {
 					WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $provider_id );

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -378,7 +378,8 @@ class AgenticCheckoutUtils {
 			);
 		}
 
-		$registry = get_option( \Automattic\WooCommerce\Internal\Admin\Agentic\AgenticSettingsPage::REGISTRY_OPTION, array() );
+		$registry               = get_option( \Automattic\WooCommerce\Internal\Admin\Agentic\AgenticSettingsPage::REGISTRY_OPTION, array() );
+		$authenticated_provider = null;
 
 		// Check each provider's bearer token.
 		foreach ( $registry as $provider_id => $provider_config ) {
@@ -387,11 +388,16 @@ class AgenticCheckoutUtils {
 			}
 
 			if ( wp_check_password( $provided_token, $provider_config['bearer_token'] ) ) {
-				if ( WC()->session ) {
-					WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $provider_id );
-				}
-				return true;
+				// Store and continue checking to minimize timing attack.
+				$authenticated_provider = $provider_id;
 			}
+		}
+
+		if ( null !== $authenticated_provider ) {
+			if ( WC()->session ) {
+				WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $authenticated_provider );
+			}
+			return true;
 		}
 
 		return new \WP_Error(

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -387,7 +387,8 @@ class AgenticCheckoutUtils {
 				continue;
 			}
 
-			if ( hash_equals( $provider_config['bearer_token'], $provided_token ) ) {
+			// Use wp_check_password for hashed token verification.
+			if ( wp_check_password( $provided_token, $provider_config['bearer_token'] ) ) {
 				if ( WC()->session ) {
 					WC()->session->set( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID, $provider_id );
 				}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -57,7 +57,7 @@ class CheckoutSessions extends ControllerTestCase {
 			'woocommerce_agentic_agent_registry',
 			array(
 				'openai' => array(
-					'bearer_token' => $this->test_bearer_token,
+					'bearer_token' => wp_hash_password( $this->test_bearer_token ),
 				),
 			),
 			false

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -511,18 +511,6 @@ class CheckoutSessions extends ControllerTestCase {
 	}
 
 	/**
-	 * Test feature flag disabled returns 403.
-	 */
-	public function test_feature_flag_disabled_returns_403() {
-		// Disable feature.
-		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
-
-		$response = $this->create_session( $this->create_checkout_request() );
-
-		$this->assertEquals( 403, $response->get_status() );
-	}
-
-	/**
 	 * Test currency format is lowercase.
 	 */
 	public function test_currency_format_is_lowercase() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessions.php
@@ -27,6 +27,13 @@ class CheckoutSessions extends ControllerTestCase {
 	protected $products = array();
 
 	/**
+	 * Test bearer token for authorization.
+	 *
+	 * @var string
+	 */
+	protected $test_bearer_token;
+
+	/**
 	 * Setup test product data. Called before every test.
 	 */
 	protected function setUp(): void {
@@ -43,6 +50,18 @@ class CheckoutSessions extends ControllerTestCase {
 
 		// Enable the agentic_checkout feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with test bearer token for authorization.
+		$this->test_bearer_token = 'test_token_' . uniqid();
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => $this->test_bearer_token,
+				),
+			),
+			false
+		);
 
 		$fixtures = new FixtureData();
 		$fixtures->shipping_add_flat_rate();
@@ -83,6 +102,7 @@ class CheckoutSessions extends ControllerTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
+		delete_option( 'woocommerce_agentic_agent_registry' );
 
 		// Clear session data.
 		WC()->session->set( SessionKey::CHOSEN_SHIPPING_METHODS, null );
@@ -186,6 +206,7 @@ class CheckoutSessions extends ControllerTestCase {
 	 */
 	private function create_session( $body_params ) {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_body_params( $body_params );
 		return rest_get_server()->dispatch( $request );
 	}
@@ -579,6 +600,7 @@ class CheckoutSessions extends ControllerTestCase {
 	 */
 	private function update_session( $session_id, $body_params ) {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions/' . $session_id );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_body_params( $body_params );
 		return rest_get_server()->dispatch( $request );
 	}
@@ -977,6 +999,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$idempotency_key = 'test-idempotency-123';
 		$request         = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_body_params( $this->create_checkout_request() );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_header( 'Idempotency-Key', $idempotency_key );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -993,6 +1016,7 @@ class CheckoutSessions extends ControllerTestCase {
 		$request_id = 'req_' . uniqid();
 		$request    = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
 		$request->set_body_params( $this->create_checkout_request() );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_header( 'Request-Id', $request_id );
 
 		$response = rest_get_server()->dispatch( $request );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
@@ -33,6 +33,13 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	protected $mock_gateway;
 
 	/**
+	 * Test bearer token for authorization.
+	 *
+	 * @var string
+	 */
+	protected $test_bearer_token;
+
+	/**
 	 * Setup test product data. Called before every test.
 	 */
 	protected function setUp(): void {
@@ -49,6 +56,18 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 
 		// Enable the agentic_checkout feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with test bearer token for authorization.
+		$this->test_bearer_token = 'test_token_' . uniqid();
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => $this->test_bearer_token,
+				),
+			),
+			false
+		);
 
 		$fixtures = new FixtureData();
 		$fixtures->shipping_add_flat_rate();
@@ -86,6 +105,7 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
+		delete_option( 'woocommerce_agentic_agent_registry' );
 
 		// Clear session data.
 		WC()->session->set( SessionKey::CHOSEN_SHIPPING_METHODS, null );
@@ -201,6 +221,7 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	 */
 	private function create_session( $body_params ) {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions' );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_body_params( $body_params );
 		return rest_get_server()->dispatch( $request );
 	}
@@ -214,6 +235,7 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	 */
 	private function update_session( $session_id, $body_params ) {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions/' . $session_id );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_body_params( $body_params );
 		return rest_get_server()->dispatch( $request );
 	}
@@ -227,6 +249,7 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	 */
 	private function complete_session( $session_id, $body_params ) {
 		$request = new \WP_REST_Request( 'POST', '/wc/agentic/v1/checkout_sessions/' . $session_id . '/complete' );
+		$request->set_header( 'Authorization', 'Bearer ' . $this->test_bearer_token );
 		$request->set_body_params( $body_params );
 		return rest_get_server()->dispatch( $request );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
@@ -63,7 +63,7 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 			'woocommerce_agentic_agent_registry',
 			array(
 				'openai' => array(
-					'bearer_token' => $this->test_bearer_token,
+					'bearer_token' => wp_hash_password( $this->test_bearer_token ),
 				),
 			),
 			false

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
@@ -683,44 +683,6 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	}
 
 	/**
-	 * Test completing checkout with feature flag disabled fails.
-	 */
-	public function test_complete_checkout_session_feature_disabled() {
-		// Create session first (while feature is enabled).
-		$create_response = $this->create_session(
-			$this->create_checkout_request(
-				array(
-					'fulfillment_address' => $this->get_test_address(),
-				)
-			)
-		);
-
-		$create_data        = $create_response->get_data();
-		$session_id         = $create_data['id'];
-		$shipping_method_id = $create_data['fulfillment_options'][0]['id'];
-
-		$this->update_session(
-			$session_id,
-			array(
-				'fulfillment_option_id' => $shipping_method_id,
-			)
-		);
-
-		// Disable feature.
-		delete_option( 'woocommerce_feature_agentic_checkout_enabled' );
-
-		// Try to complete checkout.
-		$complete_response = $this->complete_session(
-			$session_id,
-			array(
-				'payment_data' => $this->get_payment_data(),
-			)
-		);
-
-		$this->assertEquals( 403, $complete_response->get_status() );
-	}
-
-	/**
 	 * Test error response format matches ACP spec.
 	 */
 	public function test_complete_error_response_format() {

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
@@ -148,19 +148,19 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Enable the feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
 
-		// Set up registry with OpenAI token.
+		// Set up registry with OpenAI token (hashed).
 		$test_token = 'test_bearer_token_12345';
 		update_option(
 			'woocommerce_agentic_agent_registry',
 			array(
 				'openai' => array(
-					'bearer_token' => $test_token,
+					'bearer_token' => wp_hash_password( $test_token ),
 				),
 			),
 			false
 		);
 
-		// Create mock request with Authorization header.
+		// Create mock request with Authorization header (plaintext).
 		$request = new \WP_REST_Request();
 		$request->set_header( 'Authorization', 'Bearer ' . $test_token );
 
@@ -181,12 +181,12 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Enable the feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
 
-		// Set up registry with OpenAI token.
+		// Set up registry with OpenAI token (hashed).
 		update_option(
 			'woocommerce_agentic_agent_registry',
 			array(
 				'openai' => array(
-					'bearer_token' => 'correct_token',
+					'bearer_token' => wp_hash_password( 'correct_token' ),
 				),
 			),
 			false
@@ -297,7 +297,7 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Enable the feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
 
-		// Set up registry with multiple providers.
+		// Set up registry with multiple providers (hashed tokens).
 		$token_a = 'provider_a_token';
 		$token_b = 'provider_b_token';
 		update_option(
@@ -307,23 +307,23 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 					'enable_products_default' => 'yes',
 				),
 				'provider_a' => array(
-					'bearer_token' => $token_a,
+					'bearer_token' => wp_hash_password( $token_a ),
 				),
 				'provider_b' => array(
-					'bearer_token' => $token_b,
+					'bearer_token' => wp_hash_password( $token_b ),
 				),
 			),
 			false
 		);
 
-		// Test with provider A token.
+		// Test with provider A token (plaintext).
 		$request = new \WP_REST_Request();
 		$request->set_header( 'Authorization', 'Bearer ' . $token_a );
 		$result = AgenticCheckoutUtils::is_authorized( $request );
 		$this->assertTrue( $result );
 		$this->assertEquals( 'provider_a', WC()->session->get( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID ) );
 
-		// Test with provider B token.
+		// Test with provider B token (plaintext).
 		$request = new \WP_REST_Request();
 		$request->set_header( 'Authorization', 'Bearer ' . $token_b );
 		$result = AgenticCheckoutUtils::is_authorized( $request );
@@ -338,19 +338,19 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Enable the feature.
 		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
 
-		// Set up registry.
+		// Set up registry (hashed token).
 		$test_token = 'test_token';
 		update_option(
 			'woocommerce_agentic_agent_registry',
 			array(
 				'openai' => array(
-					'bearer_token' => $test_token,
+					'bearer_token' => wp_hash_password( $test_token ),
 				),
 			),
 			false
 		);
 
-		// Test with different casings of "Bearer".
+		// Test with different casings of "Bearer" (plaintext token).
 		$casings = array( 'Bearer', 'bearer', 'BEARER', 'BeArEr' );
 		foreach ( $casings as $casing ) {
 			$request = new \WP_REST_Request();

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
@@ -199,10 +199,12 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Test authorization.
 		$result = AgenticCheckoutUtils::is_authorized( $request );
 
-		// Assert authorization fails.
+		// Assert authorization fails with ACP error format.
 		$this->assertWPError( $result );
-		$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_token', $result->get_error_code() );
-		$this->assertEquals( 401, $result->get_error_data()['status'] );
+		$this->assertEquals( 'invalid_request', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
+		$this->assertEquals( 'invalid_request', $result->get_error_data()['type'] );
+		$this->assertEquals( 'authentication_failed', $result->get_error_data()['code'] );
 	}
 
 	/**
@@ -218,10 +220,12 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Test authorization.
 		$result = AgenticCheckoutUtils::is_authorized( $request );
 
-		// Assert authorization fails.
+		// Assert authorization fails with ACP error format.
 		$this->assertWPError( $result );
-		$this->assertEquals( 'woocommerce_rest_agentic_checkout_missing_auth', $result->get_error_code() );
-		$this->assertEquals( 401, $result->get_error_data()['status'] );
+		$this->assertEquals( 'invalid_request', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
+		$this->assertEquals( 'invalid_request', $result->get_error_data()['type'] );
+		$this->assertEquals( 'invalid_authorization_format', $result->get_error_data()['code'] );
 	}
 
 	/**
@@ -246,29 +250,11 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 			$result = AgenticCheckoutUtils::is_authorized( $request );
 
 			$this->assertWPError( $result, "Failed for header: $header" );
-			$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_auth_format', $result->get_error_code() );
-			$this->assertEquals( 401, $result->get_error_data()['status'] );
+			$this->assertEquals( 'invalid_request', $result->get_error_code() );
+			$this->assertEquals( 400, $result->get_error_data()['status'] );
+			$this->assertEquals( 'invalid_request', $result->get_error_data()['type'] );
+			$this->assertEquals( 'invalid_authorization_format', $result->get_error_data()['code'] );
 		}
-	}
-
-	/**
-	 * Test authorization when feature is disabled.
-	 */
-	public function test_is_authorized_when_feature_disabled() {
-		// Disable the feature.
-		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'no' );
-
-		// Create mock request with valid token.
-		$request = new \WP_REST_Request();
-		$request->set_header( 'Authorization', 'Bearer test_token' );
-
-		// Test authorization.
-		$result = AgenticCheckoutUtils::is_authorized( $request );
-
-		// Assert authorization fails due to disabled feature.
-		$this->assertWPError( $result );
-		$this->assertEquals( 'woocommerce_rest_agentic_checkout_disabled', $result->get_error_code() );
-		$this->assertEquals( 403, $result->get_error_data()['status'] );
 	}
 
 	/**
@@ -296,9 +282,12 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Test authorization.
 		$result = AgenticCheckoutUtils::is_authorized( $request );
 
-		// Assert authorization fails (empty tokens are skipped).
+		// Assert authorization fails with ACP error format (empty tokens are skipped).
 		$this->assertWPError( $result );
-		$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_token', $result->get_error_code() );
+		$this->assertEquals( 'invalid_request', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
+		$this->assertEquals( 'invalid_request', $result->get_error_data()['type'] );
+		$this->assertEquals( 'authentication_failed', $result->get_error_data()['code'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
@@ -140,4 +140,234 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 		// Assert that status is READY_FOR_PAYMENT after clearing IN_PROGRESS.
 		$this->assertNotEquals( CheckoutSessionStatus::IN_PROGRESS, $status );
 	}
+
+	/**
+	 * Test authorization with valid OpenAI token.
+	 */
+	public function test_is_authorized_with_valid_token() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with OpenAI token.
+		$test_token = 'test_bearer_token_12345';
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => $test_token,
+				),
+			),
+			false
+		);
+
+		// Create mock request with Authorization header.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer ' . $test_token );
+
+		// Test authorization.
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+
+		// Assert authorization succeeds.
+		$this->assertTrue( $result );
+
+		// Assert provider ID is stored in session.
+		$this->assertEquals( 'openai', WC()->session->get( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID ) );
+	}
+
+	/**
+	 * Test authorization with invalid token.
+	 */
+	public function test_is_authorized_with_invalid_token() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with OpenAI token.
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => 'correct_token',
+				),
+			),
+			false
+		);
+
+		// Create mock request with wrong token.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer wrong_token' );
+
+		// Test authorization.
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+
+		// Assert authorization fails.
+		$this->assertWPError( $result );
+		$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_token', $result->get_error_code() );
+		$this->assertEquals( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test authorization with missing Authorization header.
+	 */
+	public function test_is_authorized_with_missing_header() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Create mock request without Authorization header.
+		$request = new \WP_REST_Request();
+
+		// Test authorization.
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+
+		// Assert authorization fails.
+		$this->assertWPError( $result );
+		$this->assertEquals( 'woocommerce_rest_agentic_checkout_missing_auth', $result->get_error_code() );
+		$this->assertEquals( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test authorization with malformed Bearer token format.
+	 */
+	public function test_is_authorized_with_malformed_header() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Test various malformed formats.
+		$malformed_headers = array(
+			'token_without_bearer',
+			'Basic token123',
+			'Bearertoken123', // Missing space.
+			'Bearer',         // No token.
+		);
+
+		foreach ( $malformed_headers as $header ) {
+			$request = new \WP_REST_Request();
+			$request->set_header( 'Authorization', $header );
+
+			$result = AgenticCheckoutUtils::is_authorized( $request );
+
+			$this->assertWPError( $result, "Failed for header: $header" );
+			$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_auth_format', $result->get_error_code() );
+			$this->assertEquals( 401, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * Test authorization when feature is disabled.
+	 */
+	public function test_is_authorized_when_feature_disabled() {
+		// Disable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'no' );
+
+		// Create mock request with valid token.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer test_token' );
+
+		// Test authorization.
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+
+		// Assert authorization fails due to disabled feature.
+		$this->assertWPError( $result );
+		$this->assertEquals( 'woocommerce_rest_agentic_checkout_disabled', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test authorization with empty provider tokens.
+	 */
+	public function test_is_authorized_with_empty_provider_tokens() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with empty token.
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => '',
+				),
+			),
+			false
+		);
+
+		// Create mock request with token.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer some_token' );
+
+		// Test authorization.
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+
+		// Assert authorization fails (empty tokens are skipped).
+		$this->assertWPError( $result );
+		$this->assertEquals( 'woocommerce_rest_agentic_checkout_invalid_token', $result->get_error_code() );
+	}
+
+	/**
+	 * Test authorization with multiple providers.
+	 */
+	public function test_is_authorized_with_multiple_providers() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry with multiple providers.
+		$token_a = 'provider_a_token';
+		$token_b = 'provider_b_token';
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'general'    => array(
+					'enable_products_default' => 'yes',
+				),
+				'provider_a' => array(
+					'bearer_token' => $token_a,
+				),
+				'provider_b' => array(
+					'bearer_token' => $token_b,
+				),
+			),
+			false
+		);
+
+		// Test with provider A token.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer ' . $token_a );
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'provider_a', WC()->session->get( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID ) );
+
+		// Test with provider B token.
+		$request = new \WP_REST_Request();
+		$request->set_header( 'Authorization', 'Bearer ' . $token_b );
+		$result = AgenticCheckoutUtils::is_authorized( $request );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'provider_b', WC()->session->get( SessionKey::AGENTIC_CHECKOUT_PROVIDER_ID ) );
+	}
+
+	/**
+	 * Test authorization with case-insensitive Bearer keyword.
+	 */
+	public function test_is_authorized_with_case_insensitive_bearer() {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
+
+		// Set up registry.
+		$test_token = 'test_token';
+		update_option(
+			'woocommerce_agentic_agent_registry',
+			array(
+				'openai' => array(
+					'bearer_token' => $test_token,
+				),
+			),
+			false
+		);
+
+		// Test with different casings of "Bearer".
+		$casings = array( 'Bearer', 'bearer', 'BEARER', 'BeArEr' );
+		foreach ( $casings as $casing ) {
+			$request = new \WP_REST_Request();
+			$request->set_header( 'Authorization', $casing . ' ' . $test_token );
+			$result = AgenticCheckoutUtils::is_authorized( $request );
+			$this->assertTrue( $result, "Failed for casing: $casing" );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Implements bearer token authorization for Agentic Checkout API endpoints using the agent registry system. This replaces the placeholder V1 implementation that allowed all requests.
- Uses error responses that align with the Agentic Checkout Protocol.
- Adds provider ID to the checkout session.

Closes WOOPTP-7

### How to test the changes in this Pull Request:

1. Enable the `agentic_checkout` feature flag
2. Navigate to WooCommerce > Settings > Integrations > Agentic Commerce
3. Configure a bearer token for the OpenAI provider (any test value like `test_token_123`)


**Test Valid Authorization:**
1. Make a REST API call to create a checkout session:
```bash
curl -X POST https://your-site.test/wp-json/wc/agentic/v1/checkout_sessions \
  -H "Authorization: Bearer test_token_123" \
  -H "Content-Type: application/json" \
  -d '{"items": [{"id": "1", "quantity": 1}]}'
```
2. Verify you receive a 200 response with checkout session data
3. Verify the provider ID is tracked in the session

**Test Invalid Token:**
1. Make a request with wrong token:
```bash
curl -X POST https://your-site.test/wp-json/wc/agentic/v1/checkout_sessions \
  -H "Authorization: Bearer wrong_token" \
  -H "Content-Type: application/json" \
  -d '{"items": [{"id": "1", "quantity": 1}]}'
```
2. Verify you receive a 400 error with ACP format:
```json
{
  "type": "invalid_request",
  "code": "authentication_failed",
  "message": "Invalid authorization."
}
```

**Test Missing Header:**
1. Make a request without Authorization header
2. Verify you receive a 400 error with `code: "invalid_authorization_format"`

**Test Malformed Header:**
1. Try various malformed formats:
   - `Authorization: test_token_123` (no "Bearer")
   - `Authorization: Basic test_token_123` (wrong auth type)
   - `Authorization: Bearertest_token_123` (no space)
2. Verify all return 400 with `code: "invalid_authorization_format"`

<!-- End testing instructions -->

### Testing that has already taken place:

- Added and ensured unit tests pass.
- Manual testing of good/bad token.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
