### PR TITLE
fix: Fixed path of Getting Started in README under docs/block-development

### DIFF
--- a/docs/block-development/README.md
+++ b/docs/block-development/README.md
@@ -7,7 +7,7 @@ Whether you’re new to block development or looking to deepen your expertise, t
 
 ## Start Here
 
-- **[Getting Started](/docs/block-development/getting-started/extensibility-overview/)**: Set up your environment and create your first block.
+- **[Getting Started](/docs/block-development/getting-started/extensibility-overview.md/)**: Set up your environment and create your first block.
 - **[Tutorials](/docs/category/tutorials/)**: Follow hands-on guides to build and enhance your blocks.
 - **[Reference](/docs/category/reference/)**: Look up APIs, filters, and block details as you build.
 - **[Extensibility](/docs/category/extensible-blocks/)**: Learn to extend and customize blocks for advanced use cases.

--- a/docs/block-development/extensible-blocks/product-collection-block/README.md
+++ b/docs/block-development/extensible-blocks/product-collection-block/README.md
@@ -10,5 +10,5 @@ Display a collection of products from your store.
 
 ## Start here
 
-1. [DOM events sent from product collection block](/docs/block-development/extensible-blocks/product-collection-block/dom-events)
-2. [Registering custom collections in product collection block](/docs/block-development/extensible-blocks/product-collection-block/register-product-collection)
+1. [DOM events sent from product collection block](/docs/block-development/extensible-blocks/product-collection-block/dom-events.md)
+2. [Registering custom collections in product collection block](/docs/block-development/extensible-blocks/product-collection-block/register-product-collection.md)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- README under docs/block-development contained wrong URL towards Getting-Started.
- Before Fix (Page Not Found):
<img width="1260" height="474" alt="before" src="https://github.com/user-attachments/assets/4a9ac749-da41-41e4-a0d6-cbc884e3f20f" />

- After Fix (Page Correctly Loaded):
<img width="1332" height="566" alt="after" src="https://github.com/user-attachments/assets/d61e6843-3559-47d6-ba96-d0b4a2cad6a9" />

#### Change
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

</details>
