### PR TITLE
Revert "Add TypeScript ESLint rules for handling promises"

### DIFF
--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -78,15 +78,9 @@ module.exports = {
 		},
 		{
 			files: [ '*.ts', '*.tsx' ],
-			parser: '@typescript-eslint/parser',
-			parserOptions: {
-				project: true,
-			},
 			rules: {
 				// Making use of typescript no-shadow instead.
 				'no-shadow': 'off',
-				'@typescript-eslint/no-floating-promises': 'error',
-				'@typescript-eslint/require-await': 'error',
 			},
 		},
 		{


### PR DESCRIPTION
Reverts woocommerce/woocommerce#61565

I just noticed that the CI doesn't run eslint across all the packages. We need to fix all the errors before merge #61565.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Revert: Add TypeScript ESLint rules for handling promises.

</details>