### PR TITLE
Remove unnecessary animation from Add to Cart + Options block skeleton

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-static-skeleton
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-static-skeleton
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary animation from Add to Cart + Options block skeleton

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
@@ -3,13 +3,13 @@
  */
 import { Skeleton } from '../..';
 
-interface ProductShortDescriptionSkeletonProps {
+interface MultiLineTextSkeletonProps {
 	isStatic?: boolean;
 }
 
-export const ProductShortDescriptionSkeleton = ( {
+export const MultiLineTextSkeleton = ( {
 	isStatic = false,
-}: ProductShortDescriptionSkeletonProps ) => {
+}: MultiLineTextSkeletonProps ) => {
 	return (
 		<div className="wc-block-components-skeleton">
 			<Skeleton height="16px" isStatic={ isStatic } />

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
@@ -6,9 +6,9 @@ import { Skeleton } from '../..';
 export const MultiLineTextSkeleton = () => {
 	return (
 		<div className="wc-block-components-skeleton">
-			<Skeleton height="16px" />
-			<Skeleton height="16px" />
-			<Skeleton height="16px" width="80%" />
+			<Skeleton height="16px" isStatic={ true } />
+			<Skeleton height="16px" isStatic={ true } />
+			<Skeleton height="16px" width="80%" isStatic={ true } />
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
@@ -3,12 +3,18 @@
  */
 import { Skeleton } from '../..';
 
-export const MultiLineTextSkeleton = () => {
+interface MultiLineTextSkeletonProps {
+	isStatic?: boolean;
+}
+
+export const MultiLineTextSkeleton = ( {
+	isStatic = false,
+}: MultiLineTextSkeletonProps ) => {
 	return (
 		<div className="wc-block-components-skeleton">
-			<Skeleton height="16px" isStatic={ true } />
-			<Skeleton height="16px" isStatic={ true } />
-			<Skeleton height="16px" width="80%" isStatic={ true } />
+			<Skeleton height="16px" isStatic={ isStatic } />
+			<Skeleton height="16px" isStatic={ isStatic } />
+			<Skeleton height="16px" width="80%" isStatic={ isStatic } />
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/skeleton/patterns/multi-line-text-skeleton/index.tsx
@@ -3,18 +3,12 @@
  */
 import { Skeleton } from '../..';
 
-interface MultiLineTextSkeletonProps {
-	isStatic?: boolean;
-}
-
-export const MultiLineTextSkeleton = ( {
-	isStatic = false,
-}: MultiLineTextSkeletonProps ) => {
+export const MultiLineTextSkeleton = () => {
 	return (
 		<div className="wc-block-components-skeleton">
-			<Skeleton height="16px" isStatic={ isStatic } />
-			<Skeleton height="16px" isStatic={ isStatic } />
-			<Skeleton height="16px" width="80%" isStatic={ isStatic } />
+			<Skeleton height="16px" />
+			<Skeleton height="16px" />
+			<Skeleton height="16px" width="80%" />
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
-import { ProductShortDescriptionSkeleton } from '@woocommerce/base-components/skeleton/patterns/product-short-description';
+import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/patterns/multi-line-text-skeleton';
 import {
 	BlockControls,
 	InspectorControls,
@@ -63,7 +63,7 @@ const AddToCartOptionsEdit = (
 			) : (
 				<div { ...blockProps }>
 					<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-						<ProductShortDescriptionSkeleton />
+						<MultiLineTextSkeleton isStatic={ true } />
 					</div>
 					<Disabled>
 						<button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -63,7 +63,7 @@ const AddToCartOptionsEdit = (
 			) : (
 				<div { ...blockProps }>
 					<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-						<MultiLineTextSkeleton isStatic={ true } />
+						<MultiLineTextSkeleton />
 					</div>
 					<Disabled>
 						<button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -63,7 +63,7 @@ const AddToCartOptionsEdit = (
 			) : (
 				<div { ...blockProps }>
 					<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-						<MultiLineTextSkeleton />
+						<MultiLineTextSkeleton isStatic={ true } />
 					</div>
 					<Disabled>
 						<button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { ProductShortDescriptionSkeleton } from '@woocommerce/base-components/skeleton/patterns/product-short-description';
+import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/patterns/multi-line-text-skeleton';
 import { BlockEditProps } from '@wordpress/blocks';
 import { Disabled, Tooltip } from '@wordpress/components';
 import { isSiteEditorPage } from '@woocommerce/utils';
@@ -56,7 +56,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					position="bottom right"
 				>
 					<div className="wc-block-editor-add-to-cart-form-container">
-						<ProductShortDescriptionSkeleton isStatic={ true } />
+						<MultiLineTextSkeleton isStatic={ true } />
 						<Disabled>
 							{ props.attributes.quantitySelectorStyle ===
 								QuantitySelectorStyle.Input && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -56,7 +56,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					position="bottom right"
 				>
 					<div className="wc-block-editor-add-to-cart-form-container">
-						<MultiLineTextSkeleton isStatic={ true } />
+						<MultiLineTextSkeleton />
 						<Disabled>
 							{ props.attributes.quantitySelectorStyle ===
 								QuantitySelectorStyle.Input && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -56,7 +56,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					position="bottom right"
 				>
 					<div className="wc-block-editor-add-to-cart-form-container">
-						<MultiLineTextSkeleton />
+						<MultiLineTextSkeleton isStatic={ true } />
 						<Disabled>
 							{ props.attributes.quantitySelectorStyle ===
 								QuantitySelectorStyle.Input && (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Kudos to @xristos3490 for reporting this issue.

This PR:

1. Removes the animation from the _Add to Cart + Options_ block skeleton in the editor, which made it look like it was loading.
2. Renames the `<ProductShortDescriptionSkeleton />` to `<MultiLineTextSkeleton />` to better represent what it is.
3. ~Removes the `isStatic` prop from it, as it was `true` everywhere the component was used.~ I undid this, as this prop might be valuable in https://github.com/woocommerce/woocommerce/pull/61663.

### How to test the changes in this Pull Request:

1. Install an extension that registers a 3rd-party product type, like [Product Bundles](https://woocommerce.com/products/product-bundles/) or [Composite Products](https://woocommerce.com/products/composite-products/).
2. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and add the _Add to Cart + Options_ block.
3. In the product type selector, choose the 3rd-party product type.
4. Verify the skeleton is not animated.

<img width="1123" height="378" alt="imatge" src="https://github.com/user-attachments/assets/0851ddd8-1b4a-4718-8776-75335ddc9d64" />