### PR TITLE
Add a REST API output caching engine

### DIFF
--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -1,0 +1,849 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\Traits;
+
+use Automattic\WooCommerce\Internal\Caches\EntityVersionKeysCache;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * This trait provides transient-based caching capabilities for REST API endpoints
+ * (see "why transients?" at the end of this comment).
+ *
+ * - The output of all the REST API endpoints whose callback declaration is wrapped
+ *   in a call to 'with_cache' will be cached using transients.
+ * - Response headers are cached together with the response data, excluding certain fixed
+ *   headers (like Set-Cookie) and optionally others specified via configuration
+ *   (per-controller or per-endpoint).
+ * - For the purposes of caching, a request is uniquely identified by its route
+ *   and query string. Optionally, the user ID can also be included in the cache key
+ *   when 'vary_by_user' is enabled, making responses user-specific.
+ * - The EntityVersionKeysCache class is used to track versions of entities included
+ *   in the responses (an "entity" is any object that is uniquely identified by type and id
+ *   and contributes with information to be included in the response),
+ *   so that when those entities change, the relevant cached responses become invalid.
+ *   Modification of entity versions must be done externally by the code that modifies
+ *   those entities (via calls to EntityVersionKeysCache::regenerate_entity_version).
+ * - Various parameters (cached outputs TTL, entity type for a given response, extraction
+ *   of entity ids from the response data, filters that affect the response) can be configured
+ *   globally for the controller (via overriding protected methods) or per-endpoint
+ *   (via arguments passed to with_cache).
+ * - Caching can be disabled for a given request by adding a '_skip_cache=true|1'
+ *   to the query string.
+ * - A X-WC-Cache HTTP header is added to responses to indicate cache status:
+ *   HIT, MISS, or SKIP.
+ *
+ * IMPORTANT: Caching only occurs when EntityVersionKeysCache::should_use() returns true,
+ * and by default this only happens when object caching is enabled site-wide
+ * (configurable via the 'woocommerce_should_use_entity_version_keys_cache' hook).
+ *
+ * Required setup:
+ *
+ * 1. `use RestApiCache;` in the controller class.
+ * 1. Call `$this->initialize_rest_api_cache()` in the controller's constructor.
+ * 2. Either override `get_default_entity_type()` to return the default entity type
+ *    associated to all endpoints (e.g., 'product', 'order'),  OR specify 'entity_type'
+ *    in the config array for every `with_cache()` call.
+ *
+ * Usage: Wrap endpoint callbacks with the `with_cache()` method when registering routes,
+ * so `'callback' => $this->with_cache( array( $this, 'get_item' ), [ ...config... ] )`.
+ *
+ * Example:
+ *
+ * class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
+ *     use RestApiCache;
+ *
+ *     public function __construct() {
+ *         parent::__construct();
+ *         $this->initialize_rest_api_cache();  // REQUIRED
+ *     }
+ *
+ *     protected function get_default_entity_type(): ?string {
+ *         return 'product';  // REQUIRED (or specify entity_type in each with_cache call)
+ *     }
+ *
+ *     public function register_routes() {
+ *         register_rest_route(
+ *             $this->namespace,
+ *             '/' . $this->rest_base . '/(?P<id>[\d]+)',
+ *             array(
+ *                 'methods'  => WP_REST_Server::READABLE,
+ *                 'callback' => $this->with_cache(
+ *                     array( $this, 'get_item' ),
+ *                     array(
+ *                         // String, optional if get_default_entity_type() is overridden.
+ *                         'entity_type'        => 'product',
+ *                         // Optional callback, defaults to the controller's get_cache_ttl().
+ *                         'cache_ttl'          => HOUR_IN_SECONDS,
+ *                         // Optional callback, defaults to the controller's extract_entity_ids().
+ *                         'extract_entity_ids' => array( $this, 'custom_extract_ids' ),
+ *                         // Optional callback, defaults to the controller's must_cache().
+ *                         'must_cache'         => array( $this, 'should_cache' ),
+ *                         // Optional array, defaults to the controller's get_hooks_relevant_to_caching().
+ *                         'relevant_hooks'     => array( 'filter_name_1', 'filter_name_2' ),
+ *                         // Optional bool, defaults to the controller's response_cache_vary_by_user().
+ *                         'vary_by_user'       => true,
+ *                         // Optional array, defaults to the controller's get_response_headers_to_exclude_from_caching().
+ *                         'exclude_headers'    => array( 'X-Custom-Header' ),
+ *                         // Optional, this will be passed to all the caching-related methods.
+ *                         'endpoint_id'        => 'get_product'
+ *                     )
+ *                 ),
+ *             )
+ *         );
+ *     }
+ * }
+ *
+ * Override these methods in your controller as needed:
+ * - get_default_entity_type(): Default entity type for endpoints without explicit config.
+ * - response_cache_vary_by_user(): Whether cache should be user-specific.
+ * - get_hooks_relevant_to_caching(): Hook names to track for cache invalidation.
+ * - get_cache_ttl(): TTL for cached outputs in seconds.
+ * - must_cache(): Whether to cache a specific request or not.
+ * - extract_entity_ids(): Extract entity IDs from response data.
+ *
+ * Cache invalidation happens when:
+ * - Entity versions change (tracked via EntityVersionKeysCache).
+ * - Filter callbacks change
+ *   (if the `get_hooks_relevant_to_caching()` call result or the 'relevant_hooks' array isn't empty).
+ * - Cached response TTL expires.
+ *
+ * NOTE: Why transients and not the WordPress global cache?
+ *
+ * Using transients for this kind of cache implementation in a site without a proper persistent global cache
+ * configured is a bad idea, as it can lead to performance issues since as transients are stored directly
+ * in the database. However, if a global cache is in place, transients will be stored using it, making
+ * the usage of transients functionally equivalent to using the WordPress global cache.
+ *
+ * By default this caching mechanism is only enabled when an external object cache is enabled
+ * (checked via call to EntityVersionKeysCache::should_use()), so database-backed transients won't be used.
+ * However it's still possible to force-enable it via the 'woocommerce_should_use_entity_version_keys_cache' filter,
+ * and this can be useful in scenarios without a global cache in place for testing, experimenting, troubleshooting,
+ * staging, and development purposes.
+ *
+ * @since   10.4.0
+ */
+trait RestApiCache {
+	/**
+	 * The instance of EntityVersionKeysCache to use, or null if caching is disabled.
+	 *
+	 * @var EntityVersionKeysCache|null
+	 */
+	private ?EntityVersionKeysCache $entity_versions_cache;
+
+	/**
+	 * Initialize the entity versions cache.
+	 * This MUST be called from the controller's constructor.
+	 */
+	protected function initialize_rest_api_cache(): void {
+		$cache                       = wc_get_container()->get( EntityVersionKeysCache::class );
+		$this->entity_versions_cache = $cache->should_use() ? $cache : null;
+	}
+
+	/**
+	 * Wrap an endpoint callback declaration with caching logic.
+	 * Usage: `'callback' => $this->with_cache( array( $this, 'endpoint_callback_method' ), [ ...config... ] )`
+	 *
+	 * @param callable $callback The original endpoint callback.
+	 * @param array    $config   Caching configuration:
+	 *                           - endpoint_id: string (optional friendly identifier for the endpoint).
+	 *                           - entity_type: string (falls back to get_default_entity_type()).
+	 *                           - cache_ttl: int (defaults to HOUR_IN_SECONDS).
+	 *                           - extract_entity_ids: callable (defaults to $this->extract_entity_ids).
+	 *                           - must_cache: callable (defaults to $this->must_cache).
+	 *                           - relevant_hooks: array (defaults to $this->get_hooks_relevant_to_caching()).
+	 *                           - vary_by_user: bool (defaults to $this->response_cache_vary_by_user()).
+	 *                           - exclude_headers: array (defaults to $this->get_response_headers_to_exclude_from_caching()).
+	 * @return callable Wrapped callback.
+	 */
+	protected function with_cache( callable $callback, array $config = array() ): callable {
+		return fn( $request ) => $this->handle_cacheable_request( $request, $callback, $config );
+	}
+
+	/**
+	 * Handle a request with caching logic.
+	 *
+	 * Strategy: Try to use cached response if available and valid, otherwise execute the endpoint
+	 * callback and cache the response (if successful) for future requests.
+	 *
+	 * @param WP_REST_Request $request  The request object.
+	 * @param callable        $callback The original endpoint callback.
+	 * @param array           $config   Caching configuration specified for the endpoint.
+	 * @return WP_REST_Response|\WP_Error The response.
+	 */
+	private function handle_cacheable_request( WP_REST_Request $request, callable $callback, array $config ) {
+		if ( is_null( $this->entity_versions_cache ) ) {
+			return call_user_func( $callback, $request );
+		}
+
+		if ( ! $this->should_use_cache_for_request( $request, $config ) ) {
+			$response = call_user_func( $callback, $request );
+			if ( $response instanceof WP_REST_Response ) {
+				$response->header( 'X-WC-Cache', 'SKIP' );
+			}
+			return $response;
+		}
+
+		$cached_config = $this->build_cache_config( $request, $config );
+		if ( is_null( $cached_config ) ) {
+			$response = call_user_func( $callback, $request );
+			if ( $response instanceof WP_REST_Response ) {
+				$response->header( 'X-WC-Cache', 'SKIP' );
+			}
+			return $response;
+		}
+
+		$cached_response = $this->get_cached_response( $request, $cached_config );
+
+		if ( $cached_response ) {
+			$cached_response->header( 'X-WC-Cache', 'HIT' );
+			return $cached_response;
+		}
+
+		$authoritative_response = call_user_func( $callback, $request );
+
+		return $this->maybe_cache_response( $request, $authoritative_response, $cached_config );
+	}
+
+	/**
+	 * Check if caching should be used for a particular incoming request.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @param array           $config  Caching configuration.
+	 * @return bool True if caching should be used, false otherwise.
+	 */
+	private function should_use_cache_for_request( WP_REST_Request $request, array $config ): bool {
+		$endpoint_id = $config['endpoint_id'] ?? null;
+
+		// Check for explicit skip parameter.
+		$skip_cache   = $request->get_param( '_skip_cache' );
+		$should_cache = ! ( 'true' === $skip_cache || '1' === $skip_cache );
+
+		// Check custom must_cache callback.
+		if ( $should_cache ) {
+			$must_cache_fn = $config['must_cache'] ?? array( $this, 'must_cache' );
+			$should_cache  = call_user_func( $must_cache_fn, $request, $endpoint_id );
+		}
+
+		/**
+		 * Filter whether to enable response caching for a given REST API controller.
+		 *
+		 * Based on the _skip_cache parameter and must_cache callback evaluation,
+		 * the first parameter indicates whether caching should be enabled.
+		 * This filter can override that decision.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param bool            $enable_caching Whether to enable response caching (result of !_skip_cache && must_cache evaluation).
+		 * @param object          $controller     The controller instance.
+		 * @param WP_REST_Request $request        The request object.
+		 * @param string|null     $endpoint_id    Optional friendly identifier for the endpoint.
+		 * @return bool True to enable response caching, false to disable.
+		 */
+		return apply_filters(
+			'woocommerce_rest_api_enable_response_caching',
+			$should_cache,
+			$this,
+			$request,
+			$endpoint_id
+		);
+	}
+
+	/**
+	 * Build the output cache entry configuration from the request and per-endpoint config.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @param array           $config  Raw configuration array passed to with_cache.
+	 * @return array|null Normalized cache config with keys: endpoint_id, entity_type, cache_ttl, extract_entity_ids, relevant_hooks, vary_by_user, cache_key. Returns null if entity type is not available.
+	 */
+	private function build_cache_config( WP_REST_Request $request, array $config ): ?array {
+		$endpoint_id  = $config['endpoint_id'] ?? null;
+		$entity_type  = $config['entity_type'] ?? $this->get_default_entity_type();
+		$vary_by_user = $config['vary_by_user'] ?? $this->response_cache_vary_by_user( $request, $endpoint_id );
+
+		if ( ! $entity_type ) {
+			wc_get_container()->get( LegacyProxy::class )->call_function(
+				'wc_doing_it_wrong',
+				__METHOD__,
+				'No entity type provided and no default entity type available. Skipping cache.',
+				'10.4.0'
+			);
+			return null;
+		}
+
+		return array(
+			'endpoint_id'        => $endpoint_id,
+			'entity_type'        => $entity_type,
+			'cache_ttl'          => $config['cache_ttl'] ?? $this->get_cache_ttl( $request, $endpoint_id ),
+			'extract_entity_ids' => $config['extract_entity_ids'] ?? array( $this, 'extract_entity_ids' ),
+			'relevant_hooks'     => $config['relevant_hooks'] ?? $this->get_hooks_relevant_to_caching( $request, $endpoint_id ),
+			'vary_by_user'       => $vary_by_user,
+			'exclude_headers'    => $config['exclude_headers'] ?? $this->get_response_headers_to_exclude_from_caching( $request, $endpoint_id ),
+			'cache_key'          => $this->get_cache_key( $request, $entity_type, $vary_by_user, $endpoint_id ),
+		);
+	}
+
+	/**
+	 * Cache the response if it's successful and return it with appropriate headers.
+	 *
+	 * Only caches responses with 2xx status codes. Always adds the X-WC-Cache header
+	 * with value MISS if the response was cached, or SKIP if it was not cached.
+	 *
+	 * @param WP_REST_Request            $request       The request object.
+	 * @param WP_REST_Response|\WP_Error $response      The response to potentially cache.
+	 * @param array                      $cached_config Built caching configuration from build_cache_config().
+	 * @return WP_REST_Response|\WP_Error The response with appropriate cache headers.
+	 */
+	private function maybe_cache_response( WP_REST_Request $request, $response, array $cached_config ) {
+		if ( ! ( $response instanceof WP_REST_Response ) ) {
+			return $response;
+		}
+
+		$cached = false;
+
+		$status = $response->get_status();
+		if ( $status >= 200 && $status <= 299 ) {
+			$data       = $response->get_data();
+			$entity_ids = call_user_func( $cached_config['extract_entity_ids'], $data, $request, $cached_config['endpoint_id'] );
+
+			$response_headers  = $response->get_headers();
+			$cacheable_headers = $this->filter_cacheable_headers( $response_headers, $cached_config['exclude_headers'] );
+
+			$this->store_cached_response(
+				$cached_config['cache_key'],
+				$data,
+				$status,
+				$cached_config['entity_type'],
+				$entity_ids,
+				$cached_config['cache_ttl'],
+				$cached_config['relevant_hooks'],
+				$cacheable_headers
+			);
+
+			$cached = true;
+		}
+
+		$response->header( 'X-WC-Cache', $cached ? 'MISS' : 'SKIP' );
+		return $response;
+	}
+
+	/**
+	 * Get the default type for entities included in responses.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('entity_type' key).
+	 *
+	 * @return string|null Entity type (e.g., 'product', 'order'), or null if no controller-wide default.
+	 */
+	protected function get_default_entity_type(): ?string {
+		return null;
+	}
+
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
+
+	/**
+	 * Determine whether the response cache should vary by user.
+	 *
+	 * When true, the user ID is included in the cache key, making responses
+	 * user-specific. This is useful for endpoints that return user-specific data.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('vary_by_user' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return bool True to make cache user-specific, false otherwise.
+	 */
+	protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return true;
+	}
+
+	/**
+	 * Get the names of filters that can customize the response.
+	 *
+	 * All the existing instances of add_action/add_filter for these filters
+	 * will be included in the information that gets cached together with the response,
+	 * and if any of these has changed when the cached response is retrieved,
+	 * the cache entry will be invalidated.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('relevant_hooks' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array Array of filter names to track.
+	 */
+	protected function get_hooks_relevant_to_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return array();
+	}
+
+	/**
+	 * Get the TTL (Time To Live) for a cached response in seconds.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('cache_ttl' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return int Cache TTL in seconds.
+	 */
+	protected function get_cache_ttl( WP_REST_Request $request, ?string $endpoint_id = null ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return HOUR_IN_SECONDS;
+	}
+
+	/**
+	 * Determine whether a given request should be cached.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('must_cache' key).
+	 *
+	 * Note: Additionally, the _skip_cache query parameter and the woocommerce_rest_api_enable_response_caching filter
+	 * can be used to control the enabling of caching for a given request.
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return bool True to cache the request, false to skip caching.
+	 */
+	protected function must_cache( WP_REST_Request $request, ?string $endpoint_id = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return true;
+	}
+
+	/**
+	 * Get response headers to exclude from caching.
+	 *
+	 * These headers will not be stored in the cache. Certain headers
+	 * are always excluded (X-WC-Cache, Set-Cookie, Date, Expires, Last-Modified,
+	 * Age, ETag, Cache-Control, Pragma) as they don't make sense to cache.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('exclude_headers' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array Array of header names to exclude (case-insensitive).
+	 */
+	protected function get_response_headers_to_exclude_from_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return array();
+	}
+
+	// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter
+
+	/**
+	 * Extract entity IDs from response data.
+	 *
+	 * The default implementation assumes the response is either:
+	 * - An array with an 'id' field (single item)
+	 * - An array of arrays each having an 'id' field (collection)
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('extract_entity_ids' key).
+	 *
+	 * @param array           $data        Response data.
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array Array of entity IDs.
+	 */
+	protected function extract_entity_ids( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$ids = array();
+
+		if ( isset( $data[0] ) && is_array( $data[0] ) ) {
+			foreach ( $data as $item ) {
+				if ( isset( $item['id'] ) ) {
+					$ids[] = $item['id'];
+				}
+			}
+		} elseif ( isset( $data['id'] ) ) {
+			$ids[] = $data['id'];
+		}
+
+		// Filter out null/false values but keep 0 and empty strings as they could be valid IDs.
+		return array_unique(
+			array_filter(
+				$ids,
+				function ( $id ) {
+					return ! is_null( $id ) && false !== $id;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Filter response headers to get only those that should be cached.
+	 *
+	 * Always excludes certain headers that don't make sense to cache:
+	 * X-WC-Cache, Set-Cookie, Date, Expires, Last-Modified, Age, ETag, Cache-Control, Pragma.
+	 *
+	 * @param array $headers         Response headers.
+	 * @param array $exclude_headers Additional header names to exclude (case-insensitive).
+	 * @return array Filtered headers array.
+	 */
+	private function filter_cacheable_headers( array $headers, array $exclude_headers ): array {
+		$always_exclude = array(
+			'X-WC-Cache',
+			'Set-Cookie',
+			'Date',
+			'Expires',
+			'Last-Modified',
+			'Age',
+			'ETag',
+			'Cache-Control',
+			'Pragma',
+		);
+
+		$all_exclude_lowercase = array_map( 'strtolower', array_merge( $always_exclude, $exclude_headers ) );
+
+		return array_filter(
+			$headers,
+			function ( $name ) use ( $all_exclude_lowercase ) {
+				return ! in_array( strtolower( $name ), $all_exclude_lowercase, true );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+	}
+
+	/**
+	 * Get cache key information that uniquely identifies a request.
+	 *
+	 * Controllers can override this method to customize what information
+	 * uniquely identifies a request for caching purposes.
+	 *
+	 * @param WP_REST_Request $request      The request object.
+	 * @param bool            $vary_by_user Whether to include user ID in cache key.
+	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
+	 * @return array Array of cache key information parts.
+	 */
+	protected function get_cache_key_info( WP_REST_Request $request, bool $vary_by_user = false, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$request_query_params = $request->get_query_params();
+		if ( is_array( $request_query_params ) ) {
+			ksort( $request_query_params );
+		}
+		$cache_key_parts = array(
+			$request->get_route(),
+			wp_json_encode( $request_query_params ),
+		);
+
+		if ( $vary_by_user ) {
+			$user_id           = wc_get_container()->get( LegacyProxy::class )->call_function( 'get_current_user_id' );
+			$cache_key_parts[] = "user_{$user_id}";
+		}
+
+		return $cache_key_parts;
+	}
+
+	/**
+	 * Generate a cache key for a given request.
+	 *
+	 * @param WP_REST_Request $request      The request object.
+	 * @param string          $entity_type  The entity type.
+	 * @param bool            $vary_by_user Whether to include user ID in cache key.
+	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
+	 * @return string Cache key.
+	 */
+	private function get_cache_key( WP_REST_Request $request, string $entity_type, bool $vary_by_user = false, ?string $endpoint_id = null ): string {
+		$cache_key_parts = $this->get_cache_key_info( $request, $vary_by_user, $endpoint_id );
+
+		/**
+		 * Filter the information used to generate the cache key for a REST API request.
+		 *
+		 * Allows customization of what uniquely identifies a request for caching purposes.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param array           $cache_key_parts Array of cache key information parts.
+		 * @param WP_REST_Request $request         The request object.
+		 * @param bool            $vary_by_user    Whether user ID is included in cache key.
+		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint.
+		 * @param object          $controller      The controller instance.
+		 * @return array Filtered cache key information parts.
+		 */
+		$cache_key_parts = apply_filters(
+			'woocommerce_rest_api_cache_key_info',
+			$cache_key_parts,
+			$request,
+			$vary_by_user,
+			$endpoint_id,
+			$this
+		);
+
+		$request_hash = md5( implode( '-', $cache_key_parts ) );
+		return "wc_rest_api_cache_{$entity_type}-{$request_hash}";
+	}
+
+	/**
+	 * Generate a hash based on the actual usages of the hooks that affect the response.
+	 *
+	 * @param array $filter_names Array of hook names to track.
+	 * @return string Hooks hash.
+	 */
+	private function generate_hooks_hash( array $filter_names ): string {
+		if ( empty( $filter_names ) ) {
+			return '';
+		}
+
+		global $wp_filter;
+
+		$cache_hash_data = array();
+
+		foreach ( $filter_names as $filter_name ) {
+			if ( empty( $wp_filter[ $filter_name ] ) ) {
+				continue;
+			}
+
+			$cache_hash_data[ $filter_name ] = array();
+			$callbacks_by_priority           = $wp_filter[ $filter_name ]->callbacks ?? array();
+
+			foreach ( $callbacks_by_priority as $priority => $callbacks ) {
+				$normalized = array();
+				foreach ( $callbacks as $cb ) {
+					if ( ! isset( $cb['function'] ) ) {
+						continue;
+					}
+					$normalized[] = $this->normalize_callback_for_hash( $cb['function'] );
+				}
+				if ( $normalized ) {
+					$cache_hash_data[ $filter_name ][ $priority ] = array_values( array_unique( $normalized ) );
+				}
+			}
+		}
+
+		/**
+		 * Filter the data used to generate the hooks hash for REST API response caching.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param array  $cache_hash_data Hook callbacks data used for hash generation.
+		 * @param array  $filter_names    Filter names being tracked.
+		 * @param object $controller      Controller instance.
+		 */
+		$cache_hash_data = apply_filters(
+			'woocommerce_rest_api_cache_hooks_hash_data',
+			$cache_hash_data,
+			$filter_names,
+			$this
+		);
+
+		return md5( wp_json_encode( $cache_hash_data ) );
+	}
+
+	/**
+	 * Normalize a hook callback into a stable string for hashing.
+	 *
+	 * Converts various callback types to stable string representations to ensure
+	 * consistent hash generation across requests. This prevents spurious cache
+	 * invalidations caused by callback serialization inconsistencies.
+	 *
+	 * @param mixed $callback A WordPress hook callback.
+	 * @return string Normalized callback representation.
+	 */
+	private function normalize_callback_for_hash( $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$class = is_object( $callback[0] ) ? get_class( $callback[0] ) : $callback[0];
+			return "{$class}::{$callback[1]}";
+		}
+
+		if ( $callback instanceof \Closure ) {
+			return 'Closure@' . spl_object_hash( $callback );
+		}
+
+		if ( is_object( $callback ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return 'unknown_callback';
+	}
+
+	/**
+	 * Get a cached response, but only if it's valid
+	 * (otherwise the cached response will be invalidated).
+	 *
+	 * @param WP_REST_Request $request       The request object.
+	 * @param array           $cached_config Built caching configuration from build_cache_config().
+	 * @return WP_REST_Response|null Cached response, or null if not available or has been invalidated.
+	 */
+	private function get_cached_response( WP_REST_Request $request, array $cached_config ): ?WP_REST_Response {
+		$cache_key      = $cached_config['cache_key'];
+		$entity_type    = $cached_config['entity_type'];
+		$cache_ttl      = $cached_config['cache_ttl'];
+		$relevant_hooks = $cached_config['relevant_hooks'];
+
+		$cached = $this->get_cached( $cache_key );
+
+		if ( ! $cached || ! isset( $cached['data'], $cached['entity_versions'], $cached['created_at'] ) ) {
+			return null;
+		}
+
+		$current_time    = wc_get_container()->get( LegacyProxy::class )->call_function( 'time' );
+		$expiration_time = $cached['created_at'] + $cache_ttl;
+		if ( $current_time >= $expiration_time ) {
+			$this->delete_cached( $cache_key );
+			return null;
+		}
+
+		if ( ! empty( $relevant_hooks ) ) {
+			$current_hooks_hash = $this->generate_hooks_hash( $relevant_hooks );
+			$cached_hooks_hash  = $cached['hooks_hash'] ?? '';
+
+			if ( $current_hooks_hash !== $cached_hooks_hash ) {
+				$this->delete_cached( $cache_key );
+				return null;
+			}
+		}
+
+		foreach ( $cached['entity_versions'] as $entity_id => $cached_version ) {
+			$current_version = $this->entity_versions_cache->get_entity_version( $entity_type, $entity_id );
+			if ( $current_version !== $cached_version ) {
+				$this->delete_cached( $cache_key );
+				return null;
+			}
+		}
+
+		// In this point the cached response is valid.
+		$status_code = $cached['status_code'] ?? 200;
+		$response    = new WP_REST_Response( $cached['data'], $status_code );
+
+		if ( ! empty( $cached['headers'] ) ) {
+			foreach ( $cached['headers'] as $name => $value ) {
+				$response->header( $name, $value );
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Store a response in cache.
+	 *
+	 * @param string $cache_key        The cache key.
+	 * @param array  $data             The response data to cache.
+	 * @param int    $status_code      The HTTP status code of the response.
+	 * @param string $entity_type      The entity type.
+	 * @param array  $entity_ids       Array of entity IDs in the response.
+	 * @param int    $cache_ttl        Cache TTL in seconds.
+	 * @param array  $relevant_hooks   Hook names to track for invalidation.
+	 * @param array  $headers          Response headers to cache.
+	 */
+	private function store_cached_response( string $cache_key, array $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl, array $relevant_hooks, array $headers = array() ): void {
+		$entity_versions = array();
+		foreach ( $entity_ids as $entity_id ) {
+			$version = $this->entity_versions_cache->get_entity_version( $entity_type, $entity_id );
+			if ( $version ) {
+				$entity_versions[ $entity_id ] = $version;
+			}
+		}
+
+		$cache_data = array(
+			'data'            => $data,
+			'entity_versions' => $entity_versions,
+			'created_at'      => wc_get_container()->get( LegacyProxy::class )->call_function( 'time' ),
+		);
+
+		if ( 200 !== $status_code ) {
+			$cache_data['status_code'] = $status_code;
+		}
+
+		if ( ! empty( $relevant_hooks ) ) {
+			$cache_data['hooks_hash'] = $this->generate_hooks_hash( $relevant_hooks );
+		}
+
+		if ( ! empty( $headers ) ) {
+			$cache_data['headers'] = $headers;
+		}
+
+		$this->set_cached( $cache_key, $cache_data, $cache_ttl );
+	}
+
+	/**
+	 * Get a value from the cache.
+	 *
+	 * @param string $cache_key The cache key.
+	 * @return mixed|false The cached value or false if not found.
+	 */
+	protected function get_cached( string $cache_key ) {
+		/**
+		 * Filter to override the REST API cache get operation.
+		 *
+		 * If this filter returns a non-null value, that value will be used as the cached value
+		 * and the default wp_cache_get call will be bypassed.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param mixed|null $pre_value  The pre-filtered value (null to use default behavior).
+		 * @param string     $cache_key  The cache key.
+		 * @return mixed|null The cached value, or null to use default behavior.
+		 */
+		$value = apply_filters( 'woocommerce_pre_rest_api_cache_get', null, $cache_key );
+
+		if ( ! is_null( $value ) ) {
+			return $value;
+		}
+
+		return wp_cache_get( $cache_key, 'woocommerce_rest_api_cache' );
+	}
+
+	/**
+	 * Set a value in the cache.
+	 *
+	 * @param string $cache_key The cache key.
+	 * @param mixed  $value     The value to cache.
+	 * @param int    $ttl       Time to live in seconds.
+	 * @return bool True on success, false on failure.
+	 */
+	protected function set_cached( string $cache_key, $value, int $ttl ): bool {
+		/**
+		 * Filter to override the REST API cache set operation.
+		 *
+		 * If this filter returns a non-null value, that value will be used as the result
+		 * and the default wp_cache_set call will be bypassed.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param bool|null $pre_result The pre-filtered result (null to use default behavior).
+		 * @param string    $cache_key  The cache key.
+		 * @param mixed     $value      The value to cache.
+		 * @param int       $ttl        Time to live in seconds.
+		 * @return bool|null True on success, false on failure, or null to use default behavior.
+		 */
+		$result = apply_filters( 'woocommerce_pre_rest_api_cache_set', null, $cache_key, $value, $ttl );
+
+		if ( ! is_null( $result ) ) {
+			return $result;
+		}
+
+		return wp_cache_set( $cache_key, $value, 'woocommerce_rest_api_cache', $ttl );
+	}
+
+	/**
+	 * Delete a value from the cache.
+	 *
+	 * @param string $cache_key The cache key.
+	 * @return bool True on success, false on failure.
+	 */
+	protected function delete_cached( string $cache_key ): bool {
+		/**
+		 * Filter to override the REST API cache delete operation.
+		 *
+		 * If this filter returns a non-null value, that value will be used as the result
+		 * and the default wp_cache_delete call will be bypassed.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param bool|null $pre_result The pre-filtered result (null to use default behavior).
+		 * @param string    $cache_key  The cache key.
+		 * @return bool|null True on success, false on failure, or null to use default behavior.
+		 */
+		$result = apply_filters( 'woocommerce_pre_rest_api_cache_delete', null, $cache_key );
+
+		if ( ! is_null( $result ) ) {
+			return $result;
+		}
+
+		return wp_cache_delete( $cache_key, 'woocommerce_rest_api_cache' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -1,0 +1,2024 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\Traits;
+
+use Automattic\WooCommerce\Internal\Caches\EntityVersionKeysCache;
+use Automattic\WooCommerce\Internal\Traits\RestApiCache;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_Error;
+
+/**
+ * Tests for the RestApiCache trait.
+ *
+ * Worth knowing:
+ *
+ * - A trait can't be used directly, so for each test we instantiate
+ *   a test controller class that uses it and has customization points
+ *   (see create_test_controller).
+ * - We use a mock version of EntityVersionKeysCache that stores cached entries
+ *   in a local array, for easier testing.
+ *
+ * IMPORTANT: If you add new tests, find the "TESTS END HERE" comment
+ * and add them before that point.
+ */
+class RestApiCacheTest extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var object
+	 */
+	private $sut;
+
+	/**
+	 * Mock EntityVersionKeysCache instance.
+	 *
+	 * @var object
+	 */
+	private $mock_entity_cache;
+
+	/**
+	 * REST API server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	protected $server;
+
+	/**
+	 * Fixed timestamp for testing.
+	 *
+	 * @var int
+	 */
+	private $fixed_time = 1234567890;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array(
+				'time' => function () {
+					return $this->fixed_time;
+				},
+			)
+		);
+
+		$this->mock_entity_cache = $this->create_mock_entity_version_keys_cache();
+		wc_get_container()->replace( EntityVersionKeysCache::class, $this->mock_entity_cache );
+
+		$this->sut = $this->create_test_controller();
+
+		// Set up filters for entity version keys cache to use the mock's array.
+		add_filter(
+			'woocommerce_pre_entity_version_keys_cache_get',
+			function ( $pre_value, $cache_key ) {
+				return $this->mock_entity_cache->cache[ $cache_key ]['value'] ?? null;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_pre_entity_version_keys_cache_set',
+			function ( $pre_result, $cache_key, $value, $ttl ) {
+				$this->mock_entity_cache->cache[ $cache_key ] = array(
+					'value' => $value,
+					'ttl'   => $ttl,
+				);
+				return true;
+			},
+			10,
+			4
+		);
+
+		add_filter(
+			'woocommerce_pre_entity_version_keys_cache_delete',
+			function ( $pre_result, $cache_key ) {
+				unset( $this->mock_entity_cache->cache[ $cache_key ] );
+				return true;
+			},
+			10,
+			2
+		);
+
+		// Set up filters to use the controller's local cache array.
+		add_filter(
+			'woocommerce_pre_rest_api_cache_get',
+			function ( $pre_value, $cache_key ) {
+				return $this->sut->cache[ $cache_key ] ?? false;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_pre_rest_api_cache_set',
+			function ( $pre_result, $cache_key, $value, $ttl ) {
+				$this->sut->cache[ $cache_key ] = $value;
+				return true;
+			},
+			10,
+			4
+		);
+
+		add_filter(
+			'woocommerce_pre_rest_api_cache_delete',
+			function ( $pre_result, $cache_key ) {
+				unset( $this->sut->cache[ $cache_key ] );
+				return true;
+			},
+			10,
+			2
+		);
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'rest_api_init' );
+		$this->sut->register_routes();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		// Remove the cache filters.
+		remove_all_filters( 'woocommerce_pre_entity_version_keys_cache_get' );
+		remove_all_filters( 'woocommerce_pre_entity_version_keys_cache_set' );
+		remove_all_filters( 'woocommerce_pre_entity_version_keys_cache_delete' );
+		remove_all_filters( 'woocommerce_pre_rest_api_cache_get' );
+		remove_all_filters( 'woocommerce_pre_rest_api_cache_set' );
+		remove_all_filters( 'woocommerce_pre_rest_api_cache_delete' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox First request returns MISS and caches response, second request returns HIT with cached data.
+	 */
+	public function test_caching_workflow_miss_then_hit() {
+		$response1 = $this->query_endpoint( 'multiple_entities' );
+
+		// Verify response.
+
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertEquals( $this->sut->responses['multiple_entities'], $response1->get_data() );
+
+		// Verify the structure and contents of the cache entry for the response.
+
+		$this->assertCount( 1, $this->sut->cache );
+		$cache_key    = array_key_first( $this->sut->cache );
+		$cached_entry = $this->sut->cache[ $cache_key ];
+
+		$this->assertArrayHasKey( 'data', $cached_entry );
+		$this->assertArrayHasKey( 'entity_versions', $cached_entry );
+		$this->assertArrayHasKey( 'created_at', $cached_entry );
+		$this->assertEquals( $this->sut->responses['multiple_entities'], $cached_entry['data'] );
+		$this->assertEquals( $this->fixed_time, $cached_entry['created_at'] );
+		$this->assertCount( 2, $cached_entry['entity_versions'] );
+		$this->assertArrayHasKey( 2, $cached_entry['entity_versions'] );
+		$this->assertArrayHasKey( 3, $cached_entry['entity_versions'] );
+
+		// Verify versions were created in entity cache.
+
+		$this->assertNotEmpty( $this->mock_entity_cache->get_entity_version( 'product', 2 ) );
+		$this->assertNotEmpty( $this->mock_entity_cache->get_entity_version( 'product', 3 ) );
+
+		// Modify the cached response data and query again,
+		// the response should be a cache HIT with the modified data.
+
+		$modified_data                          = array(
+			array(
+				'id'   => 999,
+				'name' => 'Modified Product',
+			),
+		);
+		$this->sut->cache[ $cache_key ]['data'] = $modified_data;
+
+		$response2 = $this->query_endpoint( 'multiple_entities' );
+
+		$this->assertCacheHitHeader( $response2 );
+		$this->assertEquals( $modified_data, $response2->get_data() );
+		$this->assertNotEquals( $this->sut->responses['multiple_entities'], $response2->get_data() );
+	}
+
+	/**
+	 * @testdox Expired cache entries are rejected and deleted.
+	 */
+	public function test_expired_cache_entries_are_rejected() {
+
+		// First request - cache MISS, creates cache entry.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Advance time beyond TTL (default is HOUR_IN_SECONDS = 3600).
+
+		$this->fixed_time += HOUR_IN_SECONDS + 1;
+
+		// Third request after expiration - should be cache MISS.
+
+		$response3 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify exactly one cache entry exists (old deleted, new created)
+		// and the cache entry is new (created_at timestamp changed).
+		$this->assertCount( 1, $this->sut->cache );
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+	}
+
+	/**
+	 * @testdox Cache is invalidated when relevant hooks change.
+	 */
+	public function test_cache_invalidated_when_hooks_change() {
+
+		// Configure custom_endpoint_config endpoint with relevant_hooks.
+
+		$this->reconfigure_custom_endpoint_config_endpoint(
+			array(
+				'relevant_hooks' => array( 'test_hook_for_caching' ),
+			)
+		);
+
+		// First request - cache MISS, creates cache entry.
+
+		$response1 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Add a filter to the relevant hook to change the hooks hash.
+
+		add_filter( 'test_hook_for_caching', '__return_true' );
+
+		// Advance time to ensure new cache entry has different timestamp.
+
+		$this->fixed_time += 1;
+
+		// Third request after hooks changed - should be cache MISS.
+
+		$response3 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify exactly one cache entry exists (old deleted, new created).
+		// and the cache entry is new (created_at timestamp changed).
+
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCount( 1, $this->sut->cache );
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+
+		// Clean up.
+
+		remove_filter( 'test_hook_for_caching', '__return_true' );
+	}
+
+	/**
+	 * @testdox Cache is invalidated when controller-level hooks change.
+	 */
+	public function test_cache_invalidated_when_controller_hooks_change() {
+		// First request to single_entity - cache MISS, creates cache entry.
+		// single_entity uses controller-level hooks from get_hooks_relevant_to_caching().
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Add a filter to the controller-level hook to change the hooks hash.
+
+		add_filter( 'test_controller_hook_for_caching', '__return_false' );
+
+		// Advance time to ensure new cache entry has different timestamp.
+
+		$this->fixed_time += 1;
+
+		// Third request after hooks changed - should be cache MISS.
+
+		$response3 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify exactly one cache entry exists (old deleted, new created),
+		// and the cache entry is new (created_at timestamp changed).
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Clean up.
+
+		remove_filter( 'test_controller_hook_for_caching', '__return_false' );
+	}
+
+	/**
+	 * @testdox Entity ID extraction works for single entity responses.
+	 */
+	public function test_entity_id_extraction_for_single_entity() {
+		// First request to single_entity - cache MISS, creates cache entry.
+		// single_entity returns single entity with id=1.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Modify the entity version for entity 1 (the entity in the response).
+
+		$this->mock_entity_cache->regenerate_entity_version( 'product', 1 );
+
+		// Advance time to ensure new cache entry has different timestamp.
+
+		$this->fixed_time += 1;
+
+		// Third request after entity 1 version changed - should be cache MISS.
+
+		$response3 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify exactly one cache entry exists (old deleted, new created),
+		// and the cache entry is new (created_at timestamp changed).
+		$this->assertCount( 1, $this->sut->cache );
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+
+		// Verify that modifying a different entity (e.g., entity 2) does NOT invalidate cache.
+
+		$old_cache_info2 = $this->get_cache_info();
+		$this->mock_entity_cache->regenerate_entity_version( 'product', 2 );
+		$this->fixed_time += 1;
+
+		// Fourth request - should still be cache HIT (entity 2 change doesn't affect entity 1 cache).
+
+		$response4 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response4 );
+
+		// Verify cache entry was not recreated.
+
+		$new_cache_info2 = $this->get_cache_info();
+		$this->assertCacheInfoEqual( $old_cache_info2, $new_cache_info2 );
+	}
+
+	/**
+	 * @testdox Custom entity ID extraction works correctly.
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_custom_entity_id_extraction( bool $use_with_cache_config ) {
+
+		if ( $use_with_cache_config ) {
+			// Configure custom_endpoint_config endpoint with custom extract_entity_ids callback.
+			$this->reconfigure_custom_endpoint_config_endpoint(
+				array(
+					// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+					'extract_entity_ids' => fn( $data, $request ) => array( $data['id'] * 10 ),
+				)
+			);
+			$endpoint           = 'custom_endpoint_config';
+			$original_entity_id = 6;
+			$extracted_id       = 60;
+		} else {
+			// Enable custom entity ID extraction via controller method (IDs multiplied by 10).
+			$this->sut->use_custom_entity_id_extraction = true;
+			$endpoint                                   = 'single_entity';
+			$original_entity_id                         = 1;
+			$extracted_id                               = 10;
+		}
+
+		// First request - cache MISS, creates cache entry with custom extracted ID.
+
+		$response1 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Verify cache entry stores modified entity ID (original * 10).
+
+		$cache_entry = array_values( $this->sut->cache )[0];
+		$entity_ids  = array_keys( $cache_entry['entity_versions'] );
+		$this->assertEquals( array( $extracted_id ), $entity_ids, "Cache should store custom extracted entity ID ({$original_entity_id} * 10 = {$extracted_id})" );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Modify entity version for the extracted ID.
+
+		$this->mock_entity_cache->regenerate_entity_version( 'product', $extracted_id );
+		$this->fixed_time += 1;
+
+		// Third request - should be cache MISS (extracted entity changed).
+
+		$response3 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify cache was recreated.
+
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+
+		// Verify that modifying the original entity ID does NOT invalidate cache.
+
+		$old_cache_info2 = $this->get_cache_info();
+		$this->mock_entity_cache->regenerate_entity_version( 'product', $original_entity_id );
+		$this->fixed_time += 1;
+
+		// Fourth request - should still be cache HIT (original entity change doesn't affect cache tracking extracted entity).
+
+		$response4 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response4 );
+
+		// Verify cache entry was not recreated.
+
+		$new_cache_info2 = $this->get_cache_info();
+		$this->assertCacheInfoEqual( $old_cache_info2, $new_cache_info2 );
+
+		// Reset custom extraction if using controller method.
+
+		if ( ! $use_with_cache_config ) {
+			$this->sut->use_custom_entity_id_extraction = false;
+		}
+	}
+
+	/**
+	 * @testdox Cache is invalidated when entity versions change for collection responses.
+	 * @testWith [1, false]
+	 *           [2, true]
+	 *           [3, true]
+	 *           [999, false]
+	 *
+	 * @param int  $entity_id                   Entity ID to modify.
+	 * @param bool $cache_invalidation_expected Whether cache invalidation is expected.
+	 */
+	public function test_cache_invalidated_when_entity_version_changes( int $entity_id, bool $cache_invalidation_expected ) {
+
+		// First request to multiple_entities - cache MISS, creates cache entry.
+		// multiple_entities returns collection with entities 2, 3, and one without ID.
+
+		$response1 = $this->query_endpoint( 'multiple_entities' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'multiple_entities' );
+
+		$this->assertCacheHitHeader( $response2 );
+
+		// Modify the entity version for the specified entity.
+
+		$this->mock_entity_cache->regenerate_entity_version( 'product', $entity_id );
+
+		// Advance time to ensure new cache entry has different timestamp.
+
+		$this->fixed_time += 1;
+
+		// Third request after entity version changed.
+
+		$response3 = $this->query_endpoint( 'multiple_entities' );
+
+		if ( $cache_invalidation_expected ) {
+
+			// Cache should be invalidated (MISS).
+
+			$this->assertCacheMissHeader( $response3 );
+
+			// Verify exactly one cache entry exists (old deleted, new created).
+
+			$this->assertCount( 1, $this->sut->cache );
+
+			// Verify the cache entry is new (created_at timestamp changed).
+
+			$new_cache_info = $this->get_cache_info();
+			$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+		} else {
+			// Cache should still be valid (HIT).
+
+			$this->assertCacheHitHeader( $response3 );
+
+			// Verify cache entry was not recreated (same created_at timestamp).
+
+			$new_cache_info = $this->get_cache_info();
+			$this->assertCacheInfoEqual( $old_cache_info, $new_cache_info );
+		}
+	}
+
+	/**
+	 * @testdox Custom cache TTL is respected.
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_custom_cache_ttl( bool $use_with_cache_config ) {
+
+		if ( $use_with_cache_config ) {
+			// Configure custom_endpoint_config endpoint with custom cache_ttl (20 seconds).
+			$this->reconfigure_custom_endpoint_config_endpoint(
+				array(
+					'cache_ttl' => 20,
+				)
+			);
+			$endpoint    = 'custom_endpoint_config';
+			$time_within = 15;
+			$time_beyond = 6;
+		} else {
+			// Set custom TTL to 10 seconds via controller property.
+			$this->sut->custom_cache_ttl = 10;
+			$endpoint                    = 'single_entity';
+			$time_within                 = 5;
+			$time_beyond                 = 6;
+		}
+
+		// First request - cache MISS, creates cache entry with custom TTL.
+
+		$response1 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Advance time (within TTL) - cache should still be valid.
+
+		$this->fixed_time += $time_within;
+
+		$response3 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response3 );
+
+		// Advance time beyond TTL.
+
+		$this->fixed_time += $time_beyond;
+
+		// Fourth request after custom TTL expiration - should be cache MISS.
+
+		$response4 = $this->query_endpoint( $endpoint );
+
+		$this->assertCacheMissHeader( $response4 );
+
+		// Verify exactly one cache entry exists (old deleted, new created).
+
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Verify the cache entry is new (created_at timestamp changed).
+
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+
+		// Reset custom TTL if using controller method.
+
+		if ( ! $use_with_cache_config ) {
+			$this->sut->custom_cache_ttl = null;
+		}
+	}
+
+	/**
+	 * @testdox Custom entity type via with_cache config is respected.
+	 */
+	public function test_custom_entity_type_via_with_cache_config() {
+
+		// Configure custom_endpoint_config endpoint with custom entity_type.
+
+		$this->reconfigure_custom_endpoint_config_endpoint(
+			array(
+				'entity_type' => 'custom_entity',
+			)
+		);
+
+		// First request - cache MISS, creates cache entry.
+
+		$response1 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the old cache info for verification.
+
+		$old_cache_info = $this->get_cache_info();
+
+		// Second request immediately after - cache HIT.
+
+		$response2 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Modify entity version for 'custom_entity' type (not 'product').
+
+		$this->mock_entity_cache->regenerate_entity_version( 'custom_entity', 6 );
+
+		// Advance time to ensure new cache entry has different timestamp.
+
+		$this->fixed_time += 1;
+
+		// Third request after custom entity version changed - should be cache MISS.
+
+		$response3 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify exactly one cache entry exists (old deleted, new created).
+
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Verify the cache entry is new (created_at timestamp changed).
+
+		$new_cache_info = $this->get_cache_info();
+		$this->assertCacheInfoDifferent( $old_cache_info, $new_cache_info, $this->fixed_time );
+
+		// Verify that modifying 'product' entity does NOT invalidate cache for 'custom_entity'.
+
+		$old_cache_info2 = $this->get_cache_info();
+		$this->mock_entity_cache->regenerate_entity_version( 'product', 6 );
+		$this->fixed_time += 1;
+
+		// Fourth request - should still be cache HIT (product entity change doesn't affect custom_entity cache).
+
+		$response4 = $this->query_endpoint( 'custom_endpoint_config' );
+		$this->assertCacheHitHeader( $response4 );
+
+		// Verify cache entry was not recreated.
+
+		$new_cache_info2 = $this->get_cache_info();
+		$this->assertCacheInfoEqual( $old_cache_info2, $new_cache_info2 );
+	}
+
+	/**
+	 * @testdox Cache keys differ based on query string parameters.
+	 */
+	public function test_cache_key_depends_on_query_string() {
+
+		// First request without query string - should be a cache MISS.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+
+		// Verify response has MISS header and original data.
+
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertEquals( 200, $response1->get_status() );
+		$this->assertEquals( $this->sut->responses['single_entity'], $response1->get_data() );
+
+		// Store original response for later comparison.
+
+		$original_data = $response1->get_data();
+
+		// Verify response was cached.
+
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Modify the response in the controller for subsequent requests.
+
+		$modified_data                         = array(
+			'id'   => 999,
+			'name' => 'Modified Product',
+		);
+		$this->sut->responses['single_entity'] = $modified_data;
+
+		// Second request WITH query string - should be a cache MISS with modified data.
+
+		$response2 = $this->query_endpoint( 'single_entity', array( 'foo' => 'bar' ) );
+
+		// Verify response has MISS header and modified data.
+
+		$this->assertCacheMissHeader( $response2 );
+		$this->assertEquals( 200, $response2->get_status() );
+		$this->assertEquals( $modified_data, $response2->get_data() );
+
+		// Verify we now have two cache entries (different query strings = different cache keys).
+
+		$this->assertCount( 2, $this->sut->cache );
+
+		// Third request without query string - should be a cache HIT with original data.
+
+		$response3 = $this->query_endpoint( 'single_entity' );
+
+		// Verify response has HIT header and original cached data.
+
+		$this->assertCacheHitHeader( $response3 );
+		$this->assertEquals( 200, $response3->get_status() );
+		$this->assertEquals( $original_data, $response3->get_data() );
+		$this->assertNotEquals( $modified_data, $response3->get_data() );
+
+		// Fourth request WITH same query string - should be a cache HIT with modified data.
+
+		$response4 = $this->query_endpoint( 'single_entity', array( 'foo' => 'bar' ) );
+
+		// Verify response has HIT header and modified cached data.
+
+		$this->assertCacheHitHeader( $response4 );
+		$this->assertEquals( 200, $response4->get_status() );
+		$this->assertEquals( $modified_data, $response4->get_data() );
+		$this->assertNotEquals( $original_data, $response4->get_data() );
+
+		// Verify we still have exactly two cache entries (no new entries created).
+
+		$this->assertCount( 2, $this->sut->cache );
+	}
+
+	/**
+	 * @testdox Caching is skipped when _skip_cache parameter is set.
+	 * @testWith ["1"]
+	 *           ["true"]
+	 *
+	 * @param string $skip_cache_value Value for _skip_cache parameter ("1" or "true").
+	 */
+	public function test_skip_cache_parameter_bypasses_caching( $skip_cache_value ) {
+
+		// First request with _skip_cache - should be a cache SKIP.
+
+		$response1 = $this->query_endpoint( 'single_entity', array( '_skip_cache' => $skip_cache_value ) );
+
+		// Verify caching was skipped.
+
+		$this->assertCachingSkipped( $response1, $this->sut->responses['single_entity'] );
+
+		// Store original response for later comparison.
+
+		$original_data = $response1->get_data();
+
+		// Modify the response in the controller for subsequent requests.
+
+		$modified_data                         = array(
+			'id'   => 999,
+			'name' => 'Modified Product',
+		);
+		$this->sut->responses['single_entity'] = $modified_data;
+
+		// Second request with _skip_cache - should still be a cache SKIP with modified data.
+
+		$response2 = $this->query_endpoint( 'single_entity', array( '_skip_cache' => $skip_cache_value ) );
+
+		// Verify caching was still skipped with modified data.
+
+		$this->assertCachingSkipped( $response2, $modified_data );
+		$this->assertNotEquals( $original_data, $response2->get_data() );
+	}
+
+	/**
+	 * @testdox Caching is skipped (without X-WC-Cache header) when entity versions cache is disabled.
+	 */
+	public function test_caching_skipped_when_entity_cache_disabled() {
+
+		// Disable the entity version keys cache.
+
+		$this->mock_entity_cache->should_use_cache = false;
+
+		// Re-initialize the cache in the controller to pick up the disabled state.
+
+		$this->sut->reinitialize_cache();
+
+		// Request single_entity.
+
+		$response = $this->query_endpoint( 'single_entity' );
+
+		// Verify caching was skipped.
+
+		$this->assertNoCacheHeader( $response );
+	}
+
+	/**
+	 * @testdox Caching is skipped when woocommerce_rest_api_enable_response_caching filter returns false.
+	 */
+	public function test_caching_skipped_when_filter_returns_false() {
+
+		// Track filter calls and arguments.
+
+		$filter_called = false;
+		$filter_args   = array();
+
+		// Add filter that returns false and captures arguments.
+
+		add_filter(
+			'woocommerce_rest_api_enable_response_caching',
+			function ( $enabled, $controller, $request ) use ( &$filter_called, &$filter_args ) {
+				$filter_called = true;
+				$filter_args   = array(
+					'enabled'    => $enabled,
+					'controller' => $controller,
+					'request'    => $request,
+				);
+				return false;
+			},
+			10,
+			3
+		);
+
+		// Request single_entity.
+
+		$response = $this->query_endpoint( 'single_entity' );
+
+		// Verify filter was called with correct arguments.
+
+		$this->assertTrue( $filter_called, 'Filter should have been called' );
+		$this->assertTrue( $filter_args['enabled'], 'Default enabled value should be true' );
+		$this->assertSame( $this->sut, $filter_args['controller'], 'Controller should be passed to filter' );
+		$this->assertInstanceOf( WP_REST_Request::class, $filter_args['request'], 'Request should be passed to filter' );
+
+		// Verify caching was skipped.
+
+		$this->assertCachingSkipped( $response, $this->sut->responses['single_entity'] );
+
+		// Clean up filter.
+
+		remove_all_filters( 'woocommerce_rest_api_enable_response_caching' );
+	}
+
+	/**
+	 * @testdox Caching is skipped when must_cache returns false.
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_caching_skipped_when_must_cache_returns_false( bool $use_with_cache_config ) {
+
+		if ( $use_with_cache_config ) {
+			// Request false_must_cache endpoint which has a custom must_cache callback that returns false.
+			$endpoint = 'false_must_cache';
+		} else {
+			// Set controller's must_cache return value to false.
+			$this->sut->must_cache_return_value = false;
+			$endpoint                           = 'single_entity';
+		}
+
+		// Request endpoint.
+
+		$response = $this->query_endpoint( $endpoint );
+
+		// Verify caching was skipped.
+
+		$this->assertCachingSkipped( $response, $this->sut->responses[ $endpoint ] );
+	}
+
+	/**
+	 * @testdox Caching is skipped when no entity type is available and wc_doing_it_wrong is called.
+	 */
+	public function test_caching_skipped_when_no_entity_type_available() {
+
+		// Track wc_doing_it_wrong calls via LegacyProxy.
+
+		$doing_it_wrong_args = null;
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames
+				'wc_doing_it_wrong' => function ( $function, $message, $version ) use ( &$doing_it_wrong_args ) {
+					$doing_it_wrong_args = array(
+						'function' => $function,
+						'message'  => $message,
+						'version'  => $version,
+					);
+				},
+			)
+		);
+
+		// Override controller's get_default_entity_type to return null.
+
+		$this->sut->default_entity_type = null;
+
+		// Request single_entity endpoint (which doesn't specify entity_type in config).
+
+		$response = $this->query_endpoint( 'single_entity' );
+
+		// Verify wc_doing_it_wrong was called with correct arguments.
+
+		$this->assertNotNull( $doing_it_wrong_args, 'wc_doing_it_wrong should be called when no entity type is available' );
+		$this->assertStringContainsString( 'build_cache_config', $doing_it_wrong_args['function'] );
+		$this->assertStringContainsString( 'No entity type provided', $doing_it_wrong_args['message'] );
+		$this->assertEquals( '10.4.0', $doing_it_wrong_args['version'] );
+
+		// Verify caching was skipped.
+
+		$this->assertCachingSkipped( $response, $this->sut->responses['single_entity'] );
+	}
+
+	/**
+	 * @testdox Cache keys are unique per route and query string only (without user variance).
+	 */
+	public function test_cache_key_without_user_variance() {
+		$this->sut->vary_by_user_return_value = false;
+
+		// Mock get_current_user_id to return user 1.
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 1,
+			)
+		);
+
+		// First request by user 1 - cache MISS.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the cache key and modify cached data.
+
+		$cache_key                              = array_key_first( $this->sut->cache );
+		$modified_data                          = array(
+			'id'   => 999,
+			'name' => 'User 1 Modified',
+		);
+		$this->sut->cache[ $cache_key ]['data'] = $modified_data;
+
+		// Mock get_current_user_id to return user 2 (different user).
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 2,
+			)
+		);
+
+		// Second request by user 2 to same endpoint - should be cache HIT with user 1's data.
+		// (Since vary_by_user is false, user ID is NOT included in cache key).
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+		$this->assertEquals( $modified_data, $response2->get_data() );
+
+		// Verify still only one cache entry (same cache key for both users).
+
+		$this->assertCount( 1, $this->sut->cache );
+		$this->assertEquals( $cache_key, array_key_first( $this->sut->cache ), 'Cache key should be the same for different users when vary_by_user is false' );
+	}
+
+	/**
+	 * @testdox Cache varies by user when vary_by_user is enabled.
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_cache_varies_by_user( bool $use_with_cache_config ) {
+
+		if ( $use_with_cache_config ) {
+			// Configure custom_endpoint_config endpoint with vary_by_user: true.
+			$this->reconfigure_custom_endpoint_config_endpoint(
+				array(
+					'vary_by_user' => true,
+				)
+			);
+			$endpoint = 'custom_endpoint_config';
+		} else {
+			// Enable vary_by_user via controller method.
+			$this->sut->vary_by_user_return_value = true;
+			$endpoint                             = 'single_entity';
+		}
+
+		// Mock get_current_user_id to return user 1.
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 1,
+			)
+		);
+
+		// First request by user 1 - cache MISS.
+
+		$response1 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertEquals( $this->sut->responses[ $endpoint ], $response1->get_data() );
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store user 1's cache info and modify cached data.
+
+		$user1_cache_info = $this->get_cache_info();
+		$user1_data       = array(
+			'id'   => 101,
+			'name' => 'User 1 Data',
+		);
+		$this->sut->cache[ $user1_cache_info['key'] ]['data'] = $user1_data;
+
+		// Mock get_current_user_id to return user 2 (different user).
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 2,
+			)
+		);
+
+		// Second request by user 2 to same endpoint - should be cache MISS (different cache key).
+
+		$response2 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response2 );
+		$this->assertEquals( $this->sut->responses[ $endpoint ], $response2->get_data() );
+
+		// Verify we now have two cache entries (different users = different cache keys).
+
+		$this->assertCount( 2, $this->sut->cache );
+
+		// Store user 2's cache info and modify cached data.
+
+		$user2_cache_keys                             = array_diff( array_keys( $this->sut->cache ), array( $user1_cache_info['key'] ) );
+		$user2_cache_key                              = reset( $user2_cache_keys );
+		$user2_data                                   = array(
+			'id'   => 202,
+			'name' => 'User 2 Data',
+		);
+		$this->sut->cache[ $user2_cache_key ]['data'] = $user2_data;
+
+		// Third request by user 1 again - should be cache HIT with user 1's modified data.
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 1,
+			)
+		);
+
+		$response3 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response3 );
+		$this->assertEquals( $user1_data, $response3->get_data() );
+
+		// Fourth request by user 2 again - should be cache HIT with user 2's modified data.
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_current_user_id' => fn() => 2,
+			)
+		);
+
+		$response4 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response4 );
+		$this->assertEquals( $user2_data, $response4->get_data() );
+
+		// Verify still only two cache entries (one per user).
+
+		$this->assertCount( 2, $this->sut->cache );
+
+		// Verify cache keys are different.
+
+		$this->assertNotEquals( $user1_cache_info['key'], $user2_cache_key, 'Cache keys should differ for different users when vary_by_user is true' );
+
+		// Reset vary_by_user if using controller method.
+
+		if ( ! $use_with_cache_config ) {
+			$this->sut->vary_by_user_return_value = false;
+		}
+	}
+
+	/**
+	 * @testdox Response headers are cached and restored on cache hit.
+	 */
+	public function test_response_headers_are_cached() {
+		$this->sut->response_headers['single_entity'] = array(
+			'X-Custom-Header'  => 'custom-value',
+			'X-Another-Header' => 'another-value',
+		);
+
+		// First request - cache MISS.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response1 );
+
+		// Verify cache entry contains the custom headers.
+
+		$cache_key    = array_key_first( $this->sut->cache );
+		$cached_entry = $this->sut->cache[ $cache_key ];
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertEquals( 'custom-value', $cached_entry['headers']['X-Custom-Header'] );
+		$this->assertEquals( 'another-value', $cached_entry['headers']['X-Another-Header'] );
+
+		// Second request - cache HIT, should restore headers.
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+
+		// Verify custom headers are restored.
+
+		$headers = $response2->get_headers();
+		$this->assertEquals( 'custom-value', $headers['X-Custom-Header'] );
+		$this->assertEquals( 'another-value', $headers['X-Another-Header'] );
+	}
+
+	/**
+	 * @testdox Certain response headers are always excluded from caching.
+	 */
+	public function test_headers_always_excluded_from_caching() {
+		$this->sut->response_headers['single_entity'] = array(
+			'Set-Cookie'     => 'session=abc123',  // Always excluded.
+			'Date'           => 'Mon, 01 Jan 2024 00:00:00 GMT',  // Always excluded.
+			'X-Custom-Valid' => 'should-be-present',  // NOT excluded.
+		);
+
+		// First request - cache MISS.
+
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response1 );
+
+		// Verify cache entry does NOT contain always-excluded headers, but does contain valid custom header.
+
+		$cache_key    = array_key_first( $this->sut->cache );
+		$cached_entry = $this->sut->cache[ $cache_key ];
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'Set-Cookie', $cached_entry['headers'], 'Set-Cookie should be excluded from cache' );
+		$this->assertArrayNotHasKey( 'Date', $cached_entry['headers'], 'Date should be excluded from cache' );
+		$this->assertEquals( 'should-be-present', $cached_entry['headers']['X-Custom-Valid'] );
+
+		// Second request - cache HIT, verify excluded headers are NOT restored.
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHitHeader( $response2 );
+
+		$headers = $response2->get_headers();
+
+		// Verify always-excluded headers are NOT present.
+
+		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie header should not be cached' );
+		$this->assertArrayNotHasKey( 'Date', $headers, 'Date header should not be cached' );
+
+		// Verify non-excluded custom header IS present.
+
+		$this->assertEquals( 'should-be-present', $headers['X-Custom-Valid'] );
+	}
+
+	/**
+	 * @testdox Custom headers can be excluded from caching via controller method and endpoint config.
+	 *
+	 * @testWith [false]
+	 *           [true]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_custom_headers_excluded_from_caching( bool $use_with_cache_config ) {
+		if ( $use_with_cache_config ) {
+			$this->reconfigure_custom_endpoint_config_endpoint(
+				array(
+					'exclude_headers' => array( 'X-Custom-Exclude' ),
+				)
+			);
+			$endpoint = 'custom_endpoint_config';
+		} else {
+			$this->sut->custom_exclude_headers = array( 'X-Custom-Exclude' );
+			$endpoint                          = 'single_entity';
+		}
+
+		// Configure endpoint to return headers including custom-excluded ones.
+
+		$this->sut->response_headers[ $endpoint ] = array(
+			'X-Custom-Exclude' => 'should-not-be-cached',
+			'X-Custom-Include' => 'should-be-cached',
+		);
+
+		// First request - cache MISS.
+
+		$response1 = $this->query_endpoint( $endpoint );
+		$this->assertCacheMissHeader( $response1 );
+
+		// Verify cache entry does NOT contain custom-excluded header, but does contain included header.
+
+		$cache_key    = array_key_first( $this->sut->cache );
+		$cached_entry = $this->sut->cache[ $cache_key ];
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'X-Custom-Exclude', $cached_entry['headers'], 'Custom excluded header should be excluded from cache' );
+		$this->assertEquals( 'should-be-cached', $cached_entry['headers']['X-Custom-Include'] );
+
+		// Second request - cache HIT.
+
+		$response2 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHitHeader( $response2 );
+
+		$headers = $response2->get_headers();
+
+		// Verify excluded header is NOT present.
+
+		$this->assertArrayNotHasKey( 'X-Custom-Exclude', $headers, 'Custom excluded header should not be cached' );
+
+		// Verify included header IS present.
+
+		$this->assertEquals( 'should-be-cached', $headers['X-Custom-Include'] );
+
+		// Reset custom exclusion if using controller method.
+
+		if ( ! $use_with_cache_config ) {
+			$this->sut->custom_exclude_headers = array();
+		}
+	}
+
+	/**
+	 * @testdox Endpoint IDs are passed to customization methods.
+	 */
+	public function test_endpoint_ids_passed_to_methods() {
+
+		// Track which methods received endpoint_id.
+
+		$this->sut->received_endpoint_ids = array();
+
+		// Make a request to single_entity endpoint (has endpoint_id: 'single_entity').
+
+		$response = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheMissHeader( $response );
+
+		// Verify endpoint_id was passed to all relevant methods.
+
+		$received = $this->sut->received_endpoint_ids;
+
+		$this->assertEquals( 'single_entity', $received['response_cache_vary_by_user'] ?? null, 'endpoint_id should be passed to response_cache_vary_by_user' );
+		$this->assertEquals( 'single_entity', $received['get_hooks_relevant_to_caching'] ?? null, 'endpoint_id should be passed to get_hooks_relevant_to_caching' );
+		$this->assertEquals( 'single_entity', $received['get_cache_ttl'] ?? null, 'endpoint_id should be passed to get_cache_ttl' );
+		$this->assertEquals( 'single_entity', $received['must_cache'] ?? null, 'endpoint_id should be passed to must_cache' );
+		$this->assertEquals( 'single_entity', $received['extract_entity_ids'] ?? null, 'endpoint_id should be passed to extract_entity_ids' );
+		$this->assertEquals( 'single_entity', $received['get_response_headers_to_exclude_from_caching'] ?? null, 'endpoint_id should be passed to get_response_headers_to_exclude_from_caching' );
+	}
+
+	/**
+	 * @testdox Query strings with the same parameters in different order produce the same cache key.
+	 */
+	public function test_query_string_parameter_order_independence() {
+
+		// First request with query parameters in one order: ?foo=1&bar=2&baz=3.
+
+		$response1 = $this->query_endpoint(
+			'single_entity',
+			array(
+				'foo' => '1',
+				'bar' => '2',
+				'baz' => '3',
+			)
+		);
+
+		// Verify response is cache MISS and data is correct.
+
+		$this->assertCacheMissHeader( $response1 );
+		$this->assertEquals( 200, $response1->get_status() );
+		$this->assertEquals( $this->sut->responses['single_entity'], $response1->get_data() );
+
+		// Verify response was cached.
+
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Store the cache key and modify cached data to verify subsequent request uses cached value.
+
+		$cache_key                              = array_key_first( $this->sut->cache );
+		$modified_data                          = array(
+			'id'   => 999,
+			'name' => 'Cached Product',
+		);
+		$this->sut->cache[ $cache_key ]['data'] = $modified_data;
+
+		// Second request with SAME parameters but DIFFERENT order: ?baz=3&foo=1&bar=2.
+
+		$response2 = $this->query_endpoint(
+			'single_entity',
+			array(
+				'baz' => '3',
+				'foo' => '1',
+				'bar' => '2',
+			)
+		);
+
+		// Verify response is cache HIT (same cache key was used).
+
+		$this->assertCacheHitHeader( $response2 );
+		$this->assertEquals( 200, $response2->get_status() );
+		$this->assertEquals( $modified_data, $response2->get_data() );
+
+		// Verify still only one cache entry exists (same cache key was used).
+
+		$this->assertCount( 1, $this->sut->cache );
+
+		// Verify the cache key is the same.
+
+		$cache_key_after = array_key_first( $this->sut->cache );
+		$this->assertEquals( $cache_key, $cache_key_after, 'Cache key should be the same for query strings with same parameters in different order' );
+
+		// Third request with DIFFERENT parameter value should create new cache entry: ?foo=1&bar=2&baz=DIFFERENT.
+
+		$response3 = $this->query_endpoint(
+			'single_entity',
+			array(
+				'foo' => '1',
+				'bar' => '2',
+				'baz' => 'DIFFERENT',
+			)
+		);
+
+		// Verify response is cache MISS (different parameters = different cache key).
+
+		$this->assertCacheMissHeader( $response3 );
+
+		// Verify we now have two cache entries (different cache keys).
+
+		$this->assertCount( 2, $this->sut->cache );
+	}
+
+	// TESTS END HERE. Below there's auxiliary methods only.
+
+	/**
+	 * Reconfigure custom_endpoint_config endpoint and re-register routes.
+	 *
+	 * @param array $config Configuration array for custom_endpoint_config endpoint.
+	 */
+	private function reconfigure_custom_endpoint_config_endpoint( array $config ) {
+		$this->sut->custom_endpoint_config_cache_config = $config;
+
+		// Recreate REST server to clear routes.
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		// Trigger rest_api_init to register core routes.
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'rest_api_init' );
+
+		// Reinitialize cache and register routes with new configuration.
+
+		$this->sut->reinitialize_cache();
+		$this->sut->register_routes();
+	}
+
+	/**
+	 * Query an endpoint and return the response.
+	 *
+	 * @param string     $endpoint_name Endpoint name (e.g., 'single_entity', 'multiple_entities').
+	 * @param array|null $query_params  Optional query parameters.
+	 * @return WP_REST_Response The response from the endpoint.
+	 */
+	private function query_endpoint( $endpoint_name, $query_params = null ) {
+		$request = new WP_REST_Request( 'GET', "/wc/v3/rest_api_cache_test/{$endpoint_name}" );
+		if ( ! is_null( $query_params ) ) {
+			$request->set_query_params( $query_params );
+		}
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Get current cache information (key, entry, created_at timestamp).
+	 *
+	 * @return array|null Array with 'key', 'entry', and 'created_at', or null if cache is empty.
+	 */
+	private function get_cache_info() {
+		if ( empty( $this->sut->cache ) ) {
+			return null;
+		}
+
+		$cache_key   = array_key_first( $this->sut->cache );
+		$cache_entry = $this->sut->cache[ $cache_key ];
+		$created_at  = $cache_entry['created_at'];
+
+		return array(
+			'key'        => $cache_key,
+			'entry'      => $cache_entry,
+			'created_at' => $created_at,
+		);
+	}
+
+	/**
+	 * Assert that two cache info sets are equal (same key and created_at timestamp).
+	 *
+	 * @param array  $expected Expected cache info.
+	 * @param array  $actual   Actual cache info.
+	 * @param string $message  Optional message for assertion failure.
+	 */
+	private function assertCacheInfoEqual( array $expected, array $actual, string $message = '' ) {
+		$this->assertEquals( $expected['key'], $actual['key'], $message ? "{$message}: Cache key should be the same" : 'Cache key should be the same' );
+		$this->assertEquals( $expected['created_at'], $actual['created_at'], $message ? "{$message}: Cache entry should not have been recreated" : 'Cache entry should not have been recreated' );
+	}
+
+	/**
+	 * Assert that two cache info sets are different (same key but different created_at timestamp).
+	 *
+	 * @param array  $expected       Expected cache info.
+	 * @param array  $actual         Actual cache info.
+	 * @param int    $expected_time  Expected new created_at timestamp.
+	 * @param string $message        Optional message for assertion failure.
+	 */
+	private function assertCacheInfoDifferent( array $expected, array $actual, int $expected_time, string $message = '' ) {
+		$this->assertEquals( $expected['key'], $actual['key'], $message ? "{$message}: Cache key should be the same" : 'Cache key should be the same' );
+		$this->assertNotEquals( $expected['created_at'], $actual['created_at'], $message ? "{$message}: Cache entry should have new created_at timestamp" : 'Cache entry should have new created_at timestamp' );
+		$this->assertEquals( $expected_time, $actual['created_at'], $message ? "{$message}: New cache entry should use current time" : 'New cache entry should use current time' );
+	}
+
+	/**
+	 * Assert that response has X-WC-Cache: HIT header.
+	 *
+	 * @param WP_REST_Response $response The response to check.
+	 */
+	private function assertCacheHitHeader( $response ) {
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'HIT', $response->get_headers()['X-WC-Cache'] );
+	}
+
+	/**
+	 * Assert that response has X-WC-Cache: MISS header.
+	 *
+	 * @param WP_REST_Response $response The response to check.
+	 */
+	private function assertCacheMissHeader( $response ) {
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'MISS', $response->get_headers()['X-WC-Cache'] );
+	}
+
+	/**
+	 * Assert that response has X-WC-Cache: SKIP header.
+	 *
+	 * @param WP_REST_Response $response The response to check.
+	 */
+	private function assertCacheSkipHeader( $response ) {
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'SKIP', $response->get_headers()['X-WC-Cache'] );
+	}
+
+	/**
+	 * Assert that response has no X-WC-Cache header.
+	 *
+	 * @param WP_REST_Response $response The response to check.
+	 */
+	private function assertNoCacheHeader( $response ) {
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertArrayNotHasKey( 'X-WC-Cache', $response->get_headers() );
+	}
+
+	/**
+	 * Assert that caching was skipped (SKIP header, nothing cached, no entity versions).
+	 *
+	 * @param WP_REST_Response $response      The response to check.
+	 * @param array            $expected_data Expected response data.
+	 */
+	private function assertCachingSkipped( $response, $expected_data ) {
+
+		// Verify response has SKIP header.
+
+		$this->assertCacheSkipHeader( $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		// Verify nothing was cached.
+
+		$this->assertCount( 0, $this->sut->cache );
+
+		// Verify no entity versions were created.
+
+		$this->assertCount( 0, $this->mock_entity_cache->cache );
+	}
+
+	/**
+	 * Create a mock EntityVersionKeysCache that stores cache entries in an array.
+	 *
+	 * @return object Mock EntityVersionKeysCache instance.
+	 */
+	private function create_mock_entity_version_keys_cache() {
+		return new class() extends EntityVersionKeysCache {
+			/**
+			 * Cache storage.
+			 *
+			 * @var array
+			 */
+			public $cache = array();
+
+			/**
+			 * Whether the cache should be used.
+			 *
+			 * @var bool
+			 */
+			public $should_use_cache = true;
+
+			/**
+			 * Check if cache should be used.
+			 *
+			 * @return bool
+			 */
+			public function should_use(): bool {
+				return $this->should_use_cache;
+			}
+
+			/**
+			 * Get entity version.
+			 *
+			 * @param string     $entity_type Entity type.
+			 * @param string|int $entity_id   Entity ID.
+			 * @return string Entity version.
+			 */
+			public function get_entity_version( string $entity_type, $entity_id ): string {
+				$key = "wc_entity_version_key_{$entity_type}_{$entity_id}";
+				if ( ! isset( $this->cache[ $key ] ) ) {
+					// Auto-create version if it doesn't exist (matching real EntityVersionKeysCache behavior).
+					return $this->regenerate_entity_version( $entity_type, $entity_id );
+				}
+				return $this->cache[ $key ]['value'] ?? '';
+			}
+
+			/**
+			 * Regenerate entity version (generate new version).
+			 *
+			 * @param string     $entity_type Entity type.
+			 * @param string|int $entity_id   Entity ID.
+			 * @return string New version.
+			 */
+			public function regenerate_entity_version( string $entity_type, $entity_id ): string {
+				$key                 = "wc_entity_version_key_{$entity_type}_{$entity_id}";
+				$version             = wp_generate_uuid4();
+				$this->cache[ $key ] = array(
+					'value' => $version,
+					'ttl'   => HOUR_IN_SECONDS,
+				);
+				return $version;
+			}
+
+			/**
+			 * Delete entity version (delete from cache).
+			 *
+			 * @param string     $entity_type Entity type.
+			 * @param string|int $entity_id   Entity ID.
+			 * @return bool True on success.
+			 */
+			public function delete_entity_version( string $entity_type, $entity_id ): bool {
+				$key = "wc_entity_version_key_{$entity_type}_{$entity_id}";
+				unset( $this->cache[ $key ] );
+				return true;
+			}
+
+			/**
+			 * Override store_entity_version to use local cache array.
+			 *
+			 * @param string     $entity_type Entity type.
+			 * @param string|int $entity_id   Entity ID.
+			 * @param string     $version     The version key to store.
+			 * @return bool True on success.
+			 */
+			protected function store_entity_version( string $entity_type, $entity_id, string $version ): bool {
+				$key                 = "wc_entity_version_key_{$entity_type}_{$entity_id}";
+				$this->cache[ $key ] = array(
+					'value' => $version,
+					'ttl'   => DAY_IN_SECONDS,
+				);
+				return true;
+			}
+
+			/**
+			 * Override get_cached to use local cache array.
+			 *
+			 * @param string $cache_key The cache key.
+			 * @return mixed The cached value or null if not found.
+			 */
+			protected function get_cached( string $cache_key ) {
+				return $this->cache[ $cache_key ]['value'] ?? null;
+			}
+
+			/**
+			 * Override set_cached to use local cache array.
+			 *
+			 * @param string $cache_key The cache key.
+			 * @param mixed  $value     The value to cache.
+			 * @param int    $ttl       Time to live in seconds.
+			 * @return bool True on success.
+			 */
+			protected function set_cached( string $cache_key, $value, int $ttl ): bool {
+				$this->cache[ $cache_key ] = array(
+					'value' => $value,
+					'ttl'   => $ttl,
+				);
+				return true;
+			}
+
+			/**
+			 * Override delete_cached to use local cache array.
+			 *
+			 * @param string $cache_key The cache key.
+			 * @return bool True on success.
+			 */
+			protected function delete_cached( string $cache_key ): bool {
+				unset( $this->cache[ $cache_key ] );
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * Create a test controller.
+	 *
+	 * @return object Test controller instance.
+	 */
+	private function create_test_controller() {
+		return new class() extends WP_REST_Controller {
+			use RestApiCache {
+				extract_entity_ids as parent_extract_entity_ids;
+			}
+
+			/**
+			 * Response data for each endpoint.
+			 *
+			 * @var array
+			 */
+			public $responses = array(
+				'single_entity'          => array(
+					'id'   => 1,
+					'name' => 'Product 1',
+				),
+				'multiple_entities'      => array(
+					array(
+						'id'   => 2,
+						'name' => 'Product 2',
+					),
+					array(
+						'id'   => 3,
+						'name' => 'Product 3',
+					),
+					array( 'name' => 'Product without ID' ),
+				),
+				'entity_without_id'      => array( 'name' => 'Product without ID' ),
+				'not_with_cache'         => array(
+					'id'   => 4,
+					'name' => 'Product 4',
+				),
+				'false_must_cache'       => array(
+					'id'   => 5,
+					'name' => 'Product 5',
+				),
+				'custom_endpoint_config' => array(
+					'id'   => 6,
+					'name' => 'Product 6',
+				),
+			);
+
+			/**
+			 * Stored requests for each endpoint.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			/**
+			 * Status codes for each endpoint (defaults to 200).
+			 *
+			 * @var array
+			 */
+			public $status_codes = array();
+
+			/**
+			 * Local cache storage for testing.
+			 *
+			 * @var array
+			 */
+			public $cache = array();
+
+			/**
+			 * Return value for must_cache method.
+			 *
+			 * @var bool
+			 */
+			public $must_cache_return_value = true;
+
+			/**
+			 * Default entity type to return from get_default_entity_type.
+			 *
+			 * @var string|null
+			 */
+			public $default_entity_type = 'product';
+
+			/**
+			 * Custom cache TTL to return from get_cache_ttl.
+			 *
+			 * @var int|null
+			 */
+			public $custom_cache_ttl = null;
+
+			/**
+			 * Configuration for custom_endpoint_config endpoint with_cache call.
+			 *
+			 * @var array
+			 */
+			public $custom_endpoint_config_cache_config = array();
+
+			/**
+			 * Whether to use custom entity ID extraction (multiply IDs by 10).
+			 *
+			 * @var bool
+			 */
+			public $use_custom_entity_id_extraction = false;
+
+			/**
+			 * Return value for response_cache_vary_by_user method.
+			 *
+			 * @var bool
+			 */
+			public $vary_by_user_return_value = false;
+
+			/**
+			 * Custom headers to exclude from caching.
+			 *
+			 * @var array
+			 */
+			public $custom_exclude_headers = array();
+
+			/**
+			 * Track which methods received endpoint_id and what value.
+			 *
+			 * @var array
+			 */
+			public $received_endpoint_ids = array();
+
+			/**
+			 * Custom response headers to add to responses for each endpoint.
+			 *
+			 * @var array
+			 */
+			public $response_headers = array();
+
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->namespace = 'wc/v3';
+				$this->rest_base = 'rest_api_cache_test';
+				$this->initialize_rest_api_cache();
+			}
+
+			/**
+			 * Register routes.
+			 */
+			public function register_routes() {
+				// single_entity - cacheable, returns single entity.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/single_entity',
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								return $this->handle_request( 'single_entity', $request );
+							},
+							array(
+								'endpoint_id' => 'single_entity',
+							)
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				// multiple_entities - cacheable, returns collection.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/multiple_entities',
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								return $this->handle_request( 'multiple_entities', $request );
+							},
+							array(
+								'endpoint_id' => 'multiple_entities',
+							)
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				// entity_without_id - cacheable, returns entity without ID.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/entity_without_id',
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								return $this->handle_request( 'entity_without_id', $request );
+							},
+							array(
+								'endpoint_id' => 'entity_without_id',
+							)
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				// not_with_cache - not cacheable.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/not_with_cache',
+					array(
+						'methods'             => 'GET',
+						'callback'            => function ( $request ) {
+							return $this->handle_request( 'not_with_cache', $request );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				// false_must_cache - cacheable but with must_cache callback that returns false.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/false_must_cache',
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								return $this->handle_request( 'false_must_cache', $request );
+							},
+							array(
+								'endpoint_id' => 'false_must_cache',
+								'must_cache'  => '__return_false',
+							)
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				// custom_endpoint_config - cacheable with configurable per-endpoint settings.
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/custom_endpoint_config',
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								return $this->handle_request( 'custom_endpoint_config', $request );
+							},
+							array_merge(
+								array( 'endpoint_id' => 'custom_endpoint_config' ),
+								$this->custom_endpoint_config_cache_config
+							)
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+
+			/**
+			 * Get default entity type.
+			 *
+			 * @return string|null
+			 */
+			protected function get_default_entity_type(): ?string {
+				return $this->default_entity_type;
+			}
+
+			/**
+			 * Override must_cache to use configurable return value.
+			 *
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return bool
+			 */
+			protected function must_cache( $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['must_cache'] = $endpoint_id;
+				return $this->must_cache_return_value;
+			}
+
+			/**
+			 * Override get_hooks_relevant_to_caching to return test hooks.
+			 *
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return array Array of filter names.
+			 */
+			protected function get_hooks_relevant_to_caching( $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['get_hooks_relevant_to_caching'] = $endpoint_id;
+				return array( 'test_controller_hook_for_caching' );
+			}
+
+			/**
+			 * Override get_cache_ttl to return custom TTL.
+			 *
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return int Cache TTL in seconds.
+			 */
+			protected function get_cache_ttl( $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['get_cache_ttl'] = $endpoint_id;
+				return $this->custom_cache_ttl ?? HOUR_IN_SECONDS;
+			}
+
+			/**
+			 * Override response_cache_vary_by_user to use configurable return value.
+			 *
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return bool
+			 */
+			protected function response_cache_vary_by_user( $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['response_cache_vary_by_user'] = $endpoint_id;
+				return $this->vary_by_user_return_value;
+			}
+
+			/**
+			 * Override extract_entity_ids to use custom extraction logic.
+			 *
+			 * @param array           $data        Response data.
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return array Array of entity IDs.
+			 */
+			protected function extract_entity_ids( $data, $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['extract_entity_ids'] = $endpoint_id;
+				$ids = $this->parent_extract_entity_ids( $data, $request, $endpoint_id );
+
+				if ( $this->use_custom_entity_id_extraction ) {
+					$ids = array_map( fn( $id ) => $id * 10, $ids );
+				}
+
+				return $ids;
+			}
+
+			/**
+			 * Override get_response_headers_to_exclude_from_caching.
+			 *
+			 * @param WP_REST_Request $request     Request object.
+			 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+			 * @return array Array of header names to exclude.
+			 */
+			protected function get_response_headers_to_exclude_from_caching( $request, $endpoint_id = null ) {
+				$this->received_endpoint_ids['get_response_headers_to_exclude_from_caching'] = $endpoint_id;
+				return $this->custom_exclude_headers;
+			}
+
+			/**
+			 * Generic request handler.
+			 *
+			 * @param string          $endpoint Endpoint name.
+			 * @param WP_REST_Request $request  Request object.
+			 * @return WP_REST_Response|WP_Error
+			 */
+			private function handle_request( string $endpoint, WP_REST_Request $request ) {
+				$this->requests[ $endpoint ] = $request;
+
+				if ( is_null( $this->responses[ $endpoint ] ) ) {
+					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+					return new WP_Error( 'server_error', 'Internal server error', array( 'status' => 500 ) );
+				}
+
+				$status_code = $this->status_codes[ $endpoint ] ?? 200;
+				$response    = new WP_REST_Response( $this->responses[ $endpoint ], $status_code );
+
+				// Add custom headers if configured for this endpoint.
+				if ( ! empty( $this->response_headers[ $endpoint ] ) ) {
+					foreach ( $this->response_headers[ $endpoint ] as $name => $value ) {
+						$response->header( $name, $value );
+					}
+				}
+
+				return $response;
+			}
+
+			/**
+			 * Public wrapper to reinitialize the REST API cache.
+			 *
+			 * This allows tests to reinitialize the cache after changing mock state.
+			 */
+			public function reinitialize_cache() {
+				$this->initialize_rest_api_cache();
+			}
+		};
+	}
+}


### PR DESCRIPTION
_This is the second of a series of pull request to implement output caching for the WooCommerce REST API endpoints. Previous: https://github.com/woocommerce/woocommerce/pull/61601_

_NOTE: The functionality implemented here was initially introduced in https://github.com/woocommerce/woocommerce/pull/61414_

_NOTE: After https://github.com/woocommerce/woocommerce/pull/61600 is merged this pull request must be retargeted to `trunk`_

### Changes proposed in this Pull Request:

This pull requests adds a transient-based caching engine for the output of REST API endpoints, in the form of a `RestApiCache` trait that can be added to any controller. Features:

- By default the engine activates only if an external object cache is in place (if `wp_using_ext_object_cache()` returns true, checked via a call to via `EntityVersionsCache::is_active`). See note below.
- Caches the output of any endpoint whose callback is wrapped into a `$this->with_cache` call.
- Caches response headers too, excluding a fixed set (including e.g. `Date`) and a customizable (per-controller and per-endpoint) set.
- Requests are uniquely identified by the combination of the request route and the query string contents, and by default (configurable per-controller and per-endpoint) also by the current user id. Controllers can customize this (to add a different way of uniquely identifying a request) via the `woocommerce_rest_api_cache_key_info` filter.
- Entity version tracking implemented for invalidation of cached responses involving modified entries. Entity versions are tracked using the `EntityVersionsCache` class introduced in https://github.com/woocommerce/woocommerce/pull/61600.
- Extracts the list of relevant entity ids from the response (for entity version tracking) assuming an `id` field is present, this behavior can be customized per controller and per endpoint.
- Takes in account filters that modifiy the response before it's sent: if the hookings to these filters change, cached responses get invalidated. The list of relevant filters can be specified per controller and per endpoint.
- Configurable lifetime for cached responses, defaulting to one hour. This behavior can be customized per controller and per endpoint.
- Configurable (via filter) lifetime for cached entity versions, defaults to one hour. 
- Implements an `X-WC-Cache` response header, with values "HIT", "MISS" or "SKIP".
- Caching can be disabled for a given request by adding `_skip_caching=true|1` to the query string.
- Caching can be disabled per request using a filter (`woocommerce_rest_api_enable_response_caching`), a `must_cache` method in the controller, or endpoint caching configuration.

This lays the foundation for implementing actual caching in existing REST API controllers, and for ETag-based caching of REST API responses later on.

#### Note about the usage of transients

This implementation uses the WordPress transients API to cache REST API endpoints outputs and entity versions. By default WordPress uses the options table to store transients, and in that case using transients as a heavy-duty cache is not a good idea; but if an external object cache is in place (which is by default mandatory for this caching engine to activate), then that cache is used instead to store the transients.

That's the reason why the transients API is used instead of the `wp_cache_*` functions here: transients will be stored in the external cache anyway if it's active (via `EntityVersionsCache::is_active`), and if not, the caching engine can be activated anyway (for development or testing purposes) via the `woocommerce_enable_entity_versions_cache` filter.


### How to test the changes in this Pull Request:

Note: these testing instructions cover basic scenarios but there are more per-controller and per-endpoint customizations available, these are all covered by unit tests but feel free to take a look at the docblock and the code of `RestApiCache` and tinker with additional method overrides, filters and configurations passed to `with_cache`.

Prerrequisite: either install a persistent object cache in your WordPress instance, or add the following snippet: `add_filter('woocommerce_enable_entity_versions_cache', '__return_true');` - without doing one of these, the cache engine won't activate and you won't see any changes in behavior compared to `trunk`.

1. Add the following snippet to your site, this will create a simple "things" controller for testing the caching trait:

```php
add_action( 'rest_api_init', function() {
    $controller = new class() extends WP_REST_Controller {
        use Automattic\WooCommerce\Internal\Traits\RestApiCache;

        public function __construct() {
            $this->initialize_rest_api_cache();
        }

        protected function get_default_entity_type(): ?string {
            return 'thing';
        }

        public function register_routes() {
            register_rest_route(
                'wc',
                '/things',
                array(
                    'methods'             => WP_REST_Server::READABLE,
                    'callback'            => $this->with_cache(
                        array( $this, 'get_items' ),
                        array(
                            'cache_ttl'       => 60, // 1 minute
                            'relevant_hooks'  => array( 'woocommerce_modify_things' ),
                            'exclude_headers' => array( 'X-Exclude-Me' )
                        )
                    ),
                    'permission_callback' => '__return_true',
                )
            );
        }

        public function get_items( $request ) {
            // 1 second delay just for fun
            sleep( 1 );

            $data = array(
                array( 'id' => 1, 'name' => 'Thing 1' ),
                array( 'id' => 2, 'name' => 'Thing 2' ),
            );

            $data = apply_filters( 'woocommerce_modify_things', $data, $request );

            $response = rest_ensure_response( $data );
            $response->header( 'X-Custom-Header', 'CustomValue-' . time() );
            $response->header( 'X-Exclude-Me', 'Ok' );
            $response->header( 'Cache-Control', 'No, thank you.' );
            return $response;
        }
    };

    $controller->register_routes();
} );
```

2. Run the following command:

```
time curl -i http://localhost/wp-json/wc/things
```

The time should be slightly over 1s, and the response should contain a `X-WC-Cache: MISS` header. Also you should see the `X-Custom-Header`, `X-Exclude-Me` a `Cache-Control` headers in the response.

3. Wait a few seconds and repeat the command. Now the response should come much faster, and the response should contain a `X-WC-Cache: HIT` header. You should see the `X-Custom-Header` header with the same value in the response, and you should *not* see a `X-Exclude-Me` nor a `Cache-Control` header.

4. Wait one minute and repeat the request twice, you should get again a MISS followed by a HIT. (Now you can increase the value of `'cache_ttl'` to ease testing if you want).

4. Repeat the request twice adding `?foo=bar` to the query string, you should get again a MISS followed by a HIT.

5. Add the following additional snippet:

```php
add_filter( 'woocommerce_modify_things', function( $data, $request ) {
    $data[0]['modified'] = true;
    return $data;
}, 10, 2 );
```

and again repeat the request twice, you should get again a MISS followed by a HIT.

6. Run the following: `wp eval 'wc_get_container()->get( Automattic\WooCommerce\Internal\Caches\EntityVersionsCache::class )->modify_entity_version( "thing", 1 );'` - repeating the request should again result in a MISS followed by a HIT.

7 Add `?_skip_cache=true` to the query string, now the response should always be slow and include `X-WC-Cache: SKIP`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
