### PR TITLE
[Rest API v4] Order Refunds v4

### DIFF
--- a/plugins/woocommerce/changelog/add-refund-api-v4
+++ b/plugins/woocommerce/changelog/add-refund-api-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Refunds endpoint for experimental v4 rest api
+
+

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Internal\RestApi\Routes\V4\OrderNotes\Controller as O
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\ShippingZones\Controller as ShippingZonesController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\ShippingZoneMethod\Controller as ShippingZoneMethodController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Orders\Controller as OrdersController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Controller as RefundsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Products\Controller as SettingsProductsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Products\Controller as ProductsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\PaymentGateways\Controller as PaymentGatewaysController;
@@ -235,6 +236,7 @@ class Server {
 			'shipping-zones'            => ShippingZonesController::class,
 			'shipping-zone-method'      => ShippingZoneMethodController::class,
 			'orders'                    => OrdersController::class,
+			'refunds'                   => RefundsController::class,
 			'offline-payment-methods'   => OfflinePaymentMethodsController::class,
 			'settings-general'          => GeneralSettingsController::class,
 			'settings-email'            => EmailSettingsController::class,

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/AbstractController.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/AbstractController.php
@@ -80,6 +80,15 @@ abstract class AbstractController extends WP_REST_Controller {
 	}
 
 	/**
+	 * List of args for endpoints. These may alter how data is returned or formatted. Extended by routes.
+	 *
+	 * @return array
+	 */
+	protected function get_endpoint_args(): array {
+		return array();
+	}
+
+	/**
 	 * Add default context collection params and filter the result. This does not inherit from
 	 * WP_REST_Controller::get_collection_params because some endpoints do not paginate results.
 	 *

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/CollectionQuery.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/CollectionQuery.php
@@ -34,39 +34,7 @@ class CollectionQuery extends AbstractCollectionQuery {
 	 */
 	public function get_query_schema(): array {
 		return array(
-			'num_decimals'            => array(
-				'default'           => wc_get_price_decimals(),
-				'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'exclude_meta'            => array(
-				'default'           => array(),
-				'description'       => __( 'Ensure meta_data excludes specific keys.', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'string',
-				),
-				'sanitize_callback' => 'wp_parse_list',
-			),
-			'include_meta'            => array(
-				'default'           => array(),
-				'description'       => __( 'Limit meta_data to specific keys.', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'string',
-				),
-				'sanitize_callback' => 'wp_parse_list',
-			),
-			'order_item_display_meta' => array(
-				'default'           => false,
-				'description'       => __( 'Only show meta which is meant to be displayed for an order.', 'woocommerce' ),
-				'type'              => 'boolean',
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'page'                    => array(
+			'page'               => array(
 				'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 				'type'              => 'integer',
 				'default'           => 1,
@@ -74,7 +42,7 @@ class CollectionQuery extends AbstractCollectionQuery {
 				'validate_callback' => 'rest_validate_request_arg',
 				'minimum'           => 1,
 			),
-			'per_page'                => array(
+			'per_page'           => array(
 				'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 				'type'              => 'integer',
 				'default'           => 10,
@@ -83,51 +51,14 @@ class CollectionQuery extends AbstractCollectionQuery {
 				'sanitize_callback' => 'absint',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'offset'                  => array(
-				'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'created_via'             => array(
-				'description'       => __( 'Limit result set to orders created via specific sources (e.g. checkout, admin).', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'string',
-				),
-				'validate_callback' => 'rest_validate_request_arg',
-				'sanitize_callback' => 'wp_parse_list',
-			),
-			'customer'                => array(
-				'description'       => __( 'Limit result set to orders assigned a specific customer.', 'woocommerce' ),
-				'type'              => array( 'string', 'integer' ),
-				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'product'                 => array(
-				'description'       => __( 'Limit result set to orders assigned a specific product.', 'woocommerce' ),
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'status'                  => array(
-				'default'           => 'any',
-				'description'       => __( 'Limit result set to orders which have specific statuses.', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'string',
-					'enum' => array_map( OrderUtil::class . '::remove_status_prefix', array_merge( array( 'any', OrderStatus::TRASH ), array_keys( wc_get_order_statuses() ) ) ),
-				),
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'order'                   => array(
+			'order'              => array(
 				'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 				'type'              => 'string',
 				'default'           => 'desc',
 				'enum'              => array( 'asc', 'desc' ),
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'orderby'                 => array(
+			'orderby'            => array(
 				'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 				'type'              => 'string',
 				'default'           => 'date',
@@ -142,61 +73,74 @@ class CollectionQuery extends AbstractCollectionQuery {
 				),
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'search'                  => array(
+			'created_via'        => array(
+				'description'       => __( 'Limit result set to orders created via specific sources (e.g. checkout, admin).', 'woocommerce' ),
+				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string',
+				),
+				'validate_callback' => 'rest_validate_request_arg',
+				'sanitize_callback' => 'wp_parse_list',
+			),
+			'customer'           => array(
+				'description'       => __( 'Limit result set to orders assigned a specific customer.', 'woocommerce' ),
+				'type'              => array( 'string', 'integer' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'product'            => array(
+				'description'       => __( 'Limit result set to orders assigned a specific product.', 'woocommerce' ),
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'status'             => array(
+				'default'           => 'any',
+				'description'       => __( 'Limit result set to orders which have specific statuses.', 'woocommerce' ),
+				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string',
+					'enum' => array_map( OrderUtil::class . '::remove_status_prefix', array_merge( array( 'any', OrderStatus::TRASH ), array_keys( wc_get_order_statuses() ) ) ),
+				),
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'search'             => array(
 				'description'       => __( 'Limit results to those matching a string.', 'woocommerce' ),
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'exclude'                 => array(
-				'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'integer',
-				),
-				'default'           => array(),
-				'sanitize_callback' => 'wp_parse_id_list',
-			),
-			'include'                 => array(
-				'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
-				'type'              => 'array',
-				'items'             => array(
-					'type' => 'integer',
-				),
-				'default'           => array(),
-				'sanitize_callback' => 'wp_parse_id_list',
-			),
-			'after'                   => array(
+			'after'              => array(
 				'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 				'type'              => 'string',
 				'format'            => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'before'                  => array(
+			'before'             => array(
 				'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 				'type'              => 'string',
 				'format'            => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'modified_after'          => array(
+			'modified_after'     => array(
 				'description'       => __( 'Limit response to resources modified after a given ISO8601 compliant date.', 'woocommerce' ),
 				'type'              => 'string',
 				'format'            => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'modified_before'         => array(
+			'modified_before'    => array(
 				'description'       => __( 'Limit response to resources modified before a given ISO8601 compliant date.', 'woocommerce' ),
 				'type'              => 'string',
 				'format'            => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'dates_are_gmt'           => array(
+			'dates_are_gmt'      => array(
 				'description'       => __( 'Whether to consider GMT post dates when limiting response by published or modified date.', 'woocommerce' ),
 				'type'              => 'boolean',
 				'default'           => false,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'total'                   => array(
+			'total'              => array(
 				'description'       => __( 'Limit result set to orders with specific total amounts. For between operators, list two values.', 'woocommerce' ),
 				'type'              => array( 'string', 'array' ),
 				'items'             => array(
@@ -204,7 +148,7 @@ class CollectionQuery extends AbstractCollectionQuery {
 				),
 				'sanitize_callback' => 'wp_parse_list',
 			),
-			'total_operator'          => array(
+			'total_operator'     => array(
 				'description'       => __( 'The comparison operator to use for total filtering.', 'woocommerce' ),
 				'type'              => 'string',
 				'enum'              => self::OPERATORS,
@@ -223,7 +167,7 @@ class CollectionQuery extends AbstractCollectionQuery {
 					return $valid;
 				},
 			),
-			'fulfillment_status'      => array(
+			'fulfillment_status' => array(
 				'description'       => __( 'Limit result set to orders with specific fulfillment statuses.', 'woocommerce' ),
 				'type'              => 'array',
 				'items'             => array(
@@ -244,14 +188,10 @@ class CollectionQuery extends AbstractCollectionQuery {
 	 */
 	public function get_query_args( WP_REST_Request $request ): array {
 		$args = array(
-			'offset'         => $request['offset'],
 			'order'          => $request['order'],
 			'orderby'        => $request['orderby'],
 			'page'           => $request['page'],
-			'post__in'       => $request['include'],
-			'post__not_in'   => $request['exclude'],
 			'posts_per_page' => $request['per_page'],
-			'name'           => $request['slug'],
 			's'              => $request['search'],
 			'created_via'    => $request['created_via'],
 			'status'         => $request['status'],

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderItemSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderItemSchema.php
@@ -167,7 +167,7 @@ class OrderItemSchema extends AbstractLineItemSchema {
 			'total'        => wc_format_decimal( $order_item->get_total(), $dp ),
 			'total_tax'    => wc_format_decimal( $order_item->get_total_tax(), $dp ),
 			'taxes'        => $this->prepare_taxes( $order_item, $request ),
-			'meta_data'    => $this->filter_meta_data( $this->prepare_meta_data( $order_item ), $order_item, $request ),
+			'meta_data'    => $this->prepare_meta_data( $order_item ),
 		);
 
 		// Add COGS data.
@@ -177,31 +177,6 @@ class OrderItemSchema extends AbstractLineItemSchema {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Filter the meta data for the order item.
-	 *
-	 * @param array                 $meta_data Meta data.
-	 * @param WC_Order_Item_Product $order_item Order item instance.
-	 * @param WP_REST_Request       $request Request object.
-	 * @return array
-	 */
-	protected function filter_meta_data( array $meta_data, WC_Order_Item_Product $order_item, WP_REST_Request $request ) {
-		$product               = $order_item->get_product();
-		$item_name             = $order_item->get_name();
-		$filter_variation_meta = true === $request['order_item_display_meta'] && $product && $product->is_type( ProductType::VARIATION );
-		$return                = array();
-
-		foreach ( $meta_data as $meta ) {
-			// Filter out product variations.
-			if ( $filter_variation_meta && wc_is_attribute_in_product_name( $meta['display_value'], $item_name ) ) {
-				continue;
-			}
-			$return[] = $meta;
-		}
-
-		return $return;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
@@ -692,7 +692,7 @@ class OrderSchema extends AbstractSchema {
 		}
 
 		if ( in_array( 'meta_data', $include_fields, true ) ) {
-			$filtered_meta_data = $this->filter_internal_meta_keys( $this->get_meta_data_for_response( $order->get_meta_data(), $request ) );
+			$filtered_meta_data = $this->filter_internal_meta_keys( $order->get_meta_data() );
 			$data['meta_data']  = array();
 			foreach ( $filtered_meta_data as $meta_item ) {
 				$data['meta_data'][] = array(
@@ -732,43 +732,6 @@ class OrderSchema extends AbstractSchema {
 				return ! in_array( $meta->key, $cpt_hidden_keys, true );
 			}
 		);
-		return array_values( $meta_data );
-	}
-
-	/**
-	 * Limit the contents of the meta_data property based on certain request parameters.
-	 *
-	 * Note that if both `include_meta` and `exclude_meta` are present in the request,
-	 * `include_meta` will take precedence.
-	 *
-	 * @param array            $meta_data All of the meta data for an object.
-	 * @param \WP_REST_Request $request   The request.
-	 *
-	 * @return array
-	 */
-	protected function get_meta_data_for_response( $meta_data, $request ) {
-		$include = (array) $request['include_meta'];
-		$exclude = (array) $request['exclude_meta'];
-
-		if ( ! empty( $include ) ) {
-			$meta_data = array_filter(
-				$meta_data,
-				function ( \WC_Meta_Data $item ) use ( $include ) {
-					$data = $item->get_data();
-					return in_array( $data['key'], $include, true );
-				}
-			);
-		} elseif ( ! empty( $exclude ) ) {
-			$meta_data = array_filter(
-				$meta_data,
-				function ( \WC_Meta_Data $item ) use ( $exclude ) {
-					$data = $item->get_data();
-					return ! in_array( $data['key'], $exclude, true );
-				}
-			);
-		}
-
-		// Ensure the array indexes are reset so it doesn't get converted to an object in JSON.
 		return array_values( $meta_data );
 	}
 }

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/CollectionQuery.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/CollectionQuery.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * CollectionQuery class.
+ *
+ * @package WooCommerce\RestApi
+ * @internal This file is for internal use only and should not be used by external code.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_REST_Request;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractCollectionQuery;
+use WC_Order_Query;
+
+/**
+ * CollectionQuery class.
+ *
+ * @internal This class is for internal use only and should not be used by external code.
+ */
+class CollectionQuery extends AbstractCollectionQuery {
+	/**
+	 * Get query schema.
+	 *
+	 * @return array
+	 */
+	public function get_query_schema(): array {
+		return array(
+			'order_id'      => array(
+				'description'       => __( 'Filter refunds by order ID.', 'woocommerce' ),
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'page'          => array(
+				'description'       => __( 'Current page of the collection.', 'woocommerce' ),
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+				'minimum'           => 1,
+			),
+			'per_page'      => array(
+				'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+				'type'              => 'integer',
+				'default'           => 10,
+				'minimum'           => 1,
+				'maximum'           => 100,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'order'         => array(
+				'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
+				'type'              => 'string',
+				'default'           => 'desc',
+				'enum'              => array( 'asc', 'desc' ),
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'orderby'       => array(
+				'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
+				'type'              => 'string',
+				'default'           => 'date',
+				'enum'              => array(
+					'date',
+					'id',
+					'include',
+					'title',
+					'slug',
+					'modified',
+					'total',
+				),
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'after'         => array(
+				'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
+				'type'              => 'string',
+				'format'            => 'date-time',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'before'        => array(
+				'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
+				'type'              => 'string',
+				'format'            => 'date-time',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'dates_are_gmt' => array(
+				'description'       => __( 'Whether to consider GMT post dates when limiting response by published or modified date.', 'woocommerce' ),
+				'type'              => 'boolean',
+				'default'           => false,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+		);
+	}
+
+	/**
+	 * Prepares query args.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return array
+	 */
+	public function get_query_args( WP_REST_Request $request ): array {
+		$args = array(
+			'order'          => $request['order'],
+			'orderby'        => $request['orderby'],
+			'page'           => $request['page'],
+			'posts_per_page' => $request['per_page'],
+		);
+
+		if ( 'date' === $args['orderby'] ) {
+			$args['orderby'] = 'date ID';
+		}
+
+		$date_query = array();
+		$use_gmt    = $request['dates_are_gmt'];
+
+		if ( isset( $request['before'] ) ) {
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_date_gmt' : 'post_date',
+				'before' => $request['before'],
+			);
+		}
+
+		if ( isset( $request['after'] ) ) {
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_date_gmt' : 'post_date',
+				'after'  => $request['after'],
+			);
+		}
+
+		if ( ! empty( $date_query ) ) {
+			$date_query['relation'] = 'AND';
+			$args['date_query']     = $date_query;
+		}
+
+		$order_id = absint( $request['order_id'] ?? 0 );
+
+		if ( $order_id ) {
+			$args['post_parent__in'] = array( $order_id );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get results of the query.
+	 *
+	 * @param array           $query_args The query arguments from prepare_query().
+	 * @param WP_REST_Request $request The request object.
+	 * @return array
+	 */
+	public function get_query_results( array $query_args, WP_REST_Request $request ): array {
+		$query   = new WC_Order_Query(
+			array_merge(
+				$query_args,
+				array(
+					'paginate' => true,
+				)
+			)
+		);
+		$results = $query->get_orders();
+
+		return array(
+			'results' => $results->orders,
+			'total'   => $results->total,
+			'pages'   => $results->max_num_pages,
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -313,6 +313,10 @@ class Controller extends AbstractController {
 					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item not found.', 'woocommerce' ) );
 				}
 
+				if ( ! $item instanceof \WC_Order_Item_Product && ! $item instanceof \WC_Order_Item_Fee && ! $item instanceof \WC_Order_Item_Shipping ) {
+					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item is not a product, fee, or shipping line.', 'woocommerce' ) );
+				}
+
 				// Validate item quantity is not greater than the item quantity.
 				if ( $item->get_quantity() < $line_item['qty'] ) {
 					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item quantity cannot be greater than the item quantity.', 'woocommerce' ) );
@@ -330,30 +334,34 @@ class Controller extends AbstractController {
 					);
 				}
 
-				if ( isset( $line_item['refund_tax'] ) && ( $item_taxes = $item->get_taxes() ) ) {
-					$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
+				if ( isset( $line_item['refund_tax'] ) ) {
+					$item_taxes = $item->get_taxes();
 
-					foreach ( $line_item['refund_tax'] as $tax_id => $refund_total ) {
-						if ( ! in_array( $tax_id, $allowed_tax_ids, true ) ) {
-							return $this->get_route_error_response(
-								'invalid_line_item',
-								sprintf(
+					if ( $item_taxes ) {
+						$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
+
+						foreach ( $line_item['refund_tax'] as $tax_id => $refund_total ) {
+							if ( ! in_array( $tax_id, $allowed_tax_ids, true ) ) {
+								return $this->get_route_error_response(
+									'invalid_line_item',
+									sprintf(
 									/* translators: %s: tax IDs */
-									__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
-									implode( ', ', $allowed_tax_ids )
-								)
-							);
-						}
+										__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
+										implode( ', ', $allowed_tax_ids )
+									)
+								);
+							}
 
-						if ( $item_taxes['total'][ $tax_id ] < $refund_total ) {
-							return $this->get_route_error_response(
-								'invalid_refund_amount',
-								sprintf(
+							if ( $item_taxes['total'][ $tax_id ] < $refund_total ) {
+								return $this->get_route_error_response(
+									'invalid_refund_amount',
+									sprintf(
 									/* translators: %s: tax total */
-									__( 'Refund tax total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
-									$item_taxes['total'][ $tax_id ]
-								)
-							);
+										__( 'Refund tax total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+										$item_taxes['total'][ $tax_id ]
+									)
+								);
+							}
 						}
 					}
 				}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -1,0 +1,508 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * REST API Refunds controller
+ *
+ * Handles route registration, permissions, CRUD operations, and schema definition.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\RestApiParameterUtil;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
+use Automattic\WooCommerce\StoreApi\Utilities\Pagination;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema\RefundSchema;
+use WP_Http;
+use WP_Error;
+use WC_Order_Refund;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Refunds Controller.
+ */
+class Controller extends AbstractController {
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'refunds';
+
+	/**
+	 * Post type used for orders.
+	 *
+	 * @var string
+	 */
+	protected $post_type = 'shop_order_refund';
+
+	/**
+	 * Schema class for this route.
+	 *
+	 * @var OrderSchema
+	 */
+	protected $item_schema;
+
+	/**
+	 * Collection query class.
+	 *
+	 * @var CollectionQuery
+	 */
+	protected $collection_query;
+
+	/**
+	 * Initialize the controller.
+	 *
+	 * @param RefundSchema    $item_schema Refund schema class.
+	 * @param CollectionQuery $collection_query Collection query class.
+	 * @internal
+	 */
+	final public function init( RefundSchema $item_schema, CollectionQuery $collection_query ) {
+		$this->item_schema      = $item_schema;
+		$this->collection_query = $collection_query;
+	}
+
+	/**
+	 * Get the schema for the current resource. This use consumed by the AbstractController to generate the item schema
+	 * after running various hooks on the response.
+	 */
+	protected function get_schema(): array {
+		return $this->item_schema->get_item_schema();
+	}
+
+	/**
+	 * Get the collection args schema.
+	 *
+	 * @return array
+	 */
+	protected function get_query_schema(): array {
+		return $this->collection_query->get_query_schema();
+	}
+
+	/**
+	 * List of args for endpoints. These may alter how data is returned or formatted. Extended by routes.
+	 *
+	 * @return array
+	 */
+	protected function get_endpoint_args(): array {
+		return array(
+			'num_decimals' => array(
+				'default'           => wc_get_price_decimals(),
+				'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+		);
+	}
+
+	/**
+	 * Register the routes for orders.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'args'   => $this->get_endpoint_args(),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array_merge(
+						$this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+						array(
+							'api_refund'  => array(
+								'description' => __( 'When true, the payment gateway API is used to perform the refund. If the payment gateway does not support refunds, the refund will fail.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'edit' ),
+								'default'     => false,
+							),
+							'api_restock' => array(
+								'description' => __( 'When true, refunded items are restocked.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'edit' ),
+								'default'     => false,
+							),
+							'line_items'  => array(
+								'description' => __( 'Line items to refund. This can include products, fees, and shipping lines, combined into a single array.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'edit' ),
+								'default'     => array(),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'           => array(
+											'description' => __( 'Item ID.', 'woocommerce' ),
+											'type'        => 'integer',
+										),
+										'quantity'     => array(
+											'description' => __( 'Quantity to refund for this item.', 'woocommerce' ),
+											'type'        => 'integer',
+											'minimum'     => 0,
+										),
+										'refund_total' => array(
+											'description' => __( 'Amount to refund for this item.', 'woocommerce' ),
+											'type'        => 'number',
+											'minimum'     => 0,
+										),
+										'refund_tax'   => array(
+											'description' => __( 'Taxes to refund for this item.', 'woocommerce' ),
+											'type'        => 'array',
+											'default'     => array(),
+											'items'       => array(
+												'type' => 'object',
+												'properties' => array(
+													'id' => array(
+														'description' => __( 'Tax ID.', 'woocommerce' ),
+														'type'        => 'integer',
+													),
+													'refund_total' => array(
+														'description' => __( 'Amount to refund for this tax.', 'woocommerce' ),
+														'type'        => 'number',
+														'minimum'     => 0,
+													),
+												),
+											),
+										),
+									),
+								),
+							),
+						)
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'schema' => array( $this, 'get_public_item_schema' ),
+				'args'   => array_merge(
+					$this->get_endpoint_args(),
+					array(
+						'id' => array(
+							'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+							'type'        => 'integer',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Prepare a single order object for response.
+	 *
+	 * @param WC_Order_Refund $refund Refund object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	protected function get_item_response( $refund, WP_REST_Request $request ): array {
+		return $this->item_schema->get_item_response( $refund, $request, $this->get_fields_for_response( $request ) );
+	}
+
+	/**
+	 * Get a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$refund = wc_get_order( (int) $request['id'] );
+
+		if ( ! $this->is_valid_refund_for_request( $refund ) ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
+		}
+
+		return $this->prepare_item_for_response( $refund, $request );
+	}
+
+	/**
+	 * Get collection of refunds.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$query_args = $this->collection_query->get_query_args( $request );
+		$results    = $this->collection_query->get_query_results(
+			array_merge(
+				$query_args,
+				array(
+					'post_type'   => $this->post_type,
+					'post_status' => array_keys( wc_get_order_statuses() ),
+				)
+			),
+			$request
+		);
+		$items      = array();
+
+		foreach ( $results['results'] as $result ) {
+			$items[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $result, $request ) );
+		}
+
+		$pagination_util = new Pagination();
+		$response        = $pagination_util->add_headers( rest_ensure_response( $items ), $request, $results['total'], $results['pages'] );
+
+		return $response;
+	}
+
+	/**
+	 * Create a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
+			return $this->get_route_error_by_code( self::RESOURCE_EXISTS );
+		}
+
+		try {
+			RestApiParameterUtil::adjust_create_refund_request_parameters( $request );
+
+			$order = wc_get_order( $request['order_id'] );
+
+			if ( ! $order ) {
+				return $this->get_route_error_by_code( self::INVALID_ID );
+			}
+
+			if ( 0 > $request['amount'] || ! $request['amount'] ) {
+				return $this->get_route_error_response( 'invalid_refund_amount', __( 'Refund total must be greater than zero.', 'woocommerce' ) );
+			}
+
+			// Validate line items.
+			foreach ( $request['line_items'] as $line_item_id => $line_item ) {
+				if ( ! $line_item_id ) {
+					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item ID is required.', 'woocommerce' ) );
+				}
+
+				$item = $order->get_item( $line_item_id );
+
+				// Validate item exists and belongs to the order.
+				if ( ! $item || $item->get_order_id() !== $order->get_id() ) {
+					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item not found.', 'woocommerce' ) );
+				}
+
+				// Validate item quantity is not greater than the item quantity.
+				if ( $item->get_quantity() < $line_item['qty'] ) {
+					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item quantity cannot be greater than the item quantity.', 'woocommerce' ) );
+				}
+
+				// Validate refund total is not greater than the item total.
+				if ( $item->get_total() < $line_item['refund_total'] ) {
+					return $this->get_route_error_response(
+						'invalid_refund_amount',
+						sprintf(
+							/* translators: %s: tax total */
+							__( 'Refund total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+							$item->get_total()
+						)
+					);
+				}
+
+				if ( isset( $line_item['refund_tax'] ) && ( $item_taxes = $item->get_taxes() ) ) {
+					$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
+
+					foreach ( $line_item['refund_tax'] as $tax_id => $refund_total ) {
+						if ( ! in_array( $tax_id, $allowed_tax_ids, true ) ) {
+							return $this->get_route_error_response(
+								'invalid_line_item',
+								sprintf(
+									/* translators: %s: tax IDs */
+									__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
+									implode( ', ', $allowed_tax_ids )
+								)
+							);
+						}
+
+						if ( $item_taxes['total'][ $tax_id ] < $refund_total ) {
+							return $this->get_route_error_response(
+								'invalid_refund_amount',
+								sprintf(
+									/* translators: %s: tax total */
+									__( 'Refund tax total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+									$item_taxes['total'][ $tax_id ]
+								)
+							);
+						}
+					}
+				}
+			}
+
+			$refund = wc_create_refund(
+				array(
+					'order_id'       => $order->get_id(),
+					'amount'         => $request['amount'],
+					'reason'         => $request['reason'],
+					'line_items'     => $request['line_items'],
+					'refund_payment' => $request['api_refund'],
+					'restock_items'  => $request['api_restock'],
+				)
+			);
+
+			if ( ! $refund ) {
+				return $this->get_route_error_response( 'cannot_create_refund', __( 'Cannot create order refund.', 'woocommerce' ) );
+			}
+
+			if ( is_wp_error( $refund ) ) {
+				return $this->get_route_error_response( 'cannot_create_refund', $refund->get_error_message() );
+			}
+
+			if ( ! empty( $request['meta_data'] ) && is_array( $request['meta_data'] ) ) {
+				foreach ( $request['meta_data'] as $meta ) {
+					$refund->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+				}
+				$refund->save_meta_data();
+			}
+
+			$this->update_additional_fields_for_object( $refund, $request );
+
+			/**
+			 * Fires after a single object is created via the REST API.
+			 *
+			 * @param WC_Order_Refund         $refund    Inserted object.
+			 * @param WP_REST_Request $request   Request object.
+			 * @since 10.2.0
+			 */
+			do_action( $this->get_hook_prefix() . 'created', $refund, $request );
+
+			$request->set_param( 'context', 'edit' );
+			$response = $this->prepare_item_for_response( $refund, $request );
+			$response->set_status( WP_Http::CREATED );
+			$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $refund->get_id() ) ) );
+
+			return $response;
+		} catch ( \WC_Data_Exception $e ) {
+			return $this->get_route_error_response( $e->getErrorCode(), $e->getMessage() );
+		} catch ( \WC_REST_Exception $e ) {
+			return $this->get_route_error_response( $e->getErrorCode(), $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Delete a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$refund = wc_get_order( (int) $request['id'] );
+
+		if ( ! $this->is_valid_refund_for_request( $refund ) ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
+		}
+
+		$request->set_param( 'context', 'edit' );
+
+		$response = new WP_REST_Response( null, 204 );
+		$result   = $refund->delete( true );
+
+		if ( ! $result ) {
+			return $this->get_route_error_by_code( self::CANNOT_DELETE );
+		}
+
+		/**
+		 * Fires after a single object is deleted or trashed via the REST API.
+		 *
+		 * @param WC_Order_Refund  $refund   The deleted object.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
+		 * @since 10.2.0
+		 */
+		do_action( $this->get_hook_prefix() . 'deleted', $refund, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Check if an order is valid.
+	 *
+	 * @param WC_Order_Refund $refund The refund object.
+	 * @return bool True if the refund is valid, false otherwise.
+	 */
+	protected function is_valid_refund_for_request( $refund ): bool {
+		return $refund instanceof WC_Order_Refund && $refund->get_id() !== 0 && 'shop_order_refund' === $refund->get_type();
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( $this->post_type, 'read' ) ) {
+			return $this->get_authentication_error_by_method( $request->get_method() );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to read an item.
+	 *
+	 * @param  WP_REST_Request $request The request object.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( $this->post_type, 'read', $request['id'] ) ) {
+			return $this->get_authentication_error_by_method( $request->get_method() );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to create an item.
+	 *
+	 * @param  WP_REST_Request $request The request object.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( $this->post_type, 'create' ) ) {
+			return $this->get_authentication_error_by_method( $request->get_method() );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to delete an item.
+	 *
+	 * @param  WP_REST_Request $request The request object.
+	 * @return bool|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( $this->post_type, 'delete', $request['id'] ) ) {
+			return $this->get_authentication_error_by_method( $request->get_method() );
+		}
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -269,7 +269,7 @@ class Controller extends AbstractController {
 
 			// Convert line items to internal format.
 			$line_item_data = $this->data_utils->convert_line_items_to_internal_format( $request['line_items'] );
-			$refund_amount  = $this->data_utils->calculate_refund_amount( $request['line_items'] );
+			$refund_amount  = ! empty( $request['amount'] ) ? $request['amount'] : $this->data_utils->calculate_refund_amount( $request['line_items'] );
 
 			if ( 0 > $refund_amount || ! $refund_amount ) {
 				return $this->get_route_error_response( 'invalid_refund_amount', __( 'Refund total must be greater than zero.', 'woocommerce' ) );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -13,7 +13,6 @@ namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Internal\RestApiParameterUtil;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
 use Automattic\WooCommerce\StoreApi\Utilities\Pagination;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema\RefundSchema;
@@ -57,15 +56,24 @@ class Controller extends AbstractController {
 	protected $collection_query;
 
 	/**
+	 * Data utils class.
+	 *
+	 * @var DataUtils
+	 */
+	protected $data_utils;
+
+	/**
 	 * Initialize the controller.
 	 *
 	 * @param RefundSchema    $item_schema Refund schema class.
 	 * @param CollectionQuery $collection_query Collection query class.
+	 * @param DataUtils       $data_utils Data utils class.
 	 * @internal
 	 */
-	final public function init( RefundSchema $item_schema, CollectionQuery $collection_query ) {
+	final public function init( RefundSchema $item_schema, CollectionQuery $collection_query, DataUtils $data_utils ) {
 		$this->item_schema      = $item_schema;
 		$this->collection_query = $collection_query;
+		$this->data_utils       = $data_utils;
 	}
 
 	/**
@@ -125,60 +133,18 @@ class Controller extends AbstractController {
 						$this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 						array(
 							'api_refund'  => array(
-								'description' => __( 'When true, the payment gateway API is used to perform the refund. If the payment gateway does not support refunds, the refund will fail.', 'woocommerce' ),
-								'type'        => 'boolean',
-								'context'     => array( 'edit' ),
-								'default'     => false,
+								'description'       => __( 'When true, the payment gateway API is used to perform the refund. If the payment gateway does not support refunds, the refund will fail.', 'woocommerce' ),
+								'type'              => 'boolean',
+								'context'           => array( 'edit' ),
+								'default'           => false,
+								'sanitize_callback' => 'rest_sanitize_boolean',
 							),
 							'api_restock' => array(
-								'description' => __( 'When true, refunded items are restocked.', 'woocommerce' ),
-								'type'        => 'boolean',
-								'context'     => array( 'edit' ),
-								'default'     => false,
-							),
-							'line_items'  => array(
-								'description' => __( 'Line items to refund. This can include products, fees, and shipping lines, combined into a single array.', 'woocommerce' ),
-								'type'        => 'array',
-								'context'     => array( 'edit' ),
-								'default'     => array(),
-								'items'       => array(
-									'type'       => 'object',
-									'properties' => array(
-										'id'           => array(
-											'description' => __( 'Item ID.', 'woocommerce' ),
-											'type'        => 'integer',
-										),
-										'quantity'     => array(
-											'description' => __( 'Quantity to refund for this item.', 'woocommerce' ),
-											'type'        => 'integer',
-											'minimum'     => 0,
-										),
-										'refund_total' => array(
-											'description' => __( 'Amount to refund for this item.', 'woocommerce' ),
-											'type'        => 'number',
-											'minimum'     => 0,
-										),
-										'refund_tax'   => array(
-											'description' => __( 'Taxes to refund for this item.', 'woocommerce' ),
-											'type'        => 'array',
-											'default'     => array(),
-											'items'       => array(
-												'type' => 'object',
-												'properties' => array(
-													'id' => array(
-														'description' => __( 'Tax ID.', 'woocommerce' ),
-														'type'        => 'integer',
-													),
-													'refund_total' => array(
-														'description' => __( 'Amount to refund for this tax.', 'woocommerce' ),
-														'type'        => 'number',
-														'minimum'     => 0,
-													),
-												),
-											),
-										),
-									),
-								),
+								'description'       => __( 'When true, refunded items are restocked.', 'woocommerce' ),
+								'type'              => 'boolean',
+								'context'           => array( 'edit' ),
+								'default'           => false,
+								'sanitize_callback' => 'rest_sanitize_boolean',
 							),
 						)
 					),
@@ -288,91 +254,33 @@ class Controller extends AbstractController {
 		}
 
 		try {
-			RestApiParameterUtil::adjust_create_refund_request_parameters( $request );
-
 			$order = wc_get_order( $request['order_id'] );
 
 			if ( ! $order ) {
 				return $this->get_route_error_by_code( self::INVALID_ID );
 			}
 
-			if ( 0 > $request['amount'] || ! $request['amount'] ) {
-				return $this->get_route_error_response( 'invalid_refund_amount', __( 'Refund total must be greater than zero.', 'woocommerce' ) );
+			// Validate request line_items before proceeding against the order being refunded.
+			$validation_error = $this->data_utils->validate_line_items( $request['line_items'], $order );
+
+			if ( is_wp_error( $validation_error ) ) {
+				return $this->get_route_error_response( $validation_error->get_error_code(), $validation_error->get_error_message() );
 			}
 
-			// Validate line items.
-			foreach ( $request['line_items'] as $line_item_id => $line_item ) {
-				if ( ! $line_item_id ) {
-					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item ID is required.', 'woocommerce' ) );
-				}
+			// Convert line items to internal format.
+			$line_item_data = $this->data_utils->convert_line_items_to_internal_format( $request['line_items'] );
+			$refund_amount  = $this->data_utils->calculate_refund_amount( $request['line_items'] );
 
-				$item = $order->get_item( $line_item_id );
-
-				// Validate item exists and belongs to the order.
-				if ( ! $item || $item->get_order_id() !== $order->get_id() ) {
-					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item not found.', 'woocommerce' ) );
-				}
-
-				if ( ! $item instanceof \WC_Order_Item_Product && ! $item instanceof \WC_Order_Item_Fee && ! $item instanceof \WC_Order_Item_Shipping ) {
-					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item is not a product, fee, or shipping line.', 'woocommerce' ) );
-				}
-
-				// Validate item quantity is not greater than the item quantity.
-				if ( $item->get_quantity() < $line_item['qty'] ) {
-					return $this->get_route_error_response( 'invalid_line_item', __( 'Line item quantity cannot be greater than the item quantity.', 'woocommerce' ) );
-				}
-
-				// Validate refund total is not greater than the item total.
-				if ( $item->get_total() < $line_item['refund_total'] ) {
-					return $this->get_route_error_response(
-						'invalid_refund_amount',
-						sprintf(
-							/* translators: %s: tax total */
-							__( 'Refund total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
-							$item->get_total()
-						)
-					);
-				}
-
-				if ( isset( $line_item['refund_tax'] ) ) {
-					$item_taxes = $item->get_taxes();
-
-					if ( $item_taxes ) {
-						$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
-
-						foreach ( $line_item['refund_tax'] as $tax_id => $refund_total ) {
-							if ( ! in_array( $tax_id, $allowed_tax_ids, true ) ) {
-								return $this->get_route_error_response(
-									'invalid_line_item',
-									sprintf(
-									/* translators: %s: tax IDs */
-										__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
-										implode( ', ', $allowed_tax_ids )
-									)
-								);
-							}
-
-							if ( $item_taxes['total'][ $tax_id ] < $refund_total ) {
-								return $this->get_route_error_response(
-									'invalid_refund_amount',
-									sprintf(
-									/* translators: %s: tax total */
-										__( 'Refund tax total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
-										$item_taxes['total'][ $tax_id ]
-									)
-								);
-							}
-						}
-					}
-				}
+			if ( 0 > $refund_amount || ! $refund_amount ) {
+				return $this->get_route_error_response( 'invalid_refund_amount', __( 'Refund total must be greater than zero.', 'woocommerce' ) );
 			}
 
 			$refund = wc_create_refund(
 				array(
 					'order_id'       => $order->get_id(),
-					'amount'         => $request['amount'],
+					'amount'         => $refund_amount,
 					'reason'         => $request['reason'],
-					'line_items'     => $request['line_items'],
+					'line_items'     => $line_item_data,
 					'refund_payment' => $request['api_refund'],
 					'restock_items'  => $request['api_restock'],
 				)

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -174,8 +174,8 @@ class DataUtils {
 					}
 				}
 			}
-
-			return true;
 		}
+
+		return true;
 	}
 }

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -40,6 +40,9 @@ class DataUtils {
 		$prepared_line_items = array();
 
 		foreach ( $line_items as $line_item ) {
+			if ( ! isset( $line_item['line_item_id'], $line_item['quantity'], $line_item['refund_total'] ) ) {
+				continue;
+			}
 			$prepared_line_items[ $line_item['line_item_id'] ] = array(
 				'qty'          => $line_item['quantity'],
 				'refund_total' => $line_item['refund_total'],
@@ -60,6 +63,9 @@ class DataUtils {
 		$prepared_taxes = array();
 
 		foreach ( $line_item_taxes as $line_item_tax ) {
+			if ( ! isset( $line_item_tax['id'], $line_item_tax['refund_total'] ) ) {
+				continue;
+			}
 			$prepared_taxes[ $line_item_tax['id'] ] = $line_item_tax['refund_total'];
 		}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * DataUtils class file.
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+use WC_Order;
+
+/**
+ * Helper methods for the REST API.
+ *
+ * Class DataUtils
+ *
+ * @package Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds
+ */
+class DataUtils {
+	/**
+	 * Convert line items (schema format) to internal format. This keys arrays by item ID and has some different naming
+	 * conventions.
+	 *
+	 * 111 => [
+	 *   "qty" => 1,
+	 *   "refund_total" => 123,
+	 *   "refund_tax" => [
+	 *     1 => 123,
+	 *     2 => 456,
+	 *   ],
+	 * ]
+	 *
+	 * @param array $line_items The line items to convert.
+	 * @return array The converted line items.
+	 */
+	public function convert_line_items_to_internal_format( $line_items ) {
+		$prepared_line_items = array();
+
+		foreach ( $line_items as $line_item ) {
+			$prepared_line_items[ $line_item['line_item_id'] ] = array(
+				'qty'          => $line_item['quantity'],
+				'refund_total' => $line_item['refund_total'],
+				'refund_tax'   => $this->convert_line_item_taxes_to_internal_format( $line_item['refund_tax'] ),
+			);
+		}
+
+		return $prepared_line_items;
+	}
+
+	/**
+	 * Convert line itemtaxes (schema format) to internal format. This keys arrays by tax ID and has some different naming
+	 *
+	 * @param array $line_item_taxes The taxes to convert.
+	 * @return array The converted taxes.
+	 */
+	private function convert_line_item_taxes_to_internal_format( $line_item_taxes ) {
+		$prepared_taxes = array();
+
+		foreach ( $line_item_taxes as $line_item_tax ) {
+			$prepared_taxes[ $line_item_tax['id'] ] = $line_item_tax['refund_total'];
+		}
+
+		return $prepared_taxes;
+	}
+
+	/**
+	 * Calculate the refund amount from line items.
+	 *
+	 * @param array $line_items The line items to calculate the refund amount from.
+	 * @return float|null The refund amount, or null if it can't be calculated.
+	 */
+	public function calculate_refund_amount( array $line_items ): ?float {
+		if ( empty( $line_items ) ) {
+			return null;
+		}
+
+		$amount = 0;
+
+		foreach ( $line_items as $line_item ) {
+			if ( ! empty( $line_item['refund_total'] ) && is_numeric( $line_item['refund_total'] ) ) {
+				$amount += $line_item['refund_total'];
+			}
+
+			if ( ! empty( $line_item['refund_tax'] ) && is_array( $line_item['refund_tax'] ) ) {
+				foreach ( $line_item['refund_tax'] as $tax ) {
+					if ( ! empty( $tax['refund_total'] ) && is_numeric( $tax['refund_total'] ) ) {
+						$amount += $tax['refund_total'];
+					}
+				}
+			}
+		}
+
+		return $amount;
+	}
+
+	/**
+	 * Validate line items (schema format) before conversion to internal format.
+	 *
+	 * @param array    $line_items The line items to validate.
+	 * @param WC_Order $order The order object.
+	 * @return boolean|WP_Error
+	 */
+	public function validate_line_items( $line_items, WC_Order $order ) {
+		foreach ( $line_items as $line_item ) {
+			$line_item_id = $line_item['line_item_id'] ?? null;
+
+			if ( ! $line_item_id ) {
+				return new WP_Error( 'invalid_line_item', __( 'Line item ID is required.', 'woocommerce' ) );
+			}
+
+			$item = $order->get_item( $line_item_id );
+
+			// Validate item exists and belongs to the order.
+			if ( ! $item || $item->get_order_id() !== $order->get_id() ) {
+				return new WP_Error( 'invalid_line_item', __( 'Line item not found.', 'woocommerce' ) );
+			}
+
+			if ( ! $item instanceof \WC_Order_Item_Product && ! $item instanceof \WC_Order_Item_Fee && ! $item instanceof \WC_Order_Item_Shipping ) {
+				return new WP_Error( 'invalid_line_item', __( 'Line item is not a product, fee, or shipping line.', 'woocommerce' ) );
+			}
+
+			// Validate item quantity is not greater than the item quantity.
+			if ( $item->get_quantity() < $line_item['quantity'] ) {
+				/* translators: %s: item quantity */
+				return new WP_Error( 'invalid_line_item', sprintf( __( 'Line item quantity cannot be greater than the item quantity (%s).', 'woocommerce' ), $item->get_quantity() ) );
+			}
+
+			// Validate refund total is not greater than the item total.
+			if ( $item->get_total() < $line_item['refund_total'] ) {
+				return new WP_Error(
+					'invalid_refund_amount',
+					sprintf(
+						/* translators: %s: tax total */
+						__( 'Refund total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+						$item->get_total()
+					)
+				);
+			}
+
+			if ( isset( $line_item['refund_tax'] ) ) {
+				$item_taxes = $item->get_taxes();
+
+				if ( $item_taxes ) {
+					$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
+
+					foreach ( $line_item['refund_tax'] as $refund_tax ) {
+						$tax_id           = $refund_tax['id'];
+						$tax_refund_total = $refund_tax['refund_total'];
+
+						if ( ! in_array( $tax_id, $allowed_tax_ids, true ) ) {
+							return new WP_Error(
+								'invalid_line_item',
+								sprintf(
+								/* translators: %s: tax IDs */
+									__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
+									implode( ', ', $allowed_tax_ids )
+								)
+							);
+						}
+
+						if ( $item_taxes['total'][ $tax_id ] < $tax_refund_total ) {
+							return new WP_Error(
+								'invalid_refund_amount',
+								sprintf(
+								/* translators: %s: tax total */
+									__( 'Refund tax total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+									$item_taxes['total'][ $tax_id ]
+								)
+							);
+						}
+					}
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -43,7 +43,7 @@ class DataUtils {
 			$prepared_line_items[ $line_item['line_item_id'] ] = array(
 				'qty'          => $line_item['quantity'],
 				'refund_total' => $line_item['refund_total'],
-				'refund_tax'   => $this->convert_line_item_taxes_to_internal_format( $line_item['refund_tax'] ),
+				'refund_tax'   => $this->convert_line_item_taxes_to_internal_format( $line_item['refund_tax'] ?? array() ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -54,7 +54,7 @@ class DataUtils {
 	}
 
 	/**
-	 * Convert line itemtaxes (schema format) to internal format. This keys arrays by tax ID and has some different naming
+	 * Convert line item taxes (schema format) to internal format. This keys arrays by tax ID and has some different naming
 	 *
 	 * @param array $line_item_taxes The taxes to convert.
 	 * @return array The converted taxes.
@@ -139,8 +139,8 @@ class DataUtils {
 				return new WP_Error(
 					'invalid_refund_amount',
 					sprintf(
-						/* translators: %s: tax total */
-						__( 'Refund total cannot be greater than the line item tax total (%s).', 'woocommerce' ),
+						/* translators: %s: item total */
+						__( 'Refund total cannot be greater than the line item total (%s).', 'woocommerce' ),
 						$item->get_total()
 					)
 				);
@@ -153,6 +153,9 @@ class DataUtils {
 					$allowed_tax_ids = array_keys( $item_taxes['total'] ?? array() );
 
 					foreach ( $line_item['refund_tax'] as $refund_tax ) {
+						if ( ! isset( $refund_tax['id'], $refund_tax['refund_total'] ) ) {
+							return new WP_Error( 'invalid_line_item', __( 'Tax id and refund_total are required.', 'woocommerce' ) );
+						}
 						$tax_id           = $refund_tax['id'];
 						$tax_refund_total = $refund_tax['refund_total'];
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
@@ -225,6 +225,7 @@ class RefundSchema extends AbstractSchema {
 							'description' => __( 'Taxes refunded for this item.', 'woocommerce' ),
 							'type'        => 'array',
 							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'default'     => array(),
 							'items'       => array(
 								'type'       => 'object',
 								'properties' => array(

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
@@ -102,10 +102,12 @@ class RefundSchema extends AbstractSchema {
 				'sanitize_callback' => 'absint',
 			),
 			'amount'           => array(
-				'description' => __( 'Amount that was refunded', 'woocommerce' ),
-				'type'        => 'number',
-				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-				'readonly'    => true,
+				'description'       => __( 'Amount that was refunded. This is calculated from the line items if not provided.', 'woocommerce' ),
+				'type'              => 'number',
+				'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+				'default'           => 0,
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'reason'           => array(
 				'description'       => __( 'Reason for the refund.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * RefundSchema class.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Orders\Schema\OrderItemSchema;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Orders\Schema\OrderFeeSchema;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Orders\Schema\OrderTaxSchema;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Orders\Schema\OrderShippingSchema;
+use WP_REST_Request;
+
+/**
+ * RefundSchema class.
+ */
+class RefundSchema extends AbstractSchema {
+	use CogsAwareTrait;
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order';
+
+	/**
+	 * The order item schema.
+	 *
+	 * @var OrderItemSchema
+	 */
+	private $order_item_schema;
+
+	/**
+	 * The order fee schema.
+	 *
+	 * @var OrderFeeSchema
+	 */
+	private $order_fee_schema;
+
+	/**
+	 * The order tax schema.
+	 *
+	 * @var OrderTaxSchema
+	 */
+	private $order_tax_schema;
+
+	/**
+	 * The order shipping schema.
+	 *
+	 * @var OrderShippingSchema
+	 */
+	private $order_shipping_schema;
+
+	/**
+	 * Initialize the schema.
+	 *
+	 * @internal
+	 * @param OrderItemSchema     $order_item_schema The order item schema.
+	 * @param OrderFeeSchema      $order_fee_schema The order fee schema.
+	 * @param OrderTaxSchema      $order_tax_schema The order tax schema.
+	 * @param OrderShippingSchema $order_shipping_schema The order shipping schema.
+	 */
+	final public function init( OrderItemSchema $order_item_schema, OrderFeeSchema $order_fee_schema, OrderTaxSchema $order_tax_schema, OrderShippingSchema $order_shipping_schema ) {
+		$this->order_item_schema     = $order_item_schema;
+		$this->order_fee_schema      = $order_fee_schema;
+		$this->order_tax_schema      = $order_tax_schema;
+		$this->order_shipping_schema = $order_shipping_schema;
+	}
+
+	/**
+	 * Return all properties for the item schema.
+	 *
+	 * Note that context determines under which context data should be visible. For example, edit would be the context
+	 * used when getting records with the intent of editing them. embed context allows the data to be visible when the
+	 * item is being embedded in another response.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema_properties(): array {
+		$schema = array(
+			'id'               => array(
+				'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'order_id'         => array(
+				'description' => __( 'The ID of the order the refund belongs to.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'required'    => true,
+			),
+			'amount'           => array(
+				'description' => __( 'Refund amount.', 'woocommerce' ),
+				'type'        => 'number',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'reason'           => array(
+				'description' => __( 'Reason for refund.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'default'     => '',
+			),
+			'currency'         => array(
+				'description' => __( 'Currency the refund was created with, in ISO format.', 'woocommerce' ),
+				'type'        => 'string',
+				'default'     => get_woocommerce_currency(),
+				'enum'        => array_keys( get_woocommerce_currencies() ),
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'currency_symbol'  => array(
+				'description' => __( 'Currency symbol for the currency which can be used to format returned prices.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'date_created'     => array(
+				'description' => __( "The date the refund was created, in the site's timezone.", 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'date_created_gmt' => array(
+				'description' => __( 'The date the refund was created, as GMT.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+			),
+			'refunded_by'      => array(
+				'description' => __( 'User ID of user who created the refund.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'refunded_payment' => array(
+				'description' => __( 'If the payment was refunded via the API.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'meta_data'        => array(
+				'description' => __( 'Meta data.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'    => array(
+							'description' => __( 'Meta ID.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'readonly'    => true,
+						),
+						'key'   => array(
+							'description' => __( 'Meta key.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+						),
+						'value' => array(
+							'description' => __( 'Meta value.', 'woocommerce' ),
+							'type'        => array( 'null', 'object', 'string', 'number', 'boolean', 'integer', 'array' ),
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+						),
+					),
+				),
+			),
+			'line_items'       => array(
+				'description' => __( 'A list of line items (products) that were refunded.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'refund_item_id' => array(
+							'description' => __( 'ID of the record for the refunded item.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'readonly'    => true,
+						),
+						'quantity'       => array(
+							'description' => __( 'Quantity refunded.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'readonly'    => true,
+						),
+						'refund_total'   => array(
+							'description' => __( 'Total refunded for this item.', 'woocommerce' ),
+							'type'        => 'number',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'readonly'    => true,
+						),
+						'refund_tax'     => array(
+							'description' => __( 'Taxes refunded for this item.', 'woocommerce' ),
+							'type'        => 'array',
+							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+							'readonly'    => true,
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'           => array(
+										'description' => __( 'Tax ID.', 'woocommerce' ),
+										'type'        => 'integer',
+										'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+										'readonly'    => true,
+									),
+									'refund_total' => array(
+										'description' => __( 'Amount refunded for this tax.', 'woocommerce' ),
+										'type'        => 'number',
+										'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+										'readonly'    => true,
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		if ( $this->cogs_is_enabled() ) {
+			$schema = $this->add_cogs_related_schema( $schema );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Add the Cost of Goods Sold related fields to the schema.
+	 *
+	 * @param array $schema The original schema.
+	 * @return array The updated schema.
+	 */
+	private static function add_cogs_related_schema( array $schema ): array {
+		$schema['cost_of_goods_sold'] = array(
+			'description' => __( 'Cost of Goods Sold data.', 'woocommerce' ),
+			'type'        => 'object',
+			'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+			'readonly'    => true,
+			'properties'  => array(
+				'total_value' => array(
+					'description' => __( 'Total value of the Cost of Goods Sold for the refund.', 'woocommerce' ),
+					'type'        => 'number',
+					'readonly'    => true,
+					'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				),
+			),
+		);
+		return $schema;
+	}
+
+	/**
+	 * Get an item response.
+	 *
+	 * @param WC_Order_Refund $refund Refund instance.
+	 * @param WP_REST_Request $request Request object.
+	 * @param array           $include_fields Fields to include in the response.
+	 * @return array
+	 */
+	public function get_item_response( $refund, WP_REST_Request $request, array $include_fields = array() ): array {
+		$dp   = is_null( $request['num_decimals'] ) ? wc_get_price_decimals() : absint( $request['num_decimals'] );
+		$data = array(
+			'id'               => $refund->get_id(),
+			'order_id'         => $refund->get_parent_id(),
+			'currency'         => $refund->get_currency(),
+			'currency_symbol'  => html_entity_decode( get_woocommerce_currency_symbol( $refund->get_currency() ), ENT_QUOTES ),
+			'date_created'     => wc_rest_prepare_date_response( $refund->get_date_created(), false ),
+			'date_created_gmt' => wc_rest_prepare_date_response( $refund->get_date_created() ),
+			'amount'           => wc_format_decimal( $refund->get_amount(), $dp ),
+			'reason'           => $refund->get_reason(),
+			'refunded_by'      => $refund->get_refunded_by(),
+			'refunded_payment' => $refund->get_refunded_payment(),
+		);
+
+		if ( in_array( 'line_items', $include_fields, true ) ) {
+			$data['line_items'] = array_merge(
+				$this->get_line_items_response( $refund->get_items( 'line_item' ) ),
+				$this->get_line_items_response( $refund->get_items( 'fee' ) ),
+				$this->get_line_items_response( $refund->get_items( 'shipping' ) ),
+			);
+		}
+
+		if ( in_array( 'meta_data', $include_fields, true ) ) {
+			$filtered_meta_data = $this->filter_internal_meta_keys( $refund->get_meta_data() );
+			$data['meta_data']  = array();
+			foreach ( $filtered_meta_data as $meta_item ) {
+				$data['meta_data'][] = array(
+					'id'    => $meta_item->id,
+					'key'   => $meta_item->key,
+					'value' => $meta_item->value,
+				);
+			}
+		}
+
+		// Add COGS data.
+		if ( $this->cogs_is_enabled() && in_array( 'cost_of_goods_sold', $include_fields, true ) ) {
+			$data['cost_of_goods_sold']['total_value'] = $refund->get_cogs_total_value();
+		}
+
+		$data = array_intersect_key( $data, array_flip( $include_fields ) );
+
+		return $data;
+	}
+
+	/**
+	 * Standardize the line items response.
+	 *
+	 * @param array $line_items Line items.
+	 * @return array
+	 */
+	protected function get_line_items_response( $line_items ) {
+		$line_items_response = array();
+		foreach ( $line_items as $line_item ) {
+			$line_items_response[] = $this->prepare_line_item( $line_item );
+		}
+		return $line_items_response;
+	}
+
+	/**
+	 * Standardize the line item response.
+	 *
+	 * @param WC_Order_Item $line_item Line item instance.
+	 * @return array
+	 */
+	protected function prepare_line_item( $line_item ) {
+		$tax_response = array();
+		$taxes        = $line_item->get_taxes();
+		foreach ( $taxes['total'] ?? array() as $tax_rate_id => $tax ) {
+			$tax_response[] = array(
+				'id'           => $tax_rate_id,
+				'refund_total' => $tax,
+			);
+		}
+		return array(
+			'id'           => (int) $line_item->get_meta( '_refunded_item_id' ),
+			'quantity'     => $line_item->get_quantity(),
+			'refund_total' => $line_item->get_total(),
+			'refund_tax'   => $tax_response,
+		);
+	}
+
+	/**
+	 * With HPOS, few internal meta keys such as _billing_address_index, _shipping_address_index are not considered internal anymore (since most internal keys were flattened into dedicated columns).
+	 *
+	 * This function helps in filtering out any remaining internal meta keys with HPOS is enabled.
+	 *
+	 * @param array $meta_data Order meta data.
+	 * @return array Filtered order meta data.
+	 */
+	protected function filter_internal_meta_keys( $meta_data ) {
+		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			return $meta_data;
+		}
+		$cpt_hidden_keys = ( new \WC_Order_Data_Store_CPT() )->get_internal_meta_keys();
+		$meta_data       = array_filter(
+			$meta_data,
+			function ( $meta ) use ( $cpt_hidden_keys ) {
+				return ! in_array( $meta->key, $cpt_hidden_keys, true );
+			}
+		);
+		return array_values( $meta_data );
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Schema/RefundSchema.php
@@ -89,28 +89,30 @@ class RefundSchema extends AbstractSchema {
 	public function get_item_schema_properties(): array {
 		$schema = array(
 			'id'               => array(
-				'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+				'description' => __( 'Unique identifier for the refund.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
 			'order_id'         => array(
-				'description' => __( 'The ID of the order the refund belongs to.', 'woocommerce' ),
-				'type'        => 'integer',
-				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-				'required'    => true,
+				'description'       => __( 'The ID of the order that was refunded.', 'woocommerce' ),
+				'type'              => 'integer',
+				'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+				'required'          => true,
+				'sanitize_callback' => 'absint',
 			),
 			'amount'           => array(
-				'description' => __( 'Refund amount.', 'woocommerce' ),
+				'description' => __( 'Amount that was refunded', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
 			'reason'           => array(
-				'description' => __( 'Reason for refund.', 'woocommerce' ),
-				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
-				'default'     => '',
+				'description'       => __( 'Reason for the refund.', 'woocommerce' ),
+				'type'              => 'string',
+				'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'currency'         => array(
 				'description' => __( 'Currency the refund was created with, in ISO format.', 'woocommerce' ),
@@ -143,13 +145,13 @@ class RefundSchema extends AbstractSchema {
 			'refunded_by'      => array(
 				'description' => __( 'User ID of user who created the refund.', 'woocommerce' ),
 				'type'        => 'integer',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
 			'refunded_payment' => array(
 				'description' => __( 'If the payment was refunded via the API.', 'woocommerce' ),
 				'type'        => 'boolean',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 				'readonly'    => true,
 			),
 			'meta_data'        => array(
@@ -180,36 +182,47 @@ class RefundSchema extends AbstractSchema {
 				),
 			),
 			'line_items'       => array(
-				'description' => __( 'A list of line items (products) that were refunded.', 'woocommerce' ),
+				'description' => __( 'Refunded line items. This can include products, fees, and shipping lines, combined into a single array.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-				'readonly'    => true,
+				'default'     => array(),
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'refund_item_id' => array(
-							'description' => __( 'ID of the record for the refunded item.', 'woocommerce' ),
+						'id'           => array(
+							'description' => __( 'ID of the refund line item. This is not the ID of the original line item.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
 							'readonly'    => true,
 						),
-						'quantity'       => array(
-							'description' => __( 'Quantity refunded.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-							'readonly'    => true,
+						'line_item_id' => array(
+							'description'       => __( 'ID of the original line item.', 'woocommerce' ),
+							'type'              => 'integer',
+							'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+							'validate_callback' => 'rest_validate_request_arg',
 						),
-						'refund_total'   => array(
-							'description' => __( 'Total refunded for this item.', 'woocommerce' ),
-							'type'        => 'number',
-							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-							'readonly'    => true,
+						'quantity'     => array(
+							'description'       => __( 'Quantity refunded.', 'woocommerce' ),
+							'type'              => 'integer',
+							'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+							'default'           => 0,
+							'sanitize_callback' => 'wc_stock_amount',
+							'validate_callback' => 'rest_validate_request_arg',
 						),
-						'refund_tax'     => array(
+						'refund_total' => array(
+							'description'       => __( 'Total refunded for this item.', 'woocommerce' ),
+							'type'              => 'number',
+							'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+							'default'           => 0,
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+						'refund_tax'   => array(
 							'description' => __( 'Taxes refunded for this item.', 'woocommerce' ),
 							'type'        => 'array',
 							'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-							'readonly'    => true,
 							'items'       => array(
 								'type'       => 'object',
 								'properties' => array(
@@ -217,13 +230,17 @@ class RefundSchema extends AbstractSchema {
 										'description' => __( 'Tax ID.', 'woocommerce' ),
 										'type'        => 'integer',
 										'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-										'readonly'    => true,
+										'required'    => true,
+										'sanitize_callback' => 'absint',
+										'validate_callback' => 'rest_validate_request_arg',
 									),
 									'refund_total' => array(
 										'description' => __( 'Amount refunded for this tax.', 'woocommerce' ),
 										'type'        => 'number',
 										'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-										'readonly'    => true,
+										'required'    => true,
+										'sanitize_callback' => 'sanitize_text_field',
+										'validate_callback' => 'rest_validate_request_arg',
 									),
 								),
 							),
@@ -289,9 +306,9 @@ class RefundSchema extends AbstractSchema {
 
 		if ( in_array( 'line_items', $include_fields, true ) ) {
 			$data['line_items'] = array_merge(
-				$this->get_line_items_response( $refund->get_items( 'line_item' ) ),
-				$this->get_line_items_response( $refund->get_items( 'fee' ) ),
-				$this->get_line_items_response( $refund->get_items( 'shipping' ) ),
+				$this->get_line_items_response( $refund->get_items( 'line_item' ), $request ),
+				$this->get_line_items_response( $refund->get_items( 'fee' ), $request ),
+				$this->get_line_items_response( $refund->get_items( 'shipping' ), $request ),
 			);
 		}
 
@@ -320,13 +337,14 @@ class RefundSchema extends AbstractSchema {
 	/**
 	 * Standardize the line items response.
 	 *
-	 * @param array $line_items Line items.
+	 * @param array           $line_items Line items.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function get_line_items_response( $line_items ) {
+	protected function get_line_items_response( $line_items, WP_REST_Request $request ) {
 		$line_items_response = array();
 		foreach ( $line_items as $line_item ) {
-			$line_items_response[] = $this->prepare_line_item( $line_item );
+			$line_items_response[] = $this->prepare_line_item( $line_item, $request );
 		}
 		return $line_items_response;
 	}
@@ -334,22 +352,25 @@ class RefundSchema extends AbstractSchema {
 	/**
 	 * Standardize the line item response.
 	 *
-	 * @param WC_Order_Item $line_item Line item instance.
+	 * @param WC_Order_Item   $line_item Line item instance.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_line_item( $line_item ) {
+	protected function prepare_line_item( $line_item, WP_REST_Request $request ) {
+		$dp           = is_null( $request['num_decimals'] ) ? wc_get_price_decimals() : absint( $request['num_decimals'] );
 		$tax_response = array();
 		$taxes        = $line_item->get_taxes();
 		foreach ( $taxes['total'] ?? array() as $tax_rate_id => $tax ) {
 			$tax_response[] = array(
-				'id'           => $tax_rate_id,
-				'refund_total' => $tax,
+				'id'           => absint( $tax_rate_id ),
+				'refund_total' => wc_format_decimal( abs( (float) $tax ), $dp ),
 			);
 		}
 		return array(
-			'id'           => (int) $line_item->get_meta( '_refunded_item_id' ),
-			'quantity'     => $line_item->get_quantity(),
-			'refund_total' => $line_item->get_total(),
+			'id'           => absint( $line_item->get_id() ),
+			'line_item_id' => absint( $line_item->get_meta( '_refunded_item_id' ) ),
+			'quantity'     => wc_stock_amount( abs( (float) $line_item->get_quantity() ) ),
+			'refund_total' => wc_format_decimal( abs( (float) $line_item->get_total() ), $dp ),
 			'refund_tax'   => $tax_response,
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Customers/class-wc-rest-customers-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Customers/class-wc-rest-customers-v4-controller-tests.php
@@ -1,4 +1,5 @@
-<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+<?php
+declare( strict_types=1 );
 
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Customers\Controller as CustomersController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Customers\CustomerSchema;

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OrderNotes/class-wc-rest-order-notes-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OrderNotes/class-wc-rest-order-notes-v4-controller-tests.php
@@ -1,10 +1,8 @@
-<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+<?php
+declare( strict_types=1 );
 
-use Automattic\WooCommerce\Enums\OrderStatus;
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
-
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\OrderNotes\Controller as OrderNotesController;
 
 /**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
@@ -923,8 +923,6 @@ class WC_REST_Orders_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 204, $response->get_status() );
-
-		$order->delete( true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
@@ -857,73 +857,6 @@ class WC_REST_Orders_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test edge case: meta data filtering with include_meta.
-	 */
-	public function test_meta_data_include_filtering(): void {
-		$order = $this->create_test_order();
-		$order->add_meta_data( 'test_meta_1', 'value_1', true );
-		$order->add_meta_data( 'test_meta_2', 'value_2', true );
-		$order->add_meta_data( 'internal_meta', 'internal_value', true );
-		$order->save();
-
-		$request = new WP_REST_Request( 'GET', '/wc/v4/orders/' . $order->get_id() );
-		$request->set_param( 'include_meta', array( 'test_meta_1', 'test_meta_2' ) );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$response_data = $response->get_data();
-
-		$this->assertArrayHasKey( 'meta_data', $response_data );
-		$this->assertCount( 2, $response_data['meta_data'] );
-
-		$meta_keys = array_map(
-			function ( $meta_item ) {
-				return $meta_item['key'];
-			},
-			$response_data['meta_data']
-		);
-
-		$this->assertContains( 'test_meta_1', $meta_keys );
-		$this->assertContains( 'test_meta_2', $meta_keys );
-		$this->assertNotContains( 'internal_meta', $meta_keys );
-
-		$order->delete( true );
-	}
-
-	/**
-	 * Test edge case: meta data filtering with exclude_meta.
-	 */
-	public function test_meta_data_exclude_filtering(): void {
-		$order = $this->create_test_order();
-		$order->add_meta_data( 'test_meta_1', 'value_1', true );
-		$order->add_meta_data( 'test_meta_2', 'value_2', true );
-		$order->add_meta_data( 'internal_meta', 'internal_value', true );
-		$order->save();
-
-		$request = new WP_REST_Request( 'GET', '/wc/v4/orders/' . $order->get_id() );
-		$request->set_param( 'exclude_meta', 'test_meta_1' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$response_data = $response->get_data();
-
-		$this->assertArrayHasKey( 'meta_data', $response_data );
-
-		$meta_keys = array_map(
-			function ( $meta_item ) {
-				return $meta_item['key'];
-			},
-			$response_data['meta_data']
-		);
-
-		$this->assertNotContains( 'test_meta_1', $meta_keys );
-		$this->assertContains( 'test_meta_2', $meta_keys );
-		$this->assertContains( 'internal_meta', $meta_keys );
-
-		$order->delete( true );
-	}
-
-	/**
 	 * Test edge case: created_via filtering when COT is enabled.
 	 */
 	public function test_created_via_filtering_with_cot_enabled(): void {
@@ -984,6 +917,16 @@ class WC_REST_Orders_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 		// Check the order was actually deleted (trashed).
 		$order = wc_get_order( $order_id );
 		$this->assertEquals( OrderStatus::TRASH, $order->get_status( 'edit' ) );
+
+		// Force deletion, skip tash.
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/orders/' . $order_id );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 204, $response->get_status() );
+
+		// Check the order was actually deleted (deleted).
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( 0, $order->get_id() );
 
 		$order->delete( true );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
@@ -924,10 +924,6 @@ class WC_REST_Orders_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 204, $response->get_status() );
 
-		// Check the order was actually deleted (deleted).
-		$order = wc_get_order( $order_id );
-		$this->assertEquals( 0, $order->get_id() );
-
 		$order->delete( true );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-controller-tests.php
@@ -918,7 +918,7 @@ class WC_REST_Orders_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$order = wc_get_order( $order_id );
 		$this->assertEquals( OrderStatus::TRASH, $order->get_status( 'edit' ) );
 
-		// Force deletion, skip tash.
+		// Force deletion, skip trash.
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/orders/' . $order_id );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -287,7 +287,7 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		if ( $response->get_status() !== 201 ) {
 			$response_data = $response->get_data();
-			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) );
+			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		}
 		$response_data = $response->get_data();
 
@@ -476,7 +476,7 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		if ( $response->get_status() !== 201 ) {
 			$response_data = $response->get_data();
-			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) );
+			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		}
 		$response_data = $response->get_data();
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -1,0 +1,492 @@
+<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Controller as RefundsController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema\RefundSchema;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\CollectionQuery;
+
+/**
+ * Refunds Controller tests for V4 REST API.
+ *
+ * @group refund-query-tests
+ */
+class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	/**
+	 * Endpoint instance.
+	 *
+	 * @var RefundsController
+	 */
+	private $endpoint;
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Refund schema instance.
+	 *
+	 * @var RefundSchema
+	 */
+	private $refund_schema;
+
+	/**
+	 * Collection of created orders for cleanup.
+	 *
+	 * @var array
+	 */
+	private $created_orders = array();
+
+	/**
+	 * Collection of created refunds for cleanup.
+	 *
+	 * @var array
+	 */
+	private $created_refunds = array();
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		// Clean up created refunds.
+		foreach ( $this->created_refunds as $refund_id ) {
+			$refund = wc_get_order( $refund_id );
+			if ( $refund ) {
+				$refund->delete( true );
+			}
+		}
+		$this->created_refunds = array();
+
+		// Clean up created orders.
+		foreach ( $this->created_orders as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( $order ) {
+				$order->delete( true );
+			}
+		}
+		$this->created_orders = array();
+
+		parent::tearDown();
+		$this->disable_rest_api_v4_feature();
+	}
+
+	/**
+	 * Enable the REST API v4 feature.
+	 */
+	public static function enable_rest_api_v4_feature() {
+		add_filter(
+			'woocommerce_admin_features',
+			function ( $features ) {
+				$features[] = 'rest-api-v4';
+				return $features;
+			},
+		);
+	}
+
+	/**
+	 * Disable the REST API v4 feature.
+	 */
+	public static function disable_rest_api_v4_feature() {
+		add_filter(
+			'woocommerce_admin_features',
+			function ( $features ) {
+				$features = array_diff( $features, array( 'rest-api-v4' ) );
+				return $features;
+			}
+		);
+	}
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		$this->enable_rest_api_v4_feature();
+		parent::setUp();
+
+		// Create schema instances with dependency injection.
+		$this->refund_schema = new RefundSchema();
+
+		// Create utils instances.
+		$collection_query = new CollectionQuery();
+
+		$this->endpoint = new RefundsController();
+		$this->endpoint->init( $this->refund_schema, $collection_query );
+
+		$this->user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_email' => 'test@example.com',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+	 * Helper method to create a simple order.
+	 *
+	 * @param array $order_data Optional order data.
+	 * @return WC_Order
+	 */
+	private function create_test_order( array $order_data = array() ): WC_Order {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 10.00 );
+		$product->save();
+
+		$default_data = array(
+			'status'     => OrderStatus::COMPLETED,
+			'billing'    => array(
+				'first_name' => 'John',
+				'last_name'  => 'Doe',
+				'email'      => 'john.doe@example.com',
+				'phone'      => '555-1234',
+				'address_1'  => '123 Main St',
+				'city'       => 'Anytown',
+				'state'      => 'CA',
+				'postcode'   => '12345',
+				'country'    => 'US',
+			),
+			'line_items' => array(
+				array(
+					'product_id' => $product->get_id(),
+					'quantity'   => 1,
+				),
+			),
+		);
+
+		$order_data = wp_parse_args( $order_data, $default_data );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/orders' );
+		$request->set_body_params( $order_data );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$data = $response->get_data();
+
+		$order                  = wc_get_order( $data['id'] );
+		$this->created_orders[] = $order->get_id();
+
+		$product->delete( true );
+
+		return $order;
+	}
+
+	/**
+	 * Helper method to create a test refund.
+	 *
+	 * @param WC_Order $order Order to refund.
+	 * @param array    $refund_data Optional refund data.
+	 * @return WC_Order_Refund
+	 */
+	private function create_test_refund( WC_Order $order, array $refund_data = array() ): WC_Order_Refund {
+		$default_data = array(
+			'amount'     => 5.00,
+			'reason'     => 'Test refund',
+			'line_items' => array(),
+		);
+
+		$refund_data = wp_parse_args( $refund_data, $default_data );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/refunds' );
+		$request->set_body_params(
+			array_merge(
+				$refund_data,
+				array( 'order_id' => $order->get_id() )
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$data = $response->get_data();
+
+		$refund                  = wc_get_order( $data['id'] );
+		$this->created_refunds[] = $refund->get_id();
+
+		return $refund;
+	}
+
+	/**
+	 * Helper method to validate response against schema.
+	 *
+	 * @param array $response_data Response data to validate.
+	 * @param array $schema_properties Schema properties to check against.
+	 */
+	private function validate_response_against_schema( array $response_data, array $schema_properties ): void {
+		foreach ( $schema_properties as $property => $schema ) {
+			$this->assertArrayHasKey( $property, $response_data, "Response should contain property: {$property}" );
+		}
+	}
+
+	/**
+	 * Test GET /wc/v4/refunds endpoint returns collection of refunds.
+	 */
+	public function test_refunds_list_endpoint(): void {
+		// Create test orders and refunds.
+		$order1  = $this->create_test_order();
+		$order2  = $this->create_test_order();
+		$refund1 = $this->create_test_refund( $order1 );
+		$refund2 = $this->create_test_refund( $order2 );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/refunds' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertGreaterThanOrEqual( 2, count( $response_data ) );
+
+		// Validate first refund against schema.
+		$first_refund      = $response_data[0];
+		$schema_properties = $this->refund_schema->get_item_schema_properties();
+		$this->validate_response_against_schema( $first_refund, $schema_properties );
+	}
+
+	/**
+	 * Test GET /wc/v4/refunds/{id} endpoint returns single refund.
+	 */
+	public function test_refunds_get_endpoint(): void {
+		$order  = $this->create_test_order();
+		$refund = $this->create_test_refund( $order );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/refunds/' . $refund->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertEquals( $refund->get_id(), $response_data['id'] );
+
+		// Validate response against schema.
+		$schema_properties = $this->refund_schema->get_item_schema_properties();
+		$this->validate_response_against_schema( $response_data, $schema_properties );
+	}
+
+	/**
+	 * Test POST /wc/v4/refunds endpoint creates refund.
+	 */
+	public function test_refunds_create_endpoint(): void {
+		$order       = $this->create_test_order();
+		$refund_data = array(
+			'order_id'   => $order->get_id(),
+			'amount'     => 5.00,
+			'reason'     => 'Customer requested refund',
+			'line_items' => array(),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/refunds' );
+		$request->set_body_params( $refund_data );
+		$response = $this->server->dispatch( $request );
+
+		if ( $response->get_status() !== 201 ) {
+			$response_data = $response->get_data();
+			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) );
+		}
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertArrayHasKey( 'id', $response_data );
+		$this->assertEquals( $order->get_id(), $response_data['order_id'] );
+		$this->assertEquals( '5.00', $response_data['amount'] );
+		$this->assertEquals( 'Customer requested refund', $response_data['reason'] );
+
+		// Track for cleanup.
+		$this->created_refunds[] = $response_data['id'];
+
+		// Validate response against schema.
+		$schema_properties = $this->refund_schema->get_item_schema_properties();
+		$this->validate_response_against_schema( $response_data, $schema_properties );
+	}
+
+	/**
+	 * Test DELETE /wc/v4/refunds/{id} endpoint deletes refund (hard delete only).
+	 */
+	public function test_refunds_delete_endpoint(): void {
+		$order     = $this->create_test_order();
+		$refund    = $this->create_test_refund( $order );
+		$refund_id = $refund->get_id();
+
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/refunds/' . $refund_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 204, $response->get_status() );
+
+		// Check the refund was actually deleted (hard delete).
+		$deleted_refund = wc_get_order( $refund_id );
+		$this->assertFalse( $deleted_refund );
+	}
+
+	/**
+	 * Test pagination works correctly for refunds collection.
+	 */
+	public function test_refunds_pagination(): void {
+		// Create 4 test orders and refunds.
+		$refunds = array();
+		for ( $i = 1; $i <= 4; $i++ ) {
+			$order     = $this->create_test_order(
+				array(
+					'billing' => array(
+						'first_name' => "Test{$i}",
+						'last_name'  => 'User',
+						'email'      => "test{$i}@example.com",
+					),
+				)
+			);
+			$refund    = $this->create_test_refund( $order );
+			$refunds[] = $refund;
+		}
+
+		// Test first page (page=1, per_page=2) - should return 2 refunds.
+		$request = new WP_REST_Request( 'GET', '/wc/v4/refunds' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 2 );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertCount( 2, $response_data, 'First page should return exactly 2 refunds' );
+
+		// Test second page (page=2, per_page=2) - should return 2 refunds.
+		$request->set_param( 'page', 2 );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertCount( 2, $response_data, 'Second page should return exactly 2 refunds' );
+
+		// Test third page (page=3, per_page=2) - should return 0 refunds.
+		$request->set_param( 'page', 3 );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertCount( 0, $response_data, 'Third page should return 0 refunds' );
+	}
+
+	/**
+	 * Test order_id filter works correctly for refunds collection.
+	 */
+	public function test_refunds_order_id_filter(): void {
+		// Create two orders with refunds.
+		$order1  = $this->create_test_order();
+		$order2  = $this->create_test_order();
+		$refund1 = $this->create_test_refund( $order1 );
+		$refund2 = $this->create_test_refund( $order2 );
+
+		// Test filtering by order_id.
+		$request = new WP_REST_Request( 'GET', '/wc/v4/refunds' );
+		$request->set_param( 'order_id', $order1->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertCount( 1, $response_data, 'Should return exactly 1 refund for the specified order' );
+		$this->assertEquals( $order1->get_id(), $response_data[0]['order_id'] );
+
+		// Test filtering by different order_id.
+		$request->set_param( 'order_id', $order2->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertCount( 1, $response_data, 'Should return exactly 1 refund for the second order' );
+		$this->assertEquals( $order2->get_id(), $response_data[0]['order_id'] );
+	}
+
+	/**
+	 * Test refund creation with line items.
+	 */
+	public function test_refunds_create_with_line_items(): void {
+		// Create order with product.
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = $this->create_test_order(
+			array(
+				'line_items' => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 2,
+					),
+				),
+			)
+		);
+
+		// Get the line item ID.
+		$line_items = $order->get_items();
+		$line_item  = reset( $line_items );
+
+		$refund_data = array(
+			'order_id'   => $order->get_id(),
+			'amount'     => 5.00,
+			'reason'     => 'Partial refund for damaged item',
+			'line_items' => array(
+				array(
+					'id'           => $line_item->get_id(),
+					'quantity'     => 1,
+					'refund_total' => 5.00,
+				),
+			),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/refunds' );
+		$request->set_body_params( $refund_data );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertArrayHasKey( 'id', $response_data );
+		$this->assertEquals( $order->get_id(), $response_data['order_id'] );
+		$this->assertEquals( '5.00', $response_data['amount'] );
+		$this->assertArrayHasKey( 'line_items', $response_data );
+		$this->assertCount( 1, $response_data['line_items'] );
+
+		// Track for cleanup.
+		$this->created_refunds[] = $response_data['id'];
+
+		// Clean up product.
+		$product->delete( true );
+	}
+
+	/**
+	 * Test refund creation with API refund and restock options.
+	 */
+	public function test_refunds_create_with_api_options(): void {
+		$order       = $this->create_test_order();
+		$refund_data = array(
+			'order_id'    => $order->get_id(),
+			'amount'      => 5.00,
+			'reason'      => 'API refund test',
+			'api_refund'  => false,
+			'api_restock' => true,
+			'line_items'  => array(),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/refunds' );
+		$request->set_body_params( $refund_data );
+		$response = $this->server->dispatch( $request );
+
+		if ( $response->get_status() !== 201 ) {
+			$response_data = $response->get_data();
+			$this->fail( 'Expected 201, got ' . $response->get_status() . '. Response: ' . print_r( $response_data, true ) );
+		}
+		$response_data = $response->get_data();
+
+		$this->assertIsArray( $response_data );
+		$this->assertArrayHasKey( 'id', $response_data );
+		$this->assertEquals( $order->get_id(), $response_data['order_id'] );
+		$this->assertEquals( '5.00', $response_data['amount'] );
+		$this->assertEquals( 'API refund test', $response_data['reason'] );
+
+		// Track for cleanup.
+		$this->created_refunds[] = $response_data['id'];
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -428,7 +428,7 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 			'reason'     => 'Partial refund for damaged item',
 			'line_items' => array(
 				array(
-					'id'           => $line_item->get_id(),
+					'line_item_id' => $line_item->get_id(),
 					'quantity'     => 1,
 					'refund_total' => 5.00,
 				),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -1,4 +1,5 @@
-<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+<?php
+declare( strict_types=1 );
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Refunds/class-wc-rest-refunds-v4-controller-tests.php
@@ -5,6 +5,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Controller as RefundsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema\RefundSchema;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\CollectionQuery;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\DataUtils;
 
 /**
  * Refunds Controller tests for V4 REST API.
@@ -113,9 +114,10 @@ class WC_REST_Refunds_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		// Create utils instances.
 		$collection_query = new CollectionQuery();
+		$data_utils       = new DataUtils();
 
 		$this->endpoint = new RefundsController();
-		$this->endpoint->init( $this->refund_schema, $collection_query );
+		$this->endpoint->init( $this->refund_schema, $collection_query, $data_utils );
 
 		$this->user_id = wp_insert_user(
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rest API v4 refunds endpoint. I've opted to simplify and unify the response and request properties, returning less data. 

Example POST to `wp-json/wc/v4/refunds/?order_id=134`:

```json
{
  "reason": "Test refund",
  "api_refund": false,
  "api_restock": true,
  "line_items": [
    {
      "line_item_id": 187,
      "quantity": 1,
      "refund_total": 1,
      "refund_tax": [
        {
          "id": 1,
          "refund_total": 1
        }
      ]
    }
  ]
}
```

Example response:

```json
{
  "id": 160,
  "order_id": 134,
  "currency": "USD",
  "currency_symbol": "$",
  "date_created": "2025-10-24T17:46:47",
  "date_created_gmt": "2025-10-24T17:46:47",
  "amount": "2.00",
  "reason": "Test refund",
  "refunded_by": 1,
  "refunded_payment": false,
  "line_items": [
    {
      "id": 123,
      "line_item_id": 187,
      "quantity": 1,
      "refund_total": "1",
      "refund_tax": [
        {
          "id": 1,
          "refund_total": "1"
        }
      ]
    }
  ],
  "meta_data": [
    {
      "id": 4159,
      "key": "_refund_type",
      "value": "partial"
    }
  ]
}
```

Closes WOOPRD-856

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

You must have experimental Rest API v4 feature flag enabled to test this PR.

1. Test `GET http://localhost:9001/wp-json/wc/v4/refunds` lists all refunds
2. Test `GET http://localhost:9001/wp-json/wc/v4/refunds/?order_id=123` lists an order refunds
3. Test `POST http://localhost:9001/wp-json/wc/v4/refunds/?order_id=123` to create a refund. An example payload is below. Test invalid data (remove some properties such as item ID), invalid item IDs, invalid amounts etc to ensure only valid requests succeed. Check the response after a successful request.

Example create refund payload:

```json
{
  "reason": "Test refund",
  "api_refund": false,
  "api_restock": true,
  "line_items": [
    {
      "line_item_id": 123,
      "quantity": 1,
      "refund_total": 1,
      "refund_tax": [
        {
          "id": 1,
          "refund_total": 2
        }
      ]
    }
  ]
}
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
