### PR TITLE
Packages: Updates changelogger to handle undefined array item

### DIFF
--- a/tools/package-release/src/changelogger.ts
+++ b/tools/package-release/src/changelogger.ts
@@ -126,7 +126,7 @@ export const hasValidChangelogs = ( name: string ): boolean | void => {
 
 			if ( textAfterComment ) {
 				// Return true if there is more than just whitespace.
-				return textAfterComment[ 1 ].trim().length > 0;
+				return ( textAfterComment[ 1 ] || '').trim().length > 0;
 			}
 
 			return false;

--- a/tools/package-release/src/changelogger.ts
+++ b/tools/package-release/src/changelogger.ts
@@ -126,7 +126,7 @@ export const hasValidChangelogs = ( name: string ): boolean | void => {
 
 			if ( textAfterComment ) {
 				// Return true if there is more than just whitespace.
-				return ( textAfterComment[ 1 ] || '').trim().length > 0;
+				return ( textAfterComment[ 1 ] || '' ).trim().length > 0;
 			}
 
 			return false;

--- a/tools/package-release/src/changelogger.ts
+++ b/tools/package-release/src/changelogger.ts
@@ -122,11 +122,11 @@ export const hasValidChangelogs = ( name: string ): boolean | void => {
 				return true;
 			}
 
-			const textAfterComment = /Comment:.*\n([\s\S]*)?/.exec( contents );
+			const textAfterComment = /Comment:.*\n([\s\S]*)/.exec( contents );
 
 			if ( textAfterComment ) {
 				// Return true if there is more than just whitespace.
-				return ( textAfterComment[ 1 ] || '' ).trim().length > 0;
+				return textAfterComment[ 1 ].trim().length > 0;
 			}
 
 			return false;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `prepare` command was failing with a `TypeError: Cannot read  properties of undefined (reading 'trim')` when processing specific packages with changelog comments missing at least a newline (in this case it was the `@woocommerce/date` package). 

([Example](https://github.com/woocommerce/woocommerce/actions/runs/18790061567/job/53617894211)). 

It looks like in some cases it could be trying to read `textAfterComment[ 1 ]` without confirming it exists.

```
  Error:
  TypeError: Cannot read properties of undefined (reading
  'trim')
      at /home/runner/work/woocommerce/woocommerce/tools/package
  -release/src/changelogger.ts:129:34
```

This PR simply uses a fallback to an empty string when the value is undefined:

```
  return ( textAfterComment[ 1 ] || '' ).trim().length > 0;
```
 
This ensures that:
  1. If textAfterComment[1] is undefined or null, it falls back to an empty string
  2. The empty string is safely trimmed and has length 0, returning false
  3. If there's text after the comment but it's only whitespace, it returns false
  4. If there's actual content after the comment, it returns true

@jorgeatorres LMK if this seems like the best approach to the tool failing.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `./tools/package-release/bin/dev prepare @woocommerce/date` with/without this PR and compare results
2. Also recommended to run with other packages just to confirm that packages that worked before aren't seeing any changes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
