### PR TITLE
Prevent loading core address autocomplete scripts if the setting is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-prevent-loading-autocomplete-if-disabled
+++ b/plugins/woocommerce/changelog/fix-prevent-loading-autocomplete-if-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent autocomplete scripts loading if the setting is disabled

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -387,17 +387,19 @@ class WC_Frontend_Scripts {
 			),
 		);
 
-		$scripts['wc-address-autocomplete-common'] = array(
-			'src'     => self::get_asset_url( 'assets/js/frontend/utils/address-autocomplete-common' . $suffix . '.js' ),
-			'deps'    => array(),
-			'version' => $version,
-		);
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) === true ) {
+			$scripts['wc-address-autocomplete-common'] = array(
+				'src'     => self::get_asset_url( 'assets/js/frontend/utils/address-autocomplete-common' . $suffix . '.js' ),
+				'deps'    => array(),
+				'version' => $version,
+			);
 
-		$scripts['wc-address-autocomplete'] = array(
-			'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
-			'deps'    => array( 'wc-address-autocomplete-common', 'wc-dompurify' ),
-			'version' => $version,
-		);
+			$scripts['wc-address-autocomplete'] = array(
+				'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
+				'deps'    => array( 'wc-address-autocomplete-common', 'wc-dompurify' ),
+				'version' => $version,
+			);
+		}
 
 		return $scripts;
 	}
@@ -450,12 +452,14 @@ class WC_Frontend_Scripts {
 			),
 		);
 
-		$register_styles['wc-address-autocomplete'] = array(
-			'src'     => self::get_asset_url( 'assets/css/address-autocomplete.css' ),
-			'deps'    => array(),
-			'version' => $version,
-			'has_rtl' => false,
-		);
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) === true ) {
+			$register_styles['wc-address-autocomplete'] = array(
+				'src'     => self::get_asset_url( 'assets/css/address-autocomplete.css' ),
+				'deps'    => array(),
+				'version' => $version,
+				'has_rtl' => false,
+			);
+		}
 
 		foreach ( $register_styles as $name => $props ) {
 			self::register_style( $name, $props['src'], $props['deps'], $props['version'], 'all', $props['has_rtl'] );
@@ -497,14 +501,16 @@ class WC_Frontend_Scripts {
 			self::enqueue_script( 'wc-checkout' );
 		}
 
-		$address_provider_service = wc_get_container()->get( AddressProviderController::class );
-		if ( $address_provider_service && method_exists( $address_provider_service, 'get_providers' ) ) {
-			$registered_providers = $address_provider_service->get_providers();
-			if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
-				// Always enqueue the common module if providers are registered.
-				self::enqueue_script( 'wc-address-autocomplete-common' );
-				self::enqueue_script( 'wc-address-autocomplete' );
-				self::enqueue_style( 'wc-address-autocomplete' );
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) === true ) {
+			$address_provider_service = wc_get_container()->get( AddressProviderController::class );
+			if ( $address_provider_service && method_exists( $address_provider_service, 'get_providers' ) ) {
+				$registered_providers = $address_provider_service->get_providers();
+				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
+					// Always enqueue the common module if providers are registered.
+					self::enqueue_script( 'wc-address-autocomplete-common' );
+					self::enqueue_script( 'wc-address-autocomplete' );
+					self::enqueue_style( 'wc-address-autocomplete' );
+				}
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -60,6 +60,11 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	 */
 	public function load_jwt() {
 
+		// If the address autocomplete is disabled, we don't load the JWT.
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) !== true ) {
+			return;
+		}
+
 		// If we already have a loaded, valid token, we return early.
 		if ( $this->jwt && is_string( $this->jwt ) && JsonWebToken::shallow_validate( $this->jwt ) ) {
 			return;
@@ -265,6 +270,11 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	 * Enqueues the checkout script, checks if it's already registered or not so we don't duplicate, and prints out the JWT to the page to be consumed.
 	 */
 	public function load_scripts() {
+		// If the address autocomplete setting is disabled, don't load the scripts.
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) !== true ) {
+			return;
+		}
+
 		if ( ! is_checkout() ) {
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Prevent registering scripts if the core setting is disabled and the check to other places that should only run if the setting is turned on.
- Add tests to ensure the scripts aren't loaded if the setting is disabled.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5734

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/60840 / https://github.com/woocommerce/woocommerce/pull/59426


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooPayments
2. Go to WC -> Settings and disable "Enable Predictive Address Search"
3. Go to the shortcode checkout, ensure the address 1 field does not show a search icon, and does not show address suggestions after typing 3+ characters.
4. Test the blocks checkout also (although this was unaffected by the bug).
5. Go to WC -> Settings and enable "Enable Predictive Address Search"
6. Go to the Checkout shortcode and ensure you can search addresses. Test the Checkout block too.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
