### PR TITLE
Add MCP Abilities for variations and batch operations

### DIFF
--- a/plugins/woocommerce/changelog/add-variation-batch-mcp-abilities
+++ b/plugins/woocommerce/changelog/add-variation-batch-mcp-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add MCP Abilities for variations and batch operations

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -89,7 +89,7 @@ class AbilitiesRestBridge {
 						'id'          => 'woocommerce/product-variations-create',
 						'operation'   => 'create',
 						'label'       => __( 'Create Product Variation', 'woocommerce' ),
-						'description' => __( 'Create a new product variation with name, price, description,and other attributes.', 'woocommerce' ),
+						'description' => __( 'Create a new product variation with name, price, description, and other attributes.', 'woocommerce' ),
 					),
 					array(
 						'id'          => 'woocommerce/product-variations-update',

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -64,6 +64,42 @@ class AbilitiesRestBridge {
 				),
 			),
 			array(
+				'controller' => \WC_REST_Product_Variations_Controller::class,
+				'route'      => '/wc/v3/products',
+				'abilities'  => array(
+					array(
+						'id'          => 'woocommerce/product-variations-list',
+						'operation'   => 'list',
+						'label'       => __( 'List All Product Variations', 'woocommerce' ),
+						'description' => __( 'Retrieve a paginated list of a product\'s variations, with optional filters for status, price range, and other attributes.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-variations-get',
+						'operation'   => 'get',
+						'label'       => __( 'Get Product Variation', 'woocommerce' ),
+						'description' => __( 'Retrieve detailed information about a single product variation by ID, including price, description, image, and metadata.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-variations-create',
+						'operation'   => 'create',
+						'label'       => __( 'Create Product Variation', 'woocommerce' ),
+						'description' => __( 'Create a new product variation with name, price, description,and other attributes.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-variations-update',
+						'operation'   => 'update',
+						'label'       => __( 'Update Product Variation', 'woocommerce' ),
+						'description' => __( 'Update an existing product variation by modifying its attributes such as price, stock, description, or metadata.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-variations-delete',
+						'operation'   => 'delete',
+						'label'       => __( 'Delete Product Variation', 'woocommerce' ),
+						'description' => __( 'Permanently delete a product variation from the store. This action cannot be undone.', 'woocommerce' ),
+					),
+				),
+			),
+			array(
 				'controller' => \WC_REST_Orders_Controller::class,
 				'route'      => '/wc/v3/orders',
 				'abilities'  => array(

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -61,6 +61,12 @@ class AbilitiesRestBridge {
 						'label'       => __( 'Delete Product', 'woocommerce' ),
 						'description' => __( 'Permanently delete a product from the store. This action cannot be undone.', 'woocommerce' ),
 					),
+					array(
+						'id'          => 'woocommerce/product-batch',
+						'operation'   => 'batch',
+						'label'       => __( 'Batch Create, Update and Delete Multiple Products', 'woocommerce' ),
+						'description' => __( 'Create new products, update existing ones, and permanently delete others. Deleting products cannot be undone.', 'woocommerce' ),
+					),
 				),
 			),
 			array(
@@ -96,6 +102,12 @@ class AbilitiesRestBridge {
 						'operation'   => 'delete',
 						'label'       => __( 'Delete Product Variation', 'woocommerce' ),
 						'description' => __( 'Permanently delete a product variation from the store. This action cannot be undone.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-variations-batch',
+						'operation'   => 'batch',
+						'label'       => __( 'Batch Create, Update and Delete Multiple Variations of a Same Variable Product', 'woocommerce' ),
+						'description' => __( 'Create new variations, update existing ones, and permanently delete others. All changes must be for the same variable product. Deleting variations cannot be undone.', 'woocommerce' ),
 					),
 				),
 			),

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -133,6 +133,16 @@ class RestAbilityFactory {
 						$schema['required'][] = 'id';
 					}
 
+					if ( $controller instanceof \WC_REST_Product_Variations_Controller ) {
+						$schema['properties']['product_id'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the parent product', 'woocommerce' ),
+						);
+						if ( ! in_array( 'product_id', $schema['required'], true ) ) {
+							$schema['required'][] = 'product_id';
+						}
+					}
+
 					return $schema;
 				}
 				break;
@@ -282,8 +292,14 @@ class RestAbilityFactory {
 	private static function execute_operation( $controller, string $operation, array $input, string $route ) {
 		$method = self::get_http_method_for_operation( $operation );
 
-		// Build final route - add ID for single item operations.
+		// Build final route - add ID for single item operations. and product ID for operations on variations.
 		$request_route = $route;
+
+		if ( $controller instanceof \WC_REST_Product_Variations_Controller && isset( $input['product_id'] ) ) {
+			$request_route .= '/' . intval( $input['product_id'] ) . '/variations';
+			unset( $input['product_id'] );
+		}
+
 		if ( isset( $input['id'] ) && in_array( $operation, array( 'get', 'update', 'delete' ), true ) ) {
 			$request_route .= '/' . intval( $input['id'] );
 			unset( $input['id'] );

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -160,6 +160,45 @@ class RestAbilityFactory {
 					),
 					'required'   => array( 'id' ),
 				);
+
+			case 'batch':
+				// Use controller's batch schema.
+				if ( method_exists( $controller, 'get_public_batch_schema' ) ) {
+					$schema = $controller->get_public_batch_schema( \WP_REST_Server::EDITABLE );
+
+					if ( $controller instanceof \WC_REST_Product_Variations_Controller ) {
+						$schema['properties']['product_id'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the parent product', 'woocommerce' ),
+						);
+					}
+
+					if ( isset( $schema['properties']['create']['type'] ) && 'array' === $schema['properties']['create']['type'] ) {
+						$schema['properties']['create']['items'] = self::sanitize_args_to_schema(
+							$controller->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE )
+						);
+					}
+					if ( isset( $schema['properties']['update']['type'] ) && 'array' === $schema['properties']['update']['type'] ) {
+						$schema['properties']['update']['items'] = self::sanitize_args_to_schema(
+							$controller->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE )
+						);
+
+						// Add ID field for update operations.
+						$schema['properties']['update']['items']['properties']['id'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the resource', 'woocommerce' ),
+						);
+					}
+					if ( isset( $schema['properties']['delete']['type'] ) && 'array' === $schema['properties']['delete']['type'] ) {
+						$schema['properties']['delete']['items'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the resource', 'woocommerce' ),
+						);
+					}
+
+					return $schema;
+				}
+				break;
 		}
 
 		// Fallback.
@@ -271,6 +310,24 @@ class RestAbilityFactory {
 						'previous' => $schema,
 					),
 				);
+			} elseif ( 'batch' === $operation ) {
+				return array(
+					'type'       => 'object',
+					'properties' => array(
+						'create' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+						'update' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+						'delete' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+					),
+				);
 			}
 
 			// For get, create, update operations.
@@ -303,6 +360,10 @@ class RestAbilityFactory {
 		if ( isset( $input['id'] ) && in_array( $operation, array( 'get', 'update', 'delete' ), true ) ) {
 			$request_route .= '/' . intval( $input['id'] );
 			unset( $input['id'] );
+		}
+
+		if ( 'batch' === $operation ) {
+			$request_route .= '/batch';
 		}
 
 		// Create REST request.
@@ -341,6 +402,7 @@ class RestAbilityFactory {
 			'create' => 'POST',
 			'update' => 'PUT',
 			'delete' => 'DELETE',
+			'batch'  => 'POST',
 		);
 		return $method_map[ $operation ] ?? 'GET';
 	}

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -171,6 +171,12 @@ class RestAbilityFactory {
 							'type'        => 'integer',
 							'description' => __( 'Unique identifier for the parent product', 'woocommerce' ),
 						);
+						if ( ! isset( $schema['required'] ) ) {
+							$schema['required'] = array();
+						}
+						if ( ! in_array( 'product_id', $schema['required'], true ) ) {
+							$schema['required'][] = 'product_id';
+						}
 					}
 
 					if ( isset( $schema['properties']['create']['type'] ) && 'array' === $schema['properties']['create']['type'] ) {


### PR DESCRIPTION
### Submission Review Guidelines:

 - [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 - [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
 - [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Register new MCP abilities regarding variations and batch operations on products and variations.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set up your environment (WooCommerce and Claude) as instructed in https://github.com/woocommerce/woocommerce/pull/60901.
2. Test with sentences like the following:
    - Using woocommerce_mcp, list all variations of product 60. If using the "wocommerce-product-variations-list" tool, always provide the `product_id`.
    - Using woocommerce_mcp, create two more variations, with title "Dummy 1" and "Dummy 2", description "Description 1" and "Description 2", and prices 10 and 20. Use a batch tool.
    - Using woocommerce_mcp, list all variations of product 60 again.
    - Using woocommerce_mcp, change the prices of these two variations to 30 and 40, respectively. Use a batch tool.
    - Using woocommerce_mcp, delete these two variations. Use a batch tool.
    - Using woocommerce_mcp, create a single variation, with title "Dummy 3", description "Description 3", and price 50. Don't use a batch tool.
    - Using woocommerce_mcp, change the price of this variation you just created to price 60. Don't use a batch tool.
    - Using woocommerce_mcp, get this variation's data. Don't use a batch tool.
    - Using woocommerce_mcp, delete this variation. Don't use a batch tool.
    - Using woocommerce_mcp, create 1 simple product with title "Dummy 4", description "Description 4" and price 70, add an attribute (color, size, whatever you'd like) to product 60, and delete product 61, all using a batch tool.

### Testing that has already taken place:

I performed the tests described in the section above.

### Changelog entry

Changelog included in PR.
