### PR TITLE
Fix: order metadata being deleted when order logs were deleted

### DIFF
--- a/plugins/woocommerce/changelog/pr-61635
+++ b/plugins/woocommerce/changelog/pr-61635
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: order metadata being deleted when order logs were deleted

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -266,13 +266,20 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 		// otherwise the next sync process will restore the rows we just deleted from the authoritative meta table.
 
 		$order_ids    = array_map( fn( $item ) => absint( $item['order_id'] ), $batch );
-		$placeholders = implode( ',', array_map( 'absint', $order_ids ) );
+		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
 
 		$table_name     = $this->hpos_in_use ? $wpdb->postmeta : "{$wpdb->prefix}wc_orders_meta";
 		$id_column_name = $this->hpos_in_use ? 'post_id' : 'order_id';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$wpdb->query( "DELETE FROM {$table_name} WHERE {$id_column_name} IN ({$placeholders})" );
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table_name}
+				 WHERE {$id_column_name} IN ({$placeholders})
+				 AND meta_key = %s",
+				array_merge( $order_ids, array( '_debug_log_source_pending_deletion' ) )
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -271,7 +271,7 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 		$table_name     = $this->hpos_in_use ? $wpdb->postmeta : "{$wpdb->prefix}wc_orders_meta";
 		$id_column_name = $this->hpos_in_use ? 'post_id' : 'order_id';
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$table_name}
@@ -280,6 +280,7 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 				array_merge( $order_ids, array( '_debug_log_source_pending_deletion' ) )
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -19,9 +19,6 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 
 	/**
 	 * Constant representing the default size of the batches to process.
-	 *
-	 * Note that meta entry ids taken from batch items will be concatenated to form a
-	 * "delete ... where id in (id, id...)" SQL query, so this value can't be very big.
 	 */
 	public const DEFAULT_BATCH_SIZE = 1000;
 
@@ -157,7 +154,7 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 
 	/**
 	 * Get the next batch of items to process.
-	 * An item will be an associative array of 'meta_id' and 'meta_value'.
+	 * An item will be an associative array of 'order_id' and 'meta_value'.
 	 *
 	 * @param int $size Maximum size of the batch to return.
 	 * @return array
@@ -184,10 +181,10 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT id as meta_id, meta_value, order_id
+				"SELECT order_id, meta_value
                  FROM {$wpdb->prefix}wc_orders_meta
                  WHERE meta_key = %s
-                 ORDER BY id
+                 ORDER BY order_id
                  LIMIT %d",
 				'_debug_log_source_pending_deletion',
 				$size
@@ -207,12 +204,12 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT p.ID as order_id,pm.meta_id, pm.meta_value
+				"SELECT p.ID as order_id, pm.meta_value
                  FROM {$wpdb->postmeta} pm
                  INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
                  WHERE pm.meta_key = %s
                  AND p.post_type = 'shop_order'
-                 ORDER BY pm.meta_id
+                 ORDER BY p.ID
                  LIMIT %d",
 				'_debug_log_source_pending_deletion',
 				$size
@@ -238,9 +235,9 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 			return;
 		}
 
-		$invalid_items = array_filter( $batch, fn( $item ) => ! is_array( $item ) || ! isset( $item['meta_id'] ) || ! isset( $item['meta_value'] ) || ! isset( $item['order_id'] ) );
+		$invalid_items = array_filter( $batch, fn( $item ) => ! is_array( $item ) || ! isset( $item['meta_value'] ) || ! isset( $item['order_id'] ) );
 		if ( $invalid_items ) {
-			throw new \Exception( "\$batch must be an array of arrays, each having a 'meta_id' key, a 'meta_value' key and an 'order_id' key" );
+			throw new \Exception( "\$batch must be an array of arrays, each having a 'meta_value' key and an 'order_id' key" );
 		}
 
 		$logger = $this->legacy_proxy->call_function( 'wc_get_logger' );
@@ -249,14 +246,23 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 		}
 
 		global $wpdb;
+
+		$order_ids    = array_map( 'absint', array_column( $batch, 'order_id' ) );
+		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+
 		$table_name     = $this->hpos_in_use ? "{$wpdb->prefix}wc_orders_meta" : $wpdb->postmeta;
-		$id_column_name = $this->hpos_in_use ? 'id' : 'meta_id';
+		$id_column_name = $this->hpos_in_use ? 'order_id' : 'post_id';
 
-		$meta_ids     = array_map( 'absint', array_column( $batch, 'meta_id' ) );
-		$placeholders = implode( ',', $meta_ids );
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$wpdb->query( "DELETE FROM {$table_name} WHERE {$id_column_name} IN ({$placeholders})" );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table_name}
+				 WHERE {$id_column_name} IN ({$placeholders})
+				 AND meta_key = %s",
+				array_merge( $order_ids, array( '_debug_log_source_pending_deletion' ) )
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		if ( ! $this->data_synchronizer->data_sync_is_enabled() ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -235,13 +235,11 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 			return;
 		}
 
-		$invalid_items = array_filter( $batch, fn( $item ) => ! is_array( $item ) || ! isset( $item['meta_value'] ) || ! isset( $item['order_id'] ) );
-		if ( $invalid_items ) {
-			throw new \Exception( "\$batch must be an array of arrays, each having a 'meta_value' key and an 'order_id' key" );
-		}
-
 		$logger = $this->legacy_proxy->call_function( 'wc_get_logger' );
 		foreach ( $batch as $item ) {
+			if ( ! is_array( $item ) || ! isset( $item['meta_value'] ) || ! isset( $item['order_id'] ) ) {
+				throw new \Exception( "\$batch must be an array of arrays, each having a 'meta_value' key and an 'order_id' key" );
+			}
 			$logger->clear( $item['meta_value'] );
 		}
 

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -252,8 +252,8 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 		$table_name     = $this->hpos_in_use ? "{$wpdb->prefix}wc_orders_meta" : $wpdb->postmeta;
 		$id_column_name = $this->hpos_in_use ? 'id' : 'meta_id';
 
-		$meta_ids     = array_map( fn( $item ) => absint( $item['meta_id'] ), $batch );
-		$placeholders = implode( ',', array_map( 'absint', $meta_ids ) );
+		$meta_ids     = array_map( 'absint', array_column( $batch, 'meta_id' ) );
+		$placeholders = implode( ',', $meta_ids );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query( "DELETE FROM {$table_name} WHERE {$id_column_name} IN ({$placeholders})" );

--- a/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
+++ b/plugins/woocommerce/src/Internal/Logging/OrderLogsDeletionProcessor.php
@@ -243,37 +243,31 @@ class OrderLogsDeletionProcessor implements BatchProcessorInterface {
 			$logger->clear( $item['meta_value'] );
 		}
 
+		$order_ids = array_map( 'absint', array_column( $batch, 'order_id' ) );
+
+		// Delete from the authoritative meta table.
+		$this->delete_debug_log_source_meta_entries( true, $order_ids );
+
+		if ( $this->data_synchronizer->data_sync_is_enabled() ) {
+			// When HPOS data sync is enabled we need to manually delete the entries in the backup meta table too,
+			// otherwise the next sync process will restore the rows we just deleted from the authoritative meta table.
+			$this->delete_debug_log_source_meta_entries( false, $order_ids );
+		}
+	}
+
+	/**
+	 * Delete meta entries for the given order IDs.
+	 *
+	 * @param bool  $from_authoritative_table True to delete from the authoritative table, false for the backup table.
+	 * @param array $order_ids Array of order IDs to delete.
+	 */
+	private function delete_debug_log_source_meta_entries( bool $from_authoritative_table, array $order_ids ): void {
 		global $wpdb;
 
-		$order_ids    = array_map( 'absint', array_column( $batch, 'order_id' ) );
-		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
-
-		$table_name     = $this->hpos_in_use ? "{$wpdb->prefix}wc_orders_meta" : $wpdb->postmeta;
-		$id_column_name = $this->hpos_in_use ? 'order_id' : 'post_id';
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM {$table_name}
-				 WHERE {$id_column_name} IN ({$placeholders})
-				 AND meta_key = %s",
-				array_merge( $order_ids, array( '_debug_log_source_pending_deletion' ) )
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		if ( ! $this->data_synchronizer->data_sync_is_enabled() ) {
-			return;
-		}
-
-		// When HPOS data sync is enabled we need to manually delete the entries in the backup meta table too,
-		// otherwise the next sync process will restore the rows we just deleted from the authoritative meta table.
-
-		$order_ids    = array_map( fn( $item ) => absint( $item['order_id'] ), $batch );
-		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
-
-		$table_name     = $this->hpos_in_use ? $wpdb->postmeta : "{$wpdb->prefix}wc_orders_meta";
-		$id_column_name = $this->hpos_in_use ? 'post_id' : 'order_id';
+		$use_hpos_table = $this->hpos_in_use === $from_authoritative_table;
+		$table_name     = $use_hpos_table ? "{$wpdb->prefix}wc_orders_meta" : $wpdb->postmeta;
+		$id_column_name = $use_hpos_table ? 'order_id' : 'post_id';
+		$placeholders   = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query(

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
@@ -68,6 +68,14 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 				$this->sources_cleared[] = $source;
 			}
 
+			/**
+			 * During sync tests, the migration controller may fail to set transaction isolation level
+			 * (MySQL error: "Transaction characteristics can't be changed while a transaction is in progress").
+			 * These errors are harmless in the test environment and don't affect deletion behavior assertions.
+			 */
+			public function error( $message, $context = array() ) {
+			}
+
 			public function reset() {
 				$this->sources_cleared = array();
 			}
@@ -284,7 +292,7 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 
 		global $wpdb;
 
-		$this->setup_hpos_and_reset_container( true );
+		$this->setup_hpos_and_reset_container( $with_hpos );
 		$previous_data_sync_option = get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
@@ -272,6 +272,96 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox process_batch with sync enabled should NOT delete other order metadata
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $with_hpos Test with HPOS active or not.
+	 */
+	public function test_process_batch_preserves_other_metadata_when_sync_enabled( bool $with_hpos ) {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		global $wpdb;
+
+		$this->setup_hpos_and_reset_container( true );
+		$previous_data_sync_option = get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );
+		update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
+
+		// Create order with custom metadata entries and simulate log source pending deletion.
+
+		$order = OrderHelper::create_order();
+		$order->add_meta_data( '_test_custom_field_1', 'some_data_1', true );
+		$order->add_meta_data( '_test_custom_field_2', 'some_data_2', true );
+		$order->add_meta_data( '_debug_log_source_pending_deletion', 'place-order-debug-test', true );
+		$order->save();
+
+		$order_id = $order->get_id();
+
+		// Force sync to replicate metadata to backup table.
+
+		$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
+		$sync_batch        = $data_synchronizer->get_next_batch_to_process( 1 );
+		$data_synchronizer->process_batch( $sync_batch );
+
+		// Verify metadata exists in backup table before deletion.
+
+		$backup_table = $with_hpos ? $wpdb->postmeta : "{$wpdb->prefix}wc_orders_meta";
+		$id_field     = $with_hpos ? 'post_id' : 'order_id';
+
+		$meta_before = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_key FROM {$backup_table} WHERE {$id_field} = %d",
+				$order_id
+			),
+			ARRAY_A
+		);
+
+		$meta_keys_before  = array_column( $meta_before, 'meta_key' );
+		$meta_count_before = count( $meta_keys_before );
+
+		$this->assertContains( '_test_custom_field_1', $meta_keys_before, 'Test custom field 1 should exist before deletion' );
+		$this->assertContains( '_test_custom_field_2', $meta_keys_before, 'Test custom field 2 should exist before deletion' );
+		$this->assertContains( '_debug_log_source_pending_deletion', $meta_keys_before, 'Debug log should exist before deletion' );
+
+		// Process deletion batch.
+
+		$batch = $this->sut->get_next_batch_to_process( 1 );
+		$this->sut->process_batch( $batch );
+
+		// Verify _debug_log_source_pending_deletion was deleted but all other metadata was preserved in the backup table.
+
+		$remaining_meta = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_key, meta_value FROM {$backup_table} WHERE {$id_field} = %d",
+				$order_id
+			),
+			ARRAY_A
+		);
+
+		$meta_keys = array_column( $remaining_meta, 'meta_key' );
+
+		$this->assertContains( '_test_custom_field_1', $meta_keys, 'Custom field 1 should not be deleted' );
+		$this->assertContains( '_test_custom_field_2', $meta_keys, 'Custom field 2 should not be deleted' );
+		$this->assertNotContains( '_debug_log_source_pending_deletion', $meta_keys, 'Debug log metadata should be deleted' );
+
+		// Verify the count decreased by exactly 1 (only the debug log entry).
+
+		$meta_count_after = count( $remaining_meta );
+		$this->assertEquals( $meta_count_before - 1, $meta_count_after, 'Only one metadata entry should be deleted' );
+
+		// Restore previous state.
+
+		if ( false === $previous_data_sync_option ) {
+			delete_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );
+		} else {
+			update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, $previous_data_sync_option );
+		}
+
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
 	 * @testdox process_batch throws an exception if an invalid batch is supplied.
 	 *
 	 * @testWith [[null]]

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/OrderLogsDeletionProcessorTest.php
@@ -149,21 +149,17 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 
 		$order_ids = $this->create_orders_with_logs( 5 );
 
-		$actual_meta_ids = $this->get_meta_ids( $with_hpos, 3 );
-		$expected_batch  = array(
+		$expected_batch = array(
 			array(
 				'order_id'   => $order_ids[0],
-				'meta_id'    => $actual_meta_ids[0],
 				'meta_value' => 'place-order-debug-0',
 			),
 			array(
 				'order_id'   => $order_ids[1],
-				'meta_id'    => $actual_meta_ids[1],
 				'meta_value' => 'place-order-debug-1',
 			),
 			array(
 				'order_id'   => $order_ids[2],
-				'meta_id'    => $actual_meta_ids[2],
 				'meta_value' => 'place-order-debug-2',
 			),
 		);
@@ -190,16 +186,13 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 2, $this->sut->get_total_pending_count() );
 
-		$actual_meta_ids = $this->get_meta_ids( $with_hpos, 3 );
-		$expected_batch  = array(
+		$expected_batch = array(
 			array(
 				'order_id'   => $order_ids[3],
-				'meta_id'    => $actual_meta_ids[0],
 				'meta_value' => 'place-order-debug-3',
 			),
 			array(
 				'order_id'   => $order_ids[4],
-				'meta_id'    => $actual_meta_ids[1],
 				'meta_value' => 'place-order-debug-4',
 			),
 		);
@@ -374,14 +367,13 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 	 *
 	 * @testWith [[null]]
 	 *           [[34]]
-	 *           [[{"meta_id": 34}]]
 	 *           [[{"meta_value": "MSX"}]]
 	 *           [[{"order_id": 34}]]
 	 *
 	 * @param mixed $batch Batch to try to process.
 	 */
 	public function test_process_invalid_batch( $batch ) {
-		$this->expectExceptionMessage( "\$batch must be an array of arrays, each having a 'meta_id' key, a 'meta_value' key and an 'order_id' key" );
+		$this->expectExceptionMessage( "\$batch must be an array of arrays, each having a 'meta_value' key and an 'order_id' key" );
 		$this->sut->process_batch( $batch );
 	}
 
@@ -447,26 +439,6 @@ class OrderLogsDeletionProcessorTest extends \WC_Unit_Test_Case {
 		}
 
 		return $order_ids;
-	}
-
-	/**
-	 * Get the ids of order debug meta entries, sorted by meta id.
-	 *
-	 * @param bool $with_hpos Test with HPOS active or not.
-	 * @param int  $limit Maximum count of ids to return.
-	 * @return array
-	 */
-	private function get_meta_ids( bool $with_hpos, int $limit ): array {
-		global $wpdb;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$meta_ids =
-			$with_hpos ?
-				$wpdb->get_results( $wpdb->prepare( "select id from {$wpdb->prefix}wc_orders_meta where meta_key=%s order by order_id limit {$limit}", '_debug_log_source_pending_deletion' ), ARRAY_N ) :
-				$wpdb->get_results( $wpdb->prepare( "select meta_id from {$wpdb->postmeta} where meta_key=%s order by post_id limit {$limit}", '_debug_log_source_pending_deletion' ), ARRAY_N );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		return array_map( fn( $item ) => $item[0], $meta_ids );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/61121 introduced a bug that caused all the metadata for orders in the backup table (and not just the `_debug_log_source_pending_deletion` entry) to be deleted when data syncrhonization ("compatibility mode") was enabled and the order logs deletion process ran. This pull request fixes that.

Additionally, the order ids for the DELETE statement are now specified using `%d` placeholders instead of being hardcoded (standard practice for SQL statements in WordPress).

Bug introduced in PR #61121.

### How to test the changes in this Pull Request:

1. Enable HPOS and compatibility mode, either via admin UI (WooCommerce - Advanced - Settings - Features) or via CLI:

```
wp wc hpos sync
wp wc hpos enable
wp wc hpos compatibility-mode enable
```

2. Place an order and take note of the order id.

3. Verify that the order metadata is identical for both the authoritative and the backup table, and it includes the `_debug_log_source_pending_deletion` entry:

```
ORDER_ID=<the order id>

# Authoritative table
wp db query "SELECT meta_key, meta_value FROM wp_wc_orders_meta WHERE order_id = $ORDER_ID ORDER BY meta_key;"

#Backup table
wp db query "SELECT meta_key, meta_value FROM wp_postmeta WHERE post_id = $ORDER_ID ORDER BY meta_key;"
```

4. Run scheduled actions to force the logs deletion process to run: `wp action-scheduler run`

5. Repeat step 3 and verify that all the metadata is still present in both tables (minus the `_debug_log_source_pending_deletion` entry, which is expected to have been deleted). Without this fix the backup table would not contain any metadata for the order at this point.

6. Repeat with HPOS disabled, same steps except that now the roles of the authoritative and the backup table are reversed.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
