### PR TITLE
Add to Cart + Options: support the Product block when a variation is selected

### DIFF
--- a/plugins/woocommerce/changelog/fix-56289-add-to-cart-with-options-variation
+++ b/plugins/woocommerce/changelog/fix-56289-add-to-cart-with-options-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: support the Product block when a variation is selected

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -57,7 +57,7 @@ export const getProductData = (
 ): NormalizedProductData | NormalizedVariationData | null => {
 	const { products } = getConfig( 'woocommerce' ) as WooCommerceConfig;
 
-	if ( ! Array.isArray( products ) || ! products[ id ] ) {
+	if ( ! products || ! products[ id ] ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -71,9 +71,8 @@ export const getProductData = (
 		selectedAttributes &&
 		selectedAttributes.length > 0
 	) {
-		const variations = products[ id ].variations;
 		const matchedVariation = getMatchedVariation(
-			variations,
+			product.variations,
 			selectedAttributes
 		);
 		if ( matchedVariation ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -57,15 +57,19 @@ export const getProductData = (
 	selectedAttributes: SelectedAttributes[]
 ): NormalizedProductData | NormalizedVariationData | null => {
 	let productId = id;
-	let productData;
-
 	const { products } = getConfig( 'woocommerce' ) as WooCommerceConfig;
 
-	let type: ProductData[ 'type' ] | 'variation' = 'simple';
-	if ( selectedAttributes && selectedAttributes.length > 0 ) {
-		if ( ! products || ! products[ id ] ) {
-			return null;
-		}
+	if ( ! products || ! products[ id ] ) {
+		return null;
+	}
+
+	let productData = products?.[ id ] as ProductData;
+
+	if (
+		productData.type === 'variable' &&
+		selectedAttributes &&
+		selectedAttributes.length > 0
+	) {
 		const variations = products[ id ].variations;
 		const matchedVariation = getMatchedVariation(
 			variations,
@@ -73,14 +77,13 @@ export const getProductData = (
 		);
 		if ( matchedVariation?.variation_id ) {
 			productId = matchedVariation.variation_id;
-			productData = products?.[ id ]?.variations?.[
-				matchedVariation?.variation_id
-			] as VariationData;
-			type = 'variation';
+			productData = {
+				...( products?.[ id ]?.variations?.[
+					matchedVariation?.variation_id
+				] as VariationData ),
+				type: 'variation',
+			};
 		}
-	} else {
-		productData = products?.[ productId ] as ProductData;
-		type = productData?.type;
 	}
 
 	if ( typeof productData !== 'object' || productData === null ) {
@@ -100,7 +103,6 @@ export const getProductData = (
 		min,
 		max,
 		step,
-		type,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -86,10 +86,9 @@ export const getProductData = (
 
 	const min = typeof product.min === 'number' ? product.min : 1;
 	const max =
-		typeof product.max === 'number' && product.max >= 1
-			? product.max
-			: Infinity;
-	const step = product.step || 1;
+		typeof product.max === 'number' ? Math.max( product.max, 0 ) : Infinity;
+	const step =
+		typeof product.step === 'number' && product.step > 0 ? product.step : 1;
 
 	return {
 		...product,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -6,7 +6,6 @@ import type {
 	Store as WooCommerce,
 	SelectedAttributes,
 	ProductData,
-	VariationData,
 	WooCommerceConfig,
 } from '@woocommerce/stores/woocommerce/cart';
 import '@woocommerce/stores/woocommerce/product-data';
@@ -56,17 +55,19 @@ export const getProductData = (
 	id: number,
 	selectedAttributes: SelectedAttributes[]
 ): NormalizedProductData | NormalizedVariationData | null => {
-	let productId = id;
 	const { products } = getConfig( 'woocommerce' ) as WooCommerceConfig;
 
-	if ( ! products || ! products[ id ] ) {
+	if ( ! Array.isArray( products ) || ! products[ id ] ) {
 		return null;
 	}
 
-	let productData = products?.[ id ] as ProductData;
+	let product = {
+		id,
+		...products[ id ],
+	} as ProductData & { id: number };
 
 	if (
-		productData.type === 'variable' &&
+		product.type === 'variable' &&
 		selectedAttributes &&
 		selectedAttributes.length > 0
 	) {
@@ -75,31 +76,24 @@ export const getProductData = (
 			variations,
 			selectedAttributes
 		);
-		if ( matchedVariation?.variation_id ) {
-			productId = matchedVariation.variation_id;
-			productData = {
-				...( products?.[ id ]?.variations?.[
-					matchedVariation?.variation_id
-				] as VariationData ),
+		if ( matchedVariation ) {
+			product = {
+				...matchedVariation,
+				id: matchedVariation.variation_id,
 				type: 'variation',
 			};
 		}
 	}
 
-	if ( typeof productData !== 'object' || productData === null ) {
-		return null;
-	}
-
-	const min = typeof productData.min === 'number' ? productData.min : 1;
+	const min = typeof product.min === 'number' ? product.min : 1;
 	const max =
-		typeof productData.max === 'number' && productData.max >= 1
-			? productData.max
+		typeof product.max === 'number' && product.max >= 1
+			? product.max
 			: Infinity;
-	const step = productData.step || 1;
+	const step = product.step || 1;
 
 	return {
-		id: productId,
-		...productData,
+		...product,
 		min,
 		max,
 		step,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -943,6 +943,26 @@ test.describe( 'Add to Cart + Options Block', () => {
 		).toBeVisible();
 	} );
 
+	test( 'allows adding variations to cart when inside the Product block', async ( {
+		page,
+		pageObject,
+	} ) => {
+		await pageObject.createPostWithProductBlock(
+			'hoodie',
+			'hoodie-blue-yes'
+		);
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect(
+			page.getByRole( 'button', { name: '1 in cart', exact: true } )
+		).toBeVisible();
+	} );
+
 	test( 'allows adding grouped products to cart when inside the Product block', async ( {
 		page,
 		pageObject,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -89,7 +89,7 @@ class AddToCartWithOptionsPage {
 		await this.updateAddToCartWithOptionsBlock();
 	}
 
-	async createPostWithProductBlock( product: string ) {
+	async createPostWithProductBlock( product: string, variation?: string ) {
 		await this.admin.createNewPost();
 		await this.editor.insertBlock( { name: 'woocommerce/single-product' } );
 		const singleProductBlock = await this.editor.getBlockByName(
@@ -100,6 +100,13 @@ class AddToCartWithOptionsPage {
 			.locator( `input[type="radio"][value="${ product }"]` )
 			.nth( 0 )
 			.click();
+
+		if ( variation ) {
+			await singleProductBlock
+				.locator( `input[type="radio"][value="${ variation }"]` )
+				.nth( 0 )
+				.click();
+		}
 
 		await singleProductBlock.getByText( 'Done' ).click();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -145,7 +145,8 @@ class AddToCartWithOptions extends AbstractBlock {
 			return '';
 		}
 
-		$product_type = $product->get_type();
+		// For variations, we display the simple product form.
+		$product_type = ProductType::VARIATION === $product->get_type() ? ProductType::SIMPLE : $product->get_type();
 
 		$slug = $product_type . '-product-add-to-cart-with-options';
 
@@ -288,9 +289,21 @@ class AddToCartWithOptions extends AbstractBlock {
 						),
 					)
 				);
-			}
+			} elseif ( $product->is_type( ProductType::VARIATION ) ) {
+				$variation_attributes = $product->get_variation_attributes();
+				$formatted_attributes = array_map(
+					function ( $key, $value ) {
+						return [
+							'attribute' => $key,
+							'value'     => $value,
+						];
+					},
+					array_keys( $variation_attributes ),
+					$variation_attributes
+				);
 
-			if ( $product->is_type( ProductType::GROUPED ) ) {
+				$context['selectedAttributes'] = $formatted_attributes;
+			} elseif ( $product->is_type( ProductType::GROUPED ) ) {
 				// Add context for purchasable child products.
 				$children_product_data = array();
 				foreach ( $product->get_children() as $child_product_id ) {
@@ -608,7 +621,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				 *
 				 * @since 9.9.0
 				 */
-				do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
+				do_action( 'woocommerce_' . $product_type . '_add_to_cart' );
 				add_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
 			}
 
@@ -625,7 +638,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			 *
 			 * @since 9.7.0
 			 */
-			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
+			do_action( 'woocommerce_' . $product_type . '_add_to_cart' );
 
 			$wrapper_attributes = array(
 				'class' => $classes,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56289.

Previously, the _Add to Cart with Options_ block didn't support variations. However, in https://github.com/woocommerce/woocommerce/pull/58148 we added support to the non-blockified version. This PR introduces the same capability to the blockified _Add to Cart + Options_ block for full feature parity.

Internally, it reuses the simple product template part, since simple products are the most similar product type to variations. We could introduce an extra template part for variations, but I believe that would bring little benefit and make things more complex for users.

To avoid confusion, the template part remains non-editable when a variation is selected. This prevents users from making changes assuming they apply only to variations, when they would also affect simple products. Not a strong opinion, but I feel this is the best way to keep things simpler for users.

### How to test the changes in this Pull Request:

1. Create a post or page and add the _Product_ block.
2. Select a variation.
3. Update the non-blockified _Add to Cart with Options_ block to the blockified version.
4. In the frontend, try adding the variation to the cart.
5. Verify it works as expected.

https://github.com/user-attachments/assets/a0856220-d8f3-4233-9e9c-622d26ff8af9

