### PR TITLE
dev: fix CI configuration for blocks e2e

### DIFF
--- a/plugins/woocommerce/changelog/dev-fix-ci-config-for-blocks-e2e-with
+++ b/plugins/woocommerce/changelog/dev-fix-ci-config-for-blocks-e2e-with
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: dev: update CI configuration for blocks e2e
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -784,6 +784,7 @@
 					"changes": [
 						"client/blocks/tests/e2e/**"
 					],
+					"onlyForDependencies": [],
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
@@ -821,6 +822,7 @@
 					"changes": [
 						"client/blocks/tests/e2e/**"
 					],
+					"onlyForDependencies": [],
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Fix CI job matching logic for Blocks e2e tests on WP pre-release and latest-1 versions.

These jobs were incorrectly triggered on PRs that only changed non tests files in `@woocommerce/block-library`, even though their `changes` pattern was set to `"client/blocks/tests/e2e/**"` (test files only).

The fix was to add `"onlyForDependencies": []` to both job configurations to prevent them from running on dependency changes. Now they only run when test files matching `"client/blocks/tests/e2e/**"` are actually modified.

## Testing
Verified with `pnpm utils ci-jobs --pr-number 61531 --event pull_request` that these jobs no longer appear for PRs with only implementation changes.
