### PR TITLE
Spike: Render the ExperimentalDiscountsMeta in the iAPI Mini-cart block

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/available-slot-fills.md
@@ -131,7 +131,7 @@ Checkout:
 -   `renderPickupLocation`: a render function that renders the address details of a local pickup option.
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 -   `extensions`: external data registered by third-party developers using `ExtendSchema`, if you used `ExtendSchema` on `wc/store/cart` you would find your data under your namespace here.
--   `components`: an object containing components you can use to render your own pickup rates, it contains `ShippingRatesControlPackage` and `RadioControl`.
+-   `components`: an object containing components you can use to render your own pickup rates, it contains `ShippingRatesControlPackage` and `LocalPickupSelect`.
 
 ## ExperimentalDiscountsMeta
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/utilities/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/utilities/index.tsx
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
+import {
+	FormattedMonetaryAmount,
+	RadioControlOptionType,
+} from '@woocommerce/blocks-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { getSetting } from '@woocommerce/settings';
+import type {
+	PackageRateOption,
+	CartShippingPackageShippingRate,
+} from '@woocommerce/types';
+
+import { Icon, mapMarker } from '@wordpress/icons';
+import ReadMore from '@woocommerce/base-components/read-more';
+
+/**
+ * Renders a shipping rate control option.
+ *
+ * @param {Object} option Shipping Rate.
+ */
+const renderShippingRatesControlOption = (
+	option: CartShippingPackageShippingRate
+): PackageRateOption => {
+	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
+		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
+		: parseInt( option.price, 10 );
+
+	const secondaryLabel =
+		priceWithTaxes === 0 ? (
+			<span className="wc-block-checkout__shipping-option--free">
+				{ __( 'Free', 'woocommerce' ) }
+			</span>
+		) : (
+			<FormattedMonetaryAmount
+				currency={ getCurrencyFromPriceResponse( option ) }
+				value={ priceWithTaxes }
+			/>
+		);
+
+	return {
+		label: decodeEntities( option.name ),
+		value: option.rate_id,
+		description: decodeEntities( option.delivery_time ),
+		secondaryLabel,
+		secondaryDescription: decodeEntities( option.description ),
+	};
+};
+
+const getPickupLocation = (
+	option: CartShippingPackageShippingRate
+): string => {
+	if ( option?.meta_data ) {
+		const match = option.meta_data.find(
+			( meta ) => meta.key === 'pickup_location'
+		);
+		return match ? match.value : '';
+	}
+	return '';
+};
+
+const getPickupAddress = (
+	option: CartShippingPackageShippingRate
+): string => {
+	if ( option?.meta_data ) {
+		const match = option.meta_data.find(
+			( meta ) => meta.key === 'pickup_address'
+		);
+		return match ? match.value : '';
+	}
+	return '';
+};
+
+const getPickupDetails = (
+	option: CartShippingPackageShippingRate
+): string => {
+	if ( option?.meta_data ) {
+		const match = option.meta_data.find(
+			( meta ) => meta.key === 'pickup_details'
+		);
+		return match ? match.value : '';
+	}
+	return '';
+};
+
+const renderPickupLocation = (
+	option: CartShippingPackageShippingRate,
+	packageCount: number
+): RadioControlOptionType => {
+	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
+		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
+		: parseInt( option.price, 10 );
+	const location = getPickupLocation( option );
+	const address = getPickupAddress( option );
+	const details = getPickupDetails( option );
+
+	const isSelected = option?.selected;
+
+	// Default to showing "free" as the secondary label. Price checks below will update it if needed.
+	let secondaryLabel = <em>{ __( 'free', 'woocommerce' ) }</em>;
+
+	// If there is a cost for local pickup, show the cost per package.
+	if ( priceWithTaxes > 0 ) {
+		// If only one package, show the price and not the package count.
+		if ( packageCount === 1 ) {
+			secondaryLabel = (
+				<FormattedMonetaryAmount
+					currency={ getCurrencyFromPriceResponse( option ) }
+					value={ priceWithTaxes }
+				/>
+			);
+		} else {
+			secondaryLabel = createInterpolateElement(
+				/* translators: <price/> is the price of the package, <packageCount/> is the number of packages. These must appear in the translated string. */
+				_n(
+					'<price/> x <packageCount/> package',
+					'<price/> x <packageCount/> packages',
+					packageCount,
+					'woocommerce'
+				),
+				{
+					price: (
+						<FormattedMonetaryAmount
+							currency={ getCurrencyFromPriceResponse( option ) }
+							value={ priceWithTaxes }
+						/>
+					),
+					packageCount: <>{ packageCount }</>,
+				}
+			);
+		}
+	}
+
+	return {
+		value: option.rate_id,
+		label: location
+			? decodeEntities( location )
+			: decodeEntities( option.name ),
+		secondaryLabel,
+		description: address ? (
+			<>
+				<Icon
+					icon={ mapMarker }
+					className="wc-block-editor-components-block-icon"
+				/>
+				{ decodeEntities( address ) }
+			</>
+		) : undefined,
+		secondaryDescription:
+			isSelected && details ? (
+				<ReadMore maxLines={ 2 }>
+					{ decodeEntities( details ) }
+				</ReadMore>
+			) : undefined,
+	};
+};
+
+export { renderShippingRatesControlOption, renderPickupLocation };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -912,3 +912,154 @@ store(
 	},
 	{ lock: true }
 );
+
+store(
+	'woocommerce/mini-cart-footer-block',
+	{
+		state: {
+			get itemsInCartText() {
+				const cartItemsCount = miniCartState.totalItemsInCart;
+
+				return itemsInCartTextTemplate.replace(
+					'%d',
+					cartItemsCount.toString()
+				);
+			},
+			get totalDiscount(): string {
+				return woocommerceState.cart.totals.total_discount;
+			},
+			get totalDiscountLabel(): string {
+				return 'Discount: ';
+			},
+		},
+		callbacks: {
+			renderDiscountsMetaSlot() {
+				const container = document.querySelector(
+					'.wc-block-mini-cart__footer-discounts-meta-slot'
+				);
+
+				if (
+					! container ||
+					! ( window as any ).wp?.element?.createElement ||
+					! ( window as any ).wp?.element?.createRoot ||
+					! ( window as any ).wp?.plugins?.PluginArea ||
+					! ( window as any ).wc?.blocksCheckout
+						?.ExperimentalDiscountsMeta ||
+					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider
+				) {
+					console.warn(
+						'Mini Cart: Missing dependencies for rendering discount slot',
+						{
+							hasContainer: !! container,
+							hasCreateElement: !! ( window as any ).wp?.element
+								?.createElement,
+							hasCreateRoot: !! ( window as any ).wp?.element
+								?.createRoot,
+							hasPluginArea: !! ( window as any ).wp?.plugins
+								?.PluginArea,
+							hasDiscountsMeta: !! ( window as any ).wc
+								?.blocksCheckout?.ExperimentalDiscountsMeta,
+							hasSlotFillProvider: !! ( window as any ).wc
+								?.blocksCheckout?.SlotFillProvider,
+						}
+					);
+					return;
+				}
+
+				const { createElement, Fragment } = ( window as any ).wp
+					.element;
+				const { PluginArea } = ( window as any ).wp.plugins;
+				const { ExperimentalDiscountsMeta, SlotFillProvider } = (
+					window as any
+				).wc.blocksCheckout;
+
+				// Create React root and render the slot component
+				// We need to use createElement instead of calling the component as a function
+				// and wrap it in SlotFillProvider for the slot/fill context
+				const root = ( window as any ).wp.element.createRoot(
+					container
+				);
+
+				// Transform Interactivity API cart format to match StoreCart format
+				// that plugins expect from useStoreCart() hook
+				const transformedCart = {
+					// Map raw Cart properties to StoreCart properties
+					cartCoupons: woocommerceState.cart.coupons || [],
+					cartItems: woocommerceState.cart.items || [],
+					cartItemsCount: woocommerceState.cart.itemsCount || 0,
+					cartItemsWeight: woocommerceState.cart.itemsWeight || 0,
+					cartTotals: woocommerceState.cart.totals || {},
+					cartFees: woocommerceState.cart.fees || [],
+					cartNeedsShipping:
+						woocommerceState.cart.needsShipping ?? true,
+					cartNeedsPayment:
+						woocommerceState.cart.needsPayment ?? false,
+					cartHasCalculatedShipping:
+						woocommerceState.cart.hasCalculatedShipping ?? false,
+					shippingAddress: woocommerceState.cart.shippingAddress || {},
+					billingAddress: woocommerceState.cart.billingAddress || {},
+					shippingRates: woocommerceState.cart.shippingRates || [],
+					crossSellsProducts: woocommerceState.cart.crossSells || [],
+					cartErrors: woocommerceState.cart.errors || [],
+					extensions: woocommerceState.cart.extensions || {},
+					paymentMethods: woocommerceState.cart.paymentMethods || [],
+					paymentRequirements:
+						woocommerceState.cart.paymentRequirements || [],
+					// Keep original raw cart for any direct access
+					...woocommerceState.cart,
+				};
+
+				const slotElement = createElement(
+					ExperimentalDiscountsMeta.Slot,
+					{
+						extensions: woocommerceState.cart.extensions,
+						cart: transformedCart,
+						context: 'woocommerce/mini-cart',
+					}
+				);
+
+				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
+				// This allows fills registered via registerPlugin to appear
+				const pluginAreaElement = createElement( PluginArea, {
+					scope: 'woocommerce-checkout',
+				} );
+
+				// Wrap both the slot and PluginArea in SlotFillProvider so fills can be registered
+				const providerElement = createElement(
+					SlotFillProvider,
+					null,
+					createElement(
+						Fragment,
+						null,
+						slotElement,
+						pluginAreaElement
+					)
+				);
+
+				console.log(
+					'Mini Cart: Rendering discount slot with cart:',
+					woocommerceState.cart
+				);
+				console.log(
+					'Mini Cart: PluginArea will render plugins with scope "woocommerce-checkout"'
+				);
+
+				root.render( providerElement );
+
+				// Log registered plugins for debugging
+				setTimeout( () => {
+					if ( ( window as any ).wp?.plugins?.getPlugins ) {
+						const plugins = ( window as any ).wp.plugins.getPlugins(
+							'woocommerce-checkout'
+						);
+						console.log(
+							'Mini Cart: Registered plugins for woocommerce-checkout:',
+							plugins
+						);
+					}
+				}, 100 );
+			},
+		},
+	},
+	{ lock: true }
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -913,6 +913,10 @@ store(
 	{ lock: true }
 );
 
+// Store React root and render function for discounts slot at module level
+let discountsSlotReactRoot: any = null;
+let discountsSlotRenderFn: ( () => void ) | null = null;
+
 store(
 	'woocommerce/mini-cart-footer-block',
 	{
@@ -971,93 +975,113 @@ store(
 				const { PluginArea } = ( window as any ).wp.plugins;
 				const { ExperimentalDiscountsMeta, SlotFillProvider } = (
 					window as any
-				).wc.blocksCheckout;
+				 ).wc.blocksCheckout;
 
-				// Create React root and render the slot component
+				// Create React root once and render the slot component
 				// We need to use createElement instead of calling the component as a function
 				// and wrap it in SlotFillProvider for the slot/fill context
-				const root = ( window as any ).wp.element.createRoot(
-					container
-				);
+				if ( ! discountsSlotReactRoot ) {
+					discountsSlotReactRoot = (
+						window as any
+					 ).wp.element.createRoot( container );
+				}
 
-				// Transform Interactivity API cart format to match StoreCart format
-				// that plugins expect from useStoreCart() hook
-				const transformedCart = {
-					// Map raw Cart properties to StoreCart properties
-					cartCoupons: woocommerceState.cart.coupons || [],
-					cartItems: woocommerceState.cart.items || [],
-					cartItemsCount: woocommerceState.cart.itemsCount || 0,
-					cartItemsWeight: woocommerceState.cart.itemsWeight || 0,
-					cartTotals: woocommerceState.cart.totals || {},
-					cartFees: woocommerceState.cart.fees || [],
-					cartNeedsShipping:
-						woocommerceState.cart.needsShipping ?? true,
-					cartNeedsPayment:
-						woocommerceState.cart.needsPayment ?? false,
-					cartHasCalculatedShipping:
-						woocommerceState.cart.hasCalculatedShipping ?? false,
-					shippingAddress: woocommerceState.cart.shippingAddress || {},
-					billingAddress: woocommerceState.cart.billingAddress || {},
-					shippingRates: woocommerceState.cart.shippingRates || [],
-					crossSellsProducts: woocommerceState.cart.crossSells || [],
-					cartErrors: woocommerceState.cart.errors || [],
-					extensions: woocommerceState.cart.extensions || {},
-					paymentMethods: woocommerceState.cart.paymentMethods || [],
-					paymentRequirements:
-						woocommerceState.cart.paymentRequirements || [],
-					// Keep original raw cart for any direct access
-					...woocommerceState.cart,
+				// Create render function that can be called from watch callback
+				discountsSlotRenderFn = () => {
+					// Transform Interactivity API cart format to match StoreCart format
+					// move this to a getter in the WooCommerce store
+					const transformedCart = {
+						cartCoupons: woocommerceState.cart.coupons || [],
+						cartItems: woocommerceState.cart.items || [],
+						cartItemsCount: woocommerceState.cart.itemsCount || 0,
+						cartItemsWeight: woocommerceState.cart.itemsWeight || 0,
+						cartTotals: woocommerceState.cart.totals || {},
+						cartFees: woocommerceState.cart.fees || [],
+						cartNeedsShipping:
+							woocommerceState.cart.needsShipping ?? true,
+						cartNeedsPayment:
+							woocommerceState.cart.needsPayment ?? false,
+						cartHasCalculatedShipping:
+							woocommerceState.cart.hasCalculatedShipping ??
+							false,
+						shippingAddress:
+							woocommerceState.cart.shippingAddress || {},
+						billingAddress:
+							woocommerceState.cart.billingAddress || {},
+						shippingRates:
+							woocommerceState.cart.shippingRates || [],
+						crossSellsProducts:
+							woocommerceState.cart.crossSells || [],
+						cartErrors: woocommerceState.cart.errors || [],
+						extensions: woocommerceState.cart.extensions || {},
+						paymentMethods:
+							woocommerceState.cart.paymentMethods || [],
+						paymentRequirements:
+							woocommerceState.cart.paymentRequirements || [],
+						...woocommerceState.cart,
+					};
+
+					const slotElement = createElement(
+						ExperimentalDiscountsMeta.Slot,
+						{
+							extensions: woocommerceState.cart.extensions,
+							cart: transformedCart,
+							context: 'woocommerce/mini-cart',
+						}
+					);
+
+					// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
+					// This allows fills registered via registerPlugin to appear
+					const pluginAreaElement = createElement( PluginArea, {
+						scope: 'woocommerce-checkout',
+					} );
+
+					// Wrap both the slot and PluginArea in SlotFillProvider so fills can be registered
+					const providerElement = createElement(
+						SlotFillProvider,
+						null,
+						createElement(
+							Fragment,
+							null,
+							slotElement,
+							pluginAreaElement
+						)
+					);
+
+					console.log(
+						'Mini Cart: Rendering discount slot with cart:',
+						woocommerceState.cart
+					);
+					console.log(
+						'Mini Cart: PluginArea will render plugins with scope "woocommerce-checkout"'
+					);
+					discountsSlotReactRoot.render( providerElement );
 				};
 
-				const slotElement = createElement(
-					ExperimentalDiscountsMeta.Slot,
-					{
-						extensions: woocommerceState.cart.extensions,
-						cart: transformedCart,
-						context: 'woocommerce/mini-cart',
-					}
-				);
+				// Initial render
+				discountsSlotRenderFn();
+			},
 
-				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
-				// This allows fills registered via registerPlugin to appear
-				const pluginAreaElement = createElement( PluginArea, {
-					scope: 'woocommerce-checkout',
-				} );
+			// Log registered plugins for debugging
 
-				// Wrap both the slot and PluginArea in SlotFillProvider so fills can be registered
-				const providerElement = createElement(
-					SlotFillProvider,
-					null,
-					createElement(
-						Fragment,
-						null,
-						slotElement,
-						pluginAreaElement
-					)
-				);
+			watchCartForSlotUpdate() {
+				// Access cart properties to make this callback reactive to cart changes
+				// When any of these properties change, this callback will run again
+				// woocommerceState is accessed the same way as in state getters above
+				const { coupons, items, totals } = woocommerceState.cart;
 
-				console.log(
-					'Mini Cart: Rendering discount slot with cart:',
-					woocommerceState.cart
-				);
-				console.log(
-					'Mini Cart: PluginArea will render plugins with scope "woocommerce-checkout"'
-				);
-
-				root.render( providerElement );
-
-				// Log registered plugins for debugging
-				setTimeout( () => {
-					if ( ( window as any ).wp?.plugins?.getPlugins ) {
-						const plugins = ( window as any ).wp.plugins.getPlugins(
-							'woocommerce-checkout'
-						);
-						console.log(
-							'Mini Cart: Registered plugins for woocommerce-checkout:',
-							plugins
-						);
-					}
-				}, 100 );
+				// Trigger re-render when cart changes
+				if ( discountsSlotRenderFn ) {
+					console.log(
+						'Mini Cart: Cart changed via data-wp-watch, re-rendering slot',
+						{
+							couponsCount: ( coupons as any[] )?.length,
+							itemsCount: ( items as any[] )?.length,
+							totalPrice: ( totals as any )?.total_price,
+						}
+					);
+					discountsSlotRenderFn();
+				}
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -913,14 +913,16 @@ store(
 	{ lock: true }
 );
 
-// Store React root and render function for discounts slot at module level
+// Store React roots and render functions for slots at module level
 let discountsSlotReactRoot: any = null;
-let discountsSlotRenderFn: ( () => void ) | null = null;
+let shippingPackagesSlotReactRoot: any = null;
+let localPickupPackagesSlotReactRoot: any = null;
 
-store(
+const { state: footerState } = store(
 	'woocommerce/mini-cart-footer-block',
 	{
 		state: {
+			activeTab: 'shipping',
 			get itemsInCartText() {
 				const cartItemsCount = miniCartState.totalItemsInCart;
 
@@ -934,6 +936,40 @@ store(
 			},
 			get totalDiscountLabel(): string {
 				return 'Discount: ';
+			},
+			get selectedShippingMethod(): string {
+				return woocommerceState.cart.extensions.subscriptions
+					.map( ( subscription: any ) => {
+						const selectedRate =
+							subscription.shipping_rates[ 0 ]?.shipping_rates?.find(
+								( rate: any ) => rate.selected
+							);
+						return `${ subscription.shipping_rates[ 0 ].name }: ${
+							selectedRate?.name || 'None'
+						}`;
+					} )
+					.join( ', ' );
+			},
+			get isShippingTabActive(): boolean {
+				return footerState.activeTab === 'shipping';
+			},
+			get isLocalPickupTabActive(): boolean {
+				return footerState.activeTab === 'local-pickup';
+			},
+			get isShippingPanelHidden(): boolean {
+				return footerState.activeTab !== 'shipping';
+			},
+			get isLocalPickupPanelHidden(): boolean {
+				return footerState.activeTab !== 'local-pickup';
+			},
+		},
+		actions: {
+			switchTab( event: MouseEvent ) {
+				const button = event.currentTarget as HTMLButtonElement;
+				const tabName = button.getAttribute( 'data-tab' );
+				if ( tabName ) {
+					footerState.activeTab = tabName;
+				}
 			},
 		},
 		callbacks: {
@@ -1016,6 +1052,208 @@ store(
 				);
 
 				discountsSlotReactRoot.render( providerElement );
+			},
+			renderShippingPackagesSlot() {
+				const container = document.querySelector(
+					'.wc-block-mini-cart__footer-shipping-packages-slot'
+				);
+
+				if (
+					! container ||
+					! ( window as any ).wp?.element?.createElement ||
+					! ( window as any ).wp?.element?.createRoot ||
+					! ( window as any ).wp?.plugins?.PluginArea ||
+					! ( window as any ).wc?.blocksCheckout
+						?.ExperimentalOrderShippingPackages ||
+					! ( window as any ).wc?.blocksCheckout
+						?.MiniCartSlotWrapper ||
+					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider ||
+					! ( window as any ).wc?.blocksCheckout
+						?.ShippingRatesControlPackage ||
+					! ( window as any ).wc?.blocksCheckout?.LocalPickupSelect ||
+					! ( window as any ).wc?.blocksCheckout
+						?.renderShippingRatesControlOption
+				) {
+					console.warn(
+						'Mini Cart: Missing dependencies for rendering shipping packages slot',
+						{
+							hasContainer: !! container,
+							hasCreateElement: !! ( window as any ).wp?.element
+								?.createElement,
+							hasCreateRoot: !! ( window as any ).wp?.element
+								?.createRoot,
+							hasPluginArea: !! ( window as any ).wp?.plugins
+								?.PluginArea,
+							hasShippingPackages: !! ( window as any ).wc
+								?.blocksCheckout
+								?.ExperimentalOrderShippingPackages,
+							hasMiniCartSlotWrapper: !! ( window as any ).wc
+								?.blocksCheckout?.MiniCartSlotWrapper,
+							hasSlotFillProvider: !! ( window as any ).wc
+								?.blocksCheckout?.SlotFillProvider,
+							hasShippingRatesControlPackage: !! ( window as any )
+								.wc?.blocksCheckout
+								?.ShippingRatesControlPackage,
+							hasLocalPickupSelect: !! ( window as any ).wc
+								?.blocksCheckout?.LocalPickupSelect,
+							hasRenderShippingRatesControlOption: !! (
+								window as any
+							 ).wc?.blocksCheckout
+								?.renderShippingRatesControlOption,
+						}
+					);
+					return;
+				}
+
+				const { createElement, Fragment } = ( window as any ).wp
+					.element;
+				const { PluginArea } = ( window as any ).wp.plugins;
+				const {
+					ExperimentalOrderShippingPackages,
+					MiniCartSlotWrapper,
+					SlotFillProvider,
+					ShippingRatesControlPackage,
+					LocalPickupSelect,
+					renderShippingRatesControlOption,
+					NoticeBanner,
+				} = ( window as any ).wc.blocksCheckout;
+
+				// Create React root once and render the slot component
+				if ( ! shippingPackagesSlotReactRoot ) {
+					shippingPackagesSlotReactRoot = (
+						window as any
+					 ).wp.element.createRoot( container );
+				}
+
+				// Render using MiniCartSlotWrapper with slot-specific props
+				const wrapperElement = createElement( MiniCartSlotWrapper, {
+					slotComponent: ExperimentalOrderShippingPackages.Slot,
+					slotProps: {
+						components: {
+							ShippingRatesControlPackage,
+							LocalPickupSelect,
+						},
+						// stateless flag to collapse the shipping packages
+						collapsible: true,
+						// We're just using a generic banner, instead of the 2 ones
+						// that are used in the checkout block
+						// https://github.com/woocommerce/woocommerce/blob/9209a054e0de33f180070badaffd60889ef4b712/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx#L142
+						noResultsMessage: createElement( NoticeBanner, {
+							status: 'warning',
+							children:
+								'No shipping options are available for this address. Please verify the address is correct or try a different address.',
+						} ),
+						renderOption: renderShippingRatesControlOption,
+					},
+				} );
+
+				const pluginAreaElement = createElement( PluginArea, {
+					scope: 'woocommerce-checkout',
+				} );
+
+				const providerElement = createElement(
+					SlotFillProvider,
+					null,
+					createElement(
+						Fragment,
+						null,
+						wrapperElement,
+						pluginAreaElement
+					)
+				);
+
+				shippingPackagesSlotReactRoot.render( providerElement );
+			},
+			renderLocalPickupPackagesSlot() {
+				const container = document.querySelector(
+					'.wc-block-mini-cart__footer-local-pickup-packages-slot'
+				);
+
+				if (
+					! container ||
+					! ( window as any ).wp?.element?.createElement ||
+					! ( window as any ).wp?.element?.createRoot ||
+					! ( window as any ).wp?.plugins?.PluginArea ||
+					! ( window as any ).wc?.blocksCheckout
+						?.ExperimentalOrderLocalPickupPackages ||
+					! ( window as any ).wc?.blocksCheckout
+						?.MiniCartSlotWrapper ||
+					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider ||
+					! ( window as any ).wc?.blocksCheckout?.renderPickupLocation
+				) {
+					console.warn(
+						'Mini Cart: Missing dependencies for rendering local pickup packages slot',
+						{
+							hasContainer: !! container,
+							hasCreateElement: !! ( window as any ).wp?.element
+								?.createElement,
+							hasCreateRoot: !! ( window as any ).wp?.element
+								?.createRoot,
+							hasPluginArea: !! ( window as any ).wp?.plugins
+								?.PluginArea,
+							hasLocalPickupPackages: !! ( window as any ).wc
+								?.blocksCheckout
+								?.ExperimentalOrderLocalPickupPackages,
+							hasMiniCartSlotWrapper: !! ( window as any ).wc
+								?.blocksCheckout?.MiniCartSlotWrapper,
+							hasSlotFillProvider: !! ( window as any ).wc
+								?.blocksCheckout?.SlotFillProvider,
+							renderPickupLocation: !! ( window as any ).wc
+								?.blocksCheckout?.renderPickupLocation,
+						}
+					);
+					return;
+				}
+
+				const { createElement, Fragment } = ( window as any ).wp
+					.element;
+				const { PluginArea } = ( window as any ).wp.plugins;
+				const {
+					ExperimentalOrderLocalPickupPackages,
+					MiniCartSlotWrapper,
+					SlotFillProvider,
+					LocalPickupSelect,
+					ShippingRatesControlPackage,
+					renderPickupLocation,
+				} = ( window as any ).wc.blocksCheckout;
+
+				// Create React root once and render the slot component
+				if ( ! localPickupPackagesSlotReactRoot ) {
+					localPickupPackagesSlotReactRoot = (
+						window as any
+					 ).wp.element.createRoot( container );
+				}
+
+				// Render using MiniCartSlotWrapper which handles cart data automatically
+				const wrapperElement = createElement( MiniCartSlotWrapper, {
+					slotComponent: ExperimentalOrderLocalPickupPackages.Slot,
+					slotProps: {
+						components: {
+							LocalPickupSelect,
+							ShippingRatesControlPackage,
+						},
+						renderPickupLocation: renderPickupLocation,
+					},
+				} );
+
+				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
+				// This allows fills registered via registerPlugin to appear
+				const pluginAreaElement = createElement( PluginArea, {
+					scope: 'woocommerce-checkout',
+				} );
+
+				const providerElement = createElement(
+					SlotFillProvider,
+					null,
+					createElement(
+						Fragment,
+						null,
+						wrapperElement,
+						pluginAreaElement
+					)
+				);
+
+				localPickupPackagesSlotReactRoot.render( providerElement );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -918,6 +918,93 @@ let discountsSlotReactRoot: any = null;
 let shippingPackagesSlotReactRoot: any = null;
 let localPickupPackagesSlotReactRoot: any = null;
 
+/**
+ * Helper function to check base dependencies required for slot rendering.
+ *
+ * @param {Element | null} container - The DOM container element for the slot.
+ * @param {string}         debugName - Name for debugging/logging purposes.
+ * @return {boolean} True if all base dependencies are available, false otherwise.
+ */
+function checkBaseDependencies(
+	container: Element | null,
+	debugName: string
+): boolean {
+	if (
+		! container ||
+		! ( window as any ).wp?.element?.createElement ||
+		! ( window as any ).wp?.element?.createRoot ||
+		! ( window as any ).wp?.plugins?.PluginArea ||
+		! ( window as any ).wc?.blocksCheckout?.MiniCartSlotWrapper ||
+		! ( window as any ).wc?.blocksCheckout?.SlotFillProvider
+	) {
+		console.warn(
+			`Mini Cart: Missing base dependencies for rendering ${ debugName }`,
+			{
+				hasContainer: !! container,
+				hasCreateElement: !! ( window as any ).wp?.element
+					?.createElement,
+				hasCreateRoot: !! ( window as any ).wp?.element?.createRoot,
+				hasPluginArea: !! ( window as any ).wp?.plugins?.PluginArea,
+				hasMiniCartSlotWrapper: !! ( window as any ).wc?.blocksCheckout
+					?.MiniCartSlotWrapper,
+				hasSlotFillProvider: !! ( window as any ).wc?.blocksCheckout
+					?.SlotFillProvider,
+			}
+		);
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Helper function to get or create a React root for a slot container.
+ *
+ * @param {any}     rootVar   - The existing React root variable (may be null).
+ * @param {Element} container - The DOM container element for the slot.
+ * @return {any} The React root instance.
+ */
+function getOrCreateRoot( rootVar: any, container: Element ): any {
+	if ( ! rootVar ) {
+		return ( window as any ).wp.element.createRoot( container );
+	}
+	return rootVar;
+}
+
+/**
+ * Helper function to render a slot with standard SlotFillProvider structure.
+ *
+ * @param {any}    root          - The React root to render into.
+ * @param {any}    slotComponent - The slot component to render.
+ * @param {any}    slotProps     - Props to pass to the slot component.
+ * @param {string} scope         - The plugin area scope (default: 'woocommerce-checkout').
+ */
+function renderSlotWithProvider(
+	root: any,
+	slotComponent: any,
+	slotProps: any,
+	scope: string = 'woocommerce-checkout'
+): void {
+	const { createElement, Fragment } = ( window as any ).wp.element;
+	const { PluginArea } = ( window as any ).wp.plugins;
+	const { MiniCartSlotWrapper, SlotFillProvider } = ( window as any ).wc
+		.blocksCheckout;
+
+	const wrapperElement = createElement( MiniCartSlotWrapper, {
+		slotComponent,
+		slotProps,
+	} );
+
+	const pluginAreaElement = createElement( PluginArea, { scope } );
+
+	const providerElement = createElement(
+		SlotFillProvider,
+		null,
+		createElement( Fragment, null, wrapperElement, pluginAreaElement )
+	);
+
+	root.render( providerElement );
+}
+
 const { state: footerState } = store(
 	'woocommerce/mini-cart-footer-block',
 	{
@@ -978,282 +1065,154 @@ const { state: footerState } = store(
 					'.wc-block-mini-cart__footer-discounts-meta-slot'
 				);
 
+				if ( ! checkBaseDependencies( container, 'discount slot' ) ) {
+					return;
+				}
+
 				if (
-					! container ||
-					! ( window as any ).wp?.element?.createElement ||
-					! ( window as any ).wp?.element?.createRoot ||
-					! ( window as any ).wp?.plugins?.PluginArea ||
 					! ( window as any ).wc?.blocksCheckout
-						?.ExperimentalDiscountsMeta ||
-					! ( window as any ).wc?.blocksCheckout
-						?.MiniCartSlotWrapper ||
-					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider
+						?.ExperimentalDiscountsMeta
 				) {
 					console.warn(
-						'Mini Cart: Missing dependencies for rendering discount slot',
+						'Mini Cart: Missing ExperimentalDiscountsMeta component for discount slot',
 						{
-							hasContainer: !! container,
-							hasCreateElement: !! ( window as any ).wp?.element
-								?.createElement,
-							hasCreateRoot: !! ( window as any ).wp?.element
-								?.createRoot,
-							hasPluginArea: !! ( window as any ).wp?.plugins
-								?.PluginArea,
 							hasDiscountsMeta: !! ( window as any ).wc
 								?.blocksCheckout?.ExperimentalDiscountsMeta,
-							hasMiniCartSlotWrapper: !! ( window as any ).wc
-								?.blocksCheckout?.MiniCartSlotWrapper,
-							hasSlotFillProvider: !! ( window as any ).wc
-								?.blocksCheckout?.SlotFillProvider,
 						}
 					);
 					return;
 				}
 
-				const { createElement, Fragment } = ( window as any ).wp
-					.element;
-				const { PluginArea } = ( window as any ).wp.plugins;
-				const {
-					ExperimentalDiscountsMeta,
-					MiniCartSlotWrapper,
-					SlotFillProvider,
-				} = ( window as any ).wc.blocksCheckout;
+				const { ExperimentalDiscountsMeta } = ( window as any ).wc
+					.blocksCheckout;
 
-				// Create React root once and render the slot component
-				if ( ! discountsSlotReactRoot ) {
-					discountsSlotReactRoot = (
-						window as any
-					 ).wp.element.createRoot( container );
-				}
-
-				// Render using MiniCartSlotWrapper which handles cart data automatically
-				const wrapperElement = createElement( MiniCartSlotWrapper, {
-					slotComponent: ExperimentalDiscountsMeta.Slot,
-					slotProps: {
-						context: 'woocommerce/mini-cart',
-					},
-				} );
-
-				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
-				// This allows fills registered via registerPlugin to appear
-				const pluginAreaElement = createElement( PluginArea, {
-					scope: 'woocommerce-checkout',
-				} );
-
-				const providerElement = createElement(
-					SlotFillProvider,
-					null,
-					createElement(
-						Fragment,
-						null,
-						wrapperElement,
-						pluginAreaElement
-					)
+				discountsSlotReactRoot = getOrCreateRoot(
+					discountsSlotReactRoot,
+					container
 				);
 
-				discountsSlotReactRoot.render( providerElement );
+				renderSlotWithProvider(
+					discountsSlotReactRoot,
+					ExperimentalDiscountsMeta.Slot,
+					{
+						context: 'woocommerce/mini-cart',
+					}
+				);
 			},
 			renderShippingPackagesSlot() {
 				const container = document.querySelector(
 					'.wc-block-mini-cart__footer-shipping-packages-slot'
 				);
 
+				if ( ! checkBaseDependencies( container, 'shipping packages slot' ) ) {
+					return;
+				}
+
+				const blocksCheckout = ( window as any ).wc?.blocksCheckout;
 				if (
-					! container ||
-					! ( window as any ).wp?.element?.createElement ||
-					! ( window as any ).wp?.element?.createRoot ||
-					! ( window as any ).wp?.plugins?.PluginArea ||
-					! ( window as any ).wc?.blocksCheckout
-						?.ExperimentalOrderShippingPackages ||
-					! ( window as any ).wc?.blocksCheckout
-						?.MiniCartSlotWrapper ||
-					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider ||
-					! ( window as any ).wc?.blocksCheckout
-						?.ShippingRatesControlPackage ||
-					! ( window as any ).wc?.blocksCheckout?.LocalPickupSelect ||
-					! ( window as any ).wc?.blocksCheckout
-						?.renderShippingRatesControlOption
+					! blocksCheckout?.ExperimentalOrderShippingPackages ||
+					! blocksCheckout?.ShippingRatesControlPackage ||
+					! blocksCheckout?.LocalPickupSelect ||
+					! blocksCheckout?.renderShippingRatesControlOption ||
+					! blocksCheckout?.NoticeBanner
 				) {
 					console.warn(
-						'Mini Cart: Missing dependencies for rendering shipping packages slot',
+						'Mini Cart: Missing components for shipping packages slot',
 						{
-							hasContainer: !! container,
-							hasCreateElement: !! ( window as any ).wp?.element
-								?.createElement,
-							hasCreateRoot: !! ( window as any ).wp?.element
-								?.createRoot,
-							hasPluginArea: !! ( window as any ).wp?.plugins
-								?.PluginArea,
-							hasShippingPackages: !! ( window as any ).wc
-								?.blocksCheckout
-								?.ExperimentalOrderShippingPackages,
-							hasMiniCartSlotWrapper: !! ( window as any ).wc
-								?.blocksCheckout?.MiniCartSlotWrapper,
-							hasSlotFillProvider: !! ( window as any ).wc
-								?.blocksCheckout?.SlotFillProvider,
-							hasShippingRatesControlPackage: !! ( window as any )
-								.wc?.blocksCheckout
-								?.ShippingRatesControlPackage,
-							hasLocalPickupSelect: !! ( window as any ).wc
-								?.blocksCheckout?.LocalPickupSelect,
-							hasRenderShippingRatesControlOption: !! (
-								window as any
-							 ).wc?.blocksCheckout
-								?.renderShippingRatesControlOption,
+							hasShippingPackages: !! blocksCheckout?.ExperimentalOrderShippingPackages,
+							hasShippingRatesControlPackage: !! blocksCheckout?.ShippingRatesControlPackage,
+							hasLocalPickupSelect: !! blocksCheckout?.LocalPickupSelect,
+							hasRenderShippingRatesControlOption: !! blocksCheckout?.renderShippingRatesControlOption,
+							hasNoticeBanner: !! blocksCheckout?.NoticeBanner,
 						}
 					);
 					return;
 				}
 
-				const { createElement, Fragment } = ( window as any ).wp
-					.element;
-				const { PluginArea } = ( window as any ).wp.plugins;
 				const {
 					ExperimentalOrderShippingPackages,
-					MiniCartSlotWrapper,
-					SlotFillProvider,
 					ShippingRatesControlPackage,
 					LocalPickupSelect,
 					renderShippingRatesControlOption,
 					NoticeBanner,
-				} = ( window as any ).wc.blocksCheckout;
+				} = blocksCheckout;
 
-				// Create React root once and render the slot component
-				if ( ! shippingPackagesSlotReactRoot ) {
-					shippingPackagesSlotReactRoot = (
-						window as any
-					 ).wp.element.createRoot( container );
-				}
+				shippingPackagesSlotReactRoot = getOrCreateRoot(
+					shippingPackagesSlotReactRoot,
+					container
+				);
 
-				// Render using MiniCartSlotWrapper with slot-specific props
-				const wrapperElement = createElement( MiniCartSlotWrapper, {
-					slotComponent: ExperimentalOrderShippingPackages.Slot,
-					slotProps: {
+				const { createElement } = ( window as any ).wp.element;
+
+				renderSlotWithProvider(
+					shippingPackagesSlotReactRoot,
+					ExperimentalOrderShippingPackages.Slot,
+					{
 						components: {
 							ShippingRatesControlPackage,
 							LocalPickupSelect,
 						},
-						// stateless flag to collapse the shipping packages
 						collapsible: true,
-						// We're just using a generic banner, instead of the 2 ones
-						// that are used in the checkout block
-						// https://github.com/woocommerce/woocommerce/blob/9209a054e0de33f180070badaffd60889ef4b712/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx#L142
 						noResultsMessage: createElement( NoticeBanner, {
 							status: 'warning',
 							children:
 								'No shipping options are available for this address. Please verify the address is correct or try a different address.',
 						} ),
 						renderOption: renderShippingRatesControlOption,
-					},
-				} );
-
-				const pluginAreaElement = createElement( PluginArea, {
-					scope: 'woocommerce-checkout',
-				} );
-
-				const providerElement = createElement(
-					SlotFillProvider,
-					null,
-					createElement(
-						Fragment,
-						null,
-						wrapperElement,
-						pluginAreaElement
-					)
+					}
 				);
-
-				shippingPackagesSlotReactRoot.render( providerElement );
 			},
 			renderLocalPickupPackagesSlot() {
 				const container = document.querySelector(
 					'.wc-block-mini-cart__footer-local-pickup-packages-slot'
 				);
 
+				if ( ! checkBaseDependencies( container, 'local pickup packages slot' ) ) {
+					return;
+				}
+
+				const blocksCheckout = ( window as any ).wc?.blocksCheckout;
 				if (
-					! container ||
-					! ( window as any ).wp?.element?.createElement ||
-					! ( window as any ).wp?.element?.createRoot ||
-					! ( window as any ).wp?.plugins?.PluginArea ||
-					! ( window as any ).wc?.blocksCheckout
-						?.ExperimentalOrderLocalPickupPackages ||
-					! ( window as any ).wc?.blocksCheckout
-						?.MiniCartSlotWrapper ||
-					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider ||
-					! ( window as any ).wc?.blocksCheckout?.renderPickupLocation
+					! blocksCheckout?.ExperimentalOrderLocalPickupPackages ||
+					! blocksCheckout?.LocalPickupSelect ||
+					! blocksCheckout?.ShippingRatesControlPackage ||
+					! blocksCheckout?.renderPickupLocation
 				) {
 					console.warn(
-						'Mini Cart: Missing dependencies for rendering local pickup packages slot',
+						'Mini Cart: Missing components for local pickup packages slot',
 						{
-							hasContainer: !! container,
-							hasCreateElement: !! ( window as any ).wp?.element
-								?.createElement,
-							hasCreateRoot: !! ( window as any ).wp?.element
-								?.createRoot,
-							hasPluginArea: !! ( window as any ).wp?.plugins
-								?.PluginArea,
-							hasLocalPickupPackages: !! ( window as any ).wc
-								?.blocksCheckout
-								?.ExperimentalOrderLocalPickupPackages,
-							hasMiniCartSlotWrapper: !! ( window as any ).wc
-								?.blocksCheckout?.MiniCartSlotWrapper,
-							hasSlotFillProvider: !! ( window as any ).wc
-								?.blocksCheckout?.SlotFillProvider,
-							renderPickupLocation: !! ( window as any ).wc
-								?.blocksCheckout?.renderPickupLocation,
+							hasLocalPickupPackages: !! blocksCheckout?.ExperimentalOrderLocalPickupPackages,
+							hasLocalPickupSelect: !! blocksCheckout?.LocalPickupSelect,
+							hasShippingRatesControlPackage: !! blocksCheckout?.ShippingRatesControlPackage,
+							hasRenderPickupLocation: !! blocksCheckout?.renderPickupLocation,
 						}
 					);
 					return;
 				}
 
-				const { createElement, Fragment } = ( window as any ).wp
-					.element;
-				const { PluginArea } = ( window as any ).wp.plugins;
 				const {
 					ExperimentalOrderLocalPickupPackages,
-					MiniCartSlotWrapper,
-					SlotFillProvider,
 					LocalPickupSelect,
 					ShippingRatesControlPackage,
 					renderPickupLocation,
-				} = ( window as any ).wc.blocksCheckout;
+				} = blocksCheckout;
 
-				// Create React root once and render the slot component
-				if ( ! localPickupPackagesSlotReactRoot ) {
-					localPickupPackagesSlotReactRoot = (
-						window as any
-					 ).wp.element.createRoot( container );
-				}
+				localPickupPackagesSlotReactRoot = getOrCreateRoot(
+					localPickupPackagesSlotReactRoot,
+					container
+				);
 
-				// Render using MiniCartSlotWrapper which handles cart data automatically
-				const wrapperElement = createElement( MiniCartSlotWrapper, {
-					slotComponent: ExperimentalOrderLocalPickupPackages.Slot,
-					slotProps: {
+				renderSlotWithProvider(
+					localPickupPackagesSlotReactRoot,
+					ExperimentalOrderLocalPickupPackages.Slot,
+					{
 						components: {
 							LocalPickupSelect,
 							ShippingRatesControlPackage,
 						},
 						renderPickupLocation: renderPickupLocation,
-					},
-				} );
-
-				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
-				// This allows fills registered via registerPlugin to appear
-				const pluginAreaElement = createElement( PluginArea, {
-					scope: 'woocommerce-checkout',
-				} );
-
-				const providerElement = createElement(
-					SlotFillProvider,
-					null,
-					createElement(
-						Fragment,
-						null,
-						wrapperElement,
-						pluginAreaElement
-					)
+					}
 				);
-
-				localPickupPackagesSlotReactRoot.render( providerElement );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -973,17 +973,23 @@ function getOrCreateRoot( rootVar: any, container: Element ): any {
 /**
  * Helper function to render a slot with standard SlotFillProvider structure.
  *
- * @param {any}    root          - The React root to render into.
- * @param {any}    slotComponent - The slot component to render.
- * @param {any}    slotProps     - Props to pass to the slot component.
- * @param {string} scope         - The plugin area scope (default: 'woocommerce-checkout').
+ * @param {Object} params                     - The parameters object.
+ * @param {any}    params.root                - The React root to render into.
+ * @param {any}    params.slotComponent       - The slot component to render.
+ * @param {any}    params.slotProps           - Props to pass to the slot component.
+ * @param {string} params.pluginAreaScope     - The plugin area scope (default: 'woocommerce-checkout').
  */
-function renderSlotWithProvider(
-	root: any,
-	slotComponent: any,
-	slotProps: any,
-	scope: string = 'woocommerce-checkout'
-): void {
+function renderSlotWithProvider( {
+	root,
+	slotComponent,
+	slotProps,
+	pluginAreaScope = 'woocommerce-checkout',
+}: {
+	root: any;
+	slotComponent: any;
+	slotProps: any;
+	pluginAreaScope?: string;
+} ): void {
 	const { createElement, Fragment } = ( window as any ).wp.element;
 	const { PluginArea } = ( window as any ).wp.plugins;
 	const { MiniCartSlotWrapper, SlotFillProvider } = ( window as any ).wc
@@ -994,7 +1000,9 @@ function renderSlotWithProvider(
 		slotProps,
 	} );
 
-	const pluginAreaElement = createElement( PluginArea, { scope } );
+	const pluginAreaElement = createElement( PluginArea, {
+		scope: pluginAreaScope,
+	} );
 
 	const providerElement = createElement(
 		SlotFillProvider,
@@ -1091,20 +1099,25 @@ const { state: footerState } = store(
 					container
 				);
 
-				renderSlotWithProvider(
-					discountsSlotReactRoot,
-					ExperimentalDiscountsMeta.Slot,
-					{
+				renderSlotWithProvider( {
+					root: discountsSlotReactRoot,
+					slotComponent: ExperimentalDiscountsMeta.Slot,
+					slotProps: {
 						context: 'woocommerce/mini-cart',
-					}
-				);
+					},
+				} );
 			},
 			renderShippingPackagesSlot() {
 				const container = document.querySelector(
 					'.wc-block-mini-cart__footer-shipping-packages-slot'
 				);
 
-				if ( ! checkBaseDependencies( container, 'shipping packages slot' ) ) {
+				if (
+					! checkBaseDependencies(
+						container,
+						'shipping packages slot'
+					)
+				) {
 					return;
 				}
 
@@ -1119,10 +1132,14 @@ const { state: footerState } = store(
 					console.warn(
 						'Mini Cart: Missing components for shipping packages slot',
 						{
-							hasShippingPackages: !! blocksCheckout?.ExperimentalOrderShippingPackages,
-							hasShippingRatesControlPackage: !! blocksCheckout?.ShippingRatesControlPackage,
-							hasLocalPickupSelect: !! blocksCheckout?.LocalPickupSelect,
-							hasRenderShippingRatesControlOption: !! blocksCheckout?.renderShippingRatesControlOption,
+							hasShippingPackages:
+								!! blocksCheckout?.ExperimentalOrderShippingPackages,
+							hasShippingRatesControlPackage:
+								!! blocksCheckout?.ShippingRatesControlPackage,
+							hasLocalPickupSelect:
+								!! blocksCheckout?.LocalPickupSelect,
+							hasRenderShippingRatesControlOption:
+								!! blocksCheckout?.renderShippingRatesControlOption,
 							hasNoticeBanner: !! blocksCheckout?.NoticeBanner,
 						}
 					);
@@ -1144,10 +1161,10 @@ const { state: footerState } = store(
 
 				const { createElement } = ( window as any ).wp.element;
 
-				renderSlotWithProvider(
-					shippingPackagesSlotReactRoot,
-					ExperimentalOrderShippingPackages.Slot,
-					{
+				renderSlotWithProvider( {
+					root: shippingPackagesSlotReactRoot,
+					slotComponent: ExperimentalOrderShippingPackages.Slot,
+					slotProps: {
 						components: {
 							ShippingRatesControlPackage,
 							LocalPickupSelect,
@@ -1159,15 +1176,20 @@ const { state: footerState } = store(
 								'No shipping options are available for this address. Please verify the address is correct or try a different address.',
 						} ),
 						renderOption: renderShippingRatesControlOption,
-					}
-				);
+					},
+				} );
 			},
 			renderLocalPickupPackagesSlot() {
 				const container = document.querySelector(
 					'.wc-block-mini-cart__footer-local-pickup-packages-slot'
 				);
 
-				if ( ! checkBaseDependencies( container, 'local pickup packages slot' ) ) {
+				if (
+					! checkBaseDependencies(
+						container,
+						'local pickup packages slot'
+					)
+				) {
 					return;
 				}
 
@@ -1181,10 +1203,14 @@ const { state: footerState } = store(
 					console.warn(
 						'Mini Cart: Missing components for local pickup packages slot',
 						{
-							hasLocalPickupPackages: !! blocksCheckout?.ExperimentalOrderLocalPickupPackages,
-							hasLocalPickupSelect: !! blocksCheckout?.LocalPickupSelect,
-							hasShippingRatesControlPackage: !! blocksCheckout?.ShippingRatesControlPackage,
-							hasRenderPickupLocation: !! blocksCheckout?.renderPickupLocation,
+							hasLocalPickupPackages:
+								!! blocksCheckout?.ExperimentalOrderLocalPickupPackages,
+							hasLocalPickupSelect:
+								!! blocksCheckout?.LocalPickupSelect,
+							hasShippingRatesControlPackage:
+								!! blocksCheckout?.ShippingRatesControlPackage,
+							hasRenderPickupLocation:
+								!! blocksCheckout?.renderPickupLocation,
 						}
 					);
 					return;
@@ -1202,17 +1228,17 @@ const { state: footerState } = store(
 					container
 				);
 
-				renderSlotWithProvider(
-					localPickupPackagesSlotReactRoot,
-					ExperimentalOrderLocalPickupPackages.Slot,
-					{
+				renderSlotWithProvider( {
+					root: localPickupPackagesSlotReactRoot,
+					slotComponent: ExperimentalOrderLocalPickupPackages.Slot,
+					slotProps: {
 						components: {
 							LocalPickupSelect,
 							ShippingRatesControlPackage,
 						},
 						renderPickupLocation: renderPickupLocation,
-					}
-				);
+					},
+				} );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -949,6 +949,8 @@ store(
 					! ( window as any ).wp?.plugins?.PluginArea ||
 					! ( window as any ).wc?.blocksCheckout
 						?.ExperimentalDiscountsMeta ||
+					! ( window as any ).wc?.blocksCheckout
+						?.MiniCartSlotWrapper ||
 					! ( window as any ).wc?.blocksCheckout?.SlotFillProvider
 				) {
 					console.warn(
@@ -963,6 +965,8 @@ store(
 								?.PluginArea,
 							hasDiscountsMeta: !! ( window as any ).wc
 								?.blocksCheckout?.ExperimentalDiscountsMeta,
+							hasMiniCartSlotWrapper: !! ( window as any ).wc
+								?.blocksCheckout?.MiniCartSlotWrapper,
 							hasSlotFillProvider: !! ( window as any ).wc
 								?.blocksCheckout?.SlotFillProvider,
 						}
@@ -973,115 +977,45 @@ store(
 				const { createElement, Fragment } = ( window as any ).wp
 					.element;
 				const { PluginArea } = ( window as any ).wp.plugins;
-				const { ExperimentalDiscountsMeta, SlotFillProvider } = (
-					window as any
-				 ).wc.blocksCheckout;
+				const {
+					ExperimentalDiscountsMeta,
+					MiniCartSlotWrapper,
+					SlotFillProvider,
+				} = ( window as any ).wc.blocksCheckout;
 
 				// Create React root once and render the slot component
-				// We need to use createElement instead of calling the component as a function
-				// and wrap it in SlotFillProvider for the slot/fill context
 				if ( ! discountsSlotReactRoot ) {
 					discountsSlotReactRoot = (
 						window as any
 					 ).wp.element.createRoot( container );
 				}
 
-				// Create render function that can be called from watch callback
-				discountsSlotRenderFn = () => {
-					// Transform Interactivity API cart format to match StoreCart format
-					// move this to a getter in the WooCommerce store
-					const transformedCart = {
-						cartCoupons: woocommerceState.cart.coupons || [],
-						cartItems: woocommerceState.cart.items || [],
-						cartItemsCount: woocommerceState.cart.itemsCount || 0,
-						cartItemsWeight: woocommerceState.cart.itemsWeight || 0,
-						cartTotals: woocommerceState.cart.totals || {},
-						cartFees: woocommerceState.cart.fees || [],
-						cartNeedsShipping:
-							woocommerceState.cart.needsShipping ?? true,
-						cartNeedsPayment:
-							woocommerceState.cart.needsPayment ?? false,
-						cartHasCalculatedShipping:
-							woocommerceState.cart.hasCalculatedShipping ??
-							false,
-						shippingAddress:
-							woocommerceState.cart.shippingAddress || {},
-						billingAddress:
-							woocommerceState.cart.billingAddress || {},
-						shippingRates:
-							woocommerceState.cart.shippingRates || [],
-						crossSellsProducts:
-							woocommerceState.cart.crossSells || [],
-						cartErrors: woocommerceState.cart.errors || [],
-						extensions: woocommerceState.cart.extensions || {},
-						paymentMethods:
-							woocommerceState.cart.paymentMethods || [],
-						paymentRequirements:
-							woocommerceState.cart.paymentRequirements || [],
-						...woocommerceState.cart,
-					};
+				// Render using MiniCartSlotWrapper which handles cart data automatically
+				const wrapperElement = createElement( MiniCartSlotWrapper, {
+					slotComponent: ExperimentalDiscountsMeta.Slot,
+					slotProps: {
+						context: 'woocommerce/mini-cart',
+					},
+				} );
 
-					const slotElement = createElement(
-						ExperimentalDiscountsMeta.Slot,
-						{
-							extensions: woocommerceState.cart.extensions,
-							cart: transformedCart,
-							context: 'woocommerce/mini-cart',
-						}
-					);
+				// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
+				// This allows fills registered via registerPlugin to appear
+				const pluginAreaElement = createElement( PluginArea, {
+					scope: 'woocommerce-checkout',
+				} );
 
-					// Add PluginArea with scope 'woocommerce-checkout' to render registered plugins
-					// This allows fills registered via registerPlugin to appear
-					const pluginAreaElement = createElement( PluginArea, {
-						scope: 'woocommerce-checkout',
-					} );
-
-					// Wrap both the slot and PluginArea in SlotFillProvider so fills can be registered
-					const providerElement = createElement(
-						SlotFillProvider,
+				const providerElement = createElement(
+					SlotFillProvider,
+					null,
+					createElement(
+						Fragment,
 						null,
-						createElement(
-							Fragment,
-							null,
-							slotElement,
-							pluginAreaElement
-						)
-					);
+						wrapperElement,
+						pluginAreaElement
+					)
+				);
 
-					console.log(
-						'Mini Cart: Rendering discount slot with cart:',
-						woocommerceState.cart
-					);
-					console.log(
-						'Mini Cart: PluginArea will render plugins with scope "woocommerce-checkout"'
-					);
-					discountsSlotReactRoot.render( providerElement );
-				};
-
-				// Initial render
-				discountsSlotRenderFn();
-			},
-
-			// Log registered plugins for debugging
-
-			watchCartForSlotUpdate() {
-				// Access cart properties to make this callback reactive to cart changes
-				// When any of these properties change, this callback will run again
-				// woocommerceState is accessed the same way as in state getters above
-				const { coupons, items, totals } = woocommerceState.cart;
-
-				// Trigger re-render when cart changes
-				if ( discountsSlotRenderFn ) {
-					console.log(
-						'Mini Cart: Cart changed via data-wp-watch, re-rendering slot',
-						{
-							couponsCount: ( coupons as any[] )?.length,
-							itemsCount: ( items as any[] )?.length,
-							totalPrice: ( totals as any )?.total_price,
-						}
-					);
-					discountsSlotRenderFn();
-				}
+				discountsSlotReactRoot.render( providerElement );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -231,3 +231,11 @@ h2.wc-block-mini-cart__title {
 		}
 	}
 }
+
+// Skipe styles for the shipping packages and local pickup packages slots
+
+.wc-block-mini-cart__footer-debug {
+	font-size: 0.875em;
+	background-color: palegoldenrod;
+	padding: 5px;
+}

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
@@ -4,6 +4,7 @@ export { default as ExperimentalOrderMeta } from './order-meta';
 export { default as ExperimentalDiscountsMeta } from './discounts-meta';
 export { default as ExperimentalOrderShippingPackages } from './order-shipping-packages';
 export { default as ExperimentalOrderLocalPickupPackages } from './order-local-pickup-packages';
+export { default as MiniCartSlotWrapper } from './mini-cart-slot-wrapper';
 export { default as Panel } from '../../components/panel';
 export { default as Button } from '../../components/button';
 export { default as Label } from './label';

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/mini-cart-slot-wrapper/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/mini-cart-slot-wrapper/index.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { useStoreCart } from '@woocommerce/base-context/hooks';
+import type { ComponentType } from 'react';
+
+interface SlotComponentProps {
+	extensions: Record< string, unknown >;
+	cart: Record< string, unknown >;
+	context?: string;
+	[ key: string ]: unknown;
+}
+
+interface MiniCartSlotWrapperProps {
+	slotComponent: ComponentType< SlotComponentProps >;
+	slotProps?: Record< string, unknown >;
+}
+
+/**
+ * Generic wrapper for Mini-Cart slot components.
+ * Automatically provides cart data in the correct format and handles re-rendering.
+ */
+const MiniCartSlotWrapper = ( {
+	slotComponent: SlotComponent,
+	slotProps = {},
+}: MiniCartSlotWrapperProps ) => {
+	// useStoreCart provides cart in camelCase format
+	// eslint-disable-next-line no-unused-vars
+	const { extensions, receiveCart, ...cart } = useStoreCart();
+
+	return (
+		<SlotComponent
+			extensions={ extensions || {} }
+			cart={ cart }
+			{ ...slotProps }
+		/>
+	);
+};
+
+export default MiniCartSlotWrapper;

--- a/plugins/woocommerce/client/blocks/packages/checkout/index.js
+++ b/plugins/woocommerce/client/blocks/packages/checkout/index.js
@@ -3,7 +3,18 @@ export * from './utils';
 export * from './slot';
 export * from './filter-registry';
 export * from './blocks-registry';
-
 // It is very important to export this directly from the build module to avoid introducing side-effects
 // from importing the index of the @wordpress/components package.
 export { Provider as SlotFillProvider } from 'wordpress-components-slotfill/build-module/slot-fill';
+
+// Exporting components from the base components package
+// These are needed for the OrderShippingPackagesSlot in compatibility mode
+// They need to be accesible under window.wc.blocksCheckout
+// To do: discuss a better way to do this
+export { default as ShippingRatesControlPackage } from '../../assets/js/base/components/cart-checkout/shipping-rates-control-package';
+export { default as LocalPickupSelect } from '../../assets/js/base/components/cart-checkout/local-pickup-select';
+export {
+	renderShippingRatesControlOption,
+	renderPickupLocation,
+} from '../../assets/js/base/components/cart-checkout/utilities';
+export { default as NoticeBanner } from '../../assets/js/base/components/notice-banner';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -501,6 +501,9 @@ class MiniCart extends AbstractBlock {
 			wp_enqueue_script( $handle );
 		}
 
+		wp_enqueue_script( 'wc-blocks-checkout' );
+		wp_enqueue_script( 'wp-element' );
+
 		$this->register_cart_interactivity( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 		$this->initialize_shared_config( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 		$this->placeholder_image( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -67,9 +67,45 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 				</div>
 			</div>
 			<div class="wc-block-mini-cart__footer-discounts-meta-slot" data-wp-init="callbacks.renderDiscountsMetaSlot"></div>
-			<div>
+			<div class="wc-block-mini-cart__footer-tabs">
+				<div class="wc-block-mini-cart__footer-tabs-header">
+			<button
+					class="wc-block-mini-cart__footer-tab-button"
+					data-tab="shipping"
+					data-wp-on--click="actions.switchTab"
+					data-wp-class--wc-block-mini-cart__footer-tab-button--active="state.isShippingTabActive"
+					data-wp-bind--disabled="state.isShippingTabActive">
+						<?php echo esc_html__( 'Shipping', 'woocommerce' ); ?>
+					</button>
+			<button
+					class="wc-block-mini-cart__footer-tab-button"
+					data-tab="local-pickup"
+					data-wp-on--click="actions.switchTab"
+					data-wp-class--wc-block-mini-cart__footer-tab-button--active="state.isLocalPickupTabActive"
+					data-wp-bind--disabled="state.isLocalPickupTabActive">
+						<?php echo esc_html__( 'Local pickup', 'woocommerce' ); ?>
+					</button>
+				</div>
+				<div class="wc-block-mini-cart__footer-tabs-content">
+					<div
+					class="wc-block-mini-cart__footer-tab-panel"
+					data-tab-panel="shipping"
+					data-wp-bind--hidden="state.isShippingPanelHidden">
+						<div class="wc-block-mini-cart__footer-shipping-packages-slot" data-wp-init="callbacks.renderShippingPackagesSlot"></div>
+					</div>
+					<div
+					class="wc-block-mini-cart__footer-tab-panel"
+					data-tab-panel="local-pickup"
+					data-wp-bind--hidden="state.isLocalPickupPanelHidden">
+						<div class="wc-block-mini-cart__footer-local-pickup-packages-slot" data-wp-init="callbacks.renderLocalPickupPackagesSlot"></div>
+					</div>
+				</div>
+			</div>
+			<div class="wc-block-mini-cart__footer-debug">
 				<span class="wc-block-components-totals-item__discount-label" data-wp-text="state.totalDiscountLabel"></span>
 				<span class="wc-block-components-totals-item__discount" data-wp-text="state.totalDiscount"></span>
+				<br />
+				<span class="wc-block-components-totals-item__shipping-method" data-wp-text="state.selectedShippingMethod"></span>
 				<br />
 			</div>
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -66,9 +66,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 					<?php echo esc_html( $other_costs_label ); ?>
 				</div>
 			</div>
-			<div class="wc-block-mini-cart__footer-discounts-meta-slot"
-			data-wp-init="callbacks.renderDiscountsMetaSlot"
-			data-wp-watch="callbacks.watchCartForSlotUpdate"></div>
+			<div class="wc-block-mini-cart__footer-discounts-meta-slot" data-wp-init="callbacks.renderDiscountsMetaSlot"></div>
 			<div>
 				<span class="wc-block-components-totals-item__discount-label" data-wp-text="state.totalDiscountLabel"></span>
 				<span class="wc-block-components-totals-item__discount" data-wp-text="state.totalDiscount"></span>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -66,6 +66,14 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 					<?php echo esc_html( $other_costs_label ); ?>
 				</div>
 			</div>
+			<div class="wc-block-mini-cart__footer-discounts-meta-slot"
+			data-wp-init="callbacks.renderDiscountsMetaSlot"></div>
+			<div>
+				<span class="wc-block-components-totals-item__discount-label" data-wp-text="state.totalDiscountLabel"></span>
+				<span class="wc-block-components-totals-item__discount" data-wp-text="state.totalDiscount"></span>
+				<br />
+			</div>
+
 			<div class="wc-block-mini-cart__footer-actions">
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -67,7 +67,8 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 				</div>
 			</div>
 			<div class="wc-block-mini-cart__footer-discounts-meta-slot"
-			data-wp-init="callbacks.renderDiscountsMetaSlot"></div>
+			data-wp-init="callbacks.renderDiscountsMetaSlot"
+			data-wp-watch="callbacks.watchCartForSlotUpdate"></div>
 			<div>
 				<span class="wc-block-components-totals-item__discount-label" data-wp-text="state.totalDiscountLabel"></span>
 				<span class="wc-block-components-totals-item__discount" data-wp-text="state.totalDiscount"></span>


### PR DESCRIPTION
Fixes WOOPRD-1146

This PR should not be merged. It's used to collect feedback on trying to render React Slot/Fills in the Mini-Cart block.

Watch this video to understand the spike https://drive.google.com/file/d/1mvq7ZSkcpXvlPTePmbLoEuqCVRjwb8FZ/view?usp=sharing
^ THE approach from the video is outdated

To get this working locally, you need clone https://github.com/woocommerce/woocommerce-points-and-rewards and add this code after[ this line ](https://github.com/woocommerce/woocommerce-points-and-rewards/blob/b43e0506a495d87bbcc967f1439512112ab7963e/woocommerce-points-and-rewards.php#L306)

```
	add_action(
				'woocommerce_blocks_mini-cart_block_registration',
				function( $integration_registry ) {
					$integration_registry->register( new WC_Points_Rewards_Integration() );
				}
			);
```

The spike does not handle cleaning up React after the Mini Cart unmounts. 
