### PR TITLE
Add to Cart + Options: improve editor display for users without permissions to edit the template parts

### DIFF
--- a/plugins/woocommerce/changelog/fix-56521-add-to-cart-with-options-not-editable-for-authors
+++ b/plugins/woocommerce/changelog/fix-56521-add-to-cart-with-options-not-editable-for-authors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: improve editor display for users without permissions to edit the template parts

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -99,7 +99,7 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 	if ( ! templatePartId || ! canEditTemplatePart ) {
 		return (
 			<div { ...blockProps }>
-				<Skeleton productType={ productType } />
+				<Skeleton productType={ productType } isStatic={ true } />
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -83,9 +83,22 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 
 	const { canEditTemplatePart, isLoading } = useSelect(
 		( select ) => {
-			const { hasFinishedResolution } = select( coreStore );
+			if ( ! templatePartId ) {
+				return {
+					canEditTemplatePart: false,
+					isLoading: false,
+				};
+			}
 
-			const hasResolvedEntity = hasFinishedResolution( 'canUser', [
+			const { canUser, hasFinishedResolution } = select( coreStore );
+
+			const canUserUpdate = canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_template_part',
+				id: templatePartId,
+			} );
+
+			const isLoadingCanUserUpdate = ! hasFinishedResolution( 'canUser', [
 				'update',
 				{
 					kind: 'postType',
@@ -95,14 +108,8 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 			] );
 
 			return {
-				canEditTemplatePart:
-					templatePartId &&
-					select( coreStore ).canUser( 'update', {
-						kind: 'postType',
-						name: 'wp_template_part',
-						id: templatePartId,
-					} ),
-				isLoading: ! hasResolvedEntity,
+				canEditTemplatePart: canUserUpdate,
+				isLoading: isLoadingCanUserUpdate,
 			};
 		},
 		[ templatePartId ]

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -18,9 +18,11 @@ import { Skeleton } from './skeleton';
 
 const TemplatePartInnerBlocks = ( {
 	blockProps,
+	productType,
 	templatePartId,
 }: {
 	blockProps: Record< string, unknown >;
+	productType: string;
 	templatePartId: string | undefined;
 } ) => {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
@@ -33,13 +35,10 @@ const TemplatePartInnerBlocks = ( {
 		( select ) => {
 			const { hasFinishedResolution } = select( coreStore );
 
-			const hasResolvedEntity = templatePartId
-				? hasFinishedResolution( 'getEditedEntityRecord', [
-						'postType',
-						'wp_template_part',
-						templatePartId,
-				  ] )
-				: false;
+			const hasResolvedEntity = hasFinishedResolution(
+				'getEditedEntityRecord',
+				[ 'postType', 'wp_template_part', templatePartId ]
+			);
 
 			return {
 				isLoading: ! hasResolvedEntity,
@@ -61,7 +60,7 @@ const TemplatePartInnerBlocks = ( {
 	if ( isLoading ) {
 		return (
 			<div { ...blockProps }>
-				<Spinner />
+				<Skeleton productType={ productType } />
 			</div>
 		);
 	}
@@ -98,21 +97,18 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 		[ templatePartId ]
 	);
 
-	if ( ! templatePartId ) {
+	if ( ! templatePartId || ! canEditTemplatePart ) {
 		return (
 			<div { ...blockProps }>
-				<Spinner />
+				<Skeleton productType={ productType } />
 			</div>
 		);
-	}
-
-	if ( ! canEditTemplatePart ) {
-		return <Skeleton productType={ productType } />;
 	}
 
 	return (
 		<TemplatePartInnerBlocks
 			blockProps={ blockProps }
+			productType={ productType }
 			templatePartId={ templatePartId }
 		/>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -99,7 +99,7 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 	if ( ! templatePartId || ! canEditTemplatePart ) {
 		return (
 			<div { ...blockProps }>
-				<Skeleton productType={ productType } isStatic={ true } />
+				<Skeleton productType={ productType } isLoading={ false } />
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -83,22 +83,16 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 
 	const blockProps = useBlockProps();
 
-	const { canViewTemplatePart, canEditTemplatePart } = useSelect(
+	const { canEditTemplatePart } = useSelect(
 		( select ) => {
-			const templatePartData = {
-				kind: 'postType',
-				name: 'wp_template_part',
-				id: templatePartId,
-			};
 			return {
-				canViewTemplatePart: !! select( coreStore ).canUser(
-					'read',
-					templatePartData
-				),
-				canEditTemplatePart: !! select( coreStore ).canUser(
-					'update',
-					templatePartData
-				),
+				canEditTemplatePart:
+					templatePartId &&
+					select( coreStore ).canUser( 'update', {
+						kind: 'postType',
+						name: 'wp_template_part',
+						id: templatePartId,
+					} ),
 			};
 		},
 		[ templatePartId ]
@@ -112,7 +106,7 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 		);
 	}
 
-	if ( ! canViewTemplatePart || ! canEditTemplatePart ) {
+	if ( ! canEditTemplatePart ) {
 		return <Skeleton productType={ productType } />;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -11,6 +11,11 @@ import {
 } from '@wordpress/block-editor';
 import { getSetting } from '@woocommerce/settings';
 
+/**
+ * Internal dependencies
+ */
+import { Skeleton } from './skeleton';
+
 const TemplatePartInnerBlocks = ( {
 	blockProps,
 	templatePartId,
@@ -78,12 +83,37 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 
 	const blockProps = useBlockProps();
 
+	const { canViewTemplatePart, canEditTemplatePart } = useSelect(
+		( select ) => {
+			const templatePartData = {
+				kind: 'postType',
+				name: 'wp_template_part',
+				id: templatePartId,
+			};
+			return {
+				canViewTemplatePart: !! select( coreStore ).canUser(
+					'read',
+					templatePartData
+				),
+				canEditTemplatePart: !! select( coreStore ).canUser(
+					'update',
+					templatePartData
+				),
+			};
+		},
+		[ templatePartId ]
+	);
+
 	if ( ! templatePartId ) {
 		return (
 			<div { ...blockProps }>
 				<Spinner />
 			</div>
 		);
+	}
+
+	if ( ! canViewTemplatePart || ! canEditTemplatePart ) {
+		return <Skeleton productType={ productType } />;
 	}
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Spinner } from '@wordpress/components';
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
 	InnerBlocks,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -59,7 +59,7 @@ const TemplatePartInnerBlocks = ( {
 	if ( isLoading ) {
 		return (
 			<div { ...blockProps }>
-				<Skeleton productType={ productType } />
+				<Skeleton productType={ productType } isLoading={ true } />
 			</div>
 		);
 	}
@@ -81,8 +81,19 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 
 	const blockProps = useBlockProps();
 
-	const { canEditTemplatePart } = useSelect(
+	const { canEditTemplatePart, isLoading } = useSelect(
 		( select ) => {
+			const { hasFinishedResolution } = select( coreStore );
+
+			const hasResolvedEntity = hasFinishedResolution( 'canUser', [
+				'update',
+				{
+					kind: 'postType',
+					name: 'wp_template_part',
+					id: templatePartId,
+				},
+			] );
+
 			return {
 				canEditTemplatePart:
 					templatePartId &&
@@ -91,6 +102,7 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 						name: 'wp_template_part',
 						id: templatePartId,
 					} ),
+				isLoading: ! hasResolvedEntity,
 			};
 		},
 		[ templatePartId ]
@@ -99,7 +111,7 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 	if ( ! templatePartId || ! canEditTemplatePart ) {
 		return (
 			<div { ...blockProps }>
-				<Skeleton productType={ productType } isLoading={ false } />
+				<Skeleton productType={ productType } isLoading={ isLoading } />
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
 import {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -4,8 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
-import { Disabled } from '@wordpress/components';
-import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/patterns/multi-line-text-skeleton';
 import {
 	BlockControls,
 	InspectorControls,
@@ -21,6 +19,7 @@ import { DowngradeNotice } from '../components/downgrade-notice';
 import { UpgradeProductImageGallery } from '../components/upgrade-product-image-gallery';
 import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
+import { Skeleton } from './skeleton';
 import type { Attributes } from '../types';
 
 const AddToCartOptionsEdit = (
@@ -64,17 +63,10 @@ const AddToCartOptionsEdit = (
 				/>
 			) : (
 				<div { ...blockProps }>
-					<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-						<MultiLineTextSkeleton isStatic={ true } />
-					</div>
-					<Disabled>
-						<button
-							className={ `alt wp-element-button ${ productType }_add_to_cart_button` }
-						>
-							{ ( product && product.add_to_cart?.single_text ) ||
-								__( 'Add to cart', 'woocommerce' ) }
-						</button>
-					</Disabled>
+					<Skeleton
+						buttonText={ product?.add_to_cart?.single_text }
+						productType={ productType }
+					/>
 				</div>
 			) }
 		</>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -65,6 +65,7 @@ const AddToCartOptionsEdit = (
 					<Skeleton
 						buttonText={ product?.add_to_cart?.single_text }
 						productType={ productType }
+						isStatic={ true }
 					/>
 				</div>
 			) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -65,7 +65,7 @@ const AddToCartOptionsEdit = (
 					<Skeleton
 						buttonText={ product?.add_to_cart?.single_text }
 						productType={ productType }
-						isStatic={ true }
+						isLoading={ false }
 					/>
 				</div>
 			) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
@@ -8,7 +8,7 @@ import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/pat
 export const Skeleton = ( {
 	buttonText,
 	productType,
-	isLoading = true,
+	isLoading = false,
 }: {
 	buttonText?: string | undefined;
 	productType?: string | undefined;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
@@ -8,16 +8,25 @@ import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/pat
 export const Skeleton = ( {
 	buttonText,
 	productType,
-	isStatic = false,
+	isLoading = true,
 }: {
 	buttonText?: string | undefined;
 	productType?: string | undefined;
-	isStatic?: boolean;
+	isLoading?: boolean;
 } ) => {
 	return (
-		<>
+		<div
+			aria-label={
+				isLoading
+					? __(
+							'Loading the Add to Cart + Options template part',
+							'woocommerce'
+					  )
+					: __( 'Add to Cart + Options form', 'woocommerce' )
+			}
+		>
 			<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-				<MultiLineTextSkeleton isStatic={ isStatic } />
+				<MultiLineTextSkeleton isStatic={ ! isLoading } />
 			</div>
 			<Disabled>
 				<button
@@ -28,6 +37,6 @@ export const Skeleton = ( {
 					{ buttonText || __( 'Add to cart', 'woocommerce' ) }
 				</button>
 			</Disabled>
-		</>
+		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
@@ -8,14 +8,16 @@ import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/pat
 export const Skeleton = ( {
 	buttonText,
 	productType,
+	isStatic = false,
 }: {
 	buttonText?: string | undefined;
 	productType?: string | undefined;
+	isStatic?: boolean;
 } ) => {
 	return (
 		<>
 			<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
-				<MultiLineTextSkeleton />
+				<MultiLineTextSkeleton isStatic={ isStatic } />
 			</div>
 			<Disabled>
 				<button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/skeleton.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Disabled } from '@wordpress/components';
+import { MultiLineTextSkeleton } from '@woocommerce/base-components/skeleton/patterns/multi-line-text-skeleton';
+
+export const Skeleton = ( {
+	buttonText,
+	productType,
+}: {
+	buttonText?: string | undefined;
+	productType?: string | undefined;
+} ) => {
+	return (
+		<>
+			<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
+				<MultiLineTextSkeleton />
+			</div>
+			<Disabled>
+				<button
+					className={ `alt wp-element-button ${
+						productType || 'simple'
+					}_add_to_cart_button` }
+				>
+					{ buttonText || __( 'Add to cart', 'woocommerce' ) }
+				</button>
+			</Disabled>
+		</>
+	);
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -9,6 +9,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { dispatch } from '@wordpress/data';
 import { productsStore } from '@woocommerce/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -109,6 +110,19 @@ const handlers = [
 		return HttpResponse.json( mockProduct );
 	} ),
 
+	// Once `@wordpress/data` used in tests is updated to 6.7, this request will
+	// match the path in production: `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
+	http.options( '/wp/v2/[object%20Object]', () => {
+		return HttpResponse.json(
+			{},
+			{
+				headers: {
+					allow: 'GET, POST, PUT, PATCH, DELETE',
+				},
+			}
+		);
+	} ),
+
 	http.get( '/wp/v2/template-parts/*', ( request ) => {
 		if (
 			request.params[ 0 ] ===
@@ -164,6 +178,7 @@ const server = setupServer( ...handlers );
 beforeAll( () => server.listen() );
 afterEach( () => {
 	dispatch( productsStore ).invalidateResolutionForStore();
+	dispatch( coreStore ).invalidateResolutionForStore();
 	server.resetHandlers();
 } );
 afterAll( () => server.close() );
@@ -199,79 +214,107 @@ const expectHasBlock = async ( blockName: string ) => {
 };
 
 describe( 'Add to Cart + Options block', () => {
-	it( 'should render inner blocks for simple and external products', async () => {
-		await setup();
-		await expectHasBlock( 'Add to Cart + Options (Beta)' );
+	describe( 'with a user with permissions', () => {
+		it( 'should render inner blocks for simple and external products', async () => {
+			await setup();
+			await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-		// Simple products.
-		await expectHasBlock( 'Product Stock Indicator' );
-		await expectHasBlock( 'Product Quantity (Beta)' );
-		await expectHasBlock( 'Add to Cart Button' );
+			// Simple products.
+			await expectHasBlock( 'Product Stock Indicator' );
+			await expectHasBlock( 'Product Quantity (Beta)' );
+			await expectHasBlock( 'Add to Cart Button' );
 
-		// External products.
-		await switchProductType( 'External/Affiliate product' );
+			// External products.
+			await switchProductType( 'External/Affiliate product' );
 
-		await waitFor( () => {
-			expect(
-				screen.queryByLabelText( 'Block: Product Stock Indicator' )
-			).not.toBeInTheDocument();
+			await waitFor( () => {
+				expect(
+					screen.queryByLabelText( 'Block: Product Stock Indicator' )
+				).not.toBeInTheDocument();
+			} );
+			await expectHasBlock( 'Add to Cart Button' );
 		} );
-		await expectHasBlock( 'Add to Cart Button' );
+
+		it( 'should render inner blocks for grouped products', async () => {
+			expect.hasAssertions();
+
+			await setup();
+			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+
+			await switchProductType( 'Grouped product' );
+
+			await expectHasBlock( 'Grouped Product Selector (Beta)' );
+			await expectHasBlock( 'Grouped Product: Template (Beta)' );
+			await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
+			await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
+			await expectHasBlock( 'Product Price' );
+			await expectHasBlock( 'Product Stock Indicator' );
+		} );
+
+		it( 'should render inner blocks for grouped products with no store products', async () => {
+			expect.hasAssertions();
+
+			server.use(
+				http.get( '/wc/v3/products', () => {
+					return HttpResponse.json( [] );
+				} )
+			);
+
+			await setup();
+			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+
+			await switchProductType( 'Grouped product' );
+
+			await expectHasBlock( 'Grouped Product Selector (Beta)' );
+			await expectHasBlock( 'Grouped Product: Template (Beta)' );
+			await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
+			await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
+			await expectHasBlock( 'Product Price' );
+			await expectHasBlock( 'Product Stock Indicator' );
+		} );
+
+		it( 'should render inner blocks for variable products', async () => {
+			expect.hasAssertions();
+
+			await setup();
+			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+
+			await switchProductType( 'Variable product' );
+
+			await expectHasBlock( 'Variation Selector (Beta)' );
+			await expectHasBlock( 'Variation Selector: Attribute Name (Beta)' );
+			await expectHasBlock(
+				'Variation Selector: Attribute Options (Beta)'
+			);
+			await expectHasBlock( 'Variation Selector: Template (Beta)' );
+			await expectHasBlock( 'Variation Description (Beta)' );
+			await expectHasBlock( 'Product Stock Indicator' );
+			await expectHasBlock( 'Product Quantity (Beta)' );
+			await expectHasBlock( 'Add to Cart Button' );
+		} );
 	} );
 
-	it( 'should render inner blocks for grouped products', async () => {
-		expect.hasAssertions();
-
-		await setup();
-		await expectHasBlock( 'Add to Cart + Options (Beta)' );
-
-		await switchProductType( 'Grouped product' );
-
-		await expectHasBlock( 'Grouped Product Selector (Beta)' );
-		await expectHasBlock( 'Grouped Product: Template (Beta)' );
-		await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
-		await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
-		await expectHasBlock( 'Product Price' );
-		await expectHasBlock( 'Product Stock Indicator' );
-	} );
-
-	it( 'should render inner blocks for grouped products with no store products', async () => {
-		expect.hasAssertions();
-
+	it( 'should render the placeholder with a user without permissions', async () => {
 		server.use(
-			http.get( '/wc/v3/products', () => {
-				return HttpResponse.json( [] );
+			// Once `@wordpress/data` used in tests is updated to 6.7, this request will
+			// match the path in production: `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
+			http.options( '/wp/v2/[object%20Object]', () => {
+				return HttpResponse.json(
+					{},
+					{
+						headers: {
+							allow: 'GET',
+						},
+					}
+				);
 			} )
 		);
 
 		await setup();
 		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-		await switchProductType( 'Grouped product' );
-
-		await expectHasBlock( 'Grouped Product Selector (Beta)' );
-		await expectHasBlock( 'Grouped Product: Template (Beta)' );
-		await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
-		await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
-		await expectHasBlock( 'Product Price' );
-		await expectHasBlock( 'Product Stock Indicator' );
-	} );
-
-	it( 'should render inner blocks for variable products', async () => {
-		expect.hasAssertions();
-
-		await setup();
-		await expectHasBlock( 'Add to Cart + Options (Beta)' );
-
-		await switchProductType( 'Variable product' );
-
-		await expectHasBlock( 'Variation Selector (Beta)' );
-		await expectHasBlock( 'Variation Selector: Attribute Name (Beta)' );
-		await expectHasBlock( 'Variation Selector: Attribute Options (Beta)' );
-		await expectHasBlock( 'Variation Selector: Template (Beta)' );
-		await expectHasBlock( 'Variation Description (Beta)' );
-		await expectHasBlock( 'Product Stock Indicator' );
-		await expectHasBlock( 'Product Quantity (Beta)' );
-		await expectHasBlock( 'Add to Cart Button' );
+		expect(
+			screen.getByLabelText( 'Add to Cart + Options form' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -214,84 +214,80 @@ const expectHasBlock = async ( blockName: string ) => {
 };
 
 describe( 'Add to Cart + Options block', () => {
-	describe( 'with a user with permissions', () => {
-		it( 'should render inner blocks for simple and external products', async () => {
-			await setup();
-			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+	it( 'should render inner blocks for simple and external products', async () => {
+		await setup();
+		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-			// Simple products.
-			await expectHasBlock( 'Product Stock Indicator' );
-			await expectHasBlock( 'Product Quantity (Beta)' );
-			await expectHasBlock( 'Add to Cart Button' );
+		// Simple products.
+		await expectHasBlock( 'Product Stock Indicator' );
+		await expectHasBlock( 'Product Quantity (Beta)' );
+		await expectHasBlock( 'Add to Cart Button' );
 
-			// External products.
-			await switchProductType( 'External/Affiliate product' );
+		// External products.
+		await switchProductType( 'External/Affiliate product' );
 
-			await waitFor( () => {
-				expect(
-					screen.queryByLabelText( 'Block: Product Stock Indicator' )
-				).not.toBeInTheDocument();
-			} );
-			await expectHasBlock( 'Add to Cart Button' );
+		await waitFor( () => {
+			expect(
+				screen.queryByLabelText( 'Block: Product Stock Indicator' )
+			).not.toBeInTheDocument();
 		} );
+		await expectHasBlock( 'Add to Cart Button' );
+	} );
 
-		it( 'should render inner blocks for grouped products', async () => {
-			expect.hasAssertions();
+	it( 'should render inner blocks for grouped products', async () => {
+		expect.hasAssertions();
 
-			await setup();
-			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+		await setup();
+		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-			await switchProductType( 'Grouped product' );
+		await switchProductType( 'Grouped product' );
 
-			await expectHasBlock( 'Grouped Product Selector (Beta)' );
-			await expectHasBlock( 'Grouped Product: Template (Beta)' );
-			await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
-			await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
-			await expectHasBlock( 'Product Price' );
-			await expectHasBlock( 'Product Stock Indicator' );
-		} );
+		await expectHasBlock( 'Grouped Product Selector (Beta)' );
+		await expectHasBlock( 'Grouped Product: Template (Beta)' );
+		await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
+		await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
+		await expectHasBlock( 'Product Price' );
+		await expectHasBlock( 'Product Stock Indicator' );
+	} );
 
-		it( 'should render inner blocks for grouped products with no store products', async () => {
-			expect.hasAssertions();
+	it( 'should render inner blocks for grouped products with no store products', async () => {
+		expect.hasAssertions();
 
-			server.use(
-				http.get( '/wc/v3/products', () => {
-					return HttpResponse.json( [] );
-				} )
-			);
+		server.use(
+			http.get( '/wc/v3/products', () => {
+				return HttpResponse.json( [] );
+			} )
+		);
 
-			await setup();
-			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+		await setup();
+		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-			await switchProductType( 'Grouped product' );
+		await switchProductType( 'Grouped product' );
 
-			await expectHasBlock( 'Grouped Product Selector (Beta)' );
-			await expectHasBlock( 'Grouped Product: Template (Beta)' );
-			await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
-			await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
-			await expectHasBlock( 'Product Price' );
-			await expectHasBlock( 'Product Stock Indicator' );
-		} );
+		await expectHasBlock( 'Grouped Product Selector (Beta)' );
+		await expectHasBlock( 'Grouped Product: Template (Beta)' );
+		await expectHasBlock( 'Grouped Product: Item Selector (Beta)' );
+		await expectHasBlock( 'Grouped Product: Item Label (Beta)' );
+		await expectHasBlock( 'Product Price' );
+		await expectHasBlock( 'Product Stock Indicator' );
+	} );
 
-		it( 'should render inner blocks for variable products', async () => {
-			expect.hasAssertions();
+	it( 'should render inner blocks for variable products', async () => {
+		expect.hasAssertions();
 
-			await setup();
-			await expectHasBlock( 'Add to Cart + Options (Beta)' );
+		await setup();
+		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-			await switchProductType( 'Variable product' );
+		await switchProductType( 'Variable product' );
 
-			await expectHasBlock( 'Variation Selector (Beta)' );
-			await expectHasBlock( 'Variation Selector: Attribute Name (Beta)' );
-			await expectHasBlock(
-				'Variation Selector: Attribute Options (Beta)'
-			);
-			await expectHasBlock( 'Variation Selector: Template (Beta)' );
-			await expectHasBlock( 'Variation Description (Beta)' );
-			await expectHasBlock( 'Product Stock Indicator' );
-			await expectHasBlock( 'Product Quantity (Beta)' );
-			await expectHasBlock( 'Add to Cart Button' );
-		} );
+		await expectHasBlock( 'Variation Selector (Beta)' );
+		await expectHasBlock( 'Variation Selector: Attribute Name (Beta)' );
+		await expectHasBlock( 'Variation Selector: Attribute Options (Beta)' );
+		await expectHasBlock( 'Variation Selector: Template (Beta)' );
+		await expectHasBlock( 'Variation Description (Beta)' );
+		await expectHasBlock( 'Product Stock Indicator' );
+		await expectHasBlock( 'Product Quantity (Beta)' );
+		await expectHasBlock( 'Add to Cart Button' );
 	} );
 
 	it( 'should render the placeholder with a user without permissions', async () => {
@@ -313,8 +309,10 @@ describe( 'Add to Cart + Options block', () => {
 		await setup();
 		await expectHasBlock( 'Add to Cart + Options (Beta)' );
 
-		expect(
-			screen.getByLabelText( 'Add to Cart + Options form' )
-		).toBeInTheDocument();
+		await waitFor( () =>
+			expect(
+				screen.getByLabelText( 'Add to Cart + Options form' )
+			).toBeInTheDocument()
+		);
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -110,8 +110,9 @@ const handlers = [
 		return HttpResponse.json( mockProduct );
 	} ),
 
-	// Once `@wordpress/data` used in tests is updated to 6.7, this request will
-	// match the path in production: `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
+	// Once the `@wordpress/data` package used in tests is updated to 6.7, this
+	// request will match the path in production:
+	// `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
 	http.options( '/wp/v2/[object%20Object]', () => {
 		return HttpResponse.json(
 			{},
@@ -290,10 +291,11 @@ describe( 'Add to Cart + Options block', () => {
 		await expectHasBlock( 'Add to Cart Button' );
 	} );
 
-	it( 'should render the placeholder with a user without permissions', async () => {
+	it( 'should render the placeholder when viewed as a user without permissions to edit template parts', async () => {
 		server.use(
-			// Once `@wordpress/data` used in tests is updated to 6.7, this request will
-			// match the path in production: `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
+			// Once the `@wordpress/data` package used in tests is updated to 6.7,
+			// this request will match the path in production:
+			// `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
 			http.options( '/wp/v2/[object%20Object]', () => {
 				return HttpResponse.json(
 					{},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/test/block.ts
@@ -110,8 +110,8 @@ const handlers = [
 		return HttpResponse.json( mockProduct );
 	} ),
 
-	// Once the `@wordpress/data` package used in tests is updated to 6.7, this
-	// request will match the path in production:
+	// @todo When updating the `@wordpress/data` package to 6.7 or later,
+	// this request will need to be updated to match the path in production:
 	// `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
 	http.options( '/wp/v2/[object%20Object]', () => {
 		return HttpResponse.json(
@@ -293,8 +293,8 @@ describe( 'Add to Cart + Options block', () => {
 
 	it( 'should render the placeholder when viewed as a user without permissions to edit template parts', async () => {
 		server.use(
-			// Once the `@wordpress/data` package used in tests is updated to 6.7,
-			// this request will match the path in production:
+			// @todo When updating the `@wordpress/data` package to 6.7 or later,
+			// this request will need to be updated to match the path in production:
 			// `/wp/v2/template-parts/woocommerce/woocommerce//<template-part-slug>`.
 			http.options( '/wp/v2/[object%20Object]', () => {
 				return HttpResponse.json(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -39,7 +39,9 @@ class AddToCartWithOptionsPage {
 		);
 
 		await addToCartWithOptionsBlock
-			.locator( '.components-spinner' )
+			.locator(
+				'.components-spinner, .wc-block-components-skeleton__element:not(.wc-block-components-skeleton__element--static)'
+			)
 			.waitFor( {
 				state: 'hidden',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -39,9 +39,13 @@ class AddToCartWithOptionsPage {
 		);
 
 		await addToCartWithOptionsBlock
-			.locator(
-				'.components-spinner, .wc-block-components-skeleton__element:not(.wc-block-components-skeleton__element--static)'
-			)
+			.getByLabel( 'Loading the Add to Cart + Options template part' )
+			.waitFor( {
+				state: 'hidden',
+			} );
+
+		await addToCartWithOptionsBlock
+			.locator( '.components-spinner' )
 			.waitFor( {
 				state: 'hidden',
 			} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56521.

This PR makes it so if the _Add to Cart + Options_ is viewed by a user without permissions in the editor, it displays the skeleton instead of the inner blocks. This prevents users from thinking they can edit the template parts and then getting an error on save.

### How to test the changes in this Pull Request:

1. With an `author` user, create a post or page.
2. Add the _Single Product_ block and select a product.
3. Update the _Add to Cart with Options_ block to the blockified one.
4. Verify the skeleton is shown instead of the real _Add to Cart + Options_ template part, and you can't modify the inner blocks.

<img width="1046" height="652" alt="imatge" src="https://github.com/user-attachments/assets/59c98bee-354a-4c3e-ad6d-3ee1c8b37cf6" />