### PR TITLE
Remove deprecation notices from legacy script handles

### DIFF
--- a/plugins/woocommerce/changelog/update-script-prefixes-remove-deprecation-notices
+++ b/plugins/woocommerce/changelog/update-script-prefixes-remove-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove deprecation notices from legacy script handles

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -38,30 +38,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
-			add_action( 'shutdown', array( $this, 'add_legacy_script_warnings' ) );
-		}
-
-		/**
-		 * Add warnings for deprecated script handles.
-		 */
-		public function add_legacy_script_warnings() {
-			$scripts = $this->get_scripts();
-			foreach ( $scripts as $script ) {
-				if ( ! isset( $script['legacy_handle'] ) ) {
-					continue;
-				}
-
-				$exists = wp_script_is( $script['legacy_handle'] );
-
-				if ( $exists ) {
-					wc_deprecated_argument(
-						'wp_enqueue_script',
-						'10.3.0',
-						/* translators: %1$s: new script handle, %2$s: previous script handle */
-						sprintf( __( 'Please use the new handle %1$s in place of the previous handle %2$s.', 'woocommerce' ), $script['handle'], $script['legacy_handle'] )
-					);
-				}
-			}
 		}
 
 		/**

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -55,31 +55,6 @@ class WC_Frontend_Scripts {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'load_scripts' ) );
 		add_action( 'wp_print_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
 		add_action( 'wp_print_footer_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
-		add_action( 'shutdown', array( __CLASS__, 'add_legacy_script_warnings' ) );
-	}
-
-	/**
-	 * Add warnings for deprecated script handles.
-	 */
-	public static function add_legacy_script_warnings() {
-		$scripts = self::get_scripts();
-
-		foreach ( $scripts as $handle => $script ) {
-			if ( ! isset( $script['legacy_handle'] ) ) {
-				continue;
-			}
-
-			$exists = wp_script_is( $script['legacy_handle'] );
-
-			if ( $exists ) {
-				wc_deprecated_argument(
-					'wp_enqueue_script',
-					'10.3.0',
-					/* translators: %1$s: new script handle, %2$s: previous script handle */
-					sprintf( __( 'Please use the new handle %1$s in place of the previous handle %2$s.', 'woocommerce' ), $handle, $script['legacy_handle'] )
-				);
-			}
-		}
 	}
 
 	/**
@@ -305,7 +280,7 @@ class WC_Frontend_Scripts {
 				'version'       => '2.7.0-wc.' . $version,
 				'legacy_handle' => 'jquery-blockui',
 			),
-			'wc-jquery-cookie'           => array( // deprecated.
+			'wc-jquery-cookie'           => array(
 				'src'           => self::get_asset_url( 'assets/js/jquery-cookie/jquery.cookie' . $suffix . '.js' ),
 				'deps'          => array( 'jquery' ),
 				'version'       => '1.4.1-wc.' . $version,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the deprecation notices from the legacy script handles.  While we do want to deprecate the legacy script handles, the deprecation notices are causing panic in some store owners who maintain their own stores.

For now we'll maintain both the legacy and new script handle while keeping the L-1 policy in place.  A dev announcement will be needed at some point to try and encourage authors to use better practices in consuming these scripts and maintaining their own dependencies.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add the following snippet to your site:
```php
add_action( 'init', function() {
        wp_enqueue_script( 'accounting' );
} );
add_action( 'admin_init', function() {
	wp_enqueue_script( 'jquery-blockui' );
} );
```
2. Check that your debug log does not show warnings for either script

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
