### PR TITLE
Align Payment Settings header size with other tabs under WC Settings

### DIFF
--- a/plugins/woocommerce/changelog/61671-fix-styling-payments-setting-page
+++ b/plugins/woocommerce/changelog/61671-fix-styling-payments-setting-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Align Payment Settings header size with other tabs under WC Settings

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.scss
@@ -21,38 +21,6 @@
 		flex-basis: 100%;
 	}
 
-	&:has(.woocommerce-settings-payments-header__title) {
-		padding: $gap-large 2 * $gap-large;
-
-		.woocommerce-layout__header-heading {
-			height: initial;
-			padding: 0;
-		}
-
-		.woocommerce-layout__header-wrapper {
-			min-height: 40px;
-			gap: $gap-smaller;
-		}
-
-		.woocommerce-settings-payments__back-button {
-			+ .woocommerce-layout__header-heading {
-				font-size: 16px;
-				font-style: normal;
-				font-weight: 600;
-				line-height: 24px;
-				flex-basis: 50%;
-			}
-		}
-
-		@media screen and ( max-width: $break-xlarge ) {
-			padding: $gap-large;
-		}
-
-		@media screen and ( max-width: $break-medium ) {
-			padding: $gap-large $gap;
-		}
-	}
-
 	&:has(.woocommerce-settings-payments-header__description) {
 		.woocommerce-layout__header-heading,
 		.woocommerce-settings-payments-header__title,

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -43,18 +43,6 @@
 	}
 }
 
-// Align the nav tabs with the overall page spacings for page internal consistency,
-// although not cross settings pages consistency.
-body.woocommerce-settings-payments-tab {
-	.nav-tab-wrapper {
-		padding-left: $grid-unit-60;
-
-		@media screen and (max-width: $break-xlarge) {
-			padding-left: $grid-unit-30;
-		}
-	}
-}
-
 .settings-payments-main__container {
 	margin: 0 -30px;
 	padding-bottom: 32px;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes the current disparity between Payments tab and other tabs in the Settings.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before:
![top-header-bar](https://github.com/user-attachments/assets/aadd5013-2c06-4217-b31f-3dc353d5b493)    

After:

https://github.com/user-attachments/assets/221f89af-27c6-4514-8b15-e2c373a50d8e




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR and build the changes locally
2. Go to WooCommerce > Settings
3. Navigate between the Payments Tab and other tabs and make sure the header and spacing are the same.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Align Payment Settings header size with other tabs under WC Settings

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
