### PR TITLE
Email Editor: Add unregister method to Personalization_Tags_Registry

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-1010-allow-woocommerce-personalization-tags-in-marketing-emails
+++ b/packages/php/email-editor/changelog/wooprd-1010-allow-woocommerce-personalization-tags-in-marketing-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add unregister method to Personalization_Tags_Registry

--- a/packages/php/email-editor/docs/personalization-tags.md
+++ b/packages/php/email-editor/docs/personalization-tags.md
@@ -85,13 +85,13 @@ Personalization Tags use HTML comment syntax with a specific format: `<!--[token
 
 ```html
 <p>
-    Hello
-    <!--[customer/first-name]-->, your order
-    <!--[order/number]-->
-    was placed on
-    <!--[my-plugin/formatted-date date="order_date" format="F j, Y"]-->
-    and is currently
-    <!--[order/status]-->. Thank you for your purchase!
+	Hello
+	<!--[customer/first-name]-->, your order
+	<!--[order/number]-->
+	was placed on
+	<!--[my-plugin/formatted-date date="order_date" format="F j, Y"]-->
+	and is currently
+	<!--[order/status]-->. Thank you for your purchase!
 </p>
 ```
 
@@ -122,6 +122,7 @@ The central registry for managing personalization tags.
 **Key Methods:**
 
 -   `register(Personalization_Tag $tag)`: Register a new tag
+-   `unregister(string|Personalization_Tag $token_or_tag)`: Unregister a tag by token or tag instance
 -   `get_by_token(string $token)`: Retrieve a tag by its token
 -   `get_all()`: Get all registered tags
 -   `initialize()`: Initialize the registry and load all providers
@@ -141,7 +142,7 @@ $registry->initialize();
 
 
 // Register a custom tag
-$registry->register( new Personalization_Tag(
+$tag = new Personalization_Tag(
     'Custom Field',
     'my-plugin/custom-field',
     'Customer',
@@ -151,7 +152,14 @@ $registry->register( new Personalization_Tag(
     array(),
     null,
     array( 'my-post-type' )
-));
+);
+$registry->register( $tag );
+
+// Unregister a tag by token string
+$registry->unregister( '[my-plugin/custom-field]' );
+
+// Or unregister by passing the tag instance
+$registry->unregister( $tag );
 ```
 
 ### Personalization_Tag
@@ -177,6 +185,7 @@ new Personalization_Tag(
 -   `get_name()`: Get the display name
 -   `get_token()`: Get the token
 -   `get_category()`: Get the category
+-   `get_callback()`: Get the callback function
 -   `execute_callback($context, $args)`: Execute the callback function
 -   `get_attributes()`: Get default attributes
 -   `get_value_to_insert()`: Get the value to insert in UI
@@ -270,8 +279,8 @@ $registry->register(
 
 ```html
 <p>
-    Order placed on:
-    <!--[my-plugin/formatted-date date="2024-01-15" format="F j, Y"]-->
+	Order placed on:
+	<!--[my-plugin/formatted-date date="2024-01-15" format="F j, Y"]-->
 </p>
 ```
 

--- a/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
+++ b/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
@@ -182,6 +182,15 @@ class Personalization_Tag {
 	}
 
 	/**
+	 * Returns the callback function of the personalization tag.
+	 *
+	 * @return callable
+	 */
+	public function get_callback(): callable {
+		return $this->callback;
+	}
+
+	/**
 	 * Executes the callback function for the personalization tag.
 	 *
 	 * @param mixed $context The context for the personalization tag.

--- a/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tags-registry.php
+++ b/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tags-registry.php
@@ -82,12 +82,27 @@ class Personalization_Tags_Registry {
 	}
 
 	/**
-	 * Unregister a personalization tag by its token.
+	 * Unregister a personalization tag by its token or tag instance.
 	 *
-	 * @param string $token The token of the personalization tag to unregister.
+	 * @param string|Personalization_Tag $token_or_tag The token string or Personalization_Tag instance to unregister.
 	 * @return Personalization_Tag|null The unregistered tag or null if not found.
 	 */
-	public function unregister( string $token ): ?Personalization_Tag {
+	public function unregister( $token_or_tag ): ?Personalization_Tag {
+		// Extract token from the argument.
+		if ( $token_or_tag instanceof Personalization_Tag ) {
+			$token = $token_or_tag->get_token();
+		} elseif ( is_string( $token_or_tag ) ) {
+			$token = $token_or_tag;
+		} else {
+			$this->logger->warning(
+				'Invalid argument type for unregister method',
+				array(
+					'type' => gettype( $token_or_tag ),
+				)
+			);
+			return null;
+		}
+
 		$tag = $this->tags[ $token ] ?? null;
 		if ( $tag ) {
 			unset( $this->tags[ $token ] );

--- a/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tags-registry.php
+++ b/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tags-registry.php
@@ -82,6 +82,28 @@ class Personalization_Tags_Registry {
 	}
 
 	/**
+	 * Unregister a personalization tag by its token.
+	 *
+	 * @param string $token The token of the personalization tag to unregister.
+	 * @return Personalization_Tag|null The unregistered tag or null if not found.
+	 */
+	public function unregister( string $token ): ?Personalization_Tag {
+		$tag = $this->tags[ $token ] ?? null;
+		if ( $tag ) {
+			unset( $this->tags[ $token ] );
+			$this->logger->debug(
+				'Personalization tag unregistered',
+				array(
+					'token'    => $token,
+					'name'     => $tag->get_name(),
+					'category' => $tag->get_category(),
+				)
+			);
+		}
+		return $tag;
+	}
+
+	/**
 	 * Retrieve a personalization tag by its token.
 	 * Example: get_by_token( 'user:first_name' ) will return the instance of Personalization_Tag with identical token.
 	 *

--- a/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tag_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tag_Test.php
@@ -40,6 +40,30 @@ class Personalization_Tag_Test extends TestCase {
 	}
 
 	/**
+	 * Test that the callback can be retrieved.
+	 */
+	public function testGetCallback(): void {
+		$callback = function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			return 'callback result: ' . ( $context['value'] ?? 'default' );
+		};
+
+		$tag = new Personalization_Tag(
+			'Test Tag',
+			'test_token',
+			'Test Category',
+			$callback
+		);
+
+		// Get the callback and verify it's the same one.
+		$retrieved_callback = $tag->get_callback();
+		$this->assertSame( $callback, $retrieved_callback );
+
+		// Verify the callback can be executed.
+		$result = call_user_func( $retrieved_callback, array( 'value' => 'test' ), array() );
+		$this->assertSame( 'callback result: test', $result );
+	}
+
+	/**
 	 * Test that deserialization is prevented for security reasons.
 	 */
 	public function testUnserializeThrowsException(): void {

--- a/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
@@ -188,6 +188,69 @@ class PersonalizationTagsRegistryTest extends TestCase {
 	}
 
 	/**
+	 * Unregister a tag by passing the Personalization_Tag instance.
+	 */
+	public function testUnregisterTagByInstance(): void {
+		$callback = function () {
+			return 'Value';
+		};
+
+		// Register a tag.
+		$tag = new Personalization_Tag( 'tag1', '[tag-1]', 'Category 1', $callback );
+		$this->registry->register( $tag );
+
+		// Verify the tag is registered.
+		$this->assertNotNull( $this->registry->get_by_token( '[tag-1]' ) );
+
+		// Unregister the tag by passing the instance.
+		$unregistered_tag = $this->registry->unregister( $tag );
+
+		// Assert the unregistered tag is returned.
+		$this->assertNotNull( $unregistered_tag );
+		$this->assertSame( 'tag1', $unregistered_tag->get_name() );
+		$this->assertSame( '[tag-1]', $unregistered_tag->get_token() );
+
+		// Verify the tag is no longer in the registry.
+		$this->assertNull( $this->registry->get_by_token( '[tag-1]' ) );
+	}
+
+	/**
+	 * Try to unregister a tag by passing a Personalization_Tag instance that doesn't exist in the registry.
+	 */
+	public function testUnregisterNonexistentTagByInstance(): void {
+		$callback = function () {
+			return 'Value';
+		};
+
+		// Create a tag but don't register it.
+		$tag = new Personalization_Tag( 'tag1', '[tag-1]', 'Category 1', $callback );
+
+		// Attempt to unregister the tag that was never registered.
+		$result = $this->registry->unregister( $tag );
+
+		// Assert that null is returned.
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Try to unregister a tag by passing an invalid argument type.
+	 */
+	public function testUnregisterWithInvalidArgumentType(): void {
+		// Attempt to unregister with invalid types.
+		// @phpstan-ignore-next-line - testing invalid argument.
+		$result1 = $this->registry->unregister( 123 );
+		// @phpstan-ignore-next-line - testing invalid argument.
+		$result2 = $this->registry->unregister( array( 'token' => '[tag-1]' ) );
+		// @phpstan-ignore-next-line - testing invalid argument.
+		$result3 = $this->registry->unregister( null );
+
+		// Assert that null is returned for all invalid types.
+		$this->assertNull( $result1 );
+		$this->assertNull( $result2 );
+		$this->assertNull( $result3 );
+	}
+
+	/**
 	 * Initialize the registry and apply a filter.
 	 */
 	public function testInitializeAppliesFilter(): void {

--- a/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
@@ -150,7 +150,42 @@ class PersonalizationTagsRegistryTest extends TestCase {
 		$this->assertArrayHasKey( '[tag-2]', $all_tags );
 	}
 
+	/**
+	 * Unregister a tag and ensure it's removed.
+	 */
+	public function testUnregisterTag(): void {
+		$callback = function () {
+			return 'Value';
+		};
 
+		// Register a tag.
+		$this->registry->register( new Personalization_Tag( 'tag1', '[tag-1]', 'Category 1', $callback ) );
+
+		// Verify the tag is registered.
+		$this->assertNotNull( $this->registry->get_by_token( '[tag-1]' ) );
+
+		// Unregister the tag.
+		$unregistered_tag = $this->registry->unregister( '[tag-1]' );
+
+		// Assert the unregistered tag is returned.
+		$this->assertNotNull( $unregistered_tag );
+		$this->assertSame( 'tag1', $unregistered_tag->get_name() );
+		$this->assertSame( '[tag-1]', $unregistered_tag->get_token() );
+
+		// Verify the tag is no longer in the registry.
+		$this->assertNull( $this->registry->get_by_token( '[tag-1]' ) );
+	}
+
+	/**
+	 * Try to unregister a tag that doesn't exist.
+	 */
+	public function testUnregisterNonexistentTag(): void {
+		// Attempt to unregister a tag that was never registered.
+		$result = $this->registry->unregister( '[nonexistent]' );
+
+		// Assert that null is returned.
+		$this->assertNull( $result );
+	}
 
 	/**
 	 * Initialize the registry and apply a filter.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an `unregister` method to the `Personalization_Tags_Registry`, allowing extensions and plugins to unregister tags. It also introduces a `get_callback` method to the `Personalization_Tag` class, which alongside the existing getter methods enables cloning of personalization tags.

Together, these additions make it possible to use a re-registration pattern to modify existing tags.

Related to [WOOPRD-1010: Allow WooCommerce Personalization Tags in marketing emails](https://linear.app/a8c/issue/WOOPRD-1010/allow-woocommerce-personalization-tags-in-marketing-emails).

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Review code changes.
2. Confirm tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
