### PR TITLE
[Backport to release/10.3] Fix PayPal Standard locale code

### DIFF
--- a/plugins/woocommerce/changelog/61573-fix-paypal-locale-code
+++ b/plugins/woocommerce/changelog/61573-fix-paypal-locale-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the locale code sent when creating a PayPal Standard order, limiting it to two characters.

--- a/plugins/woocommerce/changelog/61688-cherry-pick-PR61573-to-release-2
+++ b/plugins/woocommerce/changelog/61688-cherry-pick-PR61573-to-release-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the locale code sent when creating a PayPal Standard order, limiting it to two characters.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-constants.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-constants.php
@@ -63,6 +63,7 @@ class WC_Gateway_Paypal_Constants {
 	const PAYPAL_STATE_MAX_LENGTH           = 300;
 	const PAYPAL_CITY_MAX_LENGTH            = 120;
 	const PAYPAL_POSTAL_CODE_MAX_LENGTH     = 60;
+	const PAYPAL_LOCALE_MAX_LENGTH          = 10;
 
 	/**
 	 * Supported payment sources.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -417,8 +417,6 @@ class WC_Gateway_Paypal_Request {
 			$locale_parts = explode( '_', $src_locale );
 			if ( count( $locale_parts ) >= 2 ) {
 				$src_locale = $locale_parts[0] . '_' . $locale_parts[1];
-			} else {
-				$src_locale = $locale_parts[0];
 			}
 		}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -410,6 +410,14 @@ class WC_Gateway_Paypal_Request {
 		$payee_email         = sanitize_email( (string) $this->gateway->get_option( 'email' ) );
 		$shipping_preference = $this->get_paypal_shipping_preference( $order );
 
+		$src_locale = get_locale();
+		// If the locale is longer than PayPal's string limit (10).
+		if ( strlen( $src_locale ) > WC_Gateway_Paypal_Constants::PAYPAL_LOCALE_MAX_LENGTH ) {
+			// Keep only the main language and region parts.
+			$locale_parts = explode( '_', $src_locale );
+			$src_locale   = $locale_parts[0] . '_' . $locale_parts[1];
+		}
+
 		$params = array(
 			'intent'         => $this->get_paypal_order_intent(),
 			'payment_source' => array(
@@ -422,8 +430,7 @@ class WC_Gateway_Paypal_Request {
 						// Customer redirected here on cancellation.
 						'cancel_url'            => esc_url_raw( $order->get_cancel_order_url_raw() ),
 						// Convert WordPress locale format (e.g., 'en_US') to PayPal's expected format (e.g., 'en-US').
-						// Limit to 5 characters to handle edge cases like 'de_DE_formal' while preserving region.
-						'locale'                => str_replace( '_', '-', substr( get_locale(), 0, 5 ) ),
+						'locale'                => str_replace( '_', '-', substr( $src_locale, 0, 5 ) ),
 						'app_switch_preference' => array(
 							'launch_paypal_app' => true,
 						),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -422,7 +422,7 @@ class WC_Gateway_Paypal_Request {
 						// Customer redirected here on cancellation.
 						'cancel_url'            => esc_url_raw( $order->get_cancel_order_url_raw() ),
 						// Convert WordPress locale format (e.g., 'en_US') to PayPal's expected format (e.g., 'en-US').
-						'locale'                => str_replace( '_', '-', get_locale() ),
+						'locale'                => substr( get_locale(), 0, 2 ),
 						'app_switch_preference' => array(
 							'launch_paypal_app' => true,
 						),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -432,7 +432,7 @@ class WC_Gateway_Paypal_Request {
 						// Customer redirected here on cancellation.
 						'cancel_url'            => esc_url_raw( $order->get_cancel_order_url_raw() ),
 						// Convert WordPress locale format (e.g., 'en_US') to PayPal's expected format (e.g., 'en-US').
-						'locale'                => str_replace( '_', '-', $src_locale ) ),
+						'locale'                => str_replace( '_', '-', $src_locale ),
 						'app_switch_preference' => array(
 							'launch_paypal_app' => true,
 						),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -415,7 +415,11 @@ class WC_Gateway_Paypal_Request {
 		if ( strlen( $src_locale ) > WC_Gateway_Paypal_Constants::PAYPAL_LOCALE_MAX_LENGTH ) {
 			// Keep only the main language and region parts.
 			$locale_parts = explode( '_', $src_locale );
-			$src_locale   = $locale_parts[0] . '_' . $locale_parts[1];
+			if ( count( $locale_parts ) >= 2 ) {
+				$src_locale = $locale_parts[0] . '_' . $locale_parts[1];
+			} else {
+				$src_locale = $locale_parts[0];
+			}
 		}
 
 		$params = array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -422,7 +422,8 @@ class WC_Gateway_Paypal_Request {
 						// Customer redirected here on cancellation.
 						'cancel_url'            => esc_url_raw( $order->get_cancel_order_url_raw() ),
 						// Convert WordPress locale format (e.g., 'en_US') to PayPal's expected format (e.g., 'en-US').
-						'locale'                => substr( get_locale(), 0, 2 ),
+						// Limit to 5 characters to handle edge cases like 'de_DE_formal' while preserving region.
+						'locale'                => str_replace( '_', '-', substr( get_locale(), 0, 5 ) ),
 						'app_switch_preference' => array(
 							'launch_paypal_app' => true,
 						),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -430,7 +430,7 @@ class WC_Gateway_Paypal_Request {
 						// Customer redirected here on cancellation.
 						'cancel_url'            => esc_url_raw( $order->get_cancel_order_url_raw() ),
 						// Convert WordPress locale format (e.g., 'en_US') to PayPal's expected format (e.g., 'en-US').
-						'locale'                => str_replace( '_', '-', substr( $src_locale, 0, 5 ) ),
+						'locale'                => str_replace( '_', '-', $src_locale ) ),
 						'app_switch_preference' => array(
 							'launch_paypal_app' => true,
 						),


### PR DESCRIPTION
This PR is a cherry-pick of #61573 to `release/10.3`.

## Original PR Description

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes PAYPAL-105

Some PayPal Standard transactions are failing due to an invalid `locale` parameter. This happens because we are currently using the default `get_locale` function to retrieve the user's locale code. This function can return values such as `de_DE_formal`. PayPal only accepts values up to 10 characters, which causes the order creation request to fail.

Example error:
```
{
    "http_code": 400,
    "response": {
        "name": "INVALID_REQUEST",
        "message": "Request is not well-formed, syntactically incorrect, or violates schema.",
        "debug_id": "cb857048fc691",
        "details": [
            {
                "field": "\/payment_source\/paypal\/experience_context\/locale",
                "value": "de-DE-formal",
                "location": "body",
                "issue": "must match \"^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}))?$\""
            },
            {
                "field": "\/payment_source\/paypal\/experience_context\/locale",
                "value": "de-DE-formal",
                "location": "body",
                "issue": "size must be between 2 and 10"
            }
        ],
        "links": [
            {
                "href": "https:\/\/developer.paypal.com\/docs\/api\/orders\/v2\/#error-must match \"^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}))?$\"",
                "rel": "information_link",
                "encType": "application\/json"
            },
            {
                "href": "https:\/\/developer.paypal.com\/docs\/api\/orders\/v2\/#error-size must be between 2 and 10",
                "rel": "information_link",
                "encType": "application\/json"
            }
        ]
    },
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Code review.

If you want to test this specific change:
- Setup a new filter to return a long locale value:
```php
add_filter( 'locale', function() { return 'de_DE_formal'; }, 10 );
```
- Follow https://github.com/woocommerce/woocommerce/pull/61034 and attempt to perform some purchases
- Confirm everything works

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixes the locale code sent when creating a PayPal Standard order, limiting it to two characters.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
