### PR TITLE
[Backport to release/10.3] PayPal - Fix SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED errors

### DIFF
--- a/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
+++ b/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Resolve PayPal order creation failures caused by a mismatch between the total and breakdown amounts.

--- a/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
+++ b/plugins/woocommerce/changelog/61580-update-include-fee-in-purchase-unit
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Resolve PayPal order creation failures caused by a mismatch between the total and breakdown amounts.

--- a/plugins/woocommerce/changelog/61634-fix-shipping-callback-config-not-supported
+++ b/plugins/woocommerce/changelog/61634-fix-shipping-callback-config-not-supported
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED errors for PayPal Standard

--- a/plugins/woocommerce/changelog/61689-cherry-pick-PR61634-to-release-2
+++ b/plugins/woocommerce/changelog/61689-cherry-pick-PR61634-to-release-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED errors for PayPal Standard

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -442,7 +442,13 @@ class WC_Gateway_Paypal_Request {
 			),
 		);
 
-		if ( WC_Gateway_Paypal_Constants::SHIPPING_NO_SHIPPING !== $shipping_preference ) {
+		if ( ! in_array(
+			$shipping_preference,
+			[
+				WC_Gateway_Paypal_Constants::SHIPPING_NO_SHIPPING,
+				WC_Gateway_Paypal_Constants::SHIPPING_SET_PROVIDED_ADDRESS,
+			], true
+		) ) {
 			$params['payment_source'][ $payment_source ]['experience_context']['order_update_callback_config'] = array(
 				'callback_events' => array( 'SHIPPING_ADDRESS', 'SHIPPING_OPTIONS' ),
 				'callback_url'    => esc_url_raw( rest_url( 'wc/v3/paypal-standard/update-shipping' ) ),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -444,10 +444,11 @@ class WC_Gateway_Paypal_Request {
 
 		if ( ! in_array(
 			$shipping_preference,
-			[
+			array(
 				WC_Gateway_Paypal_Constants::SHIPPING_NO_SHIPPING,
 				WC_Gateway_Paypal_Constants::SHIPPING_SET_PROVIDED_ADDRESS,
-			], true
+			),
+			true
 		) ) {
 			$params['payment_source'][ $payment_source ]['experience_context']['order_update_callback_config'] = array(
 				'callback_events' => array( 'SHIPPING_ADDRESS', 'SHIPPING_OPTIONS' ),


### PR DESCRIPTION
This PR is a cherry-pick of #61634 to `release/10.3`.

## Original PR Description

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes PAYPAL-107

Sometimes we see errors like the following in the transact Slack alert channel:

```
{
    "http_code": 422,
    "response": {
        "name": "UNPROCESSABLE_ENTITY",
        "details": [
            {
                "issue": "SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED",
                "description": "The shipping address callback URL in 'order_update_callback_config' field is not supported when `shipping.type` is specified or when 'application_context.shipping_preference' is set as 'NO_SHIPPING' or 'SET_PROVIDED_ADDRESS'."
            }
        ],
        "message": "The requested action could not be performed, semantically incorrect, or failed business validation.",
        "debug_id": "55a764112bb3d",
        "links": [
            {
                "href": "https:\/\/developer.paypal.com\/api\/rest\/reference\/orders\/v2\/errors\/#SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED",
                "rel": "information_link",
                "method": "GET"
            }
        ]
    },
...
```

This PR just does what it is said in the error message, and sets the `order_update_callback_config` parameter only when `shipping_preference` is not `NO_SHIPPING` or `SET_PROVIDED_ADDRESS`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Code review. If you want to test this flow, you can follow https://github.com/woocommerce/woocommerce/pull/61034 to see if no regression was introduced.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixes the SHIPPING_CALLBACK_CONFIG_NOT_SUPPORTED errors for PayPal Standard

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

cc @Mayisha 