### PR TITLE
[Backport to release/10.3] Fix PayPal Standard country code format

### DIFF
--- a/plugins/woocommerce/changelog/61576-fix-paypal-country-code-two-letter-format
+++ b/plugins/woocommerce/changelog/61576-fix-paypal-country-code-two-letter-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sets the country code sent to PayPal when using PayPal Standard to the expected two-letter format

--- a/plugins/woocommerce/changelog/61691-cherry-pick-PR61576-to-release-2
+++ b/plugins/woocommerce/changelog/61691-cherry-pick-PR61576-to-release-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sets the country code sent to PayPal when using PayPal Standard to the expected two-letter format

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-constants.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-constants.php
@@ -60,6 +60,7 @@ class WC_Gateway_Paypal_Constants {
 	const PAYPAL_ORDER_ITEM_NAME_MAX_LENGTH = 127;
 	const PAYPAL_INVOICE_ID_MAX_LENGTH      = 127;
 	const PAYPAL_ADDRESS_LINE_MAX_LENGTH    = 300;
+	const PAYPAL_COUNTRY_CODE_LENGTH        = 2;
 	const PAYPAL_STATE_MAX_LENGTH           = 300;
 	const PAYPAL_CITY_MAX_LENGTH            = 120;
 	const PAYPAL_POSTAL_CODE_MAX_LENGTH     = 60;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -649,7 +649,12 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		// Make sure the country code is in the correct format.
-		$country = strtoupper( substr( $country, 0, WC_Gateway_Paypal_Constants::PAYPAL_COUNTRY_CODE_LENGTH ) );
+		if ( strlen( $country ) >= 3 ) {
+			if ( strlen( $country ) > 3 ) { // Log if we get an unexpected country code length.
+				WC_Gateway_Paypal::log( sprintf( 'Unexpected country code length (%d) for country: %s', strlen( $country ), $country ) );
+			}
+			$country = substr( $country, 0, WC_Gateway_Paypal_Constants::PAYPAL_COUNTRY_CODE_LENGTH );
+		}
 
 		// Postal code is typically required, but not always. The create-order request
 		// will fail if it is missing for a country that requires it.
@@ -669,7 +674,7 @@ class WC_Gateway_Paypal_Request {
 				'admin_area_1'   => $this->limit_length( $state, WC_Gateway_Paypal_Constants::PAYPAL_STATE_MAX_LENGTH ),
 				'admin_area_2'   => $this->limit_length( $city, WC_Gateway_Paypal_Constants::PAYPAL_CITY_MAX_LENGTH ),
 				'postal_code'    => $this->limit_length( $postcode, WC_Gateway_Paypal_Constants::PAYPAL_POSTAL_CODE_MAX_LENGTH ),
-				'country_code'   => $country,
+				'country_code'   => strtoupper( $country ),
 			),
 		);
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -649,7 +649,7 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		// Make sure the country code is in the correct format.
-		$country = strtoupper( substr( $country, 2 ) );
+		$country = strtoupper( substr( $country, 0, 2 ) );
 
 		// Postal code is typically required, but not always. The create-order request
 		// will fail if it is missing for a country that requires it.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -649,7 +649,7 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		// Make sure the country code is in the correct format.
-		$country = strtoupper( substr( $country, 0, 2 ) );
+		$country = strtoupper( substr( $country, 0, WC_Gateway_Paypal_Constants::PAYPAL_COUNTRY_CODE_LENGTH ) );
 
 		// Postal code is typically required, but not always. The create-order request
 		// will fail if it is missing for a country that requires it.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -648,6 +648,9 @@ class WC_Gateway_Paypal_Request {
 			return null;
 		}
 
+		// Make sure the country code is in the correct format.
+		$country = strtoupper( substr( $country, 2 ) );
+
 		// Postal code is typically required, but not always. The create-order request
 		// will fail if it is missing for a country that requires it.
 		// As a simple heuristic, if the postal code is not set, but name and address_line_1 are,


### PR DESCRIPTION
This PR is a cherry-pick of #61576 to `release/10.3`.

## Original PR Description

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes PAYPAL-106

Some PayPal Standard transactions are failing due to an invalid country code parameter. We are not totally sure how this can happen in practice, since we are using the same country PayPal sends to us when creating the order. But in this PR, we are ensuring the expected format (two-letter code) is sent.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Code review. If you want to test this flow, you can follow https://github.com/woocommerce/woocommerce/pull/61034 to see if no regression was introduced.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Sets the country code sent to PayPal when using PayPal Standard to the expected two-letter format

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
