### PR TITLE
Fix COGS calculation for product order items

### DIFF
--- a/plugins/woocommerce/changelog/pr-61694
+++ b/plugins/woocommerce/changelog/pr-61694
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix COGS calculation for product order items

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -571,19 +571,6 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @return float|null The calculated value, null if the product associated to the line item no longer exists.
 	 */
 	public function calculate_cogs_value_core(): ?float {
-		// Refund items should always recalculate based on their (negative) quantity.
-		// Preserving would give incorrect values since they're cloned from original items.
-		$is_refund_item = $this->get_quantity() < 0;
-
-		// If this is a regular item (not refund) that has been loaded from the database and has a saved COGS value, preserve it.
-		// COGS values should be "snapshotted" at order creation time, not recalculated later.
-		// This prevents historical orders from having their costs changed when product prices are updated.
-		// Note: cogs_value will be null if the item was loaded but had no _cogs_value metadata.
-		if ( ! $is_refund_item && $this->get_id() > 0 && $this->get_object_read() && isset( $this->data['cogs_value'] ) && ! is_null( $this->data['cogs_value'] ) ) {
-			return $this->get_cogs_value( 'edit' );
-		}
-
-		// For new items, refund items, or items without saved COGS, calculate from the product.
 		$product = $this->get_product();
 		if ( ! $product ) {
 			return null;

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -269,5 +269,4 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 
 		WC_Helper_Product::delete_product( $product_without_cogs->get_id() );
 	}
-
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -173,4 +173,101 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		$expected = sprintf( 'cost: %s, item: %s, order: %s', $refunded_cost, $this->item->get_id(), $this->order->get_id() );
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * @testdox calculate_cogs_value_core recalculates COGS from product even for saved line items.
+	 */
+	public function test_calculate_cogs_value_core_recalculates_from_product() {
+		$this->enable_cogs_feature();
+
+		// Create a line item with 3 units of a product with COGS = 10.
+
+		$this->product->set_cogs_value( 10.00 );
+		$this->product->save();
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_quantity( 3 );
+		$item->set_order_id( $this->order->get_id() );
+		$item->save();
+
+		$calculated_cogs = $item->calculate_cogs_value_core();
+		$this->assertEquals( 30.00, $calculated_cogs );
+
+		// Now change the product's COGS value and recalculate COGS for the line.
+
+		$this->product->set_cogs_value( 15.00 );
+		$this->product->save();
+
+		$reloaded_item = new WC_Order_Item_Product( $item->get_id() );
+
+		$recalculated_cogs = $reloaded_item->calculate_cogs_value_core();
+		$this->assertEquals( 45.00, $recalculated_cogs );
+	}
+
+	/**
+	 * @testdox calculate_cogs_value_core calculates correctly with quantity $quantity and COGS $cogs_value.
+	 *
+	 * @param float $cogs_value The COGS value per unit.
+	 * @param int   $quantity The quantity (positive for regular items, negative for refunds).
+	 * @param float $expected The expected calculated COGS value.
+	 *
+	 * @testWith [12.50, 5, 62.50]
+	 *           [20.00, -2, -40.00]
+	 */
+	public function test_calculate_cogs_value_core_with_various_quantities( float $cogs_value, int $quantity, float $expected ) {
+		$this->enable_cogs_feature();
+
+		$this->product->set_cogs_value( $cogs_value );
+		$this->product->save();
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_quantity( $quantity );
+		$item->set_order_id( $this->order->get_id() );
+		$item->save();
+
+		$calculated_cogs = $item->calculate_cogs_value_core();
+		$this->assertEquals( $expected, $calculated_cogs );
+	}
+
+	/**
+	 * @testdox calculate_cogs_value_core returns null when product no longer exists.
+	 */
+	public function test_calculate_cogs_value_core_returns_null_when_product_missing() {
+		$this->enable_cogs_feature();
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_quantity( 2 );
+		$item->set_order_id( $this->order->get_id() );
+		$item->save();
+
+		$product_id = $this->product->get_id();
+		wp_delete_post( $product_id, true );
+
+		$reloaded_item = new WC_Order_Item_Product( $item->get_id() );
+
+		$calculated_cogs = $reloaded_item->calculate_cogs_value_core();
+		$this->assertNull( $calculated_cogs );
+	}
+
+	/**
+	 * @testdox calculate_cogs_value_core returns zero when product has no COGS value.
+	 */
+	public function test_calculate_cogs_value_core_with_product_without_cogs() {
+		$this->enable_cogs_feature();
+
+		$product_without_cogs = WC_Helper_Product::create_simple_product();
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $product_without_cogs );
+		$item->set_quantity( 3 );
+
+		$calculated_cogs = $item->calculate_cogs_value_core();
+		$this->assertEquals( 0.0, $calculated_cogs );
+
+		WC_Helper_Product::delete_product( $product_without_cogs->get_id() );
+	}
+
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/61307 introduced a change in WC_Order_Item_Product::calculate_cogs_value_core: if the item had an already saved COGS value retrieved from the database, the method wouldn't modify it, as a means to preserve "historical" cost values for completed orders. However this implies that there's no way left for modiying order COGS values if the cost of the corresponding products change, even for orders not yet completed.

While the idea of preserving cost values for completed orders even when product costs change, an implementation for that is something to be considered and designed more carefully, so for now the change is being reverted.

Additionally, this pull request adds unit tests covering these changes.

Bug introduced in PR #61307.

### How to test the changes in this Pull Request:

1. Make sure that COGS is enabled (WooCommerce - Settings - Advanced - Features - Cost of Goods Sold).

2. Add cost for one product.

3. In the admin area create an order and add a line item for the product. Leave the order in any state that allows editing it, like "Pending payment".

4. Modify the cost value for the product.

5. Recalculate the order ("Recalculate" button or "Update" button). The order cost (both total cost and line item cost) should have been updated to reflect the new product cost.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
