### PR TITLE
e2e tests: update expected js count to pass for WP 6.9

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-js-monitor-count-test-wp-6.9
+++ b/plugins/woocommerce/changelog/e2e-update-js-monitor-count-test-wp-6.9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: e2e tests: update expected js count
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
@@ -13,7 +13,7 @@ const merchantPages = [
 	{
 		name: 'WC Dashboard',
 		url: 'wp-admin/admin.php?page=wc-admin',
-		expectedCount: 81,
+		expectedCount: 83,
 	},
 	{
 		name: 'Reports',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes [QAO-141](https://linear.app/a8c/issue/QAO-141/update-expected-js-file-count-for-e2e-tests-in-wp-69)

Increase the expected count of JS files to 83. This ensures the test passes for WP 6.9.

- All e2e tests pass in CI
