### PR TITLE
Add to Cart + Options: stretch Product Quantity to the same height as the Add to Cart Button

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-stretch-quantity
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-stretch-quantity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: stretch Product Quantity to the same height as the Add to Cart Button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/editor.scss
@@ -29,3 +29,9 @@
 		color: inherit;
 	}
 }
+
+// It allows the `.wc-block-components-quantity-selector` height: 100% to work
+// when the block contents are wrapped in a <Disabled> component.
+:where(.wc-block-add-to-cart-with-options__quantity-selector .components-disabled) {
+	display: contents;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -15,6 +15,13 @@
 	}
 }
 
+// Set the height to 100% so when the quantity selector is inside a flex
+// container with `verticalAlignment: stretch` (that's the default in WC core
+// templates), the quantity selector will stretch to the height of the container.
+:where(.wc-block-add-to-cart-with-options__quantity-selector .wc-block-components-quantity-selector) {
+	height: 100% !important;
+}
+
 :where(.wc-block-add-to-cart-with-options__quantity-selector),
 :where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
 	// This resets some WC component styles, so we need it to have specificity

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -19,7 +19,7 @@
 // container with `verticalAlignment: stretch` (that's the default in WC core
 // templates), the quantity selector will stretch to the height of the container.
 :where(.wc-block-add-to-cart-with-options__quantity-selector .wc-block-components-quantity-selector) {
-	height: 100% !important;
+	height: 100%;
 }
 
 :where(.wc-block-add-to-cart-with-options__quantity-selector),

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 <!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -27,7 +27,7 @@
 
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/61712.

We want the _Product Quantity_ block to have the same height as the _Add to Cart Button_ when they are displayed next to each other.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and upgrade from the non-blockified _Add to Cart with Options_ block to the blockified one.
2. Go to _Appearance_ > _Editor_ > _Patterns_ > _Add to Cart + Options_ and delete any modifications you might have in the simple and variable template parts.
3. Visit the frontend of a simple and variable products and verify the _Product Quantity_ block has the same height as the _Add to Cart Button_.

Before | After
--- | ---
<img width="836" height="733" alt="image" src="https://github.com/user-attachments/assets/c2fb6dd7-43ee-4239-b8e7-400b89dbd062" /> | <img width="836" height="733" alt="image" src="https://github.com/user-attachments/assets/3cd4fc58-df80-46e8-82c6-d28013902dce" />
