### PR TITLE
Add support for hidden quantity input style in add-to-cart-form block

### DIFF
--- a/plugins/woocommerce/changelog/issues-add-to-cart-form-hidden-input
+++ b/plugins/woocommerce/changelog/issues-add-to-cart-form-hidden-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for hidden quantity input style in add-to-cart-form block

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -11,6 +11,10 @@
 	}
 }
 
+.wc-block-components-quantity-selector--hidden {
+	display: none;
+}
+
 .wc-block-components-quantity-selector {
 	border-radius: $universal-border-radius;
 	// needed so that buttons fill the container.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -11,6 +11,23 @@
 	"supports": {
 		"interactivity": true
 	},
+	"styles": [
+		{
+			"name": "input",
+			"label": "Input",
+			"isDefault": false
+		},
+		{
+			"name": "stepper",
+			"label": "Stepper",
+			"isDefault": true
+		},
+		{
+			"name": "hidden",
+			"label": "Hidden",
+			"isDefault": false
+		}
+	],
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"style": "file:../woocommerce/add-to-cart-with-options-quantity-selector-style.css",
 	"viewScriptModule": "woocommerce/add-to-cart-with-options-quantity-selector"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -21,11 +21,6 @@
 			"name": "stepper",
 			"label": "Stepper",
 			"isDefault": true
-		},
-		{
-			"name": "hidden",
-			"label": "Hidden",
-			"isDefault": false
 		}
 	],
 	"$schema": "https://schemas.wp.org/trunk/block.json",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
@@ -6,7 +6,7 @@
 	"attributes": {
 		"quantitySelectorStyle": {
 			"type": "string",
-			"enum": [ "input", "stepper" ],
+			"enum": [ "input", "stepper", "hidden" ],
 			"default": "input"
 		}
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -19,10 +19,11 @@ import type { Attributes } from './';
 const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
-	const quantitySelectorStyleClass =
-		props.attributes.quantitySelectorStyle === QuantitySelectorStyle.Input
-			? 'wc-block-add-to-cart-form--input'
-			: 'wc-block-add-to-cart-form--stepper';
+	const quantitySelectorStyleClass = `wc-block-add-to-cart-form--${
+        props.attributes.quantitySelectorStyle || QuantitySelectorStyle.Input
+    }`;
+
+	console.debug('AddToCartFormEdit render with quantitySelectorStyle:', props.attributes.quantitySelectorStyle);
 
 	const blockProps = useBlockProps( {
 		className: `wc-block-add-to-cart-form ${ quantitySelectorStyleClass }`,
@@ -58,8 +59,8 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					<div className="wc-block-editor-add-to-cart-form-container">
 						<MultiLineTextSkeleton isStatic={ true } />
 						<Disabled>
-							{ props.attributes.quantitySelectorStyle ===
-								QuantitySelectorStyle.Input && (
+							{ ( props.attributes.quantitySelectorStyle === QuantitySelectorStyle.Input ||
+								props.attributes.quantitySelectorStyle === QuantitySelectorStyle.Hidden ) && (
 								<>
 									<div className="quantity">
 										<input
@@ -78,7 +79,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 													  }
 													: {}
 											}
-											type="number"
+											type={ props.attributes.quantitySelectorStyle === QuantitySelectorStyle.Hidden ? 'hidden' : 'number' }
 											value="1"
 											className="input-text qty text"
 											readOnly

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -23,8 +23,6 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
         props.attributes.quantitySelectorStyle || QuantitySelectorStyle.Input
     }`;
 
-	console.debug('AddToCartFormEdit render with quantitySelectorStyle:', props.attributes.quantitySelectorStyle);
-
 	const blockProps = useBlockProps( {
 		className: `wc-block-add-to-cart-form ${ quantitySelectorStyleClass }`,
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -18,6 +18,7 @@ import {
 export enum QuantitySelectorStyle {
 	Input = 'input',
 	Stepper = 'stepper',
+	Hidden = 'hidden',
 }
 
 type AddToCartFormSettingsProps = {
@@ -68,6 +69,10 @@ export const AddToCartFormSettings = ( {
 					<ToggleGroupControlOption
 						label={ __( 'Stepper', 'woocommerce' ) }
 						value={ QuantitySelectorStyle.Stepper }
+					/>
+					<ToggleGroupControlOption
+						label={ __( 'Hidden', 'woocommerce' ) }
+						value={ QuantitySelectorStyle.Hidden }
 					/>
 				</ToggleGroupControl>
 			</PanelBody>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -30,6 +30,10 @@
 		.quantity {
 			display: inline-flex;
 			align-items: stretch;
+
+			&.wc-block-components-quantity-selector--hidden {
+				display: none;
+			}
 		}
 
 		> *:not(.quantity) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -68,6 +68,29 @@ class AddToCartForm extends AbstractBlock {
 	}
 
 	/**
+	 * Switch the input to type="hidden".
+	 *
+	 * @param string $product_html The Add to Cart form HTML.
+	 *
+	 * @return string The Add to Cart form HTML with classes added.
+	 */
+	private function hide_input( $product_html ) {
+		$html = new \WP_HTML_Tag_Processor( $product_html );
+
+		// Add classes to the form.
+		while ( $html->next_tag( array( 'class_name' => 'quantity' ) ) ) {
+			$html->add_class( 'wc-block-components-quantity-selector--hidden' );
+		}
+
+		$html = new \WP_HTML_Tag_Processor( $html->get_updated_html() );
+		while ( $html->next_tag( array( 'class_name' => 'qty' ) ) ) {
+			$html->set_attribute( 'type', 'hidden' );
+		}
+
+		return $html->get_updated_html();
+	}
+
+	/**
 	 * Add increment and decrement buttons to the quantity input field.
 	 *
 	 * @param string $product_html Add to Cart form HTML.
@@ -180,7 +203,7 @@ class AddToCartForm extends AbstractBlock {
 		$managing_stock               = $product->managing_stock();
 		$stock_quantity               = $product->get_stock_quantity();
 
-		$should_hide_quantity_selector = $product->is_sold_individually() || Utils::is_min_max_quantity_same( $product ) || ( $managing_stock && $stock_quantity <= 1 );
+		$should_hide_quantity_selector = 'hidden' === $attributes['quantitySelectorStyle'] || $product->is_sold_individually() || Utils::is_min_max_quantity_same( $product ) || ( $managing_stock && $stock_quantity <= 1 );
 
 		/**
 		 * The stepper buttons don't show when the product is sold individually or stock quantity is less or equal to 1 because the quantity input field is hidden.
@@ -224,6 +247,7 @@ class AddToCartForm extends AbstractBlock {
 		}
 
 		$product_name = $product->get_name();
+		$product_html = $should_hide_quantity_selector ? $this->hide_input( $product_html ) : $product_html;
 		$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
 
 		$product_html       = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Allow the add to cart form block to hide the quantity input (frequently used for things like donations and invoices)

### Screenshots or screen recordings:

Before
<img width="1215" height="717" alt="image" src="https://github.com/user-attachments/assets/6854b386-e66a-47ca-9b7f-e289a8ea9707" />

After
<img width="1475" height="694" alt="image" src="https://github.com/user-attachments/assets/952e577f-eddd-415a-9ad8-2daa41e37117" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add a single product block to a page
2. Edit the add to cart form inner block
3. Toggle the "Quantity selector style" to "hidden"
4. Input should be hidden in the editor and then after save, also on the front end

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

