### PR TITLE
Fix missing data in certain WooCommerce blocks inside the Product block when editing as an author

### DIFF
--- a/plugins/woocommerce/changelog/fix-61369-wc-blocks-in-product-author-ii
+++ b/plugins/woocommerce/changelog/fix-61369-wc-blocks-in-product-author-ii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing data in certain WooCommerce blocks inside the Product block when editing as an author

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+/**
+ * Internal dependencies
+ */
+import { initializeEditor } from '../../../../../tests/integration/helpers/integration-test-editor';
+import '../';
+import '../../../atomic/blocks/product-elements/price';
+import '../../../atomic/blocks/product-elements/summary';
+
+const mockProduct = {
+	id: 82,
+	name: 'Beanie with Logo',
+	short_description: 'This is a short description',
+	prices: {
+		price: '2000',
+		regular_price: '2000',
+		sale_price: '',
+		price_range: null,
+		currency_code: 'EUR',
+		currency_symbol: '€',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '',
+		currency_suffix: ' €',
+	},
+	images: [
+		{
+			id: 1,
+			src: 'test-image-1.jpg',
+			thumbnail: 'test-thumb-1.jpg',
+			alt: 'Test 1',
+		},
+		{
+			id: 2,
+			src: 'test-image-2.jpg',
+			thumbnail: 'test-thumb-2.jpg',
+			alt: 'Test 2',
+		},
+		{
+			id: 3,
+			src: 'test-image-3.jpg',
+			thumbnail: 'test-thumb-3.jpg',
+			alt: 'Test 3',
+		},
+	],
+};
+
+// Setup MSW.
+const handlers = [
+	http.get( '/wp/v2/types', () => {
+		return HttpResponse.json( {} );
+	} ),
+
+	http.get( '/wc/store/v1/products/:id', () => {
+		return HttpResponse.json( mockProduct );
+	} ),
+];
+
+const server = setupServer( ...handlers );
+
+// Start MSW.
+beforeAll( () => server.listen() );
+afterEach( () => server.resetHandlers() );
+afterAll( () => server.close() );
+
+async function setup() {
+	const singleProductBlock = [
+		{
+			name: 'woocommerce/single-product',
+			attributes: {
+				productId: '82',
+			},
+		},
+	];
+	return initializeEditor( singleProductBlock );
+}
+
+describe( 'Product block', () => {
+	it( 'should render inner blocks for users without edit permissions', async () => {
+		server.use(
+			http.get( '/wc/v3/products/:id', () => {
+				return HttpResponse.json( '', { status: 403 } );
+			} )
+		);
+
+		await setup();
+
+		const block = await screen.findAllByLabelText( `Block: Product` );
+		expect( block.length ).toBeGreaterThan( 0 );
+
+		const productDescription = await screen.findByText(
+			'This is a short description'
+		);
+		expect( productDescription ).toBeInTheDocument();
+
+		const productPrice = await screen.findByText( '20,00 €' );
+		expect( productPrice ).toBeInTheDocument();
+	} );
+
+	it( 'should render inner blocks for admins', async () => {
+		server.use(
+			http.get( '/wc/v3/products/:id', () => {
+				return HttpResponse.json( mockProduct );
+			} )
+		);
+
+		await setup();
+
+		const block = await screen.findAllByLabelText( `Block: Product` );
+		expect( block.length ).toBeGreaterThan( 0 );
+
+		const productDescription = await screen.findByText(
+			'This is a short description'
+		);
+		expect( productDescription ).toBeInTheDocument();
+
+		const productPrice = await screen.findByText( '20,00 €' );
+		expect( productPrice ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/test/block.ts
@@ -85,6 +85,9 @@ async function setup() {
 
 describe( 'Product block', () => {
 	it( 'should render inner blocks for users without edit permissions', async () => {
+		// The V4 of this endpoint will return product data to authors,
+		// see https://github.com/woocommerce/woocommerce/pull/61718.
+		// However, V3 didn't, that's why we need this test.
 		server.use(
 			http.get( '/wc/v3/products/:id', () => {
 				return HttpResponse.json( '', { status: 403 } );

--- a/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/context/product-data-context.tsx
@@ -108,7 +108,7 @@ export const useProductDataContext = (
 	const context = useContext( ProductDataContext );
 	const { isAdmin, product, isResolving } = props;
 
-	if ( ! isAdmin ) {
+	if ( ! isAdmin || ! product ) {
 		return context;
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -135,8 +135,9 @@ class Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
-	 * Override the get_item permissions so that published products are
-	 * available to users without the 'read_private_posts' capability.
+	 * Override the get_item permissions so that published products which are
+	 * not password-protected are available to users without the
+	 * 'read_private_posts' capability but can edit posts.
 	 * This is required for the Product block in the editor, see:
 	 * https://github.com/woocommerce/woocommerce/pull/61470
 	 *
@@ -151,18 +152,20 @@ class Controller extends WC_REST_Products_V2_Controller {
 				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 
-			$object_id = $object->get_id();
-
-			if ( post_password_required( $object_id ) ) {
-				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
-			$cap = 'publish' === $object->get_status() ? 'read' : 'read_private_posts';
-
+			$object_id        = $object->get_id();
 			$post_type_object = get_post_type_object( 'product' );
 			$permission       = false;
+
 			if ( $post_type_object instanceof \WP_Post_Type ) {
-				$permission = current_user_can( $post_type_object->cap->$cap, $object_id );
+				// These are the default permissions inherited from
+				// `WC_REST_Products_V2_Controller`.
+				$permission = current_user_can( $post_type_object->cap->read_private_posts, $object_id );
+
+				// We add an especial case when the post is published, not
+				// password-protected and the user has post edit capabilities.
+				if ( ! $permission && 'publish' === $object->get_status() && ! post_password_required( $object_id ) ) {
+					$permission = current_user_can( 'edit_posts' ) && current_user_can( $post_type_object->cap->read, $object_id );
+				}
 			}
 
 			/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -151,11 +151,16 @@ class Controller extends WC_REST_Products_V2_Controller {
 				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 
+			$object_id = $object->get_id();
+
+			if ( post_password_required( $object_id ) ) {
+				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
 			$cap = 'publish' === $object->get_status() ? 'read' : 'read_private_posts';
 
 			$post_type_object = get_post_type_object( 'product' );
 			$permission       = false;
-			$object_id        = $object->get_id();
 			if ( $post_type_object instanceof \WP_Post_Type ) {
 				$permission = current_user_can( $post_type_object->cap->$cap, $object_id );
 			}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -135,6 +135,51 @@ class Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
+	 * Override the get_item permissions so that published products are
+	 * available to users without the 'read_private_posts' capability.
+	 * This is required for the Product block in the editor, see:
+	 * https://github.com/woocommerce/woocommerce/pull/61470
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		$object = $this->get_object( (int) $request['id'] );
+
+		if ( $object && 0 !== $object->get_id() ) {
+			if ( 'product' !== $object->post_type && 'product_variation' !== $object->post_type ) {
+				return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+			}
+
+			$cap = 'publish' === $object->get_status() ? 'read' : 'read_private_posts';
+
+			$post_type_object = get_post_type_object( 'product' );
+			$permission       = false;
+			$object_id        = $object->get_id();
+			if ( $post_type_object instanceof \WP_Post_Type ) {
+				$permission = current_user_can( $post_type_object->cap->$cap, $object_id );
+			}
+
+			/**
+			* Filter the permission to view a product.
+			*
+			* @since 10.4.0
+			* @param bool $permission The permission to view a product.
+			* @param string $cap The capability to check.
+			* @param int $object_id The ID of the product.
+			* @param string $post_type The post type of the product.
+			*/
+			$permission = apply_filters( 'woocommerce_rest_check_permissions', $permission, 'read', $object_id, 'product' );
+
+			if ( ! $permission ) {
+				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Duplicate a product and returns the duplicated product.
 	 * The product status is set to "draft" and the name includes a "(copy)" at the end by default.
 	 *

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -148,7 +148,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 
 		if ( $object && 0 !== $object->get_id() ) {
 			if ( 'product' !== $object->post_type && 'product_variation' !== $object->post_type ) {
-				return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 
 			$cap = 'publish' === $object->get_status() ? 'read' : 'read_private_posts';

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -153,7 +153,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 			}
 
 			$object_id        = $object->get_id();
-			$post_type_object = get_post_type_object( 'product' );
+			$post_type_object = get_post_type_object( $object->post_type );
 			$permission       = false;
 
 			if ( $post_type_object instanceof \WP_Post_Type ) {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -161,7 +161,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 				// `WC_REST_Products_V2_Controller`.
 				$permission = current_user_can( $post_type_object->cap->read_private_posts, $object_id );
 
-				// We add an especial case when the post is published, not
+				// We add an special case when the post is published, not
 				// password-protected and the user has post edit capabilities.
 				if ( ! $permission && 'publish' === $object->get_status() && ! post_password_required( $object_id ) ) {
 					$permission = current_user_can( 'edit_posts' ) && current_user_can( $post_type_object->cap->read, $object_id );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -169,7 +169,7 @@ class Controller extends WC_REST_Products_V2_Controller {
 			* @param int $object_id The ID of the product.
 			* @param string $post_type The post type of the product.
 			*/
-			$permission = apply_filters( 'woocommerce_rest_check_permissions', $permission, 'read', $object_id, 'product' );
+			$permission = apply_filters( 'woocommerce_rest_check_permissions', $permission, 'read', $object_id, $object->post_type );
 
 			if ( ! $permission ) {
 				return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/README.md
@@ -24,6 +24,14 @@ As discussed in the team conversation:
 
 ## Change Log
 
+### 2025-11-07 - Make the GET `/wc/v4/products/<id>` endpoint available to users with `edit_posts` capabilities
+
+**Summary**: The GET `/wc/v4/products/<id>` REST endpoint has been updated so that users who have the `edit_posts` capability (for example Authors) can retrieve published, non-password-protected products. Access remains restricted for users without either the `edit_posts` or `read_private_products` capabilities.
+
+**PR**: [#61718](https://github.com/woocommerce/woocommerce/pull/61718)
+
+**Breaking Changes**: None
+
 ### 2025-09-08 - Add Add to Cart Field
 
 **Summary**: Added new `add_to_cart` field to product responses providing comprehensive add-to-cart information. The field includes an object with `url`, `description`, `text`, and `single_text` properties that correspond to the product's add-to-cart methods. This enhancement improves frontend integration by providing all necessary add-to-cart data in a single API call, particularly beneficial for block-based implementations and external product types.

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
@@ -2028,9 +2028,33 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that published products are viewable by subscribers.
+	 * Test that published products are viewable by authors.
 	 */
-	public function test_get_published_product_as_subscriber_is_viewable() {
+	public function test_get_published_product_as_author_is_viewable() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Published Product',
+				'status' => ProductStatus::PUBLISH,
+			)
+		);
+
+		$author = $this->factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		wp_set_current_user( $author );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that published products are hidden from subscribers.
+	 */
+	public function test_get_published_product_as_subscriber_is_forbidden() {
 		$product = WC_Helper_Product::create_simple_product(
 			true,
 			array(
@@ -2048,13 +2072,14 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_cannot_view', $response->get_data()['code'] );
 	}
 
 	/**
-	 * Test that draft products are not viewable by subscribers (no read_private_posts).
+	 * Test that draft products are hidden from authors.
 	 */
-	public function test_get_draft_product_as_subscriber_is_forbidden() {
+	public function test_get_draft_product_as_author_is_forbidden() {
 		$product = WC_Helper_Product::create_simple_product(
 			true,
 			array(
@@ -2063,12 +2088,38 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		$subscriber = $this->factory->user->create(
+		$author = $this->factory->user->create(
 			array(
-				'role' => 'subscriber',
+				'role' => 'author',
 			)
 		);
-		wp_set_current_user( $subscriber );
+		wp_set_current_user( $author );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_cannot_view', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test that password-protected products are hidden from authors.
+	 */
+	public function test_get_password_protected_product_as_author_is_forbidden() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'          => 'Password Protected Product',
+				'status'        => ProductStatus::PUBLISH,
+				'post_password' => 'test',
+			)
+		);
+
+		$author = $this->factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		wp_set_current_user( $author );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Products/ProductsControllerTest.php
@@ -2026,4 +2026,53 @@ class ProductsControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( '', $data['min_price'] );
 		$this->assertEquals( '', $data['max_price'] );
 	}
+
+	/**
+	 * Test that published products are viewable by subscribers.
+	 */
+	public function test_get_published_product_as_subscriber_is_viewable() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Published Product',
+				'status' => ProductStatus::PUBLISH,
+			)
+		);
+
+		$subscriber = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that draft products are not viewable by subscribers (no read_private_posts).
+	 */
+	public function test_get_draft_product_as_subscriber_is_forbidden() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Draft Product',
+				'status' => ProductStatus::DRAFT,
+			)
+		);
+
+		$subscriber = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() ) );
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_cannot_view', $response->get_data()['code'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/61369.

Alternative approach to https://github.com/woocommerce/woocommerce/pull/61470.

This PR updates the `/wc/v4/products/<id>` endpoint so it works for users with `edit_posts` capabilities (like _Authors_) when the product is published and not password-protected. This allows the endpoint to work in the post/page editor for authors, so the _Product_ block can render real product data.

As mentioned, for now I restricted this endpoint to users with the `edit_posts` capability so shoppers don't have access to it, even if the products are public. That's because I expect anything public-facing to be using the store API.

### How to test the changes in this Pull Request:

1. Create a user with *Author* role.
2. Create a post and add the *Product* block.
3. Select a product and verify the _Product Image Gallery_, _Product Rating_, _Product Summary_ and _Product Price_ blocks render the correct data. (Note: _Product Title_ is expected to be empty, that's a known issue)
4. Install WooCommerce Beta Tester, go to _Tools_ > _WCA Test Helper_ > _Features_ and enable _rest-api-v4_.
5. Repeat steps 1-3.

Before | After
--- | ---
<img width="867" height="712" alt="imatge" src="https://github.com/user-attachments/assets/e196d0d6-1766-4ce4-b026-7a3be8cc302e" /> | <img width="867" height="712" alt="imatge" src="https://github.com/user-attachments/assets/f37f9aed-9060-43f7-accf-494a34c45d8d" />

6. Now, repeat steps 1-5 with an admin user.