### PR TITLE
Use color-mix instead of ::after hack for translucent borders

### DIFF
--- a/plugins/woocommerce/changelog/fix-color-mix-for-translucent-border
+++ b/plugins/woocommerce/changelog/fix-color-mix-for-translucent-border
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Use color-mix instead of ::after hack for translucent borders

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -242,27 +242,6 @@ $fontSizes: (
 	}
 }
 
-// Shows a border with the current color and a custom opacity. That can't be achieved
-// with normal border because `currentColor` doesn't allow tweaking the opacity, and
-// setting the opacity of the entire element would change the children's opacity too.
-@mixin with-translucent-border($border-width: 1px, $opacity: 0.3) {
-	position: relative;
-
-	&::after {
-		border-style: solid;
-		border-width: $border-width;
-		bottom: 0;
-		content: "";
-		display: block;
-		left: 0;
-		opacity: $opacity;
-		pointer-events: none;
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
-}
-
 // Positions an element absolutely and stretches it over the container
 @mixin absolute-stretch() {
 	margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_variables.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_variables.scss
@@ -12,3 +12,4 @@ $gap-smallest: 0.5 * $grid-unit; // 4px
 
 // Standard border radius for forms.
 $universal-border-radius: 4px;
+$universal-translucent-border-color: color-mix(in srgb, currentColor 30%, transparent);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
@@ -66,7 +66,7 @@ $drawer-animation-duration: 0.3s;
 }
 
 .wc-block-components-drawer {
-	@include with-translucent-border(0 0 0 1px);
+	border-left: 1px solid $universal-translucent-border-color;
 	background: #fff;
 	display: block;
 	height: 100%;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -12,6 +12,7 @@
 }
 
 .wc-block-components-quantity-selector {
+	border: 1px solid $universal-translucent-border-color;
 	border-radius: $universal-border-radius;
 	// needed so that buttons fill the container.
 	box-sizing: content-box;
@@ -19,19 +20,6 @@
 	margin: 0 0 0.25em 0;
 	position: relative;
 	width: 107px;
-
-	&::after {
-		border-radius: $universal-border-radius;
-		border: 1px solid currentColor;
-		bottom: 0;
-		content: "";
-		left: 0;
-		pointer-events: none;
-		position: absolute;
-		right: 0;
-		top: 0;
-		opacity: 0.3;
-	}
 
 	// Extra label for specificity needed in the editor.
 	input.wc-block-components-quantity-selector__input {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -14,8 +14,7 @@
 .wc-block-components-quantity-selector {
 	border: 1px solid $universal-translucent-border-color;
 	border-radius: $universal-border-radius;
-	// needed so that buttons fill the container.
-	box-sizing: content-box;
+	box-sizing: border-box;
 	display: flex;
 	margin: 0 0 0.25em 0;
 	position: relative;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -162,7 +162,7 @@ h2.wc-block-mini-cart__title {
 }
 
 .wc-block-mini-cart__footer {
-	@include with-translucent-border(1px 0 0);
+	border-top: 1px solid $universal-translucent-border-color;
 	padding: $gap-large $gap;
 
 	.wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {

--- a/plugins/woocommerce/client/blocks/packages/components/panel/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/panel/style.scss
@@ -1,5 +1,6 @@
 .wc-block-components-panel.has-border {
-	@include with-translucent-border(1px 0);
+	border: 1px solid $universal-translucent-border-color;
+	border-width: 1px 0;
 
 	+ .wc-block-components-panel.has-border::after {
 		border-top-width: 0;
@@ -7,10 +8,7 @@
 }
 
 .wc-block-components-panel.has-border.no-top-border {
-	@include with-translucent-border(1px 0);
-	&::after {
-		border-top-width: 0;
-	}
+	border-width: 0 0 1px;
 }
 
 .wc-block-components-panel__button {

--- a/plugins/woocommerce/client/blocks/packages/components/panel/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/panel/style.scss
@@ -2,13 +2,13 @@
 	border: 1px solid $universal-translucent-border-color;
 	border-width: 1px 0;
 
-	+ .wc-block-components-panel.has-border::after {
+	+ .wc-block-components-panel.has-border {
 		border-top-width: 0;
 	}
 }
 
 .wc-block-components-panel.has-border.no-top-border {
-	border-width: 0 0 1px;
+	border-top-width: 0;
 }
 
 .wc-block-components-panel__button {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Apparently, we were using a hack using the `::after` pseudoelement to have translucent borders in several elements. Since ~2023 that's no longer needed as CSS has a `color-mix()` function.

This PR updates the code where we were using the `::after` hack to use `color-mix()`, which should help reduce the CSS files size a bit.

### How to test the changes in this Pull Request:

This PR doesn't introduce any visual change, so testing means making sure there are no regressions:

1. In `trunk`: open the _Single Product_ template in the frontend, the _Mini-Cart_ block and the _Cart_ page.
2. Switch to this branch and reload the pages mentioned above. Verify the border of the inputs has the same color as before.