### PR TITLE
Remove CedCommerce from onboarding marketing task

### DIFF
--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -1,5 +1,5 @@
 ---
-alwaysApply: false
+alwaysApply: true
 ---
 
 # Generating a Pull Request Description

--- a/plugins/woocommerce/changelog/61758-update-woomkt-335-remove-ced-from-onboarding
+++ b/plugins/woocommerce/changelog/61758-update-woomkt-335-remove-ced-from-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove CedCommerce from onboarding marketing task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -27,13 +27,17 @@ class Marketing extends Task {
 		$plugin_basename = basename( plugin_basename( $plugin ), '.php' );
 
 		// Example: How to mark the marketing task as complete when a specific plugin is activated.
-		// if ( $plugin_basename === 'pluginbasename-slug' &&
-		//     $this->task_list->visible &&
-		//     ! $this->task_list->is_hidden() &&
-		//     ! $this->is_complete()
-		// ) {
-		//     $this->mark_actioned();
-		// }
+		/**
+		 * Example:
+		 * if (
+		 *     $plugin_basename === 'multichannel-by-cedcommerce' &&
+		 *     $this->task_list->visible &&
+		 *     ! $this->task_list->is_hidden() &&
+		 *     ! $this->is_complete()
+		 * ) {
+		 *     $this->mark_actioned();
+		 * }
+		 */
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -16,6 +16,24 @@ class Marketing extends Task {
 	 */
 	public function __construct( $task_list ) {
 		parent::__construct( $task_list );
+
+		add_action( 'activated_plugin', array( $this, 'on_activated_plugin' ), 10, 1 );
+	}
+
+	/**
+	 * Mark the task as complete when related plugins are activated.
+	 */
+	public function on_activated_plugin( $plugin ) {
+		$plugin_basename = basename( plugin_basename( $plugin ), '.php' );
+
+		// Example: How to mark the marketing task as complete when a specific plugin is activated.
+		// if ( $plugin_basename === 'pluginbasename-slug' &&
+		//     $this->task_list->visible &&
+		//     ! $this->task_list->is_hidden() &&
+		//     ! $this->is_complete()
+		// ) {
+		//     $this->mark_actioned();
+		// }
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -16,23 +16,6 @@ class Marketing extends Task {
 	 */
 	public function __construct( $task_list ) {
 		parent::__construct( $task_list );
-
-		add_action( 'activated_plugin', array( $this, 'on_activated_plugin' ), 10, 1 );
-	}
-
-	/**
-	 * Mark the task as complete when related plugins are activated.
-	 */
-	public function on_activated_plugin( $plugin ) {
-		$plugin_basename = basename( plugin_basename( $plugin ), '.php' );
-
-		if ( $plugin_basename === 'multichannel-by-cedcommerce' &&
-			$this->task_list->visible &&
-			! $this->task_list->is_hidden() &&
-			! $this->is_complete()
-		) {
-			$this->mark_actioned();
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -136,18 +136,6 @@ class DefaultFreeExtensions {
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
 			),
-			'multichannel-by-cedcommerce'   => array(
-				'name'             => __( 'Multichannel for WooCommerce', 'woocommerce' ),
-				'description'      => __( 'Sync your sales data across platforms and manage everything from a unified dashboard.', 'woocommerce' ),
-				'image_url'        => plugins_url( '/assets/images/onboarding/multichannel.webp', WC_PLUGIN_FILE ),
-				'manage_url'       => 'admin.php?page=sales_channel',
-				'is_built_by_wc'   => false,
-				'install_external' => true,
-				'learn_more_link'  => 'https://woocommerce.com/products/multichannel-by-cedcommerce-ebay-amazon-walmart-etsy-integration/?utm_source=marketing_task&utm_medium=product',
-				'tags'             => array(
-					'marketplace',
-				),
-			),
 			'facebook-for-woocommerce'      => array(
 				'name'           => __( 'Facebook for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'List products and create ads on Facebook and Instagram with <a href="https://woocommerce.com/products/facebook/">Facebook for WooCommerce</a>', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -69,7 +69,6 @@ class DefaultFreeExtensions {
 				'title'   => __( 'Grow your store', 'woocommerce' ),
 				'plugins' => array(
 					self::get_plugin( 'google-listings-and-ads:alt' ),
-					self::get_plugin( 'multichannel-by-cedcommerce' ),
 					self::get_plugin( 'tiktok-for-business' ),
 					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 					self::get_plugin( 'facebook-for-woocommerce:alt' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Remove CedCommerce (multichannel-by-cedcommerce) from the onboarding marketing task.

This PR removes CedCommerce from:

-   The marketing task bundle (`task-list/grow`) in `DefaultFreeExtensions.php`
-   The plugin definition in `DefaultFreeExtensions.php`
-   The plugin activation handler in `Marketing.php` (commented out as an example for future use)

The activation handler logic is preserved as a commented example showing how to mark the marketing task as complete when specific plugins are activated.

### Screenshots or screen recordings:

This PR removes CedCommerce from the onboarding UI. Before this change, CedCommerce appeared in the marketing task onboarding flow. After this change, it will no longer appear.

| Before                                                                              | After                                                          |
| ----------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| <img width="5088" height="3976" alt="image" src="https://github.com/user-attachments/assets/26a8ee2d-f575-4410-a56e-c2a26caeb6c2" />| <img width="5088" height="3976" alt="image" src="https://github.com/user-attachments/assets/b50be111-b3f5-4339-8099-03fe4f30d286" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh WooCommerce installation.
2. Set the `woocommerce_show_marketplace_suggestions` option to "no". You can use wp cli `wp option set woocommerce_show_marketplace_suggestions no`
2. Navigate to `http://localhost:8888/wp-admin/admin.php?page=wc-admin&task=marketing` (replace localhost with whatever your testing site url is)
5. Verify that other marketing extensions (Google for WooCommerce, TikTok, Pinterest) still appear correctly in the task

Also, verify that the `cedcommerce` string isn't anywhere else in the codebase.

### Testing that has already taken place:

-   Verified that CedCommerce references have been removed from the onboarding code
-   Confirmed PHP syntax is valid (no syntax errors)
-   Checked that other marketing extensions remain in the bundle and display correctly
-   Verified the commented activation handler structure is preserved for future reference

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove CedCommerce from onboarding marketing task

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
