### PR TITLE
[Woo POS] Products catalog API: integrate with the Product Feed plugin

### DIFF
--- a/plugins/woocommerce/changelog/WOOMOB-1455-pos-catalog-api-integration-with-product-feed-plugin
+++ b/plugins/woocommerce/changelog/WOOMOB-1455-pos-catalog-api-integration-with-product-feed-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the feature-flagged `POST /products/catalog` endpoint to integrate with async product feed generation from the `WooCommerce Product Feed for OpenAI` plugin when installed and active.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -329,18 +329,6 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'download_url' => isset( $status['url'] ) ? $status['url'] : null,
 			);
 
-			// TODO: debug only, delete later
-			// Include progress information if available.
-			if ( isset( $status['progress'] ) ) {
-				$response_data['progress'] = $status['progress'];
-			}
-			if ( isset( $status['processed'] ) ) {
-				$response_data['processed'] = $status['processed'];
-			}
-			if ( isset( $status['total'] ) ) {
-				$response_data['total'] = $status['total'];
-			}
-
 			return rest_ensure_response( $response_data );
 		} catch ( \Exception $e ) {
 			return new WP_Error(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -295,14 +295,37 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 */
 	private function request_catalog_async( $fields, $force_generate ) {
 		try {
-			$plugin    = \Automattic\WooCommerce\ProductFeedForOpenAI\Core\Plugin::get_instance();
+			$plugin = \Automattic\WooCommerce\ProductFeedForOpenAI\Core\Plugin::get_instance();
+			if ( ! $plugin ) {
+				return new WP_Error(
+					'async_generation_unavailable',
+					__( 'Product Feed plugin instance unavailable.', 'woocommerce' ),
+					array( 'status' => 500 )
+				);
+			}
+
 			$generator = $plugin->get( \Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog\AsyncGenerator::class );
+			if ( ! $generator ) {
+				return new WP_Error(
+					'async_generation_unavailable',
+					__( 'Catalog async generator unavailable.', 'woocommerce' ),
+					array( 'status' => 500 )
+				);
+			}
 
 			$args = array( 'fields' => $fields );
 
 			$status = $force_generate
 				? $generator->force_regeneration( $args )
 				: $generator->get_status( $args );
+
+			if ( ! is_array( $status ) ) {
+				return new WP_Error(
+					'async_generation_failed',
+					__( 'Invalid response from catalog async generator.', 'woocommerce' ),
+					array( 'status' => 500 )
+				);
+			}
 
 			// Map AsyncGenerator state to catalog API generation status.
 			switch ( $status['state'] ?? '' ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -342,14 +342,14 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 					return new WP_Error(
 						'async_generation_failed',
 						/* translators: %s: The unknown state value returned by the catalog async generator */
-						sprintf( __( 'Unknown state: %s', 'woocommerce' ), $status['state'] ),
+						sprintf( __( 'Unknown state: %s', 'woocommerce' ), is_scalar( $status['state'] ) ? $status['state'] : gettype( $status['state'] ) ),
 						array( 'status' => 500 )
 					);
 			}
 
 			$response_data = array(
 				'status'       => $response_status,
-				'download_url' => isset( $status['url'] ) ? $status['url'] : null,
+				'download_url' => ( isset( $status['url'] ) && is_string( $status['url'] ) && '' !== $status['url'] ) ? $status['url'] : null,
 			);
 
 			return rest_ensure_response( $response_data );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -81,7 +81,13 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	public function request_catalog( $request ) {
 		$fields         = $this->sanitize_fields_arg( $request->get_param( 'fields' ) ?? array() );
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
-		$file_info      = $this->get_catalog_file_info( $fields );
+
+		// Use AsyncGenerator if the Product Feed plugin is available.
+		if ( $this->is_async_generator_available() ) {
+			return $this->request_catalog_async( $fields, $force_generate );
+		}
+
+		$file_info = $this->get_catalog_file_info( $fields );
 
 		if ( is_wp_error( $file_info ) ) {
 			return $file_info;
@@ -269,5 +275,73 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$fields = array_values( array_unique( array_map( 'strval', $fields ) ) );
 		sort( $fields, SORT_STRING );
 		return $fields;
+	}
+
+	/**
+	 * Check if AsyncGenerator from Product Feed plugin is available.
+	 *
+	 * @return bool True if AsyncGenerator is available, false otherwise.
+	 */
+	private function is_async_generator_available() {
+		return defined( 'WPFOAI_VERSION' ) && class_exists( '\Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog\AsyncGenerator' );
+	}
+
+	/**
+	 * Request products catalog using AsyncGenerator (async processing).
+	 *
+	 * @param array $fields         Product/variation fields to include in the catalog.
+	 * @param bool  $force_generate Whether to force regenerate the catalog.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	private function request_catalog_async( $fields, $force_generate ) {
+		try {
+			$plugin    = \Automattic\WooCommerce\ProductFeedForOpenAI\Core\Plugin::get_instance();
+			$generator = $plugin->get( \Automattic\WooCommerce\ProductFeedForOpenAI\Integrations\POSCatalog\AsyncGenerator::class );
+
+			$args = array( 'fields' => $fields );
+
+			$status = $force_generate
+				? $generator->force_regeneration( $args )
+				: $generator->get_status( $args );
+
+			// Map AsyncGenerator state to our API response format.
+			$response_status = 'pending';
+			switch ( $status['state'] ?? '' ) {
+				case 'scheduled':
+					$response_status = 'pending';
+					break;
+				case 'in_progress':
+					$response_status = 'processing';
+					break;
+				case 'completed':
+					$response_status = 'complete';
+					break;
+			}
+
+			$response_data = array(
+				'status'       => $response_status,
+				'download_url' => isset( $status['url'] ) ? $status['url'] : null,
+			);
+
+			// TODO: debug only, delete later
+			// Include progress information if available.
+			if ( isset( $status['progress'] ) ) {
+				$response_data['progress'] = $status['progress'];
+			}
+			if ( isset( $status['processed'] ) ) {
+				$response_data['processed'] = $status['processed'];
+			}
+			if ( isset( $status['total'] ) ) {
+				$response_data['total'] = $status['total'];
+			}
+
+			return rest_ensure_response( $response_data );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'async_generation_failed',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -172,7 +172,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				'status'       => array(
 					'description' => __( 'Products catalog generation status.', 'woocommerce' ),
 					'type'        => 'string',
-					'enum'        => array( 'pending', 'processing', 'complete', 'failed' ),
+					'enum'        => array( 'pending', 'processing', 'complete' ),
 				),
 				'download_url' => array(
 					'description' => __( 'Products catalog file URL. Null when catalog is not ready.', 'woocommerce' ),
@@ -304,8 +304,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				? $generator->force_regeneration( $args )
 				: $generator->get_status( $args );
 
-			// Map AsyncGenerator state to our API response format.
-			$response_status = 'pending';
+			// Map AsyncGenerator state to catalog API generation status.
 			switch ( $status['state'] ?? '' ) {
 				case 'scheduled':
 					$response_status = 'pending';
@@ -316,6 +315,13 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				case 'completed':
 					$response_status = 'complete';
 					break;
+				default:
+					return new WP_Error(
+						'async_generation_failed',
+						/* translators: %s: The unknown state value returned by the catalog async generator */
+						sprintf( __( 'Unknown state: %s', 'woocommerce' ), $status['state'] ),
+						array( 'status' => 500 )
+					);
 			}
 
 			$response_data = array(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -50,10 +50,18 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 					'permission_callback' => array( $this, 'request_catalog_permissions_check' ),
 					'args'                => array(
 						'fields'         => array(
-							'description'       => __( 'Product/variation fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
+							'description'       => __( 'Product fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
 							'type'              => array( 'array', 'string' ),
 							'items'             => array( 'type' => 'string' ),
 							'required'          => true,
+							'validate_callback' => array( $this, 'validate_fields_arg' ),
+							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
+						),
+						'variation_fields' => array(
+							'description'       => __( 'Variation fields to include in the catalog. Can be an array or comma-separated string.', 'woocommerce' ),
+							'type'              => array( 'array', 'string' ),
+							'items'             => array( 'type' => 'string' ),
+							'required'          => false,
 							'validate_callback' => array( $this, 'validate_fields_arg' ),
 							'sanitize_callback' => array( $this, 'sanitize_fields_arg' ),
 						),
@@ -80,14 +88,15 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 */
 	public function request_catalog( $request ) {
 		$fields         = $this->sanitize_fields_arg( $request->get_param( 'fields' ) ?? array() );
+		$variation_fields = $this->sanitize_fields_arg( $request->get_param( 'variation_fields' ) ?? array() );
 		$force_generate = $request->get_param( 'force_generate' ) ?? false;
 
 		// Use AsyncGenerator if the Product Feed plugin is available.
 		if ( $this->is_async_generator_available() ) {
-			return $this->request_catalog_async( $fields, $force_generate );
+			return $this->request_catalog_async( $fields, $variation_fields, $force_generate );
 		}
 
-		$file_info = $this->get_catalog_file_info( $fields );
+		$file_info = $this->get_catalog_file_info( $fields, $variation_fields );
 
 		if ( is_wp_error( $file_info ) ) {
 			return $file_info;
@@ -241,10 +250,11 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	/**
 	 * Get catalog file information based on fields.
 	 *
-	 * @param array $fields Product/variation fields to include in the catalog.
+	 * @param array $fields Product fields to include in the catalog.
+	 * @param array $variation_fields Variation fields to include in the catalog.
 	 * @return array|WP_Error Array with 'filepath', 'url', and 'directory' keys, or WP_Error on failure.
 	 */
-	private function get_catalog_file_info( $fields ) {
+	private function get_catalog_file_info( $fields, $variation_fields ) {
 		$upload_dir = wp_upload_dir();
 
 		if ( ! empty( $upload_dir['error'] ) ) {
@@ -255,7 +265,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 		$catalog_url = trailingslashit( $upload_dir['baseurl'] ) . 'wc-catalog/';
 
 		$today        = gmdate( 'Y-m-d' );
-		$catalog_hash = wp_hash( $today . wp_json_encode( $fields ) );
+		$catalog_hash = wp_hash( $today . wp_json_encode( $fields ) . wp_json_encode( $variation_fields ) );
 		$filename     = "products-{$today}-{$catalog_hash}.json";
 
 		return array(
@@ -293,7 +303,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 	 * @param bool  $force_generate Whether to force regenerate the catalog.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	private function request_catalog_async( $fields, $force_generate ) {
+	private function request_catalog_async( $fields, $variation_fields, $force_generate ) {
 		try {
 			$plugin = \Automattic\WooCommerce\ProductFeedForOpenAI\Core\Plugin::get_instance();
 			if ( ! $plugin ) {
@@ -313,7 +323,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				);
 			}
 
-			$args = array( '_fields' => implode( ',', $fields ) );
+			$args = array( '_fields' => implode( ',', $fields ), '_variation_fields' => implode( ',', $variation_fields ) );
 
 			$status = $force_generate
 				? $generator->force_regeneration( $args )

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -313,7 +313,7 @@ class WC_REST_Products_Catalog_Controller extends WC_REST_Controller {
 				);
 			}
 
-			$args = array( 'fields' => $fields );
+			$args = array( '_fields' => implode( ',', $fields ) );
 
 			$status = $force_generate
 				? $generator->force_regeneration( $args )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of WOOMOB-1455

This PR updates the feature-flagged `POST /wp-json/wc/v3/products/catalog` endpoint to integrate with async product feed generation from the `WooCommerce Product Feed for OpenAI` plugin (abbreviated Product Feed plugin below) when installed and active. The plan is to move the Product Feed foundation code to core once the plugin has been tested in production with at least a few stores.

**Key features:**
- Integrates with Product Feed plugin's `AsyncGenerator` for background catalog generation
- Single endpoint returns current generation status: `pending`, `processing`, or `complete` with download URL when ready
- Optional `force_generate` parameter to force regeneration of existing catalogs
- Fallback to empty file generation when plugin not available
- Feature-flagged behind existing `products-catalog-api` development feature flag

**Technical implementation:**
- Uses `AsyncGenerator::get_status()` or `force_regeneration()` for async processing when Product Feed plugin is active
- Maps async generator states (`scheduled`, `in_progress`, `completed`) to API response states
- Returns status and download URL (when available) in a single response
- Includes error handling

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Prerequisite: ensure the `products-catalog-api` development feature flag is enabled.

**Test Scenario 1: Async Catalog Generation (Plugin Active)**

Prerequisite:

Install the Product Feed plugin using this zip file [woocommerce-product-feed-for-openai.zip](https://github.com/user-attachments/files/23324202/woocommerce-product-feed-for-openai.zip) that includes a change to allow file access in the product feed directory p1762224153119989/1761032826.289079-slack-C09EWAXSYD9.

1. Send POST request to `/wp-json/wc/v3/products/catalog` with admin authentication
2. Verify response contains:
   - `status`: One of `pending`, `processing`, or `complete`
   - `download_url`: URL to download file (present when status is `complete`, null otherwise)
3. If status is not `complete`, send another POST request to check updated status
4. Verify status eventually reaches `complete` with a valid `download_url`
5. Download the file from `download_url` and verify it's a valid product catalog file
6. Test force regeneration by sending POST with `force_generate=true` parameter
7. Verify it triggers a new generation even if a recent catalog exists

**Test Scenario 2: Fallback Behavior (Plugin Inactive)**
1. Deactivate WooCommerce Product Feed plugin
2. Send POST request to `/wp-json/wc/v3/products/catalog`
3. Verify endpoint still works with a download URL with empty JSON content (pre-existing behavior)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>