### PR TITLE
Product Filters: support unicode value

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5762
+++ b/plugins/woocommerce/changelog/wooplug-5762
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filter: support unicode value

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Internal dependencies
+ */
+import type { ProductFiltersStore } from '../frontend';
+
+const mockGetContext = jest.fn();
+const mockGetServerContext = jest.fn();
+const mockGetConfig = jest.fn();
+
+let mockRegisteredStore: {
+	state: ProductFiltersStore[ 'state' ];
+	actions: ProductFiltersStore[ 'actions' ];
+} | null = null;
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		getContext: mockGetContext,
+		getServerContext: mockGetServerContext,
+		getConfig: mockGetConfig,
+		store: jest.fn( ( _name, definition ) => {
+			mockRegisteredStore = {
+				state: definition.state,
+				actions: definition.actions,
+			};
+			return mockRegisteredStore;
+		} ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'@wordpress/interactivity-router',
+	() => ( {
+		actions: {
+			navigate: jest.fn(),
+		},
+	} ),
+	{ virtual: true }
+);
+
+describe( 'product filters interactivity store', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockGetContext.mockReset();
+		mockGetServerContext.mockReset();
+		mockGetConfig.mockReset();
+		mockRegisteredStore = null;
+
+		jest.isolateModules( () => {
+			require( '../frontend' );
+		} );
+	} );
+
+	[
+		{
+			description: 'unicode value',
+			label: 'Café',
+			value: 'caf%C3%A9',
+			// The canonical result keeps the single encoding for the original unicode value.
+			// Without the explicit decode step the percent signs would be encoded again,
+			// producing `caf%25C3%25A9` instead of the intended `caf%C3%A9`.
+			expectedUrl: 'https://example.com/shop/?color=caf%C3%A9',
+		},
+		{
+			description: 'latin value',
+			label: 'Blue',
+			value: 'blue',
+			expectedUrl: 'https://example.com/shop/?color=blue',
+		},
+	].forEach( ( { description, label, value, expectedUrl } ) => {
+		it( `Test URL encoding before navigation: ${ description }`, () => {
+			if ( ! mockRegisteredStore ) {
+				throw new Error( 'Product filters store was not registered.' );
+			}
+
+			const originalLocation = window.location;
+
+			const locationMock = {
+				href: 'https://example.com/shop/?existing=1',
+			};
+
+			delete ( window as unknown as Record< string, unknown > ).location;
+			Object.defineProperty( window, 'location', {
+				value: locationMock,
+				writable: true,
+				configurable: true,
+			} );
+
+			const canonicalUrl = 'https://example.com/shop/';
+
+			const context = {
+				isOverlayOpened: false,
+				params: {
+					color: value,
+				},
+				activeFilters: [],
+				item: {
+					type: 'attribute/color',
+					label,
+					value,
+					selected: true,
+					count: 1,
+					attributeQueryType: 'or' as const,
+				},
+				activeLabelTemplate: '{{label}}',
+				filterType: 'attribute/color',
+			};
+
+			mockGetContext.mockReturnValue( context );
+			mockGetServerContext.mockReturnValue( context );
+
+			mockGetConfig.mockImplementation( ( key: string ) => {
+				if ( key === 'woocommerce/product-filters' ) {
+					return {
+						canonicalUrl,
+						isProductArchive: true,
+					};
+				}
+				if ( key === 'woocommerce' ) {
+					return {
+						isBlockTheme: true,
+						needsRefreshForInteractivityAPI: false,
+					};
+				}
+				return {};
+			} );
+
+			Object.defineProperty( mockRegisteredStore.state, 'params', {
+				get: () => ( {
+					color: value,
+				} ),
+			} );
+
+			const routerNavigate = jest.fn();
+
+			try {
+				const iterator = mockRegisteredStore.actions.navigate();
+
+				const firstYield = iterator.next();
+				expect( firstYield.done ).toBe( false );
+
+				iterator.next( {
+					actions: {
+						navigate: routerNavigate,
+					},
+				} );
+
+				expect( routerNavigate ).toHaveBeenCalledTimes( 1 );
+				const [ navigatedUrl ] = routerNavigate.mock.calls[ 0 ];
+				const result = new URL( navigatedUrl );
+
+				expect( result.toString() ).toBe( expectedUrl );
+			} finally {
+				Object.defineProperty( window, 'location', {
+					value: originalLocation,
+					writable: true,
+					configurable: true,
+				} );
+			}
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
@@ -55,12 +55,14 @@ describe( 'product filters interactivity store', () => {
 	[
 		{
 			description: 'unicode value',
-			label: 'Café',
-			value: 'caf%C3%A9',
+			label: 'Աուդիոգիրք',
+			value: '%D4%B1%D5%B8%D6%82%D5%A4%D5%AB%D5%B8%D5%A3%D5%AB%D6%80%D6%84',
 			// The canonical result keeps the single encoding for the original unicode value.
 			// Without the explicit decode step the percent signs would be encoded again,
-			// producing `caf%25C3%25A9` instead of the intended `caf%C3%A9`.
-			expectedUrl: 'https://example.com/shop/?color=caf%C3%A9',
+			// producing `%25D4%25B1%25D5%25B8%25D6%2582%25D5%25A4%25D5%25AB%25D5%25B8%25D5%25A3%25D5%25AB%25D6%2580%25D6%2584`
+			// instead of the intended `%D4%B1%D5%B8%D6%82%D5%A4%D5%AB%D5%B8%D5%A3%D5%AB%D6%80%D6%84`.
+			expectedUrl:
+				'https://example.com/shop/?color=%D4%B1%D5%B8%D6%82%D5%A4%D5%AB%D5%B8%D5%A3%D5%AB%D6%80%D6%84',
 		},
 		{
 			description: 'latin value',
@@ -68,96 +70,123 @@ describe( 'product filters interactivity store', () => {
 			value: 'blue',
 			expectedUrl: 'https://example.com/shop/?color=blue',
 		},
-	].forEach( ( { description, label, value, expectedUrl } ) => {
-		it( `Test URL encoding before navigation: ${ description }`, () => {
-			if ( ! mockRegisteredStore ) {
-				throw new Error( 'Product filters store was not registered.' );
-			}
-
-			const originalLocation = window.location;
-
-			const locationMock = {
-				href: 'https://example.com/shop/?existing=1',
-			};
-
-			delete ( window as unknown as Record< string, unknown > ).location;
-			Object.defineProperty( window, 'location', {
-				value: locationMock,
-				writable: true,
-				configurable: true,
-			} );
-
-			const canonicalUrl = 'https://example.com/shop/';
-
-			const context = {
-				isOverlayOpened: false,
-				params: {
-					color: value,
-				},
-				activeFilters: [],
-				item: {
-					type: 'attribute/color',
-					label,
-					value,
-					selected: true,
-					count: 1,
-					attributeQueryType: 'or' as const,
-				},
-				activeLabelTemplate: '{{label}}',
-				filterType: 'attribute/color',
-			};
-
-			mockGetContext.mockReturnValue( context );
-			mockGetServerContext.mockReturnValue( context );
-
-			mockGetConfig.mockImplementation( ( key: string ) => {
-				if ( key === 'woocommerce/product-filters' ) {
-					return {
-						canonicalUrl,
-						isProductArchive: true,
-					};
+		{
+			description: 'malformed encoded value',
+			label: 'Invalid',
+			value: '%E0%A4%A',
+			expectedUrl: 'https://example.com/shop/?color=%25E0%25A4%25A',
+			expectConsoleWarn: true,
+		},
+	].forEach(
+		( {
+			description,
+			label,
+			value,
+			expectedUrl,
+			expectConsoleWarn = false,
+		} ) => {
+			it( `Test URL encoding before navigation: ${ description }`, () => {
+				if ( ! mockRegisteredStore ) {
+					throw new Error(
+						'Product filters store was not registered.'
+					);
 				}
-				if ( key === 'woocommerce' ) {
-					return {
-						isBlockTheme: true,
-						needsRefreshForInteractivityAPI: false,
-					};
-				}
-				return {};
-			} );
 
-			Object.defineProperty( mockRegisteredStore.state, 'params', {
-				get: () => ( {
-					color: value,
-				} ),
-			} );
+				const originalLocation = window.location;
 
-			const routerNavigate = jest.fn();
+				const locationMock = {
+					href: 'https://example.com/shop/?existing=1',
+				};
 
-			try {
-				const iterator = mockRegisteredStore.actions.navigate();
-
-				const firstYield = iterator.next();
-				expect( firstYield.done ).toBe( false );
-
-				iterator.next( {
-					actions: {
-						navigate: routerNavigate,
-					},
-				} );
-
-				expect( routerNavigate ).toHaveBeenCalledTimes( 1 );
-				const [ navigatedUrl ] = routerNavigate.mock.calls[ 0 ];
-				const result = new URL( navigatedUrl );
-
-				expect( result.toString() ).toBe( expectedUrl );
-			} finally {
+				delete ( window as unknown as Record< string, unknown > )
+					.location;
 				Object.defineProperty( window, 'location', {
-					value: originalLocation,
+					value: locationMock,
 					writable: true,
 					configurable: true,
 				} );
-			}
-		} );
-	} );
+
+				const canonicalUrl = 'https://example.com/shop/';
+
+				const context = {
+					isOverlayOpened: false,
+					params: {
+						color: value,
+					},
+					activeFilters: [],
+					item: {
+						type: 'attribute/color',
+						label,
+						value,
+						selected: true,
+						count: 1,
+						attributeQueryType: 'or' as const,
+					},
+					activeLabelTemplate: '{{label}}',
+					filterType: 'attribute/color',
+				};
+
+				mockGetContext.mockReturnValue( context );
+				mockGetServerContext.mockReturnValue( context );
+
+				mockGetConfig.mockImplementation( ( key: string ) => {
+					if ( key === 'woocommerce/product-filters' ) {
+						return {
+							canonicalUrl,
+							isProductArchive: true,
+						};
+					}
+					if ( key === 'woocommerce' ) {
+						return {
+							isBlockTheme: true,
+							needsRefreshForInteractivityAPI: false,
+						};
+					}
+					return {};
+				} );
+
+				Object.defineProperty( mockRegisteredStore.state, 'params', {
+					get: () => ( {
+						color: value,
+					} ),
+				} );
+
+				const routerNavigate = jest.fn();
+				const consoleWarnSpy = jest
+					.spyOn( console, 'warn' )
+					.mockImplementation( () => {} );
+
+				try {
+					const iterator = mockRegisteredStore.actions.navigate();
+
+					const firstYield = iterator.next();
+					expect( firstYield.done ).toBe( false );
+
+					iterator.next( {
+						actions: {
+							navigate: routerNavigate,
+						},
+					} );
+
+					expect( routerNavigate ).toHaveBeenCalledTimes( 1 );
+					const [ navigatedUrl ] = routerNavigate.mock.calls[ 0 ];
+					const result = new URL( navigatedUrl );
+
+					expect( result.toString() ).toBe( expectedUrl );
+
+					expect( consoleWarnSpy ).toHaveBeenCalledTimes(
+						expectConsoleWarn ? 1 : 0
+					);
+				} finally {
+					consoleWarnSpy.mockRestore();
+
+					Object.defineProperty( window, 'location', {
+						value: originalLocation,
+						writable: true,
+						configurable: true,
+					} );
+				}
+			} );
+		}
+	);
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -204,10 +204,23 @@ const productFiltersStore = {
 			}
 
 			for ( const key in state.params ) {
-				searchParams.set(
-					key,
-					decodeURIComponent( state.params[ key ] )
-				);
+				const value = state.params[ key ];
+				let decodedValue = value;
+
+				try {
+					decodedValue = decodeURIComponent( value );
+				} catch ( error ) {
+					if ( error instanceof URIError ) {
+						// eslint-disable-next-line no-console
+						console.warn(
+							'woocommerce/product-filters: Failed to decode filter parameter',
+							key,
+							error
+						);
+					}
+				}
+
+				searchParams.set( key, decodedValue );
 			}
 
 			if ( window.location.href === url.href ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -204,7 +204,10 @@ const productFiltersStore = {
 			}
 
 			for ( const key in state.params ) {
-				searchParams.set( key, state.params[ key ] );
+				searchParams.set(
+					key,
+					decodeURIComponent( state.params[ key ] )
+				);
 			}
 
 			if ( window.location.href === url.href ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Decode filter value before using for navigation so unicode slug can be used for filter

Closes WOOPLUG-5762.
Closes https://github.com/woocommerce/woocommerce/issues/61711.

### Screenshots or screen recordings:

<img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/50d5af2a-413b-409b-aed0-19ce09ebd8ec" />

### How to test the changes in this Pull Request:

1. Create an attribute and add a term in Armenian to it, for example, name it “Աուդիոգիրք”.
2. Use that attribute for some products.
3. Add an Attribute Filter to the shop page.
4. Check the “Աուդիոգիրք” attribute.
5. Confirm filtered results contain products in step 2.

### Testing that has already taken place:

- `pnpm --filter='@woocommerce/block-library' test:js -- product-filters/__tests__/frontend.test.ts`