### PR TITLE
Product Collection: make sure next/prev arrows in carousel layout are visible on a +400% browser zoom

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5661-accessibility-product-collection-carousel-previousnext
+++ b/plugins/woocommerce/changelog/wooplug-5661-accessibility-product-collection-carousel-previousnext
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: make sure next/prev arrows are visible on a +400% browser zoom

--- a/plugins/woocommerce/changelog/wooplug-5661-accessibility-product-collection-carousel-previousnext
+++ b/plugins/woocommerce/changelog/wooplug-5661-accessibility-product-collection-carousel-previousnext
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Product Collection: make sure next/prev arrows are visible on a +400% browser zoom
+Product Collection: make sure next/prev arrows in carousel layout are visible on a +400% browser zoom

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -4,11 +4,16 @@
 	}
 
 	&:has(.is-product-collection-layout-carousel) {
+		// Hide navigation buttons on mobile phones (small touch screens), but keep them
+		// visible on tablets and desktop (even when zoomed).
+		// Combines screen size check with device capability detection.
 		@include breakpoint("<600px") {
-			// This rule is overriding a `display: flex` from WordPress core, that's
-			// why it needs a higher specificity.
-			:where(.wc-block-next-previous-buttons.wc-block-next-previous-buttons) {
-				display: none;
+			@media (hover: none) and (pointer: coarse) {
+				// This rule is overriding a `display: flex` from WordPress core, that's
+				// why it needs a higher specificity.
+				:where(.wc-block-next-previous-buttons.wc-block-next-previous-buttons) {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

ixes an accessibility issue where the Product Collection carousel navigation buttons were being hidden when users zoomed in on desktop browsers.

### Changes
- Updated the CSS media query in `style.scss` to hide navigation buttons only on actual mobile phones (small touch screens)
- Combined screen size check (`<600px`) with device capability detection (`hover: none` and `pointer: coarse`)

### Impact
- ✅ Buttons remain visible on desktop when zoomed in (improves accessibility)
- ✅ Buttons remain visible on tablets (better UX for larger touch devices)
- ✅ Buttons still hidden on mobile phones where swipe gestures are preferred

Closes https://github.com/woocommerce/woocommerce/issues/61324

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1457" height="1285" alt="image" src="https://github.com/user-attachments/assets/d114d827-83b8-4782-85ff-54554c505812" />   |    <img width="1454" height="1285" alt="image" src="https://github.com/user-attachments/assets/23e16bf9-0890-4542-9a14-ff0953f58f31" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Add Product Collection, choose "create your own"
3. Change layout to Carousel
4. Save and go to frontend
5. Zoom the page to 400/500%
6. **Expected:** Make sure the next/prev arrows are visible and clickable
7. Enable mobile view in your browser
8. **Expected:** Make sure next/prev arrows are hidden (this may not be necessarily cover by all the desktop browsers!)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
