### PR TITLE
Fix Product Collection carousel layout a11y

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-collection-carousel-a11y
+++ b/plugins/woocommerce/changelog/fix-product-collection-carousel-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: improve accessibility of carousel layout

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -4,11 +4,16 @@
 	}
 
 	&:has(.is-product-collection-layout-carousel) {
+		// Hide navigation buttons on mobile phones (small touch screens), but keep them
+		// visible on tablets and desktop (even when zoomed).
+		// Combines screen size check with device capability detection.
 		@include breakpoint("<600px") {
-			// This rule is overriding a `display: flex` from WordPress core, that's
-			// why it needs a higher specificity.
-			:where(.wc-block-next-previous-buttons.wc-block-next-previous-buttons) {
-				display: none;
+			@media (hover: none) and (pointer: coarse) {
+				// This rule is overriding a `display: flex` from WordPress core, that's
+				// why it needs a higher specificity.
+				:where(.wc-block-next-previous-buttons.wc-block-next-previous-buttons) {
+					display: none;
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
@@ -96,6 +96,8 @@ $min-product-width: 150px;
 	position: relative; // Create new stacking context
 	container-type: inline-size;
 	container-name: carousel;
+	// Padding to prevent focus outline from being clipped (WCAG 2.4.13).
+	padding: 4px;
 
 	.wc-block-product {
 		scroll-snap-align: center;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -133,8 +133,8 @@ class Renderer {
 				'hideNextPreviousButtons' => false,
 				'isDisabledPrevious'      => true,
 				'isDisabledNext'          => false,
-				'ariaLabelPrevious'       => __( 'Scroll products left', 'woocommerce' ),
-				'ariaLabelNext'           => __( 'Scroll products right', 'woocommerce' ),
+				'ariaLabelPrevious'       => __( 'Previous products', 'woocommerce' ),
+				'ariaLabelNext'           => __( 'Next products', 'woocommerce' ),
 			);
 
 			if ( $collection ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes three accessibility issues in the Product Collection carousel identified during accessibility testing.

### Changes

**1. Navigation button labels (WCAG 1.3.3 - Sensory Characteristics)**
- Updated aria-labels from "Scroll products left/right" to "Previous products/Next products"
- Labels now describe function instead of relying on directional/spatial understanding

**2. Hide buttons on mobile only (not on desktop zoom)**
- Combined screen size check (`<600px`) with device capability detection (`hover: none` and `pointer: coarse`)
- Buttons now remain visible on tablets and zoomed desktop browsers
- Only hidden on actual mobile phones with touch screens

**3. Focus outline visibility (WCAG 2.4.13 - Focus Appearance, Level AAA)**
- Added 4px padding to carousel container to prevent focus outline clipping
- Focus indicators now fully visible on all sides for keyboard users

### Impact
- ✅ Screen reader users understand button purpose without visual context
- ✅ Desktop users can access navigation buttons when zoomed in
- ✅ Keyboard users with low vision can clearly see focus indicators
- ✅ WCAG compliance improvements

Closes #61318
Closes #61324
Closes #61323
(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Add Product Collection, choose "create your own"
3. Change layout to Carousel
4. Save and go to frontend

**Navigation button labels (WCAG 1.3.3 - Sensory Characteristics)** - see https://github.com/woocommerce/woocommerce/issues/61318
1. **Expected:** Check aria labels for next/prev arrows are "Next products" and "Previous products"

**Hide buttons on mobile only (not on desktop zoom)** - see https://github.com/woocommerce/woocommerce/issues/61324
1. Zoom the page to 400/500%
2. Expected: Make sure the next/prev arrows are visible and clickable
3. Enable mobile view in your browser
4. Expected: Make sure next/prev arrows are hidden (this may not be necessarily cover by all the desktop browsers!)

**Focus outline visibility (WCAG 2.4.13 - Focus Appearance, Level AAA)** - see https://github.com/woocommerce/woocommerce/issues/61323
1. Use tab to focus on Product Images
2. **Expected:** the whole outline is visible 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
