### PR TITLE
Performance: Add cache priming for grouped product child product loops

### DIFF
--- a/plugins/woocommerce/changelog/perf-add-cache-priming-for-grouped-products
+++ b/plugins/woocommerce/changelog/perf-add-cache-priming-for-grouped-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Prime caches before fetching child products in grouped product price calculations

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -70,8 +70,15 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * @param WC_Product $product Product object.
 	 */
 	protected function update_prices_from_children( &$product ) {
+		$child_ids    = $product->get_children( 'edit' );
 		$child_prices = array();
-		foreach ( $product->get_children( 'edit' ) as $child_id ) {
+
+		// Prime caches for all child products at once to reduce queries.
+		if ( is_callable( '_prime_post_caches' ) && ! empty( $child_ids ) ) {
+			_prime_post_caches( $child_ids );
+		}
+
+		foreach ( $child_ids as $child_id ) {
 			$child = wc_get_product( $child_id );
 			if ( $child ) {
 				$child_prices[] = $child->get_price( 'edit' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds cache priming before looping over child products in grouped product price calculations. When a grouped product syncs prices from its children, `wc_get_product()` is called for each child. Without cache priming, each call results in a separate database query.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Setup:**

1. Go to **Products > Add New** in wp-admin
2. Create 5-10 simple products with different prices (e.g., $10, $20, $30, $40, $50)
3. Publish all the simple products

**Test grouped product price sync:**

1. Go to **Products > Add New**
2. In the Product data dropdown, select **Grouped product**
3. Go to the **Linked Products** tab
4. In the **Grouped products** field, search and add the simple products you created
5. Click **Publish** to save the grouped product
6. View the grouped product on the frontend
7. Verify the price range displays correctly based on the child products (e.g., "$10.00 - $50.00")

**Test price update propagation:**

1. Edit one of the child simple products
2. Change its price (e.g., from $50 to $60)
3. Save the child product
4. Edit the grouped product and click **Update** (or use a plugin that triggers sync)
5. View the grouped product on the frontend
6. Verify the price range updated to reflect the new child price (e.g., "$10.00 - $60.00")
