### PR TITLE
Add to Cart + Options: hide Product Quantity block if its inner input is hidden

### DIFF
--- a/plugins/woocommerce/changelog/fix-hidden-input-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-hidden-input-add-to-cart-with-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: hide Product Quantity block if its inner input is hidden

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -15,6 +15,10 @@
 	}
 }
 
+:where(.wc-block-add-to-cart-with-options__quantity-selector--hidden) {
+	display: none;
+}
+
 // Set the height to 100% so when the quantity selector is inside a flex
 // container with `verticalAlignment: stretch` (that's the default in WC core
 // templates), the quantity selector will stretch to the height of the container.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -226,10 +226,10 @@ class AddToCartForm extends AbstractBlock {
 		// The quantity input might be hidden if the min and max quantities
 		// returned by `woocommerce_quantity_input_args` are the same.
 		$has_visible_input = Utils::has_visible_quantity_input( $product_html );
-		if ( $has_visible_input ) {
+		if ( $has_visible_input && $is_stepper_style) {
 			$product_name = $product->get_name();
-			$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
-			$product_html = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
+			$product_html = $this->add_steppers( $product_html, $product_name );
+			$product_html = $this->add_stepper_classes_to_add_to_cart_form_input( $product_html );
 		} else {
 			$is_stepper_style = false;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -223,10 +223,17 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
-		$product_name = $product->get_name();
-		$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
+		// The quantity input might be hidden if the min and max quantities
+		// returned by `woocommerce_quantity_input_args` are the same.
+		$has_visible_input = Utils::has_visible_input( $product_html );
+		if ( $has_visible_input ) {
+			$product_name = $product->get_name();
+			$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
+			$product_html = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
+		} else {
+			$is_stepper_style = false;
+		}
 
-		$product_html       = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
 		$product_classname = $is_descendent_of_single_product_block ? 'product' : '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -225,7 +225,7 @@ class AddToCartForm extends AbstractBlock {
 
 		// The quantity input might be hidden if the min and max quantities
 		// returned by `woocommerce_quantity_input_args` are the same.
-		$has_visible_input = Utils::has_visible_input( $product_html );
+		$has_visible_input = Utils::has_visible_quantity_input( $product_html );
 		if ( $has_visible_input ) {
 			$product_name = $product->get_name();
 			$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -223,15 +223,15 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
-		// The quantity input might be hidden if the min and max quantities
-		// returned by `woocommerce_quantity_input_args` are the same.
-		$has_visible_input = Utils::has_visible_quantity_input( $product_html );
-		if ( $has_visible_input && $is_stepper_style) {
+		// If the quantity input is hidden, don't render the stepper buttons and styles.
+		if ( $is_stepper_style && ! Utils::has_visible_quantity_input( $product_html ) ) {
+			$is_stepper_style = false;
+		}
+
+		if ( $is_stepper_style ) {
 			$product_name = $product->get_name();
 			$product_html = $this->add_steppers( $product_html, $product_name );
 			$product_html = $this->add_stepper_classes_to_add_to_cart_form_input( $product_html );
-		} else {
-			$is_stepper_style = false;
 		}
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -64,6 +64,7 @@ class QuantitySelector extends AbstractBlock {
 
 		if ( AddToCartWithOptionsUtils::is_min_max_quantity_same( $product ) ) {
 			$product = $previous_product;
+
 			return '';
 		}
 
@@ -85,8 +86,16 @@ class QuantitySelector extends AbstractBlock {
 
 		$product_html = ob_get_clean();
 
-		$product_name = $product->get_name();
+		// The quantity input might be hidden if the min and max quantities
+		// returned by `woocommerce_quantity_input_args` are the same.
+		$has_visible_input = AddToCartWithOptionsUtils::has_visible_input( $product_html );
+		if ( ! $has_visible_input ) {
+			$product = $previous_product;
 
+			return '';
+		}
+
+		$product_name = $product->get_name();
 		$product_html = AddToCartWithOptionsUtils::add_quantity_steppers( $product_html, $product_name );
 		$product_html = AddToCartWithOptionsUtils::add_quantity_stepper_classes( $product_html );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -86,8 +86,7 @@ class QuantitySelector extends AbstractBlock {
 
 		$product_html = ob_get_clean();
 
-		// The quantity input might be hidden if the min and max quantities
-		// returned by `woocommerce_quantity_input_args` are the same.
+		// If the quantity input is hidden, don't render the stepper buttons and styles.
 		$has_visible_quantity_input = AddToCartWithOptionsUtils::has_visible_quantity_input( $product_html );
 		if ( $has_visible_quantity_input ) {
 			$product_name = $product->get_name();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -88,7 +88,7 @@ class QuantitySelector extends AbstractBlock {
 
 		// The quantity input might be hidden if the min and max quantities
 		// returned by `woocommerce_quantity_input_args` are the same.
-		$has_visible_input = AddToCartWithOptionsUtils::has_visible_input( $product_html );
+		$has_visible_input = AddToCartWithOptionsUtils::has_visible_quantity_input( $product_html );
 		if ( ! $has_visible_input ) {
 			$product = $previous_product;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -88,16 +88,12 @@ class QuantitySelector extends AbstractBlock {
 
 		// The quantity input might be hidden if the min and max quantities
 		// returned by `woocommerce_quantity_input_args` are the same.
-		$has_visible_input = AddToCartWithOptionsUtils::has_visible_quantity_input( $product_html );
-		if ( ! $has_visible_input ) {
-			$product = $previous_product;
-
-			return '';
+		$has_visible_quantity_input = AddToCartWithOptionsUtils::has_visible_quantity_input( $product_html );
+		if ( $has_visible_quantity_input ) {
+			$product_name = $product->get_name();
+			$product_html = AddToCartWithOptionsUtils::add_quantity_steppers( $product_html, $product_name );
+			$product_html = AddToCartWithOptionsUtils::add_quantity_stepper_classes( $product_html );
 		}
-
-		$product_name = $product->get_name();
-		$product_html = AddToCartWithOptionsUtils::add_quantity_steppers( $product_html, $product_name );
-		$product_html = AddToCartWithOptionsUtils::add_quantity_stepper_classes( $product_html );
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
@@ -107,6 +103,7 @@ class QuantitySelector extends AbstractBlock {
 				array(
 					'wp-block-add-to-cart-with-options-quantity-selector wc-block-add-to-cart-with-options__quantity-selector',
 					esc_attr( $classes_and_styles['classes'] ),
+					$has_visible_quantity_input ? '' : 'wc-block-add-to-cart-with-options__quantity-selector--hidden',
 				)
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -12,16 +12,20 @@ use WP_Block;
  */
 class Utils {
 	/**
-	 * Check if the HTML content has a visible input.
+	 * Check if the HTML content has a visible quantity input.
 	 *
 	 * @param string $html_content The HTML content.
 	 * @return bool True if the HTML content has a visible input, false otherwise.
 	 */
-	public static function has_visible_input( $html_content ) {
+	public static function has_visible_quantity_input( $html_content ) {
 		$processor = new \WP_HTML_Tag_Processor( $html_content );
 
 		while ( $processor->next_tag() ) {
-			if ( $processor->get_tag() === 'INPUT' && $processor->get_attribute( 'type' ) !== 'hidden' ) {
+			if (
+				$processor->get_tag() === 'INPUT' &&
+				$processor->get_attribute( 'name' ) === 'quantity' &&
+				$processor->get_attribute( 'type' ) !== 'hidden'
+			) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -12,6 +12,22 @@ use WP_Block;
  */
 class Utils {
 	/**
+	 * Check if the HTML content has a visible input.
+	 *
+	 * @param string $html_content The HTML content.
+	 * @return bool True if the HTML content has a visible input, false otherwise.
+	 */
+	public static function has_visible_input( $html_content ) {
+		$processor = new \WP_HTML_Tag_Processor( $html_content );
+
+		while ( $processor->next_tag() ) {
+			if ( $processor->get_tag() === 'INPUT' && $processor->get_attribute( 'type' ) !== 'hidden' ) {
+				return true;
+			}
+		}
+		return false;
+	}
+	/**
 	 * Add increment and decrement buttons to the quantity input field.
 	 *
 	 * @param string $quantity_html Quantity input HTML.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -468,7 +468,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 			// Quantity selector block should not render at all.
-			$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Quantity Selector block is not rendered when min equals max.' );
+			$this->assertStringContainsString( 'wc-block-add-to-cart-with-options__quantity-selector--hidden', $markup, 'The Quantity Selector block is hidden when min equals max.' );
 
 			// Plus and minus stepper buttons should not be present.
 			$this->assertStringNotContainsString( 'wc-block-components-quantity-selector__button--plus', $markup, 'The plus stepper is not rendered when min equals max.' );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -443,4 +443,38 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			'The Product Price block should be interactive when some variations have different prices.'
 		);
 	}
+
+	/**
+	 * Tests that the quantity selector and its steppers are hidden when
+	 * a filter sets min and max quantity to the same value for a product.
+	 */
+	public function test_quantity_selector_hidden_when_min_equals_max() {
+		$simple_product = new \WC_Product_Simple();
+		$simple_product->set_regular_price( 10 );
+		$product_id = $simple_product->save();
+
+		// Force min and max quantity to be the same via filter for this product only.
+		$filter = function ( $args, $product ) use ( $product_id ) {
+			if ( $product instanceof \WC_Product && $product->get_id() === $product_id ) {
+				$args['min_value'] = 3;
+				$args['max_value'] = 3;
+			}
+			return $args;
+		};
+
+		add_filter( 'woocommerce_quantity_input_args', $filter, 10, 2 );
+
+		try {
+			$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+			// Quantity selector block should not render at all.
+			$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Quantity Selector block is not rendered when min equals max.' );
+
+			// Plus and minus stepper buttons should not be present.
+			$this->assertStringNotContainsString( 'wc-block-components-quantity-selector__button--plus', $markup, 'The plus stepper is not rendered when min equals max.' );
+			$this->assertStringNotContainsString( 'wc-block-components-quantity-selector__button--minus', $markup, 'The minus stepper is not rendered when min equals max.' );
+		} finally {
+			remove_filter( 'woocommerce_quantity_input_args', $filter, 10 );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some extensions were using the `woocommerce_quantity_input_args` filter (instead of `woocommerce_quantity_input_min/max`) to set the min and max quantities to the same value to avoid the quantity input being rendered. However, the non-blockified _Add to Cart with Options_ block in _Stepper_ mode and the blockified _Add to Cart + Options_ block weren't checking if the input was actually visible before adding the stepper buttons. Which caused the stepper buttons to display but the input to be hidden.

This PR fixes that by checking if the quantity input is hidden, in which case we don't add the stepper buttons and styling.

### How to test the changes in this Pull Request:

**With custom code:**

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_, select the non-blockified _Add to Cart with Options_ and change its style from _Input_ to _Stepper_.
2. Add this code snippet changing the product ID to a product in your store:

```PHP
add_filter( 'woocommerce_quantity_input_args', function( $args, $product ) {
	if ( $product->get_id() === 70 ) {
		$args['max_value'] = 3;
		$args['min_value'] = 3;
	}
	return $args;
}, 10, 2 );
```

3. Visit the frontend of the product.
4. Verify you can't see the stepper buttons and you can add to cart without problems (verify when adding to cart, three items are added).
5. Go back to the template editor, select the _Add to Cart with Options_ block and replace it with the blockified _Add to Cart + Options (Beta)_ block.
6. Repeat steps 3-4.

**With an extension:**

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_, select the non-blockified _Add to Cart with Options_ and change its style from _Input_ to _Stepper_.
2. Install [WooCommerce Gift Cards](https://woocommerce.com/products/gift-cards/).
3. Visit the front-end of a _Gift card_ product.
4. Verify you can't see the stepper buttons and you can add to cart without problems.

Before | After
--- | ---
<img width="945" height="508" alt="imatge" src="https://github.com/user-attachments/assets/af66b72b-9d88-4770-8848-8adc9deb6e04" /> | <img width="945" height="508" alt="imatge" src="https://github.com/user-attachments/assets/02a8e447-0231-4cd9-9633-427dec10319a" />

5. Go back to the template editor, select the _Add to Cart with Options_ block and replace it with the blockified _Add to Cart + Options (Beta)_ block.
6. Repeat steps 2-3.