### PR TITLE
Remove price filter widget accounting script deprecation notice

### DIFF
--- a/plugins/woocommerce/changelog/update-remove-widget-script-deprecation
+++ b/plugins/woocommerce/changelog/update-remove-widget-script-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove price filter widget accounting script deprecation notice

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-price-filter.php
@@ -56,24 +56,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 			wp_enqueue_script( 'wc-price-slider' );
 		}
 
-		add_action( 'shutdown', array( $this, 'add_legacy_script_warnings' ) );
-
 		parent::__construct();
-	}
-
-	/**
-	 * Add warnings for deprecated script handles.
-	 */
-	public function add_legacy_script_warnings() {
-		$exists = wp_script_is( 'accounting' );
-		if ( $exists ) {
-			wc_deprecated_argument(
-				'wp_enqueue_script',
-				'10.3.0',
-				/* translators: %1$s: new script handle, %2$s: previous script handle */
-				sprintf( __( 'Please use the new handle %1$s in place of the previous handle %2$s.', 'woocommerce' ), 'wc-accounting', 'accounting' )
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We decided to remove the deprecation notices from script handles in https://github.com/woocommerce/woocommerce/pull/61669, however one was missed in this widget.  This removes that extra notice for any plugins using `accounting` on the frontend.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet to your site:
```php
add_action('wp_enqueue_scripts', function() {
	wp_enqueue_script( 'accounting' );
});
```
2. Check that your debug log has no deprecation notices

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the price filter widget’s accounting deprecation notice, refactors payments providers to drop LegacyProxy and tweak WooPayments onboarding (incl. experiment), and updates the Product Gallery block to “(Beta)” with a legacy rendering fallback plus small CSS/ARIA/test/documentation and email-editor changelog/version syncs.
> 
> - **Blocks/UI**:
>   - **Product Gallery**: Rename title to `Product Gallery (Beta)` in `block.json`; add temporary legacy rendering fallback in `ProductGalleryLargeImage` with corresponding legacy styles; adjust mobile/carousel CSS and pagination ARIA labels.
>   - **E2E tests**: Update selectors/labels to `Product Gallery (Beta)` and verify behaviors accordingly.
> - **Widget**:
>   - Remove `accounting` deprecation warning from `WC_Widget_Price_Filter` (drop shutdown hook); add changelog entry.
> - **Payments (Admin Settings)**:
>   - Remove `LegacyProxy` dependency from providers; instantiate providers directly in `PaymentsProviders` and `PaymentGateway`.
>   - WooPayments: switch to direct class/static calls, refine onboarding URL params and add A/B test for live vs test-drive onboarding; simplify WPCOM connection state retrieval.
>   - Update/expand unit tests and add `WC_Payments_Utils` mock for coverage.
> - **Docs**:
>   - Refresh blocks reference (supports/ancestors), remove obsolete category description/title entries, and reflect Product Gallery “(Beta)”.
> - **Email Editor**:
>   - Sync changelog/version (revert to `1.2.0`) and add changefile to export personalization components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d22c291e0704b0b580801d27de0f101a5bcd14c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->