### PR TITLE
Remove the word 'blockified' from user-facing strings

### DIFF
--- a/plugins/woocommerce/changelog/fix-blockified-copy-updates
+++ b/plugins/woocommerce/changelog/fix-blockified-copy-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove the word 'blockified' from user-facing strings
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -34,7 +34,7 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade to the <strongText /> to gain access to more customization options.',
+			'Upgrade to the <strongText /> to gain access to more customization options. You can always switch back.',
 			'woocommerce'
 		),
 		{

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -34,13 +34,13 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Gain access to more customization options when you upgrade to the <strongText />.',
+			'Upgrade to the <strongText /> to gain access to more customization options.',
 			'woocommerce'
 		),
 		{
 			strongText: (
 				<strong>
-					{ __( `blockified experience`, 'woocommerce' ) }
+					{ __( `Product Gallery block`, 'woocommerce' ) }
 				</strong>
 			),
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/upgrade-notice.tsx
@@ -34,7 +34,7 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade to the <strongText /> to gain access to more customization options. You can always switch back.',
+			'Upgrade to the <strongText /> for more flexibility.',
 			'woocommerce'
 		),
 		{
@@ -46,10 +46,7 @@ export const UpgradeNotice = ( {
 		}
 	);
 
-	const buttonLabel = __(
-		'Upgrade to the new Product Gallery block',
-		'woocommerce'
-	);
+	const buttonLabel = __( 'Use the Product Gallery block', 'woocommerce' );
 
 	return (
 		<UpgradeDowngradeNotice

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -40,7 +40,7 @@ export const UpgradeProductImageGallery = () => {
 	);
 
 	const buttonLabel = __(
-		'Upgrade to the blockified Product Gallery',
+		'Upgrade to the Product Gallery block',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -35,7 +35,7 @@ export const UpgradeProductImageGallery = () => {
 	}
 
 	const notice = __(
-		'This template contains the classic Product Image Gallery block which is not compatible with the Add to Cart + Options block. Switch to the new Product Gallery block for a better experience.',
+		'This template contains the classic Product Image Gallery block which is not compatible with the Add to Cart + Options block. Switch to the new Product Gallery block for a better experience. You can always switch back.',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/upgrade-product-image-gallery/index.tsx
@@ -35,7 +35,7 @@ export const UpgradeProductImageGallery = () => {
 	}
 
 	const notice = __(
-		'This template contains the classic Product Image Gallery block which is not compatible with the Add to Cart + Options block. Switch to the new Product Gallery block for a better experience. You can always switch back.',
+		'This template contains the classic Product Image Gallery block which is not compatible with the Add to Cart + Options block. Switch to the new Product Gallery block for a better experience.',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -44,7 +44,7 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade to the <strongText /> to gain access to more customization options.',
+			'Upgrade to the <strongText /> to gain access to more customization options. You can always switch back.',
 			'woocommerce'
 		),
 		{

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -44,13 +44,13 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Gain access to more customization options when you upgrade to the <strongText />.',
+			'Upgrade to the <strongText /> to gain access to more customization options.',
 			'woocommerce'
 		),
 		{
 			strongText: (
 				<strong>
-					{ __( `blockified experience`, 'woocommerce' ) }
+					{ __( `Add to Cart + Options block`, 'woocommerce' ) }
 				</strong>
 			),
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -44,7 +44,7 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade to the <strongText /> to gain access to more customization options. You can always switch back.',
+			'Upgrade to the <strongText /> for more flexibility. You can switch back anytime.',
 			'woocommerce'
 		),
 		{
@@ -57,7 +57,7 @@ export const UpgradeNotice = ( {
 	);
 
 	const buttonLabel = __(
-		'Upgrade to the Add to Cart + Options block',
+		'Use the Add to Cart + Options block',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -507,7 +507,7 @@ test.describe( `${ blockData.name } Block`, () => {
 
 		await page
 			.getByRole( 'button', {
-				name: 'Upgrade to the Add to Cart + Options block',
+				name: 'Use the Add to Cart + Options block',
 			} )
 			.click();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1004,7 +1004,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page
 			.getByRole( 'button', {
-				name: 'Upgrade to the blockified Product Gallery',
+				name: 'Upgrade to the Product Gallery block',
 			} )
 			.click();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -74,7 +74,7 @@ class AddToCartWithOptionsPage {
 
 		await this.page
 			.getByRole( 'button', {
-				name: 'Upgrade to the Add to Cart + Options block',
+				name: 'Use the Add to Cart + Options block',
 			} )
 			.click();
 	}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -118,7 +118,7 @@ test.describe( `${ blockData.name } editor`, () => {
 
 		await page
 			.getByRole( 'button', {
-				name: 'Upgrade to the new Product Gallery block',
+				name: 'Use the Product Gallery block',
 			} )
 			.click();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -190,7 +190,7 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 
 		await page
 			.getByRole( 'button', {
-				name: 'Upgrade to the Add to Cart + Options block',
+				name: 'Use the Add to Cart + Options block',
 			} )
 			.click();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Updates a few copies in the UI to avoid the word 'blockified'.
* Add a _You can switch back anytime_ to the _Add to Cart + Options_ upgrade notice. I didn't add it to the other blocks as they are stable and don't have downgrade notices.

More context in p1762339437220179/1761901979.572139-slack-C02UBB1EPEF.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Select the _Product Image_ block (insert it if not already in your template) and verify the copy in the sidebar is like the one in _after_:

Before | After
--- | ---
<img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/6561f1c0-c4ba-47d3-af57-f03009c97758" /> | <img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/52448c52-3f1f-4c87-9ec2-b36a28818106" />

3. Select the non-blockified _Add to Cart with Options_ block (insert it if not already in your template) and verify the copy in the sidebar is like the one in _after_:

Before | After
--- | ---
<img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/374e43c0-9e1a-494e-9843-bf8868351830" /> | <img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/49d43471-1986-4e63-920a-8b332386262a" />

4. Select the blockified _Add to Cart + Options_ block (insert it if not already in your template) and verify the copy in the sidebar is like the one in _after_:

Before | After
--- | ---
<img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/a1257b71-ddc1-4753-979e-64d598487783" /> | <img width="439" height="1011" alt="imatge" src="https://github.com/user-attachments/assets/6738db5b-5795-49aa-9e36-3c36e746a5a8" />