### PR TITLE
Prevent saving dummy products in email preview

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5790-woocommerce-core-creates-dummy-order-items-when-email
+++ b/plugins/woocommerce/changelog/wooplug-5790-woocommerce-core-creates-dummy-order-items-when-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent saving the dummy products in email preview

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -12,10 +12,11 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Throwable;
 use WC_Email;
 use WC_Order;
+use WC_Order_Item_Product;
+use WC_Order_Item_Shipping;
 use WC_Product;
 use WC_Product_Variation;
 use WP_User;
-use WC_Order_Item_Shipping;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -372,16 +373,57 @@ class EmailPreview {
 		$downloadable_product = $this->get_dummy_downloadable_product();
 
 		$order = new WC_Order();
+		$order->set_id( 12345 );
+
+		// Create and add product items manually without saving to database.
+		// Use add_item() instead of add_product() to avoid immediate database writes.
 		if ( $product ) {
-			$order->add_product( $product, 2 );
+			$item = new WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'name'         => $product->get_name(),
+					'tax_class'    => $product->get_tax_class(),
+					'product_id'   => $product->get_id(),
+					'variation_id' => 0,
+					'quantity'     => 2,
+					'subtotal'     => $product->get_price() * 2,
+					'total'        => $product->get_price() * 2,
+				)
+			);
+			$order->add_item( $item );
 		}
 		if ( $variation ) {
-			$order->add_product( $variation );
+			$item = new WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'name'         => $variation->get_name(),
+					'tax_class'    => $variation->get_tax_class(),
+					'product_id'   => $variation->get_parent_id(),
+					'variation_id' => $variation->get_id(),
+					'variation'    => $variation->get_attributes(),
+					'quantity'     => 1,
+					'subtotal'     => $variation->get_price(),
+					'total'        => $variation->get_price(),
+				)
+			);
+			$order->add_item( $item );
 		}
 		if ( $downloadable_product ) {
-			$order->add_product( $downloadable_product );
+			$item = new WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'name'         => $downloadable_product->get_name(),
+					'tax_class'    => $downloadable_product->get_tax_class(),
+					'product_id'   => $downloadable_product->get_id(),
+					'variation_id' => 0,
+					'quantity'     => 1,
+					'subtotal'     => $downloadable_product->get_price(),
+					'total'        => $downloadable_product->get_price(),
+				)
+			);
+			$order->add_item( $item );
 		}
-		$order->set_id( 12345 );
+
 		$order->set_date_created( time() );
 		$order->set_currency( 'USD' );
 		$order->set_discount_total( 10 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the email settings page is visited, WooCommerce core creates dummy order items in the database.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #61790 WOOPLUG-5790.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="2528" height="2026" alt="Screenshot 2025-11-05 at 11 23 20" src="https://github.com/user-attachments/assets/665dff1b-14d8-4bd1-9f8a-cb22deb6b96a" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Enable modern email design for transactional emails
2. Visit `wp-admin/admin.php?page=wc-settings&tab=email`
3. Observe no dummy products are stored in the database

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
