### PR TITLE
Prevent unnecessary queries for non-existent options on admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-61817
+++ b/plugins/woocommerce/changelog/fix-61817
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent unnecessary querying of non-existent options on the admin.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -177,6 +177,12 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 			$option_key = $setting['option_key'];
 			$setting    = $this->filter_setting( $setting );
 			$default    = isset( $setting['default'] ) ? $setting['default'] : '';
+
+			if ( in_array( $setting['type'] ?? '', array( 'title', 'sectionend' ), true ) ) {
+				$filtered_settings[] = $setting;
+				continue;
+			}
+
 			// Get the option value.
 			if ( is_array( $option_key ) ) {
 				$option           = get_option( $option_key[0] );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -87,6 +87,12 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 			$option_key = $setting['option_key'];
 			$setting    = $this->filter_setting( $setting );
 			$default    = isset( $setting['default'] ) ? $setting['default'] : '';
+
+			if ( in_array( $setting['type'] ?? '', array( 'title', 'sectionend' ), true ) ) {
+				$filtered_settings[] = $setting;
+				continue;
+			}
+
 			// Get the option value.
 			if ( is_array( $option_key ) ) {
 				$option           = get_option( $option_key[0] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR skips fetching option values for `title` and `sectionend` settings in the REST controllers to avoid unnecessary queries.

Closes #61817.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Install and activate Query Monitor on your test site.
1. Open any WooCommerce admin page.
1. Open your browser's console and confirm that the object `wcSettings.admin.preloadSettings.general` includes preloaded options.
1. Open Query Monitor and ensure that there are no queries associated to options `store_address`, `general_options`, `taxes_and_coupons_options` or `pricing_options`.
   Filtering by `Caller: get_option()` should make this easier.
   <img width="1512" height="97" alt="Screenshot 2025-11-05 at 16 30 23" src="https://github.com/user-attachments/assets/836f9f1a-3dda-46ff-a9ba-231c800b59a8" />
1. (Optional) Repeat 1-3 on `trunk` but notice the invalid `get_option()` related queries.

<!-- End testing instructions -->