### PR TITLE
Use different text in the product button block for the cart contents collection

### DIFF
--- a/packages/php/email-editor/changelog/add-cart-button-text
+++ b/packages/php/email-editor/changelog/add-cart-button-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add support for conditional "Finish checkout" button text in cart collections for email rendering

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-button.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-button.php
@@ -69,13 +69,23 @@ class Product_Button extends Abstract_Product_Block_Renderer {
 			return '';
 		}
 
-		$button_text = $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
+		// Check if this is a cart-contents collection to customize button text and link.
+		$collection       = $parsed_block['context']['collection'] ?? '';
+		$is_cart_contents = 'woocommerce/product-collection/cart-contents' === $collection;
 
-		if ( $product->is_type( 'external' ) && $product instanceof \WC_Product_External ) {
-			$external_url = $product->get_product_url();
-			$button_url   = $external_url ? $external_url : $product->get_permalink();
+		if ( $is_cart_contents ) {
+			// For cart contents, link to cart page instead of product page.
+			$button_text = __( 'Finish checkout', 'woocommerce' );
+			$button_url  = wc_get_cart_url();
 		} else {
-			$button_url = $product->get_permalink();
+			$button_text = $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
+
+			if ( $product->is_type( 'external' ) && $product instanceof \WC_Product_External ) {
+				$external_url = $product->get_product_url();
+				$button_url   = $external_url ? $external_url : $product->get_permalink();
+			} else {
+				$button_url = $product->get_permalink();
+			}
 		}
 
 		$block_attributes = array_replace_recursive(

--- a/plugins/woocommerce/changelog/add-cart-button-text
+++ b/plugins/woocommerce/changelog/add-cart-button-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add support for conditional "Finish checkout" button text in cart collections for email rendering

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
@@ -8,6 +8,7 @@
 		"query",
 		"queryId",
 		"postId",
+		"collection",
 		"woocommerce/isDescendantOfAddToCartWithOptions"
 	],
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
@@ -22,6 +22,7 @@ export interface BlockAttributes {
 	blockClientId?: string;
 	product?: ProductEntityResponse | undefined;
 	isAdmin?: boolean | undefined;
+	collection?: string | undefined;
 }
 
 export interface AddToCartProductDetails {
@@ -53,4 +54,5 @@ export interface AddToCartButtonAttributes {
 		button_text: string;
 	};
 	textAlign?: ( WithClass & WithStyle ) | undefined;
+	collection?: string | undefined;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- This PR changes the text of the Add to cart button when the block is used in the Cart contents block variant to the text "Finish checkout"
- The new text is supported in the email editor and also in the email preview
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPRD-1102

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="664" height="902" alt="Screenshot 2025-11-06 at 18 21 43" src="https://github.com/user-attachments/assets/19cc5e52-80e3-4768-9360-9059b2272e5f" />|<img width="645" height="901" alt="Screenshot 2025-11-06 at 18 10 35" src="https://github.com/user-attachments/assets/99e10546-200a-42ca-b809-4a931d8f0572" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use the Cart contents variant of the Product collection block in the email block editor
2. Verify that the text "Finish checkout" is visible in the editor
3. Verify that the same text is used in rendered emails

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
