### PR TITLE
Add delete operation to orders MCP tool

### DIFF
--- a/plugins/woocommerce/changelog/add-mcp-orders-delete-operation
+++ b/plugins/woocommerce/changelog/add-mcp-orders-delete-operation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add delete operation to orders MCP tool.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -40,11 +40,11 @@ class AbilitiesRestBridge {
 			),
 			array(
 				'id'          => 'woocommerce/orders',
-				'operations'  => array( 'list', 'get', 'create', 'update' ),
+				'operations'  => array( 'list', 'get', 'create', 'update', 'delete' ),
 				'controller'  => \WC_REST_Orders_Controller::class,
 				'route'       => '/wc/v3/orders',
 				'label'       => __( 'Manage orders', 'woocommerce' ),
-				'description' => __( 'Manage WooCommerce orders. Use action parameter to list, get, create, or update orders.', 'woocommerce' ),
+				'description' => __( 'Manage WooCommerce orders. Use action parameter to list, get, create, update, or delete orders.', 'woocommerce' ),
 			),
 		);
 	}


### PR DESCRIPTION
## Summary

Extends the unified orders MCP tool to support delete operations, providing feature parity with the products tool.

## Changes

- Added `delete` to the operations array for `woocommerce/orders` in `AbilitiesRestBridge`
- Updated description to mention delete capability
- Tested delete operation successfully

## Testing

- ✅ Created test order (ID 137)
- ✅ Deleted order using `action: delete` with `force: true`
- ✅ Verified deletion (get returns 404)
- ✅ All PHPUnit tests passing (10/10)
- ✅ PHP linting clean

FIXES WOOAI-145

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)