### PR TITLE
Prevent warnings coming from checkout block settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-site-editor-warnings
+++ b/plugins/woocommerce/changelog/fix-site-editor-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+prevent block settings warnings for checkout areas

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/express-payment-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/express-payment-settings.tsx
@@ -165,6 +165,7 @@ export const ExpressPaymentControls = ( {
 					className="express-payment-button-settings"
 				>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ toggleLabel }
 						checked={ attributes.showButtonStyles }
 						onChange={ () =>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/block-settings/index.tsx
@@ -18,6 +18,7 @@ export const BlockSettings = ( {
 		<InspectorControls>
 			<PanelBody title={ __( 'Style', 'woocommerce' ) }>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label={ __( 'Show form step numbers', 'woocommerce' ) }
 					checked={ showFormStepNumbers }
 					onChange={ () =>
@@ -27,6 +28,7 @@ export const BlockSettings = ( {
 					}
 				/>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label={ __( 'Dark mode inputs', 'woocommerce' ) }
 					help={ __(
 						'Inputs styled specifically for use on dark background colors.',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/edit.tsx
@@ -43,6 +43,8 @@ const Edit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 					<ToggleGroupControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						className="wc-block-editor-mini-cart__cart-icon-toggle"
 						isBlock
 						label={ __( 'Cart Icon', 'woocommerce' ) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/edit.tsx
@@ -40,6 +40,7 @@ export const Edit = ( {
 					! displayCartPricesIncludingTax && (
 						<PanelBody title={ __( 'Taxes', 'woocommerce' ) }>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								label={ __(
 									'Show rate after tax name',
 									'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-field-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-field-controls.tsx
@@ -52,6 +52,7 @@ export const AddressFieldControls = (): JSX.Element => {
 					) }
 				</p>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label={ __( 'Company', 'woocommerce' ) }
 					checked={ ! defaultFields.company.hidden }
 					onChange={ () => {
@@ -78,6 +79,7 @@ export const AddressFieldControls = (): JSX.Element => {
 					/>
 				) }
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label={ __( 'Address line 2', 'woocommerce' ) }
 					checked={ ! defaultFields.address_2.hidden }
 					onChange={ () => {
@@ -104,6 +106,7 @@ export const AddressFieldControls = (): JSX.Element => {
 					/>
 				) }
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label={ __( 'Phone', 'woocommerce' ) }
 					checked={ ! defaultFields.phone.hidden }
 					onChange={ () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -76,6 +76,8 @@ export const Edit = ( {
 
 					{ showPrice && (
 						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Price separator', 'woocommerce' ) }
 							id="price-separator"
 							value={ attributes.priceSeparator }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -57,6 +57,7 @@ export const Edit = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Options', 'woocommerce' ) }>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ __(
 							'Show a "Return to Cart" link',
 							'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/edit.tsx
@@ -33,6 +33,7 @@ export const Edit = ( {
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							label={ __(
 								'Disable product descriptions',
 								'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/edit.tsx
@@ -40,6 +40,7 @@ export const Edit = ( {
 					! displayCartPricesIncludingTax && (
 						<PanelBody title={ __( 'Taxes', 'woocommerce' ) }>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								label={ __(
 									'Show rate after tax name',
 									'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -222,6 +222,7 @@ export const Edit = ( {
 						) }
 					</p>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ __( 'Show icon', 'woocommerce' ) }
 						checked={ showIcon }
 						onChange={ () =>
@@ -231,6 +232,7 @@ export const Edit = ( {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ __( 'Show costs', 'woocommerce' ) }
 						checked={ showPrice }
 						onChange={ () =>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -121,6 +121,7 @@ export const Edit = ( {
 					) }
 				<PanelBody title={ __( 'Display options', 'woocommerce' ) }>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ __( 'Require checkbox', 'woocommerce' ) }
 						checked={ checkbox }
 						onChange={ () =>
@@ -130,6 +131,7 @@ export const Edit = ( {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						label={ __( 'Show separator', 'woocommerce' ) }
 						checked={ showSeparator }
 						onChange={ () =>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -69,6 +69,8 @@ export const BlockSettings = ( {
 			</PanelBody>
 			<PanelBody title={ __( 'Display settings', 'woocommerce' ) }>
 				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
 					className="customer-account-display-style"
 					label={ __( 'Icon options', 'woocommerce' ) }
 					value={ displayStyle }
@@ -96,6 +98,8 @@ export const BlockSettings = ( {
 				/>
 				{ displayIconStyleSelector ? (
 					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						label={ __( 'Display Style', 'woocommerce' ) }
 						isBlock
 						value={ iconStyle }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
@@ -119,6 +119,8 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 					<ToggleGroupControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						className="wc-block-editor-mini-cart__cart-icon-toggle"
 						isBlock
 						label={ __( 'Cart Icon', 'woocommerce' ) }
@@ -143,10 +145,13 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						/>
 					</ToggleGroupControl>
 					<BaseControl
+						__nextHasNoMarginBottom
 						id="wc-block-mini-cart__display-toggle"
 						label={ __( 'Display', 'woocommerce' ) }
 					>
 						<ToggleControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Display total price', 'woocommerce' ) }
 							help={ __(
 								'Toggle to display the total price of products in the shopping cart. If no products have been added, the price will not display.',
@@ -161,6 +166,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						/>
 					</BaseControl>
 					<BaseControl
+						__nextHasNoMarginBottom
 						id="wc-block-mini-cart__product-count-basecontrol"
 						label={ __( 'Show Cart Item Count:', 'woocommerce' ) }
 					>
@@ -200,6 +206,8 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					</BaseControl>
 					{ isSiteEditor && (
 						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							className="wc-block-editor-mini-cart__render-in-cart-and-checkout-toggle"
 							label={ __(
 								'Mini-Cart in cart and checkout pages',
@@ -257,10 +265,12 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						</>
 					) }
 					<BaseControl
+						__nextHasNoMarginBottom
 						id="wc-block-mini-cart__add-to-cart-behaviour-toggle"
 						label={ __( 'Behavior', 'woocommerce' ) }
 					>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							label={ __(
 								'Open drawer when adding',
 								'woocommerce'
@@ -279,6 +289,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							checked={ addToCartBehaviour === 'open_drawer' }
 						/>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							label={ __(
 								'Navigate to checkout when clicking the Mini-Cart, instead of opening the drawer.',
 								'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -79,6 +79,7 @@ const Edit = ( {
 					initialOpen
 				>
 					<UnitControl
+						__next40pxDefaultSize
 						onChange={ ( value ) => {
 							setAttributes( { width: value } );
 						} }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -112,6 +112,7 @@ export const Edit = ( {
 				<InspectorControls>
 					<PanelBody title={ __( 'Style', 'woocommerce' ) }>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							label={ __( 'Dark mode inputs', 'woocommerce' ) }
 							help={ __(
 								'Inputs styled specifically for use on dark background colors.',

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/grid-layout-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/grid-layout-control/index.tsx
@@ -56,6 +56,8 @@ const GridLayoutControl = ( {
 	return (
 		<>
 			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 				label={ __( 'Columns', 'woocommerce' ) }
 				value={ columns }
 				onChange={ ( value: number ) => {
@@ -68,6 +70,8 @@ const GridLayoutControl = ( {
 				max={ maxColumns }
 			/>
 			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 				label={ __( 'Rows', 'woocommerce' ) }
 				value={ rows }
 				onChange={ ( value: number ) => {
@@ -80,6 +84,7 @@ const GridLayoutControl = ( {
 				max={ maxRows }
 			/>
 			<ToggleControl
+				__nextHasNoMarginBottom
 				label={ __(
 					'Align the last block to the bottom',
 					'woocommerce'


### PR DESCRIPTION
Fixes WOOPLUG-5807
Closes https://github.com/woocommerce/woocommerce/issues/61833

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While testing with WordPress 6.9 I noticed some warnings coming from block settings UI elements. This PR fixes those warnings:

```
hook.js:608 Bottom margin styles for wp.components.ToggleGroupControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version. Error Component Stack
```
or 
```
Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version. Error Component Stack
```

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You can select some inner blocks for the Mini-Cart & Mini-Cart contents, Cart blocks.
2. Notice the settings look and feel.
3. See there is no warning in the console.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
