### PR TITLE
Add additional customization to RestApiCache trait

### DIFF
--- a/plugins/woocommerce/changelog/pr-61838
+++ b/plugins/woocommerce/changelog/pr-61838
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add additional customization to RestApiCache trait

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -94,13 +94,6 @@ trait RestApiCache {
 	private static string $cache_group = 'woocommerce_rest_api_cache';
 
 	/**
-	 * Cache TTL in seconds.
-	 *
-	 * @var int
-	 */
-	private static int $cache_ttl = HOUR_IN_SECONDS;
-
-	/**
 	 * The instance of VersionStringGenerator to use, or null if caching is disabled.
 	 *
 	 * @var VersionStringGenerator|null

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -21,11 +21,13 @@ use WP_REST_Response;
  *   so that when those entities change, the relevant cached responses become invalid.
  *   Modification of entity versions must be done externally by the code that modifies
  *   those entities (via calls to VersionStringGenerator::generate_version).
+ * - Various parameters (cached outputs TTL, entity type for a given response) can be configured
+ *   globally for the controller (via overriding protected methods).
+ *   or per-endpoint (via arguments passed to with_cache).
  * - Caching can be disabled for a given request by adding a '_skip_cache=true|1'
  *   to the query string.
  * - A X-WC-Cache HTTP header is added to responses to indicate cache status:
  *   HIT, MISS, or SKIP.
- * - Cached response TTL is fixed to one hour.
  *
  * Usage: Wrap endpoint callbacks with the `with_cache()` method when registering routes.
  *
@@ -54,12 +56,23 @@ use WP_REST_Response;
  *                     array(
  *                         // String, optional if get_default_response_entity_type() is overridden.
  *                         'entity_type' => 'product',
+ *                         // Optional int, defaults to the controller's get_ttl_for_cached_response().
+ *                         'cache_ttl'      => HOUR_IN_SECONDS,
+ *                         // Optional array, defaults to the controller's get_hooks_relevant_to_caching().
+ *                         'vary_by_user'   => true,
+ *                         // Optional, this will be passed to all the caching-related methods.
+ *                         'endpoint_id'    => 'get_product'
  *                     )
  *                 ),
  *             )
  *         );
  *     }
  * }
+ *
+ * Override these methods in your controller as needed:
+ * - get_default_response_entity_type(): Default entity type for endpoints without explicit config.
+ * - response_cache_vary_by_user(): Whether cache should be user-specific.
+ * - get_ttl_for_cached_response(): TTL for cached outputs in seconds.
  *
  * Cache invalidation happens when:
  * - Entity versions change (tracked via VersionStringGenerator).

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -58,7 +58,7 @@ use WP_REST_Response;
  *                         'entity_type' => 'product',
  *                         // Optional int, defaults to the controller's get_ttl_for_cached_response().
  *                         'cache_ttl'      => HOUR_IN_SECONDS,
- *                         // Optional array, defaults to the controller's get_hooks_relevant_to_caching().
+ *                         // Optional bool, defaults to the controller's response_cache_vary_by_user().
  *                         'vary_by_user'   => true,
  *                         // Optional, this will be passed to all the caching-related methods.
  *                         'endpoint_id'    => 'get_product'
@@ -83,7 +83,7 @@ use WP_REST_Response;
  * (checked via call to VersionStringGenerator::can_use()), so the cache is persistent
  * across requests and not just for the current request.
  *
- * @since   10.4.0
+ * @since   10.5.0
  */
 trait RestApiCache {
 	/**
@@ -189,7 +189,7 @@ trait RestApiCache {
 		/**
 		 * Filter whether to enable response caching for a given REST API controller.
 		 *
-		 * @since 10.4.0
+		 * @since 10.5.0
 		 *
 		 * @param bool            $enable_caching Whether to enable response caching (result of !_skip_cache evaluation).
 		 * @param object          $controller     The controller instance.
@@ -221,7 +221,7 @@ trait RestApiCache {
 				'wc_doing_it_wrong',
 				__METHOD__,
 				'No entity type provided and no default entity type available. Skipping cache.',
-				'10.4.0'
+				'10.5.0'
 			);
 			return null;
 		}
@@ -400,12 +400,12 @@ trait RestApiCache {
 		 *
 		 * Allows customization of what uniquely identifies a request for caching purposes.
 		 *
-		 * @since 10.4.0
+		 * @since 10.5.0
 		 *
 		 * @param array           $cache_key_parts Array of cache key information parts.
 		 * @param WP_REST_Request $request         The request object.
 		 * @param bool            $vary_by_user    Whether user ID is included in cache key.
-		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint.
+		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint (passed to with_cache).
 		 * @param object          $controller      The controller instance.
 		 * @return array Filtered cache key information parts.
 		 */

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -111,6 +111,9 @@ trait RestApiCache {
 	 * @param callable $callback The original endpoint callback.
 	 * @param array    $config   Caching configuration:
 	 *                           - entity_type: string (falls back to get_default_entity_type()).
+	 *                           - vary_by_user: bool (defaults to response_cache_vary_by_user()).
+	 *                           - endpoint_id: string|null (optional friendly identifier for the endpoint).
+	 *                           - cache_ttl: int (defaults to get_cache_ttl()).
 	 * @return callable Wrapped callback.
 	 */
 	protected function with_cache( callable $callback, array $config = array() ): callable {
@@ -193,10 +196,12 @@ trait RestApiCache {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @param array           $config  Raw configuration array passed to with_cache.
-	 * @return array|null Normalized cache config with keys: entity_type, cache_key. Returns null if entity type is not available.
+	 * @return array|null Normalized cache config with keys: endpoint_id, entity_type, vary_by_user, cache_ttl, cache_key. Returns null if entity type is not available.
 	 */
 	private function build_cache_config( WP_REST_Request $request, array $config ): ?array {
-		$entity_type = $config['entity_type'] ?? $this->get_default_entity_type();
+		$endpoint_id  = $config['endpoint_id'] ?? null;
+		$entity_type  = $config['entity_type'] ?? $this->get_default_entity_type();
+		$vary_by_user = $config['vary_by_user'] ?? $this->response_cache_vary_by_user( $request, $endpoint_id );
 
 		if ( ! $entity_type ) {
 			wc_get_container()->get( LegacyProxy::class )->call_function(
@@ -209,8 +214,11 @@ trait RestApiCache {
 		}
 
 		return array(
-			'entity_type' => $entity_type,
-			'cache_key'   => $this->get_cache_key( $request, $entity_type ),
+			'endpoint_id'  => $endpoint_id,
+			'entity_type'  => $entity_type,
+			'vary_by_user' => $vary_by_user,
+			'cache_ttl'    => $config['cache_ttl'] ?? $this->get_cache_ttl( $request, $endpoint_id ),
+			'cache_key'    => $this->get_cache_key( $request, $entity_type, $vary_by_user, $endpoint_id ),
 		);
 	}
 
@@ -240,14 +248,15 @@ trait RestApiCache {
 		$status = $response->get_status();
 		if ( $status >= 200 && $status <= 299 ) {
 			$data       = $response->get_data();
-			$entity_ids = is_array( $data ) ? $this->extract_entity_ids( $data ) : array();
+			$entity_ids = is_array( $data ) ? $this->extract_entity_ids( $data, $request, $cached_config['endpoint_id'] ) : array();
 
 			$this->store_cached_response(
 				$cached_config['cache_key'],
 				$data,
 				$status,
 				$cached_config['entity_type'],
-				$entity_ids
+				$entity_ids,
+				$cached_config['cache_ttl']
 			);
 
 			$cached = true;
@@ -270,16 +279,52 @@ trait RestApiCache {
 	}
 
 	/**
+	 * Whether the response cache should vary by user.
+	 *
+	 * When true, each user gets their own cached version of the response.
+	 * When false, the same cached response is shared across all users.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('vary_by_user' key).
+	 *
+	 * @param WP_REST_Request $request     The request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return bool True to make cache user-specific, false otherwise.
+	 */
+	protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return true;
+	}
+
+	/**
+	 * Get the cache TTL (time to live) for cached responses.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('cache_ttl' key).
+	 *
+	 * @param WP_REST_Request $request     The request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return int Cache TTL in seconds.
+	 */
+	protected function get_cache_ttl( WP_REST_Request $request, ?string $endpoint_id = null ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return HOUR_IN_SECONDS;
+	}
+
+	/**
 	 * Extract entity IDs from response data.
 	 *
 	 * This implementation assumes the response is either:
 	 * - An array with an 'id' field (single item)
 	 * - An array of arrays each having an 'id' field (collection)
 	 *
-	 * @param array $data Response data.
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('extract_entity_ids' key).
+	 *
+	 * @param array           $data        Response data.
+	 * @param WP_REST_Request $request     The request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
 	 * @return array Array of entity IDs.
 	 */
-	private function extract_entity_ids( array $data ): array {
+	protected function extract_entity_ids( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$ids = array();
 
 		if ( isset( $data[0] ) && is_array( $data[0] ) ) {
@@ -301,35 +346,67 @@ trait RestApiCache {
 	/**
 	 * Get cache key information that uniquely identifies a request.
 	 *
-	 * @param WP_REST_Request $request The request object.
+	 * @param WP_REST_Request $request      The request object.
+	 * @param bool            $vary_by_user Whether to include user ID in cache key.
+	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
 	 * @return array Array of cache key information parts.
 	 */
-	private function get_cache_key_info( WP_REST_Request $request ): array {
+	protected function get_cache_key_info( WP_REST_Request $request, bool $vary_by_user = false, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$request_query_params = $request->get_query_params();
 		if ( is_array( $request_query_params ) ) {
 			ksort( $request_query_params );
 		}
 
-		$user_id = wc_get_container()->get( LegacyProxy::class )->call_function( 'get_current_user_id' );
-
-		return array(
+		$cache_key_parts = array(
 			$request->get_route(),
 			$request->get_method(),
 			wp_json_encode( $request_query_params ),
-			"user_{$user_id}",
 		);
+
+		if ( $vary_by_user ) {
+			$user_id           = wc_get_container()->get( LegacyProxy::class )->call_function( 'get_current_user_id' );
+			$cache_key_parts[] = "user_{$user_id}";
+		}
+
+		return $cache_key_parts;
 	}
 
 	/**
 	 * Generate a cache key for a given request.
 	 *
-	 * @param WP_REST_Request $request     The request object.
-	 * @param string          $entity_type The entity type.
+	 * @param WP_REST_Request $request      The request object.
+	 * @param string          $entity_type  The entity type.
+	 * @param bool            $vary_by_user Whether to include user ID in cache key.
+	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
 	 * @return string Cache key.
 	 */
-	private function get_cache_key( WP_REST_Request $request, string $entity_type ): string {
-		$cache_key_parts = $this->get_cache_key_info( $request );
-		$request_hash    = md5( implode( '-', $cache_key_parts ) );
+	private function get_cache_key( WP_REST_Request $request, string $entity_type, bool $vary_by_user = false, ?string $endpoint_id = null ): string {
+		$cache_key_parts = $this->get_cache_key_info( $request, $vary_by_user, $endpoint_id );
+
+		/**
+		 * Filter the information used to generate the cache key for a REST API request.
+		 *
+		 * Allows customization of what uniquely identifies a request for caching purposes.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param array           $cache_key_parts Array of cache key information parts.
+		 * @param WP_REST_Request $request         The request object.
+		 * @param bool            $vary_by_user    Whether user ID is included in cache key.
+		 * @param string|null     $endpoint_id     Optional friendly identifier for the endpoint.
+		 * @param object          $controller      The controller instance.
+		 * @return array Filtered cache key information parts.
+		 */
+		$cache_key_parts = apply_filters(
+			'woocommerce_rest_api_cache_key_info',
+			$cache_key_parts,
+			$request,
+			$vary_by_user,
+			$endpoint_id,
+			$this
+		);
+
+		$request_hash = md5( implode( '-', $cache_key_parts ) );
 		return "wc_rest_api_cache_{$entity_type}-{$request_hash}";
 	}
 
@@ -342,6 +419,7 @@ trait RestApiCache {
 	private function get_cached_response( array $cached_config ): ?WP_REST_Response {
 		$cache_key   = $cached_config['cache_key'];
 		$entity_type = $cached_config['entity_type'];
+		$cache_ttl   = $cached_config['cache_ttl'];
 
 		$found  = false;
 		$cached = wp_cache_get( $cache_key, self::$cache_group, false, $found );
@@ -351,7 +429,7 @@ trait RestApiCache {
 		}
 
 		$current_time    = wc_get_container()->get( LegacyProxy::class )->call_function( 'time' );
-		$expiration_time = $cached['created_at'] + self::$cache_ttl;
+		$expiration_time = $cached['created_at'] + $cache_ttl;
 		if ( $current_time >= $expiration_time ) {
 			wp_cache_delete( $cache_key, self::$cache_group );
 			return null;
@@ -380,8 +458,9 @@ trait RestApiCache {
 	 * @param int    $status_code The HTTP status code of the response.
 	 * @param string $entity_type The entity type.
 	 * @param array  $entity_ids  Array of entity IDs in the response.
+	 * @param int    $cache_ttl   Cache TTL in seconds.
 	 */
-	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids ): void {
+	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl ): void {
 		$entity_versions = array();
 		foreach ( $entity_ids as $entity_id ) {
 			$version_id = "{$entity_type}_{$entity_id}";
@@ -401,6 +480,6 @@ trait RestApiCache {
 			$cache_data['status_code'] = $status_code;
 		}
 
-		wp_cache_set( $cache_key, $cache_data, self::$cache_group, self::$cache_ttl );
+		wp_cache_set( $cache_key, $cache_data, self::$cache_group, $cache_ttl );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -39,7 +39,7 @@ use WP_REST_Response;
  *         $this->initialize_rest_api_cache();  // REQUIRED
  *     }
  *
- *     protected function get_default_entity_type(): ?string {
+ *     protected function get_default_response_entity_type(): ?string {
  *         return 'product';  // REQUIRED (or specify entity_type in each with_cache call)
  *     }
  *
@@ -52,7 +52,7 @@ use WP_REST_Response;
  *                 'callback' => $this->with_cache(
  *                     array( $this, 'get_item' ),
  *                     array(
- *                         // String, optional if get_default_entity_type() is overridden.
+ *                         // String, optional if get_default_response_entity_type() is overridden.
  *                         'entity_type' => 'product',
  *                     )
  *                 ),
@@ -110,10 +110,10 @@ trait RestApiCache {
 	 *
 	 * @param callable $callback The original endpoint callback.
 	 * @param array    $config   Caching configuration:
-	 *                           - entity_type: string (falls back to get_default_entity_type()).
+	 *                           - entity_type: string (falls back to get_default_response_entity_type()).
 	 *                           - vary_by_user: bool (defaults to response_cache_vary_by_user()).
 	 *                           - endpoint_id: string|null (optional friendly identifier for the endpoint).
-	 *                           - cache_ttl: int (defaults to get_cache_ttl()).
+	 *                           - cache_ttl: int (defaults to get_ttl_for_cached_response()).
 	 * @return callable Wrapped callback.
 	 */
 	protected function with_cache( callable $callback, array $config = array() ): callable {
@@ -200,7 +200,7 @@ trait RestApiCache {
 	 */
 	private function build_cache_config( WP_REST_Request $request, array $config ): ?array {
 		$endpoint_id  = $config['endpoint_id'] ?? null;
-		$entity_type  = $config['entity_type'] ?? $this->get_default_entity_type();
+		$entity_type  = $config['entity_type'] ?? $this->get_default_response_entity_type();
 		$vary_by_user = $config['vary_by_user'] ?? $this->response_cache_vary_by_user( $request, $endpoint_id );
 
 		if ( ! $entity_type ) {
@@ -217,8 +217,8 @@ trait RestApiCache {
 			'endpoint_id'  => $endpoint_id,
 			'entity_type'  => $entity_type,
 			'vary_by_user' => $vary_by_user,
-			'cache_ttl'    => $config['cache_ttl'] ?? $this->get_cache_ttl( $request, $endpoint_id ),
-			'cache_key'    => $this->get_cache_key( $request, $entity_type, $vary_by_user, $endpoint_id ),
+			'cache_ttl'    => $config['cache_ttl'] ?? $this->get_ttl_for_cached_response( $request, $endpoint_id ),
+			'cache_key'    => $this->get_key_for_cached_response( $request, $entity_type, $vary_by_user, $endpoint_id ),
 		);
 	}
 
@@ -248,7 +248,7 @@ trait RestApiCache {
 		$status = $response->get_status();
 		if ( $status >= 200 && $status <= 299 ) {
 			$data       = $response->get_data();
-			$entity_ids = is_array( $data ) ? $this->extract_entity_ids( $data, $request, $cached_config['endpoint_id'] ) : array();
+			$entity_ids = is_array( $data ) ? $this->extract_entity_ids_from_response( $data, $request, $cached_config['endpoint_id'] ) : array();
 
 			$this->store_cached_response(
 				$cached_config['cache_key'],
@@ -274,7 +274,7 @@ trait RestApiCache {
 	 *
 	 * @return string|null Entity type (e.g., 'product', 'order'), or null if no controller-wide default.
 	 */
-	protected function get_default_entity_type(): ?string {
+	protected function get_default_response_entity_type(): ?string {
 		return null;
 	}
 
@@ -305,7 +305,7 @@ trait RestApiCache {
 	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
 	 * @return int Cache TTL in seconds.
 	 */
-	protected function get_cache_ttl( WP_REST_Request $request, ?string $endpoint_id = null ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	protected function get_ttl_for_cached_response( WP_REST_Request $request, ?string $endpoint_id = null ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return HOUR_IN_SECONDS;
 	}
 
@@ -316,25 +316,24 @@ trait RestApiCache {
 	 * - An array with an 'id' field (single item)
 	 * - An array of arrays each having an 'id' field (collection)
 	 *
-	 * This can be customized per-endpoint via the config array
-	 * passed to with_cache() ('extract_entity_ids' key).
+	 * Controllers can override this method to customize entity ID extraction.
 	 *
-	 * @param array           $data        Response data.
-	 * @param WP_REST_Request $request     The request object.
-	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @param array           $response_data Response data.
+	 * @param WP_REST_Request $request       The request object.
+	 * @param string|null     $endpoint_id   Optional friendly identifier for the endpoint.
 	 * @return array Array of entity IDs.
 	 */
-	protected function extract_entity_ids( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	protected function extract_entity_ids_from_response( array $response_data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$ids = array();
 
-		if ( isset( $data[0] ) && is_array( $data[0] ) ) {
-			foreach ( $data as $item ) {
+		if ( isset( $response_data[0] ) && is_array( $response_data[0] ) ) {
+			foreach ( $response_data as $item ) {
 				if ( isset( $item['id'] ) ) {
 					$ids[] = $item['id'];
 				}
 			}
-		} elseif ( isset( $data['id'] ) ) {
-			$ids[] = $data['id'];
+		} elseif ( isset( $response_data['id'] ) ) {
+			$ids[] = $response_data['id'];
 		}
 
 		// Filter out null/false values but keep 0 and empty strings as they could be valid IDs.
@@ -351,7 +350,7 @@ trait RestApiCache {
 	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
 	 * @return array Array of cache key information parts.
 	 */
-	protected function get_cache_key_info( WP_REST_Request $request, bool $vary_by_user = false, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	protected function get_key_info_for_cached_response( WP_REST_Request $request, bool $vary_by_user = false, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$request_query_params = $request->get_query_params();
 		if ( is_array( $request_query_params ) ) {
 			ksort( $request_query_params );
@@ -380,8 +379,8 @@ trait RestApiCache {
 	 * @param string|null     $endpoint_id  Optional friendly identifier for the endpoint.
 	 * @return string Cache key.
 	 */
-	private function get_cache_key( WP_REST_Request $request, string $entity_type, bool $vary_by_user = false, ?string $endpoint_id = null ): string {
-		$cache_key_parts = $this->get_cache_key_info( $request, $vary_by_user, $endpoint_id );
+	private function get_key_for_cached_response( WP_REST_Request $request, string $entity_type, bool $vary_by_user = false, ?string $endpoint_id = null ): string {
+		$cache_key_parts = $this->get_key_info_for_cached_response( $request, $vary_by_user, $endpoint_id );
 
 		/**
 		 * Filter the information used to generate the cache key for a REST API request.

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -352,9 +352,9 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Custom extract_entity_ids method can be overridden.
+	 * @testdox Custom extract_entity_ids_from_response method can be overridden.
 	 */
-	public function test_custom_extract_entity_ids_override() {
+	public function test_custom_extract_entity_ids_from_response_override() {
 		$custom_controller = new class() extends WP_REST_Controller {
 			// phpcs:disable Squiz.Commenting
 			use RestApiCache;
@@ -367,13 +367,13 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				$this->initialize_rest_api_cache();
 			}
 
-			protected function get_default_entity_type(): ?string {
+			protected function get_default_response_entity_type(): ?string {
 				return 'product';
 			}
 
-			protected function extract_entity_ids( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array {
+			protected function extract_entity_ids_from_response( array $response_data, WP_REST_Request $request, ?string $endpoint_id = null ): array {
 				$this->custom_extractor_called = true;
-				return isset( $data['product_id'] ) ? array( $data['product_id'] ) : array();
+				return isset( $response_data['product_id'] ) ? array( $response_data['product_id'] ) : array();
 			}
 
 			public function register_routes() {
@@ -587,31 +587,33 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				);
 			}
 
-			private function register_multi_method_route() {
-				register_rest_route(
-					$this->namespace,
-					'/' . $this->rest_base . '/multi_method',
-					array(
-						'methods'             => array( 'GET', 'POST' ),
-						'callback'            => $this->with_cache(
-							function ( $request ) {
-								$method = $request->get_method();
-								return new WP_REST_Response(
-									array(
-										'id'     => 'GET' === $method ? 10 : 20,
-										'method' => $method,
-									),
-									200
-								);
-							}
-						),
-						'permission_callback' => '__return_true',
-					)
-				);
-			}
 
-			protected function get_default_entity_type(): ?string {
-				return $this->default_entity_type;
+		private function register_multi_method_route() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/multi_method',
+				array(
+					'methods'             => array( 'GET', 'POST' ),
+					'callback'            => $this->with_cache(
+						function ( $request ) {
+							$method = $request->get_method();
+							return new WP_REST_Response(
+								array(
+									'id'     => 'GET' === $method ? 10 : 20,
+									'method' => $method,
+								),
+								200
+							);
+						}
+					),
+					'permission_callback' => '__return_true',
+				)
+			);
+		}
+
+		protected function get_default_response_entity_type(): ?string {
+			return $this->default_entity_type;
+		}
 			}
 
 			protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool {

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -510,7 +510,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			// phpcs:disable Squiz.Commenting
 			use RestApiCache;
 
-			public $responses             = array(
+			public $responses = array(
 				'single_entity'      => array(
 					'id'   => 1,
 					'name' => 'Product 1',
@@ -542,6 +542,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 					'name' => 'Product with Custom TTL',
 				),
 			);
+
 			public $default_entity_type   = 'product';
 			public $default_vary_by_user  = true;
 			public $endpoint_vary_by_user = array();
@@ -555,15 +556,15 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 
 			public function register_routes() {
 				$this->register_cached_route( 'single_entity' );
-			$this->register_cached_route( 'multiple_entities' );
-			$this->register_cached_route( 'custom_entity_type', array( 'entity_type' => 'custom_thing' ) );
-			$this->register_cached_route( 'non_array_response', array( 'entity_type' => 'custom_thing' ), true );
-			$this->register_cached_route( 'raw_array_response', array(), false, true );
-			$this->register_cached_route( 'no_vary_by_user', array( 'vary_by_user' => false ) );
-			$this->register_cached_route( 'with_endpoint_id', array( 'endpoint_id' => 'test_endpoint' ) );
-			$this->register_cached_route( 'custom_ttl', array( 'cache_ttl' => 10 ) );
-			$this->register_multi_method_route();
-		}
+				$this->register_cached_route( 'multiple_entities' );
+				$this->register_cached_route( 'custom_entity_type', array( 'entity_type' => 'custom_thing' ) );
+				$this->register_cached_route( 'non_array_response', array( 'entity_type' => 'custom_thing' ), true );
+				$this->register_cached_route( 'raw_array_response', array(), false, true );
+				$this->register_cached_route( 'no_vary_by_user', array( 'vary_by_user' => false ) );
+				$this->register_cached_route( 'with_endpoint_id', array( 'endpoint_id' => 'test_endpoint' ) );
+				$this->register_cached_route( 'custom_ttl', array( 'cache_ttl' => 10 ) );
+				$this->register_multi_method_route();
+			}
 
 			private function register_cached_route( string $endpoint, array $cache_args = array(), bool $non_array_request = false, bool $raw_response = false ) {
 				register_rest_route(
@@ -588,33 +589,33 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			}
 
 
-		private function register_multi_method_route() {
-			register_rest_route(
-				$this->namespace,
-				'/' . $this->rest_base . '/multi_method',
-				array(
-					'methods'             => array( 'GET', 'POST' ),
-					'callback'            => $this->with_cache(
-						function ( $request ) {
-							$method = $request->get_method();
-							return new WP_REST_Response(
-								array(
-									'id'     => 'GET' === $method ? 10 : 20,
-									'method' => $method,
-								),
-								200
-							);
-						}
-					),
-					'permission_callback' => '__return_true',
-				)
-			);
-		}
-
-		protected function get_default_response_entity_type(): ?string {
-			return $this->default_entity_type;
-		}
+			private function register_multi_method_route() {
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/multi_method',
+					array(
+						'methods'             => array( 'GET', 'POST' ),
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								$method = $request->get_method();
+								return new WP_REST_Response(
+									array(
+										'id'     => 'GET' === $method ? 10 : 20,
+										'method' => $method,
+									),
+									200
+								);
+							}
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
 			}
+
+			protected function get_default_response_entity_type(): ?string {
+				return $this->default_entity_type;
+			}
+
 
 			protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool {
 				if ( ! is_null( $endpoint_id ) && isset( $this->endpoint_vary_by_user[ $endpoint_id ] ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -253,7 +253,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Cache varies by user ID automatically.
+	 * @testdox Cache varies by user ID when vary_by_user is true (default).
 	 */
 	public function test_cache_varies_by_user() {
 		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
@@ -269,6 +269,149 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$response2 = $this->query_endpoint( 'single_entity' );
 		$this->assertCacheHeader( $response2, 'MISS' );
 		$this->assertCount( 2, $this->get_all_cache_keys() );
+	}
+
+	/**
+	 * @testdox Cache does not vary by user when vary_by_user is false.
+	 */
+	public function test_cache_does_not_vary_by_user_when_disabled() {
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 1 )
+		);
+		$response1 = $this->query_endpoint( 'no_vary_by_user' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+		$this->assertCount( 1, $this->get_all_cache_keys() );
+
+		wc_get_container()->get( LegacyProxy::class )->register_function_mocks(
+			array( 'get_current_user_id' => fn() => 2 )
+		);
+		$response2 = $this->query_endpoint( 'no_vary_by_user' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+		$this->assertCount( 1, $this->get_all_cache_keys() );
+	}
+
+	/**
+	 * @testdox Endpoint with endpoint_id works correctly.
+	 */
+	public function test_endpoint_id_is_supported() {
+		$response1 = $this->query_endpoint( 'with_endpoint_id' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+		$this->assertEquals( $this->sut->responses['with_endpoint_id'], $response1->get_data() );
+
+		$response2 = $this->query_endpoint( 'with_endpoint_id' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+		$this->assertEquals( $this->sut->responses['with_endpoint_id'], $response2->get_data() );
+	}
+
+	/**
+	 * @testdox Filter woocommerce_rest_api_cache_key_info allows customizing cache key parts.
+	 */
+	public function test_cache_key_info_filter() {
+		$response1 = $this->query_endpoint( 'single_entity' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+		$this->assertCount( 1, $this->get_all_cache_keys() );
+
+		$filter_called = false;
+		add_filter(
+			'woocommerce_rest_api_cache_key_info',
+			function ( $cache_key_parts, $request, $vary_by_user, $endpoint_id, $controller ) use ( &$filter_called ) {
+				$filter_called = true;
+				$this->assertIsArray( $cache_key_parts );
+				$this->assertInstanceOf( WP_REST_Request::class, $request );
+				$this->assertIsBool( $vary_by_user );
+				$this->assertIsObject( $controller );
+				$cache_key_parts[] = 'custom_part';
+				return $cache_key_parts;
+			},
+			10,
+			5
+		);
+
+		$response2 = $this->query_endpoint( 'single_entity' );
+		$this->assertTrue( $filter_called, 'Filter should have been called' );
+		$this->assertCacheHeader( $response2, 'MISS' );
+		$this->assertCount( 2, $this->get_all_cache_keys() );
+
+		remove_all_filters( 'woocommerce_rest_api_cache_key_info' );
+	}
+
+	/**
+	 * @testdox Custom cache TTL can be specified per endpoint.
+	 */
+	public function test_custom_cache_ttl() {
+		$response1 = $this->query_endpoint( 'custom_ttl' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$response2 = $this->query_endpoint( 'custom_ttl' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$this->fixed_time += 11;
+
+		$response3 = $this->query_endpoint( 'custom_ttl' );
+		$this->assertCacheHeader( $response3, 'MISS' );
+	}
+
+	/**
+	 * @testdox Custom extract_entity_ids method can be overridden.
+	 */
+	public function test_custom_extract_entity_ids_override() {
+		$custom_controller = new class() extends WP_REST_Controller {
+			// phpcs:disable Squiz.Commenting
+			use RestApiCache;
+
+			public $custom_extractor_called = false;
+
+			public function __construct() {
+				$this->namespace = 'wc/v3';
+				$this->rest_base = 'custom_extraction_test';
+				$this->initialize_rest_api_cache();
+			}
+
+			protected function get_default_entity_type(): ?string {
+				return 'product';
+			}
+
+			protected function extract_entity_ids( array $data, WP_REST_Request $request, ?string $endpoint_id = null ): array {
+				$this->custom_extractor_called = true;
+				return isset( $data['product_id'] ) ? array( $data['product_id'] ) : array();
+			}
+
+			public function register_routes() {
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base,
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) {
+								unset( $request ); // Avoid parameter not used PHPCS errors.
+								return new WP_REST_Response(
+									array(
+										'product_id' => 999,
+										'name'       => 'Custom Product',
+									),
+									200
+								);
+							}
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+			// phpcs:enable Squiz.Commenting
+		};
+
+		$custom_controller->register_routes();
+
+		$request   = new WP_REST_Request( 'GET', '/wc/v3/custom_extraction_test' );
+		$response1 = $this->server->dispatch( $request );
+
+		$this->assertTrue( $custom_controller->custom_extractor_called, 'Custom extractor should have been called' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+		$this->assertNotEmpty( $this->version_generator->get_version( 'product_999' ) );
+
+		$response2 = $this->server->dispatch( $request );
+		$this->assertCacheHeader( $response2, 'HIT' );
 	}
 
 	/**
@@ -367,7 +510,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			// phpcs:disable Squiz.Commenting
 			use RestApiCache;
 
-			public $responses           = array(
+			public $responses             = array(
 				'single_entity'      => array(
 					'id'   => 1,
 					'name' => 'Product 1',
@@ -386,8 +529,23 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 					'id'   => 100,
 					'name' => 'Custom Thing 100',
 				),
+				'no_vary_by_user'    => array(
+					'id'   => 50,
+					'name' => 'Shared Product',
+				),
+				'with_endpoint_id'   => array(
+					'id'   => 60,
+					'name' => 'Product with Endpoint ID',
+				),
+				'custom_ttl'         => array(
+					'id'   => 70,
+					'name' => 'Product with Custom TTL',
+				),
 			);
-			public $default_entity_type = 'product';
+			public $default_entity_type   = 'product';
+			public $default_vary_by_user  = true;
+			public $endpoint_vary_by_user = array();
+			public $endpoint_ids          = array();
 
 			public function __construct() {
 				$this->namespace = 'wc/v3';
@@ -397,12 +555,15 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 
 			public function register_routes() {
 				$this->register_cached_route( 'single_entity' );
-				$this->register_cached_route( 'multiple_entities' );
-				$this->register_cached_route( 'custom_entity_type', array( 'entity_type' => 'custom_thing' ) );
-				$this->register_cached_route( 'non_array_response', array( 'entity_type' => 'custom_thing' ), true );
-				$this->register_cached_route( 'raw_array_response', array(), false, true );
-				$this->register_multi_method_route();
-			}
+			$this->register_cached_route( 'multiple_entities' );
+			$this->register_cached_route( 'custom_entity_type', array( 'entity_type' => 'custom_thing' ) );
+			$this->register_cached_route( 'non_array_response', array( 'entity_type' => 'custom_thing' ), true );
+			$this->register_cached_route( 'raw_array_response', array(), false, true );
+			$this->register_cached_route( 'no_vary_by_user', array( 'vary_by_user' => false ) );
+			$this->register_cached_route( 'with_endpoint_id', array( 'endpoint_id' => 'test_endpoint' ) );
+			$this->register_cached_route( 'custom_ttl', array( 'cache_ttl' => 10 ) );
+			$this->register_multi_method_route();
+		}
 
 			private function register_cached_route( string $endpoint, array $cache_args = array(), bool $non_array_request = false, bool $raw_response = false ) {
 				register_rest_route(
@@ -451,6 +612,13 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 
 			protected function get_default_entity_type(): ?string {
 				return $this->default_entity_type;
+			}
+
+			protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool {
+				if ( ! is_null( $endpoint_id ) && isset( $this->endpoint_vary_by_user[ $endpoint_id ] ) ) {
+					return $this->endpoint_vary_by_user[ $endpoint_id ];
+				}
+				return $this->default_vary_by_user;
 			}
 
 			private function handle_request( string $endpoint, WP_REST_Request $request ) {


### PR DESCRIPTION
 _This is the third of a series of pull requests to implement output caching for the WooCommerce REST API endpoints. Previous: https://github.com/woocommerce/woocommerce/pull/61798, next: https://github.com/woocommerce/woocommerce/pull/61878_

### Changes proposed in this Pull Request:

This pull request adds some useful customization points to the `RestApiCache` trait introduced in https://github.com/woocommerce/woocommerce/pull/61798: 

- Ability to easily choose if requests (or one given request) varies by user, defaulting to true: there's a per-controller `response_cache_vary_by_user` overridable method (defaults to returning true) and a per-endpoint `vary_by_user` parameter.
- Ability to choose the TTL for cached responses, there's per-controller `get_ttl_for_cached_response` overridable method (defaults to returning one hour) and a per-endpoint `cache_ttl` parameter.
- `get_key_info_for_cached_response` is now protected and there's a new `woocommerce_rest_api_cache_key_info` filter, together these allows to fully customize the decision process on what makes a request unique.
- `extract_entity_ids_from_response` is now a protected method, so custom entity identification beyond simple `id` fields can be implemented.
- There's a new per-endpoint `endpoint_id` parameter that gets passed to all the customization protected methods for friendly endpoint identification.

### How to test the changes in this Pull Request:

> **⚠️ Testing Prerequisite:** A persistent object cache must be installed in your WordPress instance. If you are testing locally you can use [this simple file-based drop-in plugin](https://gist.github.com/Konamiman/96aeacc7933b5b89cb735c46f02adf89).

1. Add the following snippet to your site, this will create a simple "things" controller for testing the caching trait:

```php

// To easily test the per-user variance
add_filter( 'rest_pre_dispatch', function( $result, $server, $request ) {
	$user_id = $request->get_header( 'X-User-Id' );
	if ( ! is_null( $user_id ) ) {
		wp_set_current_user( (int) $user_id );
	}
	return $result;
}, 10, 3 );

add_action( 'rest_api_init', function() {
	$controller = new class() extends WP_REST_Controller {
		use Automattic\WooCommerce\Internal\Traits\RestApiCache {
			extract_entity_ids_from_response as parent_extract_entity_ids_from_response;
		}

		public function __construct() {
			$this->initialize_rest_api_cache();
		}

		protected function get_default_response_entity_type(): ?string {
			return 'thing';
		}

		protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool {
			return $endpoint_id !== 'public_things-1';
		}

		protected function get_ttl_for_cached_response( WP_REST_Request $request, ?string $endpoint_id = null ): int {
			return $endpoint_id === 'volatile_things-1' ? 30 : HOUR_IN_SECONDS;
		}

		protected function extract_entity_ids_from_response( array $response_data, WP_REST_Request $request, ?string $endpoint_id = null ): array {
		return 'special_things' === $endpoint_id ?
			array_map( fn( $item ) => $item['thing_id'], $response_data['items'] ) :
			$this->parent_extract_entity_ids_from_response( $response_data, $request, $endpoint_id );
		}

		public function register_routes() {
			// Standard endpoint - varies by user (default)
			$this->register_rest_route( '/things', array() );

			// Public endpoint - does NOT vary by user
			// (handle via response_cache_vary_by_user method)
			$this->register_rest_route( '/public-things-1', array( 'endpoint_id' => 'public_things-1' ) );

			// Public endpoint - does NOT vary by user
			// (handle via vary_by_user argument)
			$this->register_rest_route( '/public-things-2', array( 'vary_by_user' => false ) );

			// Endpoint with custom short TTL
			// (handle via get_cache_ttl method)
			$this->register_rest_route( '/volatile-things-1', array( 'endpoint_id' => 'volatile_things-1' ) );

			// Endpoint with custom short TTL
			// (handle via cache_ttl argument)
			$this->register_rest_route( '/volatile-things-2', array( 'cache_ttl' => 10 ) );

			// Endpoint with custom entity structure
			$this->register_rest_route( '/special-things', array( 'endpoint_id' => 'special_things' ), true );
		}

		private function register_rest_route( string $route, array $with_cache_args, bool $use_special_endpoint = false ) {
			register_rest_route(
				'wc',
				$route,
				array(
					'methods' => WP_REST_Server::READABLE,
					'callback' => $this->with_cache(
						array( $this, $use_special_endpoint ? 'get_special_items' : 'get_items' ),
						$with_cache_args
					),
					'permission_callback' => '__return_true',
				)
			);
		}

		public function get_items( $request ) {
			return array(
				array( 'id' => 1, 'name' => 'Thing 1' ),
				array( 'id' => 2, 'name' => 'Thing 2' ),
				array( 'random_number' => wp_rand() )
			);
		}

		public function get_special_items( $request ) {
			return array(
				'items' => array(
					array( 'thing_id' => 10, 'label' => 'Special Thing 1' ),
					array( 'thing_id' => 20, 'label' => 'Special Thing 2' )
				)
			);
		}
	};

	$controller->register_routes();
});
```

Note: additionally to the `X-WC-Cache` header, you can check the random number in the responses to tell apart cache hits and misses.

2. Run the following request a few times, you should get a cache miss followed by cache hits (compatible with the old basic version of the trait):

```
curl -i "http://localhost/wp-json/wc/things" 
```

3. Now run the following version. Every time that you change the user id you'll get a cache miss, proving that the request varies by user (default behavior):

```
curl -i -H "X-User-Id: <some existing user id>" "http://localhost/wp-json/wc/things" 
```

4. Now let's try the endpoints that don't vary by user: `public-things-1` and `public-things-2`. Now changing the user won't affect the result (you'll still get cache hits):

```
curl -i -H "X-User-Id: <some existing user id>" "http://localhost/wp-json/wc/public-things-<1 or 2>" 
```

4. Let's go now with the endpoints having custom TTLs. Querying `volatile-things-1` repeatedly will give you cache hits until 30 seconds after the first query, while for `volatile-things-2` you'll get the miss after only ten seconds:

```
curl -i "http://localhost/wp-json/wc/volatile-things-<1 or 2>" 
```

5. To test the custom entity ids extraction, just query the `special-things` endpoint, it should work just like the `things` endpoint:

```
curl -i "http://localhost/wp-json/wc/special-things" 
```

6. To test the custom request identification we will use a `X-Vary-By-Something` header that will be incorporated to the list of request identification data. Add the following additional snippet:

```php
add_filter( 'woocommerce_rest_api_cache_key_info', function( $cache_key_parts, $request, $vary_by_user, $endpoint_id, $controller ) {
	$additional_variation = $request->get_header( 'X-Vary-By-Something' );
	if ( $additional_variation ) {
		$cache_key_parts[] = 'additional_variation_' . $additional_variation;
	}

    return $cache_key_parts;
}, 10, 5 );
```

then hit the `things` endpoint with various values for the header: each time that you change the value of the header you'll get a miss:

```
curl -i -H "X-Vary-By-Something: <whatever>" "http://localhost/wp-json/wc/things"
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
- vary_by_user parameter and response_cache_vary_by_user() method
- endpoint_id parameter for friendly endpoint identification
- cache_ttl parameter and get_cache_ttl() method
- woocommerce_rest_api_cache_key_info filter
- extract_entity_ids() is now protected and has endpoint context parameters
- get_cache_key_info() is now protected and has vary_by_user support