### PR TITLE
Ensure checkout/place order logger respects log level threshold

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5592-place-order-debug-logs-generated-even-when-logging-level-set
+++ b/plugins/woocommerce/changelog/wooplug-5592-place-order-debug-logs-generated-even-when-logging-level-set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure checkout/place order logger respects log level threshold

--- a/plugins/woocommerce/includes/wc-order-step-logger-functions.php
+++ b/plugins/woocommerce/includes/wc-order-step-logger-functions.php
@@ -44,7 +44,7 @@ function wc_log_order_step( string $message, ?array $context = null, bool $final
 			return; // Whenever the method is called without a started logging session, it will be ignored.
 		}
 
-		static $logger, $order_uid, $order_uid_short, $store_url;
+		static $order_uid, $order_uid_short, $store_url;
 		static $steps = array(); // Static array to store the messages and validate against unique messages before clearing the log.
 
 		// Generate a static place order unique ID for logging purposes. When this is called multiple times in the same request,
@@ -67,10 +67,8 @@ function wc_log_order_step( string $message, ?array $context = null, bool $final
 			$order->save();
 		}
 
-		if ( ! $logger ) {
-			// Use a static logger instance to avoid unnecessary instantiations.
-			$logger = new WC_Logger();
-		}
+		// Use the global logger instance which respects site's logging configuration.
+		$logger = wc_get_logger();
 
 		if ( ! is_null( error_get_last() ) ) {
 			$context['last_error'] = error_get_last();

--- a/plugins/woocommerce/includes/wc-order-step-logger-functions.php
+++ b/plugins/woocommerce/includes/wc-order-step-logger-functions.php
@@ -69,7 +69,7 @@ function wc_log_order_step( string $message, ?array $context = null, bool $final
 
 		if ( ! $logger ) {
 			// Use a static logger instance to avoid unnecessary instantiations.
-			$logger = new WC_Logger( null, WC_Log_Levels::DEBUG );
+			$logger = new WC_Logger();
 		}
 
 		if ( ! is_null( error_get_last() ) ) {

--- a/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
@@ -13,6 +13,13 @@ use Automattic\Jetpack\Constants;
 class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
 
 	/**
+	 * Original REQUEST_METHOD value to restore after tests.
+	 *
+	 * @var string|null
+	 */
+	private $original_request_method;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
@@ -21,8 +28,10 @@ class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
 		// Clean up any previous log files.
 		$this->clean_up_log_files();
 
-		// Reset the static variables in wc_log_order_step by creating a mock request.
-		$_SERVER['REQUEST_METHOD'] = 'POST';
+		// Save the original REQUEST_METHOD and set it to POST for the test.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test setup, not user input.
+		$this->original_request_method = $_SERVER['REQUEST_METHOD'] ?? null;
+		$_SERVER['REQUEST_METHOD']     = 'POST';
 	}
 
 	/**
@@ -37,6 +46,13 @@ class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
 
 		// Reset logging settings.
 		delete_option( 'woocommerce_logs_level_threshold' );
+
+		// Restore the original REQUEST_METHOD.
+		if ( null === $this->original_request_method ) {
+			unset( $_SERVER['REQUEST_METHOD'] );
+		} else {
+			$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
+		}
 
 		parent::tearDown();
 	}

--- a/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
@@ -5,8 +5,8 @@
  * @package WooCommerce\Tests\Functions
  */
 
+declare(strict_types=1);
 use Automattic\Jetpack\Constants;
-
 /**
  * Class WC_Order_Step_Logger_Functions_Test
  */
@@ -52,7 +52,7 @@ class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $file ) {
 					if ( is_file( $file ) ) {
-						unlink( $file );
+						wp_delete_file( $file );
 					}
 				}
 			}
@@ -154,6 +154,7 @@ class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
 		);
 
 		// Verify that the log file contains the expected messages.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- The file is created in this function and only read to verify contents in the test.
 		$log_content = file_get_contents( $log_files[0] );
 		$this->assertStringContainsString( 'Test message - should be logged', $log_content );
 		$this->assertStringContainsString( 'Another step - should be logged', $log_content );

--- a/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-step-logger-functions-test.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Unit tests for wc-order-step-logger-functions.php.
+ *
+ * @package WooCommerce\Tests\Functions
+ */
+
+use Automattic\Jetpack\Constants;
+
+/**
+ * Class WC_Order_Step_Logger_Functions_Test
+ */
+class WC_Order_Step_Logger_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Clean up any previous log files.
+		$this->clean_up_log_files();
+
+		// Reset the static variables in wc_log_order_step by creating a mock request.
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+	}
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		// Clean up log files.
+		$this->clean_up_log_files();
+
+		// Clear the WC_LOG_THRESHOLD constant if set.
+		Constants::clear_single_constant( 'WC_LOG_THRESHOLD' );
+
+		// Reset logging settings.
+		delete_option( 'woocommerce_logs_level_threshold' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Clean up log files created during tests.
+	 */
+	private function clean_up_log_files(): void {
+		$log_dir = \Automattic\WooCommerce\Utilities\LoggingUtil::get_log_directory();
+
+		if ( is_dir( $log_dir ) ) {
+			$files = glob( $log_dir . 'place-order-debug-*.log' );
+			if ( ! empty( $files ) ) {
+				foreach ( $files as $file ) {
+					if ( is_file( $file ) ) {
+						unlink( $file );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get log files matching the pattern.
+	 *
+	 * @return array Array of log file paths.
+	 */
+	private function get_log_files(): array {
+		$log_dir = \Automattic\WooCommerce\Utilities\LoggingUtil::get_log_directory();
+
+		$files = glob( $log_dir . 'place-order-debug-*.log' );
+		return $files ? $files : array();
+	}
+
+	/**
+	 * @testdox Order step logging should respect the site's logging level configuration when set to CRITICAL.
+	 */
+	public function test_wc_log_order_step_respects_critical_level_threshold(): void {
+		// Set the logging level to CRITICAL only.
+		Constants::set_constant( 'WC_LOG_THRESHOLD', WC_Log_Levels::CRITICAL );
+
+		// Create an order for testing.
+		$order = WC_Helper_Order::create_order();
+
+		// Start logging.
+		wc_log_order_step(
+			'Test message - should not be logged',
+			array( 'order_object' => $order ),
+			false,
+			true
+		);
+
+		// End logging.
+		wc_log_order_step(
+			'Final step - should not be logged',
+			array( 'order_object' => $order ),
+			true,
+			false
+		);
+
+		// Get log files.
+		$log_files = $this->get_log_files();
+
+		// Assert that no log files were created since DEBUG is below CRITICAL threshold.
+		$this->assertEmpty(
+			$log_files,
+			'Expected no log files to be created when logging level is set to CRITICAL'
+		);
+
+		// Clean up the order.
+		$order->delete( true );
+	}
+
+	/**
+	 * @testdox Order step logging should write logs when logging level is set to DEBUG.
+	 */
+	public function test_wc_log_order_step_writes_logs_at_debug_level(): void {
+		// Set the logging level to DEBUG.
+		Constants::set_constant( 'WC_LOG_THRESHOLD', WC_Log_Levels::DEBUG );
+
+		// Create an order for testing.
+		$order = WC_Helper_Order::create_order();
+
+		// Start logging.
+		wc_log_order_step(
+			'Test message - should be logged',
+			array( 'order_object' => $order ),
+			false,
+			true
+		);
+
+		// Add another step.
+		wc_log_order_step(
+			'Another step - should be logged',
+			array( 'order_object' => $order ),
+			false,
+			false
+		);
+
+		// End logging.
+		wc_log_order_step(
+			'Final step - should be logged',
+			array( 'order_object' => $order ),
+			true,
+			false
+		);
+
+		// Get log files.
+		$log_files = $this->get_log_files();
+
+		// Assert that log files were created.
+		$this->assertNotEmpty(
+			$log_files,
+			'Expected log files to be created when logging level is set to DEBUG'
+		);
+
+		// Verify that the log file contains the expected messages.
+		$log_content = file_get_contents( $log_files[0] );
+		$this->assertStringContainsString( 'Test message - should be logged', $log_content );
+		$this->assertStringContainsString( 'Another step - should be logged', $log_content );
+		$this->assertStringContainsString( 'Final step - should be logged', $log_content );
+
+		// Clean up the order.
+		$order->delete( true );
+	}
+
+	/**
+	 * @testdox Order step logging should respect the site's logging level configuration when set via option.
+	 */
+	public function test_wc_log_order_step_respects_option_level_threshold(): void {
+		// Set the logging level to ERROR via option (not constant).
+		update_option( 'woocommerce_logs_level_threshold', WC_Log_Levels::ERROR );
+
+		// Create an order for testing.
+		$order = WC_Helper_Order::create_order();
+
+		// Start logging.
+		wc_log_order_step(
+			'Test message - should not be logged',
+			array( 'order_object' => $order ),
+			false,
+			true
+		);
+
+		// End logging.
+		wc_log_order_step(
+			'Final step - should not be logged',
+			array( 'order_object' => $order ),
+			true,
+			false
+		);
+
+		// Get log files.
+		$log_files = $this->get_log_files();
+
+		// Assert that no log files were created since DEBUG is below ERROR threshold.
+		$this->assertEmpty(
+			$log_files,
+			'Expected no log files to be created when logging level is set to ERROR via option'
+		);
+
+		// Clean up the order.
+		$order->delete( true );
+	}
+
+	/**
+	 * @testdox Order step logging should clean up logs after successful checkout.
+	 */
+	public function test_wc_log_order_step_cleanup_on_final_step(): void {
+		// Set the logging level to DEBUG.
+		Constants::set_constant( 'WC_LOG_THRESHOLD', WC_Log_Levels::DEBUG );
+
+		// Create an order for testing.
+		$order = WC_Helper_Order::create_order();
+
+		// Start logging.
+		wc_log_order_step(
+			'Step 1',
+			array( 'order_object' => $order ),
+			false,
+			true
+		);
+
+		// Add another step with unique message.
+		wc_log_order_step(
+			'Step 2',
+			array( 'order_object' => $order ),
+			false,
+			false
+		);
+
+		// End logging with unique final step.
+		wc_log_order_step(
+			'Step 3 - Final',
+			array( 'order_object' => $order ),
+			true,
+			false
+		);
+
+		// Verify that _debug_log_source_pending_deletion meta is set.
+		$order_meta = $order->get_meta( '_debug_log_source_pending_deletion' );
+		$this->assertNotEmpty(
+			$order_meta,
+			'Expected _debug_log_source_pending_deletion meta to be set after final step'
+		);
+
+		// Clean up the order.
+		$order->delete( true );
+	}
+
+	/**
+	 * @testdox Order step logging should not clean up logs when steps are repeated (race condition detected).
+	 */
+	public function test_wc_log_order_step_no_cleanup_on_repeated_steps(): void {
+		// Set the logging level to DEBUG.
+		Constants::set_constant( 'WC_LOG_THRESHOLD', WC_Log_Levels::DEBUG );
+
+		// Create an order for testing.
+		$order = WC_Helper_Order::create_order();
+
+		// Start logging.
+		wc_log_order_step(
+			'Step 1',
+			array( 'order_object' => $order ),
+			false,
+			true
+		);
+
+		// Add the same step twice (simulating a race condition or recursion).
+		wc_log_order_step(
+			'Step 1',
+			array( 'order_object' => $order ),
+			false,
+			false
+		);
+
+		// End logging.
+		wc_log_order_step(
+			'Step 2 - Final',
+			array( 'order_object' => $order ),
+			true,
+			false
+		);
+
+		// Verify that _debug_log_source_pending_deletion meta is NOT set due to duplicate steps.
+		$order_meta = $order->get_meta( '_debug_log_source_pending_deletion' );
+		$this->assertEmpty(
+			$order_meta,
+			'Expected _debug_log_source_pending_deletion NOT to be set when steps are repeated'
+		);
+
+		// Clean up the order.
+		$order->delete( true );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Previously, the logger used to log each step in the checkout process was instantiated like so:

`$logger = new WC_Logger( null, WC_Log_Levels::DEBUG );`

This meant that a new logger was created, and it would write any log with level DEBUG or higher to the log files. The second param of `WC_Logger`'s constructor is not used to specify what level of logs will be written, but what the threshold is for writing logs using this logger.

The change proposed removes that and uses the existing `WC_Logger` via `wc_get_logger` (which has its own cached logger, so won't instantiate unnecessarily anyway) and this respects site settings.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5592
Closes #61111

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/53230

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC -> Status -> Logs -> Settings and set the Level Threshold to critical.
2. Add an item to your cart and go to the Checkout page and fill your details in, don't check out yet.
3. Go to [plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php:643](https://github.com/woocommerce/woocommerce/blob/edbe28ca59ed77e35cdd76b4ec310242a6857305/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php#L643) and add a `die()` in the function.
4. Attempt to check out. It should fail.
5. Go to WC -> Status -> Logs and ensure there is no entry for `place-order-debug-*`
6. Go to WC -> Status -> Logs -> Settings and set the Level Threshold to debug.
7. Repeat these steps, but ensure you _do_ see an entry for `place-order-debug-*`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
