### PR TITLE
Move MCP settings to dedicated section and add tool selection UI (WOOAI-148, WOOAI-149)

### DIFF
--- a/plugins/woocommerce/changelog/add-mcp-settings-tab
+++ b/plugins/woocommerce/changelog/add-mcp-settings-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Move MCP settings to dedicated section under Advanced settings tab.

--- a/plugins/woocommerce/changelog/add-mcp-tools-ui
+++ b/plugins/woocommerce/changelog/add-mcp-tools-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add UI to control which MCP tools are enabled via checkboxes in settings.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -9,6 +9,9 @@ use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
+// Include MCP settings class.
+require_once __DIR__ . '/class-wc-settings-mcp.php';
+
 /**
  * Settings for API.
  */
@@ -50,6 +53,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			'keys'            => __( 'REST API', 'woocommerce' ),
 			'webhooks'        => __( 'Webhooks', 'woocommerce' ),
 			'legacy_api'      => __( 'Legacy API', 'woocommerce' ),
+			'mcp'             => __( 'MCP', 'woocommerce' ),
 			'woocommerce_com' => __( 'WooCommerce.com', 'woocommerce' ),
 		);
 
@@ -437,6 +441,15 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			);
 
 		return apply_filters( 'woocommerce_settings_rest_api', $settings );
+	}
+
+	/**
+	 * Get settings for the MCP section.
+	 *
+	 * @return array
+	 */
+	protected function get_settings_for_mcp_section() {
+		return WC_Settings_MCP::get_settings();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-mcp.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-mcp.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * WooCommerce MCP Settings
+ *
+ * @package WooCommerce\Admin\Settings
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Settings class for MCP (Model Context Protocol).
+ */
+class WC_Settings_MCP {
+
+	/**
+	 * Get MCP settings array.
+	 *
+	 * @return array
+	 */
+	public static function get_settings() {
+		$description = __( 'The Model Context Protocol (MCP) enables AI assistants like Claude Code to manage your WooCommerce store through a standardized interface.', 'woocommerce' );
+
+		// Check if permalinks are set correctly.
+		$permalink_structure = get_option( 'permalink_structure' );
+		if ( empty( $permalink_structure ) ) {
+			$description .= ' <strong>' . __( 'WordPress permalinks must be set to anything other than "Plain" for MCP to work.', 'woocommerce' ) . '</strong>';
+		}
+
+		// Add documentation link.
+		$description .= ' ' . sprintf(
+			/* translators: %s: Documentation URL */
+			__( '<a href="%s" target="_blank">Learn more about WooCommerce MCP</a>.', 'woocommerce' ),
+			'https://github.com/woocommerce/woocommerce/blob/trunk/docs/features/mcp/README.md'
+		);
+
+		$settings = array(
+			array(
+				'title' => __( 'Model Context Protocol (MCP)', 'woocommerce' ),
+				'type'  => 'title',
+				'desc'  => $description,
+				'id'    => 'mcp_options',
+			),
+
+			array(
+				'title'    => __( 'Enable MCP', 'woocommerce' ),
+				'desc'     => __( 'Enable WooCommerce MCP for AI-powered store operations', 'woocommerce' ),
+				'id'       => 'woocommerce_feature_mcp_integration_enabled',
+				'default'  => 'no',
+				'type'     => 'checkbox',
+				'desc_tip' => __( 'AI-generated results and actions can be unpredictable - please review before executing in your store.', 'woocommerce' ),
+			),
+
+			array(
+				'type' => 'sectionend',
+				'id'   => 'mcp_options',
+			),
+		);
+
+		/**
+		 * Filters the MCP settings array.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param array $settings Array of MCP settings.
+		 */
+		return apply_filters( 'woocommerce_settings_mcp', $settings );
+	}
+}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-mcp.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-mcp.php
@@ -8,6 +8,8 @@
 declare( strict_types=1 );
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Automattic\WooCommerce\Internal\Abilities\AbilitiesRestBridge;
+use Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -15,6 +17,37 @@ defined( 'ABSPATH' ) || exit;
  * Settings class for MCP (Model Context Protocol).
  */
 class WC_Settings_MCP {
+
+	/**
+	 * Get available MCP tools from the abilities registry.
+	 *
+	 * @return array Array of MCP tools with their metadata.
+	 */
+	private static function get_available_mcp_tools(): array {
+		// Check if abilities API is available.
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return array();
+		}
+
+		// Bypass MCP request check for settings display.
+		add_filter( 'woocommerce_mcp_bypass_request_check', '__return_true' );
+
+		// Get available MCP ability IDs (single source of truth).
+		// This triggers wp_get_abilities() which fires the hook that calls register_abilities().
+		$ability_ids = MCPAdapterProvider::get_woocommerce_mcp_abilities();
+
+		// Get full ability data for each ID.
+		$all_abilities = wp_get_abilities();
+		$mcp_tools     = array();
+
+		foreach ( $ability_ids as $ability_id ) {
+			if ( isset( $all_abilities[ $ability_id ] ) ) {
+				$mcp_tools[ $ability_id ] = $all_abilities[ $ability_id ];
+			}
+		}
+
+		return $mcp_tools;
+	}
 
 	/**
 	 * Get MCP settings array.
@@ -58,6 +91,39 @@ class WC_Settings_MCP {
 				'type' => 'sectionend',
 				'id'   => 'mcp_options',
 			),
+
+			array(
+				'title' => __( 'MCP tools', 'woocommerce' ),
+				'type'  => 'title',
+				'desc'  => __( 'Select which MCP tools are available to AI assistants. All tools are enabled by default.', 'woocommerce' ),
+				'id'    => 'mcp_tools_options',
+			),
+		);
+
+		// Add dynamic tool checkboxes.
+		$mcp_tools = self::get_available_mcp_tools();
+		foreach ( $mcp_tools as $tool_id => $tool_data ) {
+			$tool_name = str_replace( 'woocommerce/', '', $tool_id );
+			$label     = method_exists( $tool_data, 'get_label' ) ? $tool_data->get_label() : ucfirst( $tool_name );
+			$desc      = method_exists( $tool_data, 'get_description' ) ? $tool_data->get_description() : '';
+
+			$settings[] = array(
+				'title'    => $label,
+				'desc'     => sprintf(
+					/* translators: %s: Tool description */
+					__( 'Enable %s', 'woocommerce' ),
+					strtolower( $label )
+				),
+				'id'       => 'woocommerce_mcp_tool_' . $tool_name . '_enabled',
+				'default'  => 'yes',
+				'type'     => 'checkbox',
+				'desc_tip' => $desc,
+			);
+		}
+
+		$settings[] = array(
+			'type' => 'sectionend',
+			'id'   => 'mcp_tools_options',
 		);
 
 		/**

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -61,11 +61,22 @@ class AbilitiesRestBridge {
 	 * Register all configured abilities.
 	 */
 	public static function register_abilities(): void {
-		// Only register abilities if this is an MCP endpoint request.
+		/**
+		 * Filters whether to bypass the MCP request check when registering abilities.
+		 *
+		 * Allows abilities to be registered outside of MCP requests (e.g., for settings display).
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param bool $bypass_check Whether to bypass the MCP request check. Default false.
+		 */
+		$bypass_check = apply_filters( 'woocommerce_mcp_bypass_request_check', false );
+
+		// Only register abilities if this is an MCP endpoint request or check is bypassed.
 		// We check here (on abilities_api_init action) rather than earlier
 		// because REST request detection requires the WordPress REST infrastructure
 		// to be fully initialized.
-		if ( ! MCPAdapterProvider::is_mcp_request() ) {
+		if ( ! $bypass_check && ! MCPAdapterProvider::is_mcp_request() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -518,7 +518,7 @@ class FeaturesController {
 				'name'                         => __( 'WooCommerce MCP', 'woocommerce' ),
 				'description'                  => $this->get_mcp_integration_description(),
 				'enabled_by_default'           => false,
-				'disable_ui'                   => false,
+				'disable_ui'                   => true,
 				'is_experimental'              => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'is_legacy'                    => false,

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -107,7 +107,23 @@ class MCPAdapterProvider {
 	 */
 	public function initialize_mcp_server( $adapter ): void {
 		// Get filtered abilities for MCP server.
-		$abilities_ids = $this->get_woocommerce_mcp_abilities();
+		$abilities_ids = self::get_woocommerce_mcp_abilities();
+
+		// Filter abilities based on user settings (enabled/disabled checkboxes).
+		$abilities_ids = array_filter(
+			$abilities_ids,
+			function ( $ability_id ) {
+				$tool_name    = str_replace( 'woocommerce/', '', $ability_id );
+				$option_name  = 'woocommerce_mcp_tool_' . $tool_name . '_enabled';
+				$tool_enabled = get_option( $option_name, 'yes' );
+
+				// Only include if tool is enabled (default is 'yes').
+				return ( 'yes' === $tool_enabled );
+			}
+		);
+
+		// Re-index array after filtering.
+		$abilities_ids = array_values( $abilities_ids );
 
 		// Bail if no abilities are available.
 		if ( empty( $abilities_ids ) ) {
@@ -158,7 +174,7 @@ class MCPAdapterProvider {
 	 *
 	 * @return array Array of ability IDs for MCP server.
 	 */
-	private function get_woocommerce_mcp_abilities(): array {
+	public static function get_woocommerce_mcp_abilities(): array {
 		// Get all abilities from the registry.
 		$abilities_registry = wc_get_container()->get( AbilitiesRegistry::class );
 		$all_abilities_ids  = $abilities_registry->get_abilities_ids();


### PR DESCRIPTION
## Summary

Implements WOOAI-148 and WOOAI-149: Move MCP settings to Advanced settings tab and add UI to control which MCP tools are enabled.

### Changes

**WOOAI-148: Move MCP settings to dedicated section**
- Created new `WC_Settings_MCP` class (`includes/admin/settings/class-wc-settings-mcp.php`) to manage MCP settings
- Added MCP as a subsection under the Advanced settings tab
- Set `disable_ui => true` in `FeaturesController.php` to hide the toggle from experimental features UI
- Maintained backward compatibility by continuing to use `FeaturesUtil::feature_is_enabled('mcp_integration')`

**WOOAI-149: Add UI to control which MCP tools are enabled**
- Added dynamic tool checkboxes that automatically discover available MCP tools
- Tools are fetched from abilities registry using `MCPAdapterProvider::get_woocommerce_mcp_abilities()` as single source of truth
- Implemented checkbox filtering in `MCPAdapterProvider::initialize_mcp_server()`
- Added `woocommerce_mcp_bypass_request_check` filter for settings display
- All tools enabled by default (opt-out model)

### Implementation Details

**New Files:**
- `includes/admin/settings/class-wc-settings-mcp.php` - Settings class with MCP toggle, description, documentation link, and dynamic tool checkboxes

**Modified Files:**
- `includes/admin/settings/class-wc-settings-advanced.php` - Added MCP subsection registration
- `src/Internal/Features/FeaturesController.php` - Set `disable_ui => true` for mcp_integration feature
- `src/Internal/Abilities/AbilitiesRestBridge.php` - Added bypass filter for settings display
- `src/Internal/MCP/MCPAdapterProvider.php` - Added checkbox filtering in server initialization, made `get_woocommerce_mcp_abilities()` public/static

### Architecture

**Single Source of Truth:**
- `MCPAdapterProvider::get_woocommerce_mcp_abilities()` returns all `woocommerce/*` abilities
- Settings page uses this method to display available tools
- MCP server uses this method + checkbox filtering to determine enabled tools

**Dynamic Discovery:**
- Tools are automatically discovered from abilities registry
- New tools added to the system will automatically appear in settings
- No hardcoding of tool names required

### Test Plan

- [ ] Navigate to WooCommerce → Settings → Advanced → MCP
- [ ] Verify MCP settings section displays with toggle, description, and documentation link
- [ ] Verify "MCP tools" section appears with checkboxes for each registered tool
- [ ] Verify both "Manage products" and "Manage orders" tools are listed
- [ ] Verify all tools are enabled by default
- [ ] Verify permalink warning appears when permalinks are set to "Plain"
- [ ] Verify MCP toggle works (enable/disable functionality)
- [ ] Verify MCP no longer appears in experimental features section (WooCommerce → Settings → Advanced → Features)
- [ ] Test disabling "Manage products" tool and verify it's not available in MCP
- [ ] Test disabling "Manage orders" tool and verify it's not available in MCP
- [ ] Test re-enabling tools and verify they become available again
- [ ] Test that existing MCP functionality still works after enabling

### Related Issues

- Implements WOOAI-148
- Implements WOOAI-149  
- Part of WOOAI-142 (parent issue)
- Based on `add/mcp-reduce-parameters` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)