### PR TITLE
Backwords compat review: use a single comment

### DIFF
--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -31,7 +31,7 @@ jobs:
           # Enable progress tracking
           track_progress: true
 
-          # udpate a single comment, instead of posting a new one on each push
+          # update a single comment, instead of posting a new one on each push
           use_sticky_comment: true
 
           # Your custom review instructions

--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -31,6 +31,9 @@ jobs:
           # Enable progress tracking
           track_progress: true
 
+          # udpate a single comment, instead of posting a new one on each push
+          use_sticky_comment: true
+
           # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Enable sticky comments for pull request reviews, don't post a new comment on each push, it's very annoying.

### How to test the changes in this Pull Request:

I tested it in https://github.com/nb/woocommerce/pull/1 – submitted the PR and then added another commit to confirm the action used the same comment.

@ebinnion you already have a test fork, you can also test it, if you want.