### PR TITLE
Add experimental emails settings API to V4

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-926-move-notifications-listing-api-to-woocommerce
+++ b/plugins/woocommerce/changelog/wooprd-926-move-notifications-listing-api-to-woocommerce
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add experimental V4 settings/emails API
+
+

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -231,6 +231,9 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
@@ -221,6 +221,9 @@ if ( ! class_exists( 'WC_Email_Customer_Cancelled_Order', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
@@ -255,6 +255,9 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
@@ -371,6 +371,9 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
@@ -352,6 +352,9 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
@@ -232,6 +232,9 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -260,6 +260,9 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				$this->form_fields['cc']  = $this->get_cc_field();
 				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
 		}
 
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1188,6 +1188,9 @@ class WC_Email extends WC_Settings_API {
 			$this->form_fields['cc']  = $this->get_cc_field();
 			$this->form_fields['bcc'] = $this->get_bcc_field();
 		}
+		if ( $this->block_email_editor_enabled ) {
+			$this->form_fields['preheader'] = $this->get_preheader_field();
+		}
 	}
 
 	/**
@@ -1219,6 +1222,22 @@ class WC_Email extends WC_Settings_API {
 			/* translators: %s: admin email */
 			'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 			'placeholder' => '',
+			'default'     => '',
+			'desc_tip'    => true,
+		);
+	}
+
+	/**
+	 * Get the preheader field definition.
+	 *
+	 * @return array
+	 */
+	protected function get_preheader_field() {
+		return array(
+			'title'       => __( 'Preheader', 'woocommerce' ),
+			'description' => __( 'Shown as a preview in the Inbox, next to the subject line. (Max 150 characters).', 'woocommerce' ),
+			'placeholder' => '',
+			'type'        => 'text',
 			'default'     => '',
 			'desc_tip'    => true,
 		);

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\OfflinePaymentMet
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Customers\Controller as CustomersController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\General\Controller as GeneralSettingsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Email\Controller as EmailSettingsController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Controller as EmailsSettingsController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Fulfillments\Controller as FulfillmentsController;
 
 /**
@@ -241,6 +242,7 @@ class Server {
 			'offline-payment-methods'   => OfflinePaymentMethodsController::class,
 			'settings-general'          => GeneralSettingsController::class,
 			'settings-email'            => EmailSettingsController::class,
+			'settings-emails'           => EmailsSettingsController::class,
 			'settings-products'         => SettingsProductsController::class,
 			'settings-payment-gateways' => PaymentGatewaysController::class,
 			// This is a wrapper that redirects V4 settings requests to the V3 settings controller.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Controller.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * REST API Emails Settings Controller
+ *
+ * Handles requests to the /settings/emails endpoints.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails;
+
+use WP_Error;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Schema\EmailsSettingsSchema;
+use WC_Emails;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Emails Settings Controller Class.
+ */
+class Controller extends AbstractController {
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'settings/emails';
+
+	/**
+	 * Schema instance.
+	 *
+	 * @var EmailsSettingsSchema
+	 */
+	protected $schema;
+
+	/**
+	 * Initialize the controller.
+	 *
+	 * @param EmailsSettingsSchema $schema Schema class.
+	 * @internal
+	 */
+	final public function init( EmailsSettingsSchema $schema ) {
+		$this->schema = $schema;
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		// Collection endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'post_id' => array(
+							'description' => __( 'Filter by template post ID.', 'woocommerce' ),
+							'type'        => 'integer',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		// Single item endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<email_id>[\w-]+)',
+			array(
+				'args'   => array(
+					'email_id' => array(
+						'description' => __( 'Email template ID.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions for reading email settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to access email settings.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Check permissions for reading a single email setting.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check permissions for updating email settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to edit email settings.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Get all email settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_items( $request ) {
+		try {
+			$emails = WC_Emails::instance()->get_emails();
+			$items  = array();
+
+			foreach ( $emails as $email ) {
+				$item = $this->schema->get_item_response( $email, $request );
+
+				// Filter by post_id if provided.
+				$post_id = $request->get_param( 'post_id' );
+				if ( $post_id && $item['post_id'] !== (int) $post_id ) {
+					continue;
+				}
+
+				$items[] = $item;
+			}
+
+			return rest_ensure_response( $items );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'woocommerce_rest_emails_settings_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+	}
+
+	/**
+	 * Get a single email setting.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$email_id = $request['email_id'];
+		$email    = $this->get_email_by_id( $email_id );
+
+		if ( ! $email ) {
+			return new WP_Error(
+				'woocommerce_rest_email_not_found',
+				__( 'Email template not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		try {
+			$response = $this->schema->get_item_response( $email, $request );
+			return rest_ensure_response( $response );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'woocommerce_rest_email_settings_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+	}
+
+	/**
+	 * Update a single email setting.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$email_id = $request['email_id'];
+		$email    = $this->get_email_by_id( $email_id );
+
+		if ( ! $email ) {
+			return new WP_Error(
+				'woocommerce_rest_email_not_found',
+				__( 'Email template not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$params = $request->get_json_params();
+
+		if ( ! is_array( $params ) || empty( $params ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid or empty request body.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Check if the request contains a 'values' field with the flat key-value mapping.
+		$values_to_update = array();
+		if ( isset( $params['values'] ) && is_array( $params['values'] ) ) {
+			$values_to_update = $params['values'];
+		} else {
+			// Fallback to the old format for backward compatibility.
+			$values_to_update = $params;
+		}
+
+		// Validate and sanitize.
+		$validated = $this->schema->validate_and_sanitize_settings( $email, $values_to_update );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
+		// Update options.
+		$updated_fields = array();
+		foreach ( $validated as $key => $value ) {
+			$email->update_option( $key, $value );
+			$updated_fields[] = $key;
+		}
+
+		// Reload emails after the update.
+		WC_Emails::instance()->init();
+
+		// Get updated email and return formatted response.
+		$updated_email = $this->get_email_by_id( $email_id );
+		if ( ! $updated_email ) {
+			return new WP_Error(
+				'woocommerce_rest_email_update_error',
+				__( 'Failed to retrieve updated email settings.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		// Trigger action for settings update.
+		if ( ! empty( $updated_fields ) ) {
+			/**
+			 * Fires when WooCommerce email settings are updated.
+			 *
+			 * @param array  $updated_fields Array of updated field IDs.
+			 * @param string $rest_base      The REST base of the settings.
+			 * @since 10.2.0
+			 */
+			do_action( 'woocommerce_settings_updated', $updated_fields, $this->rest_base );
+		}
+
+		try {
+			$response = $this->schema->get_item_response( $updated_email, $request );
+			return rest_ensure_response( $response );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'woocommerce_rest_email_settings_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+	}
+
+	/**
+	 * Get the item response for a single email.
+	 *
+	 * @param mixed           $item    Email instance.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	protected function get_item_response( $item, WP_REST_Request $request ): array {
+		return $this->schema->get_item_response( $item, $request );
+	}
+
+	/**
+	 * Get email instance by ID.
+	 *
+	 * @param string $email_id Email ID.
+	 * @return \WC_Email|null Email instance or null if not found.
+	 */
+	private function get_email_by_id( string $email_id ) {
+		$emails = WC_Emails::instance()->get_emails();
+
+		foreach ( $emails as $email ) {
+			if ( $email->id === $email_id ) {
+				return $email;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the schema for the current resource.
+	 *
+	 * @return array
+	 */
+	protected function get_schema(): array {
+		return $this->schema->get_item_schema();
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema(): array {
+		return $this->get_schema();
+	}
+
+	/**
+	 * Get the endpoint args for item schema.
+	 *
+	 * @param string $method HTTP method of the request.
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ): array {
+		return rest_get_endpoint_args_for_schema( $this->get_item_schema(), $method );
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Controller.php
@@ -157,13 +157,11 @@ class Controller extends AbstractController {
 
 			foreach ( $emails as $email ) {
 				$item = $this->schema->get_item_response( $email, $request );
-
 				// Filter by post_id if provided.
 				$post_id = $request->get_param( 'post_id' );
-				if ( $post_id && $item['post_id'] !== (int) $post_id ) {
+				if ( $post_id && (int) $item['post_id'] !== (int) $post_id ) {
 					continue;
 				}
-
 				$items[] = $item;
 			}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -53,7 +53,12 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 */
 	private $cached_prefixes = null;
 
-	public function init() {
+	/**
+	 * Initialize the schema with dependencies.
+	 *
+	 * @internal This method is not intended to be used externally.
+	 */
+	final public function init() {
 		$this->personalization_tags_registry = Email_Editor_Container::container()->get( Personalization_Tags_Registry::class );
 	}
 
@@ -64,62 +69,62 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 */
 	public function get_item_schema_properties(): array {
 		return array(
-			'id'                 => array(
+			'id'                => array(
 				'description' => __( 'Email template ID.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'title'              => array(
+			'title'             => array(
 				'description' => __( 'Email title.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'description'        => array(
+			'description'       => array(
 				'description' => __( 'Email description.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'post_id'            => array(
+			'post_id'           => array(
 				'description' => __( 'Template post ID.', 'woocommerce' ),
 				'type'        => array( 'integer', 'null' ),
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'link'               => array(
+			'link'              => array(
 				'description' => __( 'Link to template editor.', 'woocommerce' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'email_group'        => array(
+			'email_group'       => array(
 				'description' => __( 'Email group identifier.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'email_group_title'  => array(
+			'email_group_title' => array(
 				'description' => __( 'Email group title.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'is_customer_email'  => array(
+			'is_customer_email' => array(
 				'description' => __( 'Whether this is a customer email.', 'woocommerce' ),
 				'type'        => 'boolean',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'is_manual'  => array(
+			'is_manual'         => array(
 				'description' => __( 'Whether this is sent only manually.', 'woocommerce' ),
 				'type'        => 'boolean',
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
-			'values'             => array(
+			'values'            => array(
 				'description'          => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
 				'type'                 => 'object',
 				'context'              => self::VIEW_EDIT_CONTEXT,
@@ -128,7 +133,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 					'type'        => array( 'string', 'number', 'array', 'boolean' ),
 				),
 			),
-			'groups'             => array(
+			'groups'            => array(
 				'description'          => __( 'Collection of setting groups.', 'woocommerce' ),
 				'type'                 => 'object',
 				'context'              => self::VIEW_EDIT_CONTEXT,
@@ -216,21 +221,21 @@ class EmailsSettingsSchema extends AbstractSchema {
 		$email_post_manager = WCTransactionalEmailPostsManager::get_instance();
 		$post_id            = $email_post_manager->get_email_template_post_id( $email->id ?? '' );
 		// Convert false to null, ensure int otherwise.
-		$post_id            = $post_id ? (int) $post_id : null;
+		$post_id = $post_id ? (int) $post_id : null;
 
 		$email->init_form_fields();
 		$response = array(
-			'id'                 => $email->id ?? '',
-			'title'              => $email->title ?? '',
-			'description'        => $email->description ?? '',
-			'post_id'            => $post_id,
-			'link'               => get_permalink( $post_id ),
-			'email_group'        => $email->email_group ?? '',
-			'email_group_title'  => method_exists( $email, 'get_email_group_title' ) ? $email->get_email_group_title() : '',
-			'is_customer_email'  => method_exists( $email, 'is_customer_email' ) ? $email->is_customer_email() : false,
-			'is_manual'          => method_exists( $email, 'is_manual' ) ? $email->is_manual() : false,
-			'values'             => $this->get_values( $email ),
-			'groups'             => $this->get_groups( $email ),
+			'id'                => $email->id ?? '',
+			'title'             => $email->title ?? '',
+			'description'       => $email->description ?? '',
+			'post_id'           => $post_id,
+			'link'              => get_permalink( $post_id ),
+			'email_group'       => $email->email_group ?? '',
+			'email_group_title' => method_exists( $email, 'get_email_group_title' ) ? $email->get_email_group_title() : '',
+			'is_customer_email' => method_exists( $email, 'is_customer_email' ) ? $email->is_customer_email() : false,
+			'is_manual'         => method_exists( $email, 'is_manual' ) ? $email->is_manual() : false,
+			'values'            => $this->get_values( $email ),
+			'groups'            => $this->get_groups( $email ),
 		);
 
 		if ( ! empty( $include_fields ) ) {
@@ -247,7 +252,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 * @return array
 	 */
 	private function get_values( WC_Email $email ): array {
-		$values = array();
+		$values      = array();
 		$form_fields = $email->get_form_fields();
 
 		if ( ! is_array( $form_fields ) ) {
@@ -265,7 +270,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 				continue;
 			}
 
-			// Get saved value an fallback to default
+			// Get saved value an fallback to default.
 			$default = $this->get_field_default_value( $email, $id, $field );
 			$value   = $email->get_option( $id, $default );
 
@@ -289,9 +294,9 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 * Prepare the default value for a field.
 	 * We use special methods for well known core fields and use fallback to default value if no special method is available.
 	 *
-	 * @param WC_Email $email Email instance.
-	 * @param string $id Field ID.
-	 * @param array $field Field definition.
+	 * @param WC_Email $email  Email instance.
+	 * @param string   $id     Field ID.
+	 * @param array    $field  Field definition.
 	 * @return mixed The default value for the field.
 	 */
 	private function get_field_default_value( WC_Email $email, string $id, array $field ) {
@@ -358,7 +363,8 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 * This is required for the email editor personalization.
 	 * Use negative lookbehind and lookahead to avoid double-wrapping already wrapped tags.
 	 *
-	 * @param mixed $value
+	 * @param mixed $value The value to wrap.
+	 * @return mixed The wrapped value.
 	 */
 	private function wrap_woocommerce_tags( $value ) {
 		if ( ! is_string( $value ) ) {
@@ -405,7 +411,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 			$field_schema = array(
 				'id'    => $id,
 				'label' => $field['title'] ?? $id,
-				'type'  => $field_type ,
+				'type'  => $field_type,
 				'desc'  => $field['description'] ?? '',
 			);
 
@@ -435,17 +441,17 @@ class EmailsSettingsSchema extends AbstractSchema {
 		$email->init_form_fields();
 		$validated = array();
 
-		foreach ( $values as $fieldId => $value ) {
+		foreach ( $values as $field_id => $value ) {
 			// Only allow valid form fields.
-			if ( ! isset( $email->form_fields[ $fieldId ] ) ) {
+			if ( ! isset( $email->form_fields[ $field_id ] ) ) {
 				continue;
 			}
 
-			$field      = $email->form_fields[ $fieldId ];
+			$field      = $email->form_fields[ $field_id ];
 			$field_type = $field['type'] ?? 'text';
 
 			// Unwrap personalization tags if the field supports them to make sure we don't strip them in the sanitization process.
-			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
+			if ( in_array( $field_id, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
 				$value = $this->unwrap_woocommerce_tags( $value );
 			}
 
@@ -453,17 +459,17 @@ class EmailsSettingsSchema extends AbstractSchema {
 			$sanitized = $this->sanitize_field_value( $field_type, $value );
 
 			// Sanitize Personalization tags. Wrap them in HTML comments for the email editor.
-			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
+			if ( in_array( $field_id, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
 				$sanitized = $this->wrap_woocommerce_tags( $sanitized );
 			}
 
 			// Validate.
-			$validation = $this->validate_field_value( $fieldId, $sanitized, $field );
+			$validation = $this->validate_field_value( $field_id, $sanitized, $field );
 			if ( is_wp_error( $validation ) ) {
 				return $validation;
 			}
 
-			$validated[ $fieldId ] = $sanitized;
+			$validated[ $field_id ] = $sanitized;
 		}
 
 		return $validated;

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * EmailsSettingsSchema class.
+ *
+ * @package WooCommerce\RestApi
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Schema;
+
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use WC_Email;
+use WP_Error;
+use WP_REST_Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * EmailsSettingsSchema class.
+ *
+ * Schema for individual email template settings in the REST API.
+ */
+class EmailsSettingsSchema extends AbstractSchema {
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'emails_settings';
+
+	/**
+	 * Return all properties for the item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema_properties(): array {
+		return array(
+			'id'                 => array(
+				'description' => __( 'Email template ID.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'title'              => array(
+				'description' => __( 'Email title.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'description'        => array(
+				'description' => __( 'Email description.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'post_id'            => array(
+				'description' => __( 'Template post ID.', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'link'               => array(
+				'description' => __( 'Link to template editor.', 'woocommerce' ),
+				'type'        => 'string',
+				'format'      => 'uri',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'email_group'        => array(
+				'description' => __( 'Email group identifier.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'email_group_title'  => array(
+				'description' => __( 'Email group title.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'is_customer_email'  => array(
+				'description' => __( 'Whether this is a customer email.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
+			'values'             => array(
+				'description'          => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
+				'type'                 => 'object',
+				'context'              => self::VIEW_EDIT_CONTEXT,
+				'additionalProperties' => array(
+					'description' => __( 'Setting field value.', 'woocommerce' ),
+					'type'        => array( 'string', 'number', 'array', 'boolean' ),
+				),
+			),
+			'groups'             => array(
+				'description'          => __( 'Collection of setting groups.', 'woocommerce' ),
+				'type'                 => 'object',
+				'context'              => self::VIEW_EDIT_CONTEXT,
+				'additionalProperties' => array(
+					'type'        => 'object',
+					'description' => __( 'Settings group.', 'woocommerce' ),
+					'properties'  => array(
+						'title'       => array(
+							'description' => __( 'Group title.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => self::VIEW_EDIT_CONTEXT,
+						),
+						'description' => array(
+							'description' => __( 'Group description.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => self::VIEW_EDIT_CONTEXT,
+						),
+						'order'       => array(
+							'description' => __( 'Display order for the group.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => self::VIEW_EDIT_CONTEXT,
+							'readonly'    => true,
+						),
+						'fields'      => array(
+							'description' => __( 'Settings fields.', 'woocommerce' ),
+							'type'        => 'array',
+							'context'     => self::VIEW_EDIT_CONTEXT,
+							'items'       => $this->get_field_schema(),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the schema for individual setting fields.
+	 *
+	 * @return array
+	 */
+	private function get_field_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'      => array(
+					'description' => __( 'Setting field ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'label'   => array(
+					'description' => __( 'Setting field label.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'type'    => array(
+					'description' => __( 'Setting field type.', 'woocommerce' ),
+					'type'        => 'string',
+					'enum'        => array( 'text', 'email', 'number', 'select', 'multiselect', 'checkbox', 'textarea', 'color', 'password' ),
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'desc'    => array(
+					'description' => __( 'Description for the setting field.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+				'options' => array(
+					'description' => __( 'Available options for select/multiselect fields.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => self::VIEW_EDIT_CONTEXT,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the item response for a single email.
+	 *
+	 * @param WC_Email        $email   Email instance.
+	 * @param WP_REST_Request $request Request object.
+	 * @param array           $include_fields Fields to include in the response.
+	 * @return array The item response.
+	 */
+	public function get_item_response( $email, WP_REST_Request $request, array $include_fields = array() ): array {
+		// Get template post ID.
+		$email_post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$post_id            = $email_post_manager->get_email_template_post_id( $email->id ?? '' );
+
+		$email->init_form_fields();
+		$response = array(
+			'id'                 => $email->id ?? '',
+			'title'              => $email->title ?? '',
+			'description'        => $email->description ?? '',
+			'post_id'            => $post_id,
+			'link'               => get_permalink( $post_id ),
+			'email_group'        => $email->email_group ?? '',
+			'email_group_title'  => method_exists( $email, 'get_email_group_title' ) ? $email->get_email_group_title() : '',
+			'is_customer_email'  => method_exists( $email, 'is_customer_email' ) ? $email->is_customer_email() : false,
+			'values'             => $this->get_values( $email ),
+			'groups'             => $this->get_groups( $email ),
+		);
+
+		if ( ! empty( $include_fields ) ) {
+			$response = array_intersect_key( $response, array_flip( $include_fields ) );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Get flat key-value mapping of all setting values.
+	 *
+	 * @param WC_Email $email Email instance.
+	 * @return array
+	 */
+	private function get_values( WC_Email $email ): array {
+		$values = array();
+		$form_fields = $email->get_form_fields();
+
+		if ( ! is_array( $form_fields ) ) {
+			return $values;
+		}
+
+		// Create a dummy order object, as some of the getter methods require one.
+		$email->object = new \WC_Order();
+
+		foreach ( $form_fields as $id => $field ) {
+			$field_type = $field['type'] ?? 'text';
+
+			// Skip non-data fields.
+			if ( in_array( $field_type, array( 'title', 'sectionend' ), true ) ) {
+				continue;
+			}
+
+			// Get saved value an fallback to default
+			$default = $this->get_field_default_value( $email, $id, $field );
+			$value   = $email->get_option( $id, $default );
+
+			// Convert checkbox to boolean for API.
+			if ( 'checkbox' === $field_type ) {
+				$value = ( 'yes' === $value );
+			}
+
+			$values[ $id ] = $value;
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Prepare the default value for a field.
+	 * We use special methods for well known core fields and use fallback to default value if no special method is available.
+	 *
+	 * @param WC_Email $email Email instance.
+	 * @param string $id Field ID.
+	 * @param array $field Field definition.
+	 * @return mixed The default value for the field.
+	 */
+	private function get_field_default_value( WC_Email $email, string $id, array $field ) {
+		switch ( $id ) {
+			case 'enabled':
+				return method_exists( $email, 'is_enabled' ) ? $email->is_enabled() : false;
+			case 'recipient':
+				return method_exists( $email, 'get_recipient' ) ? $email->get_recipient() : '';
+			case 'subject':
+				return method_exists( $email, 'get_subject' ) ? $email->get_subject() : '';
+			case 'heading':
+				return method_exists( $email, 'get_heading' ) ? $email->get_heading() : '';
+			case 'preheader':
+				return method_exists( $email, 'get_preheader' ) ? $email->get_preheader() : '';
+			case 'additional_content':
+				return method_exists( $email, 'get_additional_content' ) ? $email->get_additional_content() : '';
+			case 'cc':
+				return $email->cc ?? '';
+			case 'bcc':
+				return $email->bcc ?? '';
+			case 'email_type':
+				return $email->email_type ?? '';
+			default:
+				return $field['default'] ?? ( $field['placeholder'] ?? '' );
+		}
+	}
+	/**
+	 * Get grouped settings structure with field metadata.
+	 *
+	 * @param WC_Email $email Email instance.
+	 * @return array
+	 */
+	private function get_groups( WC_Email $email ): array {
+		$group = array(
+			'title'       => __( 'Email Settings', 'woocommerce' ),
+			'description' => '',
+			'order'       => 1,
+			'fields'      => array(),
+		);
+
+		$form_fields = $email->get_form_fields();
+		foreach ( $form_fields as $id => $field ) {
+			$field_type = $field['type'] ?? 'text';
+
+			// Skip non-data fields.
+			if ( in_array( $field_type, array( 'title', 'sectionend' ), true ) ) {
+				continue;
+			}
+
+			$field_schema = array(
+				'id'    => $id,
+				'label' => $field['title'] ?? $id,
+				'type'  => $field_type ,
+				'desc'  => $field['description'] ?? '',
+			);
+
+			// Add options for select/multiselect fields.
+			if ( isset( $field['options'] ) && is_array( $field['options'] ) ) {
+				$field_schema['options'] = $field['options'];
+			}
+
+			$group['fields'][] = $field_schema;
+		}
+
+		if ( empty( $group['fields'] ) ) {
+			return array();
+		}
+
+		return array( 'settings' => $group );
+	}
+
+	/**
+	 * Validate and sanitize email settings.
+	 *
+	 * @param WC_Email $email  Email instance.
+	 * @param array    $values Values to validate and sanitize.
+	 * @return array|WP_Error Validated settings or error.
+	 */
+	public function validate_and_sanitize_settings( WC_Email $email, array $values ) {
+		$email->init_form_fields();
+		$validated = array();
+
+		foreach ( $values as $fieldId => $value ) {
+			// Only allow valid form fields.
+			if ( ! isset( $email->form_fields[ $fieldId ] ) ) {
+				continue;
+			}
+
+			$field      = $email->form_fields[ $fieldId ];
+			$field_type = $field['type'] ?? 'text';
+
+			// Sanitize by type.
+			$sanitized = $this->sanitize_field_value( $field_type, $value );
+
+			// Validate.
+			$validation = $this->validate_field_value( $fieldId, $sanitized, $field );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+
+			$validated[ $fieldId ] = $sanitized;
+		}
+
+		return $validated;
+	}
+
+	/**
+	 * Sanitize field value based on type.
+	 *
+	 * @param string $type  Field type.
+	 * @param mixed  $value Field value.
+	 * @return mixed Sanitized value.
+	 */
+	private function sanitize_field_value( string $type, $value ) {
+		switch ( $type ) {
+			case 'checkbox':
+				// Ensure we have a scalar value for checkbox settings.
+				if ( is_array( $value ) ) {
+					$value = ! empty( $value ); // Convert array to boolean based on emptiness.
+				}
+				return wc_bool_to_string( $value );
+
+			case 'email':
+				return sanitize_email( $value );
+
+			case 'textarea':
+				return sanitize_textarea_field( $value );
+
+			case 'number':
+				if ( ! is_numeric( $value ) ) {
+					return 0;
+				}
+				$int_value = filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
+				return null !== $int_value ? $int_value : floatval( $value );
+
+			case 'multiselect':
+				if ( is_array( $value ) ) {
+					return array_map( 'sanitize_text_field', $value );
+				}
+				return is_string( $value ) ? array( sanitize_text_field( $value ) ) : array();
+
+			case 'color':
+			case 'password':
+			case 'text':
+			case 'select':
+			default:
+				return sanitize_text_field( $value );
+		}
+	}
+
+	/**
+	 * Validate field value.
+	 *
+	 * @param string $key   Field key.
+	 * @param mixed  $value Sanitized value.
+	 * @param array  $field Field definition.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 */
+	private function validate_field_value( string $key, $value, array $field ) {
+		$field_type = $field['type'] ?? 'text';
+
+		// Validate email format.
+		if ( 'email' === $field_type && ! empty( $value ) && ! is_email( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf(
+					/* translators: %s: field key */
+					__( 'Invalid email format for %s.', 'woocommerce' ),
+					$key
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Validate select options.
+		if ( 'select' === $field_type && ! empty( $field['options'] ) ) {
+			if ( ! array_key_exists( $value, $field['options'] ) && '' !== $value ) {
+				return new WP_Error(
+					'rest_invalid_param',
+					sprintf(
+						/* translators: 1: field key, 2: valid options */
+						__( 'Invalid value for %1$s. Valid options: %2$s', 'woocommerce' ),
+						$key,
+						implode( ', ', array_keys( $field['options'] ) )
+					),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		// Validate multiselect options.
+		if ( 'multiselect' === $field_type && ! empty( $field['options'] ) ) {
+			if ( is_array( $value ) ) {
+				foreach ( $value as $v ) {
+					if ( ! array_key_exists( $v, $field['options'] ) ) {
+						return new WP_Error(
+							'rest_invalid_param',
+							sprintf(
+								/* translators: 1: field key, 2: invalid value */
+								__( 'Invalid option "%2$s" for %1$s.', 'woocommerce' ),
+								$key,
+								$v
+							),
+							array( 'status' => 400 )
+						);
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -93,6 +93,12 @@ class EmailsSettingsSchema extends AbstractSchema {
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
+			'is_manual'  => array(
+				'description' => __( 'Whether this is sent only manually.', 'woocommerce' ),
+				'type'        => 'boolean',
+				'context'     => self::VIEW_EDIT_CONTEXT,
+				'readonly'    => true,
+			),
 			'values'             => array(
 				'description'          => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
 				'type'                 => 'object',
@@ -200,6 +206,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 			'email_group'        => $email->email_group ?? '',
 			'email_group_title'  => method_exists( $email, 'get_email_group_title' ) ? $email->get_email_group_title() : '',
 			'is_customer_email'  => method_exists( $email, 'is_customer_email' ) ? $email->is_customer_email() : false,
+			'is_manual'          => method_exists( $email, 'is_manual' ) ? $email->is_manual() : false,
 			'values'             => $this->get_values( $email ),
 			'groups'             => $this->get_groups( $email ),
 		);

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -31,6 +31,13 @@ class EmailsSettingsSchema extends AbstractSchema {
 	const IDENTIFIER = 'emails_settings';
 
 	/**
+	 * This fields support personalization tags and need to be unwrapped before returning to the client.
+	 *
+	 * @var array
+	 */
+	const FIELDS_SUPPORTING_PERSONALIZATION_TAGS = array( 'subject', 'preheader' );
+
+	/**
 	 * Return all properties for the item schema.
 	 *
 	 * @return array
@@ -233,6 +240,11 @@ class EmailsSettingsSchema extends AbstractSchema {
 			$default = $this->get_field_default_value( $email, $id, $field );
 			$value   = $email->get_option( $id, $default );
 
+			// Unwrap personalization tags if the field supports them.
+			if ( in_array( $id, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
+				$value = $this->unwrap_woocommerce_tags( $value );
+			}
+
 			// Convert checkbox to boolean for API.
 			if ( 'checkbox' === $field_type ) {
 				$value = ( 'yes' === $value );
@@ -277,6 +289,30 @@ class EmailsSettingsSchema extends AbstractSchema {
 				return $field['default'] ?? ( $field['placeholder'] ?? '' );
 		}
 	}
+
+	/**
+	 * Remove HTML comment wrappers from WooCommerce tags.
+	 *
+	 * Converts tags from <!--[woocommerce/tag-name]--> back to [woocommerce/tag-name],
+	 * <!--[mailpoet/tag-name]--> back to [mailpoet/tag-name], or
+	 * <!--[ciab/tag-name]--> back to [ciab/tag-name]
+	 *
+	 * This is required because the email editor personalization tags are wrapped in HTML comment wrappers.
+	 * We need to remove the tags to make editing easier for the end-users and also because the tags are not well formatted in the current DataForm implementation.
+	 *
+	 * @param string $value The value to unwrap.
+	 * @return string The unwrapped value.
+	 */
+	private function unwrap_woocommerce_tags( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		// Remove HTML comment wrappers from WooCommerce tags.
+		$unwrapped_value = preg_replace( '/<!--(\[(?:woocommerce|mailpoet|ciab)\/[^\]]+\])-->/i', '$1', $value );
+		return $unwrapped_value;
+	}
+
 	/**
 	 * Get grouped settings structure with field metadata.
 	 *
@@ -344,6 +380,14 @@ class EmailsSettingsSchema extends AbstractSchema {
 
 			// Sanitize by type.
 			$sanitized = $this->sanitize_field_value( $field_type, $value );
+
+			// Sanitize Personalization tags
+			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
+				// check if the subject has a value like [woocommerce/customer-first-name] or [mailpoet/...] or [ciab/...], if so, replace with <!--tagName-->
+				// this is required for the email editor personalization.
+				// Use negative lookbehind and lookahead to avoid double-wrapping already wrapped tags.
+				$sanitized = preg_replace( '/(?<!<!--)(\[(?:woocommerce|mailpoet|ciab)\/[^\]]+\])(?!-->)/i', '<!--$1-->', $value );
+			}
 
 			// Validate.
 			$validation = $this->validate_field_value( $fieldId, $sanitized, $field );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -84,7 +84,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 			),
 			'post_id'            => array(
 				'description' => __( 'Template post ID.', 'woocommerce' ),
-				'type'        => 'integer',
+				'type'        => array( 'integer', 'null' ),
 				'context'     => self::VIEW_EDIT_CONTEXT,
 				'readonly'    => true,
 			),
@@ -215,6 +215,8 @@ class EmailsSettingsSchema extends AbstractSchema {
 		// Get template post ID.
 		$email_post_manager = WCTransactionalEmailPostsManager::get_instance();
 		$post_id            = $email_post_manager->get_email_template_post_id( $email->id ?? '' );
+		// Convert false to null, ensure int otherwise.
+		$post_id            = $post_id ? (int) $post_id : null;
 
 		$email->init_form_fields();
 		$response = array(
@@ -352,6 +354,32 @@ class EmailsSettingsSchema extends AbstractSchema {
 	}
 
 	/**
+	 * Wrap personalization tags in HTML comments for the email editor.
+	 * This is required for the email editor personalization.
+	 * Use negative lookbehind and lookahead to avoid double-wrapping already wrapped tags.
+	 *
+	 * @param mixed $value
+	 */
+	private function wrap_woocommerce_tags( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		$prefixes = $this->get_personalization_tag_prefixes();
+
+		if ( empty( $prefixes ) ) {
+			return $value;
+		}
+
+		// Escape prefixes for use in regex and join with |.
+		$escaped_prefixes = array_map( 'preg_quote', $prefixes );
+		$prefixes_pattern = implode( '|', $escaped_prefixes );
+
+		// Wrap tags that aren't already wrapped.
+		return preg_replace( '/(?<!<!--)(\[(?:' . $prefixes_pattern . ')\/[^\]]+\])(?!-->)/i', '<!--$1-->', $value );
+	}
+
+	/**
 	 * Get grouped settings structure with field metadata.
 	 *
 	 * @param WC_Email $email Email instance.
@@ -416,24 +444,17 @@ class EmailsSettingsSchema extends AbstractSchema {
 			$field      = $email->form_fields[ $fieldId ];
 			$field_type = $field['type'] ?? 'text';
 
+			// Unwrap personalization tags if the field supports them to make sure we don't strip them in the sanitization process.
+			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
+				$value = $this->unwrap_woocommerce_tags( $value );
+			}
+
 			// Sanitize by type.
 			$sanitized = $this->sanitize_field_value( $field_type, $value );
 
-			// Sanitize Personalization tags.
+			// Sanitize Personalization tags. Wrap them in HTML comments for the email editor.
 			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
-				// Wrap personalization tags in HTML comments for the email editor.
-				// This is required for the email editor personalization.
-				// Use negative lookbehind and lookahead to avoid double-wrapping already wrapped tags.
-				$prefixes = $this->get_personalization_tag_prefixes();
-
-				if ( ! empty( $prefixes ) ) {
-					// Escape prefixes for use in regex and join with |.
-					$escaped_prefixes = array_map( 'preg_quote', $prefixes );
-					$prefixes_pattern = implode( '|', $escaped_prefixes );
-
-					// Wrap tags that aren't already wrapped.
-					$sanitized = preg_replace( '/(?<!<!--)(\[(?:' . $prefixes_pattern . ')\/[^\]]+\])(?!-->)/i', '<!--$1-->', $value );
-				}
+				$sanitized = $this->wrap_woocommerce_tags( $sanitized );
 			}
 
 			// Validate.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -223,13 +223,19 @@ class EmailsSettingsSchema extends AbstractSchema {
 		// Convert false to null, ensure int otherwise.
 		$post_id = $post_id ? (int) $post_id : null;
 
+		$link = '';
+		if ( $post_id ) {
+			$permalink = get_permalink( $post_id );
+			$link      = is_string( $permalink ) ? $permalink : '';
+		}
+
 		$email->init_form_fields();
 		$response = array(
 			'id'                => $email->id ?? '',
 			'title'             => $email->title ?? '',
 			'description'       => $email->description ?? '',
 			'post_id'           => $post_id,
-			'link'              => get_permalink( $post_id ),
+			'link'              => $link,
 			'email_group'       => $email->email_group ?? '',
 			'email_group_title' => method_exists( $email, 'get_email_group_title' ) ? $email->get_email_group_title() : '',
 			'is_customer_email' => method_exists( $email, 'is_customer_email' ) ? $email->is_customer_email() : false,

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -9,8 +9,10 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Schema;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractSchema;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use WC_Email;
 use WP_Error;
 use WP_REST_Request;
@@ -36,6 +38,24 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 * @var array
 	 */
 	const FIELDS_SUPPORTING_PERSONALIZATION_TAGS = array( 'subject', 'preheader' );
+
+	/**
+	 * Personalization tags registry.
+	 *
+	 * @var Personalization_Tags_Registry|null
+	 */
+	private $personalization_tags_registry;
+
+	/**
+	 * Cached array of personalization tag prefixes.
+	 *
+	 * @var array|null
+	 */
+	private $cached_prefixes = null;
+
+	public function init() {
+		$this->personalization_tags_registry = Email_Editor_Container::container()->get( Personalization_Tags_Registry::class );
+	}
 
 	/**
 	 * Return all properties for the item schema.
@@ -298,11 +318,10 @@ class EmailsSettingsSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Remove HTML comment wrappers from WooCommerce tags.
+	 * Remove HTML comment wrappers from personalization tags.
 	 *
-	 * Converts tags from <!--[woocommerce/tag-name]--> back to [woocommerce/tag-name],
-	 * <!--[mailpoet/tag-name]--> back to [mailpoet/tag-name], or
-	 * <!--[ciab/tag-name]--> back to [ciab/tag-name]
+	 * Converts tags from <!--[prefix/tag-name]--> back to [prefix/tag-name] for all registered prefixes.
+	 * For example: <!--[woocommerce/customer-name]--> becomes [woocommerce/customer-name].
 	 *
 	 * This is required because the email editor personalization tags are wrapped in HTML comment wrappers.
 	 * We need to remove the tags to make editing easier for the end-users and also because the tags are not well formatted in the current DataForm implementation.
@@ -315,8 +334,20 @@ class EmailsSettingsSchema extends AbstractSchema {
 			return $value;
 		}
 
-		// Remove HTML comment wrappers from WooCommerce tags.
-		$unwrapped_value = preg_replace( '/<!--(\[(?:woocommerce|mailpoet|ciab)\/[^\]]+\])-->/i', '$1', $value );
+		// Get all registered prefixes dynamically.
+		$prefixes = $this->get_personalization_tag_prefixes();
+
+		// If no prefixes, return the value unchanged.
+		if ( empty( $prefixes ) ) {
+			return $value;
+		}
+
+		// Escape prefixes for use in regex and join with |.
+		$escaped_prefixes = array_map( 'preg_quote', $prefixes );
+		$prefixes_pattern = implode( '|', $escaped_prefixes );
+
+		// Remove HTML comment wrappers from personalization tags.
+		$unwrapped_value = preg_replace( '/<!--(\[(?:' . $prefixes_pattern . ')\/[^\]]+\])-->/i', '$1', $value );
 		return $unwrapped_value;
 	}
 
@@ -388,12 +419,21 @@ class EmailsSettingsSchema extends AbstractSchema {
 			// Sanitize by type.
 			$sanitized = $this->sanitize_field_value( $field_type, $value );
 
-			// Sanitize Personalization tags
+			// Sanitize Personalization tags.
 			if ( in_array( $fieldId, self::FIELDS_SUPPORTING_PERSONALIZATION_TAGS, true ) ) {
-				// check if the subject has a value like [woocommerce/customer-first-name] or [mailpoet/...] or [ciab/...], if so, replace with <!--tagName-->
-				// this is required for the email editor personalization.
+				// Wrap personalization tags in HTML comments for the email editor.
+				// This is required for the email editor personalization.
 				// Use negative lookbehind and lookahead to avoid double-wrapping already wrapped tags.
-				$sanitized = preg_replace( '/(?<!<!--)(\[(?:woocommerce|mailpoet|ciab)\/[^\]]+\])(?!-->)/i', '<!--$1-->', $value );
+				$prefixes = $this->get_personalization_tag_prefixes();
+
+				if ( ! empty( $prefixes ) ) {
+					// Escape prefixes for use in regex and join with |.
+					$escaped_prefixes = array_map( 'preg_quote', $prefixes );
+					$prefixes_pattern = implode( '|', $escaped_prefixes );
+
+					// Wrap tags that aren't already wrapped.
+					$sanitized = preg_replace( '/(?<!<!--)(\[(?:' . $prefixes_pattern . ')\/[^\]]+\])(?!-->)/i', '<!--$1-->', $value );
+				}
 			}
 
 			// Validate.
@@ -513,5 +553,42 @@ class EmailsSettingsSchema extends AbstractSchema {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get all unique prefixes from registered personalization tags.
+	 *
+	 * Extracts the prefix part (before the /) from all registered personalization tags.
+	 * For example, from [woocommerce/customer-name] it extracts 'woocommerce'.
+	 * Results are cached to avoid repeated processing.
+	 *
+	 * @return array Array of unique prefixes, escaped for use in regex patterns.
+	 */
+	private function get_personalization_tag_prefixes(): array {
+		if ( null === $this->personalization_tags_registry ) {
+			return array();
+		}
+
+		// Return cached prefixes if available.
+		if ( null !== $this->cached_prefixes ) {
+			return $this->cached_prefixes;
+		}
+
+		$prefixes = array();
+		$tags     = $this->personalization_tags_registry->get_all();
+
+		foreach ( $tags as $tag ) {
+			$token = $tag->get_token(); // E.g., [woocommerce/customer-name].
+
+			// Extract the prefix from the token (the part before the /).
+			// Remove brackets and get the part before /.
+			if ( preg_match( '/^\[([^\/\]]+)\//', $token, $matches ) ) {
+				$prefixes[ $matches[1] ] = true; // Use array key to ensure uniqueness.
+			}
+		}
+
+		// Convert to array of values and cache.
+		$this->cached_prefixes = array_keys( $prefixes );
+		return $this->cached_prefixes;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Email/EmailSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Email/EmailSettingsControllerTest.php
@@ -2,19 +2,22 @@
 /**
  * Email Settings V4 controller unit tests.
  *
- * @package WooCommerce\RestApi\UnitTests
- * @since   4.0.0
+ * @package WooCommerce\Tests\Internal\RestApi\Routes\V4\Settings\Email
  */
 
 declare(strict_types=1);
 
+namespace Automattic\WooCommerce\Tests\Internal\RestApi\Routes\V4\Settings\Email;
+
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
 /**
- * Email Settings V4 controller unit tests.
+ * Tests for the Email Settings REST API controller.
  *
- * @package WooCommerce\RestApi\UnitTests
- * @since   4.0.0
+ * @class EmailSettingsControllerTest
  */
-class WC_REST_Email_Settings_V4_Controller_Test extends WC_REST_Unit_Test_Case {
+class EmailSettingsControllerTest extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * User ID.

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Emails/EmailsSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Emails/EmailsSettingsControllerTest.php
@@ -81,6 +81,7 @@ class EmailsSettingsControllerTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', $this->feature_filter );
 
 		// Enable block email editor feature.
+		$this->prev_options['woocommerce_feature_block_email_editor_enabled'] = get_option( 'woocommerce_feature_block_email_editor_enabled', null );
 		update_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
 
 		parent::setUp();

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Emails/EmailsSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/Emails/EmailsSettingsControllerTest.php
@@ -1,0 +1,737 @@
+<?php
+/**
+ * Emails Settings V4 controller unit tests.
+ *
+ * @package WooCommerce\Tests\Internal\RestApi\Routes\V4\Settings\Emails
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\RestApi\Routes\V4\Settings\Emails;
+
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Controller;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Settings\Emails\Schema\EmailsSettingsSchema;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+use WC_Emails;
+
+/**
+ * Tests for the Emails Settings REST API controller.
+ *
+ * @class EmailsSettingsControllerTest
+ */
+class EmailsSettingsControllerTest extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Sample email ID for testing.
+	 *
+	 * @var string
+	 */
+	const SAMPLE_EMAIL_ID = 'customer_completed_order';
+
+	/**
+	 * Sample email instance.
+	 *
+	 * @var WC_Email
+	 */
+	private $email;
+
+	/**
+	 * User ID with shop_manager permissions.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Feature filter callback.
+	 *
+	 * @var callable
+	 */
+	private $feature_filter;
+
+	/**
+	 * Previous option values to restore after tests.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $prev_options = array();
+
+	/**
+	 * Personalization tags registry instance.
+	 *
+	 * @var Personalization_Tags_Registry|null
+	 */
+	private $registry;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp(): void {
+		// Enable the v4 REST API feature before bootstrapping.
+		$this->feature_filter = function ( $features ) {
+			$features[] = 'rest-api-v4';
+			return $features;
+		};
+
+		add_filter( 'woocommerce_admin_features', $this->feature_filter );
+
+		// Enable block email editor feature.
+		update_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
+
+		parent::setUp();
+
+		// Register personalization tags for testing.
+		$container      = Email_Editor_Container::container();
+		$this->registry = $container->get( Personalization_Tags_Registry::class );
+		$this->register_personalization_tag( 'woocommerce', 'customer-first-name' );
+		$this->register_personalization_tag( 'woocommerce', 'order-number' );
+		$this->register_personalization_tag( 'custom-plugin', 'test-field' );
+
+		// Manually initialize controller with schema that has the registry.
+		// We do this to ensure personalization tags wrapping/unwrapping uses the registry.
+		$controller = new Controller();
+		$schema     = new EmailsSettingsSchema();
+		$schema->init();
+		$controller->init( $schema );
+		$controller->register_routes();
+
+		// Snapshot current option values to restore on tearDown.
+		$option_key                        = 'woocommerce_' . self::SAMPLE_EMAIL_ID . '_settings';
+		$this->prev_options[ $option_key ] = get_option( $option_key, null );
+
+		// Create a user with permissions.
+		$this->user_id = $this->factory->user->create(
+			array(
+				'role' => 'shop_manager',
+			)
+		);
+
+		// Initialize WC_Emails to ensure emails are registered.
+		WC_Emails::instance()->init();
+		$this->email = WC_Emails::instance()->emails['WC_Email_Customer_Completed_Order'];
+
+		// Generate transactional email template posts.
+		$email_generator = new WCTransactionalEmailPostsGenerator();
+		$email_generator->initialize();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		if ( isset( $this->feature_filter ) ) {
+			remove_filter( 'woocommerce_admin_features', $this->feature_filter );
+		}
+
+		// Restore previous option values.
+		foreach ( $this->prev_options as $key => $value ) {
+			if ( null === $value ) {
+				delete_option( (string) $key );
+			} else {
+				update_option( (string) $key, $value );
+			}
+		}
+
+		// Clean up email template posts transient.
+		delete_transient( 'wc_email_editor_initial_templates_generated' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v4/settings/emails', $routes );
+		$this->assertArrayHasKey( '/wc/v4/settings/emails/(?P<email_id>[\w-]+)', $routes );
+	}
+
+	/**
+	 * Test that get_items returns properly formatted response.
+	 */
+	public function test_get_items_returns_properly_formatted_response() {
+		wp_set_current_user( $this->user_id );
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data );
+
+		// Verify at least one item has proper structure.
+		$item = $data[0];
+		$this->assert_valid_email_item_structure( $item );
+	}
+
+	/**
+	 * Test that get_item returns properly formatted response.
+	 */
+	public function test_get_single_item_returns_properly_formatted_response() {
+		wp_set_current_user( $this->user_id );
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( self::SAMPLE_EMAIL_ID, $data['id'] );
+		$this->assert_valid_email_item_structure( $data );
+
+		// Verify values contain email-specific settings.
+		$this->assertArrayHasKey( 'values', $data );
+		$this->assertIsArray( $data['values'] );
+		$this->assertArrayHasKey( 'enabled', $data['values'] );
+		$this->assertArrayHasKey( 'subject', $data['values'] );
+		$this->assertArrayHasKey( 'heading', $data['values'] );
+	}
+
+	/**
+	 * Test that get_items can filter by post_id.
+	 */
+	public function test_get_items_can_filter_by_post_id() {
+		wp_set_current_user( $this->user_id );
+
+		// First, get an email and its post_id.
+		$request      = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response     = $this->server->dispatch( $request );
+		$email_data   = $response->get_data();
+		$test_post_id = $email_data['post_id'];
+
+		// Now filter by that post_id.
+		$request = new WP_REST_Request( 'GET', '/wc/v4/settings/emails' );
+		$request->set_param( 'post_id', $test_post_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+
+		// If post_id is valid, we should get at least the one email.
+		if ( $test_post_id > 0 ) {
+			$this->assertNotEmpty( $data );
+			foreach ( $data as $item ) {
+				$this->assertEquals( $test_post_id, $item['post_id'] );
+			}
+		}
+	}
+
+	/**
+	 * Test that filtering by nonexistent post_id returns empty array.
+	 */
+	public function test_get_items_with_nonexistent_post_id_returns_empty() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'GET', '/wc/v4/settings/emails' );
+		$request->set_param( 'post_id', 999999 );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertEmpty( $data );
+	}
+
+	/**
+	 * Test successfully updating email settings.
+	 */
+	public function test_update_item_successfully_updates_settings() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'enabled' => true,
+						'subject' => 'Test Subject',
+						'heading' => 'Test Heading',
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Test Subject', $data['values']['subject'] );
+		$this->assertEquals( 'Test Heading', $data['values']['heading'] );
+		$this->assertTrue( $data['values']['enabled'] );
+
+		// Verify database was updated.
+		$option_key = 'woocommerce_' . self::SAMPLE_EMAIL_ID . '_settings';
+		$settings   = get_option( $option_key, array() );
+		$this->assertEquals( 'Test Subject', $settings['subject'] );
+		$this->assertEquals( 'Test Heading', $settings['heading'] );
+		$this->assertEquals( 'yes', $settings['enabled'] );
+	}
+
+	/**
+	 * Test updating with invalid email ID returns 404.
+	 */
+	public function test_update_item_with_invalid_email_id_returns_404() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/invalid_email_id' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'values' => array( 'subject' => 'Test' ) ) ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'Email template not found.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test updating with empty body returns 400.
+	 */
+	public function test_update_item_with_empty_body_returns_400() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array() ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Invalid or empty request body.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test checkbox field sanitization.
+	 */
+	public function test_sanitize_checkbox_field() {
+		wp_set_current_user( $this->user_id );
+
+		// Test boolean true.
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'values' => array( 'enabled' => true ) ) ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['values']['enabled'] );
+
+		// Test boolean false.
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'values' => array( 'enabled' => false ) ) ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $response->get_data()['values']['enabled'] );
+
+		// Verify database storage.
+		$option_key = 'woocommerce_' . self::SAMPLE_EMAIL_ID . '_settings';
+		$settings   = get_option( $option_key, array() );
+		$this->assertEquals( 'no', $settings['enabled'] );
+	}
+
+	/**
+	 * Test text field sanitization.
+	 */
+	public function test_sanitize_text_field() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => '<script>alert("xss")</script>Test Subject',
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify HTML tags are stripped in stored value.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertStringNotContainsString( '<script>', $stored_subject );
+		$this->assertStringNotContainsString( '</script>', $stored_subject );
+		$this->assertStringContainsString( 'Test Subject', $stored_subject );
+	}
+
+	/**
+	 * Test unwrapping personalization tags on GET.
+	 */
+	public function test_unwrap_personalization_tags_on_get() {
+		wp_set_current_user( $this->user_id );
+
+		// Store wrapped subject directly in database.
+		$wrapped_subject                  = 'Hello <!--[woocommerce/customer-first-name]-->';
+		$this->email->settings['subject'] = $wrapped_subject;
+
+		// GET the email settings.
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		// Verify subject is unwrapped.
+		$this->assertEquals( 'Hello [woocommerce/customer-first-name]', $data['values']['subject'] );
+	}
+
+	/**
+	 * Test wrapping personalization tags on UPDATE.
+	 */
+	public function test_wrap_personalization_tags_on_update() {
+		wp_set_current_user( $this->user_id );
+
+		$unwrapped_subject = 'Hello [woocommerce/customer-first-name]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $unwrapped_subject,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify database stores wrapped version.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertEquals( 'Hello <!--[woocommerce/customer-first-name]-->', $stored_subject );
+	}
+
+	/**
+	 * Test personalization tags support multiple prefixes.
+	 */
+	public function test_personalization_tags_support_multiple_prefixes() {
+		wp_set_current_user( $this->user_id );
+		$subject_with_multiple_prefixes = 'Hello [woocommerce/customer-first-name] [custom-plugin/test-field]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $subject_with_multiple_prefixes,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify all prefixes are wrapped.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertStringContainsString( '<!--[woocommerce/customer-first-name]-->', $stored_subject );
+
+		// Custom plugin prefix should also be wrapped if registry is available.
+		$this->assertStringContainsString( '<!--[custom-plugin/test-field]-->', $stored_subject );
+
+		// GET the settings and verify all are unwrapped.
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertStringContainsString( '[woocommerce/customer-first-name]', $data['values']['subject'] );
+		$this->assertStringNotContainsString( '<!--', $data['values']['subject'] );
+		$this->assertStringNotContainsString( '-->', $data['values']['subject'] );
+	}
+
+	/**
+	 * Test that personalization tags are not double-wrapped.
+	 */
+	public function test_personalization_tags_no_double_wrapping() {
+		wp_set_current_user( $this->user_id );
+
+		$already_wrapped_subject = 'Hello <!--[woocommerce/customer-first-name]-->';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $already_wrapped_subject,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify NOT double-wrapped.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertEquals( 'Hello <!--[woocommerce/customer-first-name]-->', $stored_subject );
+		$this->assertStringNotContainsString( '<!--<!--', $stored_subject );
+		$this->assertStringNotContainsString( '-->-->', $stored_subject );
+	}
+
+	/**
+	 * Test mixed wrapped and unwrapped tags.
+	 */
+	public function test_personalization_tags_mixed_wrapped_unwrapped() {
+		wp_set_current_user( $this->user_id );
+
+		$mixed_subject = 'Hello <!--[woocommerce/customer-first-name]--> and [woocommerce/order-number]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $mixed_subject,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify only unwrapped tag gets wrapped.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertEquals( 'Hello <!--[woocommerce/customer-first-name]--> and <!--[woocommerce/order-number]-->', $stored_subject );
+	}
+
+	/**
+	 * Test personalization tags are case insensitive.
+	 */
+	public function test_personalization_tags_case_insensitive() {
+		wp_set_current_user( $this->user_id );
+
+		$uppercase_subject = 'Hello [WooCommerce/customer-first-name]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $uppercase_subject,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify wrapped correctly despite uppercase.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertStringContainsString( '<!--[WooCommerce/customer-first-name]-->', $stored_subject );
+	}
+
+	/**
+	 * Test personalization tags with attributes.
+	 */
+	public function test_personalization_tags_with_attributes() {
+		wp_set_current_user( $this->user_id );
+
+		$subject_with_attributes = 'Hello [woocommerce/customer-first-name default="Guest"]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => $subject_with_attributes,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify wrapped with attributes intact.
+		$stored_subject = $this->get_stored_subject( self::SAMPLE_EMAIL_ID );
+		$this->assertEquals( 'Hello <!--[woocommerce/customer-first-name default="Guest"]-->', $stored_subject );
+
+		// Verify unwraps back correctly.
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'Hello [woocommerce/customer-first-name default="Guest"]', $data['values']['subject'] );
+	}
+
+	/**
+	 * Test preheader field also supports personalization tags.
+	 */
+	public function test_personalization_tags_preheader_field_support() {
+		wp_set_current_user( $this->user_id );
+
+		$preheader_with_tag = 'Check your order [woocommerce/order-number]';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'preheader' => $preheader_with_tag,
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify preheader is wrapped.
+		$option_key = 'woocommerce_' . self::SAMPLE_EMAIL_ID . '_settings';
+		$settings   = get_option( $option_key, array() );
+		$this->assertEquals( 'Check your order <!--[woocommerce/order-number]-->', $settings['preheader'] );
+
+		// Verify GET unwraps preheader.
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		if ( isset( $data['values']['preheader'] ) ) {
+			$this->assertEquals( 'Check your order [woocommerce/order-number]', $data['values']['preheader'] );
+		}
+	}
+
+	/**
+	 * Test GET without permission returns 401.
+	 */
+	public function test_get_items_without_permission_returns_401() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test UPDATE without permission returns 401.
+	 */
+	public function test_update_item_without_permission_returns_401() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'values' => array( 'subject' => 'Test' ) ) ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test GET with shop_manager permission succeeds.
+	 */
+	public function test_get_items_with_shop_manager_permission() {
+		wp_set_current_user( $this->user_id );
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/settings/emails' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test UPDATE with shop_manager permission succeeds.
+	 */
+	public function test_update_item_with_shop_manager_permission() {
+		wp_set_current_user( $this->user_id );
+		$request = new WP_REST_Request( 'PUT', '/wc/v4/settings/emails/' . self::SAMPLE_EMAIL_ID );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'values' => array(
+						'subject' => 'Test Subject',
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Helper: Assert valid email item structure.
+	 *
+	 * @param array $item Email item data.
+	 */
+	private function assert_valid_email_item_structure( array $item ) {
+		// Verify required top-level fields.
+		$this->assertArrayHasKey( 'id', $item );
+		$this->assertArrayHasKey( 'title', $item );
+		$this->assertArrayHasKey( 'description', $item );
+		$this->assertArrayHasKey( 'post_id', $item );
+		$this->assertArrayHasKey( 'link', $item );
+		$this->assertArrayHasKey( 'email_group', $item );
+		$this->assertArrayHasKey( 'email_group_title', $item );
+		$this->assertArrayHasKey( 'is_customer_email', $item );
+		$this->assertArrayHasKey( 'is_manual', $item );
+		$this->assertArrayHasKey( 'values', $item );
+		$this->assertArrayHasKey( 'groups', $item );
+
+		// Verify types.
+		$this->assertIsString( $item['id'] );
+		$this->assertIsString( $item['title'] );
+		$this->assertTrue( is_int( $item['post_id'] ) || is_null( $item['post_id'] ), 'post_id should be int or null' );
+		$this->assertIsBool( $item['is_customer_email'] );
+		$this->assertIsBool( $item['is_manual'] );
+		$this->assertIsArray( $item['values'] );
+		$this->assertIsArray( $item['groups'] );
+
+		// Verify groups structure.
+		if ( ! empty( $item['groups'] ) ) {
+			foreach ( $item['groups'] as $group ) {
+				$this->assertArrayHasKey( 'title', $group );
+				$this->assertArrayHasKey( 'description', $group );
+				$this->assertArrayHasKey( 'order', $group );
+				$this->assertArrayHasKey( 'fields', $group );
+				$this->assertIsArray( $group['fields'] );
+
+				// Verify fields structure.
+				if ( ! empty( $group['fields'] ) ) {
+					foreach ( $group['fields'] as $field ) {
+						$this->assertArrayHasKey( 'id', $field );
+						$this->assertArrayHasKey( 'label', $field );
+						$this->assertArrayHasKey( 'type', $field );
+						$this->assertArrayHasKey( 'desc', $field );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Helper: Get stored subject from database.
+	 *
+	 * @param string $email_id Email ID.
+	 * @return string Stored subject.
+	 */
+	private function get_stored_subject( string $email_id ): string {
+		$option_key = 'woocommerce_' . $email_id . '_settings';
+		$settings   = get_option( $option_key, array() );
+		return $settings['subject'] ?? '';
+	}
+
+	/**
+	 * Helper: Register personalization tag for testing.
+	 *
+	 * @param string $prefix Tag prefix.
+	 * @param string $name Tag name.
+	 */
+	private function register_personalization_tag( string $prefix, string $name ) {
+		$tag = new Personalization_Tag(
+			ucfirst( $name ),
+			$prefix . '/' . $name,
+			'Custom',
+			function () {
+				return 'test-value';
+			}
+		);
+		$this->registry->register( $tag );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the `settings/emails` route to the experimental V4 API.

The endpoint was moved from the temporary endpoint and updated to align with other settings APIs (e.g. general settings). The main changes are:
- separated schema and controller
- the response format is aligned to other settings:
   - non-editable metadata are on top level (e.g. id, description, link, post_id, is_customer_email)
   - editable fields are generated dynamically based on WP_Email::get_form_fields and are nested in `values`
   - I added `is_manual` to be able to mark emails that are sent only manually
- moved test for email settings to proper location
- added test for the emails settings api

There are a few things that need to be addressed as follow-up:
- historically, the recipient field is text and is not validated as a list of comma-separated email addresses
- the api unwraps personalization tags in the subject and preheader in the GET response. I think the API should send the data as they are saved and let the client handle the unwrapping if it doesn't support the tags. I have briefly discussed this with @triple0t, and he had no strong opinion on that and is ok with the change. Other opinions are welcome. 

Closes WOOPRD-926.

### How to test the changes in this Pull Request:

The endpoint is covered by unit tests. It can also be tested with an app that uses it.

<!-- End testing instructions -->
