### PR TITLE
Ensure local pickup details render immediately after selecting rate

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5811-checkout-block-pickup-location-details-renders-awkwardly
+++ b/plugins/woocommerce/changelog/wooplug-5811-checkout-block-pickup-location-details-renders-awkwardly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent delay/jarring rendering of pickup location in checkout block.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -31,10 +31,10 @@ interface LocalPickupSelectProps {
 	renderPickupLocation: (
 		location: CartShippingPackageShippingRate,
 		pickupLocationsCount: number,
-		// This arg signals that the rate is selected in the _client_ (not necessarily the selected shipping rate on the server, yet)
+		// This is the ID of the rate that is selected in the _client_ (not necessarily the selected shipping rate on the server, yet)
 		// If the server returns a cart with a different selected shipping rate, then after "receiving" the updated cart (`receiveCart`)
-		// this arg, `isSelectedInClient`, will be true for that rate, and the UI will update.
-		isSelectedInClient?: boolean
+		// this arg, `clientSelectedOption`, will change to be the ID for that rate, and the UI will update.
+		clientSelectedOption?: string
 	) => RadioControlOptionType;
 	packageCount: number;
 	onChange: ( value: string ) => void;
@@ -124,7 +124,7 @@ export const LocalPickupSelect = ( {
 					renderPickupLocation(
 						location,
 						packageCount,
-						selectedOption === location.rate_id
+						selectedOption
 					)
 				) }
 			/>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -34,7 +34,7 @@ interface LocalPickupSelectProps {
 		// This arg signals that the rate is selected in the _client_ (not necessarily the selected shipping rate on the server, yet)
 		// If the server returns a cart with a different selected shipping rate, then after "receiving" the updated cart (`receiveCart`)
 		// this arg, `isSelectedInClient`, will be true for that rate, and the UI will update.
-		isSelectedInClient: boolean
+		isSelectedInClient?: boolean
 	) => RadioControlOptionType;
 	packageCount: number;
 	onChange: ( value: string ) => void;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -30,7 +30,11 @@ interface LocalPickupSelectProps {
 	pickupLocations: CartShippingPackageShippingRate[];
 	renderPickupLocation: (
 		location: CartShippingPackageShippingRate,
-		pickupLocationsCount: number
+		pickupLocationsCount: number,
+		// This arg signals that the rate is selected in the _client_ (not necessarily the selected shipping rate on the server, yet)
+		// If the server returns a cart with a different selected shipping rate, then after "receiving" the updated cart (`receiveCart`)
+		// this arg, `isSelectedInClient`, will be true for that rate, and the UI will update.
+		isSelectedInClient: boolean
 	) => RadioControlOptionType;
 	packageCount: number;
 	onChange: ( value: string ) => void;
@@ -117,7 +121,11 @@ export const LocalPickupSelect = ( {
 				highlightChecked={ true }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
-					renderPickupLocation( location, packageCount )
+					renderPickupLocation(
+						location,
+						packageCount,
+						selectedOption === location.rate_id
+					)
 				) }
 			/>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -18,6 +18,19 @@ import {
 jest.mock( '@woocommerce/base-context/hooks' );
 
 describe( 'LocalPickupSelect', () => {
+	const renderPickupLocationMock = jest
+		.fn()
+		.mockImplementation(
+			( location, pickupLocationsCount, isSelectedInClient ) => {
+				return {
+					value: `${ location.rate_id }`,
+					onChange: jest.fn(),
+					label: `${ location.name }`,
+					description: `${ location.description }`,
+				};
+			}
+		);
+
 	const defaultPackageData = generateShippingPackage( {
 		packageId: 0,
 		shippingRates: [],

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -183,7 +183,7 @@ describe( 'LocalPickupSelect', () => {
 			'store_2' // gets the currently selected option.
 		);
 	} );
-	it( 'Updates isSelectedInClient parameter when selection changes', () => {
+	it( 'Updates clientSelectedOption parameter when selection changes', () => {
 		renderPickupLocationMock.mockClear();
 		const pickupLocations = [
 			generateShippingRate( {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -20,12 +20,13 @@ jest.mock( '@woocommerce/base-context/hooks' );
 describe( 'LocalPickupSelect', () => {
 	const renderPickupLocationMock = jest.fn().mockImplementation(
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		( location, pickupLocationsCount, isSelectedInClient ) => {
+		( location, pickupLocationsCount, clientSelectedOption ) => {
 			return {
 				value: `${ location.rate_id }`,
 				onChange: jest.fn(),
 				label: `${ location.name }`,
 				description: `${ location.description }`,
+				clientSelectedOption,
 			};
 		}
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -134,6 +134,125 @@ describe( 'LocalPickupSelect', () => {
 		await user.click( screen.getByText( 'Store 1' ) );
 		expect( onChange ).toHaveBeenLastCalledWith( '1' );
 	} );
+	it( 'Calls renderPickupLocation with correct parameters', () => {
+		renderPickupLocationMock.mockClear();
+		render(
+			<LocalPickupSelect
+				title="Package 1"
+				onChange={ jest.fn() }
+				selectedOption="store_2"
+				pickupLocations={ [
+					generateShippingRate( {
+						rateId: 'store_1',
+						name: 'Store 1',
+						instanceID: 1,
+						price: '0',
+					} ),
+					generateShippingRate( {
+						rateId: 'store_2',
+						name: 'Store 2',
+						instanceID: 1,
+						price: '0',
+					} ),
+				] }
+				packageCount={ 1 }
+				renderPickupLocation={ renderPickupLocationMock }
+			/>
+		);
+
+		// First location: not selected
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( {
+				rate_id: 'store_1',
+				name: 'Store 1',
+			} ),
+			1, // packageCount
+			'store_2' // gets the currently selected option.
+		);
+
+		// Second location: selected
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( {
+				rate_id: 'store_2',
+				name: 'Store 2',
+			} ),
+			1, // packageCount
+			'store_2' // gets the currently selected option.
+		);
+	} );
+	it( 'Updates isSelectedInClient parameter when selection changes', () => {
+		renderPickupLocationMock.mockClear();
+		const pickupLocations = [
+			generateShippingRate( {
+				rateId: 'store_1',
+				name: 'Store 1',
+				instanceID: 1,
+				price: '0',
+			} ),
+			generateShippingRate( {
+				rateId: 'store_2',
+				name: 'Store 2',
+				instanceID: 1,
+				price: '0',
+			} ),
+		];
+
+		const { rerender } = render(
+			<LocalPickupSelect
+				title="Package 1"
+				onChange={ jest.fn() }
+				selectedOption="store_1"
+				pickupLocations={ pickupLocations }
+				packageCount={ 1 }
+				renderPickupLocation={ renderPickupLocationMock }
+			/>
+		);
+
+		// Initial render: Store 1 selected
+		expect( renderPickupLocationMock ).toHaveBeenCalledTimes( 2 );
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( { rate_id: 'store_1' } ),
+			1,
+			'store_1' // Store 1 is selected
+		);
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( { rate_id: 'store_2' } ),
+			1,
+			'store_1' // Store 2 is not selected
+		);
+
+		// Clear mock and rerender with different selection
+		renderPickupLocationMock.mockClear();
+		rerender(
+			<LocalPickupSelect
+				title="Package 1"
+				onChange={ jest.fn() }
+				selectedOption="store_2"
+				pickupLocations={ pickupLocations }
+				packageCount={ 1 }
+				renderPickupLocation={ renderPickupLocationMock }
+			/>
+		);
+
+		// After rerender: Store 2 selected
+		expect( renderPickupLocationMock ).toHaveBeenCalledTimes( 2 );
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( { rate_id: 'store_1' } ),
+			1,
+			'store_2' // Store 1 is not selected
+		);
+		expect( renderPickupLocationMock ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( { rate_id: 'store_2' } ),
+			1,
+			'store_2' // Store 2 is selected
+		);
+	} );
 
 	describe( 'packageData prop', () => {
 		it( 'Renders package name when multiple packages are present', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -18,18 +18,17 @@ import {
 jest.mock( '@woocommerce/base-context/hooks' );
 
 describe( 'LocalPickupSelect', () => {
-	const renderPickupLocationMock = jest
-		.fn()
-		.mockImplementation(
-			( location, pickupLocationsCount, isSelectedInClient ) => {
-				return {
-					value: `${ location.rate_id }`,
-					onChange: jest.fn(),
-					label: `${ location.name }`,
-					description: `${ location.description }`,
-				};
-			}
-		);
+	const renderPickupLocationMock = jest.fn().mockImplementation(
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		( location, pickupLocationsCount, isSelectedInClient ) => {
+			return {
+				value: `${ location.rate_id }`,
+				onChange: jest.fn(),
+				label: `${ location.name }`,
+				description: `${ location.description }`,
+			};
+		}
+	);
 
 	const defaultPackageData = generateShippingPackage( {
 		packageId: 0,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -71,7 +71,7 @@ const getPickupDetails = (
 const renderPickupLocation = (
 	option: CartShippingPackageShippingRate,
 	packageCount: number,
-	isSelectedInClient = false
+	clientSelectedRate = ''
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
@@ -133,7 +133,7 @@ const renderPickupLocation = (
 			</>
 		) : undefined,
 		secondaryDescription:
-			isSelectedInClient && details ? (
+			clientSelectedRate === option?.rate_id && details ? (
 				<ReadMore maxLines={ 2 }>
 					{ decodeEntities( details ) }
 				</ReadMore>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -70,7 +70,8 @@ const getPickupDetails = (
 
 const renderPickupLocation = (
 	option: CartShippingPackageShippingRate,
-	packageCount: number
+	packageCount: number,
+	isSelectedInClient = false
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
@@ -78,8 +79,6 @@ const renderPickupLocation = (
 	const location = getPickupLocation( option );
 	const address = getPickupAddress( option );
 	const details = getPickupDetails( option );
-
-	const isSelected = option?.selected;
 
 	// Default to showing "free" as the secondary label. Price checks below will update it if needed.
 	let secondaryLabel = <em>{ __( 'free', 'woocommerce' ) }</em>;
@@ -134,7 +133,7 @@ const renderPickupLocation = (
 			</>
 		) : undefined,
 		secondaryDescription:
-			isSelected && details ? (
+			isSelectedInClient && details ? (
 				<ReadMore maxLines={ 2 }>
 					{ decodeEntities( details ) }
 				</ReadMore>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -71,7 +71,7 @@ const getPickupDetails = (
 const renderPickupLocation = (
 	option: CartShippingPackageShippingRate,
 	packageCount: number,
-	clientSelectedRate = ''
+	clientSelectedOption = ''
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
@@ -133,7 +133,7 @@ const renderPickupLocation = (
 			</>
 		) : undefined,
 		secondaryDescription:
-			clientSelectedRate === option?.rate_id && details ? (
+			clientSelectedOption === option?.rate_id && details ? (
 				<ReadMore maxLines={ 2 }>
 					{ decodeEntities( details ) }
 				</ReadMore>

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
@@ -28,7 +28,7 @@ interface ExperimentalOrderLocalPickupPackagesProps {
 	renderPickupLocation: (
 		option: CartShippingPackageShippingRate,
 		packageCount: number,
-		isSelectedInClient?: boolean
+		clientSelectedRate?: string
 	) => RadioControlOption;
 }
 const Slot = ( {

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
@@ -28,7 +28,7 @@ interface ExperimentalOrderLocalPickupPackagesProps {
 	renderPickupLocation: (
 		option: CartShippingPackageShippingRate,
 		packageCount: number,
-		isSelectedInClient: boolean
+		isSelectedInClient?: boolean
 	) => RadioControlOption;
 }
 const Slot = ( {

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
@@ -27,7 +27,8 @@ interface ExperimentalOrderLocalPickupPackagesProps {
 	components: Record< string, Component >;
 	renderPickupLocation: (
 		option: CartShippingPackageShippingRate,
-		packageCount: number
+		packageCount: number,
+		isSelectedInClient: boolean
 	) => RadioControlOption;
 }
 const Slot = ( {

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/index.tsx
@@ -28,7 +28,7 @@ interface ExperimentalOrderLocalPickupPackagesProps {
 	renderPickupLocation: (
 		option: CartShippingPackageShippingRate,
 		packageCount: number,
-		clientSelectedRate?: string
+		clientSelectedOption?: string
 	) => RadioControlOption;
 }
 const Slot = ( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- When rendering `LocalPickupSelect` the `renderOption` callback was determining if it was selected based on the option in the data store (which ultimately comes from the server) rather than if the actual radio button was selected. This could lead to a delay while the server returned the new selected rate.
- I propose checking if the rate is selected on the client, rather than waiting for the server to respond giving quicker feedback.

Closes WOOPLUG-5811

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     https://www.loom.com/share/e9cf610b649c4ce58e65a5b6c8d1d761  |    https://www.loom.com/share/1ce0d7675f80455697e7aacd6f24e66a   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to WC -> Settings -> Shipping -> Local Pickup and add a few methods, some with "Pickup details" and some without.
2. Add an item to your cart and go to the Checkout block, switch to "Pickup" and then click through the options.
3. There should not be any delay in showing the pickup details and no layout shifts after initial selection.

#### Test updating shipping info from server

1. Go to https://github.com/woocommerce/woocommerce/blob/d18a7225018d90b5f1ab06ff0a7bca6d0b969f0b/plugins/woocommerce/src/StoreApi/Routes/V1/CartApplyCoupon.php#L65 and add this line:  `WC()->session->set( 'chosen_shipping_methods', array( 'pickup_location:3' ) );` Note, you may need to change this, but it should work if you have 4 local pickup methods.
2. Add a coupon to your site via Marketing -> Coupons.
3. Add an item to your cart and go to the Checkout block, switch to "Pickup" and select the first one.
4. Enter the coupon you made in step 2, apply it.
5. Ensure the selected local pickup method becomes the fourth option.
6. Verify shipping costs/info is correct in the sidebar.
7. Repeat, but instead of starting on `Pickup`, start on `Ship`, you should get the same result.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
