### PR TITLE
Fix REST API to exclude internal statuses when status='any'

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -348,8 +348,14 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			if ( in_array( $status, $this->get_order_statuses(), true ) ) {
 				$args['post_status'][] = 'wc-' . $status;
 			} elseif ( 'any' === $status ) {
-				// Set status to "any" and short-circuit out.
-				$args['post_status'] = 'any';
+				// When querying for 'any' status, filter to only include statuses that should be visible.
+				// This matches WordPress core's WP_Query behavior and the Admin Orders ListTable behavior.
+				// Internal statuses (like 'checkout-draft') are excluded by checking 'show_in_admin_all_list'.
+				$visible_statuses = array_intersect(
+					array_keys( wc_get_order_statuses() ),
+					get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
+				);
+				$args['post_status'] = array_values( $visible_statuses );
 				break;
 			} else {
 				$args['post_status'][] = $status;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/61836

## Overview

This PR fixes the issue where the REST API `/wp-json/wc/v3/orders` endpoint returns internal order statuses like `checkout-draft` when HPOS is enabled, while post-based storage correctly excludes them.

## Problem

When HPOS is enabled, requesting orders with no status parameter (defaults to `status=any`) or explicitly using `status=any` returns ALL order statuses, including internal ones like `checkout-draft`. This differs from post-based storage behavior.

**Root cause:** The REST controller was passing `status='any'` through to the query builder without filtering, resulting in different behavior from WP_Query.

## Solution Approach: REST Controller Level

This PR implements the fix at the **REST controller level** by modifying the V3 Orders controller's `prepare_objects_query()` method to filter statuses when 'any' is requested.

### Changes

- Modified `includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php`
- When `status='any'` is used in the REST API, the controller now filters to only statuses with `show_in_admin_all_list => true`
- This matches WordPress core's WP_Query behavior and the Admin Orders ListTable implementation

### Why This Location?

**Pros:**
- ✅ Smaller surface area - only affects REST API responses
- ✅ Minimal backward compatibility concerns - contained to API consumers
- ✅ Explicit and easy to understand change
- ✅ Easy to test and verify

**Cons:**
- ⚠️ Doesn't fix other HPOS queries outside REST API
- ⚠️ Requires fixing each controller individually (V2, V3, future versions)
- ⚠️ May need similar fixes in other API endpoints (Store API, etc.)

## Technical Details

### WordPress WP_Query Behavior

When `post_status='any'` is used, WordPress core excludes non-public statuses:

```php
// wp-includes/class-wp-query.php:2655-2660
if ( in_array( 'any', $q_status, true ) ) {
    foreach ( get_post_stati( array( 'exclude_from_search' => true ) ) as $status ) {
        if ( ! in_array( $status, $q_status, true ) ) {
            $e_status[] = "{$wpdb->posts}.post_status <> '$status'";
        }
    }
}
```

When `post_status` is empty, WordPress only queries public statuses:

```php
// wp-includes/class-wp-query.php:2727-2732
$public_statuses = get_post_stati( array( 'public' => true ) );
foreach ( $public_statuses as $public_status ) {
    $status_clauses[] = "{$wpdb->posts}.post_status = '$public_status'";
}
```

### WooCommerce Post-Based Storage

The post-based data store relies entirely on WP_Query's filtering:

```php
// includes/data-stores/class-wc-order-data-store-cpt.php:972
$key_mapping = array(
    'status' => 'post_status',  // Maps status to post_status
    // ...
);
```

It then passes this directly to `WP_Query`, which handles the filtering.

### Admin Orders ListTable

The Admin Orders page uses the same filtering we've implemented:

```php
// src/Internal/Admin/Orders/ListTable.php:540-563
$status = array_intersect(
    array_keys( wc_get_order_statuses() ),
    get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
);
```

## Testing

Manual testing with REST API:
- Without patch: `GET /wp-json/wc/v3/orders` returns `checkout-draft` orders
- With patch: `GET /wp-json/wc/v3/orders` excludes `checkout-draft` orders (matches post-based behavior)

## Alternative Approach

An alternative PR (#61856) implements the fix at the OrdersTableQuery level (HPOS query builder), which:
- ✅ Fixes the issue system-wide for all HPOS queries
- ✅ Single point of truth for status filtering
- ⚠️ Broader surface area with more potential BC concerns

See that PR for comparison and to help decide which approach is best.

## Backward Compatibility

This change only affects the V3 REST API endpoint behavior when `status='any'` is used. API consumers that:
- Query orders expecting to get internal statuses like `checkout-draft` without explicitly requesting them
- Rely on the current HPOS behavior differing from post-based behavior

...will need to explicitly request those statuses.

This matches WordPress core behavior and post-based storage behavior, so it's considered the correct behavior. However, if extensions or integrations have been working around the current behavior, they may need updates.

## Future Work

If this approach is chosen, similar fixes would be needed for:
- V2 REST API orders controller
- Any future REST API versions
- Store API (if applicable)
- Other endpoints that query orders

## Changelog

- Fix - Exclude internal order statuses from REST API responses when status='any' to match post-based storage behavior.