### PR TITLE
Fix Mini-Cart footer to show only enabled calculation types

### DIFF
--- a/plugins/woocommerce/changelog/61861-fix-wooplug-1937-mini-cart-tells-the-customer-shipping-will-be-calculated-at
+++ b/plugins/woocommerce/changelog/61861-fix-wooplug-1937-mini-cart-tells-the-customer-shipping-will-be-calculated-at
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Mini-Cart footer to show only enabled calculation types (shipping, taxes, discounts) instead of always showing all three.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -19,7 +19,7 @@ import clsx from 'clsx';
  */
 import CartButton from '../mini-cart-cart-button-block/block';
 import CheckoutButton from '../mini-cart-checkout-button-block/block';
-import { hasChildren, getTotalItemsDescription } from '../utils';
+import { hasChildren, getTotalsItemDescription } from '../utils';
 
 const PaymentMethodIconsElement = (): JSX.Element => {
 	const { paymentMethods } = usePaymentMethods();
@@ -61,7 +61,7 @@ const Block = ( {
 				currency={ getCurrencyFromPriceResponse( cartTotals ) }
 				label={ __( 'Subtotal', 'woocommerce' ) }
 				value={ subTotal }
-				description={ getTotalItemsDescription() }
+				description={ getTotalsItemDescription() }
 			/>
 			<div className="wc-block-mini-cart__footer-actions">
 				{ hasButtons ? (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -19,7 +19,7 @@ import clsx from 'clsx';
  */
 import CartButton from '../mini-cart-cart-button-block/block';
 import CheckoutButton from '../mini-cart-checkout-button-block/block';
-import { hasChildren } from '../utils';
+import { hasChildren, getTotalItemsDescription } from '../utils';
 
 const PaymentMethodIconsElement = (): JSX.Element => {
 	const { paymentMethods } = usePaymentMethods();
@@ -61,10 +61,7 @@ const Block = ( {
 				currency={ getCurrencyFromPriceResponse( cartTotals ) }
 				label={ __( 'Subtotal', 'woocommerce' ) }
 				value={ subTotal }
-				description={ __(
-					'Shipping, taxes, and discounts calculated at checkout.',
-					'woocommerce'
-				) }
+				description={ getTotalItemsDescription() }
 			/>
 			<div className="wc-block-mini-cart__footer-actions">
 				{ hasButtons ? (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -17,7 +17,7 @@ import { PaymentEventsProvider } from '@woocommerce/base-context';
 /**
  * Internal dependencies
  */
-import { getTotalItemsDescription } from '../utils';
+import { getTotalsItemDescription } from '../utils';
 import './editor.scss';
 
 const PaymentMethodIconsElement = (): JSX.Element => {
@@ -50,7 +50,7 @@ export const Edit = (): JSX.Element => {
 					currency={ getCurrencyFromPriceResponse( cartTotals ) }
 					label={ __( 'Subtotal', 'woocommerce' ) }
 					value={ subTotal }
-					description={ getTotalItemsDescription() }
+					description={ getTotalsItemDescription() }
 				/>
 				<div className="wc-block-mini-cart__footer-actions">
 					<InnerBlocks template={ TEMPLATE } />

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -17,6 +17,7 @@ import { PaymentEventsProvider } from '@woocommerce/base-context';
 /**
  * Internal dependencies
  */
+import { getTotalItemsDescription } from '../utils';
 import './editor.scss';
 
 const PaymentMethodIconsElement = (): JSX.Element => {
@@ -49,10 +50,7 @@ export const Edit = (): JSX.Element => {
 					currency={ getCurrencyFromPriceResponse( cartTotals ) }
 					label={ __( 'Subtotal', 'woocommerce' ) }
 					value={ subTotal }
-					description={ __(
-						'Shipping, taxes, and discounts calculated at checkout.',
-						'woocommerce'
-					) }
+					description={ getTotalItemsDescription() }
 				/>
 				<div className="wc-block-mini-cart__footer-actions">
 					<InnerBlocks template={ TEMPLATE } />

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
@@ -34,9 +34,9 @@ export const hasChildren = ( children ): boolean => {
 };
 
 /**
- * Gets the total items description text from PHP-computed setting.
+ * Gets the totals item description text from PHP-computed setting.
  *
- * @return {string} The description text for the total items.
+ * @return {string} The description text for the totals item.
  */
 export const getTotalsItemDescription = (): string => {
 	return getSetting( 'miniCartFooterDescription', '' );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { isObject } from '@woocommerce/types';
 
@@ -35,62 +34,10 @@ export const hasChildren = ( children ): boolean => {
 };
 
 /**
- * Computes the total items description text based on which settings are enabled.
+ * Gets the total items description text from PHP-computed setting.
  *
- * @return {string} The description text for the total items, or empty string if none are enabled.
+ * @return {string} The description text for the total items.
  */
 export const getTotalItemsDescription = (): string => {
-	const taxesEnabled = getSetting( 'taxesEnabled', true );
-	const shippingEnabled = getSetting( 'shippingEnabled', true );
-	const couponsEnabled = getSetting( 'couponsEnabled', true );
-
-	// All three enabled
-	if ( taxesEnabled && shippingEnabled && couponsEnabled ) {
-		return __(
-			'Shipping, taxes, and discounts calculated at checkout.',
-			'woocommerce'
-		);
-	}
-
-	// Shipping + taxes
-	if ( shippingEnabled && taxesEnabled ) {
-		return __(
-			'Shipping and taxes calculated at checkout.',
-			'woocommerce'
-		);
-	}
-
-	// Shipping + coupons
-	if ( shippingEnabled && couponsEnabled ) {
-		return __(
-			'Shipping and discounts calculated at checkout.',
-			'woocommerce'
-		);
-	}
-
-	// Taxes + coupons
-	if ( taxesEnabled && couponsEnabled ) {
-		return __(
-			'Taxes and discounts calculated at checkout.',
-			'woocommerce'
-		);
-	}
-
-	// Only shipping
-	if ( shippingEnabled ) {
-		return __( 'Shipping calculated at checkout.', 'woocommerce' );
-	}
-
-	// Only taxes
-	if ( taxesEnabled ) {
-		return __( 'Taxes calculated at checkout.', 'woocommerce' );
-	}
-
-	// Only coupons
-	if ( couponsEnabled ) {
-		return __( 'Discounts calculated at checkout.', 'woocommerce' );
-	}
-
-	// None enabled
-	return '';
+	return getSetting( 'miniCartFooterDescription', '' );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
@@ -38,6 +38,6 @@ export const hasChildren = ( children ): boolean => {
  *
  * @return {string} The description text for the total items.
  */
-export const getTotalItemsDescription = (): string => {
+export const getTotalsItemDescription = (): string => {
 	return getSetting( 'miniCartFooterDescription', '' );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 import { isObject } from '@woocommerce/types';
 
 type Variant = 'text' | 'contained' | 'outlined';
@@ -30,4 +32,65 @@ export const hasChildren = ( children ): boolean => {
 		}
 		return isObject( child ) && child.key !== null;
 	} );
+};
+
+/**
+ * Computes the total items description text based on which settings are enabled.
+ *
+ * @return {string} The description text for the total items, or empty string if none are enabled.
+ */
+export const getTotalItemsDescription = (): string => {
+	const taxesEnabled = getSetting( 'taxesEnabled', true );
+	const shippingEnabled = getSetting( 'shippingEnabled', true );
+	const couponsEnabled = getSetting( 'couponsEnabled', true );
+
+	// All three enabled
+	if ( taxesEnabled && shippingEnabled && couponsEnabled ) {
+		return __(
+			'Shipping, taxes, and discounts calculated at checkout.',
+			'woocommerce'
+		);
+	}
+
+	// Shipping + taxes
+	if ( shippingEnabled && taxesEnabled ) {
+		return __(
+			'Shipping and taxes calculated at checkout.',
+			'woocommerce'
+		);
+	}
+
+	// Shipping + coupons
+	if ( shippingEnabled && couponsEnabled ) {
+		return __(
+			'Shipping and discounts calculated at checkout.',
+			'woocommerce'
+		);
+	}
+
+	// Taxes + coupons
+	if ( taxesEnabled && couponsEnabled ) {
+		return __(
+			'Taxes and discounts calculated at checkout.',
+			'woocommerce'
+		);
+	}
+
+	// Only shipping
+	if ( shippingEnabled ) {
+		return __( 'Shipping calculated at checkout.', 'woocommerce' );
+	}
+
+	// Only taxes
+	if ( taxesEnabled ) {
+		return __( 'Taxes calculated at checkout.', 'woocommerce' );
+	}
+
+	// Only coupons
+	if ( couponsEnabled ) {
+		return __( 'Discounts calculated at checkout.', 'woocommerce' );
+	}
+
+	// None enabled
+	return '';
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -239,9 +239,7 @@ class MiniCart extends AbstractBlock {
 			'displayCartPricesIncludingTax',
 			$this->display_cart_prices_including_tax
 		);
-		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
-		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
-		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
+		$this->asset_data_registry->add( 'miniCartFooterDescription', $this->get_total_items_description() );
 
 		$template_part_edit_uri = '';
 
@@ -943,5 +941,66 @@ class MiniCart extends AbstractBlock {
 	 */
 	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
+	}
+
+	/**
+	 * Computes the total items description text based on which settings are enabled.
+	 *
+	 * @return string The description text for the total items, or empty string if none are enabled.
+	 */
+	private function get_total_items_description() {
+		$taxes_enabled    = wc_tax_enabled();
+		$shipping_enabled = wc_shipping_enabled();
+		$coupons_enabled  = wc_coupons_enabled();
+
+		// All three enabled.
+		if ( $taxes_enabled && $shipping_enabled && $coupons_enabled ) {
+			return __(
+				'Shipping, taxes, and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Shipping + taxes.
+		if ( $shipping_enabled && $taxes_enabled ) {
+			return __(
+				'Shipping and taxes calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Shipping + coupons.
+		if ( $shipping_enabled && $coupons_enabled ) {
+			return __(
+				'Shipping and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Taxes + coupons.
+		if ( $taxes_enabled && $coupons_enabled ) {
+			return __(
+				'Taxes and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Only shipping.
+		if ( $shipping_enabled ) {
+			return __( 'Shipping calculated at checkout.', 'woocommerce' );
+		}
+
+		// Only taxes.
+		if ( $taxes_enabled ) {
+			return __( 'Taxes calculated at checkout.', 'woocommerce' );
+		}
+
+		// Only coupons.
+		if ( $coupons_enabled ) {
+			return __( 'Discounts calculated at checkout.', 'woocommerce' );
+		}
+
+		// None enabled.
+		return '';
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -239,7 +239,6 @@ class MiniCart extends AbstractBlock {
 			'displayCartPricesIncludingTax',
 			$this->display_cart_prices_including_tax
 		);
-		$this->asset_data_registry->add( 'miniCartFooterDescription', $this->get_total_items_description() );
 
 		$template_part_edit_uri = '';
 
@@ -941,66 +940,5 @@ class MiniCart extends AbstractBlock {
 	 */
 	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
-	}
-
-	/**
-	 * Computes the total items description text based on which settings are enabled.
-	 *
-	 * @return string The description text for the total items, or empty string if none are enabled.
-	 */
-	private function get_total_items_description() {
-		$taxes_enabled    = wc_tax_enabled();
-		$shipping_enabled = wc_shipping_enabled();
-		$coupons_enabled  = wc_coupons_enabled();
-
-		// All three enabled.
-		if ( $taxes_enabled && $shipping_enabled && $coupons_enabled ) {
-			return __(
-				'Shipping, taxes, and discounts calculated at checkout.',
-				'woocommerce'
-			);
-		}
-
-		// Shipping + taxes.
-		if ( $shipping_enabled && $taxes_enabled ) {
-			return __(
-				'Shipping and taxes calculated at checkout.',
-				'woocommerce'
-			);
-		}
-
-		// Shipping + coupons.
-		if ( $shipping_enabled && $coupons_enabled ) {
-			return __(
-				'Shipping and discounts calculated at checkout.',
-				'woocommerce'
-			);
-		}
-
-		// Taxes + coupons.
-		if ( $taxes_enabled && $coupons_enabled ) {
-			return __(
-				'Taxes and discounts calculated at checkout.',
-				'woocommerce'
-			);
-		}
-
-		// Only shipping.
-		if ( $shipping_enabled ) {
-			return __( 'Shipping calculated at checkout.', 'woocommerce' );
-		}
-
-		// Only taxes.
-		if ( $taxes_enabled ) {
-			return __( 'Taxes calculated at checkout.', 'woocommerce' );
-		}
-
-		// Only coupons.
-		if ( $coupons_enabled ) {
-			return __( 'Discounts calculated at checkout.', 'woocommerce' );
-		}
-
-		// None enabled.
-		return '';
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -239,6 +239,9 @@ class MiniCart extends AbstractBlock {
 			'displayCartPricesIncludingTax',
 			$this->display_cart_prices_including_tax
 		);
+		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
+		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
+		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
 
 		$template_part_edit_uri = '';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -108,9 +108,9 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	 * @return string The description text for the total items, or empty string if none are enabled.
 	 */
 	private function get_total_items_description() {
-		$taxes_enabled     = wc_tax_enabled();
-		$shipping_enabled  = wc_shipping_enabled();
-		$coupons_enabled   = wc_coupons_enabled();
+		$taxes_enabled    = wc_tax_enabled();
+		$shipping_enabled = wc_shipping_enabled();
+		$coupons_enabled  = wc_coupons_enabled();
 
 		// All three enabled.
 		if ( $taxes_enabled && $shipping_enabled && $coupons_enabled ) {
@@ -136,7 +136,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			);
 		}
 
-		// Taxes + discounts
+		// Taxes + discounts.
 		if ( $taxes_enabled && $coupons_enabled ) {
 			return __(
 				'Taxes and discounts calculated at checkout.',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -110,9 +110,9 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	private function get_total_items_description() {
 		$taxes_enabled     = wc_tax_enabled();
 		$shipping_enabled  = wc_shipping_enabled();
-		$coupons_enabled = wc_coupons_enabled();
+		$coupons_enabled   = wc_coupons_enabled();
 
-		// All three enabled
+		// All three enabled.
 		if ( $taxes_enabled && $shipping_enabled && $coupons_enabled ) {
 			return __(
 				'Shipping, taxes, and discounts calculated at checkout.',
@@ -120,7 +120,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			);
 		}
 
-		// Shipping + taxes
+		// Shipping + taxes.
 		if ( $shipping_enabled && $taxes_enabled ) {
 			return __(
 				'Shipping and taxes calculated at checkout.',
@@ -128,7 +128,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			);
 		}
 
-		// Shipping + discounts
+		// Shipping + discounts.
 		if ( $shipping_enabled && $coupons_enabled ) {
 			return __(
 				'Shipping and discounts calculated at checkout.',
@@ -144,22 +144,22 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			);
 		}
 
-		// Only shipping
+		// Only shipping.
 		if ( $shipping_enabled ) {
 			return __( 'Shipping calculated at checkout.', 'woocommerce' );
 		}
 
-		// Only taxes
+		// Only taxes.
 		if ( $taxes_enabled ) {
 			return __( 'Taxes calculated at checkout.', 'woocommerce' );
 		}
 
-		// Only discounts
+		// Only discounts.
 		if ( $coupons_enabled ) {
 			return __( 'Discounts calculated at checkout.', 'woocommerce' );
 		}
 
-		// None enabled
+		// None enabled.
 		return '';
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -21,7 +21,10 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	 */
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'miniCartFooterDescription', $this->get_total_items_description() );
+		$description = $this->get_totals_item_description();
+		if ( ! empty( $description ) ) {
+			$this->asset_data_registry->add( 'miniCartFooterDescription', $description );
+		}
 	}
 
 	/**
@@ -37,7 +40,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 
 		$cart                             = $this->get_cart_instance();
 		$subtotal_label                   = __( 'Subtotal', 'woocommerce' );
-		$other_costs_label                = $this->get_total_items_description();
+		$other_costs_label                = $this->get_totals_item_description();
 		$display_cart_price_including_tax = get_option( 'woocommerce_tax_display_cart' ) === 'incl';
 		$subtotal                         = $display_cart_price_including_tax ? $cart->get_subtotal_tax() : $cart->get_subtotal();
 		$formatted_subtotal               = '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -15,9 +15,11 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	protected $block_name = 'mini-cart-footer-block';
 
 	/**
-	 * Enqueue frontend data.
+	 * Data passed through from server to client for block.
 	 *
-	 * @param array $attributes Block attributes.
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -15,6 +15,16 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	protected $block_name = 'mini-cart-footer-block';
 
 	/**
+	 * Enqueue frontend data.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
+	protected function enqueue_data( array $attributes = array() ) {
+		parent::enqueue_data( $attributes );
+		$this->asset_data_registry->add( 'miniCartFooterDescription', $this->get_total_items_description() );
+	}
+
+	/**
 	 * Render experimental iAPI powered Mini-Cart Footer block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -27,7 +27,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 
 		$cart                             = $this->get_cart_instance();
 		$subtotal_label                   = __( 'Subtotal', 'woocommerce' );
-		$other_costs_label                = __( 'Shipping, taxes, and discounts calculated at checkout.', 'woocommerce' );
+		$other_costs_label                = $this->get_total_items_description();
 		$display_cart_price_including_tax = get_option( 'woocommerce_tax_display_cart' ) === 'incl';
 		$subtotal                         = $display_cart_price_including_tax ? $cart->get_subtotal_tax() : $cart->get_subtotal();
 		$formatted_subtotal               = '';
@@ -90,6 +90,67 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Computes the total items description text based on which settings are enabled.
+	 *
+	 * @return string The description text for the total items, or empty string if none are enabled.
+	 */
+	private function get_total_items_description() {
+		$taxes_enabled     = wc_tax_enabled();
+		$shipping_enabled  = wc_shipping_enabled();
+		$coupons_enabled = wc_coupons_enabled();
+
+		// All three enabled
+		if ( $taxes_enabled && $shipping_enabled && $coupons_enabled ) {
+			return __(
+				'Shipping, taxes, and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Shipping + taxes
+		if ( $shipping_enabled && $taxes_enabled ) {
+			return __(
+				'Shipping and taxes calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Shipping + discounts
+		if ( $shipping_enabled && $coupons_enabled ) {
+			return __(
+				'Shipping and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Taxes + discounts
+		if ( $taxes_enabled && $coupons_enabled ) {
+			return __(
+				'Taxes and discounts calculated at checkout.',
+				'woocommerce'
+			);
+		}
+
+		// Only shipping
+		if ( $shipping_enabled ) {
+			return __( 'Shipping calculated at checkout.', 'woocommerce' );
+		}
+
+		// Only taxes
+		if ( $taxes_enabled ) {
+			return __( 'Taxes calculated at checkout.', 'woocommerce' );
+		}
+
+		// Only discounts
+		if ( $coupons_enabled ) {
+			return __( 'Discounts calculated at checkout.', 'woocommerce' );
+		}
+
+		// None enabled
+		return '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -107,7 +107,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	 *
 	 * @return string The description text for the total items, or empty string if none are enabled.
 	 */
-	private function get_total_items_description() {
+	private function get_totals_item_description() {
 		$taxes_enabled    = wc_tax_enabled();
 		$shipping_enabled = wc_shipping_enabled();
 		$coupons_enabled  = wc_coupons_enabled();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -103,7 +103,7 @@ class MiniCartFooterBlock extends \WP_UnitTestCase {
 
 		// Act - Use reflection to access private method.
 		$reflection = new \ReflectionClass( $this->block );
-		$method     = $reflection->getMethod( 'get_total_items_description' );
+		$method     = $reflection->getMethod( 'get_totals_item_description' );
 		$method->setAccessible( true );
 		$result = $method->invoke( $this->block );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 /**
  * Tests for the MiniCartFooterBlock block type.
  *
- * @since $VID:$
+ * @since 10.4.0
  */
 class MiniCartFooterBlock extends \WP_UnitTestCase {
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -1,0 +1,113 @@
+<?php
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartFooterBlock as MiniCartFooterBlockType;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * Tests for the MiniCartFooterBlock block type.
+ *
+ * @since $VID:$
+ */
+class MiniCartFooterBlock extends \WP_UnitTestCase {
+
+	/**
+	 * Instance of the block being tested.
+	 *
+	 * @var MiniCartFooterBlockType
+	 */
+	protected $block;
+
+	/**
+	 * Setup test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'woocommerce/mini-cart-footer-block' ) ) {
+			$registry->unregister( 'woocommerce/mini-cart-footer-block' );
+		}
+
+		$this->block = new MiniCartFooterBlockType(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry()
+		);
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	public function tearDown(): void {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'woocommerce/mini-cart-footer-block' ) ) {
+			$registry->unregister( 'woocommerce/mini-cart-footer-block' );
+		}
+		unset( $this->block );
+		parent::tearDown();
+	}
+
+	/**
+	 * Data provider for testing get_total_items_description().
+	 *
+	 * @return array<string, array{bool, bool, bool, string}>
+	 */
+	public function provider_total_items_description_scenarios(): array {
+		return array(
+			'all three enabled'    => array( true, true, true, 'Shipping, taxes, and discounts calculated at checkout.' ),
+			'shipping and taxes'   => array( true, true, false, 'Shipping and taxes calculated at checkout.' ),
+			'shipping and coupons' => array( true, false, true, 'Shipping and discounts calculated at checkout.' ),
+			'taxes and coupons'    => array( false, true, true, 'Taxes and discounts calculated at checkout.' ),
+			'only shipping'        => array( true, false, false, 'Shipping calculated at checkout.' ),
+			'only taxes'           => array( false, true, false, 'Taxes calculated at checkout.' ),
+			'only coupons'         => array( false, false, true, 'Discounts calculated at checkout.' ),
+			'none enabled'         => array( false, false, false, '' ),
+		);
+	}
+
+	/**
+	 * Test get_total_items_description returns correct message based on settings.
+	 *
+	 * @dataProvider provider_total_items_description_scenarios
+	 *
+	 * @param bool   $shipping_enabled Whether shipping is enabled.
+	 * @param bool   $taxes_enabled    Whether taxes are enabled.
+	 * @param bool   $coupons_enabled  Whether coupons are enabled.
+	 * @param string $expected         Expected description text.
+	 */
+	public function test_get_total_items_description( bool $shipping_enabled, bool $taxes_enabled, bool $coupons_enabled, string $expected ): void {
+		// Arrange - Mock WooCommerce settings.
+		add_filter(
+			'wc_shipping_enabled',
+			function () use ( $shipping_enabled ) {
+				return $shipping_enabled;
+			}
+		);
+		add_filter(
+			'wc_tax_enabled',
+			function () use ( $taxes_enabled ) {
+				return $taxes_enabled;
+			}
+		);
+		add_filter(
+			'pre_option_woocommerce_enable_coupons',
+			function () use ( $coupons_enabled ) {
+				return $coupons_enabled ? 'yes' : 'no';
+			}
+		);
+
+		// Act - Use reflection to access private method.
+		$reflection = new \ReflectionClass( $this->block );
+		$method     = $reflection->getMethod( 'get_total_items_description' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $this->block );
+
+		// Assert.
+		$this->assertSame( $expected, $result );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes the Mini-Cart footer description to dynamically show only the relevant calculation information (shipping, taxes, discounts) based on which features are enabled in WooCommerce settings.

**Problem:**
The Mini-Cart footer always displayed "Shipping, taxes, and discounts calculated at checkout" regardless of whether shipping, taxes, or coupons were actually enabled in the store settings. This confused customers when these features were disabled.

**Solution:**

-   Implemented \`get_total_items_description()\` method in \`MiniCartFooterBlock\` class that checks which features are enabled (\`wc_shipping_enabled()\`, \`wc_tax_enabled()\`, \`wc_coupons_enabled()\`)
-   Returns appropriate description text based on enabled features (8 different combinations)
-   Returns empty string when none of the features are enabled
-   Exposed the description text via \`miniCartFooterDescription\` setting to JavaScript
-   Created \`getTotalItemsDescription()\` helper function in utils.ts to retrieve the setting
-   Updated both block.tsx and edit.tsx to use the helper function. This is needed so that the editor view is accurate.
-   Added comprehensive PHPUnit tests covering all 8 scenarios

Closes #44286.
Linear: WOOPLUG-1937

### Screenshots or screen recordings:

| Before                                                                | After                                                                                    |
| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| <img width="1020" height="1864" alt="CleanShot 2025-11-08 at 14 50 39@2x" src="https://github.com/user-attachments/assets/6a26b56c-e26d-482a-985f-4e49b394a2ff" /> |  <img width="1000" height="1752" alt="CleanShot 2025-11-08 at 14 51 58@2x" src="https://github.com/user-attachments/assets/b5b5eb82-b0c0-412f-963f-8818bd7f69bc" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce
2. Add products to your cart
3. Open the Mini-Cart (add Mini-Cart block to your site if needed)
4. Observe the footer description below the subtotal

**Test different settings combinations:**

5. Go to WooCommerce > Settings > General

    - Enable shipping, taxes, and coupons
    - Check Mini-Cart footer shows: "Shipping, taxes, and discounts calculated at checkout."

6. Disable shipping (Settings > General > "Enable shipping" unchecked)

    - Check Mini-Cart footer shows: "Taxes and discounts calculated at checkout."

7. Re-enable shipping, disable taxes (Settings > Tax > "Enable taxes" unchecked)

    - Check Mini-Cart footer shows: "Shipping and discounts calculated at checkout."

8. Disable coupons (Settings > General > "Enable coupons" unchecked, shipping and taxes enabled)

    - Check Mini-Cart footer shows: "Shipping and taxes calculated at checkout."

9. Enable only shipping (disable taxes and coupons)

    - Check Mini-Cart footer shows: "Shipping calculated at checkout."

10. Enable only taxes (disable shipping and coupons)

    - Check Mini-Cart footer shows: "Taxes calculated at checkout."

11. Enable only coupons (disable shipping and taxes)

    - Check Mini-Cart footer shows: "Discounts calculated at checkout."

12. Disable all three (shipping, taxes, and coupons)
    - Check Mini-Cart footer shows no description text below the subtotal

### Testing that has already taken place:

-   **Unit tests:** Added comprehensive PHPUnit test coverage for all 8 combinations of settings in \`MiniCartFooterBlock.php\`
-   **Test execution:** All tests pass with \`pnpm test:php:env -- --filter MiniCartFooterBlock --verbose\`
-   **Environment:** Local WordPress/WooCommerce development environment
-   **Manual testing:** Verified behavior with different settings combinations in the Mini-Cart block

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix Mini-Cart footer to show only enabled calculation types (shipping, taxes, discounts) instead of always showing all three.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>