### PR TITLE
[Rest API V4] Orders API collection filter hooks

### DIFF
--- a/plugins/woocommerce/changelog/add-orders-api-collection-filter-hooks
+++ b/plugins/woocommerce/changelog/add-orders-api-collection-filter-hooks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Added filters to REST API v4 orders API to allow third party collection args
+
+

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3148,6 +3148,15 @@ FROM $order_meta_table
 			$query_vars['meta_query'][] = FulfillmentUtils::get_order_fulfillment_status_meta_query( $query_vars['fulfillment_status'] );
 		}
 
+		/**
+		 * Filter the query args before executing the query.
+		 *
+		 * @param array $query_vars The query vars.
+		 * @return array
+		 * @since 10.4.0
+		 */
+		$query_vars = apply_filters( 'woocommerce_orders_table_datastore_get_orders_query', $query_vars, $this );
+
 		try {
 			$query = new OrdersTableQuery( $query_vars );
 		} catch ( \Exception $e ) {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
@@ -272,18 +272,19 @@ class Controller extends AbstractController {
 		 * @param array           $query_args Query arguments for WC_Order_Query.
 		 * @param WP_REST_Request $request    The REST request object.
 		 * @param Controller      $controller The controller instance.
-		 * @since 10.3.0
+		 * @since 10.4.0
 		 */
-		$query_args = apply_filters(
+		$query_args = (array) apply_filters(
 			$this->get_hook_prefix() . 'collection_query_args',
-			array_merge(
-				$this->collection_query->get_query_args( $request ),
-				array(
-					'post_type' => $this->post_type,
-				)
-			),
+			$this->collection_query->get_query_args( $request ),
 			$request,
 			$this
+		);
+		$query_args = wp_parse_args(
+			$query_args,
+			array(
+				'post_type' => $this->post_type,
+			)
 		);
 		$results    = $this->collection_query->get_query_results( $query_args, $request );
 		$items      = array();

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
@@ -266,8 +266,26 @@ class Controller extends AbstractController {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$query_args = $this->collection_query->get_query_args( $request );
-		$results    = $this->collection_query->get_query_results( array_merge( $query_args, array( 'post_type' => $this->post_type ) ), $request );
+		/**
+		 * Filter collection query args before executing the query.
+		 *
+		 * @param array           $query_args Query arguments for WC_Order_Query.
+		 * @param WP_REST_Request $request    The REST request object.
+		 * @param Controller      $controller The controller instance.
+		 * @since 10.3.0
+		 */
+		$query_args = apply_filters(
+			$this->get_hook_prefix() . 'collection_query_args',
+			array_merge(
+				$this->collection_query->get_query_args( $request ),
+				array(
+					'post_type' => $this->post_type,
+				)
+			),
+			$request,
+			$this
+		);
+		$results    = $this->collection_query->get_query_results( $query_args, $request );
 		$items      = array();
 
 		foreach ( $results['results'] as $result ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds 2 hooks to allow collection params to be added via 3rd party code to the REST API v4. 

`woocommerce_rest_api_v4_orders_collection_query_args`

Allows collection query args to be defined in schema for REST API V4.

`woocommerce_orders_table_datastore_get_orders_query`

Allows the query to be modified. Equivalent of `woocommerce_order_data_store_cpt_get_orders_query` for the CPT data store.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

These hooks are not visual and should not impact any existing functionality. I will provide whoever tests this a custom plugin to test against. Just ensure CI passes/no regression.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
