### PR TITLE
WP 6.9: load WP Button block styles when rendering the Add to Cart Button

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-button-styles-wp-6.9
+++ b/plugins/woocommerce/changelog/fix-product-button-styles-wp-6.9
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WP 6.9: load WP Button block styles when rendering the Add to Cart Button

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -74,9 +74,10 @@ class ProductButton extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// This workaround ensures that WordPress loads the core/button block styles.
-		// For more details, see https://github.com/woocommerce/woocommerce/pull/53052.
-		( new \WP_Block( array( 'blockName' => 'core/button' ) ) )->render();
+		// The Product Button block uses the same classes as the GB core block
+		// because we want to inherit its styles. That's why we also need to
+		// enqueue its stylesheet.
+		wp_enqueue_style( 'wp-block-button' );
 
 		global $product;
 		$previous_product = $product;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -74,8 +74,8 @@ class ProductButton extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// The Product Button block uses the same classes as the GB core block
-		// because we want to inherit its styles. That's why we also need to
+		// This is work-around so the Product Button block inherits the styles
+		// of the core Button block. We render it with the same classes and
 		// enqueue its stylesheet.
 		wp_enqueue_style( 'wp-block-button' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

Closes #61901.

The work-around we had to load Gutenberg's _Button_ styles when rendering the _Add to Cart Button_ block stopped working in WP 6.9. I refactored it in this PR by using `wp_enqueue_style()`, which seems to work fine.

### How to test the changes in this Pull Request:

1. With a block theme and WP 6.9, go to the _Shop_ page.
2. Verify the Add to Cart buttons have the theme button style. In TT5, they are rounded, you can also tweak their styles in the Site Editor to make it more evident.
3. Repeat the test with WP 6.8 to make sure we aren't introducing a regression in previous versions.

Before | After
--- | ---
<img width="1488" height="1180" alt="imatge" src="https://github.com/user-attachments/assets/a6859cbe-afc2-4f52-b925-6339cce6dc74" /> | <img width="1488" height="1180" alt="imatge" src="https://github.com/user-attachments/assets/1a1cc730-2b06-4d82-9def-0ea53df11e97" />
