### PR TITLE
Fix 'shows password form in products protected with password' e2e tests in WP 6.9

### DIFF
--- a/plugins/woocommerce/changelog/fix-password-protected-e2e-test-wc-10.3
+++ b/plugins/woocommerce/changelog/fix-password-protected-e2e-test-wc-10.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 'shows password form in products protected with password' e2e tests in WP 6.9

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template.block_theme.spec.ts
@@ -62,7 +62,11 @@ test( 'shows password form in products protected with password', async ( {
 	// Sunglasses are defined as requiring password in /bin/scripts/products.sh.
 	await page.goto( '/product/sunglasses/' );
 	await expect(
-		page.getByText( 'This content is password protected.' ).first()
+		page
+			// WP 6.9
+			.getByText( 'This content is password-protected.' )
+			// WP 6.8
+			.or( page.getByText( 'This content is password protected' ) )
 	).toBeVisible();
 
 	// Verify after introducing the password, the page is visible.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR picks the fix for the 'shows password form in products protected with password' test from #61648 into WooCommerce 10.3.

### How to test the changes in this Pull Request:

1. Make sure the 'shows password form in products protected with password' e2e test passes.