### PR TITLE
Revert "Disable translations test" and fix mini-cart block translations

### DIFF
--- a/plugins/woocommerce/changelog/bring-back-translations-tests
+++ b/plugins/woocommerce/changelog/bring-back-translations-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a new line when concatenating translations in a script for the Mini-Cart block

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.shopper.block_theme.spec.ts
@@ -10,6 +10,8 @@ import {
 	REGULAR_PRICED_PRODUCT_NAME,
 	SIMPLE_PHYSICAL_PRODUCT_NAME,
 } from '../checkout/constants';
+import { getTestTranslation } from '../../utils/get-test-translation';
+import { translations } from '../../test-data/data/data';
 import ProductCollectionPage from '../product-collection/product-collection.page';
 
 const test = base.extend< { productCollectionPage: ProductCollectionPage } >( {
@@ -72,6 +74,57 @@ test.describe( 'Shopper → Notices', () => {
 					`The quantity of "${ SIMPLE_PHYSICAL_PRODUCT_NAME }" was`
 				)
 		).toBeHidden();
+	} );
+} );
+
+test.describe( 'Shopper → Translations', () => {
+	test.beforeEach( async () => {
+		await wpCLI( `site switch-language ${ translations.locale }` );
+	} );
+
+	test( 'User can see translation in empty Mini-Cart', async ( {
+		page,
+		frontendUtils,
+		miniCartUtils,
+	} ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await miniCartUtils.openMiniCart();
+
+		await expect(
+			page.getByRole( 'link', {
+				name: getTestTranslation( 'Start shopping' ),
+			} )
+		).toBeVisible();
+	} );
+
+	test( 'User can see translation in filled Mini-Cart', async ( {
+		page,
+		frontendUtils,
+		miniCartUtils,
+	} ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await miniCartUtils.openMiniCart();
+
+		await expect(
+			page.getByRole( 'heading', {
+				name: getTestTranslation( 'Your cart' ),
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'link', {
+				name: getTestTranslation( 'View my cart' ),
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'link', {
+				name: getTestTranslation( 'Go to checkout' ),
+			} )
+		).toBeVisible();
 	} );
 } );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -589,7 +589,7 @@ class MiniCart extends AbstractBlock {
 			}
 			ob_start();
 			?>
-		
+
 			<div
 				data-wp-interactive="woocommerce/mini-cart"
 				data-wp-init="callbacks.setupEventListeners"
@@ -599,7 +599,7 @@ class MiniCart extends AbstractBlock {
 				class="<?php echo esc_attr( $wrapper_classes ); ?>"
 				style="<?php echo esc_attr( $wrapper_styles ); ?>"
 			>
-				<button 
+				<button
 					data-wp-on--click="callbacks.openDrawer"
 					data-wp-bind--aria-label="state.buttonAriaLabel"
 					class="wc-block-mini-cart__button"
@@ -670,7 +670,7 @@ class MiniCart extends AbstractBlock {
 					</div>
 				</div>
 			</div>
-		</div>				
+		</div>
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo wp_interactivity_process_directives( ob_get_clean() );
@@ -910,7 +910,7 @@ class MiniCart extends AbstractBlock {
 
 		$translations = array_filter( $translations );
 
-		return implode( '', $translations );
+		return implode( "\n", $translations );
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit d6251b0f14ceb64bc7d23cd07b8714fa5b14eefc.
This reverts commit 78d312a54425b8db6b6c374c0af89a6c8e59b403.

Let's see if we need to bring these back, together with a fix (TBD).