### PR TITLE
Email Editor - basic compatibility fixes with Gutenberg 22

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-1201-editor-styles-dont-work-with-gutenberg-220
+++ b/packages/js/email-editor/changelog/wooprd-1201-editor-styles-dont-work-with-gutenberg-220
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Prevent crashes with Gutenberg 22.0

--- a/packages/js/email-editor/src/components/header/style.scss
+++ b/packages/js/email-editor/src/components/header/style.scss
@@ -90,3 +90,8 @@
 		left: 0;
 	}
 }
+
+// Hide core's Styles sidebar controls
+.components-button[aria-controls="edit-site:global-styles"] {
+	display: none !important;
+}

--- a/packages/js/email-editor/src/components/test/__mocks__/setup-shared-mocks.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/setup-shared-mocks.ts
@@ -1,6 +1,8 @@
 /**
  * Internal dependencies
  */
+import './wordpress-private-apis';
+import './wordpress-block-editor';
 import './wordpress-blocks';
 import './wordpress-core-data';
 import './wordpress-data';

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-block-editor.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-block-editor.ts
@@ -1,0 +1,8 @@
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: {},
+	privateApis: {
+		// Mock the private APIs that are used by the email editor
+		ColorPanel: jest.fn( () => null ),
+		useGlobalStylesOutputWithConfig: jest.fn( () => [ [], {} ] ),
+	},
+} ) );

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-data.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-data.ts
@@ -1,5 +1,10 @@
 jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn(),
+	dispatch: jest.fn( () => ( {
+		registerEntityAction: jest.fn(),
+		unregisterEntityAction: jest.fn(),
+	} ) ),
+	use: jest.fn(),
 	useDispatch: jest.fn(),
 	useSelect: jest.fn(),
 	createRegistrySelector: jest.fn(),

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-editor.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-editor.ts
@@ -1,4 +1,11 @@
 jest.mock( '@wordpress/editor', () => ( {
 	useEntitiesSavedStatesIsDirty: jest.fn(),
 	store: {},
+	privateApis: {
+		// Mock the private APIs that are used by the email editor
+		Editor: jest.fn( () => null ),
+		FullscreenMode: jest.fn( () => null ),
+		ViewMoreMenuGroup: jest.fn( () => null ),
+		BackButton: jest.fn( () => null ),
+	},
 } ) );

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-private-apis.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-private-apis.ts
@@ -1,0 +1,11 @@
+jest.mock( '@wordpress/private-apis', () => ( {
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules: jest.fn( () => ( {
+		unlock: jest.fn( ( obj ) => {
+			// Return the object itself if it has properties, or an empty object
+			if ( obj && typeof obj === 'object' ) {
+				return obj;
+			}
+			return {};
+		} ),
+	} ) ),
+} ) );

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -37,11 +37,7 @@ import {
 } from './hooks';
 import { cleanupConfigurationChanges } from './config-tools';
 import { getEditorConfigFromWindow } from './store/settings';
-import {
-	EmailEditorSettings,
-	EmailTheme,
-	EmailEditorUrls,
-} from './store/types';
+import { EmailEditorConfig } from './store/types';
 
 function Editor( {
 	postId,
@@ -100,7 +96,7 @@ function Editor( {
 	);
 }
 
-function onInit( config ) {
+function onInit( config: EmailEditorConfig ) {
 	initEventCollector();
 	initStoreTracking();
 	initDomTracking();
@@ -160,22 +156,16 @@ export function ExperimentalEmailEditor( {
 	postType: string;
 	isPreview?: boolean;
 	contentRef?: React.Ref< HTMLDivElement > | null;
-	config?: {
-		editorSettings: EmailEditorSettings;
-		theme: EmailTheme;
-		urls: EmailEditorUrls;
-		userEmail: string;
-		globalStylesPostId?: number | null;
-	};
+	config?: EmailEditorConfig;
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 
 	useLayoutEffect( () => {
 		const backupEditorSettings = select( editorStore ).getEditorSettings();
-		onInit( config );
-
 		// Set configuration to store from window object for backward compatibility
 		const editorConfig = config || getEditorConfigFromWindow();
+		onInit( editorConfig );
+
 		dispatch( storeName ).setEditorConfig( editorConfig );
 		setIsInitialized( true );
 		// Cleanup global editor settings

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -20,7 +20,7 @@ import '@wordpress/format-library'; // Enables text formatting capabilities
 import { getAllowedBlockNames, initBlocks } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { InnerEditor } from './components/block-editor';
-import { createStore, storeName } from './store';
+import { createStore, storeName, initStoreOverrides } from './store';
 import { initHooks } from './editor-hooks';
 import { initTextHooks } from './text-hooks';
 import {
@@ -96,7 +96,7 @@ function Editor( {
 	);
 }
 
-function onInit() {
+function onInit(config) {
 	initEventCollector();
 	initStoreTracking();
 	initDomTracking();
@@ -106,6 +106,7 @@ function onInit() {
 	initBlocks();
 	initHooks();
 	initTextHooks();
+	initStoreOverrides(config);
 }
 
 export function initialize( elementId: string ) {
@@ -128,7 +129,8 @@ export function initialize( elementId: string ) {
 		'woocommerce_email_editor_wrap_editor_component',
 		Editor
 	) as typeof Editor;
-	onInit();
+
+	onInit(getEditorConfigFromWindow());
 
 	// Set configuration to store from window object for backward compatibility
 	const editorConfig = getEditorConfigFromWindow();
@@ -166,7 +168,7 @@ export function ExperimentalEmailEditor( {
 
 	useLayoutEffect( () => {
 		const backupEditorSettings = select( editorStore ).getEditorSettings();
-		onInit();
+		onInit(config);
 
 		// Set configuration to store from window object for backward compatibility
 		const editorConfig = config || getEditorConfigFromWindow();

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -8,6 +8,7 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useState,
+	useMemo,
 } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { store as editorStore } from '@wordpress/editor';
@@ -73,16 +74,19 @@ function Editor( {
 	const stylesContentRef = useFilterEditorContentStylesheets();
 	const mergedContentRef = useMergeRefs( [ stylesContentRef, contentRef ] );
 
+	// Set allowed blockTypes and isPreviewMode to the editor settings.
+	const editorSettings = useMemo(
+		() => ( {
+			...settings,
+			allowedBlockTypes: getAllowedBlockNames(),
+			isPreviewMode: isPreview,
+		} ),
+		[ settings, isPreview ]
+	);
+
 	if ( ! isInitialized ) {
 		return null;
 	}
-
-	// Set allowed blockTypes and isPreviewMode to the editor settings.
-	const editorSettings = {
-		...settings,
-		allowedBlockTypes: getAllowedBlockNames(),
-		isPreviewMode: isPreview,
-	};
 
 	return (
 		<StrictMode>
@@ -96,7 +100,7 @@ function Editor( {
 	);
 }
 
-function onInit(config) {
+function onInit( config ) {
 	initEventCollector();
 	initStoreTracking();
 	initDomTracking();
@@ -106,7 +110,7 @@ function onInit(config) {
 	initBlocks();
 	initHooks();
 	initTextHooks();
-	initStoreOverrides(config);
+	initStoreOverrides( config );
 }
 
 export function initialize( elementId: string ) {
@@ -130,7 +134,7 @@ export function initialize( elementId: string ) {
 		Editor
 	) as typeof Editor;
 
-	onInit(getEditorConfigFromWindow());
+	onInit( getEditorConfigFromWindow() );
 
 	// Set configuration to store from window object for backward compatibility
 	const editorConfig = getEditorConfigFromWindow();
@@ -168,7 +172,7 @@ export function ExperimentalEmailEditor( {
 
 	useLayoutEffect( () => {
 		const backupEditorSettings = select( editorStore ).getEditorSettings();
-		onInit(config);
+		onInit( config );
 
 		// Set configuration to store from window object for backward compatibility
 		const editorConfig = config || getEditorConfigFromWindow();

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -54,11 +54,9 @@ export function useEmailCss() {
 		[ editorTheme, userTheme ]
 	);
 
-	// In the Gutenberg version 22.0+ the useGlobalStylesOutputWithConfig hook is not available.
+	// In the Gutenberg version 22.0+ the useGlobalStylesOutputWithConfig hook is not available and we return empty array.
 	// We keep this for now to support WP 6.9 and lower.
-	const [ styles ] = areExternalStylesSupported
-		? useGlobalStylesOutputWithConfig( mergedConfig )
-		: [ [] ];
+	const [ styles ] = useGlobalStylesOutputWithConfig( mergedConfig );
 
 	let rootContainerStyles = '';
 	if ( layout && deviceType !== 'Mobile' ) {
@@ -85,12 +83,7 @@ export function useEmailCss() {
 			},
 			...( editorSettingsStyles ?? [] ),
 		];
-	}, [
-		styles,
-		editorSettingsStyles,
-		rootContainerStyles,
-		areExternalStylesSupported,
-	] );
+	}, [ styles, editorSettingsStyles, rootContainerStyles ] );
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return [ finalStyles || EMPTY_ARRAY ];

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -11,7 +11,10 @@ import deepmerge from 'deepmerge';
  */
 import { EmailTheme, EmailBuiltStyles, storeName } from '../store';
 import { useUserTheme } from './use-user-theme';
-import { useGlobalStylesOutputWithConfig } from '../private-apis';
+import {
+	useGlobalStylesOutputWithConfig,
+	areExternalStylesSupported,
+} from '../private-apis';
 import { unwrapCompressedPresetStyleVariable } from '../style-variables';
 
 // Empty array to avoid re-rendering the component when the array is empty
@@ -51,7 +54,11 @@ export function useEmailCss() {
 		[ editorTheme, userTheme ]
 	);
 
-	const [ styles ] = useGlobalStylesOutputWithConfig( mergedConfig );
+	// In the Gutenberg version 22.0+ the useGlobalStylesOutputWithConfig hook is not available.
+	// We keep this for now to support WP 6.9 and lower.
+	const [ styles ] = areExternalStylesSupported
+		? useGlobalStylesOutputWithConfig( mergedConfig )
+		: [ [] ];
 
 	let rootContainerStyles = '';
 	if ( layout && deviceType !== 'Mobile' ) {
@@ -68,6 +75,9 @@ export function useEmailCss() {
 	}
 
 	const finalStyles = useMemo( () => {
+		if ( ! areExternalStylesSupported ) {
+			return EMPTY_ARRAY;
+		}
 		return [
 			...( ( styles as EmailBuiltStyles[] ) ?? [] ),
 			{
@@ -75,7 +85,12 @@ export function useEmailCss() {
 			},
 			...( editorSettingsStyles ?? [] ),
 		];
-	}, [ styles, editorSettingsStyles, rootContainerStyles ] );
+	}, [
+		styles,
+		editorSettingsStyles,
+		rootContainerStyles,
+		areExternalStylesSupported,
+	] );
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return [ finalStyles || EMPTY_ARRAY ];

--- a/packages/js/email-editor/src/hooks/use-user-theme.ts
+++ b/packages/js/email-editor/src/hooks/use-user-theme.ts
@@ -27,8 +27,8 @@ export function useUserTheme() {
 				return;
 			}
 			void dispatch( coreStore ).editEntityRecord(
-				'postType',
-				'wp_global_styles',
+				'root',
+				'globalStyles',
 				globalStylePost.id,
 				{
 					styles: newTheme.styles,

--- a/packages/js/email-editor/src/private-apis/index.ts
+++ b/packages/js/email-editor/src/private-apis/index.ts
@@ -27,7 +27,9 @@ const { ColorPanel: StylesColorPanel } = unlock( blockEditorPrivateApis );
 /**
  * The useGlobalStylesOutputWithConfig is used to generate the CSS for the email editor content from the style settings.
  */
-const { useGlobalStylesOutputWithConfig } = unlock( blockEditorPrivateApis );
+const {
+	useGlobalStylesOutputWithConfig: useGlobalStylesOutputWithConfigOriginal,
+} = unlock( blockEditorPrivateApis );
 
 /**
  * The Editor is the main component for the email editor.
@@ -40,7 +42,7 @@ const { Editor, FullscreenMode, ViewMoreMenuGroup, BackButton } =
  * useGlobalStylesOutputWithConfig function was removed with this change.
  */
 const areExternalStylesSupported =
-	useGlobalStylesOutputWithConfig !== undefined;
+	useGlobalStylesOutputWithConfigOriginal !== undefined;
 
 /**
  * The registerEntityAction and unregisterEntityAction are used to register and unregister entity actions.
@@ -50,6 +52,10 @@ const areExternalStylesSupported =
 const { registerEntityAction, unregisterEntityAction } = unlock(
 	dispatch( editorStore )
 );
+
+const useGlobalStylesOutputWithConfig = useGlobalStylesOutputWithConfigOriginal
+	? useGlobalStylesOutputWithConfigOriginal
+	: () => [ [], {} ];
 
 export {
 	StylesColorPanel,

--- a/packages/js/email-editor/src/private-apis/index.ts
+++ b/packages/js/email-editor/src/private-apis/index.ts
@@ -36,6 +36,13 @@ const { Editor, FullscreenMode, ViewMoreMenuGroup, BackButton } =
 	unlock( editorPrivateApis );
 
 /**
+ * Feature detection whether the active version of Gutenberg supports external styles being passed to Editor component.
+ * useGlobalStylesOutputWithConfig function was removed with this change.
+ */
+const areExternalStylesSupported =
+	useGlobalStylesOutputWithConfig !== undefined;
+
+/**
  * The registerEntityAction and unregisterEntityAction are used to register and unregister entity actions.
  * This is used in the move-to-trash.tsx file to modify the move to trash action.
  * Providing us with the ability to remove the default move to trash action and add a custom trash email post action.
@@ -53,4 +60,5 @@ export {
 	BackButton,
 	registerEntityAction,
 	unregisterEntityAction,
+	areExternalStylesSupported,
 };

--- a/packages/js/email-editor/src/store/index.ts
+++ b/packages/js/email-editor/src/store/index.ts
@@ -4,3 +4,4 @@
 export * from './constants';
 export * from './store';
 export * from './types';
+export * from './overrides';

--- a/packages/js/email-editor/src/store/overrides.ts
+++ b/packages/js/email-editor/src/store/overrides.ts
@@ -1,0 +1,40 @@
+import { use as useData } from '@wordpress/data';
+
+/**
+ * We wrap the core store selectors to return the global styles post id and email base theme from the email editor config.
+ * As of Gutenberg 22.0 we can no longer override styles directly via a prop see https://github.com/WordPress/gutenberg/pull/72681/files#diff-da0dfea2139990db95c1ff4cae9f222aef66ae8d3dafb6237953d0c98c63fb64
+ * @param config - The configuration object containing the global styles post id and email base theme.
+ */
+export const initStoreOverrides = ( config ) => {
+	useData( ( registry ) => ( {
+		select( store ) {
+			const base = registry.select( store );
+			if ( store.name === 'core' ) {
+				return {
+					...base,
+					// Override the base function to return the global styles post id from the config
+					__experimentalGetCurrentGlobalStylesId() {
+						// Run the original function to run resolver and return overridden value after resolution is done
+						const baseGlobalStylesId =
+							base.__experimentalGetCurrentGlobalStylesId();
+						if ( ! baseGlobalStylesId ) {
+							return null;
+						}
+						return config.globalStylesPostId;
+					},
+					// Override the base function to return email base theme
+					__experimentalGetCurrentThemeBaseGlobalStyles() {
+						// Run the original function to run resolver and return overridden value after resolution is done
+						const baseTheme =
+							base.__experimentalGetCurrentThemeBaseGlobalStyles();
+						if ( ! baseTheme ) {
+							return null;
+						}
+						return config.theme;
+					},
+				};
+			}
+			return base;
+		},
+	} ) );
+};

--- a/packages/js/email-editor/src/store/overrides.ts
+++ b/packages/js/email-editor/src/store/overrides.ts
@@ -27,7 +27,8 @@ const generateRootContainerStyles = ( config ) => {
 		baseTheme.styles,
 		userStyles,
 	] ) as EmailStyles;
-	let rootContainerStyles = `display:flow-root; max-width: ${ layout?.contentSize }; margin: 0 auto;box-sizing: border-box;`;
+	const maxWidth = layout?.contentSize || '100%';
+	let rootContainerStyles = `display:flow-root; max-width: ${ maxWidth }; margin: 0 auto;box-sizing: border-box;`;
 	const padding = mergedStyles?.spacing?.padding;
 	if ( padding ) {
 		rootContainerStyles += `padding-left:${ unwrapCompressedPresetStyleVariable(

--- a/packages/js/email-editor/src/store/overrides.ts
+++ b/packages/js/email-editor/src/store/overrides.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { use as useData, select } from '@wordpress/data';
+import { use, select } from '@wordpress/data';
 import deepmerge from 'deepmerge';
 
 /**
@@ -43,6 +43,7 @@ const generateRootContainerStyles = ( config ) => {
 /**
  * We wrap the core store selectors to return the global styles post id and email base theme from the email editor config.
  * As of Gutenberg 22.0 we can no longer override styles directly via a prop see https://github.com/WordPress/gutenberg/pull/72681/files#diff-da0dfea2139990db95c1ff4cae9f222aef66ae8d3dafb6237953d0c98c63fb64
+ *
  * @param config - The configuration object containing the global styles post id and email base theme.
  */
 export const initStoreOverrides = ( config ) => {
@@ -50,7 +51,7 @@ export const initStoreOverrides = ( config ) => {
 	if ( areExternalStylesSupported ) {
 		return;
 	}
-	useData( ( registry ) => ( {
+	use( ( registry ) => ( {
 		select( store ) {
 			const base = registry.select( store );
 			if ( store.name === 'core' ) {

--- a/packages/js/email-editor/src/store/overrides.ts
+++ b/packages/js/email-editor/src/store/overrides.ts
@@ -9,6 +9,7 @@ import deepmerge from 'deepmerge';
  */
 import { EmailStyles, EmailTheme, storeName } from './index';
 import { unwrapCompressedPresetStyleVariable } from '../style-variables';
+import { areExternalStylesSupported } from '../private-apis';
 
 /**
  * Function to generate the root container styles based on the config.
@@ -45,6 +46,10 @@ const generateRootContainerStyles = ( config ) => {
  * @param config - The configuration object containing the global styles post id and email base theme.
  */
 export const initStoreOverrides = ( config ) => {
+	// If the active version of Gutenberg supports external styles being passed to Editor component, we don't need to override the store.
+	if ( areExternalStylesSupported ) {
+		return;
+	}
 	useData( ( registry ) => ( {
 		select( store ) {
 			const base = registry.select( store );

--- a/packages/js/email-editor/src/store/overrides.ts
+++ b/packages/js/email-editor/src/store/overrides.ts
@@ -1,4 +1,43 @@
-import { use as useData } from '@wordpress/data';
+/**
+ * External dependencies
+ */
+import { use as useData, select } from '@wordpress/data';
+import deepmerge from 'deepmerge';
+
+/**
+ * Internal dependencies
+ */
+import { EmailStyles, EmailTheme, storeName } from './index';
+import { unwrapCompressedPresetStyleVariable } from '../style-variables';
+
+/**
+ * Function to generate the root container styles based on the config.
+ * As of Gutenberg 22.0 we can no longer override styles directly so we are sending additional dynamic CSS via theme's css property
+ */
+const generateRootContainerStyles = ( config ) => {
+	const layout = config.editorSettings?.__experimentalFeatures?.layout;
+	const baseTheme = config.theme;
+	const userTheme = select(
+		storeName
+	).getGlobalEmailStylesPost() as EmailTheme;
+	const userStyles = userTheme?.styles;
+	const mergedStyles = deepmerge.all( [
+		{},
+		baseTheme.styles,
+		userStyles,
+	] ) as EmailStyles;
+	let rootContainerStyles = `display:flow-root; max-width: ${ layout?.contentSize }; margin: 0 auto;box-sizing: border-box;`;
+	const padding = mergedStyles?.spacing?.padding;
+	if ( padding ) {
+		rootContainerStyles += `padding-left:${ unwrapCompressedPresetStyleVariable(
+			padding.left
+		) };`;
+		rootContainerStyles += `padding-right:${ unwrapCompressedPresetStyleVariable(
+			padding.right
+		) };`;
+	}
+	return `.is-root-container{ ${ rootContainerStyles } }`;
+};
 
 /**
  * We wrap the core store selectors to return the global styles post id and email base theme from the email editor config.
@@ -30,7 +69,14 @@ export const initStoreOverrides = ( config ) => {
 						if ( ! baseTheme ) {
 							return null;
 						}
-						return config.theme;
+						const theme = {
+							...config.theme,
+							styles: {
+								...config.theme.styles,
+								css: generateRootContainerStyles( config ),
+							},
+						};
+						return theme;
 					},
 				};
 			}

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -301,15 +301,15 @@ export const getGlobalEmailStylesPost = createRegistrySelector(
 		if ( postId ) {
 			if ( canEdit ) {
 				return select( coreDataStore ).getEditedEntityRecord(
-					'postType',
-					'wp_global_styles',
+					'root',
+					'globalStyles',
 					postId
 				) as unknown as Post;
 			}
 			return regularizedGetEntityRecord(
 				select( coreDataStore ).getEntityRecord(
-					'postType',
-					'wp_global_styles',
+					'root',
+					'globalStyles',
 					postId,
 					{ context: 'view' }
 				)

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -275,3 +275,11 @@ export type PostWithPermissions = Post & {
 		update: boolean;
 	};
 };
+
+export type EmailEditorConfig = {
+	editorSettings: EmailEditorSettings;
+	theme: EmailTheme;
+	urls: EmailEditorUrls;
+	userEmail: string;
+	globalStylesPostId?: number | null;
+};

--- a/plugins/woocommerce/changelog/wooprd-1201-editor-styles-dont-work-with-gutenberg-220
+++ b/plugins/woocommerce/changelog/wooprd-1201-editor-styles-dont-work-with-gutenberg-220
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add empty attributes to woocommerce/add-to-cart-with-options-variation-selector-attribute block to prevent an error when Gutenberg 22.0 is active
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/block.json
@@ -10,6 +10,7 @@
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"attributes": {},
 	"supports": {
 		"inserter": false,
 		"interactivity": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR contains basic fixes ensuring email editor compatibility with Gutenberg 22.0, which introduced [significant changes in how styles are applied in the editor](https://github.com/WordPress/gutenberg/issues/72317).

The fixes are backward compatible. There are still a couple of minor issues that will be fixed in follow up PRs.

Closes WOOPRD-1201.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For Gutenberg 22.0
1. Install Gutenberg 22.0 and activate it
2. Activate Email editor (WooCommerce > Settings > Advanced > Features > Block Email Editor)
3. Open and email (WooCommerce > Settings > Emails) and test it can be edited with the editor

For older Gutenberg
1. Deactivate the Gutenberg plugin. The older version from WP will be used
2. Activate Email editor (WooCommerce > Settings > Advanced > Features > Block Email Editor)
3. Open and email (WooCommerce > Settings > Emails) and test it can be edited with the editor

Remaining known issues to fix for Gutenberg 22:
- useEmailCss returns an empty array when Gutenberg 22 is active. This is ok in the editor, but it is an issue for third parties who use the hook
- CSS: there is a small gap above and below the back button
- CSS: Style settings panel has unnecessary inner border

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs created from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
