### PR TITLE
Update link to UX guidelines

### DIFF
--- a/docs/user-experience-guidelines/ux-guidelines-payments/README.md
+++ b/docs/user-experience-guidelines/ux-guidelines-payments/README.md
@@ -6,7 +6,7 @@ post_title: Payments guidelines
 
 # Payments Guidelines
 
-When building payments extensions, you should ensure you follow the [WooCommerce Extension Guidelines](https://developer.woocommerce.com/docs/category/extension-guidelines/).
+When building payments extensions, you should ensure you follow the [WooCommerce Extension Guidelines](https://developer.woocommerce.com/docs/extensions/ux-guidelines-extensions/).
 
 Payments plugins come in many types: payment processors and gateways, wallets, Buy Now Pay Later, crypto, and more.
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Changes link from https://developer.woocommerce.com/docs/category/extension-guidelines/ after move of Extensions guidelines to a separate directory. 