### PR TITLE
Add HTTP headers to cached outputs in RestApiCache

### DIFF
--- a/plugins/woocommerce/changelog/pr-61931
+++ b/plugins/woocommerce/changelog/pr-61931
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Add HTTP headers to cached outputs in ReastApiCache
+Add HTTP headers to cached outputs in RestApiCache

--- a/plugins/woocommerce/changelog/pr-61931
+++ b/plugins/woocommerce/changelog/pr-61931
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add HTTP headers to cached outputs in ReastApiCache

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -109,13 +109,6 @@ trait RestApiCache {
 	private static string $cache_group = 'woocommerce_rest_api_cache';
 
 	/**
-	 * Cache TTL in seconds.
-	 *
-	 * @var int
-	 */
-	private static int $cache_ttl = HOUR_IN_SECONDS;
-
-	/**
 	 * Response headers that are always excluded from caching.
 	 *
 	 * @var array
@@ -481,7 +474,9 @@ trait RestApiCache {
 	 * 3. The woocommerce_rest_api_cached_headers filter is applied, receiving both the candidate
 	 *    headers list and all available headers. This allows filters to both add and remove
 	 *    headers from the caching list.
-	 * 4. Only headers from the response that are in the filtered list are returned.
+	 * 4. Always-excluded headers are enforced again post-filter to prevent filters from
+	 *    re-introducing dangerous headers like Set-Cookie.
+	 * 5. Only headers from the response that are in the filtered list are returned.
 	 *
 	 * @param array            $nominal_headers Response headers.
 	 * @param array|false      $include_headers Header names to include (false to use exclusion logic).
@@ -544,8 +539,32 @@ trait RestApiCache {
 			$this
 		);
 
-		// Step 4: Return only the headers that are in the filtered list.
+		// Step 4: Enforce always-excluded headers post-filter.
 		$filtered_header_names_lowercase = array_map( 'strtolower', $filtered_header_names );
+		$reintroduced_headers            = array_filter(
+			$filtered_header_names,
+			fn( $name ) => in_array( strtolower( $name ), $always_exclude_lowercase, true )
+		);
+
+		if ( ! empty( $reintroduced_headers ) ) {
+			wc_get_container()->get( LegacyProxy::class )->call_function(
+				'wc_doing_it_wrong',
+				__METHOD__,
+				sprintf(
+					/* translators: %s: comma-separated list of header names */
+					'The woocommerce_rest_api_cached_headers filter attempted to cache always-excluded headers: %s. These headers have been removed for security reasons.',
+					implode( ', ', $reintroduced_headers )
+				),
+				'10.5.0'
+			);
+
+			$filtered_header_names_lowercase = array_filter(
+				$filtered_header_names_lowercase,
+				fn( $name ) => ! in_array( $name, $always_exclude_lowercase, true )
+			);
+		}
+
+		// Step 5: Return only the headers that are in the filtered list.
 		return array_filter(
 			$nominal_headers,
 			fn( $name ) => in_array( strtolower( $name ), $filtered_header_names_lowercase, true ),

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -478,8 +478,10 @@ trait RestApiCache {
 	 * 1. If $include_headers is an array, only those headers are included (case-insensitive).
 	 *    If $include_headers is false, all headers are included except those in $exclude_headers.
 	 * 2. Always-excluded headers (X-WC-Cache, Set-Cookie, Date, etc.) are removed.
-	 * 3. The woocommerce_rest_api_cached_headers filter is applied to the header names.
-	 * 4. Only headers in the filtered list are returned.
+	 * 3. The woocommerce_rest_api_cached_headers filter is applied, receiving both the candidate
+	 *    headers list and all available headers. This allows filters to both add and remove
+	 *    headers from the caching list.
+	 * 4. Only headers from the response that are in the filtered list are returned.
 	 *
 	 * @param array            $nominal_headers Response headers.
 	 * @param array|false      $include_headers Header names to include (false to use exclusion logic).
@@ -516,23 +518,26 @@ trait RestApiCache {
 		);
 
 		// Step 3: Apply filter to header names.
-		$header_names = array_keys( $headers_to_cache );
+		$cached_header_names = array_keys( $headers_to_cache );
+		$all_header_names    = array_keys( $nominal_headers );
 
 		/**
 		 * Filter the list of response header names to cache.
 		 *
 		 * @since 10.4.0
 		 *
-		 * @param array            $header_names List of header names to cache.
-		 * @param WP_REST_Request  $request      The request object.
-		 * @param WP_REST_Response $response     The response object.
-		 * @param string|null      $endpoint_id  Optional friendly identifier for the endpoint.
-		 * @param object           $controller   The controller instance.
+		 * @param array            $cached_header_names Candidate list of header names to cache.
+		 * @param array            $all_header_names    All header names available in the response.
+		 * @param WP_REST_Request  $request             The request object.
+		 * @param WP_REST_Response $response            The response object.
+		 * @param string|null      $endpoint_id         Optional friendly identifier for the endpoint.
+		 * @param object           $controller          The controller instance.
 		 * @return array Filtered list of header names to cache.
 		 */
 		$filtered_header_names = apply_filters(
 			'woocommerce_rest_api_cached_headers',
-			$header_names,
+			$cached_header_names,
+			$all_header_names,
 			$request,
 			$response,
 			$endpoint_id,
@@ -540,9 +545,10 @@ trait RestApiCache {
 		);
 
 		// Step 4: Return only the headers that are in the filtered list.
+		$filtered_header_names_lowercase = array_map( 'strtolower', $filtered_header_names );
 		return array_filter(
-			$headers_to_cache,
-			fn( $name ) => in_array( $name, $filtered_header_names, true ),
+			$nominal_headers,
+			fn( $name ) => in_array( strtolower( $name ), $filtered_header_names_lowercase, true ),
 			ARRAY_FILTER_USE_KEY
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -524,7 +524,7 @@ trait RestApiCache {
 		/**
 		 * Filter the list of response header names to cache.
 		 *
-		 * @since 10.4.0
+		 * @since 10.5.0
 		 *
 		 * @param array            $cached_header_names Candidate list of header names to cache.
 		 * @param array            $all_header_names    All header names available in the response.

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -14,6 +14,9 @@ use WP_REST_Response;
  *
  * - The output of all the REST API endpoints whose callback declaration is wrapped
  *   in a call to 'with_cache' will be cached using wp_cache_* functions.
+ * - Response headers are cached together with the response data, excluding certain fixed
+ *   headers (like Set-Cookie) and optionally others specified via configuration
+ *   (per-controller or per-endpoint).
  * - For the purposes of caching, a request is uniquely identified by its route,
  *   HTTP method, query string, and user ID.
  * - The VersionStringGenerator class is used to track versions of entities included
@@ -60,11 +63,15 @@ use WP_REST_Response;
  *                         // Optional int, defaults to the controller's get_ttl_for_cached_response().
  *                         'cache_ttl'      => HOUR_IN_SECONDS,
  *                         // Optional array, defaults to the controller's get_hooks_relevant_to_caching().
- *                         'relevant_hooks' => array( 'filter_name_1', 'filter_name_2' ),
+ *                         'relevant_hooks'  => array( 'filter_name_1', 'filter_name_2' ),
  *                         // Optional bool, defaults to the controller's response_cache_vary_by_user().
- *                         'vary_by_user'   => true,
+ *                         'vary_by_user'    => true,
+ *                         // Optional array, defaults to the controller's get_response_headers_to_include_in_caching().
+ *                         'include_headers' => array( 'X-Custom-Header' ),
+ *                         // Optional array, defaults to the controller's get_response_headers_to_exclude_from_caching().
+ *                         'exclude_headers' => array( 'X-Private-Header' ),
  *                         // Optional, this will be passed to all the caching-related methods.
- *                         'endpoint_id'    => 'get_product'
+ *                         'endpoint_id'     => 'get_product'
  *                     )
  *                 ),
  *             )
@@ -77,6 +84,8 @@ use WP_REST_Response;
  * - response_cache_vary_by_user(): Whether cache should be user-specific.
  * - get_hooks_relevant_to_caching(): Hook names to track for cache invalidation.
  * - get_ttl_for_cached_response(): TTL for cached outputs in seconds.
+ * - get_response_headers_to_include_in_caching(): Headers to include in cache (null = use exclusion mode).
+ * - get_response_headers_to_exclude_from_caching(): Headers to exclude from cache (when in exclusion mode).
  *
  * Cache invalidation happens when:
  * - Entity versions change (tracked via VersionStringGenerator).
@@ -98,6 +107,30 @@ trait RestApiCache {
 	 * @var string
 	 */
 	private static string $cache_group = 'woocommerce_rest_api_cache';
+
+	/**
+	 * Cache TTL in seconds.
+	 *
+	 * @var int
+	 */
+	private static int $cache_ttl = HOUR_IN_SECONDS;
+
+	/**
+	 * Response headers that are always excluded from caching.
+	 *
+	 * @var array
+	 */
+	private static array $always_excluded_headers = array(
+		'X-WC-Cache',
+		'Set-Cookie',
+		'Date',
+		'Expires',
+		'Last-Modified',
+		'Age',
+		'ETag',
+		'Cache-Control',
+		'Pragma',
+	);
 
 	/**
 	 * The instance of VersionStringGenerator to use, or null if caching is disabled.
@@ -127,6 +160,8 @@ trait RestApiCache {
 	 *                           - endpoint_id: string|null (optional friendly identifier for the endpoint).
 	 *                           - cache_ttl: int (defaults to get_ttl_for_cached_response()).
 	 *                           - relevant_hooks: array (defaults to get_hooks_relevant_to_caching()).
+	 *                           - include_headers: array|null (defaults to get_response_headers_to_include_in_caching()).
+	 *                           - exclude_headers: array (defaults to get_response_headers_to_exclude_from_caching()).
 	 * @return callable Wrapped callback.
 	 */
 	protected function with_cache( callable $callback, array $config = array() ): callable {
@@ -209,7 +244,7 @@ trait RestApiCache {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @param array           $config  Raw configuration array passed to with_cache.
-	 * @return array|null Normalized cache config with keys: endpoint_id, entity_type, vary_by_user, cache_ttl, relevant_hooks, cache_key. Returns null if entity type is not available.
+	 * @return array|null Normalized cache config with keys: endpoint_id, entity_type, vary_by_user, cache_ttl, relevant_hooks, include_headers, exclude_headers, cache_key. Returns null if entity type is not available.
 	 */
 	private function build_cache_config( WP_REST_Request $request, array $config ): ?array {
 		$endpoint_id  = $config['endpoint_id'] ?? null;
@@ -227,12 +262,14 @@ trait RestApiCache {
 		}
 
 		return array(
-			'endpoint_id'    => $endpoint_id,
-			'entity_type'    => $entity_type,
-			'vary_by_user'   => $vary_by_user,
-			'cache_ttl'      => $config['cache_ttl'] ?? $this->get_ttl_for_cached_response( $request, $endpoint_id ),
-			'relevant_hooks' => $config['relevant_hooks'] ?? $this->get_hooks_relevant_to_caching( $request, $endpoint_id ),
-			'cache_key'      => $this->get_key_for_cached_response( $request, $entity_type, $vary_by_user, $endpoint_id ),
+			'endpoint_id'     => $endpoint_id,
+			'entity_type'     => $entity_type,
+			'vary_by_user'    => $vary_by_user,
+			'cache_ttl'       => $config['cache_ttl'] ?? $this->get_ttl_for_cached_response( $request, $endpoint_id ),
+			'relevant_hooks'  => $config['relevant_hooks'] ?? $this->get_hooks_relevant_to_caching( $request, $endpoint_id ),
+			'include_headers' => array_key_exists( 'include_headers', $config ) ? $config['include_headers'] : $this->get_response_headers_to_include_in_caching( $request, $endpoint_id ),
+			'exclude_headers' => $config['exclude_headers'] ?? $this->get_response_headers_to_exclude_from_caching( $request, $endpoint_id ),
+			'cache_key'       => $this->get_key_for_cached_response( $request, $entity_type, $vary_by_user, $endpoint_id ),
 		);
 	}
 
@@ -264,6 +301,16 @@ trait RestApiCache {
 			$data       = $response->get_data();
 			$entity_ids = is_array( $data ) ? $this->extract_entity_ids_from_response( $data, $request, $cached_config['endpoint_id'] ) : array();
 
+			$response_headers  = $response->get_headers();
+			$cacheable_headers = $this->get_headers_to_cache(
+				$response_headers,
+				$cached_config['include_headers'],
+				$cached_config['exclude_headers'],
+				$request,
+				$response,
+				$cached_config['endpoint_id']
+			);
+
 			$this->store_cached_response(
 				$cached_config['cache_key'],
 				$data,
@@ -271,7 +318,8 @@ trait RestApiCache {
 				$cached_config['entity_type'],
 				$entity_ids,
 				$cached_config['cache_ttl'],
-				$cached_config['relevant_hooks']
+				$cached_config['relevant_hooks'],
+				$cacheable_headers
 			);
 
 			$cached = true;
@@ -344,6 +392,45 @@ trait RestApiCache {
 	}
 
 	/**
+	 * Get the names of response headers to include in caching.
+	 *
+	 * When this returns a non-null value, ONLY the headers whose names are returned
+	 * will be included in the cache (subject to always-excluded headers).
+	 * When this returns null, all headers will be included except those returned
+	 * by get_response_headers_to_exclude_from_caching().
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('include_headers' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array|null Array of header names to include (case-insensitive), or null to use exclusion logic.
+	 */
+	protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ): ?array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return null;
+	}
+
+	/**
+	 * Get the names of response headers to exclude from caching.
+	 *
+	 * These headers will not be stored in the cache, in addition to the
+	 * always-excluded headers (X-WC-Cache, Set-Cookie, Date, Expires, Last-Modified,
+	 * Age, ETag, Cache-Control, Pragma).
+	 *
+	 * This is only used when get_response_headers_to_include_in_caching() returns null.
+	 *
+	 * This can be customized per-endpoint via the config array
+	 * passed to with_cache() ('exclude_headers' key).
+	 *
+	 * @param WP_REST_Request $request     Request object.
+	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
+	 * @return array Array of header names to exclude (case-insensitive).
+	 */
+	protected function get_response_headers_to_exclude_from_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return array();
+	}
+
+	/**
 	 * Extract entity IDs from response data.
 	 *
 	 * This implementation assumes the response is either:
@@ -373,6 +460,82 @@ trait RestApiCache {
 		// Filter out null/false values but keep 0 and empty strings as they could be valid IDs.
 		return array_unique(
 			array_filter( $ids, fn ( $id ) => ! is_null( $id ) && false !== $id )
+		);
+	}
+
+	/**
+	 * Filter response headers to get only those that should be cached.
+	 *
+	 * The filtering process follows these steps:
+	 * 1. If $include_headers is non-null, only those headers are included (case-insensitive).
+	 *    If $include_headers is null, all headers are included except those in $exclude_headers.
+	 * 2. Always-excluded headers (X-WC-Cache, Set-Cookie, Date, etc.) are removed.
+	 * 3. The woocommerce_rest_api_cached_headers filter is applied to the header names.
+	 * 4. Only headers in the filtered list are returned.
+	 *
+	 * @param array            $nominal_headers Response headers.
+	 * @param array|null       $include_headers Header names to include (null to use exclusion logic).
+	 * @param array            $exclude_headers Header names to exclude (case-insensitive).
+	 * @param WP_REST_Request  $request         The request object.
+	 * @param WP_REST_Response $response        The response object.
+	 * @param string|null      $endpoint_id     Optional friendly identifier for the endpoint.
+	 * @return array Filtered headers array.
+	 */
+	private function get_headers_to_cache( array $nominal_headers, ?array $include_headers, array $exclude_headers, WP_REST_Request $request, WP_REST_Response $response, ?string $endpoint_id ): array {
+		// Step 1: Determine which headers to consider based on include/exclude.
+		if ( ! is_null( $include_headers ) ) {
+			$include_headers_lowercase = array_map( 'strtolower', $include_headers );
+			$headers_to_cache          = array_filter(
+				$nominal_headers,
+				fn( $name ) => in_array( strtolower( $name ), $include_headers_lowercase, true ),
+				ARRAY_FILTER_USE_KEY
+			);
+		} else {
+			$exclude_headers_lowercase = array_map( 'strtolower', $exclude_headers );
+			$headers_to_cache          = array_filter(
+				$nominal_headers,
+				fn( $name ) => ! in_array( strtolower( $name ), $exclude_headers_lowercase, true ),
+				ARRAY_FILTER_USE_KEY
+			);
+		}
+
+		// Step 2: Remove always-excluded headers.
+		$always_exclude_lowercase = array_map( 'strtolower', self::$always_excluded_headers );
+		$headers_to_cache         = array_filter(
+			$headers_to_cache,
+			fn( $name ) => ! in_array( strtolower( $name ), $always_exclude_lowercase, true ),
+			ARRAY_FILTER_USE_KEY
+		);
+
+		// Step 3: Apply filter to header names.
+		$header_names = array_keys( $headers_to_cache );
+
+		/**
+		 * Filter the list of response header names to cache.
+		 *
+		 * @since 10.4.0
+		 *
+		 * @param array            $header_names List of header names to cache.
+		 * @param WP_REST_Request  $request      The request object.
+		 * @param WP_REST_Response $response     The response object.
+		 * @param string|null      $endpoint_id  Optional friendly identifier for the endpoint.
+		 * @param object           $controller   The controller instance.
+		 * @return array Filtered list of header names to cache.
+		 */
+		$filtered_header_names = apply_filters(
+			'woocommerce_rest_api_cached_headers',
+			$header_names,
+			$request,
+			$response,
+			$endpoint_id,
+			$this
+		);
+
+		// Step 4: Return only the headers that are in the filtered list.
+		return array_filter(
+			$headers_to_cache,
+			fn( $name ) => in_array( $name, $filtered_header_names, true ),
+			ARRAY_FILTER_USE_KEY
 		);
 	}
 
@@ -530,6 +693,12 @@ trait RestApiCache {
 		// At this point the cached response is valid.
 		$response = new WP_REST_Response( $cached['data'], $cached['status_code'] ?? 200 );
 
+		if ( ! empty( $cached['headers'] ) ) {
+			foreach ( $cached['headers'] as $name => $value ) {
+				$response->header( $name, $value );
+			}
+		}
+
 		return $response;
 	}
 
@@ -543,8 +712,9 @@ trait RestApiCache {
 	 * @param array  $entity_ids     Array of entity IDs in the response.
 	 * @param int    $cache_ttl      Cache TTL in seconds.
 	 * @param array  $relevant_hooks Hook names to track for invalidation.
+	 * @param array  $headers        Response headers to cache.
 	 */
-	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl, array $relevant_hooks ): void {
+	private function store_cached_response( string $cache_key, $data, int $status_code, string $entity_type, array $entity_ids, int $cache_ttl, array $relevant_hooks, array $headers = array() ): void {
 		$entity_versions = array();
 		foreach ( $entity_ids as $entity_id ) {
 			$version_id = "{$entity_type}_{$entity_id}";
@@ -566,6 +736,10 @@ trait RestApiCache {
 
 		if ( ! empty( $relevant_hooks ) ) {
 			$cache_data['hooks_hash'] = $this->generate_hooks_hash( $relevant_hooks );
+		}
+
+		if ( ! empty( $headers ) ) {
+			$cache_data['headers'] = $headers;
 		}
 
 		wp_cache_set( $cache_key, $cache_data, self::$cache_group, $cache_ttl );

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -84,7 +84,7 @@ use WP_REST_Response;
  * - response_cache_vary_by_user(): Whether cache should be user-specific.
  * - get_hooks_relevant_to_caching(): Hook names to track for cache invalidation.
  * - get_ttl_for_cached_response(): TTL for cached outputs in seconds.
- * - get_response_headers_to_include_in_caching(): Headers to include in cache (null = use exclusion mode).
+ * - get_response_headers_to_include_in_caching(): Headers to include in cache (false = use exclusion mode).
  * - get_response_headers_to_exclude_from_caching(): Headers to exclude from cache (when in exclusion mode).
  *
  * Cache invalidation happens when:
@@ -160,7 +160,7 @@ trait RestApiCache {
 	 *                           - endpoint_id: string|null (optional friendly identifier for the endpoint).
 	 *                           - cache_ttl: int (defaults to get_ttl_for_cached_response()).
 	 *                           - relevant_hooks: array (defaults to get_hooks_relevant_to_caching()).
-	 *                           - include_headers: array|null (defaults to get_response_headers_to_include_in_caching()).
+	 *                           - include_headers: array|false (defaults to get_response_headers_to_include_in_caching()).
 	 *                           - exclude_headers: array (defaults to get_response_headers_to_exclude_from_caching()).
 	 * @return callable Wrapped callback.
 	 */
@@ -245,6 +245,7 @@ trait RestApiCache {
 	 * @param WP_REST_Request $request The request object.
 	 * @param array           $config  Raw configuration array passed to with_cache.
 	 * @return array|null Normalized cache config with keys: endpoint_id, entity_type, vary_by_user, cache_ttl, relevant_hooks, include_headers, exclude_headers, cache_key. Returns null if entity type is not available.
+	 * @throws \InvalidArgumentException If include_headers is not false or an array.
 	 */
 	private function build_cache_config( WP_REST_Request $request, array $config ): ?array {
 		$endpoint_id  = $config['endpoint_id'] ?? null;
@@ -261,13 +262,20 @@ trait RestApiCache {
 			return null;
 		}
 
+		$include_headers = $config['include_headers'] ?? $this->get_response_headers_to_include_in_caching( $request, $endpoint_id );
+		if ( false !== $include_headers && ! is_array( $include_headers ) ) {
+			throw new \InvalidArgumentException(
+				'include_headers must be either false or an array, ' . gettype( $include_headers ) . ' given.' // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			);
+		}
+
 		return array(
 			'endpoint_id'     => $endpoint_id,
 			'entity_type'     => $entity_type,
 			'vary_by_user'    => $vary_by_user,
 			'cache_ttl'       => $config['cache_ttl'] ?? $this->get_ttl_for_cached_response( $request, $endpoint_id ),
 			'relevant_hooks'  => $config['relevant_hooks'] ?? $this->get_hooks_relevant_to_caching( $request, $endpoint_id ),
-			'include_headers' => array_key_exists( 'include_headers', $config ) ? $config['include_headers'] : $this->get_response_headers_to_include_in_caching( $request, $endpoint_id ),
+			'include_headers' => $include_headers,
 			'exclude_headers' => $config['exclude_headers'] ?? $this->get_response_headers_to_exclude_from_caching( $request, $endpoint_id ),
 			'cache_key'       => $this->get_key_for_cached_response( $request, $entity_type, $vary_by_user, $endpoint_id ),
 		);
@@ -394,9 +402,9 @@ trait RestApiCache {
 	/**
 	 * Get the names of response headers to include in caching.
 	 *
-	 * When this returns a non-null value, ONLY the headers whose names are returned
+	 * When this returns an array, ONLY the headers whose names are returned
 	 * will be included in the cache (subject to always-excluded headers).
-	 * When this returns null, all headers will be included except those returned
+	 * When this returns false, all headers will be included except those returned
 	 * by get_response_headers_to_exclude_from_caching().
 	 *
 	 * This can be customized per-endpoint via the config array
@@ -404,10 +412,10 @@ trait RestApiCache {
 	 *
 	 * @param WP_REST_Request $request     Request object.
 	 * @param string|null     $endpoint_id Optional friendly identifier for the endpoint.
-	 * @return array|null Array of header names to include (case-insensitive), or null to use exclusion logic.
+	 * @return array|false Array of header names to include (case-insensitive), or false to use exclusion logic.
 	 */
-	protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ): ?array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		return null;
+	protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return false;
 	}
 
 	/**
@@ -417,7 +425,7 @@ trait RestApiCache {
 	 * always-excluded headers (X-WC-Cache, Set-Cookie, Date, Expires, Last-Modified,
 	 * Age, ETag, Cache-Control, Pragma).
 	 *
-	 * This is only used when get_response_headers_to_include_in_caching() returns null.
+	 * This is only used when get_response_headers_to_include_in_caching() returns false.
 	 *
 	 * This can be customized per-endpoint via the config array
 	 * passed to with_cache() ('exclude_headers' key).
@@ -467,23 +475,23 @@ trait RestApiCache {
 	 * Filter response headers to get only those that should be cached.
 	 *
 	 * The filtering process follows these steps:
-	 * 1. If $include_headers is non-null, only those headers are included (case-insensitive).
-	 *    If $include_headers is null, all headers are included except those in $exclude_headers.
+	 * 1. If $include_headers is an array, only those headers are included (case-insensitive).
+	 *    If $include_headers is false, all headers are included except those in $exclude_headers.
 	 * 2. Always-excluded headers (X-WC-Cache, Set-Cookie, Date, etc.) are removed.
 	 * 3. The woocommerce_rest_api_cached_headers filter is applied to the header names.
 	 * 4. Only headers in the filtered list are returned.
 	 *
 	 * @param array            $nominal_headers Response headers.
-	 * @param array|null       $include_headers Header names to include (null to use exclusion logic).
+	 * @param array|false      $include_headers Header names to include (false to use exclusion logic).
 	 * @param array            $exclude_headers Header names to exclude (case-insensitive).
 	 * @param WP_REST_Request  $request         The request object.
 	 * @param WP_REST_Response $response        The response object.
 	 * @param string|null      $endpoint_id     Optional friendly identifier for the endpoint.
 	 * @return array Filtered headers array.
 	 */
-	private function get_headers_to_cache( array $nominal_headers, ?array $include_headers, array $exclude_headers, WP_REST_Request $request, WP_REST_Response $response, ?string $endpoint_id ): array {
+	private function get_headers_to_cache( array $nominal_headers, $include_headers, array $exclude_headers, WP_REST_Request $request, WP_REST_Response $response, ?string $endpoint_id ): array {
 		// Step 1: Determine which headers to consider based on include/exclude.
-		if ( ! is_null( $include_headers ) ) {
+		if ( false !== $include_headers ) {
 			$include_headers_lowercase = array_map( 'strtolower', $include_headers );
 			$headers_to_cache          = array_filter(
 				$nominal_headers,

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -676,6 +676,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			'X-Header-Three' => 'value-three',
 		);
 
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 		$filter_callback = function ( $cached_header_names, $all_header_names, $request, $response, $endpoint_id, $controller ) {
 			if ( in_array( 'X-Header-Two', $all_header_names, true ) ) {
 				$cached_header_names[] = 'X-Header-Two';
@@ -714,6 +715,64 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
 		$this->sut->custom_include_headers = false;
+	}
+
+	/**
+	 * @testdox The woocommerce_rest_api_cached_headers filter cannot re-introduce always-excluded headers.
+	 */
+	public function test_filter_cannot_reintroduce_always_excluded_headers() {
+		$this->sut->response_headers['standard'] = array(
+			'Set-Cookie'      => 'session=abc123',
+			'Cache-Control'   => 'no-cache',
+			'X-Custom-Header' => 'custom-value',
+		);
+
+		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
+
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys   = $this->get_all_cache_keys();
+		$cache_key    = $cache_keys[0];
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'Set-Cookie', $cached_entry['headers'], 'Set-Cookie should not be cached even when filter returns it' );
+		$this->assertArrayNotHasKey( 'Cache-Control', $cached_entry['headers'], 'Cache-Control should not be cached even when filter returns it' );
+		$this->assertArrayHasKey( 'X-Custom-Header', $cached_entry['headers'], 'Non-excluded headers should still be cached' );
+		$this->assertEquals( 'custom-value', $cached_entry['headers']['X-Custom-Header'] );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie should not be in cached response' );
+		$this->assertArrayNotHasKey( 'Cache-Control', $headers, 'Cache-Control should not be in cached response' );
+		$this->assertArrayHasKey( 'X-Custom-Header', $headers );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
+	}
+
+	/**
+	 * @testdox A doing_it_wrong notice is emitted when filter tries to re-introduce always-excluded headers.
+	 */
+	public function test_doing_it_wrong_notice_when_filter_reintroduces_excluded_headers() {
+		$this->sut->response_headers['standard'] = array(
+			'Set-Cookie'      => 'session=abc123',
+			'X-Custom-Header' => 'custom-value',
+		);
+
+		$filter_callback = fn( $cached_header_names, $all_header_names )  => $all_header_names;
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
+
+		$this->setExpectedIncorrectUsage( 'Automattic\WooCommerce\Internal\Traits\RestApiCache::get_headers_to_cache' );
+
+		$this->query_endpoint( 'standard' );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -61,12 +61,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->version_generator = wc_get_container()->get( VersionStringGenerator::class );
 		$this->sut               = $this->create_test_controller();
 
-		global $wp_rest_server;
-		$wp_rest_server = new WP_REST_Server();
-		$this->server   = $wp_rest_server;
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		do_action( 'rest_api_init' );
-		$this->sut->register_routes();
+		$this->reset_rest_server();
 	}
 
 	/**
@@ -505,6 +500,214 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Response headers are cached and restored on cache hit.
+	 */
+	public function test_response_headers_are_cached() {
+		$this->sut->response_headers['standard'] = array(
+			'X-Custom-Header'  => 'custom-value',
+			'X-Another-Header' => 'another-value',
+		);
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys = $this->get_all_cache_keys();
+		$cache_key  = $cache_keys[0];
+
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayHasKey( 'X-Custom-Header', $cached_entry['headers'] );
+		$this->assertEquals( 'custom-value', $cached_entry['headers']['X-Custom-Header'] );
+		$this->assertArrayHasKey( 'X-Another-Header', $cached_entry['headers'] );
+		$this->assertEquals( 'another-value', $cached_entry['headers']['X-Another-Header'] );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+		$this->assertArrayHasKey( 'X-Custom-Header', $headers );
+		$this->assertEquals( 'custom-value', $headers['X-Custom-Header'] );
+		$this->assertArrayHasKey( 'X-Another-Header', $headers );
+		$this->assertEquals( 'another-value', $headers['X-Another-Header'] );
+	}
+
+	/**
+	 * @testdox Certain response headers are always excluded from caching.
+	 */
+	public function test_headers_always_excluded_from_caching() {
+		$this->sut->response_headers['standard'] = array(
+			'Set-Cookie'     => 'session=abc123',
+			'Date'           => 'Mon, 01 Jan 2024 00:00:00 GMT',
+			'X-Custom-Valid' => 'should-be-present',
+		);
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys = $this->get_all_cache_keys();
+		$cache_key  = $cache_keys[0];
+
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'Set-Cookie', $cached_entry['headers'], 'Set-Cookie should be excluded from cache' );
+		$this->assertArrayNotHasKey( 'Date', $cached_entry['headers'], 'Date should be excluded from cache' );
+		$this->assertArrayHasKey( 'X-Custom-Valid', $cached_entry['headers'] );
+		$this->assertEquals( 'should-be-present', $cached_entry['headers']['X-Custom-Valid'] );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+
+		$this->assertArrayNotHasKey( 'Set-Cookie', $headers, 'Set-Cookie header should not be cached' );
+		$this->assertArrayNotHasKey( 'Date', $headers, 'Date header should not be cached' );
+
+		$this->assertArrayHasKey( 'X-Custom-Valid', $headers );
+		$this->assertEquals( 'should-be-present', $headers['X-Custom-Valid'] );
+	}
+
+	/**
+	 * @testdox Custom headers can be excluded from caching via controller method and endpoint config.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $use_with_cache_config Whether to use with_cache config (true) or controller method override (false).
+	 */
+	public function test_custom_headers_excluded_from_caching( bool $use_with_cache_config ) {
+		if ( $use_with_cache_config ) {
+			$endpoint = 'custom_endpoint_config';
+			$this->sut->endpoint_cache_config[ $endpoint ]['config'] = array(
+				'exclude_headers' => array( 'X-Custom-Exclude' ),
+			);
+			$this->sut->reinitialize_cache();
+
+			$this->reset_rest_server();
+		} else {
+			$endpoint                          = 'standard';
+			$this->sut->custom_exclude_headers = array( 'X-Custom-Exclude' );
+		}
+
+		$this->sut->response_headers[ $endpoint ] = array(
+			'X-Custom-Exclude' => 'should-not-be-cached',
+			'X-Custom-Include' => 'should-be-cached',
+		);
+
+		$response1 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys = $this->get_all_cache_keys();
+		$cache_key  = $cache_keys[0];
+
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayNotHasKey( 'X-Custom-Exclude', $cached_entry['headers'], 'Custom excluded header should be excluded from cache' );
+		$this->assertArrayHasKey( 'X-Custom-Include', $cached_entry['headers'] );
+		$this->assertEquals( 'should-be-cached', $cached_entry['headers']['X-Custom-Include'] );
+
+		$response2 = $this->query_endpoint( $endpoint );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+
+		$this->assertArrayNotHasKey( 'X-Custom-Exclude', $headers, 'Custom excluded header should not be cached' );
+
+		$this->assertArrayHasKey( 'X-Custom-Include', $headers );
+		$this->assertEquals( 'should-be-cached', $headers['X-Custom-Include'] );
+
+		if ( ! $use_with_cache_config ) {
+			$this->sut->custom_exclude_headers = array();
+		}
+	}
+
+	/**
+	 * @testdox The woocommerce_rest_api_cached_headers filter can modify which headers are cached.
+	 */
+	public function test_filter_can_modify_cached_headers() {
+		$this->sut->response_headers['standard'] = array(
+			'X-Header-One'   => 'value-one',
+			'X-Header-Two'   => 'value-two',
+			'X-Header-Three' => 'value-three',
+		);
+
+		$filter_callback = function ( $header_names ) {
+			return array_values( array_filter( $header_names, fn( $name ) => 'X-Header-Two' !== $name ) );
+		};
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback );
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys = $this->get_all_cache_keys();
+		$cache_key  = $cache_keys[0];
+
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayHasKey( 'X-Header-One', $cached_entry['headers'] );
+		$this->assertArrayNotHasKey( 'X-Header-Two', $cached_entry['headers'], 'Filter should have excluded X-Header-Two' );
+		$this->assertArrayHasKey( 'X-Header-Three', $cached_entry['headers'] );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+
+		$this->assertArrayHasKey( 'X-Header-One', $headers );
+		$this->assertArrayNotHasKey( 'X-Header-Two', $headers, 'Filtered header should not be restored' );
+		$this->assertArrayHasKey( 'X-Header-Three', $headers );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback );
+	}
+
+	/**
+	 * @testdox Setting include_headers to null in endpoint config forces exclusion mode even when controller has default inclusion list.
+	 */
+	public function test_null_include_headers_overrides_controller_default() {
+		$this->sut->custom_include_headers = array( 'X-Header-One', 'X-Header-Two' );
+
+		$this->sut->endpoint_cache_config['test_null_override']['config'] = array(
+			'include_headers' => null,
+			'exclude_headers' => array( 'X-Header-Two' ),
+		);
+		$this->sut->reinitialize_cache();
+
+		$this->reset_rest_server();
+
+		$this->sut->response_headers['test_null_override'] = array(
+			'X-Header-One'   => 'value-one',
+			'X-Header-Two'   => 'value-two',
+			'X-Header-Three' => 'value-three',
+		);
+
+		$response1 = $this->query_endpoint( 'test_null_override' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys   = $this->get_all_cache_keys();
+		$cache_key    = $cache_keys[0];
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayHasKey( 'X-Header-One', $cached_entry['headers'], 'X-Header-One should be cached (not excluded)' );
+		$this->assertArrayNotHasKey( 'X-Header-Two', $cached_entry['headers'], 'X-Header-Two should be excluded (exclusion mode used)' );
+		$this->assertArrayHasKey( 'X-Header-Three', $cached_entry['headers'], 'X-Header-Three should be cached (not excluded)' );
+
+		$response2 = $this->query_endpoint( 'test_null_override' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+
+		$this->assertArrayHasKey( 'X-Header-One', $headers );
+		$this->assertArrayNotHasKey( 'X-Header-Two', $headers );
+		$this->assertArrayHasKey( 'X-Header-Three', $headers );
+
+		$this->sut->custom_include_headers = null;
+	}
+
+	/**
 	 * Query an endpoint and return the response.
 	 *
 	 * @param string      $endpoint_name Endpoint name.
@@ -545,6 +748,22 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Reset the REST server and register routes.
+	 *
+	 * This is useful when you need to re-register routes after changing
+	 * configuration, as WordPress doesn't allow re-registering routes
+	 * on the same server instance.
+	 */
+	private function reset_rest_server() {
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'rest_api_init' );
+		$this->sut->register_routes();
+	}
+
+	/**
 	 * Create a test controller.
 	 */
 	private function create_test_controller() {
@@ -552,12 +771,12 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			// phpcs:disable Squiz.Commenting
 			use RestApiCache;
 
-			public $responses = array(
-				'single_entity'         => array(
+			public $responses              = array(
+				'single_entity'          => array(
 					'id'   => 1,
 					'name' => 'Product 1',
 				),
-				'multiple_entities'     => array(
+				'multiple_entities'      => array(
 					array(
 						'id'   => 2,
 						'name' => 'Product 2',
@@ -567,37 +786,52 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 						'name' => 'Product 3',
 					),
 				),
-				'custom_entity_type'    => array(
+				'custom_entity_type'     => array(
 					'id'   => 100,
 					'name' => 'Custom Thing 100',
 				),
-				'no_vary_by_user'       => array(
+				'no_vary_by_user'        => array(
 					'id'   => 50,
 					'name' => 'Shared Product',
 				),
-				'with_endpoint_id'      => array(
+				'with_endpoint_id'       => array(
 					'id'   => 60,
 					'name' => 'Product with Endpoint ID',
 				),
-				'custom_ttl'            => array(
+				'custom_ttl'             => array(
 					'id'   => 70,
 					'name' => 'Product with Custom TTL',
 				),
-				'with_endpoint_hooks'   => array(
+				'with_endpoint_hooks'    => array(
 					'id'   => 80,
 					'name' => 'Product with Endpoint Hooks',
 				),
-				'with_controller_hooks' => array(
+				'with_controller_hooks'  => array(
 					'id'   => 90,
 					'name' => 'Product with Controller Hooks',
 				),
+				'standard'               => array(
+					'id'   => 10,
+					'name' => 'Standard Product',
+				),
+				'custom_endpoint_config' => array(
+					'id'   => 20,
+					'name' => 'Custom Config Product',
+				),
+				'test_null_override'     => array(
+					'id'   => 30,
+					'name' => 'Test Null Override Product',
+				),
 			);
-
-			public $default_entity_type   = 'product';
-			public $default_vary_by_user  = true;
-			public $endpoint_vary_by_user = array();
-			public $endpoint_ids          = array();
-			public $controller_hooks      = array();
+			public $default_entity_type    = 'product';
+			public $default_vary_by_user   = true;
+			public $endpoint_vary_by_user  = array();
+			public $endpoint_ids           = array();
+			public $controller_hooks       = array();
+			public $response_headers       = array();
+			public $custom_exclude_headers = array();
+			public $custom_include_headers = null;
+			public $endpoint_cache_config  = array();
 
 			public function __construct() {
 				$this->namespace = 'wc/v3';
@@ -617,6 +851,9 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				$this->register_multi_method_route();
 				$this->register_cached_route( 'with_endpoint_hooks', array( 'relevant_hooks' => array( 'test_endpoint_hook_for_caching' ) ) );
 				$this->register_cached_route( 'with_controller_hooks' );
+				$this->register_cached_route( 'standard' );
+				$this->register_custom_config_route( 'custom_endpoint_config' );
+				$this->register_custom_config_route( 'test_null_override' );
 			}
 
 			private function register_cached_route( string $endpoint, array $cache_args = array(), bool $non_array_request = false, bool $raw_response = false ) {
@@ -641,7 +878,6 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				);
 			}
 
-
 			private function register_multi_method_route() {
 				register_rest_route(
 					$this->namespace,
@@ -665,6 +901,27 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				);
 			}
 
+			private function register_custom_config_route( string $endpoint ) {
+				$cache_args = isset( $this->endpoint_cache_config[ $endpoint ]['config'] ) ?
+					$this->endpoint_cache_config[ $endpoint ]['config'] :
+					array();
+
+				register_rest_route(
+					$this->namespace,
+					'/' . $this->rest_base . '/' . $endpoint,
+					array(
+						'methods'             => 'GET',
+						'callback'            => $this->with_cache(
+							function ( $request ) use ( $endpoint ) {
+								return $this->handle_request( $endpoint, $request );
+							},
+							$cache_args
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+
 			protected function get_default_response_entity_type(): ?string {
 				return $this->default_entity_type;
 			}
@@ -681,8 +938,25 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				return $this->controller_hooks;
 			}
 
+			protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ): ?array {
+				return $this->custom_include_headers;
+			}
+
+			protected function get_response_headers_to_exclude_from_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array {
+				return $this->custom_exclude_headers;
+			}
+
 			private function handle_request( string $endpoint, WP_REST_Request $request ) {
-				return new WP_REST_Response( $this->responses[ $endpoint ], 200 );
+				$response = new WP_REST_Response( $this->responses[ $endpoint ], 200 );
+
+				// Add custom headers if configured for this endpoint.
+				if ( ! empty( $this->response_headers[ $endpoint ] ) ) {
+					foreach ( $this->response_headers[ $endpoint ] as $name => $value ) {
+						$response->header( $name, $value );
+					}
+				}
+
+				return $response;
 			}
 
 			private function handle_raw_array_request( string $endpoint, WP_REST_Request $request ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -633,10 +633,11 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			'X-Header-Three' => 'value-three',
 		);
 
-		$filter_callback = function ( $header_names ) {
-			return array_values( array_filter( $header_names, fn( $name ) => 'X-Header-Two' !== $name ) );
+		$filter_callback = function ( $cached_header_names, $all_header_names, $request, $response, $endpoint_id, $controller ) {
+			unset( $all_header_names, $request, $response, $endpoint_id, $controller ); // Avoid parameter not used PHPCS errors.
+			return array_values( array_filter( $cached_header_names, fn( $name ) => 'X-Header-Two' !== $name ) );
 		};
-		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback );
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
 
 		$response1 = $this->query_endpoint( 'standard' );
 		$this->assertCacheHeader( $response1, 'MISS' );
@@ -660,7 +661,59 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'X-Header-Two', $headers, 'Filtered header should not be restored' );
 		$this->assertArrayHasKey( 'X-Header-Three', $headers );
 
-		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback );
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
+	}
+
+	/**
+	 * @testdox The woocommerce_rest_api_cached_headers filter can add headers using all_header_names parameter.
+	 */
+	public function test_filter_can_add_headers_from_all_headers() {
+		$this->sut->custom_include_headers = array( 'X-Header-One' );
+
+		$this->sut->response_headers['standard'] = array(
+			'X-Header-One'   => 'value-one',
+			'X-Header-Two'   => 'value-two',
+			'X-Header-Three' => 'value-three',
+		);
+
+		$filter_callback = function ( $cached_header_names, $all_header_names, $request, $response, $endpoint_id, $controller ) {
+			if ( in_array( 'X-Header-Two', $all_header_names, true ) ) {
+				$cached_header_names[] = 'X-Header-Two';
+			}
+			if ( in_array( 'X-Header-Three', $all_header_names, true ) ) {
+				$cached_header_names[] = 'X-Header-Three';
+			}
+			return $cached_header_names;
+		};
+		add_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10, 6 );
+
+		$response1 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response1, 'MISS' );
+
+		$cache_keys = $this->get_all_cache_keys();
+		$cache_key  = $cache_keys[0];
+
+		$cached_entry = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		$this->assertArrayHasKey( 'headers', $cached_entry );
+		$this->assertArrayHasKey( 'X-Header-One', $cached_entry['headers'], 'X-Header-One should be cached (original)' );
+		$this->assertArrayHasKey( 'X-Header-Two', $cached_entry['headers'], 'X-Header-Two should be cached (added by filter)' );
+		$this->assertArrayHasKey( 'X-Header-Three', $cached_entry['headers'], 'X-Header-Three should be cached (added by filter)' );
+
+		$response2 = $this->query_endpoint( 'standard' );
+		$this->assertCacheHeader( $response2, 'HIT' );
+
+		$headers = $response2->get_headers();
+
+		$this->assertArrayHasKey( 'X-Header-One', $headers );
+		$this->assertEquals( 'value-one', $headers['X-Header-One'] );
+		$this->assertArrayHasKey( 'X-Header-Two', $headers );
+		$this->assertEquals( 'value-two', $headers['X-Header-Two'] );
+		$this->assertArrayHasKey( 'X-Header-Three', $headers );
+		$this->assertEquals( 'value-three', $headers['X-Header-Three'] );
+
+		remove_filter( 'woocommerce_rest_api_cached_headers', $filter_callback, 10 );
+		$this->sut->custom_include_headers = false;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/RestApiCacheTest.php
@@ -664,26 +664,26 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Setting include_headers to null in endpoint config forces exclusion mode even when controller has default inclusion list.
+	 * @testdox Setting include_headers to false in endpoint config forces exclusion mode even when controller has default inclusion list.
 	 */
-	public function test_null_include_headers_overrides_controller_default() {
+	public function test_false_include_headers_forces_exclusion_mode() {
 		$this->sut->custom_include_headers = array( 'X-Header-One', 'X-Header-Two' );
 
-		$this->sut->endpoint_cache_config['test_null_override']['config'] = array(
-			'include_headers' => null,
+		$this->sut->endpoint_cache_config['test_false_override']['config'] = array(
+			'include_headers' => false,
 			'exclude_headers' => array( 'X-Header-Two' ),
 		);
 		$this->sut->reinitialize_cache();
 
 		$this->reset_rest_server();
 
-		$this->sut->response_headers['test_null_override'] = array(
+		$this->sut->response_headers['test_false_override'] = array(
 			'X-Header-One'   => 'value-one',
 			'X-Header-Two'   => 'value-two',
 			'X-Header-Three' => 'value-three',
 		);
 
-		$response1 = $this->query_endpoint( 'test_null_override' );
+		$response1 = $this->query_endpoint( 'test_false_override' );
 		$this->assertCacheHeader( $response1, 'MISS' );
 
 		$cache_keys   = $this->get_all_cache_keys();
@@ -695,7 +695,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'X-Header-Two', $cached_entry['headers'], 'X-Header-Two should be excluded (exclusion mode used)' );
 		$this->assertArrayHasKey( 'X-Header-Three', $cached_entry['headers'], 'X-Header-Three should be cached (not excluded)' );
 
-		$response2 = $this->query_endpoint( 'test_null_override' );
+		$response2 = $this->query_endpoint( 'test_false_override' );
 		$this->assertCacheHeader( $response2, 'HIT' );
 
 		$headers = $response2->get_headers();
@@ -704,7 +704,24 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'X-Header-Two', $headers );
 		$this->assertArrayHasKey( 'X-Header-Three', $headers );
 
-		$this->sut->custom_include_headers = null;
+		$this->sut->custom_include_headers = false;
+	}
+
+	/**
+	 * @testdox InvalidArgumentException is thrown when include_headers is not false or an array.
+	 */
+	public function test_invalid_include_headers_throws_exception() {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'include_headers must be either false or an array' );
+
+		$this->sut->endpoint_cache_config['invalid_headers']['config'] = array(
+			'include_headers' => 'invalid-string',
+		);
+		$this->sut->reinitialize_cache();
+
+		$this->reset_rest_server();
+
+		$this->query_endpoint( 'invalid_headers' );
 	}
 
 	/**
@@ -818,9 +835,13 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 					'id'   => 20,
 					'name' => 'Custom Config Product',
 				),
-				'test_null_override'     => array(
+				'test_false_override'    => array(
 					'id'   => 30,
-					'name' => 'Test Null Override Product',
+					'name' => 'Test False Override Product',
+				),
+				'invalid_headers'        => array(
+					'id'   => 40,
+					'name' => 'Invalid Headers Product',
 				),
 			);
 			public $default_entity_type    = 'product';
@@ -830,7 +851,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 			public $controller_hooks       = array();
 			public $response_headers       = array();
 			public $custom_exclude_headers = array();
-			public $custom_include_headers = null;
+			public $custom_include_headers = false;
 			public $endpoint_cache_config  = array();
 
 			public function __construct() {
@@ -853,7 +874,8 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				$this->register_cached_route( 'with_controller_hooks' );
 				$this->register_cached_route( 'standard' );
 				$this->register_custom_config_route( 'custom_endpoint_config' );
-				$this->register_custom_config_route( 'test_null_override' );
+				$this->register_custom_config_route( 'test_false_override' );
+				$this->register_custom_config_route( 'invalid_headers' );
 			}
 
 			private function register_cached_route( string $endpoint, array $cache_args = array(), bool $non_array_request = false, bool $raw_response = false ) {
@@ -938,7 +960,7 @@ class RestApiCacheTest extends WC_REST_Unit_Test_Case {
 				return $this->controller_hooks;
 			}
 
-			protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ): ?array {
+			protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ) {
 				return $this->custom_include_headers;
 			}
 


### PR DESCRIPTION
 _This is the fifth of a series of pull requests to implement output caching for the WooCommerce REST API endpoints. Previous: https://github.com/woocommerce/woocommerce/pull/61878, next: https://github.com/woocommerce/woocommerce/pull/61476_

### Changes proposed in this Pull Request:

This pull request extends the RestApiCache trait introduced in https://github.com/woocommerce/woocommerce/pull/61798 to add support for including HTTP headers as part of the cached response. It works as follows:

- If the trait's `get_response_headers_to_include_in_caching` is overriden to return an array of header names, or if an equivalent `include_headers` parameter is passed to `with_cache`, then only the specified headers will be cached. Note that an empty array means that no headers will be cached whatsoever.
- Otherwise (the above returns `false`, which is the default), then all the response headers will be cached except those returned by the `get_response_headers_to_exclude_from_caching` method (defaulting to an empty array), overridable per-endpoint by passing an `exclude_headers` parameter to `with_cache`.
- Once the set of headers to to cache is determined, the following ones are always excluded: `X-WC-Cache`, `Set-Cookie`, `Date`,	`Expires`, `Last-Modified`, `Age`, `ETag`, `Cache-Control`, `Pragma`.
- Finally, the set of headers to cache is filtered via a `woocommerce_rest_api_cached_headers` filter. An attempt to reintroduce the always excluded headers using this filter will trigger a `doing_it_wrong`.

Without overriding any of these trait methods or using any of the equivalent `with_cache` parameters, the default behavior is to cache all headers except the specified fixed set.

### How to test the changes in this Pull Request:

> **⚠️ Testing Prerequisite:** A persistent object cache must be installed in your WordPress instance. If you are testing locally you can use [this simple file-based drop-in plugin](https://gist.github.com/Konamiman/96aeacc7933b5b89cb735c46f02adf89).

1. Add the following snippet to your site, this will create a simple "things" controller for testing the caching trait:

```php
add_action(
	'rest_api_init',
	function () {
		$controller = new class() extends WP_REST_Controller {
			use Automattic\WooCommerce\Internal\Traits\RestApiCache;

			public function __construct() {
				$this->initialize_rest_api_cache();
			}

			private function register_cached_route( $route, $cache_params = array() ) {
				register_rest_route(
					'wc',
					'/' . $route,
					array(
						'methods'             => 'GET',
						'callback'            => empty( $cache_params ) ? $this->with_cache( array( $this, 'get_items' ) ) : $this->with_cache( array( $this, 'get_items' ), $cache_params ),
						'permission_callback' => '__return_true',
					)
				);
			}

			public function register_routes() {
				// Default controller configuration (includes X-WC-Data-1, X-WC-Data-2).
				$this->register_cached_route( 'thing-1' );

				// Override to exclusion mode with custom exclude list (excludes X-WC-Data-2).
				$this->register_cached_route(
					'thing-2',
					array(
						'include_headers' => false,
						'exclude_headers' => array( 'X-WC-Data-2' ),
					)
				);

				// Override to exclusion mode using controller's exclude list (excludes X-WC-Data-4, X-WC-Data-5).
				$this->register_cached_route( 'thing-3', array( 'include_headers' => false ) );

				// Different inclusion list (includes X-WC-Data-1, X-WC-Data-3, X-WC-Data-5).
				$this->register_cached_route( 'thing-4', array( 'include_headers' => array( 'X-WC-Data-1', 'X-WC-Data-3', 'X-WC-Data-5' ) ) );

				// Empty include array (caches NO headers).
				$this->register_cached_route( 'thing-5', array( 'include_headers' => array() ) );

				// exclude_headers is ignored when include_headers is present (caches X-WC-Data-1, X-WC-Data-2, X-WC-Data-3).
				$this->register_cached_route(
					'thing-6',
					array(
						'include_headers' => array( 'X-WC-Data-1', 'X-WC-Data-2', 'X-WC-Data-3' ),
						'exclude_headers' => array( 'X-WC-Data-2' ),
					)
				);
			}

			public function get_items( $request ) {
				$response = new WP_REST_Response(
					array(
						'id'   => 1,
						'name' => 'Test Thing',
					),
					200
				);

				$response->header( 'X-WC-Data-1', 'from-get-items' );
				$response->header( 'X-WC-Data-2', 'from-get-items' );
				$response->header( 'X-WC-Data-3', 'from-get-items' );
				$response->header( 'X-WC-Data-4', 'from-get-items' );
				$response->header( 'X-WC-Data-5', 'from-get-items' );

				return $response;
			}

			protected function get_default_response_entity_type(): ?string {
				return 'thing';
			}

			protected function get_response_headers_to_include_in_caching( WP_REST_Request $request, ?string $endpoint_id = null ): ?array {
				return array( 'X-WC-Data-1', 'X-WC-Data-2' );
			}

			protected function get_response_headers_to_exclude_from_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array {
				return array( 'X-WC-Data-4', 'X-WC-Data-5' );
			}
		};

		$controller->register_routes();
	}
);
```

2. Test the six endpoints by running `curl -i "http://localhost/wp-json/wc/thing-<1 to 6>" `. On the first call for each you should get a cache miss and all the `X-WC-Data-<1 to 5>` headers should be present in the response, on the second call you should get a cache hit and a subset of these headers that depends on the endpoint:

* For `things-1`: headers 1 and 2.
* For `things-2`: headers 1, 3, 4 and 5.
* For `things-3`: headers 1, 2, and 3.
* For `things-4`: headers 1, 3, and 5.
* For `things-5`: none of these headers.
* For `things-6`: headers 1, 2, and 3.

3. Add the following additional snippet:

```php
add_filter(
	'woocommerce_rest_api_cached_headers',
	function ( $headers, $request, $endpoint_id ) {
		$headers = array_diff( $headers, array( 'X-WC-Data-1' ) );
		$headers[] = 'X-WC-Data-3';
		return $headers;
	}, 10, 3
);
```

then run ``curl -i "http://localhost/wp-json/wc/thing-1?foo=bar" ` (query string argument to force a new cached entry) twice, the second time you should get headers 2 and 3 in the response.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
