### PR TITLE
Product Gallery - keep beta label for one more version

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -1538,7 +1538,7 @@ Enable customers to filter the product collection by selecting one or more taxon
 -	**Supports:** color (text, ~~background~~), interactivity, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** displayStyle, hideEmpty, isPreview, showCounts, sortOrder, taxonomy
 
-## Product Gallery - woocommerce/product-gallery
+## Product Gallery (Beta) - woocommerce/product-gallery
 
 Showcase your products relevant images and media.
 

--- a/plugins/woocommerce/changelog/add-call-product-gallery-stable
+++ b/plugins/woocommerce/changelog/add-call-product-gallery-stable
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Product Gallery: mark block stable
+Product Gallery: remove temporary backwards compatible code for beta block

--- a/plugins/woocommerce/changelog/add-product-gallery-keep-beta-for-one-more-version
+++ b/plugins/woocommerce/changelog/add-product-gallery-keep-beta-for-one-more-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Bring back Beta label to a block for a single version. Block wasn't released without the label so there's no need to announce bringing the label back
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-gallery",
-	"title": "Product Gallery",
+	"title": "Product Gallery (Beta)",
 	"description": "Showcase your products relevant images and media.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1055,7 +1055,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await editor.selectBlocks( addToCartFormBlock );
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Product Gallery' )
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
 		).toBeHidden();
 
 		await page
@@ -1065,7 +1065,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			.click();
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Product Gallery' )
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
 		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -11,7 +11,7 @@ import { ProductGalleryPage } from './product-gallery.page';
 
 const blockData = {
 	name: 'woocommerce/product-gallery',
-	title: 'Product Gallery',
+	title: 'Product Gallery (Beta)',
 	slug: 'single-product',
 	productPage: '/product/hoodie/',
 };
@@ -389,7 +389,7 @@ test.describe( `${ blockData.name }`, () => {
 			.click();
 
 		const productGalleryBlock = editor.canvas.getByLabel(
-			'Block: Product Gallery'
+			'Block: Product Gallery (Beta)'
 		);
 
 		await expect( productGalleryBlock ).toBeVisible();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -113,7 +113,7 @@ test.describe( `${ blockData.name } editor`, () => {
 		await editor.selectBlocks( productImageGalleryBlock );
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Product Gallery' )
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
 		).toBeHidden();
 
 		await page
@@ -123,7 +123,7 @@ test.describe( `${ blockData.name } editor`, () => {
 			.click();
 
 		await expect(
-			editor.canvas.getByLabel( 'Block: Product Gallery' )
+			editor.canvas.getByLabel( 'Block: Product Gallery (Beta)' )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR brings back the beta label for the Product Gallery block for WooCommerce 10.4. 

Also, I reopened the issue https://github.com/woocommerce/woocommerce/issues/61801.

**Context:**
- Woo 10.4 will remove backward compatibility code for the Product Gallery block (https://github.com/woocommerce/woocommerce/pull/61274)
- We're keeping the beta label for one more version (10.4) as a safety measure
- In Woo 10.5, we'll remove the beta label and call the block stable

**Reasoning:**
Given that we're removing backward compatibility code in 10.4 (https://github.com/woocommerce/woocommerce/pull/61274), keeping the beta label provides an extra layer of protection. This helps manage expectations and provides a clearer signal that the block is still in a transitional state.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure block is still called `Product Gallery (Beta)`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
