### PR TITLE
Add comprehensive MCP tools for WooCommerce REST API (WOOAI-150)

### DIFF
--- a/plugins/woocommerce/changelog/add-mcp-comprehensive-tools
+++ b/plugins/woocommerce/changelog/add-mcp-comprehensive-tools
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add comprehensive MCP tools: Customers, Coupons, Product Categories, Product Tags, Product Attributes, Product Reviews, Shipping Zones, and Payment Gateways.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -7,8 +7,16 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Abilities;
 
+use Automattic\WooCommerce\Internal\Abilities\Config\CouponsConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\CustomersConfig;
 use Automattic\WooCommerce\Internal\Abilities\Config\OrdersConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\PaymentGatewaysConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\ProductAttributesConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\ProductCategoriesConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\ProductReviewsConfig;
 use Automattic\WooCommerce\Internal\Abilities\Config\ProductsConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\ProductTagsConfig;
+use Automattic\WooCommerce\Internal\Abilities\Config\ShippingZonesConfig;
 use Automattic\WooCommerce\Internal\Abilities\REST\RestAbilityFactory;
 use Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider;
 
@@ -38,8 +46,16 @@ class AbilitiesRestBridge {
 	 */
 	private static function get_configurations(): array {
 		return array(
-			ProductsConfig::get_config(),
+			CouponsConfig::get_config(),
+			CustomersConfig::get_config(),
 			OrdersConfig::get_config(),
+			PaymentGatewaysConfig::get_config(),
+			ProductAttributesConfig::get_config(),
+			ProductCategoriesConfig::get_config(),
+			ProductReviewsConfig::get_config(),
+			ProductsConfig::get_config(),
+			ProductTagsConfig::get_config(),
+			ShippingZonesConfig::get_config(),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Abilities/Config/CouponsConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/CouponsConfig.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Coupons MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Coupons MCP tool.
+ */
+class CouponsConfig {
+
+	/**
+	 * Get the configuration array for the coupons tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/coupons',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Coupons_Controller::class,
+			'route'              => '/wc/v3/coupons',
+			'label'              => __( 'Manage coupons', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce coupons. Use action parameter to list, get, create, update, or delete coupons.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list/search parameters.
+				'search',
+				'code',
+				'page',
+				'per_page',
+				// Essential create/update parameters.
+				'amount',
+				'discount_type',
+				'description',
+				'date_expires',
+				'product_ids',
+				'excluded_product_ids',
+				'usage_limit',
+				'meta_data',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/CustomersConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/CustomersConfig.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Customers MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Customers MCP tool.
+ */
+class CustomersConfig {
+
+	/**
+	 * Get the configuration array for the customers tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/customers',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Customers_Controller::class,
+			'route'              => '/wc/v3/customers',
+			'label'              => __( 'Manage customers', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce customers. Use action parameter to list, get, create, update, or delete customers.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list/search parameters.
+				'search',
+				'email',
+				'role',
+				'page',
+				'per_page',
+				'order',
+				'orderby',
+				// Essential create/update parameters.
+				'first_name',
+				'last_name',
+				'username',
+				'billing',
+				'shipping',
+				'meta_data',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/PaymentGatewaysConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/PaymentGatewaysConfig.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Payment Gateways MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Payment Gateways MCP tool.
+ */
+class PaymentGatewaysConfig {
+
+	/**
+	 * Get the configuration array for the payment gateways tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/payment-gateways',
+			'operations'         => array( 'list', 'get', 'update' ),
+			'controller'         => \WC_REST_Payment_Gateways_Controller::class,
+			'route'              => '/wc/v3/payment_gateways',
+			'label'              => __( 'Manage payment gateways', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce payment gateways. Use action parameter to list, get, or update payment gateways.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential update parameters.
+				'enabled',
+				'title',
+				'description',
+				'order',
+				'settings',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/ProductAttributesConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/ProductAttributesConfig.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Product Attributes MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Product Attributes MCP tool.
+ */
+class ProductAttributesConfig {
+
+	/**
+	 * Get the configuration array for the product attributes tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/product-attributes',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Product_Attributes_Controller::class,
+			'route'              => '/wc/v3/products/attributes',
+			'label'              => __( 'Manage product attributes', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce product attributes. Use action parameter to list, get, create, update, or delete product attributes.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list parameters.
+				'page',
+				'per_page',
+				// Essential create/update parameters.
+				'name',
+				'slug',
+				'type',
+				'order_by',
+				'has_archives',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/ProductCategoriesConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/ProductCategoriesConfig.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Product Categories MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Product Categories MCP tool.
+ */
+class ProductCategoriesConfig {
+
+	/**
+	 * Get the configuration array for the product categories tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/product-categories',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Product_Categories_Controller::class,
+			'route'              => '/wc/v3/products/categories',
+			'label'              => __( 'Manage product categories', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce product categories. Use action parameter to list, get, create, update, or delete product categories.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list/search parameters.
+				'search',
+				'page',
+				'per_page',
+				'order',
+				'orderby',
+				// Essential create/update parameters.
+				'name',
+				'slug',
+				'parent',
+				'description',
+				'image',
+				'meta_data',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/ProductReviewsConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/ProductReviewsConfig.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Product Reviews MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Product Reviews MCP tool.
+ */
+class ProductReviewsConfig {
+
+	/**
+	 * Get the configuration array for the product reviews tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/product-reviews',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Product_Reviews_Controller::class,
+			'route'              => '/wc/v3/products/reviews',
+			'label'              => __( 'Manage product reviews', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce product reviews. Use action parameter to list, get, create, update, or delete product reviews.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list/search parameters.
+				'product',
+				'status',
+				'page',
+				'per_page',
+				// Essential create/update parameters.
+				'product_id',
+				'review',
+				'reviewer',
+				'reviewer_email',
+				'rating',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/ProductTagsConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/ProductTagsConfig.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Product Tags MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Product Tags MCP tool.
+ */
+class ProductTagsConfig {
+
+	/**
+	 * Get the configuration array for the product tags tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/product-tags',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Product_Tags_Controller::class,
+			'route'              => '/wc/v3/products/tags',
+			'label'              => __( 'Manage product tags', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce product tags. Use action parameter to list, get, create, update, or delete product tags.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list/search parameters.
+				'search',
+				'page',
+				'per_page',
+				// Essential create/update parameters.
+				'name',
+				'slug',
+				'description',
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Abilities/Config/ShippingZonesConfig.php
+++ b/plugins/woocommerce/src/Internal/Abilities/Config/ShippingZonesConfig.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Shipping Zones MCP tool configuration.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Abilities\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Configuration for Shipping Zones MCP tool.
+ */
+class ShippingZonesConfig {
+
+	/**
+	 * Get the configuration array for the shipping zones tool.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return array(
+			'id'                 => 'woocommerce/shipping-zones',
+			'operations'         => array( 'list', 'get', 'create', 'update', 'delete' ),
+			'controller'         => \WC_REST_Shipping_Zones_Controller::class,
+			'route'              => '/wc/v3/shipping/zones',
+			'label'              => __( 'Manage shipping zones', 'woocommerce' ),
+			'description'        => __( 'Manage WooCommerce shipping zones. Use action parameter to list, get, create, update, or delete shipping zones.', 'woocommerce' ),
+			'allowed_parameters' => array(
+				// Core operation parameters.
+				'id',
+				'action',
+				// Essential list parameters.
+				'page',
+				'per_page',
+				// Essential create/update parameters.
+				'name',
+				'order',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Implements WOOAI-150: Expand MCP tool coverage by adding 8 new WooCommerce REST API endpoints as MCP tools.

**Status:** 🚧 DRAFT - Blocked by #61974

### New Tools Added

**Priority 1: Core Commerce Operations**
- ✅ Customers (`woocommerce/customers`) - list, get, create, update, delete
- ✅ Coupons (`woocommerce/coupons`) - list, get, create, update, delete

**Priority 2: Product Management**
- ✅ Product Categories (`woocommerce/product-categories`) - list, get, create, update, delete
- ✅ Product Tags (`woocommerce/product-tags`) - list, get, create, update, delete
- ✅ Product Attributes (`woocommerce/product-attributes`) - list, get, create, update, delete
- ✅ Product Reviews (`woocommerce/product-reviews`) - list, get, create, update, delete

**Priority 3: Configuration & Settings**
- ✅ Shipping Zones (`woocommerce/shipping-zones`) - list, get, create, update, delete
- ✅ Payment Gateways (`woocommerce/payment-gateways`) - list, get, update

**Total: 8 new tools** (10 tools including existing Products and Orders)

### Implementation

Each tool follows the existing pattern:
- Config class in `src/Internal/Abilities/Config/`
- Registered in `AbilitiesRestBridge::get_configurations()`
- Essential fields only for context optimization
- Automatically appears in settings UI
- Available via MCP when enabled

### Dependencies

**Blocked by:** #61974 (Update MCP adapter to v0.3.0)

The tools are implemented correctly but require MCP adapter v0.3.0 to function. The current version uses the deprecated `has_permission()` method which causes compatibility issues.

**Once #61974 is merged:**
1. Rebase this PR
2. All tools will work automatically
3. No code changes needed in this PR

### Testing Status

- ✅ All config files created and linting passed
- ✅ Tools registered in AbilitiesRestBridge
- ✅ Settings UI verified (all 10 tools display with checkboxes)
- ⏸️ MCP tool testing blocked pending #61974 merge

### Test Plan (After Rebase)

- [ ] Verify all 10 tools appear in WooCommerce → Settings → Advanced → MCP
- [ ] Test each tool via MCP connection
- [ ] Verify customers tool (requires admin auth)
- [ ] Test coupons create/list/update/delete operations
- [ ] Test product categories CRUD operations
- [ ] Test product tags CRUD operations
- [ ] Test product attributes CRUD operations
- [ ] Test product reviews CRUD operations
- [ ] Test shipping zones CRUD operations
- [ ] Test payment gateways list/get/update operations

### Related Issues

- Implements WOOAI-150
- Blocked by #61974 (MCP adapter v0.3.0 update)
- Depends on WOOAI-148 and WOOAI-149 (settings UI)
- Part of WOOAI-142 (parent issue)
- Based on `add/mcp-settings-tab` branch

### Technical Notes

**Why blocked by #61974:**
- Current MCP adapter (commit 7a2d22c) calls deprecated `has_permission()` method
- MCP adapter v0.3.0 uses `check_permissions()` method
- Both methods exist in Abilities API v0.3.0 (bundled with WooCommerce)
- Compatible with both WordPress 6.9+ (core Abilities API) and earlier versions (vendor package)

**Implementation notes:**
- Some tools (like Customers) require proper WordPress authentication
- Payment Gateways only supports list/get/update (no create/delete)
- All tools default to enabled in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
