### PR TITLE
iAPI MiniCart Footer: Add cart and checkout buttons when template is empty

### DIFF
--- a/plugins/woocommerce/changelog/61954-wooplug-5852-iapi-minicart-footer-missing-cartcheckout-buttons-when-they
+++ b/plugins/woocommerce/changelog/61954-wooplug-5852-iapi-minicart-footer-missing-cartcheckout-buttons-when-they
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show Cart and Checkout blocks when minicart footer is empty

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -83,15 +83,15 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			</div>
 			<div class="wc-block-mini-cart__footer-actions">
 				<?php
-					if ( empty( $content ) ) {
-						$cart_button_block     = parse_blocks( '<!-- wp:woocommerce/mini-cart-cart-button-block /-->' )[0];
-						$checkout_button_block = parse_blocks( '<!-- wp:woocommerce/mini-cart-checkout-button-block /-->' )[0];
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo render_block( $cart_button_block ) . render_block( $checkout_button_block );
-					} else {
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo $content;
-					}
+				if ( empty( $content ) ) {
+					$cart_button_block     = parse_blocks( '<!-- wp:woocommerce/mini-cart-cart-button-block /-->' )[0];
+					$checkout_button_block = parse_blocks( '<!-- wp:woocommerce/mini-cart-checkout-button-block /-->' )[0];
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo render_block( $cart_button_block ) . render_block( $checkout_button_block );
+				} else {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $content;
+				}
 				?>
 			</div>
 		</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -84,13 +84,10 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			<div class="wc-block-mini-cart__footer-actions">
 				<?php
 					if ( empty( $content ) ) {
+						$cart_button_block     = parse_blocks( '<!-- wp:woocommerce/mini-cart-cart-button-block /-->' )[0];
+						$checkout_button_block = parse_blocks( '<!-- wp:woocommerce/mini-cart-checkout-button-block /-->' )[0];
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo render_block( [
-								'blockName' => 'woocommerce/mini-cart-cart-button-block',
-							] ) 
-							. render_block( [
-								'blockName' => 'woocommerce/mini-cart-checkout-button-block',
-							] );
+						echo render_block( $cart_button_block ) . render_block( $checkout_button_block );
 					} else {
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						echo $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -83,8 +83,18 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			</div>
 			<div class="wc-block-mini-cart__footer-actions">
 				<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $content;
+					if ( empty( $content ) ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo render_block( [
+								'blockName' => 'woocommerce/mini-cart-cart-button-block',
+							] ) 
+							. render_block( [
+								'blockName' => 'woocommerce/mini-cart-checkout-button-block',
+							] );
+					} else {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo $content;
+					}
 				?>
 			</div>
 		</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -84,10 +84,8 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 			<div class="wc-block-mini-cart__footer-actions">
 				<?php
 				if ( empty( $content ) ) {
-					$cart_button_block     = parse_blocks( '<!-- wp:woocommerce/mini-cart-cart-button-block /-->' )[0];
-					$checkout_button_block = parse_blocks( '<!-- wp:woocommerce/mini-cart-checkout-button-block /-->' )[0];
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo render_block( $cart_button_block ) . render_block( $checkout_button_block );
+					echo do_blocks( '<!-- wp:woocommerce/mini-cart-cart-button-block /--><!-- wp:woocommerce/mini-cart-checkout-button-block /-->' );
 				} else {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo $content;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the Cart and Checkout buttons when the Minicart Footer content is empty. These buttons should still be shown even if the footer has no inner blocks because it used to work without inner blocks at the beginning.

Closes #61946 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="479" height="101" alt="Screenshot 2025-11-13 at 16 28 03" src="https://github.com/user-attachments/assets/6c7f5998-ea2a-4ccf-ac68-bb543da9d980" />    |    <img width="479" height="159" alt="Screenshot 2025-11-13 at 16 27 29" src="https://github.com/user-attachments/assets/d2d15f91-b4a5-464a-89bb-705f64d8c2c0" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Follow the testing instructions from the original issue: https://github.com/woocommerce/woocommerce/issues/61946

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Show Cart and Checkout blocks when minicart footer is empty

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
