### PR TITLE
Use Pagination With Product Select Control

### DIFF
--- a/plugins/woocommerce/changelog/61960-tweak-handpicked-catalog-pagination
+++ b/plugins/woocommerce/changelog/61960-tweak-handpicked-catalog-pagination
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Use pagination in hand-picked product collection queries on large catalog stores.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -65,7 +65,7 @@ function useProducts(
 				  }
 				: {
 						// For a small catalog we fetch all the products.
-						per_page: 0,
+						per_page: 100,
 				  },
 		};
 		getProducts( query ).then( ( results ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
@@ -74,4 +74,46 @@ describe( 'getProducts', () => {
 			} )
 		);
 	} );
+
+	test( 'large catalog: should paginate selected products when necessary', async () => {
+		blocksConfig.productCount = 500; // large catalog
+
+		apiFetch
+			.mockResolvedValueOnce( [
+				{ id: 1, name: 'shirt' },
+				{ id: 2, name: 'pants' },
+			] )
+			.mockResolvedValueOnce( [
+				{ id: 10, name: 'Special product' },
+				{ id: 11, name: 'Other product' },
+			] );
+
+		await getProducts( {
+			search: 'shirt',
+			selected: Array.from( { length: 101 }, ( _, i ) => i + 10 ),
+		} );
+
+		// Two requests will have been made, one for the main search and two for each selected product page.
+		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'exclude%5B0%5D=10' ),
+			} )
+		);
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'include%5B0%5D=10' ),
+			} )
+		);
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'page=1' ),
+			} )
+		);
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'page=2' ),
+			} )
+		);
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { blocksConfig } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import { getProducts } from '../';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@woocommerce/block-settings', () => ( {
+	blocksConfig: {
+		productCount: 0,
+	},
+} ) );
+
+describe( 'getProducts', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Reset productCount before each test
+		blocksConfig.productCount = 0;
+	} );
+
+	test( 'small catalog: should not load selected products separately', async () => {
+		blocksConfig.productCount = 50; // small catalog
+
+		apiFetch.mockResolvedValue( [
+			{ id: 1, name: 'shirt' },
+			{ id: 2, name: 'pants' },
+		] );
+
+		await getProducts( { search: 'shirt', selected: [ 10, 20 ] } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'search=shirt' ),
+			} )
+		);
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.not.stringContaining( 'exclude=10' ),
+			} )
+		);
+	} );
+
+	test( 'large catalog: should load selected products separately', async () => {
+		blocksConfig.productCount = 500; // large catalog
+
+		apiFetch
+			.mockResolvedValueOnce( [
+				{ id: 1, name: 'shirt' },
+				{ id: 2, name: 'pants' },
+			] )
+			.mockResolvedValueOnce( [
+				{ id: 10, name: 'Special product' },
+				{ id: 20, name: 'Other product' },
+			] );
+
+		await getProducts( { search: 'shirt', selected: [ 10, 20 ] } );
+
+		// Two requests will have been made, one for the main search and one for the selected products.
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'exclude%5B0%5D=10' ),
+			} )
+		);
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'include%5B0%5D=10' ),
+			} )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/test/index.js
@@ -93,7 +93,7 @@ describe( 'getProducts', () => {
 			selected: Array.from( { length: 101 }, ( _, i ) => i + 10 ),
 		} );
 
-		// Two requests will have been made, one for the main search and two for each selected product page.
+		// Three requests will have been made, one for the main search and two for each selected product page.
 		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As a way to avoid fetching too many products and using too much memory, large product catalogs (`> 100`) are sometimes handled differently than small product catalogs. In particular, `getProducts()` from this PR relies on `per_page: 0` to allow it to fetch all of the selected products. This pull request replaces that behavior with pagination.

Contributes to #61755.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="790" height="223" alt="before_small" src="https://github.com/user-attachments/assets/789c70eb-8b8f-41e2-8edc-e9d46eb2dd37" />|<img width="790" height="223" alt="after_small" src="https://github.com/user-attachments/assets/92fe3298-d3e3-4235-b649-6b7d17745c5c" />|
|<img width="790" height="223" alt="large_before" src="https://github.com/user-attachments/assets/66212e53-a76b-471e-a6ff-9effd082e1c0" />|<img width="790" height="223" alt="large_after" src="https://github.com/user-attachments/assets/e11c3f85-173f-4ea0-a585-c86b51d43e33" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

As a means of testing this pull request, create a Product Collection block and add the "Hand-Picked" filter.

1. Using a store with less than 100 products, confirm that it still returns the entire query and uses a single request.
2. Using a store with more than 100 products, confirm that it only returns 100 products and does a second query for the selected products.
3. Using a store with more than 100 products, select more than 100 products and confirm that it does two queries.

<!-- End testing instructions -->

### Testing that has already taken place:

I am using the standard `wp-env` environment.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Use pagination in hand-picked product collection queries on large catalog stores.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
