### PR TITLE
Fix issue where calendar dropdown showed error

### DIFF
--- a/packages/js/components/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
+++ b/packages/js/components/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix issue where DateRangePicker was saving the wrong default range and triggering an error.
+Make date handling within DateRange component more robust, for scenarious where a wrong moment date is used.

--- a/packages/js/components/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
+++ b/packages/js/components/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where DateRangePicker was saving the wrong default range and triggering an error.

--- a/packages/js/components/src/calendar/date-range.js
+++ b/packages/js/components/src/calendar/date-range.js
@@ -157,7 +157,9 @@ class DateRange extends Component {
 
 	setTnitialVisibleMonth( isDoubleCalendar, before ) {
 		return () => {
-			const visibleDate = before || moment();
+			const isValidMoment =
+				before && moment.isMoment( before ) && before.isValid();
+			const visibleDate = isValidMoment ? before : moment();
 			if ( isDoubleCalendar ) {
 				return visibleDate.clone().subtract( 1, 'month' );
 			}

--- a/packages/js/components/src/date-range-filter-picker/index.js
+++ b/packages/js/components/src/date-range-filter-picker/index.js
@@ -35,6 +35,7 @@ class DateRangeFilterPicker extends Component {
 		if (
 			date &&
 			date._isAMomentObject &&
+			date.isValid() &&
 			typeof date.format === 'function'
 		) {
 			return date.format( format );

--- a/plugins/woocommerce/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
+++ b/plugins/woocommerce/changelog/wooplug-5859-wp-69-month-must-be-a-valid-moment-object-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where updating the woocommerce_default_date_range option was saving stringified undefined values.

--- a/plugins/woocommerce/client/admin/client/analytics/settings/default-date.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/default-date.js
@@ -16,10 +16,15 @@ const DefaultDate = ( { value, onChange } ) => {
 	const { woocommerce_default_date_range: defaultDateRange } =
 		wcAdminSettings;
 	const change = ( query ) => {
+		const sanitizedQuery = Object.fromEntries(
+			Object.entries( query ).filter(
+				( [ , queryValue ] ) => typeof queryValue !== 'undefined'
+			)
+		);
 		onChange( {
 			target: {
 				name: 'woocommerce_default_date_range',
-				value: new URLSearchParams( query ).toString(),
+				value: new URLSearchParams( sanitizedQuery ).toString(),
 			},
 		} );
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Makes two small changes to fix a parsing error in the Analytics Calendar
- Updates `woocommerce_default_date_range` save logic to not include `undefined` values as a parsed string
- Updates `DateRange` component to gracefully handle the `before` date when it is not a valid `moment` date.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="772" height="777" alt="Screenshot 2025-11-14 at 17 24 31" src="https://github.com/user-attachments/assets/418ddd22-a52b-47ae-9ef6-f401949d1ed1" /> |  <img width="989" height="1003" alt="Screenshot 2025-11-14 at 17 25 05" src="https://github.com/user-attachments/assets/46b2fc1d-263e-4e60-877b-edc6206c897d" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce on a site with latest of WordPress ( I could reproduce this on WP 6.8 and 6.9 )
2. Go to Analytics > Settings
3. Click on the calendar for the Default date range field
4. First change the **default** preset to **Quarter to date** or one of the other ones
5. Click **Update** and then **Save settings**
6. Refresh one of the Analytics report pages and make sure the default date range is used.
7. Go back to **Analytics > Settings** and select the date picker again
8. Click the Custom tab, it should allow you to select a custom date range and not show an error ( it previously did ).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
