### PR TITLE
Small styling fix in Analytics advanced filter dropdown styling is broken ( WP 6.9 )

### DIFF
--- a/packages/js/components/changelog/wooplug-5860-wp-69-analytics-advanced-filter-dropdown-styling-is-broken
+++ b/packages/js/components/changelog/wooplug-5860-wp-69-analytics-advanced-filter-dropdown-styling-is-broken
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Fix styling issue for Advanced Filters dropdown.

--- a/packages/js/components/src/advanced-filters/style.scss
+++ b/packages/js/components/src/advanced-filters/style.scss
@@ -26,9 +26,8 @@
 			margin-bottom: 0;
 		}
 
-		div {
-			display: flex;
-			line-height: 38px;
+		.components-base-control {
+			display: inline-block;
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small styling fix for the Advanced filter dropdown within WordPress 6.9 or the latest Gutenberg version.

Closes #WOOPLUG-5860

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="445" height="243" alt="Screenshot 2025-11-14 at 18 07 09" src="https://github.com/user-attachments/assets/496b0562-028d-4f40-a0d5-9d0a65b9ec1a" />  |  <img width="414" height="241" alt="Screenshot 2025-11-14 at 18 07 28" src="https://github.com/user-attachments/assets/d6cef207-f69b-41dc-bdd7-b31f569c8592" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce on a site with WordPress 6.9 ( you can use the WordPress beta tester for this ) or the latest GB version
2. Go to Analytics > Orders
3. Click Advanced filters under Show
4. The width of the dropdown should be around 70px and not look shrunk like it did previously ( see screenshot ).
5. Test with WordPress 6.8 and Gutenberg disabled to see if it still looks correct.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
