### PR TITLE
Update MCP adapter to v0.3.0

### DIFF
--- a/plugins/woocommerce/changelog/update-61864-mcp-adapter-0-3-0
+++ b/plugins/woocommerce/changelog/update-61864-mcp-adapter-0-3-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated MCP adapter to v0.3.0 and refactored initialization process.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -57,7 +57,7 @@
 		"woocommerce/blueprint": "*",
 		"woocommerce/email-editor": "*",
 		"wordpress/abilities-api": "^0.3.0",
-		"wordpress/mcp-adapter": "dev-trunk#7a2d22cff92328bc94f5b1648a66ae4273e949c5"
+		"wordpress/mcp-adapter": "^0.3.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c433f2e0744104f73ad290380d910d2d",
+    "content-hash": "e25de9ccfb8c86529a8560065c4e7d09",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1351,16 +1351,16 @@
         },
         {
             "name": "wordpress/mcp-adapter",
-            "version": "dev-trunk",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/mcp-adapter.git",
-                "reference": "7a2d22cff92328bc94f5b1648a66ae4273e949c5"
+                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/7a2d22cff92328bc94f5b1648a66ae4273e949c5",
-                "reference": "7a2d22cff92328bc94f5b1648a66ae4273e949c5",
+                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/653ca8d95180b25809b1a1dc489d8305ec5beb63",
+                "reference": "653ca8d95180b25809b1a1dc489d8305ec5beb63",
                 "shasum": ""
             },
             "require": {
@@ -1382,7 +1382,6 @@
                 "wpackagist-plugin/plugin-check": "^1.6",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "installer-paths": {
@@ -1442,7 +1441,7 @@
                 "issues": "https://github.com/wordpress/mcp-adapter/issues",
                 "source": "https://github.com/wordpress/mcp-adapter"
             },
-            "time": "2025-10-30T20:39:26+00:00"
+            "time": "2025-11-06T14:56:51+00:00"
         }
     ],
     "packages-dev": [
@@ -5420,9 +5419,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "wordpress/mcp-adapter": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/plugins/woocommerce/src/Internal/MCP/Transport/WooCommerceRestTransport.php
+++ b/plugins/woocommerce/src/Internal/MCP/Transport/WooCommerceRestTransport.php
@@ -7,7 +7,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\MCP\Transport;
 
-use WP\MCP\Transport\Http\RestTransport;
+use WP\MCP\Transport\HttpTransport;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP_REST_Request;
 use WP_Error;
@@ -17,10 +17,10 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WooCommerce MCP REST Transport class.
  *
- * Extends the base RestTransport with standalone WooCommerce REST API key authentication.
+ * Extends the base HttpTransport with standalone WooCommerce REST API key authentication.
  * Uses X-MCP-API-Key header with consumer_key:consumer_secret format.
  */
-class WooCommerceRestTransport extends RestTransport {
+class WooCommerceRestTransport extends HttpTransport {
 
 	/**
 	 * Current MCP user's API key permissions.


### PR DESCRIPTION
## Summary
This PR updates the WordPress MCP adapter dependency from the current version to v0.3.0 and refactors the initialization process.

This is a systematic, incremental implementation with each change committed separately for easy review.

## Changes
- Update MCP adapter dependency to ^0.3.0
- Refactor initialization to use `mcp_adapter_init` action hook
- Update `WooCommerceRestTransport` to extend `HttpTransport`
- Update tests to match new patterns

## Testing
- All linting passes
- All tests pass
- MCP functionality verified

Fixes #61864