### PR TITLE
Remove no-op closing tag

### DIFF
--- a/plugins/woocommerce/changelog/61978-patch-7
+++ b/plugins/woocommerce/changelog/61978-patch-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove no-op closing tag to prevent calls to "default" policy if trusted types are required

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -273,9 +273,8 @@
                 }
               }
 
-              var liElement = $( '<li>' );
+              var liElement = $( '<li></li>' );
               item.appendTo( liElement );
-              liElement.append( '</li>' );
 
               slider.controlNavScaffold.append(liElement);
               j++;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- appending the `'</li>'` element is a noop, since it's there already by default by jQuery
- add the `'</li>'` although not strictly necessary directly when element is created
- while generally this won't matter, this potentially opens up an incredibly unlikely bc complex XSS attack when a CSP with "default" trusted types is used on a site and the default handler is itself vulnerable/outdated

(For Bug Fixes) Bug introduced in PR https://github.com/kkmuffme/woocommerce/commit/5155179d659f039e6ad80955f899a8b61e9fb66c flexslider 2.7.2

Does the script version also need to be updated to 2.7.3?

### How to test the changes in this Pull Request:

Same way this was tested before

### Testing that has already taken place:

While it's obvious, here's a little standalone reproducer: (paste on https://playcode.io/jquery for example)

```js
import $ from 'jquery'

const item = $( '<a></a>' ).attr( 'href', '#' ).text( 'hello' );

var liElement = $( '<li>' );
item.appendTo( liElement );
liElement.append( '</li>' ); // comment this line and you'll see nothing changes

console.log( liElement[0].outerHTML );
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove no-op closing tag to prevent calls to "default" policy if trusted types are required
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
