### PR TITLE
Add MCP Abilities for product categories and batch operations

### DIFF
--- a/plugins/woocommerce/changelog/add-category-mcp-abilities
+++ b/plugins/woocommerce/changelog/add-category-mcp-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add MCP Abilities for product categories and batch operations

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -97,6 +97,12 @@ class AbilitiesRestBridge {
 						'label'       => __( 'Delete Product Category', 'woocommerce' ),
 						'description' => __( 'Permanently delete a product category from the store. This action cannot be undone.', 'woocommerce' ),
 					),
+					array(
+						'id'          => 'woocommerce/product-categories-batch',
+						'operation'   => 'batch',
+						'label'       => __( 'Batch Create, Update and Delete Multiple Product Categories', 'woocommerce' ),
+						'description' => __( 'Create new product categories, update existing ones, and permanently delete others. Deleting product categories cannot be undone.', 'woocommerce' ),
+					),
 				),
 			),
 			array(

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesRestBridge.php
@@ -64,6 +64,42 @@ class AbilitiesRestBridge {
 				),
 			),
 			array(
+				'controller' => \WC_REST_Product_Categories_Controller::class,
+				'route'      => '/wc/v3/products/categories',
+				'abilities'  => array(
+					array(
+						'id'          => 'woocommerce/product-categories-list',
+						'operation'   => 'list',
+						'label'       => __( 'List Product Categories', 'woocommerce' ),
+						'description' => __( 'Retrieve a paginated list of product categories.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-categories-get',
+						'operation'   => 'get',
+						'label'       => __( 'Get Product Category', 'woocommerce' ),
+						'description' => __( 'Retrieve detailed information about a single product category by ID, including name, slug, parent, description, and other attributes.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-categories-create',
+						'operation'   => 'create',
+						'label'       => __( 'Create Product Category', 'woocommerce' ),
+						'description' => __( 'Create a new product category with name, slug, parent, description, and other attributes.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-categories-update',
+						'operation'   => 'update',
+						'label'       => __( 'Update Product Category', 'woocommerce' ),
+						'description' => __( 'Update an existing product category by modifying its attributes such as name, slug, parent, description, or other attributes.', 'woocommerce' ),
+					),
+					array(
+						'id'          => 'woocommerce/product-categories-delete',
+						'operation'   => 'delete',
+						'label'       => __( 'Delete Product Category', 'woocommerce' ),
+						'description' => __( 'Permanently delete a product category from the store. This action cannot be undone.', 'woocommerce' ),
+					),
+				),
+			),
+			array(
 				'controller' => \WC_REST_Orders_Controller::class,
 				'route'      => '/wc/v3/orders',
 				'abilities'  => array(

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -138,7 +138,6 @@ class RestAbilityFactory {
 				break;
 
 			case 'get':
-			case 'delete':
 				// Only need ID.
 				return array(
 					'type'       => 'object',
@@ -150,6 +149,28 @@ class RestAbilityFactory {
 					),
 					'required'   => array( 'id' ),
 				);
+
+			case 'delete':
+				$schema = array(
+					'type'       => 'object',
+					'properties' => array(
+						'id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the resource', 'woocommerce' ),
+						),
+					),
+					'required'   => array( 'id' ),
+				);
+
+				if ( $controller instanceof \WC_REST_Product_Categories_Controller ) {
+					$schema['properties']['force'] = array(
+						'description' => __( 'Required to be true, as resource does not support trashing.', 'woocommerce' ),
+						'type'        => 'boolean',
+						'default'     => false,
+					);
+				}
+
+				return $schema;
 		}
 
 		// Fallback.

--- a/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
+++ b/plugins/woocommerce/src/Internal/Abilities/REST/RestAbilityFactory.php
@@ -171,6 +171,38 @@ class RestAbilityFactory {
 				}
 
 				return $schema;
+
+			case 'batch':
+				// Use controller's batch schema.
+				if ( method_exists( $controller, 'get_public_batch_schema' ) ) {
+					$schema = $controller->get_public_batch_schema( \WP_REST_Server::EDITABLE );
+
+					if ( isset( $schema['properties']['create']['type'] ) && 'array' === $schema['properties']['create']['type'] ) {
+						$schema['properties']['create']['items'] = self::sanitize_args_to_schema(
+							$controller->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE )
+						);
+					}
+					if ( isset( $schema['properties']['update']['type'] ) && 'array' === $schema['properties']['update']['type'] ) {
+						$schema['properties']['update']['items'] = self::sanitize_args_to_schema(
+							$controller->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE )
+						);
+
+						// Add ID field for update operations.
+						$schema['properties']['update']['items']['properties']['id'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the resource', 'woocommerce' ),
+						);
+					}
+					if ( isset( $schema['properties']['delete']['type'] ) && 'array' === $schema['properties']['delete']['type'] ) {
+						$schema['properties']['delete']['items'] = array(
+							'type'        => 'integer',
+							'description' => __( 'Unique identifier for the resource', 'woocommerce' ),
+						);
+					}
+
+					return $schema;
+				}
+				break;
 		}
 
 		// Fallback.
@@ -282,6 +314,24 @@ class RestAbilityFactory {
 						'previous' => $schema,
 					),
 				);
+			} elseif ( 'batch' === $operation ) {
+				return array(
+					'type'       => 'object',
+					'properties' => array(
+						'create' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+						'update' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+						'delete' => array(
+							'type'  => 'array',
+							'items' => $schema,
+						),
+					),
+				);
 			}
 
 			// For get, create, update operations.
@@ -308,6 +358,10 @@ class RestAbilityFactory {
 		if ( isset( $input['id'] ) && in_array( $operation, array( 'get', 'update', 'delete' ), true ) ) {
 			$request_route .= '/' . intval( $input['id'] );
 			unset( $input['id'] );
+		}
+
+		if ( 'batch' === $operation ) {
+			$request_route .= '/batch';
 		}
 
 		// Create REST request.
@@ -346,6 +400,7 @@ class RestAbilityFactory {
 			'create' => 'POST',
 			'update' => 'PUT',
 			'delete' => 'DELETE',
+			'batch'  => 'POST',
 		);
 		return $method_map[ $operation ] ?? 'GET';
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Register new MCP abilities regarding product categories and batch operations on product categories.

Note that part of the code changes introduced to handle batch operations were already proposed in PR https://github.com/woocommerce/woocommerce/pull/61633.

### How to test the changes in this Pull Request:

1. Set up your environment (WooCommerce and Claude) as instructed in https://github.com/woocommerce/woocommerce/pull/60901.
2. Test the following abilities/MCP tools:
	- `woocommerce/product-categories-list`.
	- `woocommerce/product-categories-get`.
	- `woocommerce/product-categories-create`.
	- `woocommerce/product-categories-update`.
	- `woocommerce/product-categories-delete`.
	- `woocommerce/product-categories-batch`.

### Testing that has already taken place:

I tested the tools listed in the section above.

### Changelog entry

Changelog included in PR.
