### PR TITLE
Spike: Experiment with Express Payment methods in iAPI block

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
@@ -10,6 +10,7 @@
 	"supports": {
 		"html": false,
 		"multiple": false,
+		"interactivity": true,
 		"typography": {
 			"fontSize": true
 		},
@@ -18,6 +19,7 @@
 			"padding": true
 		}
 	},
+	"viewScriptModule": "woocommerce/mini-cart",
 	"example": {
 		"attributes": {
 			"isPreview": true,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/components/mini-cart-express-payment-wrapper.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/components/mini-cart-express-payment-wrapper.tsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { CartExpressPayment } from '../../cart-checkout-shared/payment-methods';
+import { ExpressPaymentContext } from '../../cart-checkout-shared/payment-methods/express-payment/express-payment-context';
+import {
+	CheckoutProvider,
+	CheckoutEventsProvider,
+} from '@woocommerce/base-context';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
+import { useSelect } from '@wordpress/data';
+import { PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+
+interface MiniCartExpressPaymentWrapperProps {
+	buttonHeight?: number;
+	buttonBorderRadius?: number;
+	showButtonStyles?: boolean;
+}
+
+/**
+ * Wrapper component for Express Payment Methods in iAPI Mini-Cart context.
+ *
+ * Uses the same structure as Cart block:
+ * - CheckoutProvider: Provides access to the Redux payment data store
+ * - CheckoutEventsProvider: Handles payment method initialization and checkout state & events
+ * - ExpressPaymentContext: Provides button styling configuration
+ * - CartExpressPayment: Renders express payment methods with loading states and notices
+ */
+const MiniCartExpressPaymentWrapper = ( {
+	buttonHeight = 48,
+	buttonBorderRadius = 4,
+	showButtonStyles = true,
+}: MiniCartExpressPaymentWrapperProps ) => {
+	const { cartItems } = useStoreCart();
+	const expressPaymentContextValue = {
+		showButtonStyles,
+		buttonHeight: String( buttonHeight ),
+		buttonBorderRadius: String( buttonBorderRadius ),
+	};
+
+	// Debug: Log payment store state
+	const paymentState = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const store = select( PAYMENT_STORE_KEY ) as any;
+		return {
+			availableExpressPaymentMethods:
+				store.getAvailableExpressPaymentMethods(),
+			registeredExpressPaymentMethods:
+				store.getRegisteredExpressPaymentMethods(),
+			expressPaymentMethodsInitialized:
+				store.expressPaymentMethodsInitialized(),
+		};
+	} );
+
+	console.log(
+		'>>>>>>> MiniCartExpressPaymentWrapper paymentState',
+		paymentState
+	);
+
+	// Don't render if cart is empty
+	if ( cartItems.length === 0 ) {
+		return null;
+	}
+
+	// TO DO: Handle editor mode.
+
+	return (
+		<CheckoutProvider>
+			<CheckoutEventsProvider redirectUrl="">
+				<ExpressPaymentContext.Provider
+					value={ expressPaymentContextValue }
+				>
+					<CartExpressPayment />
+				</ExpressPaymentContext.Provider>
+			</CheckoutEventsProvider>
+		</CheckoutProvider>
+	);
+};
+
+export default MiniCartExpressPaymentWrapper;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -39,7 +39,6 @@ const miniCartConfig = getConfig( 'woocommerce/mini-cart' ) as {
 	checkoutUrl: string;
 	displayCartPriceIncludingTax: boolean;
 	buttonAriaLabelTemplate: string;
-	reactBridgeUrl?: string;
 };
 const {
 	addToCartBehaviour,
@@ -1087,66 +1086,7 @@ store(
 );
 
 /**
- * Lazy loads the React bridge script for express payment methods.
- * Only loads once, subsequent calls return immediately if already loaded.
- *
- * @return {Promise<void>} Resolves when bridge is loaded and available
- */
-function lazyLoadReactBridge(): Promise< void > {
-	// Check if already loaded
-	if ( ( window as any ).wc?.blocksCheckout?.MiniCartExpressPaymentWrapper ) {
-		return Promise.resolve();
-	}
-
-	// Check if we have a URL
-	const bridgeUrl = miniCartConfig.reactBridgeUrl;
-	if ( ! bridgeUrl ) {
-		return Promise.reject(
-			new Error( 'React bridge URL not configured' )
-		);
-	}
-
-	// Check if already loading (prevent duplicate loads)
-	if ( ( window as any ).__wcMiniCartBridgeLoading ) {
-		return ( window as any ).__wcMiniCartBridgeLoading;
-	}
-
-	// Create promise and cache it
-	const loadPromise = new Promise< void >( ( resolve, reject ) => {
-		const script = document.createElement( 'script' );
-		script.src = bridgeUrl;
-		script.async = true;
-
-		script.onload = () => {
-			// Verify the bridge actually loaded
-			if (
-				( window as any ).wc?.blocksCheckout
-					?.MiniCartExpressPaymentWrapper
-			) {
-				delete ( window as any ).__wcMiniCartBridgeLoading;
-				resolve();
-			} else {
-				reject(
-					new Error( 'Bridge loaded but components not found' )
-				);
-			}
-		};
-
-		script.onerror = () => {
-			delete ( window as any ).__wcMiniCartBridgeLoading;
-			reject( new Error( 'Failed to load React bridge script' ) );
-		};
-
-		document.head.appendChild( script );
-	} );
-
-	( window as any ).__wcMiniCartBridgeLoading = loadPromise;
-	return loadPromise;
-}
-
-/**
  * Helper function to check base dependencies required for express payment methods rendering.
- * Note: MiniCartExpressPaymentWrapper is lazy-loaded, so not checked here.
  *
  * @param {Element | null} container - The DOM container element for the slot.
  * @param {string}         debugName - Name for debugging/logging purposes.
@@ -1179,7 +1119,7 @@ function checkBaseDependencies(
 // Helper function to render Express Payment Methods React island
 store( 'woocommerce/mini-cart-footer-block', {
 	callbacks: {
-		*renderExpressPaymentMethodsIsland() {
+		renderExpressPaymentMethodsIsland() {
 			const debugName = 'express payment methods island';
 
 			// Check if any express payment methods are actually registered
@@ -1200,19 +1140,7 @@ store( 'woocommerce/mini-cart-footer-block', {
 				return;
 			}
 
-			// Lazy load the React bridge
-			try {
-				yield lazyLoadReactBridge();
-			} catch ( error ) {
-				// eslint-disable-next-line no-console
-				console.error(
-					'Mini Cart: Failed to load React bridge for express payments:',
-					error
-				);
-				return;
-			}
-
-			// Verify dependencies are available after lazy load
+			// Verify dependencies are available
 			const container = document.querySelector(
 				'.wc-block-mini-cart__express-checkout-slot'
 			);
@@ -1223,6 +1151,18 @@ store( 'woocommerce/mini-cart-footer-block', {
 					'express payment methods island'
 				)
 			) {
+				return;
+			}
+
+			// Check for MiniCartExpressPaymentWrapper
+			if (
+				! ( window as any ).wc?.blocksCheckout
+					?.MiniCartExpressPaymentWrapper
+			) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'Mini Cart: MiniCartExpressPaymentWrapper not available'
+				);
 				return;
 			}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -33,13 +33,21 @@ const universalLock =
 const { currency, placeholderImgSrc } = getConfig(
 	'woocommerce'
 ) as WooCommerceConfig;
+const miniCartConfig = getConfig( 'woocommerce/mini-cart' ) as {
+	addToCartBehaviour: string;
+	onCartClickBehaviour: string;
+	checkoutUrl: string;
+	displayCartPriceIncludingTax: boolean;
+	buttonAriaLabelTemplate: string;
+	reactBridgeUrl?: string;
+};
 const {
 	addToCartBehaviour,
 	onCartClickBehaviour,
 	checkoutUrl,
 	displayCartPriceIncludingTax,
 	buttonAriaLabelTemplate,
-} = getConfig( 'woocommerce/mini-cart' );
+} = miniCartConfig;
 const {
 	reduceQuantityLabel,
 	increaseQuantityLabel,
@@ -1077,3 +1085,164 @@ store(
 	},
 	{ lock: true }
 );
+
+/**
+ * Lazy loads the React bridge script for express payment methods.
+ * Only loads once, subsequent calls return immediately if already loaded.
+ *
+ * @return {Promise<void>} Resolves when bridge is loaded and available
+ */
+function lazyLoadReactBridge(): Promise< void > {
+	// Check if already loaded
+	if ( ( window as any ).wc?.blocksCheckout?.MiniCartExpressPaymentWrapper ) {
+		return Promise.resolve();
+	}
+
+	// Check if we have a URL
+	const bridgeUrl = miniCartConfig.reactBridgeUrl;
+	if ( ! bridgeUrl ) {
+		return Promise.reject(
+			new Error( 'React bridge URL not configured' )
+		);
+	}
+
+	// Check if already loading (prevent duplicate loads)
+	if ( ( window as any ).__wcMiniCartBridgeLoading ) {
+		return ( window as any ).__wcMiniCartBridgeLoading;
+	}
+
+	// Create promise and cache it
+	const loadPromise = new Promise< void >( ( resolve, reject ) => {
+		const script = document.createElement( 'script' );
+		script.src = bridgeUrl;
+		script.async = true;
+
+		script.onload = () => {
+			// Verify the bridge actually loaded
+			if (
+				( window as any ).wc?.blocksCheckout
+					?.MiniCartExpressPaymentWrapper
+			) {
+				delete ( window as any ).__wcMiniCartBridgeLoading;
+				resolve();
+			} else {
+				reject(
+					new Error( 'Bridge loaded but components not found' )
+				);
+			}
+		};
+
+		script.onerror = () => {
+			delete ( window as any ).__wcMiniCartBridgeLoading;
+			reject( new Error( 'Failed to load React bridge script' ) );
+		};
+
+		document.head.appendChild( script );
+	} );
+
+	( window as any ).__wcMiniCartBridgeLoading = loadPromise;
+	return loadPromise;
+}
+
+/**
+ * Helper function to check base dependencies required for express payment methods rendering.
+ * Note: MiniCartExpressPaymentWrapper is lazy-loaded, so not checked here.
+ *
+ * @param {Element | null} container - The DOM container element for the slot.
+ * @param {string}         debugName - Name for debugging/logging purposes.
+ * @return {boolean} True if all base dependencies are available, false otherwise.
+ */
+function checkBaseDependencies(
+	container: Element | null,
+	debugName: string
+): boolean {
+	if (
+		! container ||
+		! ( window as any ).wp?.element?.createElement ||
+		! ( window as any ).wp?.element?.createRoot
+	) {
+		console.warn(
+			`Mini Cart: Missing base dependencies for rendering ${ debugName }`,
+			{
+				hasContainer: !! container,
+				hasCreateElement: !! ( window as any ).wp?.element
+					?.createElement,
+				hasCreateRoot: !! ( window as any ).wp?.element?.createRoot,
+			}
+		);
+		return false;
+	}
+
+	return true;
+}
+
+// Helper function to render Express Payment Methods React island
+store( 'woocommerce/mini-cart-footer-block', {
+	callbacks: {
+		*renderExpressPaymentMethodsIsland() {
+			const debugName = 'express payment methods island';
+
+			// Check if any express payment methods are actually registered
+			// Use the window-exposed registry as it's the canonical source populated by the main app
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const expressPaymentMethods =
+				( window as any ).wc?.wcBlocksRegistry?.getExpressPaymentMethods() ||
+				{};
+			const registeredMethodsCount = Object.keys(
+				expressPaymentMethods
+			).length;
+
+			if ( registeredMethodsCount === 0 ) {
+				// eslint-disable-next-line no-console
+				console.info(
+					`Mini Cart: No express payment methods registered, skipping ${ debugName }`
+				);
+				return;
+			}
+
+			// Lazy load the React bridge
+			try {
+				yield lazyLoadReactBridge();
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					'Mini Cart: Failed to load React bridge for express payments:',
+					error
+				);
+				return;
+			}
+
+			// Verify dependencies are available after lazy load
+			const container = document.querySelector(
+				'.wc-block-mini-cart__express-checkout-slot'
+			);
+
+			if (
+				! checkBaseDependencies(
+					container,
+					'express payment methods island'
+				)
+			) {
+				return;
+			}
+
+			// Render the React island
+			const { createElement, createRoot } = ( window as any ).wp.element;
+			const { MiniCartExpressPaymentWrapper } = ( window as any ).wc
+				.blocksCheckout;
+
+			// Create React root if not exists
+			if ( ! ( window as any ).__miniCartExpressPaymentRoot ) {
+				( window as any ).__miniCartExpressPaymentRoot =
+					createRoot( container );
+			}
+
+			const wrapperElement = createElement(
+				MiniCartExpressPaymentWrapper
+			);
+			( window as any ).__miniCartExpressPaymentRoot.render(
+				wrapperElement
+			);
+		},
+	},
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-react-bridge.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-react-bridge.tsx
@@ -1,0 +1,21 @@
+/**
+ * Bridge file to expose React components to iAPI blocks via window.wc.blocksCheckout
+ * This is a separate entry point to avoid circular dependencies.
+ */
+
+/**
+ * External dependencies
+ */
+import { ExpressPaymentMethods } from '../cart-checkout-shared/payment-methods';
+import MiniCartExpressPaymentWrapper from './components/mini-cart-express-payment-wrapper';
+
+/**
+ * Expose components to window for iAPI blocks to use
+ */
+if ( typeof window !== 'undefined' ) {
+	window.wc = window.wc || {};
+	window.wc.blocksCheckout = window.wc.blocksCheckout || {};
+	window.wc.blocksCheckout.ExpressPaymentMethods = ExpressPaymentMethods;
+	window.wc.blocksCheckout.MiniCartExpressPaymentWrapper =
+		MiniCartExpressPaymentWrapper;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-react-bridge.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-react-bridge.tsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { ExpressPaymentMethods } from '../cart-checkout-shared/payment-methods';
 import MiniCartExpressPaymentWrapper from './components/mini-cart-express-payment-wrapper';
 
 /**
@@ -15,7 +14,6 @@ import MiniCartExpressPaymentWrapper from './components/mini-cart-express-paymen
 if ( typeof window !== 'undefined' ) {
 	window.wc = window.wc || {};
 	window.wc.blocksCheckout = window.wc.blocksCheckout || {};
-	window.wc.blocksCheckout.ExpressPaymentMethods = ExpressPaymentMethods;
 	window.wc.blocksCheckout.MiniCartExpressPaymentWrapper =
 		MiniCartExpressPaymentWrapper;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/index.tsx
@@ -12,3 +12,4 @@ import './mini-cart-footer-block';
 import './mini-cart-shopping-button-block';
 import './mini-cart-cart-button-block';
 import './mini-cart-checkout-button-block';
+import './mini-cart-express-checkout-block';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/block.json
@@ -1,0 +1,29 @@
+{
+	"name": "woocommerce/mini-cart-express-checkout-block",
+	"version": "1.0.0",
+	"title": "Mini-Cart Express Checkout",
+	"description": "Block that displays express checkout options in the Mini-Cart.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": true,
+		"lock": false,
+		"interactivity": true
+	},
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": false,
+				"move": false
+			}
+		}
+	},
+	"parent": [ "woocommerce/mini-cart-footer-block" ],
+	"textdomain": "woocommerce",
+	"apiVersion": 3,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/block.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Mini Cart Express Checkout Block
+ *
+ * This block provides the container element for express payment methods.
+ * The actual React components are rendered by the iAPI frontend script
+ * via renderExpressPaymentMethodsIsland(), which uses CheckoutProvider
+ * to access the normal Redux payment data store.
+ */
+const Block = (): JSX.Element => {
+	return (
+		<div className="wc-block-mini-cart__express-checkout">
+			<div className="wc-block-mini-cart__express-checkout-title">
+				<span>Express Checkout non-interactive</span>
+			</div>
+		</div>
+	);
+};
+
+export default Block;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/edit.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Noninteractive>
+				<Block />
+			</Noninteractive>
+		</div>
+	);
+};
+
+export const Save = (): JSX.Element => {
+	return <div { ...useBlockProps.save() }></div>;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-express-checkout-block/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { Icon, payment } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Edit, Save } from './edit';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-express-checkout-block', {
+	icon: (
+		<Icon
+			icon={ payment }
+			className="wc-block-editor-components-block-icon"
+		/>
+	),
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -40,6 +40,7 @@ export const Edit = (): JSX.Element => {
 	const TEMPLATE = [
 		[ 'woocommerce/mini-cart-cart-button-block', {} ],
 		[ 'woocommerce/mini-cart-checkout-button-block', {} ],
+		[ 'woocommerce/mini-cart-express-checkout-block', {} ],
 	];
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
@@ -18,6 +18,7 @@ import miniCartItemsMetadata from './mini-cart-items-block/block.json';
 import miniCartShoppingButtonMetadata from './mini-cart-shopping-button-block/block.json';
 import miniCartCartButtonMetadata from './mini-cart-cart-button-block/block.json';
 import miniCartCheckoutButtonMetadata from './mini-cart-checkout-button-block/block.json';
+import miniCartExpressCheckoutMetadata from './mini-cart-express-checkout-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -132,6 +133,16 @@ registerCheckoutBlock( {
 		() =>
 			import(
 				/* webpackChunkName: "mini-cart-contents-block/checkout-button" */ './mini-cart-checkout-button-block/block'
+			)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: miniCartExpressCheckoutMetadata,
+	component: lazy(
+		() =>
+			import(
+				/* webpackChunkName: "mini-cart-contents-block/express-checkout" */ './mini-cart-express-checkout-block/block'
 			)
 	),
 } );

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -387,6 +387,8 @@ const entries = {
 		blocksComponents: './packages/components/index.ts',
 		'mini-cart-component':
 			'./assets/js/blocks/mini-cart/component-frontend.tsx',
+		'mini-cart-iapi-react-bridge':
+			'./assets/js/blocks/mini-cart/iapi-react-bridge.tsx',
 	},
 };
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -234,18 +234,9 @@ class MiniCart extends AbstractBlock {
 			 */
 			do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
 
-			// Register the React bridge script (for lazy loading), but don't enqueue it eagerly.
 			$script_data = $this->asset_api->get_script_data( 'assets/client/blocks/mini-cart-iapi-react-bridge-frontend.js', array() );
 			$this->asset_api->register_script( 'wc-mini-cart-iapi-react-bridge', 'assets/client/blocks/mini-cart-iapi-react-bridge-frontend.js', array() );
-
-			// Enqueue the bridge's dependencies so they're available when the bridge is lazy-loaded.
-			// This ensures WordPress packages (like @wordpress/plugins) are loaded before the bridge needs them.
-			if ( isset( wp_scripts()->registered['wc-mini-cart-iapi-react-bridge'] ) ) {
-				$bridge_deps = wp_scripts()->registered['wc-mini-cart-iapi-react-bridge']->deps;
-				foreach ( $bridge_deps as $dep ) {
-					wp_enqueue_script( $dep );
-				}
-			}
+			wp_enqueue_script( 'wc-mini-cart-iapi-react-bridge' );
 
 			// Explicitly enqueue payment method scripts to ensure they register with wcBlocksRegistry.
 			// This is needed because payment gateways may not enqueue their scripts on non-cart/checkout pages.
@@ -607,18 +598,6 @@ class MiniCart extends AbstractBlock {
 				'productCountVisibility' => $product_count_visibility,
 			);
 
-			// Get the React bridge script URL for lazy loading.
-			$bridge_handle = 'wc-mini-cart-iapi-react-bridge';
-			$bridge_url    = '';
-			if ( isset( wp_scripts()->registered[ $bridge_handle ] ) ) {
-				$bridge_script = wp_scripts()->registered[ $bridge_handle ];
-				$bridge_url    = $bridge_script->src;
-				// Convert relative URLs to absolute URLs.
-				if ( $bridge_url && ! preg_match( '|^(https?:)?//|', $bridge_url ) ) {
-					$bridge_url = site_url( $bridge_url );
-				}
-			}
-
 			wp_interactivity_config(
 				$this->get_full_block_name(),
 				array(
@@ -627,7 +606,6 @@ class MiniCart extends AbstractBlock {
 					'onCartClickBehaviour'         => $on_cart_click_behaviour,
 					'checkoutUrl'                  => wc_get_checkout_url(),
 					'buttonAriaLabelTemplate'      => $button_aria_label_template,
-					'reactBridgeUrl'               => $bridge_url,
 				)
 			);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -91,6 +91,7 @@ class MiniCart extends AbstractBlock {
 		'woocommerce/mini-cart-footer-block',
 		'woocommerce/mini-cart-cart-button-block',
 		'woocommerce/mini-cart-checkout-button-block',
+		'woocommerce/mini-cart-express-checkout-block',
 		'woocommerce/empty-mini-cart-contents-block',
 		'woocommerce/mini-cart-shopping-button-block',
 	);
@@ -221,6 +222,47 @@ class MiniCart extends AbstractBlock {
 		}
 
 		parent::enqueue_data( $attributes );
+
+		// Enqueue payment methods for iAPI Mini Cart.
+		// The React bridge is now lazy-loaded client-side to optimize performance.
+		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+			/**
+			 * Fires before mini-cart express payment scripts are enqueued.
+			 * This allows payment gateways to enqueue their express payment method scripts.
+			 *
+			 * @since 9.4.0
+			 */
+			do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
+
+			// Register the React bridge script (for lazy loading), but don't enqueue it eagerly.
+			$script_data = $this->asset_api->get_script_data( 'assets/client/blocks/mini-cart-iapi-react-bridge-frontend.js', array() );
+			$this->asset_api->register_script( 'wc-mini-cart-iapi-react-bridge', 'assets/client/blocks/mini-cart-iapi-react-bridge-frontend.js', array() );
+
+			// Enqueue the bridge's dependencies so they're available when the bridge is lazy-loaded.
+			// This ensures WordPress packages (like @wordpress/plugins) are loaded before the bridge needs them.
+			if ( isset( wp_scripts()->registered['wc-mini-cart-iapi-react-bridge'] ) ) {
+				$bridge_deps = wp_scripts()->registered['wc-mini-cart-iapi-react-bridge']->deps;
+				foreach ( $bridge_deps as $dep ) {
+					wp_enqueue_script( $dep );
+				}
+			}
+
+			// Explicitly enqueue payment method scripts to ensure they register with wcBlocksRegistry.
+			// This is needed because payment gateways may not enqueue their scripts on non-cart/checkout pages.
+			$payment_method_registry = Package::container()->get( PaymentMethodRegistry::class );
+			$payment_methods         = $payment_method_registry->get_all_active_payment_method_script_dependencies();
+
+			foreach ( $payment_methods as $payment_method ) {
+				wp_enqueue_script( $payment_method );
+			}
+
+			/**
+			 * Fires after mini-cart express payment scripts are enqueued.
+			 *
+			 * @since 9.4.0
+			 */
+			do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
+		}
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
@@ -565,6 +607,18 @@ class MiniCart extends AbstractBlock {
 				'productCountVisibility' => $product_count_visibility,
 			);
 
+			// Get the React bridge script URL for lazy loading.
+			$bridge_handle = 'wc-mini-cart-iapi-react-bridge';
+			$bridge_url    = '';
+			if ( isset( wp_scripts()->registered[ $bridge_handle ] ) ) {
+				$bridge_script = wp_scripts()->registered[ $bridge_handle ];
+				$bridge_url    = $bridge_script->src;
+				// Convert relative URLs to absolute URLs.
+				if ( $bridge_url && ! preg_match( '|^(https?:)?//|', $bridge_url ) ) {
+					$bridge_url = site_url( $bridge_url );
+				}
+			}
+
 			wp_interactivity_config(
 				$this->get_full_block_name(),
 				array(
@@ -573,6 +627,7 @@ class MiniCart extends AbstractBlock {
 					'onCartClickBehaviour'         => $on_cart_click_behaviour,
 					'checkoutUrl'                  => wc_get_checkout_url(),
 					'buttonAriaLabelTemplate'      => $button_aria_label_template,
+					'reactBridgeUrl'               => $bridge_url,
 				)
 			);
 
@@ -589,7 +644,7 @@ class MiniCart extends AbstractBlock {
 			}
 			ob_start();
 			?>
-		
+
 			<div
 				data-wp-interactive="woocommerce/mini-cart"
 				data-wp-init="callbacks.setupEventListeners"
@@ -600,7 +655,7 @@ class MiniCart extends AbstractBlock {
 				class="<?php echo esc_attr( $wrapper_classes ); ?>"
 				style="<?php echo esc_attr( $wrapper_styles ); ?>"
 			>
-				<button 
+				<button
 					data-wp-init="callbacks.saveMiniCartButtonRef"
 					data-wp-on--click="actions.openDrawer"
 					data-wp-bind--aria-label="state.buttonAriaLabel"
@@ -674,7 +729,7 @@ class MiniCart extends AbstractBlock {
 					</div>
 				</div>
 			</div>
-		</div>				
+		</div>
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo wp_interactivity_process_directives( ob_get_clean() );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -198,6 +198,7 @@ class MiniCartContents extends AbstractBlock {
 		$block_types[] = 'MiniCartShoppingButtonBlock';
 		$block_types[] = 'MiniCartCartButtonBlock';
 		$block_types[] = 'MiniCartCheckoutButtonBlock';
+		$block_types[] = 'MiniCartExpressCheckoutBlock';
 		$block_types[] = 'MiniCartTitleBlock';
 		$block_types[] = 'MiniCartTitleItemsCounterBlock';
 		$block_types[] = 'MiniCartTitleLabelBlock';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartExpressCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartExpressCheckoutBlock.php
@@ -36,7 +36,7 @@ class MiniCartExpressCheckoutBlock extends AbstractInnerBlock {
 				<span><?php esc_html_e( 'Express Checkout', 'woocommerce' ); ?></span>
 			</div>
 			<!-- React island container: MiniCartExpressPaymentWrapper renders here via iAPI frontend -->
-			<div class="wc-block-mini-cart__express-checkout-slot"></div>
+			<div class="wc-block-mini-cart__express-checkout-slot" data-wp-init="callbacks.renderExpressPaymentMethodsIsland"></div>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartExpressCheckoutBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartExpressCheckoutBlock.php
@@ -1,0 +1,60 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+
+/**
+ * MiniCartExpressCheckoutBlock class.
+ */
+class MiniCartExpressCheckoutBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-express-checkout-block';
+
+	/**
+	 * Render experimental iAPI block markup.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => 'wc-block-mini-cart__express-checkout',
+			)
+		);
+
+		ob_start();
+		?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<div class="wc-block-mini-cart__express-checkout-title">
+				<span><?php esc_html_e( 'Express Checkout', 'woocommerce' ); ?></span>
+			</div>
+			<!-- React island container: MiniCartExpressPaymentWrapper renders here via iAPI frontend -->
+			<div class="wc-block-mini-cart__express-checkout-slot"></div>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render the markup for the Mini-Cart Express Checkout block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
+		}
+
+		return $content;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/Payments/Api.php
+++ b/plugins/woocommerce/src/Blocks/Payments/Api.php
@@ -59,7 +59,7 @@ class Api {
 	 * @return array
 	 */
 	public function add_payment_method_script_dependencies( $dependencies, $handle ) {
-		if ( ! in_array( $handle, [ 'wc-checkout-block', 'wc-checkout-block-frontend', 'wc-cart-block', 'wc-cart-block-frontend' ], true ) ) {
+		if ( ! in_array( $handle, [ 'wc-checkout-block', 'wc-checkout-block-frontend', 'wc-cart-block', 'wc-cart-block-frontend', 'wc-mini-cart-iapi-react-bridge' ], true ) ) {
 			return $dependencies;
 		}
 		return array_merge( $dependencies, $this->payment_method_registry->get_all_active_payment_method_script_dependencies() );

--- a/plugins/woocommerce/templates/parts/mini-cart.html
+++ b/plugins/woocommerce/templates/parts/mini-cart.html
@@ -29,8 +29,15 @@
 			<div class="wp-block-woocommerce-mini-cart-cart-button-block"></div>
 			<!-- /wp:woocommerce/mini-cart-cart-button-block -->
 			<!-- wp:woocommerce/mini-cart-checkout-button-block -->
-			<div class="wp-block-woocommerce-mini-cart-checkout-button-block"></div>
+			<div
+				class="wp-block-woocommerce-mini-cart-checkout-button-block"
+			></div>
 			<!-- /wp:woocommerce/mini-cart-checkout-button-block -->
+			<!-- wp:woocommerce/mini-cart-express-checkout-block -->
+			<div
+				class="wp-block-woocommerce-mini-cart-express-checkout-block"
+			></div>
+			<!-- /wp:woocommerce/mini-cart-express-checkout-block -->
 		</div>
 		<!-- /wp:woocommerce/mini-cart-footer-block -->
 	</div>


### PR DESCRIPTION
Closes WOOPRD-1147

There is an updated spike, visit https://github.com/woocommerce/woocommerce/pull/62175