### PR TITLE
Removes all references to 61753 composer change in javascript packages

### DIFF
--- a/packages/js/admin-layout/changelog/61753-fix-support-composer-update
+++ b/packages/js/admin-layout/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/block-templates/changelog/61753-fix-support-composer-update
+++ b/packages/js/block-templates/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/components/changelog/61753-fix-support-composer-update
+++ b/packages/js/components/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/csv-export/changelog/61753-fix-support-composer-update
+++ b/packages/js/csv-export/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/currency/changelog/61753-fix-support-composer-update
+++ b/packages/js/currency/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/customer-effort-score/changelog/61753-fix-support-composer-update
+++ b/packages/js/customer-effort-score/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/data/changelog/61753-fix-support-composer-update
+++ b/packages/js/data/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/date/changelog/61753-fix-support-composer-update
+++ b/packages/js/date/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/dependency-extraction-webpack-plugin/changelog/61753-fix-support-composer-update
+++ b/packages/js/dependency-extraction-webpack-plugin/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/e2e-utils-playwright/changelog/61753-fix-support-composer-update
+++ b/packages/js/e2e-utils-playwright/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/eslint-plugin/changelog/61753-fix-support-composer-update
+++ b/packages/js/eslint-plugin/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/experimental/changelog/61753-fix-support-composer-update
+++ b/packages/js/experimental/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/explat/changelog/61753-fix-support-composer-update
+++ b/packages/js/explat/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/expression-evaluation/changelog/61753-fix-support-composer-update
+++ b/packages/js/expression-evaluation/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/integrate-plugin/changelog/61753-fix-support-composer-update
+++ b/packages/js/integrate-plugin/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/internal-js-tests/changelog/61753-fix-support-composer-update
+++ b/packages/js/internal-js-tests/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/navigation/changelog/61753-fix-support-composer-update
+++ b/packages/js/navigation/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/notices/changelog/61753-fix-support-composer-update
+++ b/packages/js/notices/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/number/changelog/61753-fix-support-composer-update
+++ b/packages/js/number/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/onboarding/changelog/61753-fix-support-composer-update
+++ b/packages/js/onboarding/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/product-editor/changelog/61753-fix-support-composer-update
+++ b/packages/js/product-editor/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/remote-logging/changelog/61753-fix-support-composer-update
+++ b/packages/js/remote-logging/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/settings-editor/changelog/61753-fix-support-composer-update
+++ b/packages/js/settings-editor/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.

--- a/packages/js/tracks/changelog/61753-fix-support-composer-update
+++ b/packages/js/tracks/changelog/61753-fix-support-composer-update
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Updated all PHP dependencies.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Essentially, all of the JavaScript packages have a changelog note for a composer dependency change, which only effects the package development worklows, not the use of package itself. This was resulting in all package updates appearing as a 'major' version bump with breaking changes, even if there weren't any. 


This PR removes this changelog note from #61753 from all JS packages: 

```
61753-fix-support-composer-update
```

CC @ObliviousHarmony 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

N/A

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
