### PR TITLE
Reduce options fetched by Brands on every page load

### DIFF
--- a/plugins/woocommerce/changelog/fix-61860-wc-brands
+++ b/plugins/woocommerce/changelog/fix-61860-wc-brands
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Reduce option loading in Brands code.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -57,9 +57,7 @@ class WC_Brands {
 
 		add_filter( 'post_type_link', array( $this, 'post_type_link' ), 11, 2 );
 
-		if ( 'yes' === get_option( 'wc_brands_show_description' ) ) {
-			add_action( 'woocommerce_archive_description', array( $this, 'brand_description' ) );
-		}
+		add_action( 'woocommerce_archive_description', array( $this, 'brand_description' ) );
 
 		add_filter( 'woocommerce_product_query_tax_query', array( $this, 'update_product_query_tax_query' ), 10, 1 );
 
@@ -429,6 +427,10 @@ class WC_Brands {
 	 * Displays brand description.
 	 */
 	public function brand_description() {
+		if ( 'yes' !== get_option( 'wc_brands_show_description' ) ) {
+			return;
+		}
+
 		if ( ! is_tax( 'product_brand' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -300,17 +300,9 @@ class WC_Brands {
 	 * Initializes brand taxonomy.
 	 */
 	public static function init_taxonomy() {
-		$shop_page_id = wc_get_page_id( 'shop' );
+		// Get the custom brand permalink slug, or use the default translatable slug.
+		$slug = get_option( 'woocommerce_brand_permalink', '' );
 
-		$base_slug     = $shop_page_id > 0 && get_page( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
-		$category_base = get_option( 'woocommerce_prepend_shop_page_to_urls' ) === 'yes' ? trailingslashit( $base_slug ) : '';
-
-		$slug = $category_base . __( 'brand', 'woocommerce' );
-		if ( '' === $category_base ) {
-			$slug = get_option( 'woocommerce_brand_permalink', '' );
-		}
-
-		// Can't provide transatable string as get_option default.
 		if ( '' === $slug ) {
 			$slug = __( 'brand', 'woocommerce' );
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -313,6 +313,9 @@ class WC_Install {
 			'wc_update_1040_add_idx_date_paid_status_parent',
 			'wc_update_1040_cleanup_legacy_ptk_patterns_fetching',
 		),
+		'10.5.0' => array(
+			'wc_update_1050_migrate_brand_permalink_setting',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3137,3 +3137,25 @@ function wc_update_1040_cleanup_legacy_ptk_patterns_fetching() {
 	delete_option( 'last_fetch_patterns_request' );
 	as_unschedule_all_actions( 'fetch_patterns' );
 }
+
+/**
+ * Update brand permalink setting to take into account obsolete 'woocommerce_prepend_shop_page_to_urls' option, removed in WC 2.0.3.
+ * This migration ensures any installations that still have this old option set will have their brand permalink updated appropriately.
+ *
+ * @since 10.5.0
+ */
+function wc_update_1050_migrate_brand_permalink_setting() {
+	if ( 'yes' !== get_option( 'woocommerce_prepend_shop_page_to_urls' ) ) {
+		return;
+	}
+
+	$shop_page_id = wc_get_page_id( 'shop' );
+	$shop_slug    = ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : 'shop';
+
+	if ( ! $shop_slug ) {
+		return;
+	}
+
+	$slug = trailingslashit( $shop_slug ) . __( 'brand', 'woocommerce' );
+	update_option( 'woocommerce_brand_permalink', $slug );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses part of #61860 by reducing unnecessary option loading in the Brands feature. Specifically, it handles `wc_brands_show_description` and `woocommerce_prepend_shop_page_to_urls`, which were being fetched on every page load.

The first is only needed on archive pages and the latter was used when registering the taxonomy, but corresponds to a setting that was removed in WC 2.0.3, so in the off chance someone had it set, we migrate the permalink structure to take it into account and stop relying on that option.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Install the Query Monitor plugin.
1. Ensure permalinks are enabled on your site.
1. Visit various admin and frontend pages and confirm that there aren't any queries involving `wc_brands_show_description` or `woocommerce_prepend_shop_page_to_urls`.
1. (Optional) Repeat the above on `trunk` and see those options being queried on every admin or frontend page load.
1. Go to **Products > Brands** in the admin and create a few brands with descriptions.
1. Click **View** for any of those brands. The URL you're taken is probably `/brand/<brand slug>`.
1. To simulate having the legacy `woocommerce_prepend_shop_page_to_urls` option set, add it:
   ```
   wp option set woocommerce_prepend_shop_page_to_urls yes
   ```
1. Trigger a db update as if you were updating to 10.5.0:
   ```
   wp option set woocommerce_version 10.4.0
   wp option set woocommerce_db_version 10.4.0
   wp wc update
   wp rewrite flush # <- This happens automatically as part of normal updates.
   ```
1. Go back to **Products > Brands** in the admin and click **View** for any of the brands. 
1. The URL should now be something like `/shop/brand/<brand slug>`.
1. Confirm in **Settings > Reading** on the admin side that **Product brand base** is set to `shop/brand`.

<!-- End testing instructions -->