### PR TITLE
Fix MCP CLI detection and enable WP-CLI initialization

### DIFF
--- a/plugins/woocommerce/changelog/62006-fix-mcp-cli-detection-and-initialization
+++ b/plugins/woocommerce/changelog/62006-fix-mcp-cli-detection-and-initialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix MCP CLI request detection to handle WP-CLI global flags and enable WP-CLI command registration for wp mcp-adapter commands

--- a/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
+++ b/plugins/woocommerce/src/Internal/MCP/MCPAdapterProvider.php
@@ -47,11 +47,22 @@ class MCPAdapterProvider {
 	 */
 	public function __construct() {
 		/*
-		 * Hook into rest_api_init with priority 10 to initialize only on REST API requests.
-		 * MCP adapter registers on rest_api_init with priority 20000, so we initialize earlier.
-		 * This prevents unnecessary MCP initialization on favicon, cron, or admin requests.
+		 * Initialize MCP adapter in both WP-CLI and REST API contexts.
+		 *
+		 * For WP-CLI: Hook into 'init' at priority 5 to ensure initialization
+		 * happens before the MCP adapter registers its CLI commands (priority 20).
+		 * This enables commands like 'wp mcp-adapter serve' to work properly.
+		 *
+		 * For REST: Hook into 'rest_api_init' with priority 10 to initialize only
+		 * on REST API requests. MCP adapter registers on rest_api_init with priority 20000,
+		 * so we initialize earlier. This prevents unnecessary MCP initialization on
+		 * favicon, cron, or admin requests.
 		 */
-		add_action( 'rest_api_init', array( $this, 'maybe_initialize' ), 10 );
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			add_action( 'init', array( $this, 'maybe_initialize' ), 5 );
+		} else {
+			add_action( 'rest_api_init', array( $this, 'maybe_initialize' ), 10 );
+		}
 	}
 
 	/**
@@ -213,6 +224,67 @@ class MCPAdapterProvider {
 	 * @return bool True if this is an MCP endpoint request.
 	 */
 	public static function is_mcp_request(): bool {
+		return self::is_mcp_cli_request() || self::is_mcp_rest_request();
+	}
+
+	/**
+	 * Check if the current request is a WP-CLI request for MCP adapter.
+	 *
+	 * Handles WP-CLI invocations like:
+	 * - `wp mcp-adapter serve`
+	 * - `wp --debug --user=1 mcp-adapter serve`
+	 * - `wp --path=/var/www --quiet -vvv mcp-adapter serve`
+	 *
+	 * @return bool True if this is a WP-CLI MCP adapter request.
+	 */
+	private static function is_mcp_cli_request(): bool {
+		// Check if this is a CLI request.
+		if ( ! defined( 'WP_CLI' ) || ! constant( 'WP_CLI' ) ) {
+			return false;
+		}
+
+		// Try to get the command from WP_CLI runner if available (strips global options).
+		if ( class_exists( 'WP_CLI' ) && method_exists( 'WP_CLI', 'get_runner' ) ) {
+			try {
+				$runner = \WP_CLI::get_runner();
+				if ( $runner && isset( $runner->arguments ) && is_array( $runner->arguments ) ) {
+					// Check if the first non-option argument is 'mcp-adapter'.
+					$first_arg = reset( $runner->arguments );
+					if ( 'mcp-adapter' === $first_arg ) {
+						return true;
+					}
+				}
+			} catch ( \Exception $e ) {
+				// If runner is not available or throws exception, fall through to argv check.
+				unset( $e );
+			}
+		}
+
+		// Fallback: scan $_SERVER['argv'] for the first non-flag token.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- CLI arguments are safe in WP-CLI context.
+		$cli_args = $_SERVER['argv'] ?? array();
+		foreach ( $cli_args as $index => $arg ) {
+			// Skip the script name (first element).
+			if ( 0 === $index ) {
+				continue;
+			}
+			// Skip global flags (start with '--' or single dash options like '-vvv').
+			if ( str_starts_with( $arg, '--' ) || str_starts_with( $arg, '-' ) ) {
+				continue;
+			}
+			// First non-flag argument found - check if it's 'mcp-adapter'.
+			return 'mcp-adapter' === $arg;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the current request is a REST API request for the MCP endpoint.
+	 *
+	 * @return bool True if this is a REST request to the MCP endpoint.
+	 */
+	private static function is_mcp_rest_request(): bool {
 		// Check if this is a REST request.
 		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
 			return false;

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -318,4 +318,207 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 			'Should maintain correct values after re-indexing'
 		);
 	}
+
+	/**
+	 * Test is_mcp_request() with simple WP-CLI command.
+	 */
+	public function test_is_mcp_request_simple_cli_command() {
+		// Simulate simple WP-CLI command: wp mcp-adapter serve.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', 'mcp-adapter', 'serve' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertTrue( $result, 'Should detect mcp-adapter command without flags' );
+	}
+
+	/**
+	 * Test is_mcp_request() with WP-CLI global flags before command.
+	 */
+	public function test_is_mcp_request_with_global_flags() {
+		// Simulate WP-CLI command with global flags: wp --debug --user=1 mcp-adapter serve.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', '--debug', '--user=1', 'mcp-adapter', 'serve' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertTrue( $result, 'Should detect mcp-adapter command after global flags' );
+	}
+
+	/**
+	 * Test is_mcp_request() with multiple WP-CLI flags.
+	 */
+	public function test_is_mcp_request_with_multiple_flags() {
+		// Simulate WP-CLI command with many flags: wp --path=/var/www --debug --quiet -vvv mcp-adapter serve.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', '--path=/var/www', '--debug', '--quiet', '-vvv', 'mcp-adapter', 'serve' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertTrue( $result, 'Should detect mcp-adapter command after multiple flags including single-dash options' );
+	}
+
+	/**
+	 * Test is_mcp_request() with non-mcp-adapter WP-CLI command.
+	 */
+	public function test_is_mcp_request_non_mcp_command() {
+		// Simulate non-MCP WP-CLI command: wp plugin list.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', 'plugin', 'list' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertFalse( $result, 'Should not detect non-mcp-adapter commands' );
+	}
+
+	/**
+	 * Test is_mcp_request() with non-mcp-adapter command after flags.
+	 */
+	public function test_is_mcp_request_non_mcp_command_with_flags() {
+		// Simulate non-MCP WP-CLI command with flags: wp --debug plugin list.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', '--debug', '--user=1', 'plugin', 'list' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertFalse( $result, 'Should not detect non-mcp-adapter commands even with flags' );
+	}
+
+	/**
+	 * Test is_mcp_request() with only flags (no command).
+	 */
+	public function test_is_mcp_request_only_flags() {
+		// Simulate WP-CLI invocation with only flags: wp --debug --user=1.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating CLI args.
+		$original_argv   = $_SERVER['argv'] ?? null;
+		$_SERVER['argv'] = array( 'wp', '--debug', '--user=1' );
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original argv.
+		if ( null === $original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $original_argv;
+		}
+
+		$this->assertFalse( $result, 'Should return false when no command is present' );
+	}
+
+	/**
+	 * Test is_mcp_request() detects REST API MCP requests.
+	 */
+	public function test_is_mcp_request_rest_api() {
+		// Simulate REST API request to MCP endpoint.
+		// Even though WP_CLI constant is defined in test environment,
+		// this tests the REST detection path by ensuring REST_REQUEST is set
+		// and checking the REQUEST_URI.
+		if ( ! defined( 'REST_REQUEST' ) ) {
+			define( 'REST_REQUEST', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating REST request URI.
+		$original_uri           = $_SERVER['REQUEST_URI'] ?? null;
+		$_SERVER['REQUEST_URI'] = '/wp-json/woocommerce/mcp';
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original state.
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+
+		$this->assertTrue( $result, 'Should detect MCP REST request' );
+	}
+
+	/**
+	 * Test is_mcp_request() returns false for non-MCP REST requests.
+	 */
+	public function test_is_mcp_request_rest_api_non_mcp() {
+		// Simulate REST API request to non-MCP endpoint.
+		if ( ! defined( 'REST_REQUEST' ) ) {
+			define( 'REST_REQUEST', true );
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test code simulating REST request URI.
+		$original_uri           = $_SERVER['REQUEST_URI'] ?? null;
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
+
+		$result = MCPAdapterProvider::is_mcp_request();
+
+		// Restore original state.
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+
+		$this->assertFalse( $result, 'Should not detect non-MCP REST requests' );
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes MCP CLI request detection to handle WP-CLI global flags
- Enables WP-CLI command registration for `wp mcp-adapter` commands

## Changes
1. Refactored `is_mcp_request()` to properly detect `wp mcp-adapter` commands with global flags
2. Updated `MCPAdapterProvider` constructor to initialize in WP-CLI context

## Test Plan
### WP-CLI Usage
```bash
# List registered MCP servers
wp mcp-adapter list

# List with formatting
wp mcp-adapter list --format=json

# Serve MCP server via STDIO
wp mcp-adapter serve --user=admin

# With global flags (now properly detected)
wp --debug --user=1 mcp-adapter list
```

### Using wp-env
```bash
# Restart wp-env to load changes
pnpm wp-env restart

# Test commands
pnpm wp-env run cli wp mcp-adapter list
pnpm wp-env run cli wp --debug mcp-adapter list --format=json
```

### Unit Tests
- ✅ All 18 tests passing
- Added 8 new tests for WP-CLI flag handling scenarios
- PHP linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)