### PR TITLE
Add to Cart Button: use a11y utils from script module

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-button-use-a11y-from-script-module
+++ b/plugins/woocommerce/changelog/fix-product-button-use-a11y-from-script-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart Button: use a11y utils from script module

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -309,7 +309,7 @@ const { state, actions } = store< Store >(
 				{ id, key, quantity, variation }: ClientCartItem,
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
-				const { speak } = yield import( '@wordpress/a11y' );
+				const a11yModulePromise = import( '@wordpress/a11y' );
 				let item = state.cart.items.find( ( cartItem ) => {
 					if ( cartItem.type === 'variation' ) {
 						// If it's a variation, check that attributes match.
@@ -403,6 +403,7 @@ const { state, actions } = store< Store >(
 						'woocommerce'
 					) as WooCommerceConfig;
 					if ( messages?.addedToCartText ) {
+						const { speak } = yield a11yModulePromise;
 						speak( messages.addedToCartText, 'polite' );
 					}
 
@@ -422,7 +423,7 @@ const { state, actions } = store< Store >(
 				items: ClientCartItem[],
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
-				const { speak } = yield import( '@wordpress/a11y' );
+				const a11yModulePromise = import( '@wordpress/a11y' );
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 
@@ -559,6 +560,7 @@ const { state, actions } = store< Store >(
 							'woocommerce'
 						) as WooCommerceConfig;
 						if ( messages?.addedToCartText ) {
+							const { speak } = yield a11yModulePromise;
 							speak( messages.addedToCartText, 'polite' );
 						}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getConfig, store } from '@wordpress/interactivity';
+import { speak } from '@wordpress/a11y';
 import type {
 	Cart,
 	CartItem,
@@ -402,7 +403,7 @@ const { state, actions } = store< Store >(
 						'woocommerce'
 					) as WooCommerceConfig;
 					if ( messages?.addedToCartText ) {
-						wp?.a11y?.speak( messages.addedToCartText, 'polite' );
+						speak( messages.addedToCartText, 'polite' );
 					}
 
 					// Dispatches the event to sync the @wordpress/data store.
@@ -557,10 +558,7 @@ const { state, actions } = store< Store >(
 							'woocommerce'
 						) as WooCommerceConfig;
 						if ( messages?.addedToCartText ) {
-							wp?.a11y?.speak(
-								messages.addedToCartText,
-								'polite'
-							);
+							speak( messages.addedToCartText, 'polite' );
 						}
 
 						// Dispatches the event to sync the @wordpress/data store.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { getConfig, store } from '@wordpress/interactivity';
-import { speak } from '@wordpress/a11y';
 import type {
 	Cart,
 	CartItem,
@@ -310,6 +309,7 @@ const { state, actions } = store< Store >(
 				{ id, key, quantity, variation }: ClientCartItem,
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
+				const { speak } = yield import( '@wordpress/a11y' );
 				let item = state.cart.items.find( ( cartItem ) => {
 					if ( cartItem.type === 'variation' ) {
 						// If it's a variation, check that attributes match.
@@ -422,6 +422,7 @@ const { state, actions } = store< Store >(
 				items: ClientCartItem[],
 				{ showCartUpdatesNotices = true }: CartUpdateOptions = {}
 			) {
+				const { speak } = yield import( '@wordpress/a11y' );
 				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -47,7 +47,6 @@ class ProductButton extends AbstractBlock {
 	 */
 	protected function enqueue_assets( array $attributes, $content, $block ) {
 		parent::enqueue_assets( $attributes, $content, $block );
-		wp_enqueue_script( 'wp-a11y' );
 
 		if ( wp_is_block_theme() ) {
 			add_action(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Discussed in p1763464766228529/1763354821.041539-slack-C02UBB1EPEF. We should use the `@wordpress/a11y` script module instead of manually enqueuing the `wp-a11y` script. This PR handles that.

### How to test the changes in this Pull Request:

1. Go through the testing steps in #60760 and verify there are no regressions.