### PR TITLE
[WOO13-101] feat: add v4 delete endpoint for shipping method

### DIFF
--- a/plugins/woocommerce/changelog/woo13-101-add-delete-endpoint-shipping-method
+++ b/plugins/woocommerce/changelog/woo13-101-add-delete-endpoint-shipping-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add DELETE endpoint for shipping zone methods in REST API v4.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\ShippingZoneMethod\ShippingZoneMethodService;
 use WC_Shipping_Zones;
+use WC_Shipping_Zone;
 use WP_Http;
 use WP_REST_Request;
 use WP_REST_Server;

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -101,6 +101,12 @@ class Controller extends AbstractController {
 					'permission_callback' => array( $this, 'check_permissions' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -232,22 +232,42 @@ class Controller extends AbstractController {
 	public function delete_item( $request ) {
 		$instance_id = (int) $request['id'];
 
+		// Get the method before deletion to return in response.
+		$method = WC_Shipping_Zones::get_shipping_method( $instance_id );
+		if ( ! $method ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
+		}
+
 		$zone = $this->validate_zone_by_method_instance( $instance_id );
 		if ( is_wp_error( $zone ) ) {
 			return $zone;
 		}
 
+		// Prepare response before deletion.
+		$request->set_param( 'context', 'view' );
+		$request['zone_id'] = $zone->get_id();
+		$response           = $this->prepare_item_for_response( $method, $request );
+
+		// Perform the deletion.
 		$result = $zone->delete_shipping_method( $instance_id );
 
 		if ( ! $result ) {
 			return $this->get_route_error_by_code( self::INVALID_ID );
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-			)
-		);
+		/**
+		 * Fires after a shipping zone method is deleted via the REST API.
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param WC_Shipping_Method $method   The shipping zone method being deleted.
+		 * @param WC_Shipping_Zone   $zone     The shipping zone the method belonged to.
+		 * @param WP_REST_Response   $response The response data.
+		 * @param WP_REST_Request    $request  The request sent to the API.
+		 */
+		do_action( 'woocommerce_rest_delete_shipping_zone_method', $method, $zone, $response, $request );
+
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -223,7 +223,7 @@ class Controller extends AbstractController {
 	}
 
 	/**
-	 * Delte shipping zone method by ID.
+	 * Delete shipping zone method by ID.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -106,7 +106,13 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					'args'                => array(
+						'force' => array(
+							'default'     => false,
+							'type'        => 'boolean',
+							'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
+						),
+					),
 				),
 			)
 		);
@@ -231,6 +237,16 @@ class Controller extends AbstractController {
 	 */
 	public function delete_item( $request ) {
 		$instance_id = (int) $request['id'];
+		$force       = $request['force'];
+
+		// Shipping methods do not support trashing.
+		if ( ! $force ) {
+			return new WP_Error(
+				'woocommerce_rest_trash_not_supported',
+				__( 'Shipping methods do not support trashing.', 'woocommerce' ),
+				array( 'status' => 501 )
+			);
+		}
 
 		// Get the method before deletion to return in response.
 		$method = WC_Shipping_Zones::get_shipping_method( $instance_id );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -217,6 +217,33 @@ class Controller extends AbstractController {
 	}
 
 	/**
+	 * Delte shipping zone method by ID.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$instance_id = (int) $request['id'];
+
+		$zone = $this->validate_zone_by_method_instance( $instance_id );
+		if ( is_wp_error( $zone ) ) {
+			return $zone;
+		}
+
+		$result = $zone->delete_shipping_method( $instance_id );
+
+		if ( ! $result ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+			)
+		);
+	}
+
+	/**
 	 * Get the schema for shipping methods.
 	 *
 	 * @return array

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -792,8 +792,15 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertArrayHasKey( 'success', $data );
-		$this->assertTrue( $data['success'] );
+		// Verify response contains full method object (not just success flag).
+		$this->assertArrayHasKey( 'instance_id', $data );
+		$this->assertArrayHasKey( 'zone_id', $data );
+		$this->assertArrayHasKey( 'method_id', $data );
+		$this->assertArrayHasKey( 'enabled', $data );
+		$this->assertArrayHasKey( 'settings', $data );
+		$this->assertEquals( $instance_id, $data['instance_id'] );
+		$this->assertEquals( 'flat_rate', $data['method_id'] );
+		$this->assertEquals( $zone->get_id(), $data['zone_id'] );
 
 		// Verify the method was actually deleted.
 		$methods_after = $zone->get_shipping_methods( false );
@@ -847,8 +854,48 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 			$this->assertEquals( 200, $response->get_status() );
 
 			$data = $response->get_data();
-			$this->assertTrue( $data['success'], "Delete did not return success for method type: {$method_type}" );
+			$this->assertArrayHasKey( 'method_id', $data, "Response missing method_id for method type: {$method_type}" );
+			$this->assertEquals( $method_type, $data['method_id'], "Method type mismatch for: {$method_type}" );
 		}
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test that woocommerce_rest_delete_shipping_zone_method action hook is fired.
+	 */
+	public function test_delete_item_fires_action_hook() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$zone        = $this->create_shipping_zone();
+		$instance_id = $zone->add_shipping_method( 'flat_rate' );
+
+		$hook_fired  = false;
+		$hook_method = null;
+		$hook_zone   = null;
+
+		// Add hook listener.
+		add_action(
+			'woocommerce_rest_delete_shipping_zone_method',
+			function ( $method, $zone, $response, $request ) use ( &$hook_fired, &$hook_method, &$hook_zone ) {
+				$hook_fired  = true;
+				$hook_method = $method;
+				$hook_zone   = $zone;
+			},
+			10,
+			4
+		);
+
+		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
+		$request->set_param( 'id', $instance_id );
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertTrue( $hook_fired, 'woocommerce_rest_delete_shipping_zone_method action hook was not fired' );
+		$this->assertNotNull( $hook_method, 'Hook did not receive method parameter' );
+		$this->assertNotNull( $hook_zone, 'Hook did not receive zone parameter' );
+		$this->assertEquals( $instance_id, $hook_method->instance_id, 'Hook received wrong method' );
+		$this->assertEquals( $zone->get_id(), $hook_zone->get_id(), 'Hook received wrong zone' );
 
 		wp_set_current_user( 0 );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -115,7 +115,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test route registration.
+	 * @testdox Should register routes correctly.
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -125,7 +125,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test POST endpoint route configuration.
+	 * @testdox Should configure POST endpoint route correctly.
 	 */
 	public function test_post_route_configuration() {
 		$routes = rest_get_server()->get_routes();
@@ -137,7 +137,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test GET endpoint route configuration.
+	 * @testdox Should configure GET endpoint route correctly.
 	 */
 	public function test_get_route_configuration() {
 		$routes = rest_get_server()->get_routes();
@@ -149,7 +149,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test PUT endpoint route configuration.
+	 * @testdox Should configure PUT endpoint route correctly.
 	 */
 	public function test_put_route_configuration() {
 		$routes = rest_get_server()->get_routes();
@@ -162,7 +162,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test permissions when shipping is disabled.
+	 * @testdox Should return error when shipping is disabled.
 	 */
 	public function test_check_permissions_shipping_disabled() {
 		// Disable shipping.
@@ -180,7 +180,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test permissions without proper capabilities.
+	 * @testdox Should return error without proper capabilities.
 	 */
 	public function test_check_permissions_insufficient_permissions() {
 		$user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
@@ -197,7 +197,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test permissions with proper capabilities.
+	 * @testdox Should allow access with proper capabilities.
 	 */
 	public function test_check_permissions_with_permissions() {
 		wp_set_current_user( self::$admin_user_id );
@@ -211,7 +211,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test that woocommerce_rest_check_permissions filter is applied.
+	 * @testdox Should apply woocommerce_rest_check_permissions filter.
 	 */
 	public function test_check_permissions_applies_filter() {
 		wp_set_current_user( self::$admin_user_id );
@@ -236,7 +236,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with missing zone_id parameter.
+	 * @testdox Should return error when creating item with missing zone_id parameter.
 	 */
 	public function test_create_item_missing_zone_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -257,7 +257,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with missing method_id parameter.
+	 * @testdox Should return error when creating item with missing method_id parameter.
 	 */
 	public function test_create_item_missing_method_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -280,7 +280,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with missing enabled parameter (should succeed with default value).
+	 * @testdox Should succeed when creating item with missing enabled parameter using default value.
 	 */
 	public function test_create_item_missing_enabled() {
 		wp_set_current_user( self::$admin_user_id );
@@ -302,7 +302,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with missing settings parameter (should succeed with defaults).
+	 * @testdox Should succeed when creating item with missing settings parameter using defaults.
 	 */
 	public function test_create_item_missing_settings() {
 		wp_set_current_user( self::$admin_user_id );
@@ -324,7 +324,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with invalid zone ID.
+	 * @testdox Should return error when creating item with invalid zone ID.
 	 */
 	public function test_create_item_invalid_zone_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -345,7 +345,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item with invalid method type.
+	 * @testdox Should return error when creating item with invalid method type.
 	 */
 	public function test_create_item_invalid_method_type() {
 		wp_set_current_user( self::$admin_user_id );
@@ -368,7 +368,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item successfully.
+	 * @testdox Should create item successfully.
 	 */
 	public function test_create_item_success() {
 		wp_set_current_user( self::$admin_user_id );
@@ -397,7 +397,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test create item rollback on validation failure.
+	 * @testdox Should rollback item creation on validation failure.
 	 */
 	public function test_create_item_rollback_on_validation_failure() {
 		wp_set_current_user( self::$admin_user_id );
@@ -479,7 +479,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test update item with invalid ID.
+	 * @testdox Should return error when updating item with invalid ID.
 	 */
 	public function test_update_item_invalid_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -497,7 +497,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test update item ignores zone_id since it's readonly.
+	 * @testdox Should ignore zone_id when updating since it is readonly.
 	 */
 	public function test_update_item_ignores_readonly_zone_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -529,7 +529,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test update item successfully.
+	 * @testdox Should update item successfully.
 	 */
 	public function test_update_item_success() {
 		wp_set_current_user( self::$admin_user_id );
@@ -558,7 +558,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test update item with only zone_id validation.
+	 * @testdox Should validate zone_id when updating item.
 	 */
 	public function test_update_item_zone_id_only() {
 		wp_set_current_user( self::$admin_user_id );
@@ -580,7 +580,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get item with valid ID.
+	 * @testdox Should return item with valid ID.
 	 */
 	public function test_get_item_success() {
 		wp_set_current_user( self::$admin_user_id );
@@ -608,7 +608,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get item returns 404 for invalid ID.
+	 * @testdox Should return 404 for invalid ID.
 	 */
 	public function test_get_item_invalid_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -626,7 +626,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get item returns 404 for deleted method.
+	 * @testdox Should return 404 for deleted method.
 	 */
 	public function test_get_item_deleted_method() {
 		wp_set_current_user( self::$admin_user_id );
@@ -648,7 +648,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get item works with different shipping method types.
+	 * @testdox Should return item for different shipping method types.
 	 */
 	public function test_get_item_different_method_types() {
 		wp_set_current_user( self::$admin_user_id );
@@ -677,7 +677,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get item returns method from correct zone.
+	 * @testdox Should return method from correct zone.
 	 */
 	public function test_get_item_correct_zone() {
 		wp_set_current_user( self::$admin_user_id );
@@ -713,7 +713,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test get schema.
+	 * @testdox Should return schema correctly.
 	 */
 	public function test_get_schema() {
 		$schema = $this->controller->get_item_schema();
@@ -727,7 +727,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test error prefix.
+	 * @testdox Should return correct error prefix.
 	 */
 	public function test_get_error_prefix() {
 		$reflection = new \ReflectionClass( $this->controller );
@@ -740,7 +740,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test DELETE endpoint route configuration.
+	 * @testdox Should configure DELETE endpoint route correctly.
 	 */
 	public function test_delete_route_configuration() {
 		$routes = rest_get_server()->get_routes();
@@ -752,7 +752,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete item with invalid ID.
+	 * @testdox Should return error when deleting item with invalid ID.
 	 */
 	public function test_delete_item_invalid_id() {
 		wp_set_current_user( self::$admin_user_id );
@@ -771,7 +771,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete item successfully.
+	 * @testdox Should delete item successfully.
 	 */
 	public function test_delete_item_success() {
 		wp_set_current_user( self::$admin_user_id );
@@ -812,7 +812,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete item for already deleted method.
+	 * @testdox Should return error when deleting already deleted method.
 	 */
 	public function test_delete_item_already_deleted() {
 		wp_set_current_user( self::$admin_user_id );
@@ -836,7 +836,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete item with different shipping method types.
+	 * @testdox Should delete item for different shipping method types.
 	 */
 	public function test_delete_item_different_method_types() {
 		wp_set_current_user( self::$admin_user_id );
@@ -866,7 +866,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test that woocommerce_rest_delete_shipping_zone_method action hook is fired.
+	 * @testdox Should fire woocommerce_rest_delete_shipping_zone_method action hook.
 	 */
 	public function test_delete_item_fires_action_hook() {
 		wp_set_current_user( self::$admin_user_id );
@@ -906,7 +906,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete shipping method without force parameter returns 501.
+	 * @testdox Should return 501 when deleting without force parameter.
 	 */
 	public function test_delete_item_without_force_parameter() {
 		wp_set_current_user( self::$admin_user_id );
@@ -933,7 +933,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
-	 * Test delete shipping method with force=false returns 501.
+	 * @testdox Should return 501 when deleting with force=false.
 	 */
 	public function test_delete_item_with_force_false() {
 		wp_set_current_user( self::$admin_user_id );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -877,13 +877,13 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		// Add hook listener.
 		add_action(
 			'woocommerce_rest_delete_shipping_zone_method',
-			function ( $method, $zone, $response, $request ) use ( &$hook_fired, &$hook_method, &$hook_zone ) {
+			function ( $method, $zone ) use ( &$hook_fired, &$hook_method, &$hook_zone ) {
 				$hook_fired  = true;
 				$hook_method = $method;
 				$hook_zone   = $zone;
 			},
 			10,
-			4
+			2
 		);
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -738,4 +738,118 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zone_method_', $prefix );
 	}
+
+	/**
+	 * Test DELETE endpoint route configuration.
+	 */
+	public function test_delete_route_configuration() {
+		$routes = rest_get_server()->get_routes();
+		$route  = $routes['/wc/v4/shipping-zone-method/(?P<id>[\\d]+)'];
+
+		$this->assertEquals( 'DELETE', $route[2]['methods']['DELETE'] );
+		$this->assertEquals( array( $this->controller, 'delete_item' ), $route[2]['callback'] );
+		$this->assertEquals( array( $this->controller, 'check_permissions' ), $route[2]['permission_callback'] );
+	}
+
+	/**
+	 * Test delete item with invalid ID.
+	 */
+	public function test_delete_item_invalid_id() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/99999' );
+		$request->set_param( 'id', 99999 );
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertStringContainsString( 'invalid_id', $response->get_error_code() );
+		$this->assertEquals( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test delete item successfully.
+	 */
+	public function test_delete_item_success() {
+		wp_set_current_user( self::$admin_user_id );
+
+		// Create zone and method.
+		$zone        = $this->create_shipping_zone();
+		$instance_id = $zone->add_shipping_method( 'flat_rate' );
+
+		// Verify the method exists.
+		$methods_before = $zone->get_shipping_methods( false );
+		$this->assertNotEmpty( $methods_before );
+
+		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
+		$request->set_param( 'id', $instance_id );
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+
+		// Verify the method was actually deleted.
+		$methods_after = $zone->get_shipping_methods( false );
+		$this->assertCount( count( $methods_before ) - 1, $methods_after );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test delete item for already deleted method.
+	 */
+	public function test_delete_item_already_deleted() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$zone        = $this->create_shipping_zone( 'Test Zone' );
+		$instance_id = $zone->add_shipping_method( 'flat_rate' );
+
+		// Delete the method first.
+		$zone->delete_shipping_method( $instance_id );
+
+		// Try to delete again.
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
+		$request->set_param( 'id', $instance_id );
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertStringContainsString( 'invalid_id', $response->get_error_code() );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test delete item with different shipping method types.
+	 */
+	public function test_delete_item_different_method_types() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$zone = $this->create_shipping_zone( 'Test Zone' );
+
+		// Test with different method types.
+		$method_types = array( 'flat_rate', 'free_shipping', 'local_pickup' );
+
+		foreach ( $method_types as $method_type ) {
+			$instance_id = $zone->add_shipping_method( $method_type );
+
+			$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
+			$request->set_param( 'id', $instance_id );
+			$response = $this->controller->delete_item( $request );
+
+			$this->assertNotInstanceOf( WP_Error::class, $response, "Failed to delete method type: {$method_type}" );
+			$this->assertEquals( 200, $response->get_status() );
+
+			$data = $response->get_data();
+			$this->assertTrue( $data['success'], "Delete did not return success for method type: {$method_type}" );
+		}
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -759,6 +759,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/99999' );
 		$request->set_param( 'id', 99999 );
+		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -785,6 +786,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
 		$request->set_param( 'id', $instance_id );
+		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -824,6 +826,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		// Try to delete again.
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
 		$request->set_param( 'id', $instance_id );
+		$request->set_param( 'force', true );
 		$response = $this->controller->delete_item( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
@@ -848,6 +851,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 			$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
 			$request->set_param( 'id', $instance_id );
+			$request->set_param( 'force', true );
 			$response = $this->controller->delete_item( $request );
 
 			$this->assertNotInstanceOf( WP_Error::class, $response, "Failed to delete method type: {$method_type}" );
@@ -888,6 +892,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
 		$request->set_param( 'id', $instance_id );
+		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -896,6 +901,60 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		$this->assertNotNull( $hook_zone, 'Hook did not receive zone parameter' );
 		$this->assertEquals( $instance_id, $hook_method->instance_id, 'Hook received wrong method' );
 		$this->assertEquals( $zone->get_id(), $hook_zone->get_id(), 'Hook received wrong zone' );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test delete shipping method without force parameter returns 501.
+	 */
+	public function test_delete_item_without_force_parameter() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$zone        = $this->create_shipping_zone();
+		$instance_id = $zone->add_shipping_method( 'flat_rate' );
+
+		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
+		$request->set_param( 'id', $instance_id );
+		// Don't set force parameter - should default to false
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $response->get_error_code() );
+		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
+		$this->assertEquals( 501, $response->get_error_data()['status'] );
+
+		// Verify the method was NOT deleted
+		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
+		$this->assertNotFalse( $method_after, 'Method should not be deleted without force=true' );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test delete shipping method with force=false returns 501.
+	 */
+	public function test_delete_item_with_force_false() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$zone        = $this->create_shipping_zone();
+		$instance_id = $zone->add_shipping_method( 'flat_rate' );
+
+		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
+		$request->set_param( 'id', $instance_id );
+		$request->set_param( 'force', false );
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $response->get_error_code() );
+		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
+		$this->assertEquals( 501, $response->get_error_data()['status'] );
+
+		// Verify the method was NOT deleted
+		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
+		$this->assertNotFalse( $method_after, 'Method should not be deleted with force=false' );
 
 		wp_set_current_user( 0 );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -916,7 +916,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
 		$request->set_param( 'id', $instance_id );
-		// Don't set force parameter - should default to false
+		// Don't set force parameter - should default to false.
 
 		$response = $this->controller->delete_item( $request );
 
@@ -925,7 +925,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
 		$this->assertEquals( 501, $response->get_error_data()['status'] );
 
-		// Verify the method was NOT deleted
+		// Verify the method was NOT deleted.
 		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
 		$this->assertNotFalse( $method_after, 'Method should not be deleted without force=true' );
 
@@ -952,7 +952,7 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
 		$this->assertEquals( 501, $response->get_error_data()['status'] );
 
-		// Verify the method was NOT deleted
+		// Verify the method was NOT deleted.
 		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
 		$this->assertNotFalse( $method_after, 'Method should not be deleted with force=false' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a DELETE endpoint for removing individual shipping zone methods in the WooCommerce REST API v4. This is to complete the CRUD operations for shipping zone methods in the v4 API.

**Key changes:**
- Added `delete_item()` method to `ShippingZoneMethod\Controller` (src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php:238-283)
- Registered DELETE route for `/wc/v4/shipping-zone-method/{id}` endpoint with `force` parameter (lines 105-116)
- **Requires `force=true` parameter to delete** (consistent with v2/v3 behavior)
  - Without `force=true`, returns 501 error: "Shipping methods do not support trashing"
  - This matches the existing v2/v3 API behavior

**Backward compatibility:**
- Response format matches v2/v3 APIs (returns deleted method object instead of simple success flag)
- Force parameter requirement matches v2/v3 behavior (prevents accidental deletions)
- Fires `woocommerce_rest_delete_shipping_zone_method` action hook (exists in v2 since 9.1.0)

Closes [#WOO13-101](https://linear.app/a8c/issue/WOO13-101/add-delete-endpoint-for-delivery-options-v4-api)

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Setup shipping zones and methods:**
   - Navigate to http://localhost:9001/wp-admin/new/woocommerce/settings/shipping/zones
   - Create a new shipping zone (e.g., "Test Zone")
   - Add multiple shipping methods to the zone (e.g., Flat Rate, Free Shipping)
   - Note the instance IDs from the browser URL or network requests

2. **Test DELETE endpoint with force=true (success case):**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/{instance_id}?force=true` (replace with actual instance ID)
   - Verify you receive a 200 status code
   - Verify the response contains the full method object with fields: `instance_id`, `zone_id`, `method_id`, `enabled`, `settings`
   - Verify the returned data matches the method that was deleted
   - Verify the shipping method is removed from the zone in the admin interface
   - Verify the zone still exists with remaining methods intact

3. **Test DELETE endpoint without force parameter (should fail with 501):**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/{instance_id}` (without force parameter)
   - Verify you receive a 501 status code
   - Verify error code is `woocommerce_rest_trash_not_supported`
   - Verify error message is "Shipping methods do not support trashing."
   - Verify the method is NOT deleted (still appears in admin interface)

4. **Test DELETE endpoint with force=false (should fail with 501):**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/{instance_id}?force=false`
   - Verify you receive a 501 status code
   - Verify error code is `woocommerce_rest_trash_not_supported`
   - Verify the method is NOT deleted

5. **Test DELETE endpoint with invalid instance ID:**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/99999?force=true`
   - Verify you receive a 404 status code
   - Verify error code is `woocommerce_rest_api_v4_shipping_zone_method_invalid_id`
   - Verify error message indicates "Invalid ID"

6. **Test DELETE endpoint with already deleted method:**
   - Delete a shipping method via the endpoint with `?force=true`
   - Attempt to delete the same method again using the same instance ID with `?force=true`
   - Verify you receive a 404 status code
   - Verify error code is `woocommerce_rest_api_v4_shipping_zone_method_invalid_id`

7. **Test permission handling:**
   - Make an unauthenticated request to the DELETE endpoint with `?force=true`
   - Verify you receive a 401 or 403 error
   - Make a request as a customer (non-admin)
   - Verify you receive a 403 error indicating insufficient permissions

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
