### PR TITLE
[WOO13-80] feat: add v4 delete endpoint for shipping zone

### DIFF
--- a/plugins/woocommerce/changelog/woo13-101-add-delete-endpoint-shipping-zones
+++ b/plugins/woocommerce/changelog/woo13-101-add-delete-endpoint-shipping-zones
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add DELETE endpoint for shipping zones in REST API v4.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -127,8 +127,18 @@ class Controller extends AbstractController {
 			);
 		}
 
-		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-			return $this->get_authentication_error_by_method( $request->get_method() );
+		$method = $request->get_method();
+
+		if ( 'GET' === $method ) {
+			$context = 'read';
+		} elseif ( 'DELETE' === $method ) {
+			$context = 'delete';
+		} else {
+			$context = 'edit';
+		}
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', $context ) ) {
+			return $this->get_authentication_error_by_method( $method );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -226,11 +226,9 @@ class Controller extends AbstractController {
 	/**
 	 * Delete shipping zone method by ID.
 	 *
-	 * Note: Shipping zone methods do not support trashing. Deletion is always permanent.
-	 * Unlike other WooCommerce REST API endpoints that use a `force` parameter to distinguish
-	 * between soft delete (trash) and permanent deletion, shipping zone methods are stored
-	 * as database records without trash support. This endpoint performs immediate permanent
-	 * deletion of the shipping method instance.
+	 * Note: In v2/v3, this endpoint required a `force` parameter, but since shipping zone methods
+	 * do not support trashing, it would either delete (force=true) or return a 501 error (force=false).
+	 * We removed the `force` parameter in v4 as it serves no purpose when soft delete is not supported.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -106,13 +106,6 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => array(
-						'force' => array(
-							'default'     => false,
-							'type'        => 'boolean',
-							'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
-						),
-					),
 				),
 			)
 		);
@@ -232,21 +225,17 @@ class Controller extends AbstractController {
 	/**
 	 * Delete shipping zone method by ID.
 	 *
+	 * Note: Shipping zone methods do not support trashing. Deletion is always permanent.
+	 * Unlike other WooCommerce REST API endpoints that use a `force` parameter to distinguish
+	 * between soft delete (trash) and permanent deletion, shipping zone methods are stored
+	 * as database records without trash support. This endpoint performs immediate permanent
+	 * deletion of the shipping method instance.
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
 		$instance_id = (int) $request['id'];
-		$force       = $request['force'];
-
-		// Shipping methods do not support trashing.
-		if ( ! $force ) {
-			return new WP_Error(
-				'woocommerce_rest_trash_not_supported',
-				__( 'Shipping methods do not support trashing.', 'woocommerce' ),
-				array( 'status' => 501 )
-			);
-		}
 
 		// Get the method before deletion to return in response.
 		$method = WC_Shipping_Zones::get_shipping_method( $instance_id );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php
@@ -106,6 +106,7 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -199,10 +199,15 @@ class Controller extends AbstractController {
 
 		$method = $request->get_method();
 
-		// GET requests require 'read' permission, all others require 'edit'.
-		$permission_type = ( WP_REST_Server::READABLE === $method ) ? 'read' : 'edit';
+		if ( 'GET' === $method ) {
+			$context = 'read';
+		} elseif ( 'DELETE' === $method ) {
+			$context = 'delete';
+		} else {
+			$context = 'edit';
+		}
 
-		if ( ! wc_rest_check_manager_permissions( 'settings', $permission_type ) ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', $context ) ) {
 			return $this->get_authentication_error_by_method( $method );
 		}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -124,13 +124,6 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => array(
-						'force' => array(
-							'default'     => false,
-							'type'        => 'boolean',
-							'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
-						),
-					),
 				),
 			)
 		);
@@ -245,22 +238,17 @@ class Controller extends AbstractController {
 	/**
 	 * Delete a shipping zone by zone id.
 	 *
+	 * Note: Shipping zones do not support trashing. Deletion is always permanent.
+	 * Unlike other WooCommerce REST API endpoints that use a `force` parameter to distinguish
+	 * between soft delete (trash) and permanent deletion, shipping zones are stored
+	 * as database records without trash support. This endpoint performs immediate permanent
+	 * deletion of the shipping zone.
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response Response object or WP_Error.
 	 */
 	public function delete_item( $request ) {
 		$zone_id = (int) $request['id'];
-		$force   = $request['force'];
-
-		// Shipping zones do not support trashing.
-		// This is done to ensure backward compatibility w/ v2/v3.
-		if ( ! $force ) {
-			return new WP_Error(
-				'woocommerce_rest_trash_not_supported',
-				__( 'Shipping zones do not support trashing.', 'woocommerce' ),
-				array( 'status' => 501 )
-			);
-		}
 
 		$zone = $this->validate_zone( $zone_id );
 		if ( is_wp_error( $zone ) ) {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -253,6 +253,7 @@ class Controller extends AbstractController {
 		$force   = $request['force'];
 
 		// Shipping zones do not support trashing.
+		// This is done to ensure backward compatibility w/ v2/v3
 		if ( ! $force ) {
 			return new WP_Error(
 				'woocommerce_rest_trash_not_supported',
@@ -261,16 +262,13 @@ class Controller extends AbstractController {
 			);
 		}
 
-		// Validate the zone exists.
 		$zone = $this->validate_zone( $zone_id );
 		if ( is_wp_error( $zone ) ) {
 			return $zone;
 		}
 
-		// Prepare response before deletion.
 		$response = rest_ensure_response( $this->prepare_item_for_response( $zone, $request ) );
 
-		// Perform the deletion (delete_zone returns void).
 		WC_Shipping_Zones::delete_zone( $zone_id );
 
 		return $response;

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -273,17 +273,6 @@ class Controller extends AbstractController {
 		// Perform the deletion (delete_zone returns void).
 		WC_Shipping_Zones::delete_zone( $zone_id );
 
-		/**
-		 * Fires after a shipping zone is deleted via the REST API.
-		 *
-		 * @since 10.5.0
-		 *
-		 * @param WC_Shipping_Zone $zone     The shipping zone being deleted.
-		 * @param WP_REST_Response $response The response data.
-		 * @param WP_REST_Request  $request  The request sent to the API.
-		 */
-		do_action( 'woocommerce_rest_delete_shipping_zone', $zone, $response, $request );
-
 		return $response;
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -244,21 +244,36 @@ class Controller extends AbstractController {
 	 */
 	public function delete_item( $request ) {
 		$zone_id = (int) $request['id'];
-		$result  = WC_Shipping_Zones::delete_zone( $zone_id );
 
-		if ( ! $result ) {
-			return $this->get_route_error_response(
-				$this->get_error_prefix() . 'invalid_id',
-				__( 'Invalid resource ID.', 'woocommerce' ),
-				WP_Http::NOT_FOUND
-			);
+		// Get the zone before deletion to return in response.
+		$zone = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+
+		if ( ! $zone ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-			)
-		);
+		// Prepare response before deletion.
+		$response = rest_ensure_response( $this->prepare_item_for_response( $zone, $request ) );
+
+		// Perform the deletion.
+		$result = WC_Shipping_Zones::delete_zone( $zone_id );
+
+		if ( ! $result ) {
+			return $this->get_route_error_by_code( self::INVALID_ID );
+		}
+
+		/**
+		 * Fires after a shipping zone is deleted via the REST API.
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param WC_Shipping_Zone $zone     The shipping zone being deleted.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
+		 */
+		do_action( 'woocommerce_rest_delete_shipping_zone', $zone, $response, $request );
+
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -124,6 +124,7 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -253,7 +253,7 @@ class Controller extends AbstractController {
 		$force   = $request['force'];
 
 		// Shipping zones do not support trashing.
-		// This is done to ensure backward compatibility w/ v2/v3
+		// This is done to ensure backward compatibility w/ v2/v3.
 		if ( ! $force ) {
 			return new WP_Error(
 				'woocommerce_rest_trash_not_supported',

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -231,6 +231,31 @@ class Controller extends AbstractController {
 	}
 
 	/**
+	 * Delete a shipping zone by zone id.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object or WP_Error.
+	 */
+	public function delete_item( $request ) {
+		$zone_id = (int) $request['id'];
+		$result  = WC_Shipping_Zones::delete_zone( $zone_id );
+
+		if ( ! $result ) {
+			return $this->get_route_error_response(
+				$this->get_error_prefix() . 'invalid_id',
+				__( 'Invalid resource ID.', 'woocommerce' ),
+				WP_Http::NOT_FOUND
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+			)
+		);
+	}
+
+	/**
 	 * Get route error by code, including custom shipping zone errors.
 	 *
 	 * @param string $error_code Error code.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -120,6 +120,12 @@ class Controller extends AbstractController {
 					'permission_callback' => array( $this, 'check_permissions' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
+				),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -124,7 +124,13 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::DELETABLE ),
+					'args'                => array(
+						'force' => array(
+							'default'     => false,
+							'type'        => 'boolean',
+							'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
+						),
+					),
 				),
 			)
 		);
@@ -244,23 +250,28 @@ class Controller extends AbstractController {
 	 */
 	public function delete_item( $request ) {
 		$zone_id = (int) $request['id'];
+		$force   = $request['force'];
 
-		// Get the zone before deletion to return in response.
-		$zone = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+		// Shipping zones do not support trashing.
+		if ( ! $force ) {
+			return new WP_Error(
+				'woocommerce_rest_trash_not_supported',
+				__( 'Shipping zones do not support trashing.', 'woocommerce' ),
+				array( 'status' => 501 )
+			);
+		}
 
-		if ( ! $zone ) {
-			return $this->get_route_error_by_code( self::INVALID_ID );
+		// Validate the zone exists.
+		$zone = $this->validate_zone( $zone_id );
+		if ( is_wp_error( $zone ) ) {
+			return $zone;
 		}
 
 		// Prepare response before deletion.
 		$response = rest_ensure_response( $this->prepare_item_for_response( $zone, $request ) );
 
-		// Perform the deletion.
-		$result = WC_Shipping_Zones::delete_zone( $zone_id );
-
-		if ( ! $result ) {
-			return $this->get_route_error_by_code( self::INVALID_ID );
-		}
+		// Perform the deletion (delete_zone returns void).
+		WC_Shipping_Zones::delete_zone( $zone_id );
 
 		/**
 		 * Fires after a shipping zone is deleted via the REST API.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php
@@ -239,11 +239,9 @@ class Controller extends AbstractController {
 	/**
 	 * Delete a shipping zone by zone id.
 	 *
-	 * Note: Shipping zones do not support trashing. Deletion is always permanent.
-	 * Unlike other WooCommerce REST API endpoints that use a `force` parameter to distinguish
-	 * between soft delete (trash) and permanent deletion, shipping zones are stored
-	 * as database records without trash support. This endpoint performs immediate permanent
-	 * deletion of the shipping zone.
+	 * Note: In v2/v3, this endpoint required a `force` parameter, but since shipping zones
+	 * do not support trashing, it would either delete (force=true) or return a 501 error (force=false).
+	 * We removed the `force` parameter in v4 as it serves no purpose when soft delete is not supported.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response Response object or WP_Error.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -236,6 +236,56 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 	}
 
 	/**
+	 * @testdox Should check delete permission for DELETE requests.
+	 */
+	public function test_check_permissions_delete_context() {
+		wp_set_current_user( self::$admin_user_id );
+
+		// Add filter to deny delete permissions but allow edit.
+		$filter_callback = function ( $permission, $context, $object_id, $object_type ) {
+			if ( 'settings' === $object_type && 'delete' === $context ) {
+				return false;
+			}
+			return $permission;
+		};
+		add_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10, 4 );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/1' );
+		$result  = $this->controller->check_permissions( $request );
+
+		// Should be denied because delete permission is blocked.
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		remove_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10 );
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * @testdox Should check read permission for GET requests.
+	 */
+	public function test_check_permissions_read_context() {
+		wp_set_current_user( self::$admin_user_id );
+
+		// Add filter to deny read permissions but allow edit.
+		$filter_callback = function ( $permission, $context, $object_id, $object_type ) {
+			if ( 'settings' === $object_type && 'read' === $context ) {
+				return false;
+			}
+			return $permission;
+		};
+		add_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10, 4 );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v4/shipping-zone-method/1' );
+		$result  = $this->controller->check_permissions( $request );
+
+		// Should be denied because read permission is blocked.
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		remove_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10 );
+		wp_set_current_user( 0 );
+	}
+
+	/**
 	 * @testdox Should return error when creating item with missing zone_id parameter.
 	 */
 	public function test_create_item_missing_zone_id() {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZoneMethod/class-wc-rest-shipping-zone-method-v4-controller-tests.php
@@ -759,7 +759,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/99999' );
 		$request->set_param( 'id', 99999 );
-		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -786,7 +785,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
 		$request->set_param( 'id', $instance_id );
-		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -826,7 +824,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		// Try to delete again.
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
 		$request->set_param( 'id', $instance_id );
-		$request->set_param( 'force', true );
 		$response = $this->controller->delete_item( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
@@ -851,7 +848,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 			$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zone-method/' . $instance_id );
 			$request->set_param( 'id', $instance_id );
-			$request->set_param( 'force', true );
 			$response = $this->controller->delete_item( $request );
 
 			$this->assertNotInstanceOf( WP_Error::class, $response, "Failed to delete method type: {$method_type}" );
@@ -892,7 +888,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 
 		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
 		$request->set_param( 'id', $instance_id );
-		$request->set_param( 'force', true );
 
 		$response = $this->controller->delete_item( $request );
 
@@ -901,60 +896,6 @@ class WC_REST_Shipping_Zone_Method_V4_Controller_Tests extends WC_REST_Unit_Test
 		$this->assertNotNull( $hook_zone, 'Hook did not receive zone parameter' );
 		$this->assertEquals( $instance_id, $hook_method->instance_id, 'Hook received wrong method' );
 		$this->assertEquals( $zone->get_id(), $hook_zone->get_id(), 'Hook received wrong zone' );
-
-		wp_set_current_user( 0 );
-	}
-
-	/**
-	 * @testdox Should return 501 when deleting without force parameter.
-	 */
-	public function test_delete_item_without_force_parameter() {
-		wp_set_current_user( self::$admin_user_id );
-
-		$zone        = $this->create_shipping_zone();
-		$instance_id = $zone->add_shipping_method( 'flat_rate' );
-
-		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
-		$request->set_param( 'id', $instance_id );
-		// Don't set force parameter - should default to false.
-
-		$response = $this->controller->delete_item( $request );
-
-		$this->assertInstanceOf( WP_Error::class, $response );
-		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $response->get_error_code() );
-		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
-		$this->assertEquals( 501, $response->get_error_data()['status'] );
-
-		// Verify the method was NOT deleted.
-		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
-		$this->assertNotFalse( $method_after, 'Method should not be deleted without force=true' );
-
-		wp_set_current_user( 0 );
-	}
-
-	/**
-	 * @testdox Should return 501 when deleting with force=false.
-	 */
-	public function test_delete_item_with_force_false() {
-		wp_set_current_user( self::$admin_user_id );
-
-		$zone        = $this->create_shipping_zone();
-		$instance_id = $zone->add_shipping_method( 'flat_rate' );
-
-		$request = new WP_REST_Request( 'DELETE', "/wc/v4/shipping-zone-method/{$instance_id}" );
-		$request->set_param( 'id', $instance_id );
-		$request->set_param( 'force', false );
-
-		$response = $this->controller->delete_item( $request );
-
-		$this->assertInstanceOf( WP_Error::class, $response );
-		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $response->get_error_code() );
-		$this->assertEquals( 'Shipping methods do not support trashing.', $response->get_error_message() );
-		$this->assertEquals( 501, $response->get_error_data()['status'] );
-
-		// Verify the method was NOT deleted.
-		$method_after = \WC_Shipping_Zones::get_shipping_method( $instance_id );
-		$this->assertNotFalse( $method_after, 'Method should not be deleted with force=false' );
 
 		wp_set_current_user( 0 );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1642,44 +1642,6 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test that woocommerce_rest_delete_shipping_zone action hook is fired.
-	 */
-	public function test_delete_item_fires_action_hook() {
-		$zone = $this->create_shipping_zone( 'Hook Test Zone' );
-
-		$hook_fired = false;
-		$hook_zone  = null;
-
-		// Add hook listener.
-		add_action(
-			'woocommerce_rest_delete_shipping_zone',
-			function ( $zone ) use ( &$hook_fired, &$hook_zone ) {
-				$hook_fired = true;
-				$hook_zone  = $zone;
-			},
-			10,
-			1
-		);
-
-		$zone_id = $zone->get_id();
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$request->set_param( 'force', true );
-		$this->server->dispatch( $request );
-
-		$this->assertTrue( $hook_fired, 'woocommerce_rest_delete_shipping_zone action hook was not fired' );
-		$this->assertNotNull( $hook_zone, 'Hook did not receive zone parameter' );
-		$this->assertEquals( $zone_id, $hook_zone->get_id(), 'Hook received wrong zone' );
-
-		// Remove from cleanup array since it's already deleted.
-		$this->zones = array_filter(
-			$this->zones,
-			function ( $z ) use ( $zone_id ) {
-				return $z->get_id() !== $zone_id;
-			}
-		);
-	}
-
-	/**
 	 * Test delete zone with methods attached.
 	 */
 	public function test_delete_item_with_methods() {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1513,8 +1513,12 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		$this->assertNotNull( $delete_config, 'DELETE method not found in route configuration' );
 		$this->assertEquals( 'DELETE', $delete_config['methods']['DELETE'] );
-		$this->assertEquals( array( $this->endpoint, 'delete_item' ), $delete_config['callback'] );
-		$this->assertEquals( array( $this->endpoint, 'check_permissions' ), $delete_config['permission_callback'] );
+		$this->assertIsArray( $delete_config['callback'] );
+		$this->assertInstanceOf( get_class( $this->endpoint ), $delete_config['callback'][0] );
+		$this->assertEquals( 'delete_item', $delete_config['callback'][1] );
+		$this->assertIsArray( $delete_config['permission_callback'] );
+		$this->assertInstanceOf( get_class( $this->endpoint ), $delete_config['permission_callback'][0] );
+		$this->assertEquals( 'check_permissions', $delete_config['permission_callback'][1] );
 	}
 
 	/**
@@ -1527,8 +1531,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		$this->assertEquals( 404, $response->get_status() );
 		$this->assertArrayHasKey( 'code', $data );
-		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_id', $data['code'] );
-		$this->assertEquals( 'Invalid resource ID.', $data['message'] );
+		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_zone_id', $data['code'] );
+		$this->assertEquals( 'Invalid shipping zone ID.', $data['message'] );
 	}
 
 	/**
@@ -1541,7 +1545,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		$zone_id = $zone->get_id();
 
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1589,13 +1594,14 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		);
 
 		// Try to delete again.
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 404, $response->get_status() );
 		$this->assertArrayHasKey( 'code', $data );
-		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_id', $data['code'] );
+		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_zone_id', $data['code'] );
 	}
 
 	/**
@@ -1606,7 +1612,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -1621,7 +1628,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		// Disable shipping temporarily.
 		add_filter( 'wc_shipping_enabled', '__return_false' );
 
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1655,6 +1663,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		$zone_id = $zone->get_id();
 		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request->set_param( 'force', true );
 		$this->server->dispatch( $request );
 
 		$this->assertTrue( $hook_fired, 'woocommerce_rest_delete_shipping_zone action hook was not fired' );
@@ -1678,8 +1687,9 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		$this->add_shipping_method( $zone, 'flat_rate' );
 		$this->add_shipping_method( $zone, 'free_shipping' );
 
-		$zone_id  = $zone->get_id();
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$zone_id = $zone->get_id();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1698,5 +1708,48 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 				return $z->get_id() !== $zone_id;
 			}
 		);
+	}
+
+	/**
+	 * Test delete zone without force parameter returns 501.
+	 */
+	public function test_delete_item_without_force_parameter() {
+		$zone = $this->create_shipping_zone( 'Zone Without Force' );
+
+		$zone_id  = $zone->get_id();
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 501, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $data['code'] );
+		$this->assertEquals( 'Shipping zones do not support trashing.', $data['message'] );
+
+		// Verify the zone was NOT deleted.
+		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+		$this->assertNotFalse( $zone_after, 'Zone should not be deleted without force=true' );
+	}
+
+	/**
+	 * Test delete zone with force=false returns 501.
+	 */
+	public function test_delete_item_with_force_false() {
+		$zone = $this->create_shipping_zone( 'Zone With Force False' );
+
+		$zone_id = $zone->get_id();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$request->set_param( 'force', false );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 501, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $data['code'] );
+		$this->assertEquals( 'Shipping zones do not support trashing.', $data['message'] );
+
+		// Verify the zone was NOT deleted.
+		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+		$this->assertNotFalse( $zone_after, 'Zone should not be deleted with force=false' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1525,7 +1525,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	 * Test delete zone with invalid ID.
 	 */
 	public function test_delete_item_invalid_id() {
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -149,7 +149,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test route registration.
+	 * @testdox Should register routes correctly.
 	 */
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
@@ -157,7 +157,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test getting all shipping zones.
+	 * @testdox Should return all shipping zones.
 	 */
 	public function test_get_items() {
 		// Create test zones.
@@ -246,7 +246,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test shipping method formatting.
+	 * @testdox Should format shipping methods correctly.
 	 */
 	public function test_method_formatting() {
 		$zone = $this->create_shipping_zone( 'Method Test Zone' );
@@ -291,7 +291,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test location formatting.
+	 * @testdox Should format locations correctly.
 	 */
 	public function test_location_formatting() {
 		$zone = $this->create_shipping_zone(
@@ -340,7 +340,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test empty locations.
+	 * @testdox Should handle empty locations.
 	 */
 	public function test_empty_locations() {
 		$zone = $this->create_shipping_zone( 'Empty Zone' );
@@ -364,7 +364,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test permissions.
+	 * @testdox Should return error without permissions.
 	 */
 	public function test_get_items_without_permission() {
 		wp_set_current_user( 0 );
@@ -376,7 +376,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test zone ordering.
+	 * @testdox Should order zones correctly.
 	 */
 	public function test_zone_ordering() {
 		$zone1 = $this->create_shipping_zone( 'Zone Order 3', 3 );
@@ -400,7 +400,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test non-numeric cost handling.
+	 * @testdox Should handle non-numeric cost values.
 	 */
 	public function test_non_numeric_cost_handling() {
 		$zone = $this->create_shipping_zone( 'Expression Cost Zone' );
@@ -434,7 +434,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test free shipping requirements.
+	 * @testdox Should handle free shipping requirements.
 	 */
 	public function test_free_shipping_requirements() {
 		$zone = $this->create_shipping_zone( 'Free Shipping Test Zone' );
@@ -511,7 +511,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test malformed state location code handling.
+	 * @testdox Should handle malformed state location codes.
 	 *
 	 * Note: This test simulates what would happen if malformed data exists.
 	 */
@@ -558,7 +558,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test shipping disabled response.
+	 * @testdox Should return error when shipping is disabled.
 	 */
 	public function test_shipping_disabled_response() {
 		// Disable shipping temporarily.
@@ -581,7 +581,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test schema.
+	 * @testdox Should return correct schema.
 	 */
 	public function test_get_item_schema() {
 		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v4/shipping-zones' );
@@ -616,7 +616,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test get single zone.
+	 * @testdox Should return single zone by ID.
 	 */
 	public function test_get_item() {
 		$zone = $this->create_shipping_zone( 'Single Zone Test' );
@@ -657,7 +657,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test get single zone with invalid ID.
+	 * @testdox Should return error for invalid zone ID.
 	 */
 	public function test_get_item_invalid_id() {
 		$request  = new WP_REST_Request( 'GET', '/wc/v4/shipping-zones/99999' );
@@ -673,7 +673,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test get single zone when shipping is disabled.
+	 * @testdox Should return error when getting zone with shipping disabled.
 	 */
 	public function test_get_item_shipping_disabled() {
 		$zone = $this->create_shipping_zone( 'Test Zone' );
@@ -698,7 +698,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test get single zone without permission.
+	 * @testdox Should return error when getting zone without permission.
 	 */
 	public function test_get_item_without_permission() {
 		$zone = $this->create_shipping_zone( 'Test Zone' );
@@ -711,7 +711,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test detailed location formatting for "Rest of the World" zone.
+	 * @testdox Should format Rest of World zone locations correctly.
 	 */
 	public function test_get_item_rest_of_world_zone() {
 		// "Rest of the World" zone has ID 0.
@@ -727,7 +727,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with minimal fields (name and empty locations).
+	 * @testdox Should create zone with minimal fields.
 	 */
 	public function test_create_item_minimal() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -755,7 +755,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with name and locations.
+	 * @testdox Should create zone with name and locations.
 	 */
 	public function test_create_item_with_locations() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -791,7 +791,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with all fields (name, order, locations).
+	 * @testdox Should create zone with all fields.
 	 */
 	public function test_create_item_with_all_fields() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -825,7 +825,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with missing required name field.
+	 * @testdox Should return error when creating zone without name.
 	 */
 	public function test_create_item_missing_name() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -844,7 +844,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with missing required locations field.
+	 * @testdox Should create zone without required locations.
 	 */
 	public function test_create_item_missing_locations() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -863,7 +863,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with invalid location type (should be skipped).
+	 * @testdox Should skip invalid location types.
 	 */
 	public function test_create_item_invalid_location_type() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -898,7 +898,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with location type defaulting to country.
+	 * @testdox Should default location type to country.
 	 */
 	public function test_create_item_location_type_defaults_to_country() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -929,7 +929,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone response structure and status code.
+	 * @testdox Should return correct response structure on create.
 	 */
 	public function test_create_item_response_structure() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -964,7 +964,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone sets Location header correctly.
+	 * @testdox Should set Location header on create.
 	 */
 	public function test_create_item_location_header() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -991,7 +991,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone without permission.
+	 * @testdox Should return error when creating zone without permission.
 	 */
 	public function test_create_item_without_permission() {
 		wp_set_current_user( 0 );
@@ -1010,7 +1010,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone when shipping is disabled.
+	 * @testdox Should return error when creating zone with shipping disabled.
 	 */
 	public function test_create_item_shipping_disabled() {
 		// Disable shipping temporarily.
@@ -1036,7 +1036,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with various location types.
+	 * @testdox Should create zone with various location types.
 	 */
 	public function test_create_item_with_various_location_types() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -1088,7 +1088,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with empty location code (should be skipped).
+	 * @testdox Should skip empty location codes.
 	 */
 	public function test_create_item_empty_location_code() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -1122,7 +1122,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with country:state location type (v4 specific feature).
+	 * @testdox Should create zone with country:state location type.
 	 */
 	public function test_create_item_with_country_state_location_type() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -1172,7 +1172,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with empty name fails.
+	 * @testdox Should return error for empty zone name.
 	 */
 	public function test_create_item_empty_name() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -1193,7 +1193,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test create zone with whitespace-only name fails.
+	 * @testdox Should return error for whitespace zone name.
 	 */
 	public function test_create_item_whitespace_name() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -1213,7 +1213,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update "Rest of the World" zone name fails.
+	 * @testdox Should return error when updating Rest of World zone name.
 	 */
 	public function test_update_rest_of_world_zone_name() {
 		$request = new WP_REST_Request( 'PUT', '/wc/v4/shipping-zones/0' );
@@ -1233,7 +1233,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update "Rest of the World" zone locations fails.
+	 * @testdox Should return error when updating Rest of World zone locations.
 	 */
 	public function test_update_rest_of_world_zone_locations() {
 		$request = new WP_REST_Request( 'PUT', '/wc/v4/shipping-zones/0' );
@@ -1258,7 +1258,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update "Rest of the World" zone order fails.
+	 * @testdox Should return error when updating Rest of World zone order.
 	 */
 	public function test_update_rest_of_world_zone_order() {
 		$request = new WP_REST_Request( 'PUT', '/wc/v4/shipping-zones/0' );
@@ -1278,7 +1278,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update regular zone with empty name fails.
+	 * @testdox Should return error when updating zone with empty name.
 	 */
 	public function test_update_item_empty_name() {
 		$zone          = $this->create_shipping_zone( 'Test Zone' );
@@ -1301,7 +1301,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update regular zone name successfully.
+	 * @testdox Should update zone name.
 	 */
 	public function test_update_item_name() {
 		$zone          = $this->create_shipping_zone( 'Original Name' );
@@ -1327,7 +1327,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update regular zone order successfully.
+	 * @testdox Should update zone order.
 	 */
 	public function test_update_item_order() {
 		$zone          = $this->create_shipping_zone( 'Test Zone', 0 );
@@ -1352,7 +1352,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update regular zone locations successfully.
+	 * @testdox Should update zone locations.
 	 */
 	public function test_update_item_locations() {
 		$zone          = $this->create_shipping_zone( 'Test Zone' );
@@ -1387,7 +1387,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update regular zone with all fields successfully.
+	 * @testdox Should Update regular zone with all fields successfully.
 	 */
 	public function test_update_item_all_fields() {
 		$zone          = $this->create_shipping_zone( 'Original Name', 0 );
@@ -1418,7 +1418,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update zone with invalid ID.
+	 * @testdox Should Update zone with invalid id.
 	 */
 	public function test_update_item_invalid_id() {
 		$request = new WP_REST_Request( 'PUT', '/wc/v4/shipping-zones/99999' );
@@ -1438,7 +1438,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update zone without permission.
+	 * @testdox Should Update zone without permission.
 	 */
 	public function test_update_item_without_permission() {
 		$zone          = $this->create_shipping_zone( 'Test Zone' );
@@ -1459,7 +1459,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test update zone clears locations with empty array.
+	 * @testdox Should Update zone clears locations with empty array.
 	 */
 	public function test_update_item_clear_locations() {
 		$zone          = $this->create_shipping_zone(
@@ -1496,7 +1496,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test DELETE endpoint route configuration.
+	 * @testdox Should Delete endpoint route configuration.
 	 */
 	public function test_delete_route_configuration() {
 		$routes = $this->server->get_routes();
@@ -1522,7 +1522,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone with invalid ID.
+	 * @testdox Should return error when deleting zone with invalid ID.
 	 */
 	public function test_delete_item_invalid_id() {
 		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
@@ -1536,7 +1536,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone successfully.
+	 * @testdox Should delete zone successfully.
 	 */
 	public function test_delete_item_success() {
 		$zone = $this->create_shipping_zone( 'Zone to Delete', 1 );
@@ -1575,7 +1575,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone for already deleted zone.
+	 * @testdox Should Delete zone for already deleted zone.
 	 */
 	public function test_delete_item_already_deleted() {
 		$zone    = $this->create_shipping_zone( 'Zone to Delete' );
@@ -1603,7 +1603,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone without permission.
+	 * @testdox Should return error when deleting zone without permission.
 	 */
 	public function test_delete_item_without_permission() {
 		$zone = $this->create_shipping_zone( 'Test Zone' );
@@ -1617,7 +1617,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone when shipping is disabled.
+	 * @testdox Should Delete zone when shipping is disabled.
 	 */
 	public function test_delete_item_shipping_disabled() {
 		$zone = $this->create_shipping_zone( 'Test Zone' );
@@ -1638,7 +1638,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * Test delete zone with methods attached.
+	 * @testdox Should Delete zone with methods attached.
 	 */
 	public function test_delete_item_with_methods() {
 		$zone = $this->create_shipping_zone( 'Zone with Methods' );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -376,6 +376,50 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
+	 * @testdox Should check delete permission for DELETE requests.
+	 */
+	public function test_check_permissions_delete_context() {
+		// Add filter to deny delete permissions but allow edit.
+		$filter_callback = function ( $permission, $context, $object_id, $object_type ) {
+			if ( 'settings' === $object_type && 'delete' === $context ) {
+				return false;
+			}
+			return $permission;
+		};
+		add_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10, 4 );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/1' );
+		$result  = $this->endpoint->check_permissions( $request );
+
+		// Should be denied because delete permission is blocked.
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		remove_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10 );
+	}
+
+	/**
+	 * @testdox Should check read permission for GET requests.
+	 */
+	public function test_check_permissions_read_context() {
+		// Add filter to deny read permissions but allow edit.
+		$filter_callback = function ( $permission, $context, $object_id, $object_type ) {
+			if ( 'settings' === $object_type && 'read' === $context ) {
+				return false;
+			}
+			return $permission;
+		};
+		add_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10, 4 );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v4/shipping-zones' );
+		$result  = $this->endpoint->check_permissions( $request );
+
+		// Should be denied because read permission is blocked.
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		remove_filter( 'woocommerce_rest_check_permissions', $filter_callback, 10 );
+	}
+
+	/**
 	 * @testdox Should order zones correctly.
 	 */
 	public function test_zone_ordering() {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1494,4 +1494,209 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		$zone_reloaded = WC_Shipping_Zones::get_zone( $zone->get_id() );
 		$this->assertCount( 0, $zone_reloaded->get_zone_locations() );
 	}
+
+	/**
+	 * Test DELETE endpoint route configuration.
+	 */
+	public function test_delete_route_configuration() {
+		$routes = $this->server->get_routes();
+		$route  = $routes['/wc/v4/shipping-zones/(?P<id>[\d]+)'];
+
+		// Find the DELETE method in the route configuration.
+		$delete_config = null;
+		foreach ( $route as $config ) {
+			if ( isset( $config['methods']['DELETE'] ) ) {
+				$delete_config = $config;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $delete_config, 'DELETE method not found in route configuration' );
+		$this->assertEquals( 'DELETE', $delete_config['methods']['DELETE'] );
+		$this->assertEquals( array( $this->endpoint, 'delete_item' ), $delete_config['callback'] );
+		$this->assertEquals( array( $this->endpoint, 'check_permissions' ), $delete_config['permission_callback'] );
+	}
+
+	/**
+	 * Test delete zone with invalid ID.
+	 */
+	public function test_delete_item_invalid_id() {
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_id', $data['code'] );
+		$this->assertEquals( 'Invalid resource ID.', $data['message'] );
+	}
+
+	/**
+	 * Test delete zone successfully.
+	 */
+	public function test_delete_item_success() {
+		$zone = $this->create_shipping_zone( 'Zone to Delete', 1 );
+		$zone->add_location( 'US', 'country' );
+		$zone->save();
+
+		$zone_id = $zone->get_id();
+
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify response contains full zone object (not just success flag).
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'name', $data );
+		$this->assertArrayHasKey( 'order', $data );
+		$this->assertArrayHasKey( 'locations', $data );
+		$this->assertArrayHasKey( 'methods', $data );
+		$this->assertEquals( $zone_id, $data['id'] );
+		$this->assertEquals( 'Zone to Delete', $data['name'] );
+		$this->assertEquals( 1, $data['order'] );
+
+		// Verify the zone was actually deleted.
+		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+		$this->assertFalse( $zone_after, 'Zone should be deleted' );
+
+		// Remove from cleanup array since it's already deleted.
+		$this->zones = array_filter(
+			$this->zones,
+			function ( $z ) use ( $zone_id ) {
+				return $z->get_id() !== $zone_id;
+			}
+		);
+	}
+
+	/**
+	 * Test delete zone for already deleted zone.
+	 */
+	public function test_delete_item_already_deleted() {
+		$zone    = $this->create_shipping_zone( 'Zone to Delete' );
+		$zone_id = $zone->get_id();
+
+		// Delete the zone first.
+		$zone->delete();
+
+		// Remove from cleanup array.
+		$this->zones = array_filter(
+			$this->zones,
+			function ( $z ) use ( $zone_id ) {
+				return $z->get_id() !== $zone_id;
+			}
+		);
+
+		// Try to delete again.
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_invalid_id', $data['code'] );
+	}
+
+	/**
+	 * Test delete zone without permission.
+	 */
+	public function test_delete_item_without_permission() {
+		$zone = $this->create_shipping_zone( 'Test Zone' );
+
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test delete zone when shipping is disabled.
+	 */
+	public function test_delete_item_shipping_disabled() {
+		$zone = $this->create_shipping_zone( 'Test Zone' );
+
+		// Disable shipping temporarily.
+		add_filter( 'wc_shipping_enabled', '__return_false' );
+
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 503, $response->get_status() );
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertEquals( 'woocommerce_rest_api_v4_shipping_zones_disabled', $data['code'] );
+
+		// Re-enable shipping.
+		remove_filter( 'wc_shipping_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that woocommerce_rest_delete_shipping_zone action hook is fired.
+	 */
+	public function test_delete_item_fires_action_hook() {
+		$zone = $this->create_shipping_zone( 'Hook Test Zone' );
+
+		$hook_fired = false;
+		$hook_zone  = null;
+
+		// Add hook listener.
+		add_action(
+			'woocommerce_rest_delete_shipping_zone',
+			function ( $zone, $response, $request ) use ( &$hook_fired, &$hook_zone ) {
+				$hook_fired = true;
+				$hook_zone  = $zone;
+			},
+			10,
+			3
+		);
+
+		$zone_id = $zone->get_id();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$this->server->dispatch( $request );
+
+		$this->assertTrue( $hook_fired, 'woocommerce_rest_delete_shipping_zone action hook was not fired' );
+		$this->assertNotNull( $hook_zone, 'Hook did not receive zone parameter' );
+		$this->assertEquals( $zone_id, $hook_zone->get_id(), 'Hook received wrong zone' );
+
+		// Remove from cleanup array since it's already deleted.
+		$this->zones = array_filter(
+			$this->zones,
+			function ( $z ) use ( $zone_id ) {
+				return $z->get_id() !== $zone_id;
+			}
+		);
+	}
+
+	/**
+	 * Test delete zone with methods attached.
+	 */
+	public function test_delete_item_with_methods() {
+		$zone = $this->create_shipping_zone( 'Zone with Methods' );
+		$this->add_shipping_method( $zone, 'flat_rate' );
+		$this->add_shipping_method( $zone, 'free_shipping' );
+
+		$zone_id = $zone->get_id();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'methods', $data );
+		$this->assertCount( 2, $data['methods'], 'Response should include the methods that were deleted with the zone' );
+
+		// Verify the zone was actually deleted.
+		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
+		$this->assertFalse( $zone_after, 'Zone should be deleted' );
+
+		// Remove from cleanup array.
+		$this->zones = array_filter(
+			$this->zones,
+			function ( $z ) use ( $zone_id ) {
+				return $z->get_id() !== $zone_id;
+			}
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1525,8 +1525,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	 * Test delete zone with invalid ID.
 	 */
 	public function test_delete_item_invalid_id() {
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
-		$request->set_param( 'force', true );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/99999' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1546,8 +1545,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		$zone_id = $zone->get_id();
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$request->set_param( 'force', true );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1595,8 +1593,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		);
 
 		// Try to delete again.
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$request->set_param( 'force', true );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1613,8 +1610,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
-		$request->set_param( 'force', true );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -1629,8 +1625,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		// Disable shipping temporarily.
 		add_filter( 'wc_shipping_enabled', '__return_false' );
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
-		$request->set_param( 'force', true );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone->get_id() );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1650,9 +1645,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		$this->add_shipping_method( $zone, 'flat_rate' );
 		$this->add_shipping_method( $zone, 'free_shipping' );
 
-		$zone_id = $zone->get_id();
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$request->set_param( 'force', true );
+		$zone_id  = $zone->get_id();
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -1671,48 +1665,5 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 				return $z->get_id() !== $zone_id;
 			}
 		);
-	}
-
-	/**
-	 * Test delete zone without force parameter returns 501.
-	 */
-	public function test_delete_item_without_force_parameter() {
-		$zone = $this->create_shipping_zone( 'Zone Without Force' );
-
-		$zone_id  = $zone->get_id();
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( 501, $response->get_status() );
-		$this->assertArrayHasKey( 'code', $data );
-		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $data['code'] );
-		$this->assertEquals( 'Shipping zones do not support trashing.', $data['message'] );
-
-		// Verify the zone was NOT deleted.
-		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
-		$this->assertNotFalse( $zone_after, 'Zone should not be deleted without force=true' );
-	}
-
-	/**
-	 * Test delete zone with force=false returns 501.
-	 */
-	public function test_delete_item_with_force_false() {
-		$zone = $this->create_shipping_zone( 'Zone With Force False' );
-
-		$zone_id = $zone->get_id();
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
-		$request->set_param( 'force', false );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( 501, $response->get_status() );
-		$this->assertArrayHasKey( 'code', $data );
-		$this->assertEquals( 'woocommerce_rest_trash_not_supported', $data['code'] );
-		$this->assertEquals( 'Shipping zones do not support trashing.', $data['message'] );
-
-		// Verify the zone was NOT deleted.
-		$zone_after = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
-		$this->assertNotFalse( $zone_after, 'Zone should not be deleted with force=false' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -1645,12 +1645,12 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		// Add hook listener.
 		add_action(
 			'woocommerce_rest_delete_shipping_zone',
-			function ( $zone, $response, $request ) use ( &$hook_fired, &$hook_zone ) {
+			function ( $zone ) use ( &$hook_fired, &$hook_zone ) {
 				$hook_fired = true;
 				$hook_zone  = $zone;
 			},
 			10,
-			3
+			1
 		);
 
 		$zone_id = $zone->get_id();
@@ -1678,8 +1678,8 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		$this->add_shipping_method( $zone, 'flat_rate' );
 		$this->add_shipping_method( $zone, 'free_shipping' );
 
-		$zone_id = $zone->get_id();
-		$request = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
+		$zone_id  = $zone->get_id();
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v4/shipping-zones/' . $zone_id );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds DELETE endpoints for removing shipping zones and shipping zone methods in the WooCommerce REST API v4. This completes the CRUD operations for shipping zones in the v4 API.

**Key changes:**

**Shipping Zones:**
- Added `delete_item()` method to `ShippingZones\Controller` (src/Internal/RestApi/Routes/V4/ShippingZones/Controller.php:250-262)
- Registered DELETE route for `/wc/v4/shipping-zones/{id}` endpoint (lines 123-128)

**Shipping Zone Methods:**
- Remove `force` param from the `delete_item()` method to `ShippingZoneMethod\Controller` (src/Internal/RestApi/Routes/V4/ShippingZoneMethod/Controller.php:237-280)

**Design decisions:**
- Response format matches v2/v3 APIs (returns deleted object instead of simple success flag)
- No `force` parameter required - shipping zones and methods are stored as database records without trash support, so deletion is always permanent. This simplifies the API while maintaining the same end behavior.

Closes [#WOO13-80](https://linear.app/a8c/issue/WOO13-80/add-delete-endpoint-for-shipping-zones-v4-api)

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing Shipping Zones DELETE Endpoint

1. **Setup shipping zones:**
   - Navigate to http://localhost:9001/wp-admin/new/woocommerce/settings/shipping/zones
   - Create a new shipping zone (e.g., "Test Zone")
   - Add some locations to the zone (e.g., United States, Canada)
   - Optionally add shipping methods (e.g., Flat Rate, Free Shipping)
   - Note the zone ID from the browser URL

2. **Test DELETE endpoint (success case):**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zones/{zone_id}` (replace with actual zone ID)
   - Verify you receive a 200 status code
   - Verify the response contains the full zone object with fields: `id`, `name`, `order`, `locations`, `methods`
   - Verify the returned data matches the zone that was deleted
   - Verify the shipping zone is removed from the admin interface
   - If the zone had methods, verify they are included in the response and also deleted

3. **Test DELETE endpoint with invalid zone ID:**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zones/99999`
   - Verify you receive a 404 status code
   - Verify error code is `woocommerce_rest_api_v4_shipping_zones_invalid_zone_id`
   - Verify error message indicates "Invalid shipping zone ID."

4. **Test DELETE endpoint with already deleted zone:**
   - Delete a shipping zone via the endpoint
   - Attempt to delete the same zone again using the same zone ID
   - Verify you receive a 404 status code
   - Verify error code is `woocommerce_rest_api_v4_shipping_zones_invalid_zone_id`

5. **Test permission handling:**
   - Make an unauthenticated request to the DELETE endpoint
   - Verify you receive a 401 error
   - Make a request as a customer (non-admin)
   - Verify you receive a 401 error indicating insufficient permissions

6. **Test deleting zone with shipping methods:**
   - Create a zone with multiple shipping methods (Flat Rate, Free Shipping, Local Pickup)
   - Delete the zone via the DELETE endpoint
   - Verify the response includes all the methods that were attached to the zone
   - Verify both the zone and all its methods are removed from the database

#### Testing Shipping Zone Methods DELETE Endpoint

7. **Setup shipping zone method:**
   - Create a shipping zone with at least one shipping method
   - Note the method instance ID (can be found via GET `/wp-json/wc/v4/shipping-zones/{zone_id}` in the methods array)

8. **Test DELETE method endpoint (success case):**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/{instance_id}`
   - Verify you receive a 200 status code
   - Verify the response contains the full method object with fields: `instance_id`, `zone_id`, `method_id`, `enabled`, `settings`
   - Verify the method is removed from the zone

9. **Test DELETE method with invalid ID:**
   - Make a DELETE request to `/wp-json/wc/v4/shipping-zone-method/99999`
   - Verify you receive a 404 status code
   - Verify error code contains `invalid_id`

10. **Test method permission handling:**
    - Make an unauthenticated request to the DELETE method endpoint
    - Verify you receive a 401 error

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
