### PR TITLE
Apply default locale to the Checkout block address forms and reflect this in editor

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -110,11 +110,15 @@ export const STATES = Object.fromEntries(
 	} )
 );
 
-export const COUNTRY_LOCALE = Object.fromEntries(
+const countryLocale = Object.fromEntries(
 	Object.keys( COUNTRIES ).map( ( countryCode ) => {
 		return [ countryCode, countryData[ countryCode ].locale || {} ];
 	} )
 );
+
+// Since "default" is not a country code, we add it separately - this is controlled by the `woocommerce_get_country_locale_default` hook.
+countryLocale.default = countryData?.default?.locale || {};
+export const COUNTRY_LOCALE = countryLocale;
 
 const defaultFieldsLocations: FieldsLocations = {
 	address: [

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -814,9 +814,26 @@ class CheckoutFields {
 		];
 
 		// Merge the "default" country locale with our defined core fields here, we're not using the default locale alone
-		//because it could have fields removed, so merging it with this list ensures we have the full set of fields.
+		// because it could have fields removed, so merging it with this list ensures we have the full set of fields.
 		$default_core_locale = isset( WC()->countries->locale['default'] ) ? WC()->countries->locale['default'] : [];
-		return wc_array_overlay( $blocks_defined_core_fields, $default_core_locale );
+
+		// For each field in $default_core_locale, re-map `priority` to `index` to match our field definition.
+		foreach ( $default_core_locale as $key => $field ) {
+			if ( isset( $field['priority'] ) ) {
+				$default_core_locale[ $key ]['index'] = $field['priority'];
+				unset( $default_core_locale[ $key ]['priority'] );
+			}
+		}
+
+		$merged_locales = wc_array_overlay( $blocks_defined_core_fields, $default_core_locale );
+
+		// Set email and country back to required and not hidden in case they were changed.
+		$merged_locales['email']['required']   = true;
+		$merged_locales['email']['hidden']     = false;
+		$merged_locales['country']['required'] = true;
+		$merged_locales['country']['hidden']   = false;
+
+		return $merged_locales;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -102,9 +102,24 @@ class CheckoutFields {
 	 */
 	public function init() {
 		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'update_default_locale_with_fields' ) );
+		add_filter( 'woocommerce_get_country_locale_default', array( $this, 'move_country_to_top_of_checkout_form' ) );
 		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_fields_data' ) );
 		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_fields_data' ) );
 		add_filter( 'woocommerce_customer_allowed_session_meta_keys', array( $this, 'add_session_meta_keys' ) );
+	}
+
+	/**
+	 * Move country field to the top of the checkout form. This is required because country has a default value of 40
+	 * meaning it comes after First name and last name.
+	 * As per design and for a better UX it should be at the top of the form.
+	 *
+	 * @param array $locale Locale data.
+	 */
+	public function move_country_to_top_of_checkout_form( $locale ) {
+		if ( isset( $locale['country'] ) && is_array( $locale['country'] ) ) {
+			$locale['country']['priority'] = 1;
+		}
+		return $locale;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -677,7 +677,7 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_core_fields() {
-		return [
+		$blocks_defined_core_fields = [
 			'email'      => [
 				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
@@ -812,6 +812,11 @@ class CheckoutFields {
 				'index'          => 100,
 			],
 		];
+
+		// Merge the "default" country locale with our defined core fields here, we're not using the default locale alone
+		//because it could have fields removed, so merging it with this list ensures we have the full set of fields.
+		$default_core_locale = isset( WC()->countries->locale['default'] ) ? WC()->countries->locale['default'] : [];
+		return wc_array_overlay( $blocks_defined_core_fields, $default_core_locale );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -363,6 +363,12 @@ class CartCheckoutUtils {
 			);
 		}
 
+		if ( isset( $country_locales['default'] ) && is_array( $country_locales['default'] ) ) {
+			$country_data['default'] = array(
+					'locale' => $country_locales['default'],
+			);
+		}
+
 		return $country_data;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Before this PR, changes to the default locale would not reflect in the Checkout form, e.g.

```php
add_filter(
	'woocommerce_get_country_locale_default',
	function ( $locales ) {
		$locales['city']['label'] = 'City (modified)';
		$locales['country']['hidden'] = true;
		$locales['country']['required'] = false;
		$locales['first_name']['priority'] = 40;
		$locales['first_name']['label'] = "Given name";
		$locales['last_name']['priority'] = 30;
		return $locales;
	}
);
```

Would not update either in the editor, or on the front end.

The locale for a specific country should be derived from:

Default locale -> Country-specific locale applied over the top -> any further changes mandated by WC core (e.g. forcing email and country to be `required` and not `hidden`).

This PR changes the following:

1. Adds a `default` key to the result of `CartCheckoutUtils::get_country_data` which contains the default locale. Every other country's locale is there, so it makes sense to include the default locale, imo.
2. When generating the list of core fields in `CheckoutFields:get_core_fields` merge the default locale over the top of core fields **but** ensure country and email get set back to required _and_ not hidden.
3. Re-map the default locale's index to the blocks core fields priority.
4. Add a filter to move country to the top of the checkout form. The country field is at the top for design/UX purposes, but since the default locale has it in third position (after first name and second name) it needs to be overridden. This previously wasn't an issue as default locale wasn't being applied.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

With the snippet mentioned above, this is the before/after in the front-end.

| Before | After |
| ------ | ----- |
|  <img width="697" height="408" alt="image" src="https://github.com/user-attachments/assets/d1324d9f-702d-4e91-bc30-e12363865d3f" /> | <img width="678" height="398" alt="image" src="https://github.com/user-attachments/assets/b3d4a30d-78af-4abf-8f92-2a0edde38163" /> |


And in the editor

| Before | After |
| ------ | ----- |
| <img width="832" height="411" alt="image" src="https://github.com/user-attachments/assets/ec483a44-a811-4767-8e26-e7bee75dfd95" /> | <img width="808" height="410" alt="image" src="https://github.com/user-attachments/assets/acf97cf3-e169-44e9-87ff-e041ee3af5ed" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
6.
7.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
