### PR TITLE
Ensuring transient value is an array

### DIFF
--- a/plugins/woocommerce/changelog/62025-fix-61981
+++ b/plugins/woocommerce/changelog/62025-fix-61981
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP 8.4 fatal error in WooCommerce Helper updater when transient contains malformed data

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -602,6 +602,34 @@ class WC_Helper_Updater {
 	}
 
 	/**
+	 * Validates cached update data and checks if it matches the expected hash.
+	 *
+	 * Ensures the cached data is properly structured and corresponds to the current
+	 * payload to prevent fatal errors and avoid stale cache returns.
+	 *
+	 * @since 10.3.6
+	 *
+	 * @param mixed  $data The data retrieved from the transient.
+	 * @param string $hash The expected hash to compare against.
+	 * @return bool True if the data is valid and hash matches, false otherwise.
+	 */
+	private static function should_use_cached_update_data( $data, $hash ) {
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+
+		if ( ! isset( $data['hash'], $data['products'] ) ) {
+			return false;
+		}
+
+		if ( ! is_string( $data['hash'] ) || ! is_array( $data['products'] ) ) {
+			return false;
+		}
+
+		return hash_equals( $hash, $data['hash'] );
+	}
+
+	/**
 	 * Run an update check API call.
 	 *
 	 * The call is cached based on the payload (product ids, file ids). If
@@ -619,10 +647,9 @@ class WC_Helper_Updater {
 
 		$cache_key = '_woocommerce_helper_updates';
 		$data      = get_transient( $cache_key );
-		if ( false !== $data && is_array( $data ) ) {
-			if ( hash_equals( $hash, $data['hash'] ) ) {
-				return $data['products'];
-			}
+
+		if ( self::should_use_cached_update_data( $data, $hash ) ) {
+			return $data['products'];
 		}
 
 		$data = array(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -619,7 +619,7 @@ class WC_Helper_Updater {
 
 		$cache_key = '_woocommerce_helper_updates';
 		$data      = get_transient( $cache_key );
-		if ( false !== $data ) {
+		if ( false !== $data && is_array( $data ) ) {
 			if ( hash_equals( $hash, $data['hash'] ) ) {
 				return $data['products'];
 			}

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Unit tests for WC_Helper_Updater class
+ *
+ * @package WooCommerce\Tests\Admin\Helper
+ */
+
+declare(strict_types=1);
+
+/**
+ * Class WC_Helper_Updater_Test
+ */
+class WC_Helper_Updater_Test extends WC_Unit_Test_Case {
+	private $mocked_updates = array(
+		123 => array(
+			'version'        => '2.0.0',
+			'url'            => 'https://woocommerce.com/products/test',
+			'package'        => 'https://woocommerce.com/package.zip',
+			'slug'           => 'test-plugin',
+			'upgrade_notice' => 'New version available',
+		),
+	);
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->cleanup_transients();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		$this->cleanup_transients();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Clean up transients used by WC_Helper_Updater.
+	 */
+	private function cleanup_transients() {
+		delete_transient( '_woocommerce_helper_updates' );
+		delete_transient( '_woocommerce_helper_updates_count' );
+	}
+
+	/**
+	 * Helper method to call private _update_check method via reflection.
+	 *
+	 * @param array $payload The payload to pass to _update_check.
+	 * @return array The result from _update_check.
+	 */
+	private function call_update_check( $payload ) {
+		$reflection = new ReflectionClass( 'WC_Helper_Updater' );
+		$method     = $reflection->getMethod( '_update_check' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $payload );
+	}
+
+	/**
+	 * Test that _update_check handles malformed transient data (i.e. string instead of array).
+	 */
+	public function test_update_check_handles_malformed_string_transient() {
+		set_transient( '_woocommerce_helper_updates', 'malformed_string_data', HOUR_IN_SECONDS );
+
+		// Mock WC_Helper and WC_Helper_API to avoid external dependencies.
+		add_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ), 10, 3 );
+
+		$payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		$result = $this->call_update_check( $payload );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ) );
+
+		$this->assertIsArray( $result, 'Result should be an array even when transient was malformed' );
+		$this->assertEquals( $this->mocked_updates, $result, 'Result should match mocked updates' );
+	}
+
+	/**
+	 * Test that _update_check handles valid cached data with matching hash.
+	 */
+	public function test_update_check_returns_cached_data_with_matching_hash() {
+		$payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		ksort( $payload );
+		$hash = md5( wp_json_encode( $payload ) );
+
+		$cached_data = array(
+			'hash'     => $hash,
+			'updated'  => time(),
+			'products' => array(
+				123 => array(
+					'version'        => '1.2.3',
+					'url'            => 'https://woocommerce.com/products/test',
+					'package'        => 'https://woocommerce.com/package.zip',
+					'slug'           => 'test-plugin',
+					'upgrade_notice' => 'Test upgrade notice',
+				),
+			),
+			'errors'   => array(),
+		);
+
+		set_transient( '_woocommerce_helper_updates', $cached_data, HOUR_IN_SECONDS );
+
+		// Should return cached products without making API call.
+		$result = $this->call_update_check( $payload );
+
+		$this->assertEquals( $cached_data['products'], $result, 'Result should match cached version' );
+	}
+
+	/**
+	 * Test that _update_check refreshes cache when hash doesn't match.
+	 */
+	public function test_update_check_refreshes_cache_with_mismatched_hash() {
+		$old_payload = array(
+			456 => array(
+				'product_id' => 456,
+				'file_id'    => 'old456',
+			),
+		);
+
+		ksort( $old_payload );
+		$old_hash = md5( wp_json_encode( $old_payload ) );
+
+		$cached_data = array(
+			'hash'     => $old_hash,
+			'updated'  => time(),
+			'products' => array(
+				456 => array(
+					'version' => '1.0.0',
+				),
+			),
+			'errors'   => array(),
+		);
+
+		set_transient( '_woocommerce_helper_updates', $cached_data, HOUR_IN_SECONDS );
+
+		// Mock API response for new payload.
+		add_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ), 10, 3 );
+
+		$new_payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		$result = $this->call_update_check( $new_payload );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ) );
+
+		// Should have made new API call and returned fresh data.
+		$this->assertEquals( $this->mocked_updates, $result, 'Result should match mocked updates' );
+	}
+
+	/**
+	 * Test that _update_check handles false transient (cache miss).
+	 */
+	public function test_update_check_handles_false_transient() {
+		// Ensure transient is false (cache miss).
+		delete_transient( '_woocommerce_helper_updates' );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ), 10, 3 );
+
+		$payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		$result = $this->call_update_check( $payload );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ) );
+
+		// Should have made new API call and returned fresh data.
+		$this->assertEquals( $this->mocked_updates, $result, 'Result should match mocked updates' );
+	}
+
+	/**
+	 * Test that _update_check handles empty payload.
+	 */
+	public function test_update_check_handles_empty_payload() {
+		$result = $this->call_update_check( array() );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Result should be empty for empty payload' );
+	}
+
+	/**
+	 * Test that _update_check handles numeric transient data (edge case).
+	 */
+	public function test_update_check_handles_numeric_transient() {
+		// Set up transient with numeric value.
+		set_transient( '_woocommerce_helper_updates', 12345, HOUR_IN_SECONDS );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ), 10, 3 );
+
+		$payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		// Should not throw error.
+		$result = $this->call_update_check( $payload );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ) );
+
+		// Should have made new API call and returned fresh data.
+		$this->assertEquals( $this->mocked_updates, $result, 'Result should match mocked updates' );
+	}
+
+	/**
+	 * Test that _update_check handles null transient data (edge case).
+	 */
+	public function test_update_check_handles_null_transient() {
+		// Set up transient with null value (though WordPress would typically convert to false).
+		set_transient( '_woocommerce_helper_updates', null, HOUR_IN_SECONDS );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ), 10, 3 );
+
+		$payload = array(
+			123 => array(
+				'product_id' => 123,
+				'file_id'    => 'abc123',
+			),
+		);
+
+		// Should not throw error.
+		$result = $this->call_update_check( $payload );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_helper_api_response' ) );
+
+		// Should have made new API call and returned fresh data.
+		$this->assertEquals( $this->mocked_updates, $result, 'Result should match mocked updates' );
+	}
+
+	/**
+	 * Test that flush_updates_cache clears all relevant transients.
+	 */
+	public function test_flush_updates_cache_clears_transients() {
+		// Set up transients.
+		set_transient( '_woocommerce_helper_updates', array( 'test' => 'data' ), HOUR_IN_SECONDS );
+		set_transient( '_woocommerce_helper_updates_count', 5, HOUR_IN_SECONDS );
+
+		// Verify transients are set.
+		$this->assertNotFalse( get_transient( '_woocommerce_helper_updates' ), 'Updates transient should be set' );
+		$this->assertNotFalse( get_transient( '_woocommerce_helper_updates_count' ), 'Count transient should be set' );
+
+		// Flush cache.
+		WC_Helper_Updater::flush_updates_cache();
+
+		// Verify transients are cleared.
+		$this->assertFalse( get_transient( '_woocommerce_helper_updates' ), 'Updates transient should be cleared' );
+		$this->assertFalse( get_transient( '_woocommerce_helper_updates_count' ), 'Count transient should be cleared' );
+	}
+
+	/**
+	 * Test that upgrader_process_complete clears the count transient.
+	 */
+	public function test_upgrader_process_complete_clears_count_transient() {
+		// Set up count transient.
+		set_transient( '_woocommerce_helper_updates_count', 5, HOUR_IN_SECONDS );
+
+		$this->assertNotFalse( get_transient( '_woocommerce_helper_updates_count' ), 'Count transient should be set' );
+
+		// Trigger upgrader complete.
+		WC_Helper_Updater::upgrader_process_complete();
+
+		// Verify count transient is cleared.
+		$this->assertFalse( get_transient( '_woocommerce_helper_updates_count' ), 'Count transient should be cleared after upgrade' );
+	}
+
+	/**
+	 * Mock WC_Helper_API response for testing.
+	 *
+	 * @param false|array|WP_Error $preempt A preemptive return value of an HTTP request.
+	 * @param array                $args HTTP request arguments.
+	 * @param string               $url The request URL.
+	 * @return array Mocked response.
+	 */
+	public function mock_helper_api_response( $preempt, $args, $url ) {
+		// Only mock WooCommerce.com API calls.
+		if ( strpos( $url, 'woocommerce.com' ) === false && strpos( $url, 'api.woocommerce.com' ) === false ) {
+			return $preempt;
+		}
+
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode( $this->mocked_updates ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
  * Class WC_Helper_Updater_Test
  */
 class WC_Helper_Updater_Test extends WC_Unit_Test_Case {
+	/**
+	 * The mocked response for 'update-check' API used for the tests.
+	 *
+	 * @var array
+	 */
 	private $mocked_updates = array(
 		123 => array(
 			'version'        => '2.0.0',

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-updater-test.php
@@ -67,6 +67,21 @@ class WC_Helper_Updater_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper method to call private should_use_cached_update_data method via reflection.
+	 *
+	 * @param mixed  $data The cached data to validate.
+	 * @param string $hash The expected hash.
+	 * @return bool The result from should_use_cached_update_data.
+	 */
+	private function call_should_use_cached_update_data( $data, $hash ) {
+		$reflection = new ReflectionClass( 'WC_Helper_Updater' );
+		$method     = $reflection->getMethod( 'should_use_cached_update_data' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $data, $hash );
+	}
+
+	/**
 	 * Test that _update_check handles malformed transient data (i.e. string instead of array).
 	 */
 	public function test_update_check_handles_malformed_string_transient() {
@@ -290,6 +305,133 @@ class WC_Helper_Updater_Test extends WC_Unit_Test_Case {
 
 		// Verify count transient is cleared.
 		$this->assertFalse( get_transient( '_woocommerce_helper_updates_count' ), 'Count transient should be cleared after upgrade' );
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns false when data is not an array.
+	 */
+	public function test_should_use_cached_update_data_rejects_non_array() {
+		$hash = 'test_hash';
+
+		$this->assertFalse( $this->call_should_use_cached_update_data( 'string', $hash ), 'Should reject string data' );
+		$this->assertFalse( $this->call_should_use_cached_update_data( 123, $hash ), 'Should reject numeric data' );
+		$this->assertFalse( $this->call_should_use_cached_update_data( null, $hash ), 'Should reject null data' );
+		$this->assertFalse( $this->call_should_use_cached_update_data( false, $hash ), 'Should reject false data' );
+		$this->assertFalse( $this->call_should_use_cached_update_data( true, $hash ), 'Should reject boolean data' );
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns false when required keys are missing.
+	 */
+	public function test_should_use_cached_update_data_rejects_missing_keys() {
+		$hash = 'test_hash';
+
+		// Missing both keys.
+		$this->assertFalse( $this->call_should_use_cached_update_data( array(), $hash ), 'Should reject empty array' );
+
+		// Missing 'hash' key.
+		$data = array( 'products' => array() );
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, $hash ), 'Should reject data without hash key' );
+
+		// Missing 'products' key.
+		$data = array( 'hash' => $hash );
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, $hash ), 'Should reject data without products key' );
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns false when hash is not a string.
+	 */
+	public function test_should_use_cached_update_data_rejects_non_string_hash() {
+		$data = array(
+			'hash'     => 123, // Not a string.
+			'products' => array(),
+		);
+
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, 'test_hash' ), 'Should reject numeric hash' );
+
+		$data['hash'] = null;
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, 'test_hash' ), 'Should reject null hash' );
+
+		$data['hash'] = array( 'hash' );
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, 'test_hash' ), 'Should reject array hash' );
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns false when products is not an array.
+	 */
+	public function test_should_use_cached_update_data_rejects_non_array_products() {
+		$hash = 'test_hash';
+
+		$data = array(
+			'hash'     => $hash,
+			'products' => 'string', // Not an array.
+		);
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, $hash ), 'Should reject string products' );
+
+		$data['products'] = 123;
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, $hash ), 'Should reject numeric products' );
+
+		$data['products'] = null;
+		$this->assertFalse( $this->call_should_use_cached_update_data( $data, $hash ), 'Should reject null products' );
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns false when hash doesn't match.
+	 */
+	public function test_should_use_cached_update_data_rejects_mismatched_hash() {
+		$data = array(
+			'hash'     => 'cached_hash',
+			'products' => array(
+				123 => array( 'version' => '1.0.0' ),
+			),
+		);
+
+		$this->assertFalse(
+			$this->call_should_use_cached_update_data( $data, 'different_hash' ),
+			'Should reject data with mismatched hash'
+		);
+	}
+
+	/**
+	 * Test should_use_cached_update_data returns true when all validation passes.
+	 */
+	public function test_should_use_cached_update_data_accepts_valid_data() {
+		$hash = 'matching_hash';
+		$data = array(
+			'hash'     => $hash,
+			'products' => array(
+				123 => array(
+					'version' => '2.0.0',
+					'url'     => 'https://woocommerce.com/products/test',
+				),
+			),
+			'updated'  => time(),
+			'errors'   => array(),
+		);
+
+		$this->assertTrue(
+			$this->call_should_use_cached_update_data( $data, $hash ),
+			'Should accept valid data with matching hash'
+		);
+	}
+
+	/**
+	 * Test should_use_cached_update_data accepts valid data even with extra keys.
+	 */
+	public function test_should_use_cached_update_data_accepts_data_with_extra_keys() {
+		$hash = 'test_hash';
+		$data = array(
+			'hash'        => $hash,
+			'products'    => array(),
+			'updated'     => time(),
+			'errors'      => array(),
+			'extra_field' => 'extra_value', // Extra key should not cause rejection.
+		);
+
+		$this->assertTrue(
+			$this->call_should_use_cached_update_data( $data, $hash ),
+			'Should accept valid data with extra keys'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a critical PHP 8.4 compatibility issue where the WooCommerce Helper updater crashes with a fatal `TypeError` when the `_woocommerce_helper_updates` transient contains malformed string data instead of the expected array.

**Problem:**
- On PHP 8.4, attempting to access array offsets on a string value throws a fatal `TypeError`
- The `WC_Helper_Updater::_update_check()` method was attempting to access `$data['hash']` and `$data['products']` without validating that `$data` is actually an array
- When the transient becomes corrupted or contains unexpected string data, fatal error is thrown

**Solution:**
- Add type validation to ensure `$data` is an array before attempting array access
- Changed condition from `if ( false !== $data )` to `if ( false !== $data && is_array( $data ) )`
- This allows the updater to safely handle malformed transient data by treating it as a cache miss and refreshing the data

Closes #61981
Closes WOOPLUG-5866

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Testing the fix:**

1. Set up a test site with PHP 8.4 and WooCommerce 10.3.5+
2. Manually corrupt the transient to simulate the issue:
   ```
   pnpm wp-env run cli wp transient set _woocommerce_helper_updates ''
   ```

3. Visit WooCommerce Extensions page at http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions
4. Verify that the site loads without errors
5. Check that the helper updates functionality continues to work normally

**Expected behavior:**

No fatal errors occur

### Testing that has already taken place:

- Code review and analysis of the crash scenario from merchant logs (site 10488304-zen)
- Verification that the fix handles the specific PHP 8.4 TypeError mentioned in issue #61981
- Confirmed that adding `is_array()` check prevents array access on string values
- The fix is minimal and defensive, only adding type validation without changing existing logic

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix PHP 8.4 fatal error in WooCommerce Helper updater when transient contains malformed data

</details>