### PR TITLE
Reduce options loaded on admin page loads

### DIFF
--- a/plugins/woocommerce/changelog/fix-61860-misc
+++ b/plugins/woocommerce/changelog/fix-61860-misc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Reduce options queried on admin page loads.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -63,7 +63,7 @@ class WC_Admin_Notices {
 
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
-		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
+		add_action( 'update_option_woocommerce_file_download_method', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
 		add_action( 'admin_init', array( __CLASS__, 'maybe_remove_legacy_api_removal_notice' ), 20 );
 

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -24,6 +24,7 @@ class WC_Notes_Refund_Returns {
 	 * Attach hooks.
 	 */
 	public static function init() {
+		add_action( 'wc_notes_refund_returns_page_created', array( __CLASS__, 'possibly_add_note' ) );
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
 	}
 
@@ -33,6 +34,10 @@ class WC_Notes_Refund_Returns {
 	 * @param int $page_id The ID of the page.
 	 */
 	public static function possibly_add_note( $page_id ) {
+		if ( ! WC()->is_wc_admin_active() ) {
+			return;
+		}
+
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// Do we already have this note?

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -351,7 +351,6 @@ class WC_Install {
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_email_improvements_for_newly_installed' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_customer_stock_notifications_signups' ), 20 );
 		add_action( 'woocommerce_updated', array( __CLASS__, 'enable_email_improvements_for_existing_merchants' ), 20 );
-		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'woocommerce_update_db_to_current_version', array( __CLASS__, 'update_db_version' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
@@ -2945,7 +2944,7 @@ EOT;
 
 	/**
 	 * When pages are created, we might want to take some action.
-	 * In this case we want to set an option when refund and returns
+	 * In this case we want to create an admin note when the refund and returns
 	 * page is created.
 	 *
 	 * @since 5.6.0
@@ -2955,8 +2954,9 @@ EOT;
 	 */
 	public static function page_created( $page_id, $page_data ) {
 		if ( 'refund_returns' === $page_data['post_name'] ) {
-			delete_option( 'woocommerce_refund_returns_page_created' );
-			add_option( 'woocommerce_refund_returns_page_created', $page_id, '', false );
+			if ( WC()->is_wc_admin_active() ) {
+				WC_Notes_Refund_Returns::possibly_add_note( $page_id );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2958,7 +2958,9 @@ EOT;
 	 */
 	public static function page_created( $page_id, $page_data ) {
 		if ( 'refund_returns' === $page_data['post_name'] ) {
-			if ( WC()->is_wc_admin_active() ) {
+			if ( Constants::is_true( 'WC_INSTALLING' ) ) {
+				as_schedule_single_action( time() + MINUTE_IN_SECONDS, 'wc_notes_refund_returns_page_created', array( $page_id ), 'woocommerce', true );
+			} else {
 				WC_Notes_Refund_Returns::possibly_add_note( $page_id );
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2926,9 +2926,13 @@ EOT;
 	 * Refund and returns page.
 	 *
 	 * @since 5.6.0
+	 * @deprecated 10.5.0 No longer used.
+	 *
 	 * @return void
 	 */
 	public static function add_admin_note_after_page_created() {
+		wc_deprecated_function( 'WC_Install::add_admin_note_after_page_created', '10.5.0' );
+
 		if ( ! WC()->is_wc_admin_active() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -55,9 +55,7 @@ class Register {
 		add_action(
 			'before_woocommerce_init',
 			function() {
-				if ( get_option( Synchronize::SYNC_TASK_PAGE ) > 0 ) {
-					wc_get_container()->get( Synchronize::class )->init_hooks();
-				}
+				wc_get_container()->get( Synchronize::class )->init_hooks();
 			}
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of #61860, we're reworking some of the code to reduce the number of options that are unnecessarily queried on admin/frontend pages. This PR handles `woocommerce_refund_returns_page_created`, `woocommerce_file_download_method` and `wc_product_download_dir_sync_page`.

Related to #61860.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Install Query Monitor on your test site.
1. Confirm that there are no queries on the admin side for any of these options:
   ```
   woocommerce_refund_returns_page_created
   woocommerce_file_download_method
   wc_product_download_dir_sync_page
   ```

   **Optional:** Check that on `trunk` these options are queried on every admin page load.

   <img width="1325" height="82" alt="Screenshot 2025-11-19 at 14 43 49" src="https://github.com/user-attachments/assets/de869850-662d-420f-867a-58fcdbc58e06" />
1. Check `woocommerce_file_download_method` warning continues to work:
   1. Go to **WooCommerce > Settings > Products > Downloadable products** and choose **Redirect only** as **File download method**.
   1. Confirm that you see the following notice about this method being deprecated:
      <img width="1313" height="103" alt="Screenshot 2025-11-19 at 14 44 38" src="https://github.com/user-attachments/assets/11b82ad7-d8c7-4971-9d3e-cd8e458cdb73" />
   1. Change the setting to **Force downloads** and save changes.
   1. Confirm the notice is now gone.
1. Check that approved download dirs sync works correctly:
   1. Go to **WooCommerce > Status > Tools** and run the **Synchronize approved download directories** tool.
   1. Wait for a bit or manually run A-S jobs using `wp action-scheduler run`.
   1. You should now see the following notice on **WooCommerce > Settings** (and other WC-related pages):    
      <img width="1332" height="76" alt="Screenshot 2025-11-19 at 19 33 55" src="https://github.com/user-attachments/assets/efd96324-10e4-461d-b56d-e9495e31f5ca" />
1. Check that refunds note still works correctly:
   1. Go to **Pages** and trash and permanently delete the _Refund and Returns Policy_ page if your site has one.
   1. Run the following commands to simulate the note not existing:
      ```
      wp db query "DELETE FROM $(wp db prefix)wc_admin_notes WHERE name = 'wc-refund-returns-page'"
      wp db query "DELETE FROM $(wp db prefix)wc_admin_note_actions WHERE name = 'notify-refund-returns-page'"
      ```
   1. Go to **WooCommerce > Status > Tools** and run the **Create default WooCommerce pages** tool.
   1. After the page refreshes, click **Activity** and you should have a notification about your refunds page in there:
      <img width="483" height="280" alt="Screenshot 2025-11-19 at 15 02 49" src="https://github.com/user-attachments/assets/6877832d-9ad2-4176-b0cf-4d4161d235cd" />

<!-- End testing instructions -->