### PR TITLE
Add tax label to regular and sales price in admin

### DIFF
--- a/plugins/woocommerce/changelog/62044-patch-10
+++ b/plugins/woocommerce/changelog/62044-patch-10
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add translatable “(incl. tax)” / “(excl. tax)” labels to product price fields depending on WooCommerce tax settings.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -49,15 +49,18 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 			<span class="show_if_simple show_if_external">
 		<?php endif; ?>
 		<?php
-			$tax_label = wc_tax_enabled()
-			? ( wc_prices_include_tax() ? ' ' . __( 'incl. tax', 'woocommerce' ) : ' ' . __( 'excl. tax', 'woocommerce' ) )
-			: '';
+			if ( wc_tax_enabled() ) {
+				$tax_text = wc_prices_include_tax()
+					? __( 'incl. tax', 'woocommerce' )
+					: __( 'excl. tax', 'woocommerce' );
+				$tax_label = ' (' . $tax_text . ')';
+			}
 
 			woocommerce_wp_text_input(
 				array(
 					'id'        => '_regular_price',
 					'value'     => $product_object->get_regular_price( 'edit' ),
-					'label'     => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ( $tax_label ? ' ' . $tax_label : '' ) . ')',
+					'label'     => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')' . $tax_label,
 					'data_type' => 'price',
 				)
 			);
@@ -67,7 +70,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 					'id'          => '_sale_price',
 					'value'       => $product_object->get_sale_price( 'edit' ),
 					'data_type'   => 'price',
-					'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ( $tax_label ? ' ' . $tax_label : '' ) . ')',
+					'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')' . $tax_label,
 					'description' => '<a href="#" class="sale_schedule">' . __( 'Schedule', 'woocommerce' ) . '</a>',
 				)
 			);

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -52,7 +52,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 			if ( wc_tax_enabled() ) {
 				$tax_text = wc_prices_include_tax()
 					? __( 'incl. tax', 'woocommerce' )
-					: __( 'excl. tax', 'woocommerce' );
+					: __( 'ex. tax', 'woocommerce' );
 				$tax_label = ' (' . $tax_text . ')';
 			}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -49,6 +49,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 			<span class="show_if_simple show_if_external">
 		<?php endif; ?>
 		<?php
+		$tax_label = '';
 		if ( wc_tax_enabled() ) {
 			$tax_text  = wc_prices_include_tax()
 				? __( 'incl. tax', 'woocommerce' )

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -49,11 +49,15 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 			<span class="show_if_simple show_if_external">
 		<?php endif; ?>
 		<?php
+			$tax_label = wc_tax_enabled()
+			? ( wc_prices_include_tax() ? ' ' . __( 'incl. tax', 'woocommerce' ) : ' ' . __( 'excl. tax', 'woocommerce' ) )
+			: '';
+
 			woocommerce_wp_text_input(
 				array(
 					'id'        => '_regular_price',
 					'value'     => $product_object->get_regular_price( 'edit' ),
-					'label'     => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
+					'label'     => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ( $tax_label ? ' ' . $tax_label : '' ) . ')',
 					'data_type' => 'price',
 				)
 			);
@@ -63,7 +67,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 					'id'          => '_sale_price',
 					'value'       => $product_object->get_sale_price( 'edit' ),
 					'data_type'   => 'price',
-					'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
+					'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ( $tax_label ? ' ' . $tax_label : '' ) . ')',
 					'description' => '<a href="#" class="sale_schedule">' . __( 'Schedule', 'woocommerce' ) . '</a>',
 				)
 			);

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -49,12 +49,12 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 			<span class="show_if_simple show_if_external">
 		<?php endif; ?>
 		<?php
-			if ( wc_tax_enabled() ) {
-				$tax_text = wc_prices_include_tax()
-					? __( 'incl. tax', 'woocommerce' )
-					: __( 'ex. tax', 'woocommerce' );
-				$tax_label = ' (' . $tax_text . ')';
-			}
+		if ( wc_tax_enabled() ) {
+			$tax_text  = wc_prices_include_tax()
+				? __( 'incl. tax', 'woocommerce' )
+				: __( 'ex. tax', 'woocommerce' );
+			$tax_label = ' (' . $tax_text . ')';
+		}
 
 			woocommerce_wp_text_input(
 				array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -138,7 +138,7 @@ defined( 'ABSPATH' ) || exit;
 				<?php
 
 				if ( wc_tax_enabled() ) {
-					$tax_text = wc_prices_include_tax()
+					$tax_text  = wc_prices_include_tax()
 						? __( 'incl. tax', 'woocommerce' )
 						: __( 'ex. tax', 'woocommerce' );
 					$tax_label = ' (' . $tax_text . ')';

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -137,9 +137,12 @@ defined( 'ABSPATH' ) || exit;
 			<div class="variable_pricing">
 				<?php
 
-				$tax_label = wc_tax_enabled()
-				? ( wc_prices_include_tax() ? ' ' . __( 'incl. tax', 'woocommerce' ) : ' ' . __( 'excl. tax', 'woocommerce' ) )
-				: '';
+				if ( wc_tax_enabled() ) {
+					$tax_text = wc_prices_include_tax()
+						? __( 'incl. tax', 'woocommerce' )
+						: __( 'ex. tax', 'woocommerce' );
+					$tax_label = ' (' . $tax_text . ')';
+				}
 
 				$label = sprintf(
 					/* translators: 1: currency symbol, 2: tax label (prefixed with space if present) */

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -137,6 +137,7 @@ defined( 'ABSPATH' ) || exit;
 			<div class="variable_pricing">
 				<?php
 
+				$tax_label = '';
 				if ( wc_tax_enabled() ) {
 					$tax_text  = wc_prices_include_tax()
 						? __( 'incl. tax', 'woocommerce' )

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -136,10 +136,16 @@ defined( 'ABSPATH' ) || exit;
 
 			<div class="variable_pricing">
 				<?php
+
+				$tax_label = wc_tax_enabled()
+				? ( wc_prices_include_tax() ? ' ' . __( 'incl. tax', 'woocommerce' ) : ' ' . __( 'excl. tax', 'woocommerce' ) )
+				: '';
+
 				$label = sprintf(
-					/* translators: %s: currency symbol */
-					__( 'Regular price (%s)', 'woocommerce' ),
-					get_woocommerce_currency_symbol()
+					/* translators: 1: currency symbol, 2: tax label (prefixed with space if present) */
+					__( 'Regular price (%1$s%2$s)', 'woocommerce' ),
+					get_woocommerce_currency_symbol(),
+					$tax_label ? ' ' . $tax_label : ''
 				);
 
 				woocommerce_wp_text_input(
@@ -155,9 +161,10 @@ defined( 'ABSPATH' ) || exit;
 				);
 
 				$label = sprintf(
-					/* translators: %s: currency symbol */
-					__( 'Sale price (%s)', 'woocommerce' ),
-					get_woocommerce_currency_symbol()
+					/* translators: 1: currency symbol, 2: tax label (prefixed with space if present) */
+					__( 'Sale price (%1$s%2$s)', 'woocommerce' ),
+					get_woocommerce_currency_symbol(),
+					$tax_label ? ' ' . $tax_label : ''
 				);
 
 				woocommerce_wp_text_input(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR improves clarity in the WooCommerce product edit screen by appending a translated “(incl. tax)” or “(excl. tax)” label to the Regular Price and Sale Price fields. The indicator is automatically determined based on the store’s tax configuration at
WooCommerce → Settings → Tax → Prices entered with tax, while handling scenarios where taxes are fully disabled.

This enhancement helps merchants understand whether product prices should be entered including or excluding tax, reducing confusion and data entry mistakes.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #29780 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|Price fields shown without any tax context.|<img width="880" height="136" alt="image" src="https://github.com/user-attachments/assets/05aacfec-be24-456d-820b-47115e09e01b" />|
|Price fields shown without any tax context.|<img width="852" height="121" alt="image" src="https://github.com/user-attachments/assets/683e7dce-fdf7-4f58-8d58-713933ee2c11" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To be tested options:
 -Go to WooCommerce → Settings → General and enable/disable taxes.
- Go to WooCommerce → Settings → Tax and change Prices entered with tax:
A) Set to Yes, I will enter prices inclusive of tax.
B) Set to No, I will enter prices exclusive of tax.

1. Apply patch
2. set taxes to be disabled
3. check if behaviour before applied patch still is the same (only currency)
4. activate taxes, set to prices inclusive of tax
5. check edit product screen if incl. tax is shown next to currency
6. set to prices exclusive of tax
7. check edit product screen if excl. tax is shown next to currency

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry
Add translatable “(incl. tax)” / “(excl. tax)” labels to product price fields depending on WooCommerce tax settings.
<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add translatable “(incl. tax)” / “(excl. tax)” labels to product price fields depending on WooCommerce tax settings.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
