### PR TITLE
Compatibility with WP 6.9: improve the way woocommerce-blocktheme styles are enqueued

### DIFF
--- a/plugins/woocommerce/changelog/fix-62028
+++ b/plugins/woocommerce/changelog/fix-62028
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Compatibility with WP 6.9: improve the way WooCommerce block theme styles are enqueued

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -55,6 +55,7 @@ class WC_Frontend_Scripts {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'load_scripts' ) );
 		add_action( 'wp_print_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
 		add_action( 'wp_print_footer_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'enqueue_block_assets' ) );
 	}
 
 	/**
@@ -96,16 +97,31 @@ class WC_Frontend_Scripts {
 					'media'   => 'all',
 					'has_rtl' => true,
 				),
-				'woocommerce-blocktheme'  => wp_is_block_theme() ? array(
-					'src'     => self::get_asset_url( 'assets/css/woocommerce-blocktheme.css' ),
-					'deps'    => '',
-					'version' => $version,
-					'media'   => 'all',
-					'has_rtl' => true,
-				) : false,
 			)
 		);
 		return is_array( $styles ) ? array_filter( $styles ) : array();
+	}
+
+	/**
+	 * Enqueue styles for block assets (both editor and frontend).
+	 * This ensures compatibility with WordPress 6.9+ requirements.
+	 */
+	public static function enqueue_block_assets() {
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+
+		$version = Constants::get_constant( 'WC_VERSION' );
+
+		wp_enqueue_style(
+			'woocommerce-blocktheme',
+			self::get_asset_url( 'assets/css/woocommerce-blocktheme.css' ),
+			array(),
+			$version,
+			'all'
+		);
+
+		wp_style_add_data( 'woocommerce-blocktheme', 'rtl', 'replace' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes WordPress 6.9 compatibility issue where `woocommerce-blocktheme-css` was triggering a deprecation warning when loaded in editor iframes.

WordPress 6.9 requires styles intended for editor iframes to be enqueued via `enqueue_block_assets` or `enqueue_block_editor_assets` hooks, not just `wp_enqueue_scripts`.

**Changes:**
- Moved `woocommerce-blocktheme` stylesheet from `get_styles()` to new `enqueue_block_assets()` method
- Added `enqueue_block_assets` hook to properly load styles in both frontend and editor contexts
- Maintains RTL support and block theme conditional loading

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/62028

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1168" height="209" alt="image" src="https://github.com/user-attachments/assets/35b7ff73-9f54-4b1c-8a30-01c1b7c39d0b" />    |    <img width="1170" height="175" alt="image" src="https://github.com/user-attachments/assets/ee420e96-23f5-4714-b481-79796ddce088" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With WordPress 6.9 (at the moment of submitting this PR, the latest version is RC2):
1. Create new page
2. Check console
3. **Expected:**
    - there's no deprecation warning like `woocommerce-blocktheme-css was added to the iframe incorrectly...`
    - check Network tab and make sure `woocommerce-blocktheme.css` is fetched
4. Save and go to frontend
5. **Expected:** check Network tab and make sure `woocommerce-blocktheme.css` is fetched
4. Repeat with WordPress 6.8.3

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
