### PR TITLE
Update email template design and improve structure for better styling control

### DIFF
--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -64,7 +64,9 @@ function TemplateListBox( {
 		styles.reduce( ( acc, style ) => {
 			return acc + ( style.css ?? '' );
 		}, '' ) +
-		`.is-root-container { width: ${ layout.contentSize }; margin: 0 auto; }`;
+		`.is-root-container { width: ${
+			layout?.contentSize || '660px'
+		}; margin: 0 auto; }`;
 
 	if ( selectedCategory === 'recent' && templates.length === 0 ) {
 		return <TemplateNoResults />;

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -60,7 +60,9 @@ export function useEmailCss() {
 
 	let rootContainerStyles = '';
 	if ( layout && deviceType !== 'Mobile' ) {
-		rootContainerStyles = `display:flow-root; width:${ layout?.contentSize }; margin: 0 auto;box-sizing: border-box;max-width: 100%;`;
+		rootContainerStyles = `display:flow-root; width:${
+			layout?.contentSize || '660px'
+		}; margin: 0 auto;box-sizing: border-box;max-width: 100%;`;
 	}
 	const padding = mergedConfig.styles?.spacing?.padding;
 	if ( padding ) {

--- a/packages/php/email-editor/changelog/wooprd-968-update-design-of-notification-email-template-and-contents
+++ b/packages/php/email-editor/changelog/wooprd-968-update-design-of-notification-email-template-and-contents
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update email editor core default styles.

--- a/packages/php/email-editor/src/Engine/Templates/email-general.html
+++ b/packages/php/email-editor/src/Engine/Templates/email-general.html
@@ -1,1 +1,5 @@
-<!-- wp:core/post-content {"lock":{"move":true,"remove":true},"layout":{"type":"default"}} /-->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:post-content {"lock":{"move":true,"remove":true},"layout":{"type":"default"}} /-->
+</div>
+<!-- /wp:group -->

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -247,7 +247,37 @@
           "fontFamily": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
           "fontWeight": "400",
           "fontStyle": "normal",
-          "lineHeight": "1.5"
+          "lineHeight": "1.2"
+        }
+      },
+	  "h1": {
+        "typography": {
+          "fontSize": "40px"
+        }
+      },
+      "h2": {
+        "typography": {
+          "fontSize": "32px"
+        }
+      },
+      "h3": {
+        "typography": {
+          "fontSize": "24px"
+        }
+      },
+      "h4": {
+        "typography": {
+          "fontSize": "16px"
+        }
+      },
+      "h5": {
+        "typography": {
+          "fontSize": "14px"
+        }
+      },
+      "h6": {
+        "typography": {
+          "fontSize": "12px"
         }
       }
     }

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -200,14 +200,19 @@
         },
         {
           "name": "large",
-          "size": "28px",
+          "size": "24px",
           "slug": "large"
         },
         {
           "name": "extra-large",
-          "size": "42px",
+          "size": "32px",
           "slug": "x-large"
-        }
+        },
+		{
+			"name": "extra-extra-large",
+			"size": "40px",
+			"slug": "xx-large"
+		}
       ]
     },
     "useRootPaddingAwareAlignments": true
@@ -244,53 +249,7 @@
           "fontStyle": "normal",
           "lineHeight": "1.5"
         }
-      },
-      "h1": {
-        "typography": {
-          "fontSize": "42px",
-          "fontWeight": "700",
-          "fontStyle": "normal"
-        }
-      },
-      "h2": {
-        "typography": {
-          "fontSize": "42px"
-        }
-      },
-      "h3": {
-        "typography": {
-          "fontSize": "28px"
-        }
-      },
-      "h4": {
-        "typography": {
-          "fontSize": "16px"
-        }
-      },
-      "h5": {
-        "typography": {
-          "fontSize": "13px"
-        }
-      },
-      "h6": {
-        "typography": {
-          "fontSize": "13px"
-        }
-      },
-		"button": {
-			"color": {
-				"background": "#32373c",
-				"text": "#ffffff"
-			},
-			"spacing": {
-				"padding": {
-					"bottom": "0.7em",
-					"left": "1.4em",
-					"right": "1.4em",
-					"top": "0.7em"
-				}
-			}
-		}
+      }
     }
   }
 }

--- a/packages/php/email-editor/src/Integrations/Core/theme.json
+++ b/packages/php/email-editor/src/Integrations/Core/theme.json
@@ -25,7 +25,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "28px"
+					"fontSize": "20px"
 				},
 				"elements": {
 					"cite": {

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Content_Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Content_Renderer_Test.php
@@ -54,7 +54,7 @@ class Content_Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItRendersContent(): void {
 		$template          = new \WP_Block_Template();
 		$template->id      = 'template-id';
-		$template->content = '<!-- wp:core/post-content /-->';
+		$template->content = '<!-- wp:post-content /-->';
 		$content           = $this->renderer->render(
 			$this->email_post,
 			$template
@@ -68,7 +68,7 @@ class Content_Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItInlinesContentStyles(): void {
 		$template          = new \WP_Block_Template();
 		$template->id      = 'template-id';
-		$template->content = '<!-- wp:core/post-content /-->';
+		$template->content = '<!-- wp:post-content /-->';
 		$rendered          = $this->renderer->render( $this->email_post, $template );
 		$paragraph_styles  = $this->getStylesValueForTag( $rendered, 'p' );
 		$this->assertIsString( $paragraph_styles );

--- a/packages/php/email-editor/tests/integration/Engine/Theme_Controller_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Theme_Controller_Test.php
@@ -131,8 +131,9 @@ class Theme_Controller_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItCanTranslateFontSizeSlug(): void {
 		$this->assertEquals( '13px', $this->theme_controller->translate_slug_to_font_size( 'small' ) );
 		$this->assertEquals( '16px', $this->theme_controller->translate_slug_to_font_size( 'medium' ) );
-		$this->assertEquals( '28px', $this->theme_controller->translate_slug_to_font_size( 'large' ) );
-		$this->assertEquals( '42px', $this->theme_controller->translate_slug_to_font_size( 'x-large' ) );
+		$this->assertEquals( '24px', $this->theme_controller->translate_slug_to_font_size( 'large' ) );
+		$this->assertEquals( '32px', $this->theme_controller->translate_slug_to_font_size( 'x-large' ) );
+		$this->assertEquals( '40px', $this->theme_controller->translate_slug_to_font_size( 'xx-large' ) );
 		$this->assertEquals( 'unknown', $this->theme_controller->translate_slug_to_font_size( 'unknown' ) );
 	}
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
@@ -77,11 +77,6 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$rendered    = $this->renderer->render( $email_post, 'Subject', '', 'en' );
 		$button_html = $this->extractBlockHtml( $rendered['html'], 'wp-block-button', 'td' );
 		$this->assertStringContainsString( 'color: #fff', $button_html );
-		$this->assertStringContainsString( 'padding-bottom: .7em;', $button_html );
-		$this->assertStringContainsString( 'padding-left: 1.4em;', $button_html );
-		$this->assertStringContainsString( 'padding-right: 1.4em;', $button_html );
-		$this->assertStringContainsString( 'padding-top: .7em;', $button_html );
-		$this->assertStringContainsString( 'background-color: #32373c', $button_html );
 	}
 
 	/**

--- a/plugins/woocommerce/changelog/wooprd-968-update-design-of-notification-email-template-and-contents
+++ b/plugins/woocommerce/changelog/wooprd-968-update-design-of-notification-email-template-and-contents
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update WooEmailTemplate to simplify style application.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -48,8 +48,6 @@ class WooEmailTemplate {
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
 ' . $this->get_site_logo_or_title() . '
-</div>
-<!-- /wp:group -->
 
 <!-- wp:post-content {"lock":{"move":true,"remove":false},"layout":{"type":"default"}} /-->
 
@@ -57,6 +55,8 @@ class WooEmailTemplate {
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:paragraph {"align":"center","fontSize":"small","style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px","style":"solid"},"right":[],"bottom":[],"left":[]},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"color":{"text":"#787c82"},"elements":{"link":{"color":{"text":"#787c82"}}}}} -->
 <p class="has-text-align-center has-text-color has-link-color has-small-font-size" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-style:solid;border-top-width:1px;color:#787c82;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">You received this email because you shopped at <!--[woocommerce/site-title]--></p>
 <!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 		';
 	}
@@ -73,9 +73,9 @@ class WooEmailTemplate {
 
 		if ( ! empty( $custom_logo ) ) {
 			// Use Site logo if available.
-			return '<!-- wp:site-logo {"width":130, "isLink":false} /-->';
+			return '<!-- wp:site-logo {"width":130,"isLink":false,"align":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
 		}
 
-		return '<!-- wp:site-title {"level":2} /-->';
+		return '<!-- wp:site-title {"level":2,"textAlign":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -51,7 +51,7 @@ class WooEmailTemplate {
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-<!-- wp:post-content {"lock":{"move":true,"remove":false},"layout":{"type":"default"}} /-->
+<!-- wp:post-content {"lock":{"move":true,"remove":true},"layout":{"type":"default"}} /-->
 </div>
 <!-- /wp:group -->
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -49,7 +49,11 @@ class WooEmailTemplate {
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
 ' . $this->get_site_logo_or_title() . '
 
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
 <!-- wp:post-content {"lock":{"move":true,"remove":false},"layout":{"type":"default"}} /-->
+</div>
+<!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:paragraph {"align":"center","fontSize":"small","style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px","style":"solid"},"right":[],"bottom":[],"left":[]},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"color":{"text":"#787c82"},"elements":{"link":{"color":{"text":"#787c82"}}}}} -->


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

- Refresh the base `WooEmailTemplate` structure by wrapping the entire layout and the post-content block in dedicated group blocks so spacing, backgrounds, and typography styles can be applied consistently.
- Align the default notification template (`email-general.html`) with the new structure so all emails inherit the additional group wrapper and improved padding controls.
- Rebalance the typography system by reducing oversized heading presets, introducing an `xx-large` preset, and removing hardcoded heading/button styles from `theme.json` to rely on block styles.

**Why:** WOOPRD-968 (Linear) calls for a refreshed notification email experience so merchants get templates that match the latest design direction, and have cleaner building blocks for future customization. These structural and style updates create a more reliable base while keeping rendering logic covered by updated integration tests.

Closes WOOPRD-968.


(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="846" height="990" alt="Screenshot 2025-11-20 at 6 12 25 PM" src="https://github.com/user-attachments/assets/d6767a83-6414-4e05-a255-50c0f844d9bd" />  |    <img width="834" height="993" alt="Screenshot 2025-11-20 at 6 08 36 PM" src="https://github.com/user-attachments/assets/89aef98b-aad1-4881-9701-9a4190898f95" /> |
|   <img width="2424" height="2504" alt="localhost_8888_woo_email_new_order__preview_id=1141 preview=true" src="https://github.com/user-attachments/assets/e878f800-a567-4fbb-ab12-de2378defaa5" /> |   <img width="2424" height="2424" alt="localhost_8888_woo_email_new_order__preview_id=1139 preview=true" src="https://github.com/user-attachments/assets/0ea328c9-db01-43ec-860a-4b964f4200f5" /> |
| <img width="1473" height="637" alt="Screenshot 2025-11-20 at 6 14 50 PM" src="https://github.com/user-attachments/assets/cad1eeea-b6ef-4748-8fb6-5d85df88e1eb" /> | <img width="1472" height="748" alt="Screenshot 2025-11-20 at 6 15 39 PM" src="https://github.com/user-attachments/assets/c2116278-ed2a-4cda-afec-d24eebb4010d" /> |




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Remove any previous template customization. You can confirm with
```sql
SELECT *
FROM `wp_posts`
WHERE `post_type` LIKE '%wp_template%' AND `post_name` LIKE '%wooemailtemplate%'
```
2. Remove any saved styles. You can confirm with
```sql
SELECT *
FROM `wp_posts`
WHERE `post_type` LIKE '%wp_global_styles%' AND `post_name` LIKE '%wp-global-styles-woocommerce-email%'
```
3. Enable the WooCommerce email editor feature flag if it is not already active.
4. In wp-admin, go to `WooCommerce → Settings → Emails`, pick a transactional email (e.g., “New Order”), and open it in the email editor.
5. Verify the site logo or title renders centered with the newly added padding; toggle between having and not having a site logo to confirm both paths.
6. Insert headings (H1–H3) and confirm the updated preset sizes (24px, 32px, 40px) appear in the typography panel and render in the preview.
7. Inspect the template structure via the List View and confirm the post-content lives inside two nested group blocks, allowing background and spacing controls on each wrapper.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
