### PR TITLE
Drop use of `wc_admin_show_legacy_coupon_menu` option

### DIFF
--- a/plugins/woocommerce/changelog/fix-61860-legacy-coupon-menu
+++ b/plugins/woocommerce/changelog/fix-61860-legacy-coupon-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove database option fetch for legacy coupon menu display preference.

--- a/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
@@ -96,6 +96,8 @@ trait CouponsMovedTrait {
 	/**
 	 * Set whether we should display the legacy coupon menu item.
 	 *
+	 * @deprecated 10.5.0 No longer in use.
+	 *
 	 * @param bool $display Whether the menu should be displayed or not.
 	 */
 	protected static function display_legacy_menu( $display = false ) {

--- a/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
@@ -90,7 +90,18 @@ trait CouponsMovedTrait {
 	 * @return bool
 	 */
 	protected static function should_display_legacy_menu() {
-		return ! Features::is_enabled( 'navigation' );
+		/**
+		 * Filter to determine whether to display the legacy coupon menu item.
+		 *
+		 * @since 10.5.0
+		 *
+		 * @param bool $display Whether the menu should be displayed or not.
+		 * @return bool
+		 */
+		return apply_filters(
+			'wc_admin_show_legacy_coupon_menu',
+			! Features::is_enabled( 'navigation' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/CouponsMovedTrait.php
@@ -90,7 +90,7 @@ trait CouponsMovedTrait {
 	 * @return bool
 	 */
 	protected static function should_display_legacy_menu() {
-		return ( get_option( self::$option_key, 1 ) && ! Features::is_enabled( 'navigation' ) );
+		return ! Features::is_enabled( 'navigation' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
On every admin page load, `wc_admin_show_legacy_coupon_menu` is queried to determine whether the **WooCommerce > Coupons** menu item should be shown, _in addition_ to **Marketing > Coupons** which is always displayed.

This PR removes the reliance on this option and displays the menu item unconditionally (controlled only by filter `wc_admin_show_legacy_coupon_menu`). This might seem a bit contrary to what we wanted, but it's in line with the _current_ default behavior. The way this option was meant to work has been broken for a while:

- The option [was first introduced in June 2020](https://github.com/woocommerce/woocommerce-admin/pull/4526), which moved **Coupons** to **Marketing** and included a notice that allowed merchants to "remove" the legacy menu item (this would set the option to `false`).
- In December 2021, [the option was automatically set to `false` on new installs](https://github.com/woocommerce/woocommerce-admin/pull/7995), effectively hiding **WooCommerce > Coupons** for new sites.
- In November 2024, the code that hid the legacy item on new installs [was entirely removed](https://github.com/woocommerce/woocommerce/pull/52475), thus making **WooCommerce > Coupons** display on new sites with no way to hide it.

It seems clear that the initial goal was to hide this menu by default on new installs and allow existing setups to hide it as well, but all the supporting code is no longer present in core.

Even though we're still honoring this option on sites that had it set, that seems unnecessary considering every install from Nov 2024 to this day is displaying the menu item, with no way to change this (except manually updating the option).

> [!IMPORTANT]
> **Question:** This PR brings back the menu item for everyone, but if we want to honor the spirit of the original change, it might make more sense to hide it by default (again).
> I opted for following the _current_ behavior, at least until we formally retire the legacy item probably adding one last warning about it.

Related to #61860.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to the admin and confirm that both **WooCommerce > Coupons** and **Marketing > Coupons** take you to the coupons screen.
1. Temporarily enable the following PHP snippet on your site:
   ```php
   add_filters( 'wc_admin_show_legacy_coupon_menu', '__return_false' );
   ```
1. Confirm that **WooCommerce > Coupons** is no longer present but **Marketing > Coupons** continues to work.
1. Use Query Monitor to confirm that, unlike on `trunk`, no query of the `wc_admin_show_legacy_coupon_menu` database option happens on every admin page load.

<!-- End testing instructions -->