### PR TITLE
Show tax suffix on new line in order email totals

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4778-ugly-tax-suffix-line-break-in-order-emails
+++ b/plugins/woocommerce/changelog/wooplug-4778-ugly-tax-suffix-line-break-in-order-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Show tax suffix on new line in order email totals

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.9.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\Email\EmailFont;

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -282,6 +282,10 @@ body {
 	padding-top: 5px;
 }
 
+#body_content .email-order-details .order-totals .includes_tax {
+	display: block;
+}
+
 #body_content .email-order-details .order-totals-total th {
 	font-weight: bold;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59151, closes WOOPLUG-4778.

Depending on order value, the tax suffix can be wrapped to the new line, which doesn't look good.

<img width="1272" height="910" alt="image" src="https://github.com/user-attachments/assets/5f46f8d4-5325-4b0a-9043-037cf6a2bb0b" />

This PR always renders the suffix on a new line, which also helps aligning order totals.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="605" height="226" alt="Screenshot 2025-11-21 at 14 16 30" src="https://github.com/user-attachments/assets/ad532729-e593-4925-b201-31cfc0a47325" />    |   <img width="593" height="226" alt="Screenshot 2025-11-21 at 14 15 58" src="https://github.com/user-attachments/assets/3df928a7-d06d-4e98-b76a-dfb80a9157f8" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow steps in #59151.

<!-- End testing instructions -->