### PR TITLE
Restart Start Test Environemnt command if it fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
         env: ${{ matrix.testEnv.envVars }}
         run: |
           # Retry logic: attempt up to 2 times (1 initial + 1 retry)
+          # This handles transient failures like 429 (Too Many Requests), network issues, etc.
           MAX_ATTEMPTS=2
           ATTEMPT=1
           
@@ -210,11 +211,11 @@ jobs:
             
             # Try to start the environment
             if WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; then
-              echo "Test environment started successfully on attempt $ATTEMPT"
+              echo "✓ Test environment started successfully on attempt $ATTEMPT"
               exit 0
             else
               EXIT_CODE=$?
-              echo "Failed to start test environment on attempt $ATTEMPT (exit code: $EXIT_CODE)"
+              echo "✗ Failed to start test environment on attempt $ATTEMPT (exit code: $EXIT_CODE)"
               
               if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
                 echo "Retrying in 5 seconds..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,20 +188,44 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          # randomized wp-env ports to reduce the number of ports usage conflicts in the range of 1024 - 49151
-          min=10
-          max=99
-          randomized=$(( $RANDOM % ( $max - $min + 1 ) + $min ))
-          httpport="${randomized}80"
-          mysqlport="${randomized}36"
-
-          # provision the environment to propagate the randomized ports
-          echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
-          echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
-          # WP_BASE_URL is set only to satisfy blocks E2Es setup (setupRest).
-          echo "WP_BASE_URL=http://localhost:$httpport" >> "$GITHUB_ENV"
+          # Retry logic: attempt up to 2 times (1 initial + 1 retry)
+          MAX_ATTEMPTS=2
+          ATTEMPT=1
           
-          WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS to start test environment"
+            
+            # randomized wp-env ports to reduce the number of ports usage conflicts in the range of 1024 - 49151
+            min=10
+            max=99
+            randomized=$(( $RANDOM % ( $max - $min + 1 ) + $min ))
+            httpport="${randomized}80"
+            mysqlport="${randomized}36"
+
+            # provision the environment to propagate the randomized ports
+            echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
+            echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
+            # WP_BASE_URL is set only to satisfy blocks E2Es setup (setupRest).
+            echo "WP_BASE_URL=http://localhost:$httpport" >> "$GITHUB_ENV"
+            
+            # Try to start the environment
+            if WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; then
+              echo "Test environment started successfully on attempt $ATTEMPT"
+              exit 0
+            else
+              EXIT_CODE=$?
+              echo "Failed to start test environment on attempt $ATTEMPT (exit code: $EXIT_CODE)"
+              
+              if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+                echo "Retrying in 5 seconds..."
+                sleep 5
+                ATTEMPT=$((ATTEMPT + 1))
+              else
+                echo "All attempts to start test environment failed"
+                exit $EXIT_CODE
+              fi
+            fi
+          done
 
       - name: 'Determine BuildKite Analytics Message'
         env:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Quite often Start Test Environemnt command fails, causing the test suite to fail. Most of times restart is enough to make it pass. This PR adds a logic to restart the command if it fails.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI is green
2. Check branch with invoked "demo" failure so it could restart https://github.com/woocommerce/woocommerce/pull/62062

[Example job](https://github.com/woocommerce/woocommerce/actions/runs/19565911182/job/56027830013?pr=62062)

<img width="935" height="610" alt="image" src="https://github.com/user-attachments/assets/e5c9991e-98ef-433a-b826-17397c841f15" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
