### PR TITLE
Automation: Add a checkbox for automatic milestone assignment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,6 +52,18 @@ Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerc
 <!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
 <!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
 
+### Milestone
+
+<!-- DO NOT remove or modify this section (other than to check the box). -->
+
+<!-- milestone-target-selection -->
+- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
+<!-- /milestone-target-selection -->
+
+> **Note:** Check the box above to have the milestone automatically assigned when merged.
+> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
+
+
 ### Changelog entry
 
 <!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

--- a/.github/workflows/pr-auto-milestone-on-merge.yml
+++ b/.github/workflows/pr-auto-milestone-on-merge.yml
@@ -1,0 +1,29 @@
+name: 'Auto-assign milestone on merge'
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [trunk]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign-milestone:
+    name: 'Assign milestone if so instructed'
+    if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
+
+      - name: Assign milestone
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/assign-milestone-on-merge.js');
+            await script({ github, context, core });

--- a/.github/workflows/pr-require-milestone.yml
+++ b/.github/workflows/pr-require-milestone.yml
@@ -1,7 +1,7 @@
 name: 'Require milestone on pull requests'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -14,28 +14,24 @@ on:
         - trunk
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
   ensure-milestone:
-    name: 'Ensure milestone is assigned'
+    name: 'Ensure milestone is or will be assigned'
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: 'Validate milestone'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows/scripts
+
+      - name: 'Validate milestone or checkbox selection'
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
-            const { data: issue } = await github.rest.issues.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-            });
-
-            if (!issue.milestone) {
-                core.setFailed('Assign a milestone before merging this pull request.');
-                return;
-            }
-
-            core.info(`Milestone "${issue.milestone.title}" is set.`);
+            const script = require('./.github/workflows/scripts/validate-milestone-selection.js');
+            await script({ github, context, core });

--- a/.github/workflows/scripts/assign-milestone-on-merge.js
+++ b/.github/workflows/scripts/assign-milestone-on-merge.js
@@ -1,0 +1,94 @@
+/**
+ * Assigns a milestone to a merged PR based on the checkbox selection.
+ *
+ * @param {Object} params - The parameters object
+ * @param {Object} params.github - GitHub API client
+ * @param {Object} params.context - GitHub Actions context
+ * @param {Object} params.core - GitHub Actions core utilities
+ */
+module.exports = async ({ github, context, core }) => {
+    const prNumber = context.payload.pull_request.number;
+    const body = context.payload.pull_request.body || '';
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+    const baseRef = context.payload.pull_request.base.ref;
+
+    core.info(`Repository: ${owner}/${repo}, Base ref: ${baseRef}`);
+
+    const existingMilestone = context.payload.pull_request.milestone;
+    if (existingMilestone) {
+        core.info(`Milestone "${existingMilestone.title}" is already set. Skipping automatic assignment.`);
+        return;
+    }
+
+    const nextVersionMatch = body.match(/- \[([ xX])\].*\*\*.*next WooCommerce version.*\*\*/);
+
+    if (!nextVersionMatch) {
+        core.setFailed('Milestone selection checkbox not found in PR description. Cannot assign milestone.');
+        return;
+    }
+
+    const nextVersionChecked = nextVersionMatch[1].toLowerCase() === 'x';
+
+    if (!nextVersionChecked) {
+        core.setFailed('Auto-assign checkbox not selected. Cannot assign milestone.');
+        return;
+    }
+
+    core.info(`Fetching woocommerce.php from ${owner}/${repo}@${baseRef}`);
+    const { data: fileData } = await github.rest.repos.getContent({
+        owner: owner,
+        repo: repo,
+        path: 'plugins/woocommerce/woocommerce.php',
+        ref: baseRef
+    });
+
+    const wcFileContent = Buffer.from(fileData.content, 'base64').toString('utf8');
+    const versionMatch = wcFileContent.match(/^\s*\*\s*Version:\s*(.+)$/m);
+    if (!versionMatch) {
+        core.warning(`Could not parse WooCommerce version from woocommerce.php plugin header`);
+        return;
+    }
+
+    let version = versionMatch[1].trim().replace(/-dev$/, '');
+    const versionParts = version.split('.').map(Number);
+    const major = versionParts[0];
+    const minor = versionParts[1];
+
+    core.info(`Parsed version: ${versionMatch[1].trim()} -> ${major}.${minor}`);
+
+    const targetMilestone = `${major}.${minor}.0`;
+
+    core.info(`PR #${prNumber} targets next main release`);
+    core.info(`Looking for milestone: ${targetMilestone}`);
+
+    const { data: milestones } = await github.rest.issues.listMilestones({
+        owner: owner,
+        repo: repo,
+        state: 'open'
+    });
+
+    const milestone = milestones.find(m => m.title === targetMilestone);
+    if (!milestone) {
+        const warningMessage = `Could not find milestone "${targetMilestone}". Please assign a milestone manually.\n\nAvailable open milestones: ${milestones.map(m => m.title).join(', ')}`;
+
+        await github.rest.issues.createComment({
+            owner: owner,
+            repo: repo,
+            issue_number: prNumber,
+            body: `⚠️ ${warningMessage}`
+        });
+
+        core.warning(warningMessage);
+        return;
+    }
+
+    await github.rest.issues.update({
+        owner: owner,
+        repo: repo,
+        issue_number: prNumber,
+        milestone: milestone.number
+    });
+
+    core.info(`Successfully assigned milestone "${targetMilestone}" to PR #${prNumber}`);
+};

--- a/.github/workflows/scripts/validate-milestone-selection.js
+++ b/.github/workflows/scripts/validate-milestone-selection.js
@@ -1,0 +1,44 @@
+/**
+ * Validates that a PR has either a milestone set or the auto-assign checkbox selected.
+ *
+ * @param {Object} params - The parameters object
+ * @param {Object} params.github - GitHub API client
+ * @param {Object} params.context - GitHub Actions context
+ * @param {Object} params.core - GitHub Actions core utilities
+ */
+module.exports = async ({ github, context, core }) => {
+    const prNumber = context.payload.pull_request.number;
+    const { data: pr } = await github.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: prNumber,
+    });
+
+    if (pr.milestone) {
+        core.info(`Milestone "${pr.milestone.title}" is set.`);
+        return;
+    }
+
+    const body = pr.body || '';
+
+    if (!body.includes('<!-- milestone-target-selection -->')) {
+        core.setFailed('Milestone selection section not found in PR description. Please use the PR template and select the milestone option, or manually assign a milestone.');
+        return;
+    }
+
+    const nextVersionMatch = body.match(/- \[([ xX])\].*\*\*.*next WooCommerce version.*\*\*/);
+
+    if (!nextVersionMatch) {
+        core.setFailed('Milestone selection checkbox not found or modified. Please restore the original checkbox format from the PR template.');
+        return;
+    }
+
+    const nextVersionChecked = nextVersionMatch[1].toLowerCase() === 'x';
+
+    if (!nextVersionChecked) {
+        core.setFailed('No milestone option selected. Please check the auto-assign checkbox or manually assign a milestone.');
+        return;
+    }
+
+    core.info('Auto-assign milestone checkbox selected. Milestone will be assigned on merge.');
+};

--- a/plugins/woocommerce/changelog/pr-62063
+++ b/plugins/woocommerce/changelog/pr-62063
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a checkbox for automatic milestone assignment on pull requests


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/61756 the action that automatically assigns the last available milestone to a pull request on merge was removed, and an action that fails if no milestone is added manually was added. This was done because there have been instances of people forgetting to readjust the milestone of pull requests after merge, resulting in a disruption of the WooCommerce release process (there are automations in place that rely on the milestone of merged pull requests for release branch cherry-picking and similar processes).

While that change will prevent similar errors in the future, it creates a new problem: it makes the pull request handling process more cumbersome (now a milestone must be added manually to **all** the pull request) and introduces a new vector for human errors (as the wrong milestone could be selected).

This pull request adds a new mechanism that doesn't remove the need for human interaction entirely, but makes it easier and less error-prone: an "Automatically assign milestone for the next WooCommerce version" checkbox in the pull request template:

<img width="1089" height="273" alt="image" src="https://github.com/user-attachments/assets/1788e33b-026f-4f1d-ac88-b02864dc1e52" />

It works as follows:

- If the user checks the box, upon merge the pull request will automatically get the milestone for the next WooCommerce version. The version number is taken [from woocommerce.php in trunk](https://github.com/Konamiman/woocommerce/blob/trunk/plugins/woocommerce/woocommerce.php#L6), and that's also where the link in the checkbox points.
- Alternatively, the user can always manually select a milestone (and that's what needs to be done for e.g. pull requests targeting point releases).
- If the user doesn't check the box *and* doesn't manually assign a milestone, validation fails pre-merge, as it's currently happening.

### How to test the changes in this Pull Request:

1. Create a fork of wooCommerce and make sure that the milestone corresponding to the next version (as indicated in the header of `woocommerce.php`) exists.

2. Add a remote for the fork: `git remote add woo_fork git@github.com:<username>/woocommerce.git`

3. Checkout the branch for this pull request locally and have it replace `trunk` in the fork: `git push woo_fork add-auto-milestone-selection-options:trunk --force`

4. Create a pull request in the fork. The easiest way to do it is via GitHub user interface:
    1. Open any file of the fork
    2. Click the "edit this file" button (the one with the pencil icon in the top right bar over the file contents)
    3. Make any change, e.g. add a space somewhere
    4. Click the "Commit changes..." button on the top right of the screen
    5. In the dialog that appears, choose "Create a new branch for this commit and start a pull request" and click "Propose changes"
    6. Click "Create pull request", then scroll down and click it again

5. Notice how the pull request description includes the new checkbox, right before the "Changelog entry" section. Also there should be a failing "Require milestone on pull requests" action.

6. Assign any manual milestone to the pull request. After a few seconds the action should run again and this time it should pass.

7. Remove the milestone and check the checkbox. Again, the action should re-run and pass.

8. Merge the pull request. After a moment the pull request should get the milestone corresponding to the version present in the header of `woocommerce.php`.

9. Repeat the process but assigning a manual milestone (that is not the one for the next version) additionally to checking the box. Verify that the manually set milestone is **not** replaced once the pull request is merged.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
