### PR TITLE
Prevent fatal errors when getting orders containing deleted products

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5887-uncaught-error-call-to-a-member-function
+++ b/plugins/woocommerce/changelog/wooplug-5887-uncaught-error-call-to-a-member-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when retrieving orders with deleted products on Store API

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -33,6 +33,48 @@ class OrderItemSchema extends ItemSchema {
 		$order   = $order_item->get_order();
 		$product = $order_item->get_product();
 
+		$product_properties = [
+			'short_description'  => '',
+			'description'        => '',
+			'sku'                => '',
+			'permalink'          => '',
+			'catalog_visibility' => 'hidden',
+			'prices'             => [
+				'price'                       => '',
+				'regular_price'               => '',
+				'sale_price'                  => '',
+				'price_range'                 => null,
+				'currency_code'               => '',
+				'currency_symbol'             => '',
+				'currency_minor_unit'         => 2,
+				'currency_decimal_separator'  => '.',
+				'currency_thousand_separator' => ',',
+				'currency_prefix'             => '',
+				'currency_suffix'             => '',
+				'raw_prices'                  => [
+					'precision'     => 6,
+					'price'         => '',
+					'regular_price' => '',
+					'sale_price'    => '',
+				],
+			],
+			'sold_individually'  => false,
+			'images'             => [],
+			'variation'          => [],
+		];
+
+		if ( is_a( $product, 'WC_Product' ) ) {
+			$product_properties['short_description']  = $product->get_short_description();
+			$product_properties['description']        = $product->get_description();
+			$product_properties['sku']                = $product->get_sku();
+			$product_properties['permalink']          = $product->get_permalink();
+			$product_properties['catalog_visibility'] = $product->get_catalog_visibility();
+			$product_properties['prices']             = $this->prepare_product_price_response( $product, get_option( 'woocommerce_tax_display_cart' ) );
+			$product_properties['sold_individually']  = $product->is_sold_individually();
+			$product_properties['images']             = $this->get_images( $product );
+			$product_properties['variation']          = $this->format_variation_data( $product->get_attributes(), $product );
+		}
+
 		return [
 			'key'                  => $order->get_order_key(),
 			'id'                   => $order_item->get_id(),
@@ -44,20 +86,20 @@ class OrderItemSchema extends ItemSchema {
 				'editable'    => false,
 			),
 			'name'                 => $order_item->get_name(),
-			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) ),
-			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_description() ) ) ),
-			'sku'                  => $this->prepare_html_response( $product->get_sku() ),
+			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $product_properties['short_description'] ) ) ),
+			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $product_properties['description'] ) ) ),
+			'sku'                  => $this->prepare_html_response( $product_properties['sku'] ),
 			'low_stock_remaining'  => null,
 			'backorders_allowed'   => false,
 			'show_backorder_badge' => false,
-			'sold_individually'    => $product->is_sold_individually(),
-			'permalink'            => $product->get_permalink(),
-			'images'               => $this->get_images( $product ),
-			'variation'            => $this->format_variation_data( $product->get_attributes(), $product ),
+			'sold_individually'    => $product_properties['sold_individually'] ?? false,
+			'permalink'            => $product_properties['permalink'],
+			'images'               => $product_properties['images'],
+			'variation'            => $product_properties['variation'],
 			'item_data'            => $order_item->get_all_formatted_meta_data(),
-			'prices'               => (object) $this->prepare_product_price_response( $product, get_option( 'woocommerce_tax_display_cart' ) ),
+			'prices'               => (object) $product_properties['prices'],
 			'totals'               => (object) $this->prepare_currency_response( $this->get_totals( $order_item ) ),
-			'catalog_visibility'   => $product->get_catalog_visibility(),
+			'catalog_visibility'   => $product_properties['catalog_visibility'],
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
@@ -1,0 +1,162 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\OrderItemSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use WC_Helper_Order;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * OrderItemSchemaTest class.
+ */
+class OrderItemSchemaTest extends TestCase {
+	/**
+	 * The system under test.
+	 *
+	 * @var OrderItemSchema
+	 */
+	private $sut;
+
+	/**
+	 * ExtendSchema instance.
+	 *
+	 * @var ExtendSchema
+	 */
+	private $mock_extend;
+
+	/**
+	 * SchemaController instance.
+	 *
+	 * @var SchemaController
+	 */
+	private $schema_controller;
+
+	/**
+	 * Set up before test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Set up formatters and extend schema.
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+		$this->mock_extend       = new ExtendSchema( $formatters );
+		$this->schema_controller = new SchemaController( $this->mock_extend );
+		$this->sut               = $this->schema_controller->get( OrderItemSchema::IDENTIFIER );
+	}
+
+	/**
+	 * Tear down after test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->sut               = null;
+		$this->schema_controller = null;
+		$this->mock_extend       = null;
+	}
+
+	/**
+	 * Test that get_item_response handles deleted products gracefully.
+	 *
+	 * Reproduces the issue: when a product is deleted and an order
+	 * containing that product is fetched via StoreAPI, it should not
+	 * throw an error.
+	 */
+	public function test_get_item_response_with_deleted_product(): void {
+		// Arrange - Create order with a product, then delete the product.
+		$order   = WC_Helper_Order::create_order();
+		$items   = $order->get_items();
+		$item    = reset( $items );
+		$product = $item->get_product();
+
+		// Verify product exists initially.
+		$this->assertInstanceOf( 'WC_Product', $product );
+
+		// Delete the product.
+		$product_id = $product->get_id();
+		wp_delete_post( $product_id, true );
+
+		// Verify product is now deleted (get_product returns false).
+		$item_after_delete = new \WC_Order_Item_Product( $item->get_id() );
+		$this->assertFalse( $item_after_delete->get_product() );
+
+		// Act - Get item response for order item with deleted product.
+		$result = $this->sut->get_item_response( $item_after_delete );
+
+		// Verify key fields exist.
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'short_description', $result );
+		$this->assertArrayHasKey( 'description', $result );
+		$this->assertArrayHasKey( 'sku', $result );
+		$this->assertArrayHasKey( 'permalink', $result );
+		$this->assertArrayHasKey( 'catalog_visibility', $result );
+		$this->assertArrayHasKey( 'prices', $result );
+		$this->assertArrayHasKey( 'images', $result );
+		$this->assertArrayHasKey( 'variation', $result );
+		$this->assertArrayHasKey( 'sold_individually', $result );
+
+		// Verify product-specific fields have safe defaults.
+		$this->assertEquals( '', $result['sku'] );
+		$this->assertEquals( '', $result['permalink'] );
+		$this->assertEquals( 'hidden', $result['catalog_visibility'] );
+		$this->assertFalse( $result['sold_individually'] );
+		$this->assertIsArray( $result['images'] );
+		$this->assertEmpty( $result['images'] );
+		$this->assertIsArray( $result['variation'] );
+		$this->assertEmpty( $result['variation'] );
+
+		// Verify order-level data is preserved.
+		$this->assertEquals( $item_after_delete->get_id(), $result['id'] );
+		$this->assertEquals( $item_after_delete->get_name(), $result['name'] );
+		$this->assertEquals( $item_after_delete->get_quantity(), $result['quantity'] );
+	}
+
+	/**
+	 * Test that get_item_response works correctly with existing product.
+	 *
+	 * Ensures the fix doesn't break normal behavior.
+	 */
+	public function test_get_item_response_with_existing_product(): void {
+		// Arrange - Create order with a product.
+		$order   = WC_Helper_Order::create_order();
+		$items   = $order->get_items();
+		$item    = reset( $items );
+		$product = $item->get_product();
+
+		// Verify product exists.
+		$this->assertInstanceOf( 'WC_Product', $product );
+
+		// Act - Get item response.
+		$result = $this->sut->get_item_response( $item );
+
+		// Verify key fields exist.
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'sku', $result );
+		$this->assertArrayHasKey( 'permalink', $result );
+		$this->assertArrayHasKey( 'prices', $result );
+
+		// Verify product data is populated.
+		$this->assertEquals( $product->get_sku(), $result['sku'] );
+		$this->assertEquals( $product->get_permalink(), $result['permalink'] );
+		$this->assertEquals( $product->get_catalog_visibility(), $result['catalog_visibility'] );
+		$this->assertEquals( $product->is_sold_individually(), $result['sold_individually'] );
+
+		// Verify order data.
+		$this->assertEquals( $item->get_id(), $result['id'] );
+		$this->assertEquals( $item->get_name(), $result['name'] );
+		$this->assertEquals( $item->get_quantity(), $result['quantity'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Schemas/OrderItemSchemaTest.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types = 1 );
 
-namespace Automattic\WooCommerce\Tests\StoreApi\Schemas\V1;
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\StoreApi\Schemas\V1\OrderItemSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Adds some fallback values for product data
- Tests if the product exists on the order before trying to access properties or methods on it
- If it does exist, overwrite the fallback data with data from the product
- Adds tests

Closes WOOPLUG-5887
Closes #62046

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Create Product
- Purchase it
- Trash and Delete the product
- Access yoursite.com/wp-json/wc/store/v1/order/123 (replace 123 with order ID) - you will need to authenticate to access this endpoint, I recommend using https://github.com/WP-API/Basic-Auth
- Ensure there is no fatal error 
- Repeat, but order multiple products at the same time, and delete some of them, leave others in place and check the result contains data for the remaining products, and fallback data for deleted ones.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
