### PR TITLE
Various changelog workflow enhancements

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -121,15 +121,23 @@ jobs:
           echo "Using branch: $SELECTED_BRANCH"
           echo "selected_branch=${SELECTED_BRANCH}" >> $GITHUB_OUTPUT
 
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.check-branch.outputs.selected_branch }}
+          path: release-branch
+          sparse-checkout: |
+            /plugins/woocommerce/woocommerce.php
+            /plugins/woocommerce/readme.txt
+          sparse-checkout-cone-mode: false
+
       - name: Validate input version matches current version in the selected branch
         id: validate-selected-branch-version
         env:
           VERSION: ${{ steps.validate-version.outputs.version }}
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
         run: |
-          git fetch origin ${SELECTED_BRANCH}
-          git checkout ${SELECTED_BRANCH}
-          current_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
+          current_version=$( cat release-branch/plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
 
           echo "Current version from woocommerce.php: '$current_version'"
           echo "Input version: '$VERSION'"
@@ -140,9 +148,6 @@ jobs:
           fi
 
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
-
-          # Go back to trunk.
-          git checkout trunk
 
       - name: Setup PNPM
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -177,14 +182,9 @@ jobs:
           if [[ -z "${{ github.event.inputs.append_changelog }}" || "${{ github.event.inputs.append_changelog }}" == "auto" ]]; then
             # If a prerelease, append if there's already content in the changelog.
             if [[ "$VERSION" == *"-"* || "$VERSION" =~ \.0$ ]]; then
-              git checkout ${SELECTED_BRANCH}
-
-              if sed -n '/== Changelog ==/,$p' plugins/woocommerce/readme.txt | grep -Fq '**WooCommerce**'; then
+              if sed -n '/== Changelog ==/,$p' release-branch/plugins/woocommerce/readme.txt | grep -Fq '**WooCommerce**'; then
                 APPEND_CHANGELOG="--append-changelog"
               fi
-
-              # Go back to trunk to run the tools.
-              git checkout trunk
             fi
           elif [[ "${{ github.event.inputs.append_changelog }}" == "append" ]]; then
             # append_changelog: append.

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -203,7 +203,7 @@ export const updateReleaseBranchChangelogs = async (
 		Logger.notice( `Running the changelog script in ${ tmpRepoPath }` );
 
 		execSync(
-			`pnpm --filter=@woocommerce/plugin-woocommerce changelog write --add-pr-num -n -vvv --use-version ${ mainVersion }`,
+			`pnpm --filter=@woocommerce/plugin-woocommerce changelog write --add-pr-num -n --yes -vvv --use-version ${ mainVersion }`,
 			{
 				cwd: tmpRepoPath,
 				stdio: 'inherit',

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -211,8 +211,10 @@ export const updateReleaseBranchChangelogs = async (
 		);
 
 		const noEntriesWritten =
-			changelogOutput.includes( 'No changes were found' ) ||
-			changelogOutput.includes( 'no changes with content for this write' );
+			changelogOutput.includes( `No changes were found` ) ||
+			changelogOutput.includes(
+				`no changes with content for this write`
+			);
 
 		Logger.notice( `Changelog command output: ${ changelogOutput }` );
 		Logger.notice( `Committing deleted files in ${ tmpRepoPath }` );
@@ -228,7 +230,9 @@ export const updateReleaseBranchChangelogs = async (
 			await git.commit(
 				`Delete changelog files from ${ version } release`
 			);
-			deletionCommitHash = ( await git.raw( [ 'rev-parse', 'HEAD' ] ) ).trim();
+			deletionCommitHash = (
+				await git.raw( [ 'rev-parse', 'HEAD' ] )
+			 ).trim();
 			Logger.notice( `git deletion hash: ${ deletionCommitHash }` );
 		} else {
 			Logger.notice(
@@ -263,7 +267,7 @@ export const updateReleaseBranchChangelogs = async (
 				`Changelog update was committed directly to ${ releaseBranch }`
 			);
 			return {
-				deletionCommitHash: deletionCommitHash,
+				deletionCommitHash,
 				prNumber: -1,
 			};
 		}
@@ -292,7 +296,7 @@ export const updateReleaseBranchChangelogs = async (
 		}
 
 		return {
-			deletionCommitHash: deletionCommitHash,
+			deletionCommitHash,
 			prNumber: pullRequest.number,
 		};
 	} catch ( e ) {

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -219,9 +219,22 @@ export const updateReleaseBranchChangelogs = async (
 		//Checkout pnpm-lock.yaml to prevent issues in case of an out of date lockfile.
 		await git.checkout( 'pnpm-lock.yaml' );
 		await git.add( 'plugins/woocommerce/changelog/' );
-		await git.commit( `Delete changelog files from ${ version } release` );
-		const deletionCommitHash = await git.raw( [ 'rev-parse', 'HEAD' ] );
-		Logger.notice( `git deletion hash: ${ deletionCommitHash }` );
+
+		// Check if any files were actually deleted.
+		const status = await git.status();
+		let deletionCommitHash = '';
+
+		if ( status.staged.length > 0 ) {
+			await git.commit(
+				`Delete changelog files from ${ version } release`
+			);
+			deletionCommitHash = ( await git.raw( [ 'rev-parse', 'HEAD' ] ) ).trim();
+			Logger.notice( `git deletion hash: ${ deletionCommitHash }` );
+		} else {
+			Logger.notice(
+				'No changelog files to delete, skipping deletion commit'
+			);
+		}
 
 		Logger.notice( `Updating readme.txt in ${ tmpRepoPath }` );
 		await updateReleaseChangelogs(
@@ -250,7 +263,7 @@ export const updateReleaseBranchChangelogs = async (
 				`Changelog update was committed directly to ${ releaseBranch }`
 			);
 			return {
-				deletionCommitHash: deletionCommitHash.trim(),
+				deletionCommitHash: deletionCommitHash,
 				prNumber: -1,
 			};
 		}
@@ -279,7 +292,7 @@ export const updateReleaseBranchChangelogs = async (
 		}
 
 		return {
-			deletionCommitHash: deletionCommitHash.trim(),
+			deletionCommitHash: deletionCommitHash,
 			prNumber: pullRequest.number,
 		};
 	} catch ( e ) {
@@ -306,6 +319,15 @@ export const updateBranchChangelog = async (
 ): Promise< number > => {
 	const { owner, name, version } = options;
 	const { deletionCommitHash, prNumber } = releaseBranchChanges;
+
+	// Skip if there were no changelog files to delete
+	if ( ! deletionCommitHash ) {
+		Logger.notice(
+			`No deletion commit hash found, skipping changelog deletion from ${ releaseBranch }`
+		);
+		return -1;
+	}
+
 	Logger.notice( `Deleting changelogs from trunk ${ tmpRepoPath }` );
 	const git = simpleGit( {
 		baseDir: tmpRepoPath,

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -202,13 +202,19 @@ export const updateReleaseBranchChangelogs = async (
 
 		Logger.notice( `Running the changelog script in ${ tmpRepoPath }` );
 
-		execSync(
+		const changelogOutput = execSync(
 			`pnpm --filter=@woocommerce/plugin-woocommerce changelog write --add-pr-num -n --yes -vvv --use-version ${ mainVersion }`,
 			{
 				cwd: tmpRepoPath,
-				stdio: 'inherit',
+				encoding: 'utf-8',
 			}
 		);
+
+		const noEntriesWritten =
+			changelogOutput.includes( 'No changes were found' ) ||
+			changelogOutput.includes( 'no changes with content for this write' );
+
+		Logger.notice( `Changelog command output: ${ changelogOutput }` );
 		Logger.notice( `Committing deleted files in ${ tmpRepoPath }` );
 		//Checkout pnpm-lock.yaml to prevent issues in case of an out of date lockfile.
 		await git.checkout( 'pnpm-lock.yaml' );
@@ -249,11 +255,14 @@ export const updateReleaseBranchChangelogs = async (
 			};
 		}
 		Logger.notice( `Creating PR for ${ branch }` );
+		const warningMessage = noEntriesWritten
+			? '> [!WARNING]\n> No entries were written to the changelog. Consider adding a generic changelog entry before releasing.\n\n'
+			: '';
 		const pullRequest = await createPullRequest( {
 			owner,
 			name,
 			title: `Release: Prepare the changelog for ${ version }`,
-			body: `This pull request was automatically generated to prepare the changelog for ${ version }`,
+			body: `${ warningMessage }This pull request was automatically generated to prepare the changelog for ${ version }`,
 			head: branch,
 			base: releaseBranch,
 		} );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes a few changes to the changelog workflow based on feedback received during the last release cycle. In particular:

- It removes switching from trunk to the release branch in the workflow so that possible conflicts do not prevent the workflow from working.
- Ensures that having a release branch with no changelog files (or with changelog files that don't result in an entry) doesn't prevent the workflow from completing successfully and updating dates as required.
- Improves Git handling inside the monorepo-utils library.

Closes #62066.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository, including the `trunk` branch.
1. Go to **Code > Branches** in your fork and create a `release/10.5` branch off of `trunk`.
1. Merge this branch (`fix/62066`) into your fork's `trunk` **or** push this branch to your fork as trunk (`git push fork HEAD:trunk -f`).
1. Go to your developer settings and create a classic token with repo permissions. Make note of the token.
1. Add a secret `WC_BOT_PR_CREATE_TOKEN` to your fork (under **Settings > Secrets and variables > Actions**) set to the token you generated in the previous step.
1. Go to **Actions > Release: Compile changelog** and run the workflow with **Version** set to `10.5.0`. Wait for the workflow to complete.
1. Confirm 2 PRs have been created and that they look correct: one updating the changelog in `release/10.5` and one removing those changelog files from `trunk`. Merge these PRs.
1. Go to **Actions > Release: Compile changelog** and run the workflow **again** with **Version** set to `10.5.0` and use **replace** for the **Append or replace?** dropdown or, alternatively, input any release date that is not today (don't leave the input blank).
1. Confirm that the workflow is successful and the associated `release/10.5` PR is created but no PR is generated against `trunk`.
1. Confirm that the PR indicates no changelog entry was added and suggests a generic entry is added:
   <img width="827" height="137" alt="Screenshot 2025-11-24 at 17 25 22" src="https://github.com/user-attachments/assets/9f4bd392-9697-43e3-9d99-b9aaf32b8105" />
1. Merge or close this PR.
1. Create a file under `plugins/woocommerce/changelog` on branch `release/10.5` with any name you like and the following content:
   ```
   Significance: minor
   Type: fix
   Comment: nothing to see here
   ```
1. Go to **Actions > Release: Compile changelog** and run the workflow one last time with **Version** set to `10.5.0` and a date in the release date input that is different from the one you used before.
1. Confirm that the release branch and `trunk` PRs were both generated, with the release one having the "no entry" note as above.


<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.