### PR TITLE
Product image: avoid unnecessary calculations

### DIFF
--- a/plugins/woocommerce/changelog/62107-wooplug-5855-category-archive-performance-on-block-based-themes-with
+++ b/plugins/woocommerce/changelog/62107-wooplug-5855-category-archive-performance-on-block-based-themes-with
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Optimize ProductImage block to avoid unnecessary gallery image calculations.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -161,9 +161,13 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$featured_image_id          = (int) $product->get_image_id();
-		$gallery_image_ids          = ProductGalleryUtils::get_all_image_ids( $product );
-		$available_image_ids        = array_merge( [ $featured_image_id ], $gallery_image_ids );
-		$provided_image_id_is_valid = $image_id && in_array( $image_id, $available_image_ids, true );
+		$provided_image_id_is_valid = false;
+
+		if ( $image_id ) {
+			$gallery_image_ids          = ProductGalleryUtils::get_all_image_ids( $product );
+			$available_image_ids        = array_merge( [ $featured_image_id ], $gallery_image_ids );
+			$provided_image_id_is_valid = in_array( $image_id, $available_image_ids, true );
+		}
 
 		$target_image_id = $provided_image_id_is_valid ? $image_id : $featured_image_id;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -180,7 +180,7 @@ class ProductImage extends AbstractBlock {
 		$attr = array(
 			'alt'           => empty( $alt_text ) ? $product->get_title() : $alt_text,
 			'data-testid'   => 'product-image',
-			'data-image-id' => $provided_image_id_is_valid ? $image_id : $featured_image_id,
+			'data-image-id' => $target_image_id,
 			'style'         => $image_style,
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Optimize `ProductImage::render_image()` to avoid unnecessary gallery image calculations when `image_id` is null. Previously, `ProductGalleryUtils::get_all_image_ids()` and `array_merge()` were called even when no specific image ID was provided. Now these operations only execute when `image_id` is provided.

Closes #61955

### Screenshots or screen recordings:

GitHub will automatically download this file and fail due to its size, so I'm removing the protocol here to prevent that. I'm sorry for the inconvenience.

```
cloudup.com/cz2brvjiU6W
```


### How to test the changes in this Pull Request:

1. Add a Product Image block to a product page or product archive.
2. Verify the product image displays correctly.
4. Test with products that have no featured image to ensure placeholder displays correctly.

### Testing that has already taken place:

Tested on a local development environment with products that have featured images, gallery images, and products without images.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Optimize ProductImage block to avoid unnecessary gallery image calculations.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>