### PR TITLE
Auto-Paginate Variation Loading in `ProductControl` Component

### DIFF
--- a/plugins/woocommerce/changelog/62114-tweak-61755-paginate-all-variations
+++ b/plugins/woocommerce/changelog/62114-tweak-61755-paginate-all-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Auto-paginate variation loading in the `ProductControl` component.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
@@ -53,18 +53,6 @@ const getProductsRequests = ( {
 	return requests;
 };
 
-const uniqBy = ( array, iteratee ) => {
-	const seen = new Map();
-	return array.filter( ( item ) => {
-		const key = iteratee( item );
-		if ( ! seen.has( key ) ) {
-			seen.set( key, item );
-			return true;
-		}
-		return false;
-	} );
-};
-
 /**
  * Get a promise that resolves to a list of products from the Store API.
  *
@@ -83,15 +71,16 @@ export const getProducts = ( {
 	const requests = getProductsRequests( { selected, search, queryArgs } );
 
 	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) )
-		.then( ( data ) => {
-			const flatData = data.flat();
-			const products = uniqBy( flatData, ( item ) => item.id );
-			const list = products.map( ( product ) => ( {
-				...product,
-				parent: 0,
-			} ) );
-			return list;
-		} )
+		.then( ( data ) => [
+			...new Map(
+				data.flatMap( ( products ) =>
+					products.map( ( item ) => [
+						item.id,
+						{ ...item, parent: 0 },
+					] )
+				)
+			).values(),
+		] )
 		.catch( ( e ) => {
 			throw e;
 		} );
@@ -169,10 +158,13 @@ export const getProductTags = ( { selected = [], search } ) => {
 	const requests = getProductTagsRequests( { selected, search } );
 
 	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) ).then(
-		( data ) => {
-			const flatData = data.flat();
-			return uniqBy( flatData, ( item ) => item.id );
-		}
+		( data ) => [
+			...new Map(
+				data.flatMap( ( tags ) =>
+					tags.map( ( item ) => [ item.id, item ] )
+				)
+			).values(),
+		]
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
@@ -70,8 +70,8 @@ export const getProducts = ( {
 } ) => {
 	const requests = getProductsRequests( { selected, search, queryArgs } );
 
-	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) )
-		.then( ( data ) => [
+	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) ).then(
+		( data ) => [
 			...new Map(
 				data.flatMap( ( products ) =>
 					products.map( ( item ) => [
@@ -80,10 +80,8 @@ export const getProducts = ( {
 					] )
 				)
 			).values(),
-		] )
-		.catch( ( e ) => {
-			throw e;
-		} );
+		]
+	);
 };
 
 /**
@@ -242,10 +240,7 @@ export const getProductVariations = ( product ) => {
 					variations.map( ( item ) => [ item.id, item ] )
 				)
 			).values(),
-		] )
-		.catch( ( e ) => {
-			throw e;
-		} );
+		] );
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
@@ -199,13 +199,53 @@ export const getCategory = ( categoryId ) => {
  * @param {number} product Product ID.
  */
 export const getProductVariations = ( product ) => {
+	// Fetch the first page to get total page count from headers
 	return apiFetch( {
 		path: addQueryArgs( `wc/store/v1/products`, {
-			per_page: 0,
+			per_page: 100,
 			type: 'variation',
 			parent: product,
+			page: 1,
 		} ),
-	} );
+		parse: false,
+	} )
+		.then( ( response ) => {
+			const totalPages = parseInt(
+				response.headers.get( 'X-WP-TotalPages' ) || '1',
+				10
+			);
+
+			// Parse the first page data
+			const firstPagePromise = response.json();
+
+			// Build array of fetch promises for remaining pages (starting at page 2)
+			const remainingRequests = [];
+			for ( let page = 2; page <= totalPages; page++ ) {
+				remainingRequests.push(
+					apiFetch( {
+						path: addQueryArgs( `wc/store/v1/products`, {
+							per_page: 100,
+							type: 'variation',
+							parent: product,
+							page,
+						} ),
+					} )
+				);
+			}
+
+			// Combine first page with remaining pages
+			return Promise.all( [ firstPagePromise, ...remainingRequests ] );
+		} )
+		.then( ( data ) => [
+			...new Map(
+				data.flatMap( ( variations ) =>
+					variations.map( ( item ) => [ item.id, item ] )
+				)
+			).values(),
+		] )
+		.catch( ( e ) => {
+			throw e;
+		} );
 };
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rather than using an unbounded query, `getProductVariations()` used by the `ProductControl` component should pull variations in pages. This pull request uses the response headers of the first 100 variations to query additional pages for the rest of them.

Contributes to #61755

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product with 101 variations or more.
2. Add a "Featured Product" block and find the product you created.
3. Using the Network tab in the web inspector, confirm that it makes two queries, one for each page.

<!-- End testing instructions -->

### Testing that has already taken place:

- I changed the `per_page` for the queries to `1` and confirmed that it works to load as many pages as necessary.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Auto-paginate variation loading in the `ProductControl` component.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
