### PR TITLE
Fix settings notifications preview shows 404 not found

### DIFF
--- a/docs/extensions/settings-and-config/email-editor-integration.md
+++ b/docs/extensions/settings-and-config/email-editor-integration.md
@@ -323,6 +323,7 @@ class YourPlugin_Loyalty_Welcome_Email extends WC_Email {
 
         $this->template_html  = 'emails/loyalty-welcome.php';
         $this->template_plain = 'emails/plain/loyalty-welcome.php';
+        $this->template_block = 'emails/block/loyalty-welcome.php';
         $this->template_base  = plugin_dir_path( __FILE__ ) . 'templates/';
 
         parent::__construct();

--- a/docs/extensions/settings-and-config/email-editor-integration.md
+++ b/docs/extensions/settings-and-config/email-editor-integration.md
@@ -126,11 +126,9 @@ add_filter( 'woocommerce_transactional_emails_for_block_editor', 'your_plugin_re
 
 **Development tip:** WooCommerce caches email post-generation with a transient. When testing or developing, delete the transient `wc_email_editor_initial_templates_generated` to force post-generation.
 
-## 4. Create block template
+## 4. Create the initial block template
 
 Create `templates/emails/block/your-custom-email.php`:
-
-**Note:** Block templates are the modern approach for email editor integration. However, WooCommerce maintains backward compatibility with traditional email templates. If you don't provide a block template, WooCommerce will fall back to your traditional `template_html` and `template_plain` files defined in your email class. These properties are intended to be used in the `get_content_html` and `get_content_plain` methods to load the corresponding template files. This ensures your emails continue to work even without block template support.
 
 **Template base property:** Make sure to set the `$template_base` property in your email class constructor to point to your plugin's template directory. This allows WooCommerce to properly locate and load your block template files. The block template filename is expected to match the plain template, but using the `block` directory instead of `plain`.
 
@@ -153,6 +151,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woocommerce/email-content -->
 ```
 
+Pro tip: If you use a custom path for your email templates, set the block template path using the `template_block` property on the email class.
+
 **Email content placeholder:**
 
 The `BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER` is a special placeholder that gets replaced with the main email content when the email is rendered. This placeholder is essential for integrating with WooCommerce's email system and allows the email editor to inject the core email content (like order details, customer information, etc.) into your custom template.
@@ -160,6 +160,8 @@ The `BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER` is a special placeholder
 By default, WooCommerce uses the [general block email template](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/emails/block/general-block-email.php) to generate the content that replaces this placeholder. When WooCommerce processes your email template, it replaces this placeholder with the appropriate email content based on the email type and context.
 
 If your email needs to use different content, you have two options:
+
+**Using custom block content template:**
 
 1. **Set a custom template**: Set the `$template_block_content` property in your email class constructor to point to a custom template for the block content:
 
@@ -177,37 +179,8 @@ If your email needs to use different content, you have two options:
     }
     ```
 
-**Register the template:**
-
-You need to register your block template with the email editor so it can be used for editing. This connects your template file to your email class:
-
-```php
-function your_plugin_register_email_templates( $templates_registry ) {
-    $template = new \Automattic\WooCommerce\EmailEditor\Engine\Templates\Template(
-        // Template prefix (your plugin slug)
-        'your-plugin',
-        // Template slug (unique identifier)
-        'your-custom-email-template',
-        // Display title in editor
-        __( 'Custom Email Template', 'your-plugin' ),
-        // Description
-        __( 'Custom Email Template description', 'your-plugin' ),
-        // Template content
-        '<!-- wp:paragraph -->
-<p>Custom Email Template</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-content {"lock":{"move":true,"remove":false},"layout":{"type":"default"}} /-->' ,
-        // Email post types this template can be used for
-        array( 'woo_email' )
-    );
-
-    $templates_registry->register( $template );
-
-    return $templates_registry;
-}
-add_filter( 'woocommerce_email_editor_register_templates', 'your_plugin_register_email_templates' );
-```
+**Using action hook:**
+You can use the action hook `woocommerce_email_general_block_email` to execute additional actions within the content template. 
 
 ## 5. Set Up Triggers
 
@@ -430,21 +403,6 @@ add_filter( 'woocommerce_email_groups', function( $email_groups ) {
 add_filter( 'woocommerce_transactional_emails_for_block_editor', function( $emails ) {
     $emails[] = 'loyalty_welcome_email';
     return $emails;
-} );
-
-// Register block template for the email editor
-add_filter( 'woocommerce_email_editor_register_templates', function( $registry ) {
-    $template = new \Automattic\WooCommerce\EmailEditor\Engine\Templates\Template(
-        'your-plugin',
-        'loyalty-welcome',
-        __( 'Loyalty Welcome Email', 'your-plugin' ),
-        __( 'Welcome email for new loyalty program members', 'your-plugin' ),
-        file_get_contents( plugin_dir_path( __FILE__ ) . 'templates/emails/block/loyalty-welcome.html' ),
-        array( 'woo_email' )
-    );
-    $registry->register( $template );
-
-    return $registry;
 } );
 
 // Set up trigger - when to send the email

--- a/plugins/woocommerce/changelog/stomail-7641-settings-notifications-preview-shows-404-not-found
+++ b/plugins/woocommerce/changelog/stomail-7641-settings-notifications-preview-shows-404-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensure rewrite rules are updated whenever new block email templates are generated.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -95,6 +95,13 @@ class WC_Email extends WC_Settings_API {
 	public $template_html;
 
 	/**
+	 * Initial email block template path.
+	 *
+	 * @var string
+	 */
+	public $template_block;
+
+	/**
 	 * Template path.
 	 *
 	 * @var string
@@ -1292,6 +1299,8 @@ class WC_Email extends WC_Settings_API {
 			return $this->template_html;
 		} elseif ( 'template_plain' === $type ) {
 			return $this->template_plain;
+		} elseif ( 'template_block' === $type ) {
+			return $this->template_block;
 		}
 		return '';
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1289,7 +1289,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Get template.
 	 *
-	 * @param  string $type Template type. Can be either 'template_html' or 'template_plain'.
+	 * @param  string $type Template type. Can be either 'template_html', 'template_plain' or 'template_block'.
 	 * @return string
 	 */
 	public function get_template( $type ) {

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -116,7 +116,7 @@ class WCTransactionalEmailPostsGenerator {
 	 * @return string The email template.
 	 */
 	public function get_email_template( $email ) {
-		$template_name = !empty( $email->template_block ) ? $email->template_block : str_replace( 'plain', 'block', $email->template_plain );
+		$template_name = ! empty( $email->template_block ) ? $email->template_block : str_replace( 'plain', 'block', $email->template_plain );
 
 		try {
 			$template_html = wc_get_template_html(
@@ -126,6 +126,10 @@ class WCTransactionalEmailPostsGenerator {
 				$email->template_base ?? ''
 			);
 		} catch ( \Exception $e ) {
+			// wc_get_template_html() uses ob_start(), so we need to clean the output buffer if an exception is thrown.
+			if ( ob_get_level() > 0 ) {
+				ob_end_clean();
+			}
 			$template_html = '';
 		}
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -175,7 +175,11 @@ class WCTransactionalEmailPostsGenerator {
 			return false;
 		}
 
-		set_transient( $this->transient_name, Constants::get_constant( 'WC_VERSION' ), MONTH_IN_SECONDS );
+		set_transient( $this->transient_name, Constants::get_constant( 'WC_VERSION' ), WEEK_IN_SECONDS );
+
+		// Flush rewrite rules to ensure the new templates are loaded.
+		flush_rewrite_rules();
+
 		return true;
 	}
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -116,7 +116,7 @@ class WCTransactionalEmailPostsGenerator {
 	 * @return string The email template.
 	 */
 	public function get_email_template( $email ) {
-		$template_name = str_replace( 'plain', 'block', $email->template_plain );
+		$template_name = !empty( $email->template_block ) ? $email->template_block : str_replace( 'plain', 'block', $email->template_plain );
 
 		try {
 			$template_html = wc_get_template_html(

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGeneratorTest.php
@@ -46,11 +46,25 @@ class WCTransactionalEmailPostsGeneratorTest extends \WC_Unit_Test_Case {
 	 * Test that init doesn't run if transient exists.
 	 */
 	public function testInitDoesNotRunIfTransientExists(): void {
-		set_transient( 'wc_email_editor_initial_templates_generated', WOOCOMMERCE_VERSION, MONTH_IN_SECONDS );
+		set_transient( 'wc_email_editor_initial_templates_generated', WOOCOMMERCE_VERSION, WEEK_IN_SECONDS );
 
 		$result = $this->email_generator->initialize();
 
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that get_email_template prioritizes template_block property.
+	 */
+	public function testGetEmailTemplatePrioritizesTemplateBlockProperty(): void {
+		$email                 = $this->createMock( \WC_Email::class );
+		$email->template_plain = 'emails/plain/customer-note.php';
+		$email->template_block = 'emails/block/customer-processing-order.php';
+
+		$template = $this->email_generator->get_email_template( $email );
+
+		$this->assertStringContainsString( 'Thank you for your order', $template );
+		$this->assertStringNotContainsString( 'A note has been added to your order', $template );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR addresses an issue where the "Email preview" section in **Settings > Notifications** would display a "404 not found" error.

**Key Changes:**
1.  **Flush Rewrite Rules:** Added `flush_rewrite_rules()` in `WCTransactionalEmailPostsGenerator` after generating the initial email posts. This ensures that the necessary rewrite rules for the email editor/preview endpoints are registered and recognized immediately, preventing the 404 error.
2.  **Explicit Block Template Support:** Added a new public property `$template_block` to the `WC_Email` class. This allows developers to explicitly define the path to their block template, rather than relying solely on the convention of replacing `plain` with `block` in the filename.
3.  **Transient Update:** Reduced the expiration time of the `wc_email_editor_initial_templates_generated` transient from one month to one week.
4.  **Documentation Updates:** Updated `docs/extensions/settings-and-config/email-editor-integration.md` to document the new `$template_block` property and removed outdated/complex examples for registering templates manually, as the new property simplifies this process.

Closes STOMAIL-7641

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

None

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Testing will be conducted on a garden site after this PR is merged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
