### PR TITLE
Send release published notification only if it matches with the release branch version

### DIFF
--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
+        with:
+          ref: trunk
+          sparse-checkout: |
+            /plugins/woocommerce/woocommerce.php
+          sparse-checkout-cone-mode: false
 
       - name: 'Get release branch from tag'
         id: get-branch

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -23,7 +23,47 @@ jobs:
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     if: ${{ github.event.action == 'published' && ! ( contains( inputs.release_tag_name, '-dev' ) || contains( inputs.release_tag_name, '-rc' ) ) }}
     steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
+      - name: 'Get release branch from tag'
+        id: get-branch
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag_name }}
+        run: |
+          # Extract major.minor from version (e.g., 10.3.5 -> 10.3)
+          if [[ "$RELEASE_TAG" =~ ^([0-9]+\.[0-9]+) ]]; then
+            major_minor="${BASH_REMATCH[1]}"
+            branch_name="release/${major_minor}"
+            echo "Release branch: $branch_name"
+            echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Could not extract version from tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+      - name: 'Validate release tag version matches the release branch version'
+        id: validate-version
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag_name }}
+          BRANCH_NAME: ${{ steps.get-branch.outputs.branch_name }}
+        run: |
+          git fetch origin ${BRANCH_NAME}
+          git checkout ${BRANCH_NAME}
+          current_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
+          
+          echo "Current version from woocommerce.php: '$current_version'"
+          echo "Release tag version: '$RELEASE_TAG'"
+          
+          if [[ "$current_version" != "$RELEASE_TAG" ]]; then
+            echo "::warning::The version in woocommerce.php ($current_version) does not match the release tag version ($RELEASE_TAG). Skipping notification."
+            echo "versions_match=false" >> $GITHUB_OUTPUT
+          else
+            echo "versions_match=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: 'Notify to release channel'
+        if: steps.validate-version.outputs.versions_match == 'true'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR introduces a new check to the `Notify in Slack when a new (pre)release is published` job to make sure we only send the notification when the release is the current stable on the release branch. This is to reduce noise in Slack when various drafts (for patch release, for example) are published in quick succession.

Closes #62067

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Actions` and enable workflows. Then go to `Settings > Secrets and variables > Actions` and create 2 new repository secrets:
- `CODE_FREEZE_BOT_TOKEN`: get the token value from the Test Assistant bot from the secret store.
- `WOO_RELEASE_SLACK_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
3. In the forked repo, create a PR with the `fix/62067-notify-only-version-matches` and merge it (to get this new workflow into `trunk`).
4. Use the GH UI or the tool of your choice and replace `woocommerce/woocommerce` for `<yourusername>/woocommerce` in this file:
   https://github.com/woocommerce/woocommerce/blob/c183a34c37682b3f7ab423b8649b90d444697ea8/.github/workflows/release-release-events-proxy.yml#L11
5. In your fork, create a new branch `release/10.5`.
6. Use the GH UI or the tool of your choice and change the version to `10.5.0` in the `woocommerce.php` file in the `release/10.5` branch.
7. In your fork, create a new release for this version with the tag and name `10.5.0`.
8. This should trigger the `Release: Release events proxy workflow` in the `Actions` tab. Make sure the `Notify in Slack when a new (pre)release is published` finishes successfully and it sends the new release notification to the Slack channel.
9. Remove the release and tag for `10.5.0`.
10. Now change the version in `woocommerce.php` to `10.5.1` in the `release/10.5` branch and create a new release for the `10.5.0` version again.
11. This should trigger the `Release: Release events proxy workflow` in the `Actions` tab, but this time the `Notify...` job should fail with the log: `Warning: The version in woocommerce.php (10.5.1) does not match the release tag version (10.5.0). Skipping notification.`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
