### PR TITLE
Only coerce order total into float when necessary

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -814,7 +814,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return $this->legacy_set_total( $value, $deprecated );
 		}
 
-		$this->set_prop( 'total', wc_format_decimal( (float) $value, wc_get_price_decimals() ) );
+		if ( ! is_string( $value ) || 0 === strlen( $value ) ) {
+			$value = (float) $value;
+		}
+
+		$this->set_prop( 'total', wc_format_decimal( $value, wc_get_price_decimals() ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -17,6 +17,13 @@ use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
  */
 class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'wc_get_price_thousand_separator' );
+		remove_all_filters( 'wc_get_price_decimal_separator' );
+	}
+
 	/**
 	 * Test: get_type
 	 */
@@ -207,6 +214,28 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object = new WC_Order();
 		$object->set_total( '' );
 		$this->assertEquals( 0, $object->get_total() );
+	}
+
+	/**
+	 * Test: get_total_pre_formatted_value
+	 */
+	public function test_get_total_pre_formatted_standard_value() {
+		$object = new WC_Order();
+		$object->set_total( '2,000.00' );
+		$this->assertEquals( 2000, $object->get_total() );
+	}
+
+	/**
+	 * Test: get_total_pre_formatted_value
+	 */
+	public function test_get_total_pre_formatted_eu_value() {
+		// Simulate a price format like 3.567,89.
+		add_filter( 'wc_get_price_thousand_separator', fn() => '.' );
+		add_filter( 'wc_get_price_decimal_separator', fn() => ',' );
+
+		$object = new WC_Order();
+		$object->set_total( '2.000,00' );
+		$this->assertEquals( 2000, $object->get_total() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -16,7 +16,9 @@ use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
  * @package WooCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
-
+	/**
+	 * Tear down the test class.
+	 */
 	public function tearDown(): void {
 		parent::tearDown();
 
@@ -217,7 +219,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: get_total_pre_formatted_value
+	 * Test: get_total_pre_formatted_standard_value
 	 */
 	public function test_get_total_pre_formatted_standard_value() {
 		$object = new WC_Order();
@@ -226,7 +228,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: get_total_pre_formatted_value
+	 * Test: get_total_pre_formatted_eu_value
 	 */
 	public function test_get_total_pre_formatted_eu_value() {
 		// Simulate a price format like 3.567,89.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/61257.

The previous PR introduced a small regression when `$order->set_total()` was called with a pre-formatted value like `2,000.00`.

- Without the `(float)` coercion, `wc_format_decimal()` takes the current formatting settings into account and handles the value properly.
- With the coercion, the value is coerced incorrectly before getting passed to `wc_format_decimal()`:

```php
var_dump( floatval( '2,000.00' ) );
float(2)
```

This PR makes sure that the value is only coerced when it is not a string, or an empty string. The latter was the original purpose of the related PR.

### Screenshots or screen recordings:

No visuals for reference.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

There isn't really that much to test. The change is minor and is already covered with unit tests.

If you want to see the bug in effect, take a look at a [failing run for WooPayments](https://github.com/Automattic/woocommerce-payments/actions/runs/19675497454/job/56355371037?pr=11143) with 10.4-beta-1.

<!-- End testing instructions -->

### Testing that has already taken place:

I tested the fix by applying it manually, and it allowed WooPayments tests to proceed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

This should go into the 10.4 release to avoid releasing a regression.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an adjustment of something that was going to be released with 10.4 anyway. There should be no need for an additional log entry.

</details>
