### PR TITLE
Remove unnecessary Product Collection margin

### DIFF
--- a/plugins/woocommerce/changelog/fix-margin-product-collection
+++ b/plugins/woocommerce/changelog/fix-margin-product-collection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: Remove unnecessary margin-top when there's no store notices displayed

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -9,6 +9,12 @@
 		@include font-regular-locked;
 	}
 
+	// Gutenberg adds margin between elements but notices are often empty
+	// resulting in an unnecessary margin on product template.
+	.wc-block-components-notices:not(:has(*)) + .wc-block-product-template {
+		margin-block-start: 0;
+	}
+
 	&:has(.is-product-collection-layout-carousel) {
 		// Hide navigation buttons on mobile phones (small touch screens), but keep them
 		// visible on tablets and desktop (even when zoomed).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Removes unnecessary top margin from the Product Collection block's product template when the notices container is empty.

Gutenberg automatically applies margin between block elements. When the `wc-block-components-notices` container is empty (which is most of the time), this creates an artificial gap before the product template. This PR adds a CSS rule using `:not(:has(*))` to remove the margin when no notices are present.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

x | Before | After |
| ------ | ----- | -- |
|  No notice      |   <img width="1421" height="757" alt="image" src="https://github.com/user-attachments/assets/b088fcb8-9999-4c87-ac08-0996e91a24fb" />    |  <img width="1425" height="756" alt="image" src="https://github.com/user-attachments/assets/8d5d16e3-359b-430c-bdaa-b3f6b323fb41" /> |
|  With notice      |   <img width="1391" height="834" alt="image" src="https://github.com/user-attachments/assets/1a030d6b-f87c-499f-8a90-8a9a60cbee63" />    |  <img width="1428" height="809" alt="image" src="https://github.com/user-attachments/assets/c07cc773-4a77-47a9-9e66-4576193d31f5" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a page with a Product Collection block
2. View the page on the frontend (with no notices/errors present)
3. Inspect the spacing between the top of the Product Collection block and the first product
4. **Expected:** Verify there's no unnecessary gap before the product template
5. Trigger some store notice (e.g. change product stock status to "out of stock" and without reloading the shop try adding it to cart)
6. **Expected:** Verify there's gap between notice and products

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
