### PR TITLE
Rely on Case-Insensitive Collation for Coupon Lookups

### DIFF
--- a/plugins/woocommerce/changelog/62145-tweak-60475-optimize-coupon-lookup-query
+++ b/plugins/woocommerce/changelog/62145-tweak-60475-optimize-coupon-lookup-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Rely on case-insensitive collation when looking coupon codes up.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -130,7 +130,7 @@ if ( wc_tax_enabled() ) {
 						$coupon_info = json_decode( $coupon_info, true );
 						$post_id     = $coupon_info[0]; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					} else {
-						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 					}
 					$class = $order->is_editable() ? 'code editable' : 'code';
 					?>

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -789,7 +789,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		global $wpdb;
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
+				"SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
 				wc_sanitize_coupon_code( $code )
 			)
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -213,7 +213,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 
 		// The `coupon_id_from_code` entry in the object cache must not exist when the coupon is not published, otherwise the coupon will remain available for use.
 		if ( 'publish' !== $coupon->get_status() ) {
-			$hashed_code = md5( $coupon->get_code() );
+			$hashed_code = md5( wc_strtolower( $coupon->get_code() ) );
 			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code, 'coupons' );
 		}
 
@@ -245,7 +245,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $id );
 
-			$hashed_code = md5( $coupon->get_code() );
+			$hashed_code = md5( wc_strtolower( $coupon->get_code() ) );
 			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code, 'coupons' );
 
 			$coupon->set_id( 0 );

--- a/plugins/woocommerce/includes/wc-coupon-functions.php
+++ b/plugins/woocommerce/includes/wc-coupon-functions.php
@@ -114,7 +114,7 @@ function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {
 
 	$data_store = WC_Data_Store::load( 'coupon' );
 	// Coupon code allows spaces, which doesn't work well with some cache engines (e.g. memcached).
-	$hashed_code = md5( $code );
+	$hashed_code = md5( wc_strtolower( $code ) );
 	$cache_key   = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code;
 
 	$ids = wp_cache_get( $cache_key, 'coupons' );

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-coupon.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-coupon.php
@@ -62,14 +62,13 @@ class WC_Helper_Coupon {
 	/**
 	 * Delete a coupon.
 	 *
-	 * @param $coupon_id
+	 * @param string $coupon_id
 	 *
 	 * @return bool
 	 */
 	public static function delete_coupon( $coupon_id ) {
-		wp_delete_post( $coupon_id, true );
-
-		return true;
+		$coupon = new WC_Coupon( $coupon_id );
+		return $coupon->delete( true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-coupon.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-coupon.php
@@ -56,13 +56,13 @@ class WC_Helper_Coupon {
 			update_post_meta( $coupon_id, $key, $value );
 		}
 
-		return new WC_Coupon( $coupon_code );
+		return new WC_Coupon( $coupon_id );
 	}
 
 	/**
 	 * Delete a coupon.
 	 *
-	 * @param string $coupon_id
+	 * @param $coupon_id
 	 *
 	 * @return bool
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
@@ -58,7 +58,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
 
 		// Prime the cache.
-		$hashed_code = md5( $coupon->get_code() );
+		$hashed_code = md5( wc_strtolower( $coupon->get_code() ) );
 		$cache_name  = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code;
 		wc_get_coupon_id_by_code( $coupon->get_code() );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
@@ -56,10 +56,19 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 */
 	public function test_coupon_cache_deletion() {
 		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
+
+		// Prime the cache.
+		$hashed_code = md5( $coupon->get_code() );
+		$cache_name  = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code;
+		wc_get_coupon_id_by_code( $coupon->get_code() );
+
+		$ids = wp_cache_get( $cache_name, 'coupons' );
+
+		$this->assertNotEquals( false, $ids, sprintf( 'Object cache for %s was not primed correctly.', $cache_name ) );
+
 		$coupon->delete( true );
 
-		$cache_name = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code();
-		$ids        = wp_cache_get( $cache_name, 'coupons' );
+		$ids = wp_cache_get( $cache_name, 'coupons' );
 
 		$this->assertEquals( false, $ids, sprintf( 'Object cache for %s was not removed upon deletion of coupon.', $cache_name ) );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/functions.php
@@ -80,4 +80,22 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 		$this->assertEmpty( wc_get_coupon_id_by_code( 0 ) );
 	}
 
+	/**
+	 * Test wc_get_coupon_id_by_code().
+	 *
+	 * @since 10.5
+	 */
+	public function test_wc_get_coupon_id_by_code_case_insensitive() {
+		// Create two coupons with the same code in a different case.
+		$coupon1 = WC_Helper_Coupon::create_coupon( 'testcoupon' );
+		$coupon2 = WC_Helper_Coupon::create_coupon( 'TESTCOUPON' );
+
+		// Expect the second coupon to be returned as it was created last.
+		$this->assertEquals( $coupon2->get_id(), wc_get_coupon_id_by_code( 'testCOUPON' ) );
+
+		// Delete second coupon.
+		WC_Helper_Coupon::delete_coupon( $coupon2->get_id() );
+
+		$this->assertEquals( $coupon1->get_id(), wc_get_coupon_id_by_code( 'testCOUPON' ) );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/functions.php
@@ -97,5 +97,7 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 		WC_Helper_Coupon::delete_coupon( $coupon2->get_id() );
 
 		$this->assertEquals( $coupon1->get_id(), wc_get_coupon_id_by_code( 'testCOUPON' ) );
+
+		WC_Helper_Coupon::delete_coupon( $coupon1->get_id() );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When case-insensitivity was addressed in coupon codes, `LOWER()` was added to the related lookup queries. Realistically speaking, the likelihood of a user having a case-sensitive collation is virtually 0. We can improve the performance of this query by removing the function call and relying on the collation for the case-insensitive comparison.

Closes #60475.
Bug introduced in PR #58918.

#### Performance Metrics

I tested using a store with 5000 products and 10000 coupons. In both cases I ran the query 1000 times to calculate the average.

- WITH `LOWER()`: 1.639 ms per query
- WITHOUT `LOWER()`: 1.504 ms per query

This represents an ~8% improvement in performance over `trunk`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Test each of these with different cases when adding the coupon to the cart.

1. Create a coupon and confirm that it is still usable.
2. Create a second coupon with the same code but different discounts and confirm that it gets used instead of the first.
3. Add a coupon to an order in the admin area.

<!-- End testing instructions -->

### Testing that has already taken place:

- Using `wp-env`
- All of the testing instructions above

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Rely on case-insensitive collation when looking coupon codes up.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
