### PR TITLE
Add block email editor support for order fulfillment notification emails

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1428-enable-block-email-support-for-other-woo-core-emails
+++ b/plugins/woocommerce/changelog/wooprd-1428-enable-block-email-support-for-other-woo-core-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add block email template for Fulfillment emails.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -158,11 +158,11 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 			return wc_get_template_html(
 				$this->template_block_content,
 				array(
-					'order'              => $this->object,
-					'fulfillment'        => $this->fulfillment,
-					'sent_to_admin'      => false,
-					'plain_text'         => false,
-					'email'              => $this,
+					'order'         => $this->object,
+					'fulfillment'   => $this->fulfillment,
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -54,24 +54,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 
 			$this->description = __( 'Fulfillment created emails are sent to the customer when the merchant creates a fulfillment for the order, and marks it as fulfilled. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
 
-			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
-			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
-		}
-
-		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
-			$emails[] = $this->id;
-			return $emails;
-		}
-
-		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
-			if ( $email->id !== $this->id ) {
-				return;
-			}
-			$order = $this->object;
-			$fulfillment = $this->fulfillment;
-			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+			$this->template_block_content = 'emails/block/general-block-content-for-fulfillment-emails.php';
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -53,6 +53,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 			parent::__construct();
 
 			$this->description = __( 'Fulfillment created emails are sent to the customer when the merchant creates a fulfillment for the order, and marks it as fulfilled. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
+
+			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
+			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
+		}
+
+		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
+			$emails[] = $this->id;
+			return $emails;
+		}
+
+		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
+			if ( $email->id !== $this->id ) {
+				return;
+			}
+			$order = $this->object;
+			$fulfillment = $this->fulfillment;
+			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 		}
 
 		/**
@@ -141,6 +160,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
 					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get block editor email template content.
+		 *
+		 * @return string
+		 */
+		public function get_block_editor_email_template_content() {
+			$this->maybe_init_fulfillment_for_preview( $this->object );
+			return wc_get_template_html(
+				$this->template_block_content,
+				array(
+					'order'              => $this->object,
+					'fulfillment'        => $this->fulfillment,
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
 					'email'              => $this,
 				)
 			);

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
@@ -158,11 +158,11 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Deleted', false ) ) :
 			return wc_get_template_html(
 				$this->template_block_content,
 				array(
-					'order'              => $this->object,
-					'fulfillment'        => $this->fulfillment,
-					'sent_to_admin'      => false,
-					'plain_text'         => false,
-					'email'              => $this,
+					'order'         => $this->object,
+					'fulfillment'   => $this->fulfillment,
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
@@ -54,24 +54,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Deleted', false ) ) :
 
 			$this->description = __( 'Fulfillment deleted emails are sent to the customer when the merchant cancels an already fulfilled fulfillment. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
 
-			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
-			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
-		}
-
-		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
-			$emails[] = $this->id;
-			return $emails;
-		}
-
-		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
-			if ( $email->id !== $this->id ) {
-				return;
-			}
-			$order = $this->object;
-			$fulfillment = $this->fulfillment;
-			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+			$this->template_block_content = 'emails/block/general-block-content-for-fulfillment-emails.php';
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
@@ -53,6 +53,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Deleted', false ) ) :
 			parent::__construct();
 
 			$this->description = __( 'Fulfillment deleted emails are sent to the customer when the merchant cancels an already fulfilled fulfillment. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
+
+			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
+			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
+		}
+
+		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
+			$emails[] = $this->id;
+			return $emails;
+		}
+
+		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
+			if ( $email->id !== $this->id ) {
+				return;
+			}
+			$order = $this->object;
+			$fulfillment = $this->fulfillment;
+			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 		}
 
 		/**
@@ -141,6 +160,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Deleted', false ) ) :
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
 					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get block editor email template content.
+		 *
+		 * @return string
+		 */
+		public function get_block_editor_email_template_content() {
+			$this->maybe_init_fulfillment_for_preview( $this->object );
+			return wc_get_template_html(
+				$this->template_block_content,
+				array(
+					'order'              => $this->object,
+					'fulfillment'        => $this->fulfillment,
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
 					'email'              => $this,
 				)
 			);

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
@@ -54,24 +54,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Updated', false ) ) :
 
 			$this->description = __( 'Fulfillment updated emails are sent to the customer when the merchant updates a fulfillment for the order. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
 
-			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
-			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
-		}
-
-		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
-			$emails[] = $this->id;
-			return $emails;
-		}
-
-		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
-			if ( $email->id !== $this->id ) {
-				return;
-			}
-			$order = $this->object;
-			$fulfillment = $this->fulfillment;
-			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
-			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+			$this->template_block_content = 'emails/block/general-block-content-for-fulfillment-emails.php';
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
@@ -53,6 +53,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Updated', false ) ) :
 			parent::__construct();
 
 			$this->description = __( 'Fulfillment updated emails are sent to the customer when the merchant updates a fulfillment for the order. The notification isn’t sent for draft fulfillments.', 'woocommerce' );
+
+			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'skip_order_details_in_block_editor_for_this_email' ), 10, 1 );
+			add_action( 'woocommerce_email_general_block_content', array( $this, 'add_to_general_block_content' ), 10, 3 );
+		}
+
+		public function skip_order_details_in_block_editor_for_this_email( $emails ) {
+			$emails[] = $this->id;
+			return $emails;
+		}
+
+		public function add_to_general_block_content( $sent_to_admin, $plain_text, $email ) {
+			if ( $email->id !== $this->id ) {
+				return;
+			}
+			$order = $this->object;
+			$fulfillment = $this->fulfillment;
+			do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+			do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 		}
 
 		/**
@@ -141,6 +160,25 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Updated', false ) ) :
 					'additional_content' => $this->get_additional_content(),
 					'sent_to_admin'      => false,
 					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get block editor email template content.
+		 *
+		 * @return string
+		 */
+		public function get_block_editor_email_template_content() {
+			$this->maybe_init_fulfillment_for_preview( $this->object );
+			return wc_get_template_html(
+				$this->template_block_content,
+				array(
+					'order'              => $this->object,
+					'fulfillment'        => $this->fulfillment,
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
 					'email'              => $this,
 				)
 			);

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
@@ -158,11 +158,11 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Updated', false ) ) :
 			return wc_get_template_html(
 				$this->template_block_content,
 				array(
-					'order'              => $this->object,
-					'fulfillment'        => $this->fulfillment,
-					'sent_to_admin'      => false,
-					'plain_text'         => false,
-					'email'              => $this,
+					'order'         => $this->object,
+					'fulfillment'   => $this->fulfillment,
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -73,6 +73,15 @@ class WCTransactionalEmails {
 			$emails[] = 'customer_pos_refunded_order';
 		}
 
+		if ( FeaturesUtil::feature_is_enabled( 'fulfillments' ) ) {
+			$fulfillment_emails = array(
+				'customer_fulfillment_created',
+				'customer_fulfillment_updated',
+				'customer_fulfillment_deleted'
+			);
+			$emails = array_merge( $emails, $fulfillment_emails );
+		}
+
 		/**
 		 * Filter the transactional emails for the block editor.
 		 *

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -77,9 +77,9 @@ class WCTransactionalEmails {
 			$fulfillment_emails = array(
 				'customer_fulfillment_created',
 				'customer_fulfillment_updated',
-				'customer_fulfillment_deleted'
+				'customer_fulfillment_deleted',
 			);
-			$emails = array_merge( $emails, $fulfillment_emails );
+			$emails             = array_merge( $emails, $fulfillment_emails );
 		}
 
 		/**

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer fulfillment created email (inital block version)
+ * Customer fulfillment created email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Customer fulfillment created email (inital block version)
+ *
+ * This template can be overridden by editing it in the WooCommerce email editor.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 10.5.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"> <?php echo esc_html__( 'Your item is on the way!', 'woocommerce' ); ?> </h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+	echo esc_html__( 'Woo! Some items you purchased are being fulfilled. You can use the below information to track your shipment:', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woocommerce/email-content -->
+
+<!-- wp:paragraph -->
+<p><?php
+echo esc_html__( 'Please note that couriers may need some time to provide the latest shipping information.', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer fulfillment deleted email (inital block version)
+ * Customer fulfillment deleted email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Customer fulfillment deleted email (inital block version)
+ *
+ * This template can be overridden by editing it in the WooCommerce email editor.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 10.5.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"> <?php echo esc_html__( 'One of your shipments has been removed', 'woocommerce' ); ?> </h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+	echo esc_html__( 'We wanted to let you know that one of the previously fulfilled shipments from your order has been removed from our system. This may have been due to a correction or an update in our fulfillment records. Don’t worry — this won’t affect any items you’ve already received.', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woocommerce/email-content -->
+
+<!-- wp:paragraph -->
+<p><?php
+echo esc_html__( 'If you have any questions or notice anything unexpected, feel free to reach out to our support team through your account or reply to this email.', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Customer fulfillment updated email (inital block version)
+ *
+ * This template can be overridden by editing it in the WooCommerce email editor.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 10.5.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"> <?php echo esc_html__( 'Your shipment has been updated', 'woocommerce' ); ?> </h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+	echo esc_html__( 'Some details of your shipment have recently been updated. This may include tracking information, item contents, or delivery status.', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php
+	echo esc_html__( 'Here’s the latest info we have:', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woocommerce/email-content -->
+
+<!-- wp:paragraph -->
+<p><?php
+echo esc_html__( 'If anything looks off or you have questions, feel free to contact our support team.', 'woocommerce' );
+?></p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer fulfillment updated email (inital block version)
+ * Customer fulfillment updated email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *

--- a/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer on-hold order email (inital block version)
+ * Customer on-hold order email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer POS refunded order email (inital block version)
+ * Customer POS refunded order email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer processing order email (inital block version)
+ * Customer processing order email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer refunded order email (inital block version)
+ * Customer refunded order email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/block/customer-reset-password.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer Reset Password email (inital block version)
+ * Customer Reset Password email (initial block version)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/general-block-content-for-fulfillment-emails.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-content-for-fulfillment-emails.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * General block content for fulfillment emails
+ *
+ * Note: This template is only used in the fulfillment emails.
+ *
+ * Used to render information for the email editor WooCommerce content block (BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER).
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 10.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+
+if ( ! isset( $order, $fulfillment ) ) {
+	return;
+}
+
+/**
+ * Hook for the woocommerce_email_fulfillment_details.
+ *
+ * @since 10.1.0
+ * @param WC_Order $order The order object.
+ * @param Fulfillment $fulfillment The fulfillment object.
+ * @param bool $sent_to_admin Whether the email is sent to admin.
+ * @param bool $plain_text Whether the email is plain text.
+ * @param WC_Email $email The email object.
+ *
+ * @hooked WC_Emails::fulfillment_details() Shows the fulfillment details.
+ */
+do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Hook for the woocommerce_email_fulfillment_meta.
+ *
+ * @param WC_Order $order The order object.
+ * @param Fulfillment $fulfillment The fulfillment object.
+ * @param bool $sent_to_admin Whether the email is sent to admin.
+ * @param bool $plain_text Whether the email is plain text.
+ * @param WC_Email $email The email object.
+ * @since 10.1.0
+ *
+ * @hooked WC_Emails::order_meta() Shows fulfillment meta data.
+ */
+do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Hook for woocommerce_email_customer_details.
+ *
+ * @param WC_Order $order The order object.
+ * @param bool $sent_to_admin Whether the email is sent to admin.
+ * @param bool $plain_text Whether the email is plain text.
+ * @param WC_Email $email The email object.
+ * @since 2.5.0
+ *
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -97,15 +97,18 @@ endif;
  * @param bool     $plain_text Whether the email is being sent as plain text.
  * @param WC_Email $email The email object.
  */
-do_action( 'woocommerce_email_general_block_email', $sent_to_admin, $plain_text, $email );
+do_action( 'woocommerce_email_general_block_content', $sent_to_admin, $plain_text, $email );
 
+$emails_without_order_details = apply_filters( 'woocommerce_emails_general_block_content_emails_without_order_details', array() );
 
 $accounts_related_emails = array(
 	'customer_reset_password',
 	'customer_new_account',
 );
 
-if ( isset( $order ) && ! in_array( $email->id, $accounts_related_emails, true ) ) {
+$emails_without_order_details = array_merge( $emails_without_order_details ?? array(), $accounts_related_emails );
+
+if ( isset( $order ) && ! in_array( $email->id, $emails_without_order_details, true ) ) {
 
 	/**
 	 * Woocommerce_email_order_details

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -99,6 +99,12 @@ endif;
  */
 do_action( 'woocommerce_email_general_block_content', $sent_to_admin, $plain_text, $email );
 
+/**
+ * Filter the list of email IDs that should not display order details.
+ *
+ * @since 10.5.0
+ * @param array $emails_without_order_details Array of email IDs that should not display order details.
+ */
 $emails_without_order_details = apply_filters( 'woocommerce_emails_general_block_content_emails_without_order_details', array() );
 
 $accounts_related_emails = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

#### Why are we making this change?

The order fulfillment notification emails (`customer-fulfillment-created`, `customer-fulfillment-updated`, and `customer-fulfillment-deleted`) were introduced in WooCommerce but lacked support for the new block-based email editor. This limitation was reported in a [CfT discussion](https://github.com/woocommerce/woocommerce/discussions/60922#discussioncomment-14611946) where users noted that fulfillment emails opened in the legacy email editor rather than the modern block-based editor. 

By adding block email template support for these fulfillment emails, merchants can now:
- Customize fulfillment notification emails using the modern block email editor
- Maintain consistency with other WooCommerce transactional emails
- Create more visually appealing and branded fulfillment notifications for their customers

#### What changes are included?

This PR adds block email editor support for the three order fulfillment notification emails:

1. **New Block Email Templates**:
   - `customer-fulfillment-created.php` - Notifies customers when their items are on the way
   - `customer-fulfillment-updated.php` - Informs customers about updates to their shipment details
   - `customer-fulfillment-deleted.php` - Alerts customers when a shipment has been removed

2. **Shared Template for Block Content**:
   - `general-block-content-for-fulfillment-emails.php` - A reusable template that renders fulfillment details, metadata, and customer information for all fulfillment emails

3. **Email Class Modifications**:
   - Added `get_block_editor_email_template_content()` method to each fulfillment email class
   - Set `template_block_content` property to use the shared block content template

4. **Filter for Skipping Order Details**:
   - Added `woocommerce_emails_general_block_content_emails_without_order_details` filter to allow extensions to skip order details in certain block emails (fulfillment emails show fulfillment details instead of order details)

5. **Transactional Emails Registration**:
   - Registered fulfillment emails with the block email editor when the `fulfillments` feature flag is enabled

Closes #61295
Closes WOOPRD-1428

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Email | Editor | Preview | Email Client | 
| ------ | ----- | ------ | ----- |
|  Fulfillment created  |   <img width="1728" height="995" alt="Screenshot 2025-11-27 at 12 31 41 PM" src="https://github.com/user-attachments/assets/31700a56-fca4-45fd-a953-eab3e4000de8" />  | <img width="817" height="975" alt="Screenshot 2025-11-27 at 12 33 27 PM" src="https://github.com/user-attachments/assets/35d819f2-8b7a-47b9-bf2e-c3b4a3227e07" /> |  <img width="1301" height="930" alt="519681022-5c35f656-c01e-479a-a1fa-056edf900e3e" src="https://github.com/user-attachments/assets/91e38447-0b12-4814-8b08-d41d622960f3" /> |
| Fulfillment updated | <img width="1725" height="989" alt="Screenshot 2025-11-27 at 12 36 37 PM" src="https://github.com/user-attachments/assets/394e3582-a23f-4f9d-a2e5-949aa467bb44" /> | <img width="742" height="994" alt="Screenshot 2025-11-27 at 12 37 08 PM" src="https://github.com/user-attachments/assets/0f05d22f-36ba-44e4-a32d-b5914d1d8d5e" /> | <img width="1296" height="928" alt="519683205-b19981b2-e496-4f75-a861-11bb559cdb62" src="https://github.com/user-attachments/assets/8f9d1700-002a-4474-b0bd-df78044cd034" /> | 
| Fulfillment deleted | <img width="1728" height="942" alt="Screenshot 2025-11-27 at 12 38 30 PM" src="https://github.com/user-attachments/assets/5c396d73-6afe-4fa5-9860-40c8e8a55cb4" /> | <img width="661" height="989" alt="Screenshot 2025-11-27 at 12 38 40 PM" src="https://github.com/user-attachments/assets/9aa5f61d-12ca-4733-a1f3-2c44f1c0a38a" /> | <img width="1291" height="879" alt="519684365-4c7ebe39-01dc-4072-a950-01b2b8eebeea" src="https://github.com/user-attachments/assets/33e5add6-3a03-45e9-a03a-3bac7745d53e" /> | 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites

1. Ensure you have the `fulfillments` feature flag enabled. e.g `wp-env run cli wp option add woocommerce_feature_fulfillments_enabled yes`
2. Enable the block email editor in `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` 
3. Install a mail logging plugin (e.g., WP Mail Logging) or configure SMTP (e.g., WP Mail SMTP)

#### Testing Block Email Templates in Editor

1. Go to **WooCommerce > Settings > Emails**
2. You should see three fulfillment email types:
   - "Fulfillment created"
   - "Fulfillment updated" 
   - "Fulfillment removed"
3. Click on any of these email types to open the email settings
4. Verify the email opens in the **block-based email editor** (not the legacy editor)
5. Modify the email content using the block editor:
   - Change headings and paragraph text
   - Verify the `woocommerce/email-content` block is present and locked
6. Save changes and verify they persist
7. Click on "Preview in new tab". 
8. Verify the preview renders correctly with:
   - Heading text
   - Fulfillment details
   - Customer information

#### Testing Fulfillment Email Execution

For detailed testing instructions on triggering the fulfillment emails (created, updated, deleted), refer to [PR #58558](https://github.com/woocommerce/woocommerce/pull/58558), which contains comprehensive testing steps:

**Fulfillment Created Email:**
1. Go to **WooCommerce > Orders**
2. Open the fulfillments drawer by clicking the pen icon on the fulfillment status column
3. Create a draft fulfillment - verify no email is sent even with notification checkbox on
4. Click "Fulfill items" to fulfill the draft
5. Verify the block-formatted email is received

**Fulfillment Updated Email:**
1. On a fulfilled fulfillment, click to edit
2. Add tracking number or items from the pending list
3. Update the fulfillment
4. Verify the block-formatted update email is received

**Fulfillment Removed Email:**
1. On a fulfilled fulfillment, click to edit
2. Click "Remove fulfillment" button
3. Confirm removal in the modal
4. Verify the block-formatted removal email is received


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
