### PR TITLE
Add analytics-scheduled-import feature flag

### DIFF
--- a/plugins/woocommerce/changelog/62148-wooa7s-797-add-analytics-scheduled-updates-feature-flag
+++ b/plugins/woocommerce/changelog/62148-wooa7s-797-add-analytics-scheduled-updates-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add analytics-scheduled-import feature flag to control scheduled analytics imports feature with production default of disabled (immediate import only).

--- a/plugins/woocommerce/changelog/62148-wooa7s-797-add-analytics-scheduled-updates-feature-flag
+++ b/plugins/woocommerce/changelog/62148-wooa7s-797-add-analytics-scheduled-updates-feature-flag
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Add analytics-scheduled-import feature flag to control scheduled analytics imports feature with production default of disabled (immediate import only).
+Add analytics-scheduled-import feature flag to control scheduled analytics imports feature

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -2,6 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
+		"analytics-scheduled-import": false,
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": false,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -2,6 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
+		"analytics-scheduled-import": true,
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": true,

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -683,7 +683,10 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	}
 
 	/**
-	 * Check if immediate import is enabled.
+	 * Check whether immediate import is enabled.
+	 *
+	 * When the "analytics-scheduled-import" feature is disabled, only immediate
+	 * import is supported (returns true). When enabled, checks the option value.
 	 *
 	 * @internal
 	 * @return bool

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataS
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\DataStore as TaxesDataStore;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * OrdersScheduler Class.
@@ -86,10 +87,13 @@ class OrdersScheduler extends ImportScheduler {
 			// Schedule recurring batch processor.
 			add_action( 'action_scheduler_ensure_recurring_actions', array( __CLASS__, 'schedule_recurring_batch_processor' ) );
 		}
-		// Watch for changes to the immediate import option.
-		add_action( 'add_option_' . self::IMMEDIATE_IMPORT_OPTION, array( __CLASS__, 'handle_immediate_import_option_added' ), 10, 2 );
-		add_action( 'update_option_' . self::IMMEDIATE_IMPORT_OPTION, array( __CLASS__, 'handle_immediate_import_option_change' ), 10, 2 );
-		add_action( 'delete_option', array( __CLASS__, 'handle_immediate_import_option_before_delete' ), 10, 1 );
+
+		if ( Features::is_enabled( 'analytics-scheduled-import' ) ) {
+			// Watch for changes to the immediate import option.
+			add_action( 'add_option_' . self::IMMEDIATE_IMPORT_OPTION, array( __CLASS__, 'handle_immediate_import_option_added' ), 10, 2 );
+			add_action( 'update_option_' . self::IMMEDIATE_IMPORT_OPTION, array( __CLASS__, 'handle_immediate_import_option_change' ), 10, 2 );
+			add_action( 'delete_option', array( __CLASS__, 'handle_immediate_import_option_before_delete' ), 10, 1 );
+		}
 
 		OrdersStatsDataStore::init();
 		CouponsDataStore::init();
@@ -685,6 +689,11 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 * @return bool
 	 */
 	private static function is_immediate_import_enabled(): bool {
+		if ( ! Features::is_enabled( 'analytics-scheduled-import' ) ) {
+			// If the feature is disabled, only immediate import is supported.
+			return true;
+		}
+
 		return 'no' !== get_option( self::IMMEDIATE_IMPORT_OPTION, self::IMMEDIATE_IMPORT_OPTION_DEFAULT_VALUE );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Schedulers;
 
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
 use WC_Unit_Test_Case;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * OrdersScheduler Test.
@@ -12,6 +13,13 @@ use WC_Unit_Test_Case;
  * @class OrdersSchedulerTest
  */
 class OrdersSchedulerTest extends WC_Unit_Test_Case {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Enable the analytics-scheduled-import feature.
+		Features::enable( 'analytics-scheduled-import' );
+	}
 
 	/**
 	 * Tear down the test environment.
@@ -26,6 +34,8 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 
 		// Clean up any scheduled actions.
 		$this->clear_scheduled_batch_processor();
+
+		Features::disable( 'analytics-scheduled-import' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -14,6 +14,9 @@ use Automattic\WooCommerce\Admin\Features\Features;
  */
 class OrdersSchedulerTest extends WC_Unit_Test_Case {
 
+	/**
+	 * Set up the test environment.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds a feature flag to control the analytics scheduled imports feature, enabling quick enable/disable capability for the entire feature, including backend batch processor functionality, settings UI, and related components (**To be implemented**).

#### What changed:

1. **Added \`analytics-scheduled-import\` feature flag** to config files:
   - \`core.json\`: \`false\` (disabled in production by default)
   - \`development.json\`: \`true\` (enabled for development/testing)

2. **Updated \`OrdersScheduler\` class** to respect the feature flag:
   - When feature is **disabled** (production default): Only immediate import is supported 
   - When feature is **enabled** (development): Users can choose between immediate or scheduled imports via settings
   - Conditional hook registration for option change handlers (only when feature is enabled)

3. **Enhanced documentation**:
   - Added clear docblock explaining the feature flag behavior
   - Updated test setup/teardown to manage feature flag state

4. **Test infrastructure updates**:
   - Ensures existing tests run with the feature enabled

#### Technical Details:

The feature flag controls two behaviors in \`OrdersScheduler\`:

| Feature Flag | Import Mode | Hooks Registered |
|--------------|-------------|------------------|
| OFF (production) | Immediate only | Immediate import hooks only |
| ON + option='yes' | Immediate | Immediate import hooks + option handlers |
| ON + option='no' | Scheduled batch | Batch processor + option handlers |

When the feature is disabled, the system maintains backward compatibility by forcing immediate import mode and not registering the option change handlers.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test 1: Verify feature disabled in production

1. Build the plugin `pnpm --filter @woocommerce/plugin-woocommerce build`
2. Confirm `./plugins/woocommerce/includes/react-admin/feature-config.php` contains `'analytics-scheduled-import' => false`
3. Create or update an order
4. Verify that analytics data is imported immediately (check Analytics reports)
5. Run `wp option set woocommerce_analytics_immediate_import 'no'` 
6. Navigate to WooCommerce → Status → Action Scheduler and search for `wc-admin_process_pending_orders_batch`
7. Expected: No recurring action exists

#### Test 2: Verify feature enabled in development

1. Run `pnpm --filter @woocommerce/plugin-woocommerce watch:build`
2. Confirm `./plugins/woocommerce/includes/react-admin/feature-config.php` contains `'analytics-scheduled-import' => true`
4. Delete the `woocommerce_analytics_immediate_import` option if it exists
5. Run `wp option set woocommerce_analytics_immediate_import 'no'`
6. Navigate to WooCommerce → Status → Action Scheduler and search for `wc-admin_process_pending_orders_batch`
7. Expected: Recurring action exists


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add analytics-scheduled-import feature flag to control scheduled analytics imports feature

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
