### PR TITLE
Register analytics import mode setting

### DIFF
--- a/plugins/woocommerce/changelog/62169-wooa7s-791-backend-register-analytics-import-mode-setting
+++ b/plugins/woocommerce/changelog/62169-wooa7s-791-backend-register-analytics-import-mode-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add analytics import mode setting to Settings API

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -348,6 +348,22 @@ class Settings {
 				'date_completed' => 'date_completed',
 			),
 		);
+
+		if ( Features::is_enabled( 'analytics-scheduled-import' ) ) {
+			$settings[] = array(
+				'id'          => 'woocommerce_analytics_immediate_import',
+				'option_key'  => 'woocommerce_analytics_immediate_import',
+				'label'       => __( 'Analytics Import Mode', 'woocommerce' ),
+				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
+				'type'        => 'radio',
+				'default'     => 'yes',
+				'options'     => array(
+					'no'  => __( 'Scheduled (Recommended)', 'woocommerce' ),
+					'yes' => __( 'Immediately', 'woocommerce' ),
+				),
+			);
+		}
+
 		return $settings;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -353,10 +353,10 @@ class Settings {
 			$settings[] = array(
 				'id'          => 'woocommerce_analytics_immediate_import',
 				'option_key'  => 'woocommerce_analytics_immediate_import',
-				'label'       => __( 'Analytics Import Mode', 'woocommerce' ),
+				'label'       => __( 'Update', 'woocommerce' ),
 				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
 				'type'        => 'radio',
-				'default'     => 'yes',
+				'default'     => 'no', // Default to scheduled import for new stores.
 				'options'     => array(
 					'no'  => __( 'Scheduled (Recommended)', 'woocommerce' ),
 					'yes' => __( 'Immediately', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -356,7 +356,7 @@ class Settings {
 				'label'       => __( 'Update', 'woocommerce' ),
 				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
 				'type'        => 'radio',
-				'default'     => 'no', // Default to scheduled import for new stores.
+				'default'     => 'yes', // Default to immediate import for backward compatibility to ensure we don't accidentally change the behavior for existing stores.
 				'options'     => array(
 					'no'  => __( 'Scheduled (Recommended)', 'woocommerce' ),
 					'yes' => __( 'Immediately', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds the `woocommerce_analytics_immediate_import` setting to the WooCommerce Admin Settings API to control analytics order import behavior. This is part of the analytics scheduled imports feature.

Related to WOOPLUG-5761

**Context:**
- We've implemented batch processing for analytics order imports
- This task exposes the setting via the Settings API for the UI to use
- The setting is only registered when the `analytics-scheduled-import` feature flag is enabled

**Implementation details:**
- Added new radio setting in `Settings.php::add_settings()` method
- Setting type: `radio`
- Values: `'yes'` (immediate) or `'no'` (scheduled)
- Default: `'yes` (immediate) for backward compatibility
- Feature flag gated: Only appears when `analytics-scheduled-import` is enabled

**Related:**

- Backend transition handling already implemented in PR #61907
- Feature flag implementation in PR #62149

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions):

1. Install the WooCommerce Beta Tester plugin
2. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=features` and enable `analytics-scheduled-import` feature flag
3. Confirm `window.wcSettings.admin.wcAdminSettings.woocommerce_analytics_immediate_import` exists and is set to `yes` (by default if you haven't changed it)
4. It should be `undefined` if you disable the feature flag

<img width="1145" height="451" alt="Screenshot 2025-11-28 at 15 11 39" src="https://github.com/user-attachments/assets/44f1aa48-9eba-4de3-970f-1071bde7a061" />


### Testing that has already taken place:

- PHP linting passed successfully
- Code follows WooCommerce backend development conventions
- Feature flag gating verified in the code
- Setting structure matches existing WooCommerce Admin settings pattern

**Environment:**
- Local development environment
- PHP 8.1
- WordPress latest
- WooCommerce latest

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add analytics import mode setting to Settings API 

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
