### PR TITLE
Optimize fetching WC emails in EmailApiController.php

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1277-update-email-editor-e2e-config
+++ b/plugins/woocommerce/changelog/wooprd-1277-update-email-editor-e2e-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Optimize a service used for email editor to fetch WooCommerce emails lazily
+
+

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -17,12 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * @internal
  */
 class EmailApiController {
-	/**
-	 * A list of WooCommerce emails.
-	 *
-	 * @var \WC_Email[]
-	 */
-	private array $emails;
 
 	/**
 	 * The WooCommerce transactional email post manager.
@@ -37,7 +31,6 @@ class EmailApiController {
 	 * @internal
 	 */
 	final public function init(): void {
-		$this->emails       = WC()->mailer()->get_emails();
 		$this->post_manager = WCTransactionalEmailPostsManager::get_instance();
 	}
 
@@ -238,7 +231,8 @@ class EmailApiController {
 	 * @return \WC_Email|null - The email object or null if not found.
 	 */
 	private function get_email_by_type( ?string $id ): ?WC_Email {
-		foreach ( $this->emails as $email ) {
+		$emails = WC()->mailer()->get_emails();
+		foreach ( $emails as $email ) {
 			if ( $email->id === $id ) {
 				return $email;
 			}

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -225,14 +225,22 @@ class EmailApiController {
 	}
 
 	/**
+	 * Get all WooCommerce emails.
+	 *
+	 * @return \WC_Email[]
+	 */
+	protected function get_emails(): array {
+		return WC()->mailer()->get_emails();
+	}
+
+	/**
 	 * Get the email object by ID.
 	 *
 	 * @param string $id - The email ID.
 	 * @return \WC_Email|null - The email object or null if not found.
 	 */
 	private function get_email_by_type( ?string $id ): ?WC_Email {
-		$emails = WC()->mailer()->get_emails();
-		foreach ( $emails as $email ) {
+		foreach ( $this->get_emails() as $email ) {
 			if ( $email->id === $id ) {
 				return $email;
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
@@ -88,7 +88,7 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 	 * Test that the email data is returned correctly for a supported email type.
 	 */
 	public function test_get_email_data_returns_email_data_for_supported_type(): void {
-		// Set up a WC_Email mock and inject it into the controller's emails array.
+		// Set up a WC_Email mock.
 		$mock_email     = $this->createMock( \WC_Email::class );
 		$mock_email->id = $this->email_type;
 		$mock_email->method( 'get_option' )->willReturnMap(
@@ -108,14 +108,17 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 				'recipient' => array(),
 			)
 		);
-		// Inject the mock into the controller.
-		$reflection  = new \ReflectionClass( $this->email_api_controller );
-		$emails_prop = $reflection->getProperty( 'emails' );
-		$emails_prop->setAccessible( true );
-		$emails_prop->setValue( $this->email_api_controller, array( $mock_email ) );
+
+		// Create a partial mock of the controller to override get_emails().
+		$controller = $this->getMockBuilder( EmailApiController::class )
+			->onlyMethods( array( 'get_emails' ) )
+			->getMock();
+		$controller->method( 'get_emails' )
+			->willReturn( array( $mock_email ) );
+		$controller->init();
 
 		$post_data = array( 'id' => $this->email_post->ID );
-		$result    = $this->email_api_controller->get_email_data( $post_data );
+		$result    = $controller->get_email_data( $post_data );
 		$this->assertEquals( 'Test Subject', $result['subject'] );
 		$this->assertEquals( 'Default Subject', $result['default_subject'] );
 		$this->assertEquals( 'Test Preheader', $result['preheader'] );
@@ -130,11 +133,13 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 		// Set up a real WC_Email instance for testing.
 		$email = new EmailStub();
 
-		// Inject the email into the controller.
-		$reflection  = new \ReflectionClass( $this->email_api_controller );
-		$emails_prop = $reflection->getProperty( 'emails' );
-		$emails_prop->setAccessible( true );
-		$emails_prop->setValue( $this->email_api_controller, array( $email ) );
+		// Create a partial mock of the controller to override get_emails().
+		$controller = $this->getMockBuilder( EmailApiController::class )
+			->onlyMethods( array( 'get_emails' ) )
+			->getMock();
+		$controller->method( 'get_emails' )
+			->willReturn( array( $email ) );
+		$controller->init();
 
 		$data = array(
 			'subject'   => 'Updated Subject',
@@ -143,7 +148,7 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 			'cc'        => 'cc@example.com',
 			'bcc'       => 'bcc@example.com',
 		);
-		$this->email_api_controller->save_email_data( $data, $this->email_post );
+		$controller->save_email_data( $data, $this->email_post );
 		$option = get_option( 'woocommerce_' . $this->email_type . '_settings' );
 		$this->assertEquals( 'Updated Subject', $option['subject'] );
 		$this->assertEquals( 'Updated Preheader', $option['preheader'] );
@@ -223,13 +228,17 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 			// No 'recipient' key here.
 			)
 		);
-		$reflection  = new \ReflectionClass( $this->email_api_controller );
-		$emails_prop = $reflection->getProperty( 'emails' );
-		$emails_prop->setAccessible( true );
-		$emails_prop->setValue( $this->email_api_controller, array( $mock_email ) );
+
+		// Create a partial mock of the controller to override get_emails().
+		$controller = $this->getMockBuilder( EmailApiController::class )
+			->onlyMethods( array( 'get_emails' ) )
+			->getMock();
+		$controller->method( 'get_emails' )
+			->willReturn( array( $mock_email ) );
+		$controller->init();
 
 		$post_data = array( 'id' => $this->email_post->ID );
-		$result    = $this->email_api_controller->get_email_data( $post_data );
+		$result    = $controller->get_email_data( $post_data );
 		$this->assertNull( $result['recipient'] );
 	}
 
@@ -240,11 +249,13 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 		// Set up a real WC_Email instance for testing.
 		$email = new EmailStub();
 
-		// Inject the email into the controller.
-		$reflection  = new \ReflectionClass( $this->email_api_controller );
-		$emails_prop = $reflection->getProperty( 'emails' );
-		$emails_prop->setAccessible( true );
-		$emails_prop->setValue( $this->email_api_controller, array( $email ) );
+		// Create a partial mock of the controller to override get_emails().
+		$controller = $this->getMockBuilder( EmailApiController::class )
+			->onlyMethods( array( 'get_emails' ) )
+			->getMock();
+		$controller->method( 'get_emails' )
+			->willReturn( array( $email ) );
+		$controller->init();
 
 		// Save new email data.
 		$data = array(
@@ -254,11 +265,11 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 			'cc'        => 'immediate-cc@example.com',
 			'bcc'       => 'immediate-bcc@example.com',
 		);
-		$this->email_api_controller->save_email_data( $data, $this->email_post );
+		$controller->save_email_data( $data, $this->email_post );
 
 		// Immediately retrieve the data.
 		$post_data = array( 'id' => $this->email_post->ID );
-		$result    = $this->email_api_controller->get_email_data( $post_data );
+		$result    = $controller->get_email_data( $post_data );
 
 		// Verify that the retrieved data matches what was saved.
 		$this->assertEquals( 'Immediately Updated Subject', $result['subject'] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR optimizes how EmailApiController accesses WooCommerce email instances. Previously, when the code was placed in the `init` method. The init method is called when a service is fetched from the DI container, and it was causing the emails to be loaded on every request or WP CLI call, even if they were not needed.

I considered caching emails on a private property, but I found that they are already cached within the WC_Emails, so I chose to get the emails directly.

Related to WOOPRD-1277

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Do basic smoke tests of the email editor

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
