### PR TITLE
Notify about milestoned open PRs at Feature Freeze

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -27,6 +27,10 @@ on:
         description: Type of version bump to perform
         type: string
         required: true
+      milestone:
+        description: Milestone to set on the PR (optional)
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -165,12 +169,19 @@ jobs:
             --message 'Bump version to ${{ steps.compute-new-version.outputs.nextVersion }}.'
           git push origin ${branch_name}
 
-          # Open PR.
+          # Set milestone argument (empty if not provided)
+          milestone_arg=""
+          if [[ -n "${{ inputs.milestone }}" ]]; then
+            milestone_arg="--milestone ${{ inputs.milestone }}"
+          fi
+
+          # Create PR
           gh pr create \
             --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
             --base ${{ inputs.branch }} \
             --head ${branch_name} \
             --label Release \
-            --reviewer "${{ github.actor }}"
+            --reviewer "${{ github.actor }}" \
+            ${milestone_arg}
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -169,7 +169,13 @@ jobs:
             --message 'Bump version to ${{ steps.compute-new-version.outputs.nextVersion }}.'
           git push origin ${branch_name}
 
-          # Set milestone argument (empty if not provided)
+          # Determine reviewer (when running as a standalone workflow).
+          reviewer_arg=""
+          if [ "${{ contains( github.workflow_ref, 'release-bump-version.yml' ) }}" = "true" ]; then
+            reviewer_arg="--reviewer ${{ github.actor }}"
+          fi
+
+          # Set milestone argument (empty if not provided).
           milestone_arg=""
           if [[ -n "${{ inputs.milestone }}" ]]; then
             milestone_arg="--milestone ${{ inputs.milestone }}"
@@ -182,6 +188,7 @@ jobs:
             --base ${{ inputs.branch }} \
             --head ${branch_name} \
             --label Release \
-            --reviewer "${{ github.actor }}" \
+            ${reviewer_arg} \
             ${milestone_arg}
+
 

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -254,9 +254,10 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
           slack-text: |
-            :ice_cube: Feature Freeze completed for `${{ needs.prepare-for-feature-freeze.outputs.nextReleaseBranch }}` :checking:
-            If you need a fix or change to be included in this release, please request a backport following the <https://developer.woocommerce.com/docs/contribution/releases/backporting|Backporting Guide>.
-            <${{ needs.publish-dev-release.outputs.release-zip }}|Download zip>
+            :ice_cube: *Feature Freeze completed for ${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }} (`${{ needs.prepare-for-feature-freeze.outputs.nextReleaseBranch }}`)*
+
+            • To include any new fixes in this release, please follow the <https://developer.woocommerce.com/docs/contribution/releases/backporting|Backporting Guide>.
+            • <${{ needs.publish-dev-release.outputs.release-zip }}|Download WooCommerce ${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}-dev>.
           slack-optional-unfurl_links: false
           slack-optional-unfurl_media: false
       - name: Find open PRs in now frozen milestone
@@ -270,26 +271,32 @@ jobs:
                 q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open milestone:"${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}"`,
                 sort: 'created',
                 order: 'desc',
-                per_page: 10
+                per_page: 11
               } );
 
               if ( 0 === prs.total_count ) {
                 core.setOutput( 'current-milestone-open-prs', '' );
+                core.setOutput( 'milestone-url', '' );
                 return;
               }
 
-              // Format PR list for Slack
-              const prList = prs.items
+              // Get milestone URL.
+              const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${prs.items[0].milestone.number}`;
+              core.setOutput( 'milestone-url', milestoneUrl );
+
+              // Format PR list for Slack.
+              const prList = prs
+                .items
+                .slice( 0, prs.total_count <= 11 ? prs.total_count : 10 )
                 .map( pr => `• <${pr.html_url}|#${pr.number}>: ${pr.title}` )
                 .join( '\n' );
 
               let message = prList;
 
-              // If there are more PRs than displayed, add overflow message
-              if ( prs.total_count > 10 ) {
-                const remaining = prs.total_count - 10;
-                const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${prs.items[0].milestone.number}`;
-                message += `\n_...and ${remaining} more. <${milestoneUrl}|View all PRs in milestone>_`;
+              // If there are more than 2 remaining PRs after displaying, add overflow message.
+              const remaining = prs.total_count <= 11 ? 0 : prs.total_count - 10;
+              if ( remaining > 0 ) {
+                message += `\n_... <${milestoneUrl}|and ${remaining} more>._`;
               }
 
               core.setOutput( 'current-milestone-open-prs', message );
@@ -304,10 +311,11 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
           slack-text: |
-            *Currently open PRs in `${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}` milestone:*
-            Please review these PRs to ensure the milestone is still valid or change it accordingly.
+            *Currently open PRs in <${{ steps.find-prs.outputs.milestone-url }}|`${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}` milestone>:*
 
             ${{ steps.find-prs.outputs.current-milestone-open-prs }}
+
+            Review these PRs to ensure the milestone is still valid or change it accordingly.
           slack-optional-thread_ts: ${{ fromJson( steps.notify-success.outputs.slack-result ).response.message.ts }}
           slack-optional-unfurl_links: false
           slack-optional-unfurl_media: false

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -243,8 +243,11 @@ jobs:
     name: Notify Slack
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [publish-dev-release, prepare-for-feature-freeze]
+    outputs:
+      message-ts: ${{ steps.notify-success.outputs.ts }}
     steps:
       - name: Notify Slack on success
+        id: notify-success
         uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
@@ -255,6 +258,59 @@ jobs:
             <${{ needs.publish-dev-release.outputs.release-zip }}|Download zip>
           slack-optional-unfurl_links: false
           slack-optional-unfurl_media: false
+      - name: Find open PRs in now frozen milestone
+        id: find-prs
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            // Find open PRs with milestone matching the next release version.
+            try {
+              const { data: prs } = await github.rest.search.issuesAndPullRequests( {
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open milestone:"${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}"`,
+                sort: 'created',
+                order: 'desc',
+                per_page: 10
+              } );
+
+              if ( 0 === prs.total_count ) {
+                core.setOutput( 'current-milestone-open-prs', '' );
+                return;
+              }
+
+              // Format PR list for Slack
+              const prList = prs.items
+                .map( pr => `• <${pr.html_url}|#${pr.number}>: ${pr.title}` )
+                .join( '\n' );
+
+              let message = prList;
+
+              // If there are more PRs than displayed, add overflow message
+              if ( prs.total_count > 10 ) {
+                const remaining = prs.total_count - 10;
+                const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${prs.items[0].milestone.number}`;
+                message += `\n_...and ${remaining} more. <${milestoneUrl}|View all PRs in milestone>_`;
+              }
+
+              core.setOutput( 'current-milestone-open-prs', message );
+            } catch ( error ) {
+              console.error( `Error searching for PRs: ${error.message}` );
+              core.setOutput( 'current-milestone-open-prs', '' );
+            }
+      - name: Post PR list as threaded reply
+        if: steps.find-prs.outputs.current-milestone-open-prs != ''
+        uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+          slack-text: |
+            *Currently open PRs in `${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}` milestone:*
+            Please review these PRs to ensure the milestone is still valid or change it accordingly.
+
+            ${{ steps.find-prs.outputs.current-milestone-open-prs }}
+          slack-optional-thread_ts: ${{ fromJson( steps.notify-success.outputs.slack-result ).response.message.ts }}
+          slack-optional-unfurl_links: false
+          slack-optional-unfurl_media: false
+
 
   trigger-webhook:
     name: Trigger Release Webhook

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -205,11 +205,12 @@ jobs:
   bump-version-in-trunk:
     name: Bump version in trunk for next development cycle
     uses: ./.github/workflows/release-bump-version.yml
-    needs: [run-feature-freeze]
+    needs: [prepare-for-feature-freeze, run-feature-freeze]
     secrets: inherit
     with:
       branch: trunk
       bump-type: dev
+      milestone: ${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}
 
   build-dev-release:
     name: 'Build WooCommerce -dev release'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR improves the feature freeze notification sent to Slack, and includes a list of PRs with the current milestone that are still open, so that they are re-milestoned if necessary.

It also ensures that the PR bumping the version on `trunk` after the feature freeze receives the current milestone to ensure it is taken care of as part of the current release cycle.

Closes #62065.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository.
1. Go to **Settings > Secrets and variables > Actions** in your repo and add the following secrets / values:
   | Secret name | Value |
   | ---- | ------ |
   | `WC_BOT_PR_CREATE_TOKEN` | A fine-grained PAT for your account with permissions "Metadata" (ro) and "Pull Requests" (r/w) |
   | `RELEASE_CALENDAR_ID` | `46e4204b5406a5c6df48addc0dfd3a29e5e69ad7e991b165fa4e331f03ede0e0@group.calendar.google.com` |
   | `CODE_FREEZE_BOT_TOKEN` | Token from secret store item `Test Assistant bot` |
   | `WOO_RELEASE_SLACK_CHANNEL` | `test-woo-core-release-notifications` |
   | `WPCOM_WEBHOOK_SECRET` | `foobar` |
   | `WPCOM_RELEASE_WEBHOOK_URL` | `https://postman-echo.com/post` |
   | `ENVIRONMENT` | `production` |
1. Either merge this branch (`fix/62065-notification`) into your fork's `trunk` or _carefully_ force push it using git (`git push fork fix/62065-notification:trunk -f`).
1. Delete branch `release/10.5` if it exists in your fork.
1. Go to **Issues > Milestones** and create milestone `10.5.0`.
1. Open a few PRs against `trunk` in your fork and assign them to the `10.5.0` milestone.
1. Go to **Actions > Release: Enforce Code Freeze** _in your fork_ and run the workflow.
1. Wait until it completes.
1. Confirm that:
   - A PR bumping the version on `trunk` to `10.6.0-dev` has been opened and this PR has milestone `10.5.0`.
   - Branch `release/10.5` has been created in your fork.
   - Release `10.5.0-dev` has been published in your fork.
   - Slack notification about the code freeze was sent to `#test-woo-core-release-notifications` and it includes a list of open PRs against milestone `10.5.0` as an additional comment in the thread:

      <img width="617" height="469" alt="Screenshot 2025-12-01 at 17 01 30" src="https://github.com/user-attachments/assets/b9c178a1-1370-4c6b-b50a-2423593d8971" />


<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.