### PR TITLE
Add REST API endpoints for analytics batch import status and manual triggering

### DIFF
--- a/plugins/woocommerce/changelog/wooa7s-793-backend-add-batch-status-and-manual-trigger-endpoints
+++ b/plugins/woocommerce/changelog/wooa7s-793-backend-add-batch-status-and-manual-trigger-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add analytics import status and manual trigger endpoints

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Admin\API;
 
+use WP_Error;
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
 
 defined( 'ABSPATH' ) || exit;
@@ -69,11 +70,11 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * Check if a given request has access to read import status.
 	 *
 	 * @param  \WP_REST_Request $request Full details about the request.
-	 * @return \WP_Error|boolean
+	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_rest_cannot_view',
 				__( 'Sorry, you cannot view analytics import status.', 'woocommerce' ),
 				array( 'status' => rest_authorization_required_code() )
@@ -87,11 +88,11 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * Check if a given request has access to trigger import.
 	 *
 	 * @param  \WP_REST_Request $request Full details about the request.
-	 * @return \WP_Error|boolean
+	 * @return WP_Error|boolean
 	 */
 	public function create_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_rest_cannot_create',
 				__( 'Sorry, you cannot trigger analytics imports.', 'woocommerce' ),
 				array( 'status' => rest_authorization_required_code() )
@@ -141,7 +142,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 
 		// Return error if in immediate mode.
 		if ( $is_immediate_mode ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_rest_analytics_import_immediate_mode',
 				__( 'Manual import is not available in immediate mode. Imports happen automatically.', 'woocommerce' ),
 				array( 'status' => 400 )
@@ -150,7 +151,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 
 		// Determine if a batch import has already been scheduled or is in progress, excluding the recurring import action.
 		if ( $this->has_manual_triggered_import_scheduled() ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_rest_analytics_import_already_scheduled_or_in_progress',
 				__( 'A batch import is already scheduled or in progress. Please wait for it to complete before triggering a new import.', 'woocommerce' ),
 				array( 'status' => 400 )

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -272,9 +272,8 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * @return bool True if a manual triggered import has already been scheduled, false otherwise.
 	 */
 	private function has_manual_triggered_import_scheduled() {
-		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		$hook                 = OrdersScheduler::get_action( 'process_pending_batch' );
+		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
 
-		return call_user_func( $has_scheduled_action, $hook, array( null, null ) ) ? true : false;
+		return as_has_scheduled_action( $hook, array( null, null ) );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit;
  * REST API Analytics Imports Controller.
  *
  * @internal
- * @extends WC_REST_Data_Controller
  */
 class AnalyticsImports extends \WC_REST_Data_Controller {
 	/**
@@ -37,8 +36,10 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 
 	/**
 	 * Register routes.
+	 *
+	 * @return void
 	 */
-	public function register_routes() {
+	public function register_routes(): void {
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/status',
@@ -69,7 +70,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	/**
 	 * Check if a given request has access to analytics imports.
 	 *
-	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @param  \WP_REST_Request<array<string, mixed>> $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
 	public function permissions_check( $request ) {
@@ -87,7 +88,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	/**
 	 * Get the current import status.
 	 *
-	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @param  \WP_REST_Request<array<string, mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_status( $request ) {
@@ -104,7 +105,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 		// For scheduled mode, populate additional fields.
 		if ( ! $is_immediate_mode ) {
 			$last_processed_gmt                    = get_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, null );
-			$response['last_processed_date']       = $last_processed_gmt ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
+			$response['last_processed_date']       = ( is_string( $last_processed_gmt ) && $last_processed_gmt ) ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
 			$response['next_scheduled']            = $this->get_next_scheduled_time();
 			$response['import_in_progress_or_due'] = $this->is_import_in_progress_or_due();
 		}
@@ -115,7 +116,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	/**
 	 * Trigger a manual import.
 	 *
-	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @param  \WP_REST_Request<array<string, mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function trigger_import( $request ) {
@@ -142,7 +143,14 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 		// Trigger the batch import immediately by rescheduling the recurring processor.
 		// This unschedules the current recurring action and reschedules it to run now.
 		$action_hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
-		WC()->queue()->cancel_all( $action_hook, array(), OrdersScheduler::$group );
+		if ( ! is_string( $action_hook ) ) {
+			return new WP_Error(
+				'woocommerce_rest_analytics_import_invalid_action',
+				__( 'Invalid action hook for batch import.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+		WC()->queue()->cancel_all( $action_hook, array(), (string) OrdersScheduler::$group );
 		OrdersScheduler::schedule_recurring_batch_processor();
 
 		return rest_ensure_response(
@@ -169,7 +177,10 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 */
 	private function get_next_scheduled_time() {
 		$action_hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
-		$next_time   = WC()->queue()->get_next( $action_hook, array(), OrdersScheduler::$group );
+		if ( ! is_string( $action_hook ) ) {
+			return null;
+		}
+		$next_time = WC()->queue()->get_next( $action_hook, array(), (string) OrdersScheduler::$group );
 
 		if ( ! $next_time ) {
 			return null;
@@ -257,12 +268,16 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 */
 	private function is_import_in_progress_or_due() {
 		$hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
+		if ( ! is_string( $hook ) ) {
+			return false;
+		}
 
 		// Check for actions with 'running' status.
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$in_progress_actions = WC()->queue()->search(
 			array(
 				'hook'     => $hook,
-				'status'   => \ActionScheduler_Store::STATUS_RUNNING,
+				'status'   => 'running',
 				'per_page' => 1,
 			),
 			'ids'
@@ -273,7 +288,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 		}
 
 		// Check if the next scheduled import is due within 1 minute.
-		$next_scheduled = WC()->queue()->get_next( $hook, array(), OrdersScheduler::$group );
+		$next_scheduled = WC()->queue()->get_next( $hook, array(), (string) OrdersScheduler::$group );
 		if ( $next_scheduled ) {
 			$time_until_next = $next_scheduled->getTimestamp() - time();
 			// Consider it "due" if it's scheduled to run within the next 60 seconds.

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -46,7 +46,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_status' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 				'schema' => array( $this, 'get_status_schema' ),
 			)
@@ -59,7 +59,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'trigger_import' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 				'schema' => array( $this, 'get_trigger_schema' ),
 			)
@@ -67,34 +67,16 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to read import status.
+	 * Check if a given request has access to analytics imports.
 	 *
 	 * @param  \WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_item_permissions_check( $request ) {
+	public function permissions_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return new WP_Error(
-				'woocommerce_rest_cannot_view',
-				__( 'Sorry, you cannot view analytics import status.', 'woocommerce' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Check if a given request has access to trigger import.
-	 *
-	 * @param  \WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|boolean
-	 */
-	public function create_item_permissions_check( $request ) {
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new WP_Error(
-				'woocommerce_rest_cannot_create',
-				__( 'Sorry, you cannot trigger analytics imports.', 'woocommerce' ),
+				'woocommerce_rest_cannot_access',
+				__( 'Sorry, you cannot access analytics imports.', 'woocommerce' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -272,12 +272,11 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 			return false;
 		}
 
-		// Check for actions with 'running' status.
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		// Check for actions with 'in-progress' status.
 		$in_progress_actions = WC()->queue()->search(
 			array(
 				'hook'     => $hook,
-				'status'   => 'running',
+				'status'   => 'in-progress',
 				'per_page' => 1,
 			),
 			'ids'

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -205,26 +205,26 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 			'title'      => 'analytics_import_status',
 			'type'       => 'object',
 			'properties' => array(
-				'mode'                => array(
+				'mode'                              => array(
 					'type'        => 'string',
 					'enum'        => array( 'scheduled', 'immediate' ),
 					'description' => __( 'Current import mode.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'last_processed_date' => array(
+				'last_processed_date'               => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Last processed order date (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'next_scheduled'      => array(
+				'next_scheduled'                    => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Next scheduled import time (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'manual_triggered_import_scheduled'       => array(
+				'manual_triggered_import_scheduled' => array(
 					'type'        => array( 'boolean', 'null' ),
 					'description' => __( 'Whether a manual triggered import has already been scheduled.', 'woocommerce' ),
 					'context'     => array( 'view' ),
@@ -272,7 +272,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 */
 	private function has_manual_triggered_import_scheduled() {
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
+		$hook                 = OrdersScheduler::get_action( 'process_pending_batch' );
 
 		return call_user_func( $has_scheduled_action, $hook, array( null, null ) ) ? true : false;
 	}

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -190,20 +190,20 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 			'title'      => 'analytics_import_status',
 			'type'       => 'object',
 			'properties' => array(
-				'mode'                => array(
+				'mode'                      => array(
 					'type'        => 'string',
 					'enum'        => array( 'scheduled', 'immediate' ),
 					'description' => __( 'Current import mode.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'last_processed_date' => array(
+				'last_processed_date'       => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Last processed order date (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'next_scheduled'      => array(
+				'next_scheduled'            => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Next scheduled import time (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -186,7 +186,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 */
 	public function get_status_schema() {
 		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'$schema'    => 'https://json-schema.org/draft-04/schema#',
 			'title'      => 'analytics_import_status',
 			'type'       => 'object',
 			'properties' => array(
@@ -228,7 +228,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 */
 	public function get_trigger_schema() {
 		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'$schema'    => 'https://json-schema.org/draft-04/schema#',
 			'title'      => 'analytics_import_trigger',
 			'type'       => 'object',
 			'properties' => array(

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -95,19 +95,18 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 		$mode              = $is_immediate_mode ? 'immediate' : 'scheduled';
 
 		$response = array(
-			'mode'                              => $mode,
-			'last_processed_date'               => null,
-			'next_scheduled'                    => null,
-			'manual_triggered_import_scheduled' => null,
+			'mode'                      => $mode,
+			'last_processed_date'       => null,
+			'next_scheduled'            => null,
+			'import_in_progress_or_due' => null,
 		);
 
 		// For scheduled mode, populate additional fields.
 		if ( ! $is_immediate_mode ) {
-			$last_processed_gmt              = get_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, null );
-			$response['last_processed_date'] = $last_processed_gmt ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
-			$response['next_scheduled']      = $this->get_next_scheduled_time();
-
-			$response['manual_triggered_import_scheduled'] = $this->has_manual_triggered_import_scheduled();
+			$last_processed_gmt                    = get_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, null );
+			$response['last_processed_date']       = $last_processed_gmt ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
+			$response['next_scheduled']            = $this->get_next_scheduled_time();
+			$response['import_in_progress_or_due'] = $this->is_import_in_progress_or_due();
 		}
 
 		return rest_ensure_response( $response );
@@ -131,22 +130,25 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 			);
 		}
 
-		// Determine if a batch import has already been scheduled or is in progress, excluding the recurring import action.
-		if ( $this->has_manual_triggered_import_scheduled() ) {
+		// Check if an import is already in progress or due to run soon.
+		if ( $this->is_import_in_progress_or_due() ) {
 			return new WP_Error(
-				'woocommerce_rest_analytics_import_already_scheduled_or_in_progress',
-				__( 'A batch import is already scheduled or in progress. Please wait for it to complete before triggering a new import.', 'woocommerce' ),
+				'woocommerce_rest_analytics_import_in_progress',
+				__( 'A batch import is already in progress or scheduled to run soon. Please wait for it to complete before triggering a new import.', 'woocommerce' ),
 				array( 'status' => 400 )
 			);
 		}
 
-		// Schedule the batch import action.
-		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
+		// Trigger the batch import immediately by rescheduling the recurring processor.
+		// This unschedules the current recurring action and reschedules it to run now.
+		$action_hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
+		WC()->queue()->cancel_all( $action_hook, array(), OrdersScheduler::$group );
+		OrdersScheduler::schedule_recurring_batch_processor();
 
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'message' => __( 'Batch import scheduled successfully.', 'woocommerce' ),
+				'message' => __( 'Batch import triggered successfully.', 'woocommerce' ),
 			)
 		);
 	}
@@ -166,15 +168,15 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * @return string|null Datetime string in site timezone or null if not scheduled.
 	 */
 	private function get_next_scheduled_time() {
-		$action_hook = OrdersScheduler::get_action( 'process_pending_batch' );
-		$next_time   = as_next_scheduled_action( $action_hook );
+		$action_hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
+		$next_time   = WC()->queue()->get_next( $action_hook, array(), OrdersScheduler::$group );
 
-		if ( false === $next_time ) {
+		if ( ! $next_time ) {
 			return null;
 		}
 
 		// Convert UTC timestamp to site timezone.
-		return get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $next_time ), 'Y-m-d H:i:s' );
+		return get_date_from_gmt( $next_time->format( 'Y-m-d H:i:s' ), 'Y-m-d H:i:s' );
 	}
 
 	/**
@@ -188,28 +190,28 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 			'title'      => 'analytics_import_status',
 			'type'       => 'object',
 			'properties' => array(
-				'mode'                              => array(
+				'mode'                => array(
 					'type'        => 'string',
 					'enum'        => array( 'scheduled', 'immediate' ),
 					'description' => __( 'Current import mode.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'last_processed_date'               => array(
+				'last_processed_date' => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Last processed order date (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'next_scheduled'                    => array(
+				'next_scheduled'      => array(
 					'type'        => array( 'string', 'null' ),
 					'description' => __( 'Next scheduled import time (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'manual_triggered_import_scheduled' => array(
+				'import_in_progress_or_due' => array(
 					'type'        => array( 'boolean', 'null' ),
-					'description' => __( 'Whether a manual triggered import has already been scheduled.', 'woocommerce' ),
+					'description' => __( 'Whether a batch import is currently running or scheduled to run within the next minute (null in immediate mode).', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
@@ -249,13 +251,37 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Check if a manual triggered import has already been scheduled.
+	 * Check if a batch import is currently in progress or due to run soon.
 	 *
-	 * @return bool True if a manual triggered import has already been scheduled, false otherwise.
+	 * @return bool True if a batch import is in progress or scheduled to run within the next minute, false otherwise.
 	 */
-	private function has_manual_triggered_import_scheduled() {
-		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
+	private function is_import_in_progress_or_due() {
+		$hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
 
-		return as_has_scheduled_action( $hook, array( null, null ) );
+		// Check for actions with 'running' status.
+		$in_progress_actions = WC()->queue()->search(
+			array(
+				'hook'     => $hook,
+				'status'   => \ActionScheduler_Store::STATUS_RUNNING,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+
+		if ( ! empty( $in_progress_actions ) ) {
+			return true;
+		}
+
+		// Check if the next scheduled import is due within 1 minute.
+		$next_scheduled = WC()->queue()->get_next( $hook, array(), OrdersScheduler::$group );
+		if ( $next_scheduled ) {
+			$time_until_next = $next_scheduled->getTimestamp() - time();
+			// Consider it "due" if it's scheduled to run within the next 60 seconds.
+			if ( $time_until_next <= MINUTE_IN_SECONDS ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * REST API Analytics Imports Controller
+ *
+ * Handles requests to get batch import status and trigger manual imports.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\API;
+
+use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Analytics Imports Controller.
+ *
+ * @internal
+ * @extends WC_REST_Data_Controller
+ */
+class AnalyticsImports extends \WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-analytics';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'imports';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/status',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_status' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_status_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/trigger',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'trigger_import' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_trigger_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read import status.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_cannot_view',
+				__( 'Sorry, you cannot view analytics import status.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to trigger import.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_cannot_create',
+				__( 'Sorry, you cannot trigger analytics imports.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the current import status.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_status( $request ) {
+		$is_immediate_mode = $this->is_immediate_import_enabled();
+		$mode              = $is_immediate_mode ? 'immediate' : 'scheduled';
+
+		$response = array(
+			'mode'                              => $mode,
+			'last_processed_date'               => null,
+			'next_scheduled'                    => null,
+			'manual_triggered_import_scheduled' => null,
+		);
+
+		// For scheduled mode, populate additional fields.
+		if ( ! $is_immediate_mode ) {
+			$last_processed_gmt              = get_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, null );
+			$response['last_processed_date'] = $last_processed_gmt ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
+			$response['next_scheduled']      = $this->get_next_scheduled_time();
+
+			$response['manual_triggered_import_scheduled'] = $this->has_manual_triggered_import_scheduled();
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Trigger a manual import.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function trigger_import( $request ) {
+		$is_immediate_mode = $this->is_immediate_import_enabled();
+
+		// Return error if in immediate mode.
+		if ( $is_immediate_mode ) {
+			return new \WP_Error(
+				'woocommerce_rest_analytics_import_immediate_mode',
+				__( 'Manual import is not available in immediate mode. Imports happen automatically.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Determine if a batch import has already been scheduled or is in progress, excluding the recurring import action.
+		if ( $this->has_manual_triggered_import_scheduled() ) {
+			return new \WP_Error(
+				'woocommerce_rest_analytics_import_already_scheduled_or_in_progress',
+				__( 'A batch import is already scheduled or in progress. Please wait for it to complete before triggering a new import.', 'woocommerce' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Schedule the batch import action.
+		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'message' => __( 'Batch import scheduled successfully.', 'woocommerce' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if immediate import is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_immediate_import_enabled() {
+		return 'no' !== get_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, OrdersScheduler::IMMEDIATE_IMPORT_OPTION_DEFAULT_VALUE );
+	}
+
+	/**
+	 * Get the next scheduled time for the batch processor.
+	 *
+	 * @return string|null Datetime string in site timezone or null if not scheduled.
+	 */
+	private function get_next_scheduled_time() {
+		$action_hook = OrdersScheduler::get_action( 'process_pending_batch' );
+		$next_time   = as_next_scheduled_action( $action_hook );
+
+		if ( false === $next_time ) {
+			return null;
+		}
+
+		// Convert UTC timestamp to site timezone.
+		return get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $next_time ), 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get the schema for the status endpoint, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_status_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'analytics_import_status',
+			'type'       => 'object',
+			'properties' => array(
+				'mode'                => array(
+					'type'        => 'string',
+					'enum'        => array( 'scheduled', 'immediate' ),
+					'description' => __( 'Current import mode.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'last_processed_date' => array(
+					'type'        => array( 'string', 'null' ),
+					'description' => __( 'Last processed order date (null in immediate mode).', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'next_scheduled'      => array(
+					'type'        => array( 'string', 'null' ),
+					'description' => __( 'Next scheduled import time (null in immediate mode).', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'manual_triggered_import_scheduled'       => array(
+					'type'        => array( 'boolean', 'null' ),
+					'description' => __( 'Whether a manual triggered import has already been scheduled.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the schema for the trigger endpoint, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_trigger_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'analytics_import_trigger',
+			'type'       => 'object',
+			'properties' => array(
+				'success' => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the trigger was successful.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'message' => array(
+					'type'        => 'string',
+					'description' => __( 'Result message.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Check if a manual triggered import has already been scheduled.
+	 *
+	 * @return bool True if a manual triggered import has already been scheduled, false otherwise.
+	 */
+	private function has_manual_triggered_import_scheduled() {
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
+
+		return call_user_func( $has_scheduled_action, $hook, array( null, null ) ) ? true : false;
+	}
+}

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -186,6 +186,10 @@ class Init {
 				'Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Controller',
 			);
 
+			if ( Features::is_enabled( 'analytics-scheduled-import' ) ) {
+				$analytics_controllers[] = 'Automattic\WooCommerce\Admin\API\AnalyticsImports';
+			}
+
 			// The performance indicators controllerq must be registered last, after other /stats endpoints have been registered.
 			$analytics_controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -68,6 +68,13 @@ class OrdersScheduler extends ImportScheduler {
 	const IMMEDIATE_IMPORT_OPTION_DEFAULT_VALUE = 'yes';
 
 	/**
+	 * Action name for the order batch import.
+	 *
+	 * @var string
+	 */
+	const PROCESS_PENDING_ORDERS_BATCH_ACTION = 'process_pending_batch';
+
+	/**
 	 * Attach order lookup update hooks.
 	 *
 	 * @internal
@@ -127,7 +134,7 @@ class OrdersScheduler extends ImportScheduler {
 		return array_merge(
 			parent::get_scheduler_actions(),
 			array(
-				'process_pending_batch' => 'wc-admin_process_pending_orders_batch',
+				self::PROCESS_PENDING_ORDERS_BATCH_ACTION => 'wc-admin_process_pending_orders_batch',
 			)
 		);
 	}
@@ -142,7 +149,7 @@ class OrdersScheduler extends ImportScheduler {
 		return array_merge(
 			parent::get_batch_sizes(),
 			array(
-				'process_pending_batch' => 100,
+				self::PROCESS_PENDING_ORDERS_BATCH_ACTION => 100,
 			)
 		);
 	}
@@ -196,8 +203,8 @@ class OrdersScheduler extends ImportScheduler {
 			"SELECT COUNT(*) FROM {$wpdb->posts}
 			WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
 			AND post_status NOT IN ( 'wc-auto-draft', 'auto-draft', 'trash' )
-			{$where_clause}"
-		); // phpcs:ignore unprepared SQL ok.
+			{$where_clause}",
+		);
 
 		$order_ids = absint( $count ) > 0 ? $wpdb->get_col(
 			$wpdb->prepare(
@@ -374,7 +381,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 * @internal
 	 */
 	public static function schedule_recurring_batch_processor() {
-		$action_hook = self::get_action( 'process_pending_batch' );
+		$action_hook = self::get_action( self::PROCESS_PENDING_ORDERS_BATCH_ACTION );
 		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
 		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
@@ -405,12 +412,12 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 		// If switching from batch processing to immediate import.
 		if ( 'no' === $old_value && 'yes' === $new_value ) {
 			// Unschedule the recurring batch processor.
-			$action_hook = self::get_action( 'process_pending_batch' );
+			$action_hook = self::get_action( self::PROCESS_PENDING_ORDERS_BATCH_ACTION );
 			as_unschedule_all_actions( $action_hook, array(), static::$group );
 
 			// Schedule an immediate catchup batch to process all orders up to now.
 			// This ensures no orders are missed during the transition.
-			self::schedule_action( 'process_pending_batch', array( null, null ) );
+			self::schedule_action( self::PROCESS_PENDING_ORDERS_BATCH_ACTION, array( null, null ) );
 		} elseif ( 'yes' === $old_value && 'no' === $new_value ) {
 			// Switching from immediate import to batch processing.
 			// Set the last processed order date to now with 1 minute buffer to ensure no orders are missed.
@@ -491,7 +498,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 			$cursor_date = $default_cursor_date;
 		}
 
-		$batch_size = self::get_batch_size( 'process_pending_batch' );
+		$batch_size = self::get_batch_size( self::PROCESS_PENDING_ORDERS_BATCH_ACTION );
 
 		$logger->info(
 			sprintf( 'Starting batch import. Cursor: %s (ID: %d), batch size: %d', $cursor_date, $cursor_id, $batch_size ),
@@ -505,6 +512,9 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 
 		if ( empty( $orders ) ) {
 			$logger->info( 'No orders to process', $context );
+			// Update the cursor position to the start time of the batch so that the next batch will start from that point.
+			update_option( self::LAST_PROCESSED_ORDER_DATE_OPTION, gmdate( 'Y-m-d H:i:s', $start_time ), false );
+			update_option( self::LAST_PROCESSED_ORDER_ID_OPTION, 0, false );
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -513,7 +513,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 		if ( empty( $orders ) ) {
 			$logger->info( 'No orders to process', $context );
 			// Update the cursor position to the start time of the batch so that the next batch will start from that point.
-			update_option( self::LAST_PROCESSED_ORDER_DATE_OPTION, gmdate( 'Y-m-d H:i:s', $start_time ), false );
+			update_option( self::LAST_PROCESSED_ORDER_DATE_OPTION, gmdate( 'Y-m-d H:i:s', (int) $start_time ), false );
 			update_option( self::LAST_PROCESSED_ORDER_ID_OPTION, 0, false );
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -203,7 +203,7 @@ class OrdersScheduler extends ImportScheduler {
 			"SELECT COUNT(*) FROM {$wpdb->posts}
 			WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
 			AND post_status NOT IN ( 'wc-auto-draft', 'auto-draft', 'trash' )
-			{$where_clause}",
+			{$where_clause}" // phpcs:ignore unprepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared SQL ok.
 		);
 
 		$order_ids = absint( $count ) > 0 ? $wpdb->get_col(

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -85,7 +85,7 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	 * Clear all scheduled batch import actions.
 	 */
 	private function clear_scheduled_actions() {
-		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
+		$hook = OrdersScheduler::get_action( OrdersScheduler::PROCESS_PENDING_ORDERS_BATCH_ACTION );
 		as_unschedule_all_actions( $hook );
 	}
 
@@ -111,8 +111,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		$this->assertNull( $data['last_processed_date'] );
 		$this->assertArrayHasKey( 'next_scheduled', $data );
 		$this->assertNull( $data['next_scheduled'] );
-		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
-		$this->assertNull( $data['manual_triggered_import_scheduled'] );
+		$this->assertArrayHasKey( 'import_in_progress_or_due', $data );
+		$this->assertNull( $data['import_in_progress_or_due'] );
 	}
 
 	/**
@@ -136,31 +136,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 'scheduled', $data['mode'] );
 		$this->assertArrayHasKey( 'last_processed_date', $data );
 		$this->assertIsString( $data['last_processed_date'] );
-		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
-		$this->assertIsBool( $data['manual_triggered_import_scheduled'] );
-	}
-
-	/**
-	 * Test status endpoint shows manual triggered import as scheduled.
-	 *
-	 * @return void
-	 */
-	public function test_status_shows_manual_triggered_import_scheduled(): void {
-		wp_set_current_user( $this->admin_user );
-
-		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
-
-		// Schedule a manual import.
-		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
-
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
-		$this->assertTrue( $data['manual_triggered_import_scheduled'] );
+		$this->assertArrayHasKey( 'import_in_progress_or_due', $data );
+		$this->assertIsBool( $data['import_in_progress_or_due'] );
 	}
 
 	/**
@@ -218,11 +195,11 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test trigger endpoint schedules batch import successfully.
+	 * Test trigger endpoint successfully triggers batch import.
 	 *
 	 * @return void
 	 */
-	public function test_trigger_schedules_import(): void {
+	public function test_trigger_successfully_triggers_import(): void {
 		wp_set_current_user( $this->admin_user );
 
 		// Set to scheduled mode.
@@ -237,11 +214,6 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'message', $data );
 		$this->assertIsString( $data['message'] );
-
-		// Verify the action was scheduled.
-		$hook             = OrdersScheduler::get_action( 'process_pending_batch' );
-		$has_scheduled_fn = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		$this->assertTrue( (bool) call_user_func( $has_scheduled_fn, $hook, array( null, null ) ) );
 	}
 
 	/**
@@ -263,31 +235,6 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'code', $data );
 		$this->assertSame( 'woocommerce_rest_analytics_import_immediate_mode', $data['code'] );
-	}
-
-	/**
-	 * Test trigger endpoint returns error when import already scheduled.
-	 *
-	 * @return void
-	 */
-	public function test_trigger_fails_when_already_scheduled(): void {
-		wp_set_current_user( $this->admin_user );
-
-		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
-
-		// Schedule an import first.
-		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
-
-		// Try to schedule another one.
-		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertSame( 400, $response->get_status() );
-
-		$data = $response->get_data();
-		$this->assertArrayHasKey( 'code', $data );
-		$this->assertSame( 'woocommerce_rest_analytics_import_already_scheduled_or_in_progress', $data['code'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -204,6 +204,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 
 		// Set to scheduled mode.
 		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		// Clear any scheduled actions that may have been created when setting the option.
+		$this->clear_scheduled_actions();
 
 		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
 		$response = $this->server->dispatch( $request );
@@ -261,6 +263,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 
 		// Set to scheduled mode.
 		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		// Clear any scheduled actions that may have been created when setting the option.
+		$this->clear_scheduled_actions();
 
 		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
 		$response = $this->server->dispatch( $request );

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Admin\API;
+
+use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * AnalyticsImports API controller test.
+ *
+ * @class AnalyticsImportsTest
+ */
+class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT = '/wc-analytics/imports';
+
+	/**
+	 * Administrator user.
+	 *
+	 * @var int
+	 */
+	protected $admin_user;
+
+	/**
+	 * Shop manager user.
+	 *
+	 * @var int
+	 */
+	protected $shop_manager_user;
+
+	/**
+	 * Customer user.
+	 *
+	 * @var int
+	 */
+	protected $customer_user;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create test users.
+		$this->admin_user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		$this->shop_manager_user = $this->factory->user->create(
+			array(
+				'role' => 'shop_manager',
+			)
+		);
+
+		$this->customer_user = $this->factory->user->create(
+			array(
+				'role' => 'customer',
+			)
+		);
+
+		// Clear any scheduled actions.
+		$this->clear_scheduled_actions();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		$this->clear_scheduled_actions();
+		parent::tearDown();
+	}
+
+	/**
+	 * Clear all scheduled batch import actions.
+	 */
+	private function clear_scheduled_actions() {
+		$hook = OrdersScheduler::get_action( 'process_pending_batch' );
+		as_unschedule_all_actions( $hook );
+	}
+
+	/**
+	 * Test status endpoint returns correct mode for immediate import.
+	 *
+	 * @return void
+	 */
+	public function test_status_returns_immediate_mode(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to immediate mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'yes' );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'mode', $data );
+		$this->assertSame( 'immediate', $data['mode'] );
+		$this->assertArrayHasKey( 'last_processed_date', $data );
+		$this->assertNull( $data['last_processed_date'] );
+		$this->assertArrayHasKey( 'next_scheduled', $data );
+		$this->assertNull( $data['next_scheduled'] );
+		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
+		$this->assertNull( $data['manual_triggered_import_scheduled'] );
+	}
+
+	/**
+	 * Test status endpoint returns correct mode for scheduled import.
+	 *
+	 * @return void
+	 */
+	public function test_status_returns_scheduled_mode(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		update_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, '2025-11-26 05:30:00' );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'mode', $data );
+		$this->assertSame( 'scheduled', $data['mode'] );
+		$this->assertArrayHasKey( 'last_processed_date', $data );
+		$this->assertIsString( $data['last_processed_date'] );
+		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
+		$this->assertIsBool( $data['manual_triggered_import_scheduled'] );
+	}
+
+	/**
+	 * Test status endpoint shows manual triggered import as scheduled.
+	 *
+	 * @return void
+	 */
+	public function test_status_shows_manual_triggered_import_scheduled(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		// Schedule a manual import.
+		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'manual_triggered_import_scheduled', $data );
+		$this->assertTrue( $data['manual_triggered_import_scheduled'] );
+	}
+
+	/**
+	 * Test status endpoint converts datetime to site timezone.
+	 *
+	 * @return void
+	 */
+	public function test_status_converts_datetime_to_site_timezone(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		// Set last processed date in GMT.
+		$gmt_date = '2025-11-26 05:30:00';
+		update_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, $gmt_date );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify the date was converted from GMT to site timezone.
+		$expected_date = get_date_from_gmt( $gmt_date, 'Y-m-d H:i:s' );
+		$this->assertSame( $expected_date, $data['last_processed_date'] );
+	}
+
+	/**
+	 * Test status endpoint requires manage_woocommerce capability.
+	 *
+	 * @return void
+	 */
+	public function test_status_requires_permission(): void {
+		wp_set_current_user( $this->customer_user );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test shop manager can access status endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_shop_manager_can_access_status(): void {
+		wp_set_current_user( $this->shop_manager_user );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test trigger endpoint schedules batch import successfully.
+	 *
+	 * @return void
+	 */
+	public function test_trigger_schedules_import(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'message', $data );
+		$this->assertIsString( $data['message'] );
+
+		// Verify the action was scheduled.
+		$hook             = OrdersScheduler::get_action( 'process_pending_batch' );
+		$has_scheduled_fn = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+		$this->assertTrue( (bool) call_user_func( $has_scheduled_fn, $hook, array( null, null ) ) );
+	}
+
+	/**
+	 * Test trigger endpoint returns error in immediate mode.
+	 *
+	 * @return void
+	 */
+	public function test_trigger_fails_in_immediate_mode(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to immediate mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'yes' );
+
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertSame( 'woocommerce_rest_analytics_import_immediate_mode', $data['code'] );
+	}
+
+	/**
+	 * Test trigger endpoint returns error when import already scheduled.
+	 *
+	 * @return void
+	 */
+	public function test_trigger_fails_when_already_scheduled(): void {
+		wp_set_current_user( $this->admin_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		// Schedule an import first.
+		OrdersScheduler::schedule_action( 'process_pending_batch', array( null, null ) );
+
+		// Try to schedule another one.
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'code', $data );
+		$this->assertSame( 'woocommerce_rest_analytics_import_already_scheduled_or_in_progress', $data['code'] );
+	}
+
+	/**
+	 * Test trigger endpoint requires manage_woocommerce capability.
+	 *
+	 * @return void
+	 */
+	public function test_trigger_requires_permission(): void {
+		wp_set_current_user( $this->customer_user );
+
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test shop manager can trigger import.
+	 *
+	 * @return void
+	 */
+	public function test_shop_manager_can_trigger_import(): void {
+		wp_set_current_user( $this->shop_manager_user );
+
+		// Set to scheduled mode.
+		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -76,6 +76,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		$this->clear_scheduled_actions();
+		delete_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION );
+		delete_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION );
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Tests\Admin\API;
 
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR implements REST API endpoints for analytics batch import status and manual triggering, as part of the Core Analytics Scheduled Imports UI feature (WOOPLUG-5761).

Closes WOOA7S-793 

#### What was added:

1. **New REST API Controller** (`src/Admin/API/AnalyticsImports.php`)
   - Only loads when both `analytics` and `analytics-scheduled-import` features are enabled
   - Extends `WC_REST_Data_Controller` following existing patterns

2. **GET `/wc-analytics/imports/status` Endpoint**
   - Returns current import mode (`immediate` or `scheduled`)
   - In scheduled mode, provides:
     - `last_processed_date` - Last processed order date in site timezone
     - `next_scheduled` - Next scheduled import time in site timezone  
     - `import_in_progress_or_due` - Boolean indicating if manual import is already in progress or due to run
   - In immediate mode, scheduled-related fields return `null`
   - Requires `manage_woocommerce` capability

3. **POST `/wc-analytics/imports/trigger` Endpoint**
   - Manually triggers batch import in scheduled mode
   - Returns 400 error if in immediate mode
   - Returns 400 error if manual import already scheduled
   - Requires `manage_woocommerce` capability

4. **Comprehensive Unit Tests** (`tests/php/src/Admin/API/AnalyticsImportsTest.php`)
   - 11 tests covering all functionality
   - Tests for both endpoints in different modes
   - Permission checks for admin, shop manager, and customer roles
   - Timezone conversion validation

#### Key Implementation Details:

- Datetimes are converted from GMT to site timezone using `get_date_from_gmt()`
- Manual import detection checks for specifically triggered imports (not recurring scheduled actions)
- Controller registration is conditional on feature flags

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions):

#### Prerequisites:

1. Install the WooCommerce Beta Tester plugin
2. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=features` and enable the `analytics-scheduled-import` feature flag

#### Test Status Endpoint (Immediate Mode):

1. Set import mode to immediate: `wp option update woocommerce_analytics_immediate_import yes`
2. Make a GET request to `/wp-json/wc-analytics/imports/status`

```js
wp.apiFetch( {
		path: '/wc-analytics/imports/status',
		method: 'GET',
}).then( ( response ) => {
	console.log( response );
}).catch( ( error ) => {
	console.error( error );
});
```

3. Verify response contains:
   - `mode: "immediate"`
   - All other fields should be `null`


#### Test Status Endpoint (Scheduled Mode):

1. Set import mode to scheduled: `wp option update woocommerce_analytics_immediate_import no`
2. Wait for ~10 seconds for the next scheduled action to be set
3. Make a GET request to `/wp-json/wc-analytics/imports/status`
4. Verify response contains:
   - `mode: "scheduled"`
   - `last_processed_date` (should be a datetime string in site timezone or null)
   - `next_scheduled` (should be a datetime string in site timezone or null)
   - `import_in_progress_or_due` (should be `false`)
5. Go to `/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending` and search for `wc-admin_process_pending_orders_batch` and verify the scheduled time (in GMT) matches the `next_scheduled` field.

<img width="1146" height="295" alt="Screenshot 2025-12-02 at 13 56 18" src="https://github.com/user-attachments/assets/95ca6e68-88a3-4699-a62f-e68f700539bf" />

<img width="1147" height="596" alt="Screenshot 2025-12-02 at 13 55 49" src="https://github.com/user-attachments/assets/7804a643-15df-4638-a1a2-060d3fb3afa9" />

#### Test Manual Trigger Endpoint:

1. Set import mode to scheduled: `wp option update woocommerce_analytics_immediate_import no`
2. Make a POST request to `/wp-json/wc-analytics/imports/trigger`

```js
wp.apiFetch( {
		path: '/wc-analytics/imports/trigger',
		method: 'POST',
}).then( ( response ) => {
	console.log( response );
}).catch( ( error ) => {
	console.error( error );
});
```

3. Verify response shows `success: true` with success message
4. Make another POST request immediately
5. Verify it returns 400 error indicating import already scheduled

#### Test Immediate Mode Restriction:

1. Set import mode to immediate: `wp option update woocommerce_analytics_immediate_import yes`
2. Make a POST request to `/wp-json/wc-analytics/imports/trigger`
3. Verify it returns 400 error with message about immediate mode

#### (Optional) Test Permissions:

1. As a customer user, make GET/POST requests to both endpoints
2. Verify both return 403 Forbidden errors
3. As shop manager, verify both endpoints are accessible

### Testing that has already taken place:

- All 11 PHPUnit tests passing (11 tests, 37 assertions)
- Tests cover:
  - Status endpoint in both immediate and scheduled modes
  - Manual trigger success and error cases  
  - Permission checks for different user roles
  - Datetime timezone conversion
  - Manual import detection

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
