### PR TITLE
Fix `woocommerce_block_asset_resource_hints` cache under multisite

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5912-woocommerce-blocks-wrong-domain-in-wp_resource_hints-on
+++ b/plugins/woocommerce/changelog/wooplug-5912-woocommerce-blocks-wrong-domain-in-wp_resource_hints-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update woocommerce_block_asset_resource_hints to work per-site, rather than across the network on multisite instances

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -262,7 +262,7 @@ final class AssetsController {
 			return null;
 		}
 
-		$cache = get_site_transient( 'woocommerce_block_asset_resource_hints' );
+		$cache = get_transient( 'woocommerce_block_asset_resource_hints' );
 
 		$current_version = array(
 			'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
@@ -295,7 +295,7 @@ final class AssetsController {
 		);
 
 		$updated['files'][ $filename ] = $data;
-		set_site_transient( 'woocommerce_block_asset_resource_hints', $updated, WEEK_IN_SECONDS );
+		set_transient( 'woocommerce_block_asset_resource_hints', $updated, WEEK_IN_SECONDS );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Admin\Features\Features;
 
@@ -264,7 +265,7 @@ final class AssetsController {
 		$cache = get_site_transient( 'woocommerce_block_asset_resource_hints' );
 
 		$current_version = array(
-			'woocommerce' => WOOCOMMERCE_VERSION,
+			'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 			'wordpress'   => get_bloginfo( 'version' ),
 			'site_url'    => wp_guess_url(),
 		);
@@ -287,7 +288,7 @@ final class AssetsController {
 		$updated = array(
 			'files'   => $cache ?? array(),
 			'version' => array(
-				'woocommerce' => WOOCOMMERCE_VERSION,
+				'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 				'wordpress'   => get_bloginfo( 'version' ),
 				'site_url'    => wp_guess_url(),
 			),

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -267,7 +267,7 @@ final class AssetsController {
 		$current_version = array(
 			'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 			'wordpress'   => get_bloginfo( 'version' ),
-			'site_url'    => wp_guess_url(),
+			'site_url'    => site_url(),
 		);
 
 		if ( isset( $cache['version'] ) && $cache['version'] === $current_version ) {
@@ -290,7 +290,7 @@ final class AssetsController {
 			'version' => array(
 				'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 				'wordpress'   => get_bloginfo( 'version' ),
-				'site_url'    => wp_guess_url(),
+				'site_url'    => site_url(),
 			),
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\AssetsController as TestedAssetsController;
 
@@ -195,7 +196,7 @@ class AssetsController extends \WP_UnitTestCase {
 				),
 			),
 			'version' => array(
-				'woocommerce' => WOOCOMMERCE_VERSION,
+				'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 				'wordpress'   => get_bloginfo( 'version' ),
 				'site_url'    => wp_guess_url(),
 			),
@@ -217,7 +218,7 @@ class AssetsController extends \WP_UnitTestCase {
 	 */
 	public function resource_hints_invalid_cache_provider(): array {
 		return array(
-			array( 'woocommerce', WOOCOMMERCE_VERSION . '-old' ),
+			array( 'woocommerce', Constants::get_constant( 'WC_VERSION' ) . '-old' ),
 			array( 'wordpress', get_bloginfo( 'version' ) . '-old' ),
 			array( 'site_url', 'http://old-url.local' ),
 		);
@@ -234,7 +235,7 @@ class AssetsController extends \WP_UnitTestCase {
 	 */
 	public function test_additional_resource_hints_invalid_cache( string $key, string $value ) {
 		$mock_version         = array(
-			'woocommerce' => WOOCOMMERCE_VERSION,
+			'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 			'wordpress'   => get_bloginfo( 'version' ),
 			'site_url'    => wp_guess_url(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -201,7 +201,7 @@ class AssetsController extends \WP_UnitTestCase {
 				'site_url'    => site_url(),
 			),
 		);
-		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+		set_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
 
 		$urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
 
@@ -260,7 +260,7 @@ class AssetsController extends \WP_UnitTestCase {
 			),
 			'version' => $mock_version,
 		);
-		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+		set_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
 
 		$urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -198,7 +198,7 @@ class AssetsController extends \WP_UnitTestCase {
 			'version' => array(
 				'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 				'wordpress'   => get_bloginfo( 'version' ),
-				'site_url'    => wp_guess_url(),
+				'site_url'    => site_url(),
 			),
 		);
 		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
@@ -237,7 +237,7 @@ class AssetsController extends \WP_UnitTestCase {
 		$mock_version         = array(
 			'woocommerce' => Constants::get_constant( 'WC_VERSION' ),
 			'wordpress'   => get_bloginfo( 'version' ),
-			'site_url'    => wp_guess_url(),
+			'site_url'    => site_url(),
 		);
 		$mock_version[ $key ] = $value;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the `woocommerce_block_asset_resource_hints` transient cache under multisite as it had some logic flaws which would cause cache to invalidate too often, or (potentially, as I didn't come across it on my test site) wrongfully share cache between sites on a network.

The issues I found were:

- The transients used `get_site_transient` instead of `get_transient`. Confusingly from the naming of these methods, `get_site_transient` is actually network wide. So every site on the network would share this cache. I believe this was done in error. By using `get_transient` instead, every individual site on the network will maintain its own cache.
- The cache uses `wp_guess_url`. This actually contains the full path to the current page, e.g. `testsite.local/cart`. This would cause cache invalidation on every page load! I've switched to `site_url()` which would be the same on all frontend pages.

Closes #62123

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that you cannot be in development mode since the cache is disabled for dev builds.

1. Create a multisite install with subdomains.
2. Create 2 test stores on the multisite. Add a product to each.
3. Add an item to cart on each store.
4. Go to the homepage and view source. You should see unique prefetched scripts on each, for example:

```
<link href='http://store2.multisite.local/wp-content/plugins/woocommerce/assets/client/blocks/checkout-frontend.js?ver=55d848ef967ca3cef6e6' as='script' rel='prefetch' />
```

To actually debug the contents of the cache you must either var_dump or log the `$cache` in `get_block_asset_resource_hints` or view transients in the database. You can see the `versions` data in this which contains the site url.

<!-- End testing instructions -->

### Testing that has already taken place:

- Installed multisite. Verified each site had its own transient
- Confirmed `get_block_asset_resource_hints` `versions` data was correct per individual site.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
