### PR TITLE
Soft deprecate wc_enqueue_js() for 10.4.0

### DIFF
--- a/plugins/woocommerce/changelog/release-10.4.0-soft-deprecate-wc_enqueue_js
+++ b/plugins/woocommerce/changelog/release-10.4.0-soft-deprecate-wc_enqueue_js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Temporarily disable deprecation notice for wc_enqueue_script() until 10.5.0

--- a/plugins/woocommerce/changelog/release-10.4.0-soft-deprecate-wc_enqueue_js
+++ b/plugins/woocommerce/changelog/release-10.4.0-soft-deprecate-wc_enqueue_js
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Temporarily disable deprecation notice for wc_enqueue_script() until 10.5.0
+Temporarily disable deprecation notice for wc_enqueue_js() until 10.5.0

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1016,11 +1016,11 @@ function wc_get_image_size( $image_size ) {
  * Queue some JavaScript code to be output in the footer.
  *
  * @param string $code Code.
+ *
+ * @deprecated 10.4.0
  */
 function wc_enqueue_js( $code ) {
 	global $wc_queued_js;
-
-	wc_deprecated_function( 'wc_enqueue_js', '10.4.0', 'wp_add_inline_script' );
 
 	if ( empty( $wc_queued_js ) ) {
 		$wc_queued_js = '';

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1017,7 +1017,7 @@ function wc_get_image_size( $image_size ) {
  *
  * @param string $code Code.
  *
- * @deprecated 10.4.0
+ * @deprecated 10.4.0 Use wp_add_inline_script() instead.
  */
 function wc_enqueue_js( $code ) {
 	global $wc_queued_js;

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -723,29 +723,6 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_enqueue_js and wc_print_js functions.
-	 *
-	 * @expectedDeprecated wc_enqueue_js
-	 *
-	 * @return void
-	 */
-	public function test_wc_enqueue_js_wc_print_js() {
-		$js = 'alert( "test" );';
-
-		ob_start();
-		wc_print_js();
-		$printed_js = ob_get_clean();
-		$this->assertStringNotContainsString( $js, $printed_js );
-
-		wc_enqueue_js( $js );
-
-		ob_start();
-		wc_print_js();
-		$printed_js = ob_get_clean();
-		$this->assertStringContainsString( $js, $printed_js );
-	}
-
-	/**
 	 * Test wc_get_log_file_name function.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes WOOPLUG-5937

### Changes proposed in this Pull Request:

This PR temporarily removes the deprecated notice for `wc_enqueue_js()` to give extensions developers more time to update before triggering warnings.  

The [dev advisory post](https://developer.woocommerce.com/2025/11/19/deprecation-of-wc_enqueue_js-in-10-4/)  was made only about 3 weeks before 10.4 is scheduled to be released.  Since this is a tight deadline for extension developers to get out changes and there is a negative connotation with deprecated notices appearing, we're going to postpone the notice being triggered until 10.5.0.

Note, this also adds the missing `@deprecated` docblock tag to the function.  I'll create a corresponding one for trunk.

### How to test the changes in this Pull Request:

1. Add code anywhere that calls `wc_enqueue_js( '' );`.  Check for deprecation notices.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

