### PR TITLE
Add deprecated doc tag to wc_enqueue_js().

### DIFF
--- a/plugins/woocommerce/changelog/tweak-deprecated-tag-wc_enqueue_script
+++ b/plugins/woocommerce/changelog/tweak-deprecated-tag-wc_enqueue_script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add deprecated tag to wc_enqueue_js().

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1016,6 +1016,8 @@ function wc_get_image_size( $image_size ) {
  * Queue some JavaScript code to be output in the footer.
  *
  * @param string $code Code.
+ *
+ * @deprecated 10.4.0
  */
 function wc_enqueue_js( $code ) {
 	global $wc_queued_js;

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1017,7 +1017,7 @@ function wc_get_image_size( $image_size ) {
  *
  * @param string $code Code.
  *
- * @deprecated 10.4.0
+ * @deprecated 10.4.0 Use wp_add_inline_script() instead.
  */
 function wc_enqueue_js( $code ) {
 	global $wc_queued_js;


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Paired with #62217, this adds an `@deprecated` tag to wc_enqueue_js()`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
Doc change only.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

