### PR TITLE
Add scheduled updates promotion admin notice

### DIFF
--- a/packages/js/data/changelog/wooa7s-795-onboarding-scheduled-updates-promotion-notices
+++ b/packages/js/data/changelog/wooa7s-795-onboarding-scheduled-updates-promotion-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update UserPreferences type to include scheduled_updates_promotion_notice_dismissed field

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -34,6 +34,7 @@ export type UserPreferences = {
 	};
 	launch_your_store_tour_hidden?: 'yes' | 'no' | '';
 	coming_soon_banner_dismissed?: 'yes' | 'no' | '';
+	scheduled_updates_promotion_notice_dismissed?: 'yes' | 'no' | '';
 };
 
 export type WoocommerceMeta = {

--- a/plugins/woocommerce/changelog/wooa7s-795-onboarding-scheduled-updates-promotion-notices
+++ b/plugins/woocommerce/changelog/wooa7s-795-onboarding-scheduled-updates-promotion-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add scheduled updates promotion notices

--- a/plugins/woocommerce/client/admin/client/analytics/components/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/index.js
@@ -1,3 +1,4 @@
 export { default as ReportChart } from './report-chart';
 export { default as ReportSummary } from './report-summary';
 export { default as ReportTable } from './report-table';
+export { default as ScheduledUpdatesPromotionNotice } from './scheduled-updates-promotion-notice';

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { getAdminLink } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
+import { useSettings, useUserPreferences } from '@woocommerce/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
+
+const IMMEDIATE_IMPORT_OPTION = 'woocommerce_analytics_immediate_import';
+
+export default function ScheduledUpdatesPromotionNotice() {
+	// Get settings to check option value (hooks must be called before early returns)
+	const settings = useSettings( 'wc_admin', [ 'wcAdminSettings' ] );
+	const wcAdminSettings = (
+		settings as { wcAdminSettings?: Record< string, string > }
+	 )?.wcAdminSettings;
+
+	const { updateUserPreferences, ...userData } = useUserPreferences();
+
+	// Check if feature flag is enabled
+	if ( ! window.wcAdminFeatures?.[ 'analytics-scheduled-import' ] ) {
+		return null;
+	}
+
+	// Check if this is an existing install (option is null)
+	if ( wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ] === null ) {
+		return null;
+	}
+
+	const isDismissed =
+		userData?.scheduled_updates_promotion_notice_dismissed === 'yes';
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	const onDismiss = () => {
+		updateUserPreferences( {
+			scheduled_updates_promotion_notice_dismissed: 'yes',
+		} );
+		recordEvent( 'scheduled_updates_promotion_notice_dismissed' );
+	};
+
+	return (
+		<div className="notice notice-info is-dismissible">
+			<Button
+				variant="tertiary"
+				aria-label={ __( 'Dismiss this notice.', 'woocommerce' ) }
+				className="woocommerce-message-close notice-dismiss"
+				onClick={ onDismiss }
+			/>
+
+			<p>
+				{ createInterpolateElement(
+					/* translators: <a> is a link to the analytics settings page. */
+					__(
+						'Analytics now supports scheduled updates, providing improved performance. Enable it in <a>Settings</a>.',
+						'woocommerce'
+					),
+					{
+						a: (
+							<a
+								href={ getAdminLink(
+									'admin.php?page=wc-admin&path=/analytics/settings'
+								) }
+								aria-label={ __(
+									'Analytics settings',
+									'woocommerce'
+								) }
+							/>
+						),
+					}
+				) }
+			</p>
+		</div>
+	);
+}

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
@@ -24,8 +24,9 @@ export default function ScheduledUpdatesPromotionNotice() {
 		return null;
 	}
 
-	// If option is set, the site has already migrated to scheduled updates or it's a new site.
-	if ( wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ] ) {
+	const optionValue = wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ];
+	// No need to show notice if option is already set.
+	if ( optionValue === 'no' || optionValue === 'yes' ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
@@ -24,8 +24,8 @@ export default function ScheduledUpdatesPromotionNotice() {
 		return null;
 	}
 
-	// Check if this is an existing install (option is null)
-	if ( wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ] === null ) {
+	// If option is set, the site has already migrated to scheduled updates or it's a new site.
+	if ( wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ] ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
@@ -1,0 +1,421 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { createElement } from '@wordpress/element';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordEvent } from '@woocommerce/tracks';
+import { useSettings, useUserPreferences } from '@woocommerce/data';
+import { getAdminLink } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import ScheduledUpdatesPromotionNotice from '../index';
+
+// Mock dependencies
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/data', () => {
+	const originalModule = jest.requireActual( '@woocommerce/data' );
+	return {
+		...originalModule,
+		useSettings: jest.fn(),
+		useUserPreferences: jest.fn(),
+	};
+} );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: jest.fn( ( path: string ) => `http://example.com/${ path }` ),
+} ) );
+
+const mockUseSettings = useSettings as jest.MockedFunction<
+	typeof useSettings
+>;
+const mockUseUserPreferences = useUserPreferences as jest.MockedFunction<
+	typeof useUserPreferences
+>;
+const mockRecordEvent = recordEvent as jest.MockedFunction<
+	typeof recordEvent
+>;
+const mockGetAdminLink = getAdminLink as jest.MockedFunction<
+	typeof getAdminLink
+>;
+
+describe( 'ScheduledUpdatesPromotionNotice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		// Set up default feature flag
+		( window as any ).wcAdminFeatures = {
+			'analytics-scheduled-import': true,
+		};
+
+		// Set up default mocks
+		mockUseSettings.mockReturnValue( {
+			wcAdminSettings: {},
+		} as unknown as ReturnType< typeof useSettings > );
+
+		mockUseUserPreferences.mockReturnValue( {
+			updateUserPreferences: jest.fn(),
+			scheduled_updates_promotion_notice_dismissed: undefined,
+			isRequesting: false,
+		} as unknown as ReturnType< typeof useUserPreferences > );
+
+		mockGetAdminLink.mockReturnValue(
+			'http://example.com/admin.php?page=wc-admin&path=/analytics/settings'
+		);
+	} );
+
+	describe( 'Feature flag check', () => {
+		test( 'should not render when feature flag is disabled', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': false,
+			};
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should not render when feature flag is undefined', () => {
+			( window as any ).wcAdminFeatures = {};
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should render when feature flag is enabled', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': true,
+			};
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Option value check', () => {
+		test( 'should not render when option is set to "yes"', () => {
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {
+					woocommerce_analytics_immediate_import: 'yes',
+				},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should not render when option is set to "no"', () => {
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {
+					woocommerce_analytics_immediate_import: 'no',
+				},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should render when option is undefined', () => {
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+
+		test( 'should render when option is null', () => {
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {
+					woocommerce_analytics_immediate_import: null,
+				},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Dismissal check', () => {
+		test( 'should not render when notice is dismissed', () => {
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: 'yes',
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should render when notice is not dismissed', () => {
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Dismissal functionality', () => {
+		test( 'should call updateUserPreferences when dismiss button is clicked', async () => {
+			const mockUpdateUserPreferences = jest.fn();
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: mockUpdateUserPreferences,
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			const dismissButton = screen.getByLabelText(
+				'Dismiss this notice.'
+			);
+			await userEvent.click( dismissButton );
+
+			expect( mockUpdateUserPreferences ).toHaveBeenCalledWith( {
+				scheduled_updates_promotion_notice_dismissed: 'yes',
+			} );
+		} );
+
+		test( 'should fire tracking event when dismiss button is clicked', async () => {
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			const dismissButton = screen.getByLabelText(
+				'Dismiss this notice.'
+			);
+			await userEvent.click( dismissButton );
+
+			expect( mockRecordEvent ).toHaveBeenCalledWith(
+				'scheduled_updates_promotion_notice_dismissed'
+			);
+		} );
+	} );
+
+	describe( 'Link generation', () => {
+		test( 'should generate correct settings link', () => {
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			const settingsLink = screen.getByLabelText( 'Analytics settings' );
+
+			expect( settingsLink ).toBeInTheDocument();
+			expect( settingsLink ).toHaveAttribute(
+				'href',
+				'http://example.com/admin.php?page=wc-admin&path=/analytics/settings'
+			);
+		} );
+
+		test( 'should call getAdminLink with correct path', () => {
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( mockGetAdminLink ).toHaveBeenCalledWith(
+				'admin.php?page=wc-admin&path=/analytics/settings'
+			);
+		} );
+	} );
+
+	describe( 'Notice content', () => {
+		test( 'should display correct notice message', () => {
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+
+		test( 'should have correct CSS classes', () => {
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			const notice = container.querySelector(
+				'.notice.notice-info.is-dismissible'
+			);
+			expect( notice ).toBeInTheDocument();
+		} );
+
+		test( 'should render dismiss button with correct attributes', () => {
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			const dismissButton = screen.getByLabelText(
+				'Dismiss this notice.'
+			);
+
+			expect( dismissButton ).toBeInTheDocument();
+			expect( dismissButton ).toHaveClass(
+				'woocommerce-message-close',
+				'notice-dismiss'
+			);
+		} );
+	} );
+
+	describe( 'Combined conditions', () => {
+		test( 'should render when all conditions are met', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': true,
+			};
+
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect(
+				screen.getByText( ( content, element ) => {
+					const textContent = element?.textContent || '';
+					return (
+						element?.tagName.toLowerCase() === 'p' &&
+						textContent.includes(
+							'Analytics now supports scheduled updates, providing improved performance. Enable it in'
+						) &&
+						textContent.includes( 'Settings' )
+					);
+				} )
+			).toBeInTheDocument();
+		} );
+
+		test( 'should not render when feature flag is disabled even if other conditions are met', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': false,
+			};
+
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should not render when option is set even if feature flag is enabled', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': true,
+			};
+
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {
+					woocommerce_analytics_immediate_import: 'yes',
+				},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: undefined,
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'should not render when dismissed even if feature flag is enabled and option is not set', () => {
+			( window as any ).wcAdminFeatures = {
+				'analytics-scheduled-import': true,
+			};
+
+			mockUseSettings.mockReturnValue( {
+				wcAdminSettings: {},
+			} as unknown as ReturnType< typeof useSettings > );
+
+			mockUseUserPreferences.mockReturnValue( {
+				updateUserPreferences: jest.fn(),
+				scheduled_updates_promotion_notice_dismissed: 'yes',
+				isRequesting: false,
+			} as unknown as ReturnType< typeof useUserPreferences > );
+
+			const { container } = render( <ScheduledUpdatesPromotionNotice /> );
+
+			expect( container.firstChild ).toBeNull();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
@@ -23,7 +23,7 @@ jest.mock( '@woocommerce/tracks', () => ( {
 jest.mock( '@woocommerce/data', () => {
 	const originalModule = jest.requireActual( '@woocommerce/data' );
 	return {
-		...originalModule,	
+		...originalModule,
 		useSettings: jest.fn(),
 		useUserPreferences: jest.fn(),
 	};

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
@@ -23,7 +23,7 @@ jest.mock( '@woocommerce/tracks', () => ( {
 jest.mock( '@woocommerce/data', () => {
 	const originalModule = jest.requireActual( '@woocommerce/data' );
 	return {
-		...originalModule,
+		...originalModule,	
 		useSettings: jest.fn(),
 		useUserPreferences: jest.fn(),
 	};

--- a/plugins/woocommerce/client/admin/client/analytics/report/use-reports.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/use-reports.js
@@ -134,15 +134,28 @@ const getReports = () => {
 	].filter( Boolean );
 
 	// Wrap the report component with the scheduled updates promotion notice
-	reports.forEach( ( report ) => {
+	// Create a new array to avoid mutating the original, which could lead to
+	// multiple wrappings if getReports() is called multiple times.
+	const wrappedReports = reports.map( ( report ) => {
 		const OriginalComponent = report.component;
-		report.component = function WrappedComponent( props ) {
+
+		function WrappedComponent( props ) {
 			return (
 				<Fragment>
 					<ScheduledUpdatesPromotionNotice />
 					<OriginalComponent { ...props } />
 				</Fragment>
 			);
+		}
+
+		// Add displayName to help with debugging
+		WrappedComponent.displayName = `WithScheduledNotice(${
+			OriginalComponent.displayName || OriginalComponent.name || 'Report'
+		})`;
+
+		return {
+			...report,
+			component: WrappedComponent,
 		};
 	} );
 
@@ -162,7 +175,7 @@ const getReports = () => {
 	 * @filter woocommerce_admin_reports_list
 	 * @param {Array.<report>} reports Report pages list.
 	 */
-	return applyFilters( REPORTS_FILTER, reports );
+	return applyFilters( REPORTS_FILTER, wrappedReports );
 };
 
 export function useReports() {

--- a/plugins/woocommerce/client/admin/client/analytics/report/use-reports.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/use-reports.js
@@ -3,13 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { lazy } from '@wordpress/element';
+import { lazy, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { getAdminSetting } from '~/utils/admin-settings';
 import { useFilterHook } from '~/utils/use-filter-hook';
+import { ScheduledUpdatesPromotionNotice } from '~/analytics/components';
 
 const RevenueReport = lazy( () =>
 	import( /* webpackChunkName: "analytics-report-revenue" */ './revenue' )
@@ -131,6 +132,19 @@ const getReports = () => {
 			},
 		},
 	].filter( Boolean );
+
+	// Wrap the report component with the scheduled updates promotion notice
+	reports.forEach( ( report ) => {
+		const OriginalComponent = report.component;
+		report.component = function WrappedComponent( props ) {
+			return (
+				<Fragment>
+					<ScheduledUpdatesPromotionNotice />
+					<OriginalComponent { ...props } />
+				</Fragment>
+			);
+		};
+	} );
 
 	/**
 	 * An object defining a report page.

--- a/plugins/woocommerce/client/admin/client/dashboard/index.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/index.js
@@ -13,6 +13,7 @@ import {
 	OrderAttributionInstallBannerImage,
 } from '~/order-attribution-install-banner';
 import './style.scss';
+import { ScheduledUpdatesPromotionNotice } from '~/analytics/components';
 
 const CustomizableDashboard = lazy( () =>
 	import( /* webpackChunkName: "customizable-dashboard" */ './customizable' )
@@ -38,6 +39,7 @@ class Dashboard extends Component {
 					bannerImage={ <OrderAttributionInstallBannerImage /> }
 					dismissable
 				/>
+				<ScheduledUpdatesPromotionNotice />
 				<CustomizableDashboard query={ query } path={ path } />
 			</Suspense>
 		);

--- a/plugins/woocommerce/client/admin/client/typings/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/typings/global.d.ts
@@ -49,6 +49,7 @@ declare global {
 			};
 		};
 		wcAdminFeatures: {
+			'analytics-scheduled-import': boolean;
 			'activity-panels': boolean;
 			analytics: boolean;
 			'coming-soon-newsletter-template': boolean;

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -146,6 +146,7 @@ class Analytics {
 				'dashboard_chart_interval',
 				'dashboard_leaderboard_rows',
 				'order_attribution_install_banner_dismissed',
+				'scheduled_updates_promotion_notice_dismissed',
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -356,7 +356,7 @@ class Settings {
 				'label'       => __( 'Update', 'woocommerce' ),
 				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
 				'type'        => 'radio',
-				'default'     => null, // Default to null so we can know if it's an new site or an existing site. New sites will have the option set.
+				'default'     => null, // Default to null so we can know if it's a new site or an existing site. New sites will have the option set.
 				'options'     => array(
 					'no'  => __( 'Scheduled (Recommended)', 'woocommerce' ),
 					'yes' => __( 'Immediately', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -356,7 +356,7 @@ class Settings {
 				'label'       => __( 'Update', 'woocommerce' ),
 				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
 				'type'        => 'radio',
-				'default'     => 'yes', // Default to immediate import for backward compatibility to ensure we don't accidentally change the behavior for existing stores.
+				'default'     => null, // Default to null so we can know if it's an new site or an existing site. New sites will have the option set.
 				'options'     => array(
 					'no'  => __( 'Scheduled (Recommended)', 'woocommerce' ),
 					'yes' => __( 'Immediately', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of WOOA7S-795

This PR implements an admin notice to promote the scheduled updates feature for analytics to existing installations.

**What's included:**
- Info notice component that appears on Analytics pages (overview, reports)
- User preference tracking for banner dismissal
- Feature flag integration (`analytics-scheduled-import`)
- Updated default setting for analytics data import to null for new sites

**Display logic:**
- Only shows to existing installations where `woocommerce_analytics_immediate_import` option doesn't exist
- Hidden if user has dismissed the banner

**Banner content:**
- Info icon with message: "Analytics now supports scheduled updates, providing improved performance. Enable it in Settings."
- "Settings" links to analytics settings page
- Dismissible with X button



### Screenshots or screen recordings:

<img width="1266" height="568" alt="Screenshot 2025-12-03 at 12 58 27" src="https://github.com/user-attachments/assets/baa14527-ff0e-4ed0-95df-8a7fc046bb2d" />



### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Delete the `woocommerce_analytics_immediate_import` option from the database to simulate an existing installation:
   - use WP CLI: `wp option delete woocommerce_analytics_immediate_import`
3. Navigate to `Analytics > Overview` page
4. Verify the info banner appears at the top with the message "Analytics now supports scheduled updates, providing improved performance. Enable it in Settings."
5. Click the "Settings" link and verify it navigates to the Analytics settings page
6. Go back to `Analytics > Overview`
7. Click the "X" button to dismiss the banner
8. Refresh the page and verify the banner no longer appears
9. Delete the user meta: `wp user meta delete <email> woocommerce_admin_scheduled_updates_promotion_notice_dismissed`
10. Set `woocommerce_analytics_immediate_import` to 'no' (scheduled mode)
11. Verify the banner does NOT appear

### Testing that has already taken place:

- Tested on a local development environment with wp-env
- Verified banner appears/hides based on option values
- Verified dismissal persists across page loads
- Verified feature flag integration
- Tested all display logic conditions

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.



### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>