### PR TITLE
Add scheduled updates promotion inbox notification

### DIFF
--- a/plugins/woocommerce/changelog/add-scheduled-updates-promotion-inbox-note
+++ b/plugins/woocommerce/changelog/add-scheduled-updates-promotion-inbox-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add scheduled updates promotion inbox note

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -82696,56 +82696,8 @@ parameters:
 			path: src/Internal/Admin/MobileAppBanner.php
 
 		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\CustomizeStoreWithBlocks'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
 			message: '#^Cannot access offset ''setup_client'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
 
@@ -82762,76 +82714,10 @@ parameters:
 			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizeStoreWithBlocks\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
 			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\|object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\CustomizingProductCatalog'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
 
 		-
 			message: '#^Cannot access property \$products on array\|object\.$#'
@@ -82842,42 +82728,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$total on array\|object\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
 
@@ -82894,108 +82744,6 @@ parameters:
 			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\CustomizingProductCatalog\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/CustomizingProductCatalog.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\EUVATNumber'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 2
@@ -83006,108 +82754,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EUVATNumber\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EUVATNumber.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\EditProductsOnTheMove'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
@@ -83122,184 +82768,10 @@ parameters:
 			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EditProductsOnTheMove\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EditProductsOnTheMove.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\EmailImprovements'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\EmailImprovements\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/EmailImprovements.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\FirstProduct'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
 
 		-
 			message: '#^Cannot access offset ''setup_client'' on mixed\.$#'
@@ -83310,42 +82782,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$total on array\|object\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/FirstProduct.php
 
@@ -83362,108 +82798,6 @@ parameters:
 			path: src/Internal/Admin/Notes/FirstProduct.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\FirstProduct\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/FirstProduct.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\GivingFeedbackNotes'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1
@@ -83472,60 +82806,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\GivingFeedbackNotes\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/GivingFeedbackNotes.php
 
@@ -83544,31 +82824,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
 			identifier: method.notFound
-			count: 5
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\InstallJPAndWCSPlugins'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
 			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
 
 		-
 			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
 
 		-
@@ -83579,24 +82841,6 @@ parameters:
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:action_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -83620,62 +82864,8 @@ parameters:
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:on_install_error\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\InstallJPAndWCSPlugins\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
 
@@ -83684,54 +82874,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\LaunchChecklist'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
@@ -83746,76 +82888,10 @@ parameters:
 			path: src/Internal/Admin/Notes/LaunchChecklist.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\LaunchChecklist\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
 			message: '#^Parameter \#1 \$var of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/LaunchChecklist.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\MagentoMigration'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
 
 		-
 			message: '#^Cannot access offset ''other_platform'' on mixed\.$#'
@@ -83830,49 +82906,7 @@ parameters:
 			path: src/Internal/Admin/Notes/MagentoMigration.php
 
 		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:is_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:note_exists\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/MagentoMigration.php
@@ -83884,106 +82918,10 @@ parameters:
 			path: src/Internal/Admin/Notes/MagentoMigration.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:save_note\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MagentoMigration\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MagentoMigration.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\ManageOrdersOnTheGo'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note\|null but empty return statement found\.$#'
@@ -83994,60 +82932,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\ManageOrdersOnTheGo\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
 
@@ -84066,30 +82950,12 @@ parameters:
 		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
 			identifier: method.notFound
-			count: 5
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\MarketingJetpack'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
 
 		-
 			message: '#^Cannot access offset ''product_id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
 			count: 2
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
 
@@ -84102,7 +82968,7 @@ parameters:
 		-
 			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
 
 		-
@@ -84114,24 +82980,6 @@ parameters:
 		-
 			message: '#^Constant WC_ADMIN_IMAGES_FOLDER_URL not found\.$#'
 			identifier: constant.notFound
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
 
@@ -84148,76 +82996,10 @@ parameters:
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:possibly_add_note\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Parameter \#2 \$note2 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MarketingJetpack\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|Automattic\\WooCommerce\\Admin\\Notes\\WC_Admin_Note given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/MarketingJetpack.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\MigrateFromShopify'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
 
 		-
 			message: '#^Cannot access offset ''other_platform'' on mixed\.$#'
@@ -84238,42 +83020,6 @@ parameters:
 			path: src/Internal/Admin/Notes/MigrateFromShopify.php
 
 		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 4
@@ -84286,108 +83032,6 @@ parameters:
 			path: src/Internal/Admin/Notes/MigrateFromShopify.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MigrateFromShopify\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MigrateFromShopify.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\MobileApp'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1
@@ -84396,60 +83040,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\MobileApp\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/MobileApp.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/MobileApp.php
 
@@ -84478,37 +83068,7 @@ parameters:
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\NewSalesRecord'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
 			message: '#^Cannot call method get_content_data\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
@@ -84526,24 +83086,6 @@ parameters:
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but returns false\.$#'
 			identifier: return.type
 			count: 1
@@ -84556,25 +83098,7 @@ parameters:
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:possibly_update_note\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
@@ -84604,33 +83128,9 @@ parameters:
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
 			message: '#^Parameter \#1 \$format of function date_i18n expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
@@ -84652,12 +83152,6 @@ parameters:
 			path: src/Internal/Admin/Notes/NewSalesRecord.php
 
 		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/NewSalesRecord.php
-
-		-
 			message: '#^Parameter \#4 \$total of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\NewSalesRecord\:\:get_note_with_record_data\(\) expects string, Automattic\\WooCommerce\\Internal\\Admin\\Notes\\floatval given\.$#'
 			identifier: argument.type
 			count: 1
@@ -84666,54 +83160,6 @@ parameters:
 		-
 			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
 			identifier: property.notFound
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\OnboardingPayments'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/OnboardingPayments.php
 
@@ -84730,72 +83176,6 @@ parameters:
 			path: src/Internal/Admin/Notes/OnboardingPayments.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnboardingPayments\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnboardingPayments.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\OnlineClothingStore'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
 			message: '#^Cannot access offset ''industry'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -84804,42 +83184,6 @@ parameters:
 		-
 			message: '#^Cannot access offset ''setup_client'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/OnlineClothingStore.php
 
@@ -84856,61 +83200,7 @@ parameters:
 			path: src/Internal/Admin/Notes/OnlineClothingStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
 			message: '#^Parameter \#1 \$industries of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:is_in_fashion_industry\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\OnlineClothingStore\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/OnlineClothingStore.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/OnlineClothingStore.php
@@ -84982,56 +83272,8 @@ parameters:
 			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
 
 		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\PaymentsMoreInfoNeeded'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
 			message: '#^Cannot call method has_incentive\(\) on Automattic\\WooCommerce\\Internal\\Admin\\WcPayWelcomePage\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
 
@@ -85048,116 +83290,14 @@ parameters:
 			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsMoreInfoNeeded\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsMoreInfoNeeded.php
-
-		-
 			message: '#^Binary operation "\-" between int\<1, max\> and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
 
 		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\PaymentsRemindMeLater'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
 			message: '#^Cannot call method has_incentive\(\) on Automattic\\WooCommerce\\Internal\\Admin\\WcPayWelcomePage\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
 
@@ -85174,108 +83314,6 @@ parameters:
 			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PaymentsRemindMeLater\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PaymentsRemindMeLater.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\PerformanceOnMobile'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 4
@@ -85288,110 +83326,8 @@ parameters:
 			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PerformanceOnMobile\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PerformanceOnMobile.php
-
-		-
 			message: '#^Binary operation "\." between ''post\.php\?post\='' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\PersonalizeStore'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/PersonalizeStore.php
 
@@ -85408,108 +83344,6 @@ parameters:
 			path: src/Internal/Admin/Notes/PersonalizeStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\PersonalizeStore\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/PersonalizeStore.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\RealTimeOrderAlerts'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note but empty return statement found\.$#'
 			identifier: return.empty
 			count: 2
@@ -85522,104 +83356,8 @@ parameters:
 			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\RealTimeOrderAlerts\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/RealTimeOrderAlerts.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\SellingOnlineCourses'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
 			message: '#^Cannot access offset ''industry'' on object\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
 
@@ -85630,124 +83368,10 @@ parameters:
 			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\SellingOnlineCourses\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/SellingOnlineCourses.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\TrackingOptIn'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:get_note\(\) should return Automattic\\WooCommerce\\Admin\\Notes\\Note\|null but empty return statement found\.$#'
@@ -85762,62 +83386,8 @@ parameters:
 			path: src/Internal/Admin/Notes/TrackingOptIn.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:opt_in_to_tracking\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\TrackingOptIn\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/TrackingOptIn.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/TrackingOptIn.php
 
@@ -85860,31 +83430,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
 			identifier: method.notFound
-			count: 6
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\WooCommercePayments'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
 			message: '#^Cannot call method get_action\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
@@ -85896,30 +83448,12 @@ parameters:
 		-
 			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
 			message: '#^Cannot call method set_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
@@ -85942,51 +83476,9 @@ parameters:
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:possibly_add_note\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommercePayments\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
@@ -86002,68 +83494,8 @@ parameters:
 			path: src/Internal/Admin/Notes/WooCommercePayments.php
 
 		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommercePayments.php
-
-		-
-			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Call to function method_exists\(\) with ''Automattic\\\\WooCommerce\\\\Internal\\\\Admin\\\\Notes\\\\WooCommerceSubscriptions'' and ''get_note'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
 			message: '#^Cannot access offset ''product_types'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Cannot call method get_is_deleted\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Cannot call method get_status\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|bool\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Cannot call method save\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:can_be_added\(\) should return bool but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:delete_if_not_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
 
@@ -86076,60 +83508,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:is_applicable\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:note_exists\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:possibly_add_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:possibly_delete_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:possibly_update_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Parameter \#1 \$arr1 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Parameter \#1 \$data of method WC_Data_Store\:\:delete\(\) expects WC_Data, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\{Automattic\\WooCommerce\\Admin\\Notes\\Note, non\-falsy\-string\} given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Parameter \#1 \$note1 of static method Automattic\\WooCommerce\\Internal\\Admin\\Notes\\WooCommerceSubscriptions\:\:update_note_field_if_changed\(\) expects Automattic\\WooCommerce\\Admin\\Notes\\Note, Automattic\\WooCommerce\\Admin\\Notes\\Note\|true given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
-
-		-
-			message: '#^Parameter \#2 \$arr2 of function array_udiff expects array\<\(int&TK\)\|\(string&TK\), mixed\>, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Notes/WooCommerceSubscriptions.php
 

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -203,7 +203,7 @@ trait NoteTraits {
 				self::update_note_field_if_changed( $note_in_db, $note, 'type' ),
 				self::update_note_field_if_changed( $note_in_db, $note, 'locale' ),
 				self::update_note_field_if_changed( $note_in_db, $note, 'source' ),
-				self::update_note_field_if_changed( $note_in_db, $note, 'actions' )
+				self::update_note_field_if_changed( $note_in_db, $note, 'actions' ),
 			),
 			true
 		);
@@ -261,7 +261,7 @@ trait NoteTraits {
 		 *
 		 * @var callable $getter2
 		 */
-		$getter2 = array( $note2, 'get_' . $field_name );
+		$getter2           = array( $note2, 'get_' . $field_name );
 		$note1_field_value = self::possibly_convert_object_to_array(
 			call_user_func( $getter1 )
 		);

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -43,7 +43,11 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function note_exists(): bool {
-		/** @var DataStore $data_store Data store instance. */
+		/**
+		 * Data store instance.
+		 *
+		 * @var DataStore $data_store
+		 */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		return ! empty( $note_ids );
@@ -118,7 +122,11 @@ trait NoteTraits {
 	 */
 	public static function delete_if_not_applicable(): void {
 		if ( ! self::is_applicable() ) {
-			/** @var DataStore $data_store Data store instance. */
+			/**
+			 * Data store instance.
+			 *
+			 * @var DataStore $data_store
+			 */
 			$data_store = Notes::load_data_store();
 			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -141,7 +149,11 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function possibly_delete_note(): void {
-		/** @var DataStore $data_store Data store instance. */
+		/**
+		 * Data store instance.
+		 *
+		 * @var DataStore $data_store
+		 */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -168,7 +180,11 @@ trait NoteTraits {
 		}
 
 		// Backwards compatibility for checking if the note class has a get_note method.
-		/** @phpstan-ignore-next-line Backwards compatibility check. */
+		/**
+		 * Backwards compatibility check.
+		 *
+		 * @phpstan-ignore-next-line
+		 */
 		if ( ! method_exists( self::class, 'get_note' ) ) {
 			return;
 		}
@@ -205,7 +221,11 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function has_note_been_actioned(): bool {
-		/** @var DataStore $data_store Data store instance. */
+		/**
+		 * Data store instance.
+		 *
+		 * @var DataStore $data_store
+		 */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -230,10 +250,18 @@ trait NoteTraits {
 	 */
 	private static function update_note_field_if_changed( $note1, $note2, string $field_name ): bool {
 		// We need to serialize the stdObject to compare it.
-		/** @var callable $getter1 Getter method for note1. */
-		$getter1            = array( $note1, 'get_' . $field_name );
-		/** @var callable $getter2 Getter method for note2. */
-		$getter2            = array( $note2, 'get_' . $field_name );
+		/**
+		 * Getter method for note1.
+		 *
+		 * @var callable $getter1
+		 */
+		$getter1 = array( $note1, 'get_' . $field_name );
+		/**
+		 * Getter method for note2.
+		 *
+		 * @var callable $getter2
+		 */
+		$getter2 = array( $note2, 'get_' . $field_name );
 		$note1_field_value = self::possibly_convert_object_to_array(
 			call_user_func( $getter1 )
 		);
@@ -248,8 +276,16 @@ trait NoteTraits {
 				(array) $note1_field_value,
 				(array) $note2_field_value,
 				function ( $action1, $action2 ): int {
-					/** @var object{name?: string, label?: string, query?: string} $action1 First action object. */
-					/** @var object{name?: string, label?: string, query?: string} $action2 Second action object. */
+					/**
+					 * First action object.
+					 *
+					 * @var object{name?: string, label?: string, query?: string} $action1
+					 */
+					/**
+					 * Second action object.
+					 *
+					 * @var object{name?: string, label?: string, query?: string} $action2
+					 */
 					if (
 						isset(
 							$action1->name,
@@ -274,10 +310,18 @@ trait NoteTraits {
 		}
 
 		if ( $need_update ) {
-			/** @var callable $getter2_again Getter method for note2 field. */
+			/**
+			 * Getter method for note2 field.
+			 *
+			 * @var callable $getter2_again
+			 */
 			$getter2_again = array( $note2, 'get_' . $field_name );
-			/** @var callable $setter1 Setter method for note1 field. */
-			$setter1       = array( $note1, 'set_' . $field_name );
+			/**
+			 * Setter method for note1 field.
+			 *
+			 * @var callable $setter1
+			 */
+			$setter1 = array( $note1, 'set_' . $field_name );
 			// Get note2 field again because it may have been changed during the comparison.
 			call_user_func( $setter1, call_user_func( $getter2_again ) );
 			return true;

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -43,7 +43,7 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function note_exists(): bool {
-		/** @var DataStore $data_store */
+		/** @var DataStore $data_store Data store instance. */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		return ! empty( $note_ids );
@@ -118,7 +118,7 @@ trait NoteTraits {
 	 */
 	public static function delete_if_not_applicable(): void {
 		if ( ! self::is_applicable() ) {
-			/** @var DataStore $data_store */
+			/** @var DataStore $data_store Data store instance. */
 			$data_store = Notes::load_data_store();
 			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -141,7 +141,7 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function possibly_delete_note(): void {
-		/** @var DataStore $data_store */
+		/** @var DataStore $data_store Data store instance. */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -168,8 +168,8 @@ trait NoteTraits {
 		}
 
 		// Backwards compatibility for checking if the note class has a get_note method.
-		/** @phpstan-ignore-next-line */
-		if (  ! method_exists( self::class, 'get_note' ) ) {
+		/** @phpstan-ignore-next-line Backwards compatibility check. */
+		if ( ! method_exists( self::class, 'get_note' ) ) {
 			return;
 		}
 
@@ -205,7 +205,7 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function has_note_been_actioned(): bool {
-		/** @var DataStore $data_store */
+		/** @var DataStore $data_store Data store instance. */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
@@ -230,10 +230,10 @@ trait NoteTraits {
 	 */
 	private static function update_note_field_if_changed( $note1, $note2, string $field_name ): bool {
 		// We need to serialize the stdObject to compare it.
-		/** @var callable $getter1 */
-		$getter1 = array( $note1, 'get_' . $field_name );
-		/** @var callable $getter2 */
-		$getter2 = array( $note2, 'get_' . $field_name );
+		/** @var callable $getter1 Getter method for note1. */
+		$getter1            = array( $note1, 'get_' . $field_name );
+		/** @var callable $getter2 Getter method for note2. */
+		$getter2            = array( $note2, 'get_' . $field_name );
 		$note1_field_value = self::possibly_convert_object_to_array(
 			call_user_func( $getter1 )
 		);
@@ -247,16 +247,22 @@ trait NoteTraits {
 			$diff        = array_udiff(
 				(array) $note1_field_value,
 				(array) $note2_field_value,
-				function( $action1, $action2 ): int {
-					/** @var object{name?: string, label?: string, query?: string} $action1 */
-					/** @var object{name?: string, label?: string, query?: string} $action2 */
+				function ( $action1, $action2 ): int {
+					/** @var object{name?: string, label?: string, query?: string} $action1 First action object. */
+					/** @var object{name?: string, label?: string, query?: string} $action2 Second action object. */
 					if (
 						isset(
-							$action1->name, $action2->name, $action1->label, $action2->label, $action1->query, $action2->query
+							$action1->name,
+							$action2->name,
+							$action1->label,
+							$action2->label,
+							$action1->query,
+							$action2->query
 						) &&
 						$action1->name === $action2->name &&
 						$action1->label === $action2->label &&
-						$action1->query === $action2->query ) {
+						$action1->query === $action2->query
+					) {
 						return 0;
 					}
 					return -1;
@@ -268,10 +274,10 @@ trait NoteTraits {
 		}
 
 		if ( $need_update ) {
-			/** @var callable $getter2_again */
+			/** @var callable $getter2_again Getter method for note2 field. */
 			$getter2_again = array( $note2, 'get_' . $field_name );
-			/** @var callable $setter1 */
-			$setter1 = array( $note1, 'set_' . $field_name );
+			/** @var callable $setter1 Setter method for note1 field. */
+			$setter1       = array( $note1, 'set_' . $field_name );
 			// Get note2 field again because it may have been changed during the comparison.
 			call_user_func( $setter1, call_user_func( $getter2_again ) );
 			return true;

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -39,9 +39,11 @@ trait NoteTraits {
 	/**
 	 * Check if the note has been previously added.
 	 *
+	 * @return bool
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function note_exists() {
+	public static function note_exists(): bool {
+		/** @var DataStore $data_store */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		return ! empty( $note_ids );
@@ -53,11 +55,11 @@ trait NoteTraits {
 	 * @return bool
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function can_be_added() {
+	public static function can_be_added(): bool {
 		$note = self::get_note();
 
 		if ( ! $note instanceof Note && ! $note instanceof WC_Admin_Note ) {
-			return;
+			return false;
 		}
 
 		if ( self::note_exists() ) {
@@ -77,24 +79,28 @@ trait NoteTraits {
 	/**
 	 * Add the note if it passes predefined conditions.
 	 *
+	 * @return void
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function possibly_add_note() {
+	public static function possibly_add_note(): void {
 		$note = self::get_note();
 
 		if ( ! self::can_be_added() ) {
 			return;
 		}
 
-		$note->save();
+		if ( $note instanceof Note || $note instanceof WC_Admin_Note ) {
+			$note->save();
+		}
 	}
 
 	/**
 	 * Alias this method for backwards compatibility.
 	 *
+	 * @return void
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function add_note() {
+	public static function add_note(): void {
 		self::possibly_add_note();
 	}
 
@@ -107,17 +113,20 @@ trait NoteTraits {
 
 	/**
 	 * Delete this note if it is not applicable, unless has been soft-deleted or actioned already.
+	 *
+	 * @return void
 	 */
-	public static function delete_if_not_applicable() {
+	public static function delete_if_not_applicable(): void {
 		if ( ! self::is_applicable() ) {
+			/** @var DataStore $data_store */
 			$data_store = Notes::load_data_store();
 			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 			if ( ! empty( $note_ids ) ) {
 				$note = Notes::get_note( $note_ids[0] );
 
-				if ( ! $note->get_is_deleted() && ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) ) {
-					return self::possibly_delete_note();
+				if ( $note instanceof Note && ! $note->get_is_deleted() && ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) ) {
+					self::possibly_delete_note();
 				}
 			}
 		}
@@ -128,16 +137,18 @@ trait NoteTraits {
 	 * is a hard delete, for where it doesn't make sense to soft delete or
 	 * action the note.
 	 *
+	 * @return void
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function possibly_delete_note() {
+	public static function possibly_delete_note(): void {
+		/** @var DataStore $data_store */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 		foreach ( $note_ids as $note_id ) {
 			$note = Notes::get_note( $note_id );
 
-			if ( $note ) {
+			if ( $note instanceof Note ) {
 				$data_store->delete( $note );
 			}
 		}
@@ -147,15 +158,18 @@ trait NoteTraits {
 	/**
 	 * Update the note if it passes predefined conditions.
 	 *
+	 * @return void
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function possibly_update_note() {
+	public static function possibly_update_note(): void {
 		$note_in_db = Notes::get_note_by_name( self::NOTE_NAME );
-		if ( ! $note_in_db ) {
+		if ( ! $note_in_db instanceof Note ) {
 			return;
 		}
 
-		if ( ! method_exists( self::class, 'get_note' ) ) {
+		// Backwards compatibility for checking if the note class has a get_note method.
+		/** @phpstan-ignore-next-line */
+		if (  ! method_exists( self::class, 'get_note' ) ) {
 			return;
 		}
 
@@ -190,14 +204,15 @@ trait NoteTraits {
 	 * @return bool
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
-	public static function has_note_been_actioned() {
+	public static function has_note_been_actioned(): bool {
+		/** @var DataStore $data_store */
 		$data_store = Notes::load_data_store();
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 		if ( ! empty( $note_ids ) ) {
 			$note = Notes::get_note( $note_ids[0] );
 
-			if ( Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
+			if ( $note instanceof Note && Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
 				return true;
 			}
 		}
@@ -205,31 +220,41 @@ trait NoteTraits {
 		return false;
 	}
 
-/**
+	/**
 	 * Update a note field of note1 if it's different from note2 with getter and setter.
 	 *
-	 * @param Note   $note1 Note to update.
-	 * @param Note   $note2 Note to compare against.
-	 * @param string $field_name Field to update.
+	 * @param Note|WC_Admin_Note $note1 Note to update.
+	 * @param Note|WC_Admin_Note $note2 Note to compare against.
+	 * @param string             $field_name Field to update.
 	 * @return bool True if the field was updated.
 	 */
-	private static function update_note_field_if_changed( $note1, $note2, $field_name ) {
+	private static function update_note_field_if_changed( $note1, $note2, string $field_name ): bool {
 		// We need to serialize the stdObject to compare it.
+		/** @var callable $getter1 */
+		$getter1 = array( $note1, 'get_' . $field_name );
+		/** @var callable $getter2 */
+		$getter2 = array( $note2, 'get_' . $field_name );
 		$note1_field_value = self::possibly_convert_object_to_array(
-			call_user_func( array( $note1, 'get_' . $field_name ) )
+			call_user_func( $getter1 )
 		);
 		$note2_field_value = self::possibly_convert_object_to_array(
-			call_user_func( array( $note2, 'get_' . $field_name ) )
+			call_user_func( $getter2 )
 		);
 
 		if ( 'actions' === $field_name ) {
 			// We need to individually compare the action fields because action object from db is different from action object of note.
 			// For example, action object from db has "id".
 			$diff        = array_udiff(
-				$note1_field_value,
-				$note2_field_value,
-				function( $action1, $action2 ) {
-					if ( $action1->name === $action2->name &&
+				(array) $note1_field_value,
+				(array) $note2_field_value,
+				function( $action1, $action2 ): int {
+					/** @var object{name?: string, label?: string, query?: string} $action1 */
+					/** @var object{name?: string, label?: string, query?: string} $action2 */
+					if (
+						isset(
+							$action1->name, $action2->name, $action1->label, $action2->label, $action1->query, $action2->query
+						) &&
+						$action1->name === $action2->name &&
 						$action1->label === $action2->label &&
 						$action1->query === $action2->query ) {
 						return 0;
@@ -243,11 +268,12 @@ trait NoteTraits {
 		}
 
 		if ( $need_update ) {
-			call_user_func(
-				array( $note1, 'set_' . $field_name ),
-				// Get note2 field again because it may have been changed during the comparison.
-				call_user_func( array( $note2, 'get_' . $field_name ) )
-			);
+			/** @var callable $getter2_again */
+			$getter2_again = array( $note2, 'get_' . $field_name );
+			/** @var callable $setter1 */
+			$setter1 = array( $note1, 'set_' . $field_name );
+			// Get note2 field again because it may have been changed during the comparison.
+			call_user_func( $setter1, call_user_func( $getter2_again ) );
 			return true;
 		}
 		return false;

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -32,6 +32,7 @@ use Automattic\WooCommerce\Internal\Admin\Notes\PaymentsRemindMeLater;
 use Automattic\WooCommerce\Internal\Admin\Notes\PerformanceOnMobile;
 use Automattic\WooCommerce\Internal\Admin\Notes\PersonalizeStore;
 use Automattic\WooCommerce\Internal\Admin\Notes\RealTimeOrderAlerts;
+use Automattic\WooCommerce\Internal\Admin\Notes\ScheduledUpdatesPromotion;
 use Automattic\WooCommerce\Internal\Admin\Notes\SellingOnlineCourses;
 use Automattic\WooCommerce\Internal\Admin\Notes\TrackingOptIn;
 use Automattic\WooCommerce\Internal\Admin\Notes\UnsecuredReportFiles;
@@ -87,6 +88,7 @@ class Events {
 		PerformanceOnMobile::class,
 		PersonalizeStore::class,
 		RealTimeOrderAlerts::class,
+		ScheduledUpdatesPromotion::class,
 		TrackingOptIn::class,
 		WooCommercePayments::class,
 		WooCommerceSubscriptions::class,

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Internal\Admin\Notes\WooCommercePayments;
 use Automattic\WooCommerce\Internal\Admin\Notes\InstallJPAndWCSPlugins;
 use Automattic\WooCommerce\Internal\Admin\Notes\SellingOnlineCourses;
 use Automattic\WooCommerce\Internal\Admin\Notes\MagentoMigration;
+use Automattic\WooCommerce\Internal\Admin\Notes\ScheduledUpdatesPromotion;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Admin\PluginsInstaller;
@@ -189,6 +190,7 @@ class FeaturePlugin {
 		new InstallJPAndWCSPlugins();
 		new SellingOnlineCourses();
 		new MagentoMigration();
+		new ScheduledUpdatesPromotion();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
@@ -102,8 +102,9 @@ class ScheduledUpdatesPromotion {
 	 * Enable scheduled updates when the action is triggered.
 	 *
 	 * @param Note $note The note being actioned.
+	 * @return void
 	 */
-	public function enable_scheduled_updates( $note ) {
+	public function enable_scheduled_updates( $note ): void {
 		// Verify this is our note.
 		if ( self::NOTE_NAME !== $note->get_name() ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
@@ -17,6 +17,8 @@ use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
  * ScheduledUpdatesPromotion
+ *
+ * @since 10.5.0
  */
 class ScheduledUpdatesPromotion {
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * WooCommerce Admin Scheduled Updates Promotion Note Provider.
+ *
+ * Adds a note to the merchant's inbox promoting scheduled updates for analytics.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * ScheduledUpdatesPromotion
+ */
+class ScheduledUpdatesPromotion {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-scheduled-updates-promotion';
+
+	/**
+	 * Name of the option to check.
+	 */
+	const OPTION_NAME = 'woocommerce_analytics_immediate_import';
+
+	/**
+	 * Constructor - attach action hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_note_action_scheduled-updates-enable', array( $this, 'enable_scheduled_updates' ) );
+	}
+
+	/**
+	 * Should this note exist?
+	 *
+	 * @return bool
+	 */
+	public static function is_applicable() {
+		if ( ! Features::is_enabled( 'analytics-scheduled-import' ) ) {
+			return false;
+		}
+
+		// Get the current option value.
+		// Note: get_option() returns false when option doesn't exist.
+		$immediate_import = get_option( self::OPTION_NAME, false );
+
+		// Only show to existing sites (false/not set) that haven't migrated yet.
+		// New sites have the option set during onboarding, so they won't see this.
+		if ( false !== $immediate_import ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		if ( ! self::is_applicable() ) {
+			return null;
+		}
+
+		$note = new Note();
+
+		$note->set_title( __( 'Analytics now supports scheduled updates', 'woocommerce' ) );
+		$note->set_content( __( 'This provides improved performance to your store, enable it in Settings.', 'woocommerce' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+
+		// Add "Enable" action with custom handler.
+		$note->add_action(
+			'scheduled-updates-enable',
+			__( 'Enable', 'woocommerce' ),
+			wc_admin_url(),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true,
+			__( 'Scheduled updates enabled', 'woocommerce' )
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Enable scheduled updates when the action is triggered.
+	 *
+	 * @param Note $note The note being actioned.
+	 */
+	public function enable_scheduled_updates( $note ) {
+		// Verify this is our note.
+		if ( self::NOTE_NAME !== $note->get_name() ) {
+			return;
+		}
+
+		// Update the option to enable scheduled mode.
+		update_option( self::OPTION_NAME, 'no' );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
@@ -79,7 +79,7 @@ class ScheduledUpdatesPromotion {
 		$note = new Note();
 
 		$note->set_title( __( 'Analytics now supports scheduled updates', 'woocommerce' ) );
-		$note->set_content( __( 'This provides improved performance to your store, enable it in Settings.', 'woocommerce' ) );
+		$note->set_content( __( 'This provides improved performance to your store, enable it in Analytics > Settings.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/ScheduledUpdatesPromotionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/ScheduledUpdatesPromotionTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Tests for ScheduledUpdatesPromotion class.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Notes;
+
+use Automattic\WooCommerce\Internal\Admin\Notes\ScheduledUpdatesPromotion;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use WC_Unit_Test_Case;
+
+/**
+ * Class ScheduledUpdatesPromotionTest
+ */
+class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Enable the analytics-scheduled-import feature.
+	 *
+	 * @param array $features Existing features.
+	 * @return array Modified features.
+	 */
+	public function enable_feature( $features ) {
+		$features[] = 'analytics-scheduled-import';
+		return $features;
+	}
+
+	/**
+	 * Disable the analytics-scheduled-import feature.
+	 *
+	 * @param array $features Existing features.
+	 * @return array Modified features.
+	 */
+	public function disable_feature( $features ) {
+		return array_diff( $features, array( 'analytics-scheduled-import' ) );
+	}
+
+	/**
+	 * Test is_applicable returns false when feature flag is disabled.
+	 */
+	public function test_is_applicable_returns_false_when_feature_disabled() {
+		// Disable the feature (it's enabled by default in feature-config.php).
+		add_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
+
+		// Delete option to simulate existing installation.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		$this->assertFalse( ScheduledUpdatesPromotion::is_applicable() );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
+	}
+
+	/**
+	 * Test is_applicable returns true for existing installations.
+	 */
+	public function test_is_applicable_returns_true_for_existing_installations() {
+		// Enable feature flag.
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+
+		// Delete option to simulate existing installation (doesn't exist).
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		$this->assertTrue( ScheduledUpdatesPromotion::is_applicable() );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+	}
+
+	/**
+	 * Test is_applicable returns false for new installations.
+	 */
+	public function test_is_applicable_returns_false_for_new_installations() {
+		// Enable feature flag.
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+
+		// Set option to 'yes' to simulate new installation.
+		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
+
+		$this->assertFalse( ScheduledUpdatesPromotion::is_applicable() );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+	}
+
+	/**
+	 * Test get_note returns note for existing installations.
+	 */
+	public function test_get_note_returns_note_for_existing_installations() {
+		// Enable feature flag.
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+
+		// Delete option to simulate existing installation (doesn't exist).
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		$note = ScheduledUpdatesPromotion::get_note();
+
+		$this->assertInstanceOf( Note::class, $note );
+		$this->assertEquals( 'Analytics now supports scheduled updates', $note->get_title() );
+		$this->assertEquals( Note::E_WC_ADMIN_NOTE_INFORMATIONAL, $note->get_type() );
+
+		// Verify action (only 1 action now: Enable).
+		$actions = $note->get_actions();
+		$this->assertCount( 1, $actions, 'Note should have 1 action' );
+		$this->assertEquals( 'scheduled-updates-enable', $actions[0]->name );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+	}
+
+	/**
+	 * Test get_note returns null when not applicable.
+	 */
+	public function test_get_note_returns_null_when_not_applicable() {
+		// Disable the feature (it's enabled by default in feature-config.php).
+		add_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
+
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		$note = ScheduledUpdatesPromotion::get_note();
+
+		$this->assertNull( $note );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
+	}
+
+	/**
+	 * Test that note is added via possibly_add_note for existing installations.
+	 */
+	public function test_possibly_add_note_adds_note_for_existing_installations() {
+		// Enable feature flag.
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+
+		// Delete option to simulate existing installation.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		ScheduledUpdatesPromotion::possibly_add_note();
+
+		// Verify note was created.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( ScheduledUpdatesPromotion::NOTE_NAME );
+
+		$this->assertNotEmpty( $note_ids, 'Note should be created for existing installations' );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+	}
+
+	/**
+	 * Test that possibly_add_note prevents duplicates.
+	 */
+	public function test_possibly_add_note_prevents_duplicates() {
+		// Enable feature flag.
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+
+		// Delete option to simulate existing installation.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		// Add note first time.
+		ScheduledUpdatesPromotion::possibly_add_note();
+
+		// Try to add again.
+		ScheduledUpdatesPromotion::possibly_add_note();
+
+		// Verify only one note exists.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( ScheduledUpdatesPromotion::NOTE_NAME );
+
+		$this->assertCount( 1, $note_ids, 'Only one note should exist' );
+
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
+	}
+
+	/**
+	 * Test enable action handler updates option.
+	 */
+	public function test_enable_action_updates_option() {
+		// Delete option to simulate existing installation.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		// Get the note.
+		$note = ScheduledUpdatesPromotion::get_note();
+		$note->save();
+
+		// Create instance and trigger action.
+		$promotion = new ScheduledUpdatesPromotion();
+		$promotion->enable_scheduled_updates( $note );
+
+		// Verify option was updated.
+		$this->assertEquals( 'no', get_option( 'woocommerce_analytics_immediate_import' ) );
+	}
+
+	/**
+	 * Test that enable action only responds to correct note.
+	 */
+	public function test_enable_action_ignores_wrong_note() {
+		// Delete option to simulate existing installation.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+
+		// Create a different note.
+		$other_note = new Note();
+		$other_note->set_name( 'some-other-note' );
+
+		// Create instance and trigger action.
+		$promotion = new ScheduledUpdatesPromotion();
+		$promotion->enable_scheduled_updates( $other_note );
+
+		// Verify option was NOT updated (still null/doesn't exist).
+		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ), 'Option should not exist' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Delete all test notes.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( ScheduledUpdatesPromotion::NOTE_NAME );
+
+		foreach ( $note_ids as $note_id ) {
+			$note = \Automattic\WooCommerce\Admin\Notes\Notes::get_note( $note_id );
+			if ( $note ) {
+				$note->delete();
+			}
+		}
+
+		// Reset options.
+		delete_option( 'woocommerce_analytics_immediate_import' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOA7S-795

This PR adds an inbox notification to promote the analytics scheduled updates feature to existing installations. 

**What's included:**
- `ScheduledUpdatesPromotion` note class in `src/Internal/Admin/Notes/`
- Registration in `Events.php` for daily cron processing
- Initialization in `FeaturePlugin.php` for action hooks
- Comprehensive PHPUnit test coverage

**Display logic:**
- Only shows to existing installations where `woocommerce_analytics_immediate_import` option doesn't exist
- Feature flag gated: `analytics-scheduled-import`

**Notification content:**
- Title: "Analytics now supports scheduled updates"
- Message: "This provides improved performance to your store, enable it in Settings."
- One action: "Enable" button that updates the option to 'no' and shows success message

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions):

**Prerequisites:**
- Install and activate the WooCommerce Beta Tester plugin
- Enable feature flag `analytics-scheduled-import` by going to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=tools`

**Test Case 1: Note appears for existing installations**

1. Delete the `woocommerce_analytics_immediate_import` option to simulate an existing installation:
   - Use WP CLI: `wp option delete woocommerce_analytics_immediate_import`
   - Or via database directly
2. Clean up existing notes: Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=remote-inbox-notifications` and click "Delete All"
3. Run the daily cron: Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=tools` and click "Run wc_admin_daily job"
4. Navigate to `/wp-admin/admin.php?page=wc-admin` (WooCommerce Home)
5. Check the inbox panel - verify the "Analytics now supports scheduled updates" notification appears
6. Verify the message content: "This provides improved performance to your store, enable it in Settings."
7. Verify there is one "Enable" button


<img width="1134" height="586" alt="Screenshot 2025-12-03 at 12 49 08" src="https://github.com/user-attachments/assets/409aae89-fc07-4e6f-b6b5-59846c81d387" />

**Test Case 2: Enable action works correctly**

1. Click the "Enable" button on the notification
2. Verify the notification is removed from the inbox
3. Check that `woocommerce_analytics_immediate_import` option is now set to 'no':
   - Use WP CLI: `wp option get woocommerce_analytics_immediate_import`
   - Should return: `no`

**Test Case 3: Note doesn't appear for new installations**

1. Set the `woocommerce_analytics_immediate_import` option to 'no' or 'yes:
   - Use WP CLI: `wp option update woocommerce_analytics_immediate_import yes`
2. Clean up notes and run daily cron (steps 2-3 from Test Case 1)
3. Verify the notification does NOT appear in the inbox

**Test Case 6: Feature flag integration**

1. Disable the feature flag by going to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=features`
2. Delete the option and run the daily cron
3. Verify the notification does NOT appear


### Testing that has already taken place:

- **Unit tests:** All 9 PHPUnit tests pass, covering:
  - `is_applicable()` logic for all scenarios
  - `get_note()` returns correct note structure
  - `possibly_add_note()` creates notes correctly
  - Duplicate prevention
  - Enable action handler
- **Manual testing:** Tested on local wp-env environment
- **Linting:** PHP code passes all PHPCS checks
- **Integration:** Verified with info banner from PR #62225

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

No changelog entry required as this is already included in the commits.