### PR TITLE
Include variation_id in order item invalid variation error data

### DIFF
--- a/plugins/woocommerce/changelog/62240-feat-woomob-1844-add-variation_id-to-error-data-for
+++ b/plugins/woocommerce/changelog/62240-feat-woomob-1844-add-variation_id-to-error-data-for
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add variation_id in error data for `order_item_product_invalid_variation_id` errors.

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -102,7 +102,12 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 */
 	public function set_variation_id( $value ) {
 		if ( $value > 0 && 'product_variation' !== get_post_type( $value ) ) {
-			$this->error( 'order_item_product_invalid_variation_id', __( 'Invalid variation ID', 'woocommerce' ) );
+			$this->error(
+				'order_item_product_invalid_variation_id',
+				__( 'Invalid variation ID', 'woocommerce' ),
+				400,
+				array( 'variation_id' => $value )
+			);
 		}
 		$this->set_prop( 'variation_id', absint( $value ) );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -269,4 +269,23 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 
 		WC_Helper_Product::delete_product( $product_without_cogs->get_id() );
 	}
+
+	/**
+	 * @testdox set_variation_id throws exception with variation_id in error data for invalid ID.
+	 */
+	public function test_set_variation_id_throws_exception_with_data_for_invalid_id() {
+		$invalid_id = 999999;
+		$item       = new WC_Order_Item_Product();
+
+		try {
+			$item->set_variation_id( $invalid_id );
+			$this->fail( 'Setting an invalid variation ID should have thrown an exception.' );
+		} catch ( WC_Data_Exception $e ) {
+			$this->assertEquals( 'order_item_product_invalid_variation_id', $e->getErrorCode() );
+			$error_data = $e->getErrorData();
+			$this->assertEquals( 400, $error_data['status'] );
+			$this->assertArrayHasKey( 'variation_id', $error_data );
+			$this->assertEquals( $invalid_id, $error_data['variation_id'] );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOMOB-1844

This PR adds the `variation_id` in the error `order_item_product_invalid_variation_id`

**What's included:**
- Specify the status code 400 (no change, but previously this just used the default value)
- Add a data object to the error including the `variation_id`
- Add test coverage for the exception error data

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make a new Jurassic Ninja site with this branch: feat/woomob-1844-add-variation_id-to-error-data-for
2. Make an application password for your user
3. Add a Variable product with at least one variation
4. Delete that variation
5. Use the API to make a new order with the deleted variation ID in the line items
6. Observe that you get an error, including `data: { variation_id: `

#### Request
```
curl -u "demo:application password" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{
    "line_items": [
      { "product_id": 67, "id": 0, "quantity": 1 }
    ]
  }' \
  "https://organic-antelope.jurassic.ninja/index.php?rest_route=/wc/v3/orders"
```
#### Response:
```
{"code":"order_item_product_invalid_variation_id","message":"Invalid variation ID","data":{"status":400,"variation_id":66}}% 
```

### Testing that has already taken place:

- Tested on a jurassic ninja environment, and a Pressable staging environment.
- Checked with curl as above.
- Tested in POS in iPad app, to see that the variation ID is used to show the specific variation which is causing the issue.
- Unit test added

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.



### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add variation_id in error data for `order_item_product_invalid_variation_id` errors.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>