### PR TITLE
Fix analytics overview flaky tests

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3385-flaky-test-should-allow-a-user-to-move-a-section-up
+++ b/plugins/woocommerce/changelog/wooplug-3385-flaky-test-should-allow-a-user-to-move-a-section-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix analytics overview flaky tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
@@ -226,6 +226,10 @@ test.describe(
 					await test.step( `Move first section down`, async () => {
 						await buttons_ellipsis.first().click();
 						await menuitem_moveDown.click();
+						await page.waitForResponse(
+							( response ) =>
+								response.url().includes( '/users' ) && response.ok()
+						);
 					} );
 
 					await test.step( `Expect the second section to become first, and first becomes second.`, async () => {
@@ -250,6 +254,10 @@ test.describe(
 					await test.step( `Move second section up`, async () => {
 						await buttons_ellipsis.nth( 1 ).click();
 						await menuitem_moveUp.click();
+						await page.waitForResponse(
+							( response ) =>
+								response.url().includes( '/users' ) && response.ok()
+						);
 					} );
 
 					await test.step( `Expect second section becomes first section, first becomes second`, async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
@@ -228,7 +228,8 @@ test.describe(
 						await menuitem_moveDown.click();
 						await page.waitForResponse(
 							( response ) =>
-								response.url().includes( '/users' ) && response.ok()
+								response.url().includes( '/users' ) &&
+								response.ok()
 						);
 					} );
 
@@ -256,7 +257,8 @@ test.describe(
 						await menuitem_moveUp.click();
 						await page.waitForResponse(
 							( response ) =>
-								response.url().includes( '/users' ) && response.ok()
+								response.url().includes( '/users' ) &&
+								response.ok()
 						);
 					} );
 
@@ -301,6 +303,10 @@ test.describe(
 			await test.step( `Add the Performance section back in.`, async () => {
 				await page.getByTitle( 'Add more sections' ).click();
 				await page.getByTitle( 'Add Performance section' ).click();
+				await page.waitForResponse(
+					( response ) =>
+						response.url().includes( '/users' ) && response.ok()
+				);
 			} );
 
 			await test.step( `Expect the Performance section to be added back.`, async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56243 https://github.com/woocommerce/woocommerce/issues/56248

Analytics overview tests are flaky, specifically the “should allow a user to move a section up" (#56243) and "should allow a user to add a section back in" (#56248) scenarios are failing intermittently. See the following screenshots for examples of flaky test failures:

<img width="905" height="547" alt="Screenshot 2025-12-04 at 14 33 28" src="https://github.com/user-attachments/assets/b4b2ca6d-9f26-4089-9578-b18098682d5e" />

<img width="878" height="464" alt="Screenshot 2025-12-04 at 14 33 19" src="https://github.com/user-attachments/assets/8f0dfd5e-184e-450f-a7be-17b3f861c713" />

I can't reproduce the flakiness locally. However, I suspect it's due to race conditions where concurrent API requests conflict. The tests fail when the test cleanup step ([`resetSections()`](https://github.com/woocommerce/woocommerce/blob/21cf7a18049e21389f8c562ad0458af7e715014e/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js#L84-L115) in `afterEach`) attempts to reset the dashboard sections by calling the user API. The logs show that the API request succeeds, but [the response user data still contains the previous section data](https://github.com/woocommerce/woocommerce/blob/21cf7a18049e21389f8c562ad0458af7e715014e/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js#L112), causing the test to fail. I think it's because the previous API calls are still in-flight when the cleanup step runs, causing a race condition.

**The Fix:**

Added `await page.waitForResponse()` after user actions that trigger API calls to ensure the requests complete before the test ends. This prevents the race condition between test actions and the cleanup step.

Changed tests:

- "should allow a user to move a section down" - Added waitForResponse after moveDown click
- "should allow a user to move a section up" - Added waitForResponse after moveUp click  
- "should allow a user to add a section back in" - Added waitForResponse after add section click

This matches the pattern already used in the working ["should allow a user to remove a section"](https://github.com/woocommerce/woocommerce/blob/bca7e78afbee8e2d694587a310ad492e5e9f50e8/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js#L277-L281) test, which was not experiencing flakiness.

### Screenshots or screen recordings:

N/A - Test-only changes

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up local development environment as per [the guide](https://github.com/woocommerce/woocommerce/blob/21cf7a18049e21389f8c562ad0458af7e715014e/plugins/woocommerce/tests/e2e-pw/README.md#introduction).
2. Run the analytics overview e2e tests multiple times to verify stability:

   ```bash
   cd plugins/woocommerce
   for i in {1..20}; do
     echo "Run $i"
     pnpm test:e2e -- tests/e2e-pw/tests/analytics/analytics-overview.spec.js --retries=0 || break
   done

3. All tests should pass consistently without flakiness

**Note:** The issue was difficult to reproduce locally but was consistently appearing in CI.

You can try re-running `Core e2e tests 1/6 - @woocommerce/plugin-woocommerce [e2e]` CI job multiple times to verify the fix.

<img width="836" height="522" alt="Screenshot 2025-12-04 at 15 51 33" src="https://github.com/user-attachments/assets/e3ca8413-6138-4482-b2a0-f1dc3c7775b5" />

### Testing that has already taken place:

- Analyzed the test failure logs showing `dashboard_sections` containing full JSON instead of empty string in `resetSections()`
- Identified the race condition between test actions and `afterEach` cleanup
- Verified the fix by examining the working "remove section" test which already had `waitForResponse`
- Re-running CI to confirm stability

**Environment:** GitHub Actions CI with wp-env

### Milestone

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only changes to fix flaky e2e tests. No functional changes to production code.

</details>