### PR TITLE
Fix mini cart to handle optimistic cart items on slow networks

### DIFF
--- a/plugins/woocommerce/changelog/62250-wooplug-5948-mini-cart-shows-undefined-product-title-on-slow-network
+++ b/plugins/woocommerce/changelog/62250-wooplug-5948-mini-cart-shows-undefined-product-title-on-slow-network
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Mini Cart showing undefined product title on slow network connections.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -423,8 +423,8 @@ const { state: cartItemState } = store(
 					cartItem: { id, key },
 				} = getContext< CartItemContext >( 'woocommerce' );
 
-				const cartItem = ( woocommerceState.cart.items.find(
-					( item ) => item.key === key || item.id === id
+				const cartItem = ( woocommerceState.cart.items.find( ( item ) =>
+					key ? item.key === key : item.id === id
 				) || {} ) as CartItem;
 
 				cartItem.variation = cartItem.variation || [];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -420,11 +420,11 @@ const { state: cartItemState } = store(
 			// state.cartItem to get the cart item.
 			get cartItem() {
 				const {
-					cartItem: { key },
+					cartItem: { id, key },
 				} = getContext< CartItemContext >( 'woocommerce' );
 
 				const cartItem = ( woocommerceState.cart.items.find(
-					( item ) => item.key === key
+					( item ) => item.key === key || item.id === id
 				) || {} ) as CartItem;
 
 				cartItem.variation = cartItem.variation || [];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -154,6 +154,10 @@ h2.wc-block-mini-cart__title {
 			padding-top: $gap-smaller;
 			padding-bottom: $gap-smaller;
 
+			&[hidden] {
+				display: none;
+			}
+
 			&:last-child::after {
 				content: none;
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -111,7 +111,12 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 						data-wp-each--cart-item="woocommerce::state.cart.items"
 						data-wp-each-key="state.cartItem.key"
 					>
-						<tr class="wc-block-cart-items__row" data-wp-run="callbacks.filterCartItemClass" tabindex="-1">
+						<tr
+							class="wc-block-cart-items__row"
+							data-wp-bind--hidden="!state.cartItem.key"
+							data-wp-run="callbacks.filterCartItemClass"
+							tabindex="-1"
+						>
 							<td data-wp-context='{ "isImageHidden": false }' class="wc-block-cart-item__image" aria-hidden="true">
 								<img
 									data-wp-bind--hidden="!state.isProductHiddenFromCatalog"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes an issue where the Mini Cart briefly shows `undefined` for product titles when items are added to the cart on slow network connections.

**Root cause:** When an item is optimistically added to the cart, it only contains `id`, `quantity`, and optionally `variation`. The full product data (including `name`) is not available until the API response returns. During this window, the Mini Cart would display `undefined` for the product name.

**Solution:** Hide cart item rows that don't have a `key` property yet (optimistic items) until the full product data is available from the API response.

**Changes:**
- **MiniCartProductsTableBlock.php**: Added `data-wp-bind--hidden="!state.cartItem.key"` to the table row to hide optimistic items
- **style.scss**: Added CSS to ensure `display: none` is applied when the `hidden` attribute is present on table rows (needed because `<tr>` elements have `display: table-row` by default)

Also I have made this unrelated change, simply because I have found that in the transition of the optimistic items, `cartItem` was not matching with the existing optimistic item.

- **iapi-frontend.ts**: Updated the `state.cartItem` getter to also match by `id` (for optimistic items that don't have a `key` yet)

Closes #62245.

### Screenshots or screen recordings:

#### Before

https://github.com/user-attachments/assets/78f53d6b-4754-4a64-ad83-529d7830b286


#### After

https://github.com/user-attachments/assets/c253314e-414b-4e21-a783-a610d2a43971






### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the shop page
3. Open Chrome DevTools and set network throttling to "Slow 3G"
4. Add a product to the cart
5. Quickly open the Mini Cart (click the cart icon)
6. **Expected:** The product row should not show `undefined` for the product name. Instead, the row should be hidden until the full product data loads, then appear with the correct product name.

### Testing that has already taken place:

- Manual testing with network throttling enabled in Chrome DevTools
- Verified that the Mini Cart correctly hides optimistic items and shows them once the API response returns with full product data

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix Mini Cart showing undefined product title on slow network connections.

</details>
