### PR TITLE
Styling and copy improvements to the Launch Your Store screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-launch-your-store-minor-fixes
+++ b/plugins/woocommerce/changelog/fix-launch-your-store-minor-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Styling and copy improvements to Launch Your Store screen

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -56,7 +56,7 @@ export const LaunchYourStoreHubSidebar = ( props: SidebarComponentProps ) => {
 	);
 
 	const sidebarDescription = __(
-		'Ready to start selling? Before you launch your store, make sure you’ve completed these essential tasks. If you’d like to change your store visibility, go to WooCommerce | Settings | Site visibility.',
+		'Ready to start selling? Before you launch your store, make sure you’ve completed these essential tasks. If you’d like to change your store visibility, go to WooCommerce > Settings > Site visibility.',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
@@ -289,7 +289,7 @@
 									}
 								}
 
-								&:hover {
+								&:hover:not(.all-tasks-complete) {
 									background: #ededed;
 									color: $gray-600;
 								}

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
@@ -281,6 +281,7 @@
 								align-self: stretch;
 								width: 348px;
 								border: 1.5px solid transparent;
+								max-width: 100%;
 
 								&.all-tasks-complete {
 									svg {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR fixing some small issues I noticed while reviewing https://github.com/woocommerce/woocommerce/pull/62158:

* Update LYS copy so menu hierarchy is represented with `>` instead of `|`, I believe this format is more widely used in documentation, HEs, etc.
* Added a maximum width to prevent LYS sidebar items to overflow the sidebar.
* And remove the `:hover` styles if the item is not clickable.

### Screenshots or screen recordings:

Before | After
--- | ---
<img width="560" height="486" alt="imatge" src="https://github.com/user-attachments/assets/1c720b74-20df-49de-a328-5a18d5c0cd18" /> | <img width="560" height="486" alt="imatge" src="https://github.com/user-attachments/assets/bd57025a-c9a3-4e66-8e2b-3d99930e5b41" />


### How to test the changes in this Pull Request:

0. You might need to install WooCommerce Beta Tester, go to Tools > WCA Test Helper > Tools and run the Reset Launch Your Store tool.
1. Go to WooCommerce > Launch Your Store (`/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store`).
2. Verify the 'completed' task doesn't overflow the sidebar and its styles don't change on hover.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->