### PR TITLE
k6 tests: fix broken suite - nonce extraction pattern

### DIFF
--- a/plugins/woocommerce/changelog/fix-k6-nonce-extraction-pattern
+++ b/plugins/woocommerce/changelog/fix-k6-nonce-extraction-pattern
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixed K6 perfomance tests broken by WP6.9 release
+
+

--- a/plugins/woocommerce/changelog/fix-k6-nonce-extraction-pattern
+++ b/plugins/woocommerce/changelog/fix-k6-nonce-extraction-pattern
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Fixed K6 perfomance tests broken by WP6.9 release
+Comment: Fixed K6 performance tests broken by WP6.9 release
 
 

--- a/plugins/woocommerce/tests/performance/requests/merchant/add-product.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/add-product.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /**
  * External dependencies
@@ -46,7 +45,8 @@ export function addProduct( includeTests = {} ) {
 	let post_id;
 	let api_x_wp_nonce;
 	let apiNonceHeader;
-	let includedTests = Object.assign( {
+	const includedTests = Object.assign(
+		{
 			heartbeat: true,
 			other: true,
 			permalink: true,
@@ -74,8 +74,8 @@ export function addProduct( includeTests = {} ) {
 		);
 		check( response, {
 			'is status 200': ( r ) => r.status === 200,
-			"body contains: 'Add new product' header": ( response ) =>
-				response.body.includes( 'Add new product</h1>' ),
+			"body contains: 'Add new product' header": ( r ) =>
+				r.body.includes( 'Add new product</h1>' ),
 		} );
 
 		// Correlate nonce values for use in subsequent requests.
@@ -186,7 +186,9 @@ export function addProduct( includeTests = {} ) {
 			} );
 		} );
 
-		sleep( randomIntBetween( `${ think_time_min }`, `${ think_time_max }` ) );
+		sleep(
+			randomIntBetween( `${ think_time_min }`, `${ think_time_max }` )
+		);
 	}
 
 	if ( includedTests.heartbeat ) {
@@ -255,12 +257,14 @@ export function addProduct( includeTests = {} ) {
 			);
 			check( response, {
 				'is status 200': ( r ) => r.status === 200,
-				"body contains: 'Permalink:'": ( response ) =>
-					response.body.includes( '<strong>Permalink:</strong>' ),
+				"body contains: 'Permalink:'": ( r ) =>
+					r.body.includes( '<strong>Permalink:</strong>' ),
 			} );
 		} );
 
-		sleep( randomIntBetween( `${ think_time_min }`, `${ think_time_max }` ) );
+		sleep(
+			randomIntBetween( `${ think_time_min }`, `${ think_time_max }` )
+		);
 	}
 
 	if ( includedTests.update ) {
@@ -375,10 +379,10 @@ export function addProduct( includeTests = {} ) {
 			);
 			check( response, {
 				'is status 200': ( r ) => r.status === 200,
-				"body contains: 'Edit product' header": ( response ) =>
-					response.body.includes( 'Edit product</h1>' ),
-				"body contains: 'Product published' confirmation": ( response ) =>
-					response.body.includes( 'Product published.' ),
+				"body contains: 'Edit product' header": ( r ) =>
+					r.body.includes( 'Edit product</h1>' ),
+				"body contains: 'Product published' confirmation": ( r ) =>
+					r.body.includes( 'Product published.' ),
 			} );
 		} );
 	}

--- a/plugins/woocommerce/tests/performance/requests/merchant/add-product.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/add-product.js
@@ -126,8 +126,8 @@ export function addProduct( includeTests = {} ) {
 		);
 		api_x_wp_nonce = findBetween(
 			response.body,
-			'wp-json\\/","nonce":"',
-			'",'
+			'wp.apiFetch.createNonceMiddleware( "',
+			'" )'
 		);
 
 		// Create request header with nonce value for use in subsequent requests.

--- a/plugins/woocommerce/tests/performance/requests/merchant/products.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/products.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /**
  * External dependencies
@@ -50,8 +49,8 @@ export function products() {
 		);
 		check( response, {
 			'is status 200': ( r ) => r.status === 200,
-			"body contains: 'Products' header": ( response ) =>
-				response.body.includes( 'Products</h1>' ),
+			"body contains: 'Products' header": ( r ) =>
+				r.body.includes( 'Products</h1>' ),
 		} );
 
 		// Correlate nonce values for use in subsequent requests.
@@ -62,8 +61,8 @@ export function products() {
 		);
 		api_x_wp_nonce = findBetween(
 			response.body,
-			'wp-json\\/","nonce":"',
-			'",'
+			'wp.apiFetch.createNonceMiddleware( "',
+			'" )'
 		);
 
 		// Create request header with nonce value for use in subsequent requests.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [QAO-176](https://linear.app/a8c/issue/QAO-176/k6-tests-fix-broken-suite-nonce-extraction-pattern)

Fixes broken K6 performance tests suite by updating the REST API nonce extraction pattern in failing `products.js` and `add-product.js` to match the pattern used by other working tests (orders.js, coupons.js).
Given the timing of the failures (started Dec 3), this was most likely caused by the WordPress 6.9 release on Dec 2, 2025.

Also fixed lint errors in the changed files (variable shadowing in check callbacks).

### How to test the changes in this Pull Request:

✅ K6 tests pass in CI.
