### PR TITLE
Send the team name to the release assignment webhook

### DIFF
--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -116,7 +116,7 @@ jobs:
               if (eventKey === 'final' && matchingEvent && matchingEvent.description) {
                 const teamMatch = matchingEvent.description.match(/Team\s+(\S+)/i);
                 if (teamMatch && teamMatch[1]) {
-                  teamName = teamMatch[1].toLowerCase();
+                  teamName = teamMatch[1].toLowerCase().replace(/\s+/g, '-');
                   console.log(`Team name from description: ${teamName}`);
                 }
               }

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -114,9 +114,9 @@ jobs:
 
               // Extract team name from final release event description
               if (eventKey === 'final' && matchingEvent && matchingEvent.description) {
-                const teamMatch = matchingEvent.description.match(/Team\s+(\S+)/i);
+                const teamMatch = matchingEvent.description.match(/Team\s+(.+)/i);
                 if (teamMatch && teamMatch[1]) {
-                  teamName = teamMatch[1].toLowerCase().replace(/\s+/g, '-');
+                  teamName = teamMatch[1].trim().toLowerCase().replace(/\s+/g, '-');
                   console.log(`Team name from description: ${teamName}`);
                 }
               }

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -114,7 +114,7 @@ jobs:
 
               // Extract team name from final release event description
               if (eventKey === 'final' && matchingEvent && matchingEvent.description) {
-                const teamMatch = matchingEvent.description.match(/Team\s+(.+)/i);
+                const teamMatch = matchingEvent.description.match(/Team:\s*(.+)/i);
                 if (teamMatch && teamMatch[1]) {
                   teamName = teamMatch[1].trim().toLowerCase().replace(/\s+/g, '-');
                   console.log(`Team name from description: ${teamName}`);

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -84,13 +84,12 @@ jobs:
           script: |
             const ical = require('node-ical');
             const version = '${{ steps.check-code-freeze-8-weeks.outputs.version }}';
-            const escapedVersion = version.replace('.', '\\.');
 
             const releaseEvents = {
-              'beta-1': `^WooCommerce ${escapedVersion} Beta 1$`,
-              'beta-2': `^WooCommerce ${escapedVersion} Beta 2$`,
-              'rc-1': `^WooCommerce ${escapedVersion} RC 1$`,
-              'final': `^WooCommerce ${escapedVersion} Release - Team (.+)$`,
+              'beta-1': `WooCommerce ${version} Beta 1`,
+              'beta-2': `WooCommerce ${version} Beta 2`,
+              'rc-1': `WooCommerce ${version} RC 1`,
+              final: `WooCommerce ${version} Release`,
             };
 
             const events = await ical.async.fromURL(
@@ -103,26 +102,27 @@ jobs:
 
             let teamName = null;
 
-            for (const [eventKey, regexPattern] of Object.entries(releaseEvents)) {
-              const regex = new RegExp(regexPattern, 'i');
+            for (const [eventKey, eventTitle] of Object.entries(releaseEvents)) {
               const matchingEvent = calendarEvents.find(event => 
-                regex.test(event.summary.trim())
+                event.summary.trim() === eventTitle
               );
 
               const date = matchingEvent ? new Date(matchingEvent.start).toISOString().split('T')[0] : null;
               core.setOutput(`event-${eventKey}-date`, date);
-              console.log(`Event: ${eventKey}, Pattern: ${regexPattern}, Date: ${date}`);
+              console.log(`Event: ${eventTitle}, Date: ${date}`);
 
-              // Capture team name from final release event
-              if (eventKey === 'final' && matchingEvent) {
-                const match = matchingEvent.summary.trim().match(regex);
-                if (match && match[1]) {
-                  teamName = match[1].toLowerCase();
-                  core.setOutput('team', teamName);
-                  console.log(`Team name: ${teamName}`);
+              // Extract team name from final release event description
+              if (eventKey === 'final' && matchingEvent && matchingEvent.description) {
+                const teamMatch = matchingEvent.description.match(/Team\s+(\S+)/i);
+                if (teamMatch && teamMatch[1]) {
+                  teamName = teamMatch[1].toLowerCase();
+                  console.log(`Team name from description: ${teamName}`);
                 }
               }
             }
+            
+            core.setOutput('team-name', teamName);
+            
   trigger-upcoming-code-freeze-events:
     name: Assign a release lead
     needs: check-upcoming-release-events

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -19,6 +19,7 @@ jobs:
       beta-2-release-date: ${{ steps.get-all-events-for-version.outputs.event-beta-2-date }}
       rc-1-release-date: ${{ steps.get-all-events-for-version.outputs.event-rc-1-date }}
       final-release-date: ${{ steps.get-all-events-for-version.outputs.event-final-date }}
+      team-name: ${{ steps.get-all-events-for-version.outputs.team-name }}
     steps:
       - name: Install node-ical
         run: npm install node-ical
@@ -142,7 +143,7 @@ jobs:
 
             const payload = {
               action: 'release-assignment',
-              team: '${{ needs.check-upcoming-release-events.outputs.team }}',
+              team: '${{ needs.check-upcoming-release-events.outputs.team-name }}',
               version: '${{ needs.check-upcoming-release-events.outputs.version }}',
               feature_freeze_date: '${{ needs.check-upcoming-release-events.outputs.feature-freeze-date }}',
               status: process.env.ENVIRONMENT === 'production' ? 'publish' : 'draft'

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -84,12 +84,13 @@ jobs:
           script: |
             const ical = require('node-ical');
             const version = '${{ steps.check-code-freeze-8-weeks.outputs.version }}';
+            const escapedVersion = version.replace('.', '\\.');
 
             const releaseEvents = {
-              'beta-1': `WooCommerce ${version} Beta 1`,
-              'beta-2': `WooCommerce ${version} Beta 2`,
-              'rc-1': `WooCommerce ${version} RC 1`,
-              final: `WooCommerce ${version} Release`,
+              'beta-1': `^WooCommerce ${escapedVersion} Beta 1$`,
+              'beta-2': `^WooCommerce ${escapedVersion} Beta 2$`,
+              'rc-1': `^WooCommerce ${escapedVersion} RC 1$`,
+              'final': `^WooCommerce ${escapedVersion} Release - Team (.+)$`,
             };
 
             const events = await ical.async.fromURL(
@@ -100,16 +101,28 @@ jobs:
               .filter(event => event.type === 'VEVENT')
               .filter(event => event.summary && event.start);
 
-            for (const [eventKey, eventTitle] of Object.entries(releaseEvents)) {
+            let teamName = null;
+
+            for (const [eventKey, regexPattern] of Object.entries(releaseEvents)) {
+              const regex = new RegExp(regexPattern, 'i');
               const matchingEvent = calendarEvents.find(event => 
-                event.summary.trim() === eventTitle
+                regex.test(event.summary.trim())
               );
 
               const date = matchingEvent ? new Date(matchingEvent.start).toISOString().split('T')[0] : null;
               core.setOutput(`event-${eventKey}-date`, date);
-              console.log(`Event: ${eventTitle}, Date: ${date}`);
-            }
+              console.log(`Event: ${eventKey}, Pattern: ${regexPattern}, Date: ${date}`);
 
+              // Capture team name from final release event
+              if (eventKey === 'final' && matchingEvent) {
+                const match = matchingEvent.summary.trim().match(regex);
+                if (match && match[1]) {
+                  teamName = match[1].toLowerCase();
+                  core.setOutput('team', teamName);
+                  console.log(`Team name: ${teamName}`);
+                }
+              }
+            }
   trigger-upcoming-code-freeze-events:
     name: Assign a release lead
     needs: check-upcoming-release-events
@@ -129,6 +142,7 @@ jobs:
 
             const payload = {
               action: 'release-assignment',
+              team: '${{ needs.check-upcoming-release-events.outputs.team }}',
               version: '${{ needs.check-upcoming-release-events.outputs.version }}',
               feature_freeze_date: '${{ needs.check-upcoming-release-events.outputs.feature-freeze-date }}',
               status: process.env.ENVIRONMENT === 'production' ? 'publish' : 'draft'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #62255 
### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In the forked repo, create a PR with the branch `fix/62255-send-team-name-to-release-assignment-webhook` and merge it (to get this new workflow into `trunk`).
3. Open the `release-assignment.yml` in the GH UI and remove the `create-release-kickoff` step (we don't care about it for this test).
4. Add the following secrets to your fork:
- `RELEASE_CALENDAR_ID`: `46e4204b5406a5c6df48addc0dfd3a29e5e69ad7e991b165fa4e331f03ede0e0@group.calendar.google.com`
- `WPCOM_WEBHOOK_SECRET`: `foo`
- `WPCOM_RELEASE_WEBHOOK_URL`: `https://webhook.site/6c06cf7c-5082-475c-900c-14bc9fa76d7c`
5. Check the event `WooCommerce 10.6 Release` for Feb 25th, 2026. It should include `Team Flux` in the description (the calendar should have all the necessary events to simulate the entire release cycle).
6. Go to `Actions` and run the `Release: Assignment` workflow (it's possible it fails or does not find the necessary calendar events, depending on when you test this, ping me if that's the case).
7. Make sure it finishes successfully and that you receive a request in the webhook URL with the team name in the payload `https://webhook.site/#!/view/6c06cf7c-5082-475c-900c-14bc9fa76d7c`
<img width="468" height="239" alt="Screenshot 2025-12-09 at 12 41 17" src="https://github.com/user-attachments/assets/5bfc01e0-9de0-4fa1-9e04-afe0f5281487" />

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
