### PR TITLE
Product Gallery: fix inconsistent spacing between arrows

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5888-product-gallery-missing-block-spacing-control
+++ b/plugins/woocommerce/changelog/wooplug-5888-product-gallery-missing-block-spacing-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: Fix arrows gap on the frontend

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -89,7 +89,7 @@ $dialog-padding: 20px;
 		}
 	}
 
-	:where(.wc-block-next-previous-buttons) {
+	.wc-block-next-previous-buttons {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -101,26 +101,26 @@ $dialog-padding: 20px;
 			pointer-events: all;
 		}
 
-		&:where(.alignleft) {
+		&.alignleft {
 			justify-content: flex-start;
 			gap: 0;
 		}
 
-		&:where(.alignright) {
+		&.alignright {
 			justify-content: flex-end;
 			gap: 0;
 		}
 
-		&:where(.aligncenter) {
+		&.aligncenter {
 			justify-content: center;
 			gap: 0;
 		}
 
-		&:where(.aligntop) {
+		&.aligntop {
 			align-items: flex-start;
 		}
 
-		&:where(.alignbottom) {
+		&.alignbottom {
 			align-items: flex-end;
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Increases CSS specificity for Product Gallery next/previous button alignment styles to override Gutenberg's default gap styles.

The alignment classes (`.alignleft`, `.alignright`, `.aligncenter`) were being overridden by Gutenberg's styles due to equal specificity (0,1,0). This fix ensures our `gap: 0` and alignment rules take precedence.

Closes #wooplug-5888.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

x | Before | After 
-- | ------ | ----- 
Editor (no changes) |     <img width="537" height="424" alt="image" src="https://github.com/user-attachments/assets/60c73596-a0ff-459b-bcef-b0eed7fc026f" />  | <img width="543" height="483" alt="image" src="https://github.com/user-attachments/assets/adaf27fc-0a11-49bc-a6d9-986153484124" />
Frontend (fix) | <img width="560" height="453" alt="image" src="https://github.com/user-attachments/assets/deb82030-997a-476a-8e30-1cf3dda1be63" />| <img width="576" height="455" alt="image" src="https://github.com/user-attachments/assets/8a516461-880b-463b-ba13-ef5a30570785" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor > Single Product template
2. Replace Product Image Gallery with Product Gallery (Beta)
3. Position arrows to bottom right corner (or any corner)
4. Save and go to frontend
5. **Expected:** Make sure there's no gap between arrows on the frontend

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
