### PR TITLE
Set Product Categories as the preferred taxonomy for the Breadcrumbs block

### DIFF
--- a/plugins/woocommerce/changelog/fix-breadcrumbs-product_cat-taxonomy
+++ b/plugins/woocommerce/changelog/fix-breadcrumbs-product_cat-taxonomy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Set Product Categories as the prefered taxonomy for the Breadcrumbs block

--- a/plugins/woocommerce/changelog/fix-breadcrumbs-product_cat-taxonomy
+++ b/plugins/woocommerce/changelog/fix-breadcrumbs-product_cat-taxonomy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Set Product Categories as the prefered taxonomy for the Breadcrumbs block
+Set Product Categories as the preferred taxonomy for the Breadcrumbs block

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -679,10 +679,11 @@ final class BlockTypesController {
 	 * @internal
 	 */
 	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type ) {
-		if ( 'product' === $post_type ) {
-			$settings['taxonomy'] = 'product_cat';
+		if ( ! is_array( $settings ) || 'product' !== $post_type ) {
+			return $settings;
 		}
 
+		$settings['taxonomy'] = 'product_cat';
 		return $settings;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,6 +63,7 @@ final class BlockTypesController {
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
 		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
+		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_prefered_taxonomy' ), 10, 2 );
 	}
 
 	/**
@@ -666,5 +667,20 @@ final class BlockTypesController {
 		$args['style']         = array();
 
 		return $args;
+	}
+
+	/**
+	 * Change the prefered taxonomy for the breadcrumbs block on the product post type.
+	 *
+	 * @param array  $settings The settings for the breadcrumbs block.
+	 * @param string $post_type The post type.
+	 * @return array The settings for the breadcrumbs block.
+	 */
+	public function set_product_breadcrumbs_prefered_taxonomy( $settings, $post_type ) {
+		if ( 'product' === $post_type ) {
+			$settings['taxonomy'] = 'product_cat';
+		}
+
+		return $settings;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -675,6 +675,8 @@ final class BlockTypesController {
 	 * @param array  $settings The settings for the breadcrumbs block.
 	 * @param string $post_type The post type.
 	 * @return array The settings for the breadcrumbs block.
+	 *
+	 * @internal
 	 */
 	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type ) {
 		if ( 'product' === $post_type ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,7 +63,7 @@ final class BlockTypesController {
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
 		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
-		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_prefered_taxonomy' ), 10, 2 );
+		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 2 );
 	}
 
 	/**
@@ -670,13 +670,13 @@ final class BlockTypesController {
 	}
 
 	/**
-	 * Change the prefered taxonomy for the breadcrumbs block on the product post type.
+	 * Change the preferred taxonomy for the breadcrumbs block on the product post type.
 	 *
 	 * @param array  $settings The settings for the breadcrumbs block.
 	 * @param string $post_type The post type.
 	 * @return array The settings for the breadcrumbs block.
 	 */
-	public function set_product_breadcrumbs_prefered_taxonomy( $settings, $post_type ) {
+	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type ) {
 		if ( 'product' === $post_type ) {
 			$settings['taxonomy'] = 'product_cat';
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/PaymentInfoTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/PaymentInfoTest.php
@@ -57,7 +57,7 @@ class PaymentInfoTest extends WC_Unit_Test_Case {
 		);
 		$order->save();
 
-		// Add a dummy callback to the filter. It should be prefered over metadata.
+		// Add a dummy callback to the filter. It should be preferred over metadata.
 		$filter_callback = fn() => array( 'payment_method' => 'foo' );
 		add_filter( 'wc_order_payment_card_info', $filter_callback );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so the _Breadcrumbs_ block from Gutenberg will prioritize displaying the product category over other taxonomies, matching how the _Store Breadcrumbs_ block from WC core works.

See https://github.com/WordPress/gutenberg/pull/73283.

cc @ntsekouras

### How to test the changes in this Pull Request:

1. Create a product that has a product category, product tag and/or product brand.
2. Go to Appearance > Editor > Templates > Single Product and add the _Breadcrumbs_ block from Gutenberg into the template or the header template part.
3. In the frontend, visit that product and verify the path to the product category is displayed, instead of the other taxonomies.

Before | After
--- | ---
<img width="912" height="675" alt="imatge" src="https://github.com/user-attachments/assets/921ebc2b-0f4e-48a7-9409-625835748d73" /> | <img width="912" height="675" alt="imatge" src="https://github.com/user-attachments/assets/a5ac4ff5-a271-4819-8090-c8446e235ed7" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->