### PR TITLE
Supply an ID when registering the setup wizard.

### DIFF
--- a/plugins/woocommerce/changelog/62288-fix-setup-wizard-id
+++ b/plugins/woocommerce/changelog/62288-fix-setup-wizard-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds an ID for the setup wizard, avoiding a deprecation error under PHP 8.5.

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -540,6 +540,7 @@ class PageController {
 	public function register_store_details_page() {
 		wc_admin_register_page(
 			array(
+				'id'     => 'setup-wizard',
 				'title'  => __( 'Setup Wizard', 'woocommerce' ),
 				'parent' => '',
 				'path'   => '/setup-wizard',


### PR DESCRIPTION
The problem I'm referring to is pre-existing, but as of PHP 8.5 it becomes a *little* more prominent.

<img width="3014" height="853" alt="oh-oh-something-isnt-right" src="https://github.com/user-attachments/assets/d957c1fb-d3f7-487f-8b5c-bdaaf7f98c28" />

Somewhere in the PageController we expect pages to be registered with an ID, though there is a risk one won't be supplied (we [know about this already](https://github.com/woocommerce/woocommerce/blob/10.3.6/plugins/woocommerce/src/Admin/PageController.php#L117-L118), but seem not to have implemented a proper fix just yet). The problem is that in cases where the ID is missing, it will default to `null` ... and we then try to use it [as an array index](https://github.com/woocommerce/woocommerce/blob/10.3.6/plugins/woocommerce/src/Admin/PageController.php#L118). As of PHP 8.5, however, using `null` as an index is deprecated:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead.
```

Because of my local debug settings, that leads to the weird gap you see in the above screenshot. Even without that, you can see the problem via Query Monitor (or probably just by watching your error logs). In this PR:

* I fix the registration of the setup wizard so that it supplies an ID. This solves the immediate problem.
* I *don't* fix the logic in [PageController::connect_page()](https://github.com/woocommerce/woocommerce/blob/10.3.6/plugins/woocommerce/src/Admin/PageController.php#L75-L119), but we should probably do that at some point by checking for potential collisions and auto-generating an ID if necessary (or else throwing an exception, or something like that).

### How to test the changes in this Pull Request:

These instructions essentially just verify that the setup wizard still works and is unaffected by this change.

1. Start with a brand-spanking new installation of WordPress, and then install WooCommerce (use a build that includes this fix).
2. Once it is activated, you should enter the setup wizard.
3. Confirm that you can also successfully restart the wizard at any time. To do this, visit **WooCommerce ‣ Settings** then open the **Help** pulldown and click the **Setup Wizard** button, as shown in the following screenshot:

<img width="3351" height="1512" alt="restart-wizard" src="https://github.com/user-attachments/assets/daf1be68-4268-46cb-be6b-ef6180ffb1db" />

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds an ID for the setup wizard, avoiding a deprecation error under PHP 8.5.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
