### PR TITLE
Rename the option from `woocommerce_analytics_immediate_import` to `woocommerce_analytics_scheduled_import`

### DIFF
--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
@@ -33,15 +33,15 @@ export function ImportStatusBar(): JSX.Element | null {
 		'wcAdminSettings',
 	] ) as unknown as {
 		wcAdminSettings: {
-			woocommerce_analytics_immediate_import: 'yes' | 'no';
+			woocommerce_analytics_scheduled_import: 'yes' | 'no';
 		};
 	};
 
-	// Don't render if immediate import is enabled
+	// Don't render if scheduled import is disabled (immediate mode)
 	// Use the value from the settings hook rather than the status object; accessing settings is faster because they are preloaded.
 	if (
-		! wcAdminSettings?.woocommerce_analytics_immediate_import ||
-		wcAdminSettings.woocommerce_analytics_immediate_import === 'yes'
+		! wcAdminSettings?.woocommerce_analytics_scheduled_import ||
+		wcAdminSettings.woocommerce_analytics_scheduled_import === 'no'
 	) {
 		return null;
 	}

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
@@ -31,7 +31,7 @@ jest.mock( '@woocommerce/data', () => ( {
 	...jest.requireActual( '@woocommerce/data' ),
 	useSettings: jest.fn().mockImplementation( () => ( {
 		wcAdminSettings: {
-			woocommerce_analytics_immediate_import: 'no',
+			woocommerce_analytics_scheduled_import: 'yes',
 		},
 	} ) ),
 } ) );
@@ -58,7 +58,7 @@ describe( 'ImportStatusBar', () => {
 		} );
 		mockUseSettings.mockReturnValue( {
 			wcAdminSettings: {
-				woocommerce_analytics_immediate_import: 'no',
+				woocommerce_analytics_scheduled_import: 'yes',
 			},
 		} as unknown as ReturnType< typeof useSettings > );
 	} );
@@ -82,7 +82,7 @@ describe( 'ImportStatusBar', () => {
 	it( 'should not render when mode is immediate', () => {
 		mockUseSettings.mockReturnValue( {
 			wcAdminSettings: {
-				woocommerce_analytics_immediate_import: 'yes',
+				woocommerce_analytics_scheduled_import: 'no',
 			},
 		} as unknown as ReturnType< typeof useSettings > );
 		// Mock useImportStatus to avoid destructuring error even though component returns early

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/index.tsx
@@ -8,7 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
-const IMMEDIATE_IMPORT_OPTION = 'woocommerce_analytics_immediate_import';
+const SCHEDULED_IMPORT_OPTION = 'woocommerce_analytics_scheduled_import';
 
 export default function ScheduledUpdatesPromotionNotice() {
 	// Get settings to check option value (hooks must be called before early returns)
@@ -24,9 +24,9 @@ export default function ScheduledUpdatesPromotionNotice() {
 		return null;
 	}
 
-	const optionValue = wcAdminSettings?.[ IMMEDIATE_IMPORT_OPTION ];
+	const optionValue = wcAdminSettings?.[ SCHEDULED_IMPORT_OPTION ];
 	// No need to show notice if option is already set.
-	if ( optionValue === 'no' || optionValue === 'yes' ) {
+	if ( optionValue === 'yes' || optionValue === 'no' ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/scheduled-updates-promotion-notice/test/index.tsx
@@ -113,10 +113,10 @@ describe( 'ScheduledUpdatesPromotionNotice', () => {
 	} );
 
 	describe( 'Option value check', () => {
-		test( 'should not render when option is set to "yes"', () => {
+		test( 'should not render when option is set to "no"', () => {
 			mockUseSettings.mockReturnValue( {
 				wcAdminSettings: {
-					woocommerce_analytics_immediate_import: 'yes',
+					woocommerce_analytics_scheduled_import: 'no',
 				},
 			} as unknown as ReturnType< typeof useSettings > );
 
@@ -125,10 +125,10 @@ describe( 'ScheduledUpdatesPromotionNotice', () => {
 			expect( container.firstChild ).toBeNull();
 		} );
 
-		test( 'should not render when option is set to "no"', () => {
+		test( 'should not render when option is set to "yes"', () => {
 			mockUseSettings.mockReturnValue( {
 				wcAdminSettings: {
-					woocommerce_analytics_immediate_import: 'no',
+					woocommerce_analytics_scheduled_import: 'yes',
 				},
 			} as unknown as ReturnType< typeof useSettings > );
 
@@ -161,7 +161,7 @@ describe( 'ScheduledUpdatesPromotionNotice', () => {
 		test( 'should render when option is null', () => {
 			mockUseSettings.mockReturnValue( {
 				wcAdminSettings: {
-					woocommerce_analytics_immediate_import: null,
+					woocommerce_analytics_scheduled_import: null,
 				},
 			} as unknown as ReturnType< typeof useSettings > );
 
@@ -383,7 +383,7 @@ describe( 'ScheduledUpdatesPromotionNotice', () => {
 
 			mockUseSettings.mockReturnValue( {
 				wcAdminSettings: {
-					woocommerce_analytics_immediate_import: 'yes',
+					woocommerce_analytics_scheduled_import: 'no',
 				},
 			} as unknown as ReturnType< typeof useSettings > );
 

--- a/plugins/woocommerce/client/admin/client/analytics/settings/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/config.js
@@ -23,8 +23,8 @@ export const DEFAULT_ORDER_STATUSES = [
 	'on-hold',
 ];
 export const DEFAULT_DATE_RANGE = 'period=month&compare=previous_year';
-export const IMMEDIATE_IMPORT_SETTING_NAME =
-	'woocommerce_analytics_immediate_import';
+export const SCHEDULED_IMPORT_SETTING_NAME =
+	'woocommerce_analytics_scheduled_import';
 
 const filteredOrderStatuses = Object.keys( ORDER_STATUSES )
 	.filter( ( status ) => status !== 'refunded' )
@@ -162,14 +162,14 @@ if ( !! window.wcAdminFeatures?.[ 'analytics-scheduled-import' ] ) {
 		__( '12 hours', 'woocommerce' ) // Default value for the import interval.
 	);
 
-	baseConfig[ IMMEDIATE_IMPORT_SETTING_NAME ] = {
-		name: IMMEDIATE_IMPORT_SETTING_NAME,
+	baseConfig[ SCHEDULED_IMPORT_SETTING_NAME ] = {
+		name: SCHEDULED_IMPORT_SETTING_NAME,
 		label: __( 'Updates:', 'woocommerce' ),
 		inputType: 'radio',
 		options: [
 			{
 				label: __( 'Scheduled (recommended)', 'woocommerce' ),
-				value: 'no',
+				value: 'yes',
 				description: sprintf(
 					/* translators: %s: import interval, e.g. "12 hours" */
 					__(
@@ -181,7 +181,7 @@ if ( !! window.wcAdminFeatures?.[ 'analytics-scheduled-import' ] ) {
 			},
 			{
 				label: __( 'Immediately', 'woocommerce' ),
-				value: 'yes',
+				value: 'no',
 				description: __(
 					'Updates as soon as new data is available. May slow busy stores.',
 					'woocommerce'
@@ -189,10 +189,10 @@ if ( !! window.wcAdminFeatures?.[ 'analytics-scheduled-import' ] ) {
 			},
 		],
 		// This default value is primarily used when users click "Reset defaults" for settings.
-		// We set 'no' (Scheduled) as the default for new installs, since it is the recommended, lowest-impact option.
-		// Note: The PHP backend defaults to 'yes' (Immediate) to preserve legacy behavior for existing stores and avoid disrupting current site operations.
+		// We set 'yes' (Scheduled) as the default for new installs, since it is the recommended, lowest-impact option.
+		// Note: The PHP backend defaults to 'no' (Immediate) to preserve legacy behavior for existing stores and avoid disrupting current site operations.
 		// This intentional difference ensures new stores use the best-practice default, while existing stores are not affected by updates.
-		defaultValue: 'no',
+		defaultValue: 'yes',
 	};
 }
 

--- a/plugins/woocommerce/client/admin/client/analytics/settings/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/index.js
@@ -35,6 +35,8 @@ const Settings = ( { createNotice, query } ) => {
 	const [ pendingImportModeChange, setPendingImportModeChange ] =
 		useState( null );
 
+	console.log( 'wcAdminSettings', wcAdminSettings );
+
 	useEffect( () => {
 		function warnIfUnsavedChanges( event ) {
 			if ( isDirty ) {
@@ -166,6 +168,18 @@ const Settings = ( { createNotice, query } ) => {
 		setPendingImportModeChange( null );
 	};
 
+	const getSettingValue = ( setting ) => {
+		if (
+			setting === SCHEDULED_IMPORT_SETTING_NAME &&
+			! wcAdminSettings[ setting ]
+		) {
+			// If scheduled import setting is not set, return 'no' to show the immediate import option by default
+			return 'no';
+		}
+
+		return wcAdminSettings[ setting ];
+	};
+
 	return (
 		<Fragment>
 			<SectionHeader
@@ -175,7 +189,7 @@ const Settings = ( { createNotice, query } ) => {
 				{ Object.keys( config ).map( ( setting ) => (
 					<Setting
 						handleChange={ handleInputChange }
-						value={ wcAdminSettings[ setting ] }
+						value={ getSettingValue( setting ) }
 						key={ setting }
 						name={ setting }
 						{ ...config[ setting ] }

--- a/plugins/woocommerce/client/admin/client/analytics/settings/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/index.js
@@ -14,7 +14,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import './index.scss';
-import { config, IMMEDIATE_IMPORT_SETTING_NAME } from './config';
+import { config, SCHEDULED_IMPORT_SETTING_NAME } from './config';
 import Setting from './setting';
 import HistoricalData from './historical-data';
 import { ImportModeConfirmationModal } from './import-mode-confirmation-modal';
@@ -123,10 +123,10 @@ const Settings = ( { createNotice, query } ) => {
 
 		// Intercept import mode change from scheduled to immediate
 		if (
-			name === IMMEDIATE_IMPORT_SETTING_NAME &&
-			config[ IMMEDIATE_IMPORT_SETTING_NAME ] &&
-			wcAdminSettings[ name ] === 'no' &&
-			value === 'yes'
+			name === SCHEDULED_IMPORT_SETTING_NAME &&
+			config[ SCHEDULED_IMPORT_SETTING_NAME ] &&
+			wcAdminSettings[ name ] === 'yes' &&
+			value === 'no'
 		) {
 			setPendingImportModeChange( { name, value } );
 			setIsImportModeModalOpen( true );
@@ -201,7 +201,7 @@ const Settings = ( { createNotice, query } ) => {
 			) : (
 				<HistoricalData createNotice={ createNotice } />
 			) }
-			{ config[ IMMEDIATE_IMPORT_SETTING_NAME ] && (
+			{ config[ SCHEDULED_IMPORT_SETTING_NAME ] && (
 				<ImportModeConfirmationModal
 					isOpen={ isImportModeModalOpen }
 					onClose={ handleImportModeCancel }

--- a/plugins/woocommerce/client/admin/client/analytics/settings/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/index.js
@@ -35,8 +35,6 @@ const Settings = ( { createNotice, query } ) => {
 	const [ pendingImportModeChange, setPendingImportModeChange ] =
 		useState( null );
 
-	console.log( 'wcAdminSettings', wcAdminSettings );
-
 	useEffect( () => {
 		function warnIfUnsavedChanges( event ) {
 			if ( isDirty ) {

--- a/plugins/woocommerce/client/admin/client/analytics/settings/test/index.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/test/index.test.js
@@ -68,7 +68,7 @@ describe( 'Settings - Import Mode Modal', () => {
 			updateAndPersistSettings: jest.fn(),
 			updateSettings: mockUpdateSettings,
 			wcAdminSettings: {
-				[ IMMEDIATE_IMPORT_SETTING_NAME ]: 'no',
+				[ SCHEDULED_IMPORT_SETTING_NAME ]: 'yes',
 			},
 		} );
 
@@ -168,7 +168,7 @@ describe( 'Settings - Import Mode Modal', () => {
 
 		// Setting should be updated.
 		expect( mockUpdateSettings ).toHaveBeenCalledWith( 'wcAdminSettings', {
-			woocommerce_analytics_immediate_import: 'yes',
+			woocommerce_analytics_scheduled_import: 'no',
 		} );
 	} );
 
@@ -182,7 +182,7 @@ describe( 'Settings - Import Mode Modal', () => {
 			updateAndPersistSettings: jest.fn(),
 			updateSettings: mockUpdateSettings,
 			wcAdminSettings: {
-				woocommerce_analytics_immediate_import: 'yes',
+				woocommerce_analytics_scheduled_import: 'no',
 			},
 		} );
 
@@ -199,7 +199,7 @@ describe( 'Settings - Import Mode Modal', () => {
 
 		// Setting should be updated immediately.
 		expect( mockUpdateSettings ).toHaveBeenCalledWith( 'wcAdminSettings', {
-			woocommerce_analytics_immediate_import: 'no',
+			woocommerce_analytics_scheduled_import: 'yes',
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/analytics/settings/test/index.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/test/index.test.js
@@ -8,7 +8,7 @@ import { useSettings } from '@woocommerce/data';
  * Internal dependencies
  */
 import Settings from '../index';
-import { IMMEDIATE_IMPORT_SETTING_NAME } from '../config';
+import { SCHEDULED_IMPORT_SETTING_NAME } from '../config';
 
 // Mock dependencies.
 jest.mock( '@woocommerce/data', () => ( {
@@ -26,26 +26,26 @@ window.wcAdminFeatures = {
 
 jest.mock( '../config', () => ( {
 	config: {
-		woocommerce_analytics_immediate_import: {
-			name: 'woocommerce_analytics_immediate_import',
+		woocommerce_analytics_scheduled_import: {
+			name: 'woocommerce_analytics_scheduled_import',
 			label: 'Updates:',
 			inputType: 'radio',
 			options: [
 				{
 					label: 'Scheduled (recommended)',
-					value: 'no',
+					value: 'yes',
 					description: 'Updates automatically every 12 hours.',
 				},
 				{
 					label: 'Immediately',
-					value: 'yes',
+					value: 'no',
 					description: 'Updates as soon as new data is available.',
 				},
 			],
-			defaultValue: 'no',
+			defaultValue: 'yes',
 		},
 	},
-	IMMEDIATE_IMPORT_SETTING_NAME: 'woocommerce_analytics_immediate_import',
+	SCHEDULED_IMPORT_SETTING_NAME: 'woocommerce_analytics_scheduled_import',
 } ) );
 
 jest.mock( '../historical-data', () => ( {

--- a/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
+++ b/plugins/woocommerce/src/Admin/API/AnalyticsImports.php
@@ -92,8 +92,8 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_status( $request ) {
-		$is_immediate_mode = $this->is_immediate_import_enabled();
-		$mode              = $is_immediate_mode ? 'immediate' : 'scheduled';
+		$is_scheduled_mode = $this->is_scheduled_import_enabled();
+		$mode              = $is_scheduled_mode ? 'scheduled' : 'immediate';
 
 		$response = array(
 			'mode'                      => $mode,
@@ -103,7 +103,7 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 		);
 
 		// For scheduled mode, populate additional fields.
-		if ( ! $is_immediate_mode ) {
+		if ( $is_scheduled_mode ) {
 			$last_processed_gmt                    = get_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, null );
 			$response['last_processed_date']       = ( is_string( $last_processed_gmt ) && $last_processed_gmt ) ? get_date_from_gmt( $last_processed_gmt, 'Y-m-d H:i:s' ) : null;
 			$response['next_scheduled']            = $this->get_next_scheduled_time();
@@ -120,10 +120,10 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	 * @return \WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function trigger_import( $request ) {
-		$is_immediate_mode = $this->is_immediate_import_enabled();
+		$is_scheduled_mode = $this->is_scheduled_import_enabled();
 
 		// Return error if in immediate mode.
-		if ( $is_immediate_mode ) {
+		if ( ! $is_scheduled_mode ) {
 			return new WP_Error(
 				'woocommerce_rest_analytics_import_immediate_mode',
 				__( 'Manual import is not available in immediate mode. Imports happen automatically.', 'woocommerce' ),
@@ -162,12 +162,12 @@ class AnalyticsImports extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Check if immediate import is enabled.
+	 * Check if scheduled import is enabled.
 	 *
 	 * @return bool
 	 */
-	private function is_immediate_import_enabled() {
-		return 'no' !== get_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, OrdersScheduler::IMMEDIATE_IMPORT_OPTION_DEFAULT_VALUE );
+	private function is_scheduled_import_enabled() {
+		return 'yes' === get_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, OrdersScheduler::SCHEDULED_IMPORT_OPTION_DEFAULT_VALUE );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ScheduledUpdatesPromotion.php
@@ -34,7 +34,7 @@ class ScheduledUpdatesPromotion {
 	/**
 	 * Name of the option to check.
 	 */
-	const OPTION_NAME = 'woocommerce_analytics_immediate_import';
+	const OPTION_NAME = 'woocommerce_analytics_scheduled_import';
 
 	/**
 	 * Constructor - attach action hooks.
@@ -111,6 +111,6 @@ class ScheduledUpdatesPromotion {
 		}
 
 		// Update the option to enable scheduled mode.
-		update_option( self::OPTION_NAME, 'no' );
+		update_option( self::OPTION_NAME, 'yes' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -351,15 +351,15 @@ class Settings {
 
 		if ( Features::is_enabled( 'analytics-scheduled-import' ) ) {
 			$settings[] = array(
-				'id'          => 'woocommerce_analytics_immediate_import',
-				'option_key'  => 'woocommerce_analytics_immediate_import',
+				'id'          => 'woocommerce_analytics_scheduled_import',
+				'option_key'  => 'woocommerce_analytics_scheduled_import',
 				'label'       => __( 'Updates', 'woocommerce' ),
 				'description' => __( 'Controls how analytics data is imported from orders.', 'woocommerce' ),
 				'type'        => 'radio',
 				'default'     => null, // Default to null so we can know if it's a new site or an existing site. New sites will have the option set.
 				'options'     => array(
-					'no'  => __( 'Scheduled (recommended)', 'woocommerce' ),
-					'yes' => __( 'Immediately', 'woocommerce' ),
+					'yes' => __( 'Scheduled (recommended)', 'woocommerce' ),
+					'no'  => __( 'Immediately', 'woocommerce' ),
 				),
 			);
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/AnalyticsImportsTest.php
@@ -76,7 +76,7 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		$this->clear_scheduled_actions();
-		delete_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION );
+		delete_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION );
 		delete_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION );
 		parent::tearDown();
 	}
@@ -97,8 +97,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	public function test_status_returns_immediate_mode(): void {
 		wp_set_current_user( $this->admin_user );
 
-		// Set to immediate mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'yes' );
+		// Set to immediate mode (scheduled disabled).
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
 
 		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
 		$response = $this->server->dispatch( $request );
@@ -123,8 +123,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	public function test_status_returns_scheduled_mode(): void {
 		wp_set_current_user( $this->admin_user );
 
-		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		// Set to scheduled mode (scheduled enabled).
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'yes' );
 		update_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION, '2025-11-26 05:30:00' );
 
 		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/status' );
@@ -149,7 +149,7 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->admin_user );
 
 		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'yes' );
 
 		// Set last processed date in GMT.
 		$gmt_date = '2025-11-26 05:30:00';
@@ -203,7 +203,7 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->admin_user );
 
 		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'yes' );
 		// Clear any scheduled actions that may have been created when setting the option.
 		$this->clear_scheduled_actions();
 
@@ -226,8 +226,8 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 	public function test_trigger_fails_in_immediate_mode(): void {
 		wp_set_current_user( $this->admin_user );
 
-		// Set to immediate mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'yes' );
+		// Set to immediate mode (scheduled disabled).
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
 
 		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/trigger' );
 		$response = $this->server->dispatch( $request );
@@ -262,7 +262,7 @@ class AnalyticsImportsTest extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->shop_manager_user );
 
 		// Set to scheduled mode.
-		update_option( OrdersScheduler::IMMEDIATE_IMPORT_OPTION, 'no' );
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'yes' );
 		// Clear any scheduled actions that may have been created when setting the option.
 		$this->clear_scheduled_actions();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/ScheduledUpdatesPromotionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Notes/ScheduledUpdatesPromotionTest.php
@@ -45,7 +45,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
 
 		// Delete option to simulate existing installation.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		$this->assertFalse( ScheduledUpdatesPromotion::is_applicable() );
 
@@ -60,7 +60,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
 
 		// Delete option to simulate existing installation (doesn't exist).
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		$this->assertTrue( ScheduledUpdatesPromotion::is_applicable() );
 
@@ -74,8 +74,8 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		// Enable feature flag.
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
 
-		// Set option to 'yes' to simulate new installation.
-		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
+		// Set option to 'yes' to simulate new installation (scheduled enabled).
+		update_option( 'woocommerce_analytics_scheduled_import', 'yes' );
 
 		$this->assertFalse( ScheduledUpdatesPromotion::is_applicable() );
 
@@ -90,7 +90,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
 
 		// Delete option to simulate existing installation (doesn't exist).
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		$note = ScheduledUpdatesPromotion::get_note();
 
@@ -113,7 +113,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		// Disable the feature (it's enabled by default in feature-config.php).
 		add_filter( 'woocommerce_admin_features', array( $this, 'disable_feature' ) );
 
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		$note = ScheduledUpdatesPromotion::get_note();
 
@@ -130,7 +130,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
 
 		// Delete option to simulate existing installation.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		ScheduledUpdatesPromotion::possibly_add_note();
 
@@ -151,7 +151,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_feature' ) );
 
 		// Delete option to simulate existing installation.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		// Add note first time.
 		ScheduledUpdatesPromotion::possibly_add_note();
@@ -173,7 +173,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 	 */
 	public function test_enable_action_updates_option() {
 		// Delete option to simulate existing installation.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		// Get the note.
 		$note = ScheduledUpdatesPromotion::get_note();
@@ -183,8 +183,8 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		$promotion = new ScheduledUpdatesPromotion();
 		$promotion->enable_scheduled_updates( $note );
 
-		// Verify option was updated.
-		$this->assertEquals( 'no', get_option( 'woocommerce_analytics_immediate_import' ) );
+		// Verify option was updated to 'yes' (scheduled enabled).
+		$this->assertEquals( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 	 */
 	public function test_enable_action_ignores_wrong_note() {
 		// Delete option to simulate existing installation.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 
 		// Create a different note.
 		$other_note = new Note();
@@ -203,7 +203,7 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		$promotion->enable_scheduled_updates( $other_note );
 
 		// Verify option was NOT updated (still null/doesn't exist).
-		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ), 'Option should not exist' );
+		$this->assertFalse( get_option( 'woocommerce_analytics_scheduled_import' ), 'Option should not exist' );
 	}
 
 	/**
@@ -224,6 +224,6 @@ class ScheduledUpdatesPromotionTest extends WC_Unit_Test_Case {
 		}
 
 		// Reset options.
-		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOA7S-843


1. Renamed the option from `woocommerce_analytics_immediate_import` to `woocommerce_analytics_scheduled_import` with inverted logic:

- **OLD:** `'yes'` = immediate mode (NOT recommended), `'no'` = scheduled mode (recommended)
- **NEW:** `'yes'` = scheduled mode (recommended), `'no'` = immediate mode

2. Fix a minor bug where default setting was not correctly set when option does not exist in database

**Files updated:**
- Backend PHP: `Settings.php`, `OrdersScheduler.php`, `AnalyticsImports.php`, `ScheduledUpdatesPromotion.php`
- Frontend: `config.js`, `import-status-bar.tsx`, `scheduled-updates-promotion-notice/index.tsx`
- Tests: `AnalyticsImportsTest.php`, `ScheduledUpdatesPromotionTest.php`, `index.test.js`

**Note:** Since the feature hasn't been released yet, no migration or backward compatibility is needed. This is a straightforward rename and logic inversion.

#### Why

I initially used the option name `woocommerce_analytics_immediate_import`  but I now think it's better to reverse the logic since the new schedule mode is the recommended one. 

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Install and activate the `WooCommerce Beta Tester` plugin
2. Enable the `analytics-scheduled-import` feature flag if not already enabled by going to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=features`
3. Go to **Analytics → Overview**
4. Verify the `Analytics now supports scheduled updates, providing improved performance. Enable it in Settings.` notice is visible
5. Go to **Analytics → Settings**
6. Locate the "Updates" radio control
7. Verify the `Immediately` option is selected by default
8. Select "Scheduled (recommended)" and save
9. Verify the option `woocommerce_analytics_scheduled_import` is set to `'yes'` (`wp option get woocommerce_analytics_scheduled_import`)
10. Go to **Analytics → Overview**
11. Verify the Data Status Bar is visible (only shows in scheduled mode)
12. Switch to "Immediately" mode and save
13. Verify the option `woocommerce_analytics_scheduled_import` is now `'no'` (`wp option get woocommerce_analytics_scheduled_import`)
14. Refresh **Analytics → Overview** page
15. Verify the Data Status Bar is NOT visible (hidden in immediate mode)


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Rename analytics import option to woocommerce_analytics_scheduled_import with intuitive logic. The feature is not yet released, so no changelog entry is needed.

</details>
