### PR TITLE
PayPal Standard: Add meta to prevent duplicate auth-capture request when resource not found

### DIFF
--- a/plugins/woocommerce/changelog/62304-add-paypal-standard-additiona-meta-to-prevent-duplicate-requests
+++ b/plugins/woocommerce/changelog/62304-add-paypal-standard-additiona-meta-to-prevent-duplicate-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add order meta to prevent duplicate API calls when we have already received a 404 response for a capture request on an authorised payment.

--- a/plugins/woocommerce/changelog/62304-add-paypal-standard-additiona-meta-to-prevent-duplicate-requests
+++ b/plugins/woocommerce/changelog/62304-add-paypal-standard-additiona-meta-to-prevent-duplicate-requests
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Add order meta to prevent duplicate API calls when we have already received a 404 response for a capture request on an authorised payment.
+Add order meta to prevent duplicate PayPal Standard API calls when we have already received a 404 response for a capture request on an authorised payment.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -445,9 +445,9 @@ class WC_Gateway_Paypal_Request {
 			return null;
 		}
 
-		// If '_paypal_authorization_checked' is set to 'yes' and the authorization ID is empty, it means we already checked and found no authorization data.
+		// If '_paypal_authorization_checked' is set to 'yes', it means we already checked and found no authorization data.
 		// Return null to avoid repeated API calls.
-		if ( empty( $authorization_id ) && 'yes' === $order->get_meta( '_paypal_authorization_checked', true ) ) {
+		if ( 'yes' === $order->get_meta( '_paypal_authorization_checked', true ) ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -413,6 +413,11 @@ class WC_Gateway_Paypal_Request {
 					$paypal_debug_id
 				);
 			}
+
+			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
+			if ( 404 === $http_code ) {
+				$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
+			}
 			$order->add_order_note( $note_message );
 		}
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -376,6 +376,7 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		$paypal_debug_id = null;
+		$http_code       = null;
 
 		try {
 			$request_body = array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -414,10 +414,16 @@ class WC_Gateway_Paypal_Request {
 			// This flag indicates that we've made an API call to capture PayPal payment and no authorization object was found with this authorization ID.
 			// This prevents repeated API calls for orders that have no authorization data.
 			if ( 404 === $http_code ) {
+				$paypal_dashboard_url = $this->gateway->testmode
+					? 'https://www.sandbox.paypal.com/unifiedtransactions'
+					: 'https://www.paypal.com/unifiedtransactions';
+
 				$note_message .= sprintf(
-					/* translators: %s: Authorization ID */
-					__( '. Authorization ID: %s not found', 'woocommerce' ),
+					/* translators: %1$s: Authorization ID, %2$s: open link tag, %3$s: close link tag */
+					__( '. Authorization ID: %1$s not found. Please log into your %2$sPayPal account%3$s to capture the payment', 'woocommerce' ),
 					$authorization_id,
+					'<a href="' . esc_url( $paypal_dashboard_url ) . '" target="_blank">',
+					'</a>'
 				);
 				$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
 			}
@@ -498,7 +504,7 @@ class WC_Gateway_Paypal_Request {
 					$order->save();
 				} else {
 					// Scenario 2: Order details API call returned empty authorization array (authorization object does not exist).
-                    // Store '_paypal_authorization_checked' flag to prevent repeated API calls.
+					// Store '_paypal_authorization_checked' flag to prevent repeated API calls.
 					// This flag indicates that we've made an API call to get PayPal order details and confirmed no authorization object exists.
 					WC_Gateway_Paypal::log( 'Authorization ID not found in PayPal order details. Order ID: ' . $order->get_id() );
 					$order->update_meta_data( '_paypal_authorization_checked', 'yes' );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -409,7 +409,10 @@ class WC_Gateway_Paypal_Request {
 				__( 'PayPal capture authorized payment failed', 'woocommerce' ),
 			);
 
-			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
+			// Scenario 1: Capture auth API call returned 404 (authorization object does not exist).
+			// If the authorization ID is not found (404 response), set the '_paypal_authorization_checked' flag.
+			// This flag indicates that we've made an API call to capture PayPal payment and no authorization object was found with this authorization ID.
+			// This prevents repeated API calls for orders that have no authorization data.
 			if ( 404 === $http_code ) {
 				$note_message .= sprintf(
 					/* translators: %s: Authorization ID */
@@ -448,8 +451,11 @@ class WC_Gateway_Paypal_Request {
 			return null;
 		}
 
-		// If '_paypal_authorization_checked' is set to 'yes', it means we already checked and found no authorization data.
-		// Return null to avoid repeated API calls.
+		// If '_paypal_authorization_checked' is set to 'yes', it means we've already made an API call to PayPal
+		// and confirmed that no authorization object exists. This flag is set in two scenarios:
+		// 1. Capture auth API call returned 404 (authorization object does not exist with the authorization ID).
+		// 2. Order details API call returned empty authorization array (authorization object does not exist for this PayPal order).
+		// Return null to avoid repeated API calls for orders that have no authorization data.
 		if ( 'yes' === $order->get_meta( '_paypal_authorization_checked', true ) ) {
 			return null;
 		}
@@ -491,7 +497,9 @@ class WC_Gateway_Paypal_Request {
 					WC_Gateway_Paypal::log( 'Storing authorization ID from Paypal. Order ID: ' . $order->get_id() . '; authorization ID: ' . $authorization_id );
 					$order->save();
 				} else {
-					// Store '_paypal_authorization_checked' flag to prevent repeated API calls for orders with no authorization data.
+					// Scenario 2: Order details API call returned empty authorization array (authorization object does not exist).
+                    // Store '_paypal_authorization_checked' flag to prevent repeated API calls.
+					// This flag indicates that we've made an API call to get PayPal order details and confirmed no authorization object exists.
 					WC_Gateway_Paypal::log( 'Authorization ID not found in PayPal order details. Order ID: ' . $order->get_id() );
 					$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
 					$order->save();

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -421,7 +421,7 @@ class WC_Gateway_Paypal_Request {
 				$note_message .= sprintf(
 					/* translators: %1$s: Authorization ID, %2$s: open link tag, %3$s: close link tag */
 					__( '. Authorization ID: %1$s not found. Please log into your %2$sPayPal account%3$s to capture the payment', 'woocommerce' ),
-					$authorization_id,
+					esc_html( $authorization_id ),
 					'<a href="' . esc_url( $paypal_dashboard_url ) . '" target="_blank">',
 					'</a>'
 				);

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -412,6 +412,7 @@ class WC_Gateway_Paypal_Request {
 			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
 			if ( 404 === $http_code ) {
 				$note_message .= sprintf(
+					/* translators: %s: Authorization ID */
 					__( '. Authorization ID: %s not found', 'woocommerce' ),
 					$authorization_id,
 				);

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -410,8 +410,8 @@ class WC_Gateway_Paypal_Request {
 
 			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
 			if ( 404 === $http_code ) {
-				$note_message = sprintf(
-					__( '. Authorization ID: %s not found.', 'woocommerce' ),
+				$note_message .= sprintf(
+					__( '. Authorization ID: %s not found', 'woocommerce' ),
 					$authorization_id,
 				);
 				$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
@@ -426,6 +426,7 @@ class WC_Gateway_Paypal_Request {
 			}
 
 			$order->add_order_note( $note_message );
+			$order->save();
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -403,9 +403,20 @@ class WC_Gateway_Paypal_Request {
 			$order->save();
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
+
 			$note_message = sprintf(
 				__( 'PayPal capture authorized payment failed', 'woocommerce' ),
 			);
+
+			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
+			if ( 404 === $http_code ) {
+				$note_message = sprintf(
+					__( '. Authorization ID: %s not found.', 'woocommerce' ),
+					$authorization_id,
+				);
+				$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
+			}
+
 			if ( $paypal_debug_id ) {
 				$note_message .= sprintf(
 					/* translators: %s: PayPal debug ID */
@@ -414,10 +425,6 @@ class WC_Gateway_Paypal_Request {
 				);
 			}
 
-			// If the authorization ID is not found, set the '_paypal_authorization_checked' flag to 'yes' to prevent repeated API calls.
-			if ( 404 === $http_code ) {
-				$order->update_meta_data( '_paypal_authorization_checked', 'yes' );
-			}
 			$order->add_order_note( $note_message );
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
@@ -535,6 +535,60 @@ class WC_Gateway_Paypal_Request_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test capture handles 404 error and sets authorization_checked flag.
+	 */
+	public function test_capture_authorized_payment_handles_404_error_and_sets_authorization_checked_flag() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_paypal_order_id', 'PAYPAL_ORDER_123' );
+		$order->update_meta_data( '_paypal_authorization_id', 'AUTH_123' );
+		$order->update_meta_data( '_paypal_status', WC_Gateway_Paypal_Constants::STATUS_AUTHORIZED );
+		$order->save();
+
+		$capture_api_call_count = 0;
+		$authorization_id       = 'AUTH_123';
+		add_filter(
+			'pre_http_request',
+			function ( $value, $parsed_args, $url ) use ( &$capture_api_call_count ) {
+				// Track if capture_auth endpoint is called.
+				if ( strpos( $url, 'payment/capture_auth' ) !== false ) {
+					++$capture_api_call_count;
+					return $this->return_capture_error( 404, array() );
+				}
+
+				return $value;
+			},
+			10,
+			3
+		);
+
+		$request = new WC_Gateway_Paypal_Request( new WC_Gateway_Paypal() );
+		$request->capture_authorized_payment( $order );
+
+		remove_all_filters( 'pre_http_request' );
+
+		// Verify capture_auth API was called (but returned 404).
+		$this->assertEquals( 1, $capture_api_call_count, 'Expected capture_auth API to be called once' );
+		// Verify order note was added with authorization ID message.
+		$order = wc_get_order( $order->get_id() );
+		$notes = wc_get_order_notes(
+			array(
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			)
+		);
+
+		$this->assertNotEmpty( $notes );
+		$this->assertStringContainsString( 'PayPal capture authorized payment failed', $notes[0]->content );
+		$this->assertStringContainsString( 'Authorization ID: ' . $authorization_id . ' not found', $notes[0]->content );
+		// Verify authorization_checked flag was set.
+		$this->assertEquals( 'yes', $order->get_meta( '_paypal_authorization_checked', true ), 'Expected _paypal_authorization_checked flag to be set to yes' );
+		// Verify capture ID was not set.
+		$this->assertEmpty( $order->get_meta( '_paypal_capture_id', true ) );
+		// Verify status was not updated.
+		$this->assertEquals( WC_Gateway_Paypal_Constants::STATUS_AUTHORIZED, $order->get_meta( '_paypal_status', true ) );
+	}
+
+	/**
 	 * Test capture handles WP_Error response.
 	 */
 	public function test_capture_authorized_payment_handles_wp_error_response() {

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
@@ -546,25 +546,22 @@ class WC_Gateway_Paypal_Request_Test extends \WC_Unit_Test_Case {
 
 		$capture_api_call_count = 0;
 		$authorization_id       = 'AUTH_123';
-		add_filter(
-			'pre_http_request',
-			function ( $value, $parsed_args, $url ) use ( &$capture_api_call_count ) {
-				// Track if capture_auth endpoint is called.
-				if ( strpos( $url, 'payment/capture_auth' ) !== false ) {
-					++$capture_api_call_count;
-					return $this->return_capture_error( 404, array() );
-				}
 
-				return $value;
-			},
-			10,
-			3
-		);
+		$filter_callback = function ( $value, $parsed_args, $url ) use ( &$capture_api_call_count ) {
+			// Track if capture_auth endpoint is called.
+			if ( strpos( $url, 'payment/capture_auth' ) !== false ) {
+				++$capture_api_call_count;
+				return $this->return_capture_error( 404, array() );
+			}
+
+			return $value;
+		};
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
 
 		$request = new WC_Gateway_Paypal_Request( new WC_Gateway_Paypal() );
 		$request->capture_authorized_payment( $order );
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
 
 		// Verify capture_auth API was called (but returned 404).
 		$this->assertEquals( 1, $capture_api_call_count, 'Expected capture_auth API to be called once' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- We now set the `_paypal_authorization_checked` meta to `'yes'` when we have already attempted the capture and received a 404 response.

If `_paypal_authorization_checked` is set to 'yes', it means we've already made an API call to PayPal and confirmed that no authorization object exists. This flag is set in two scenarios:
1. Capture auth API call returned 404 (authorization object does not exist with the authorization ID).
   - This is being added in this PR 
2. Order details API call returned an empty authorization array (authorization object does not exist for this PayPal order).
    - This behaviour existed prior to this PR


### How to test the changes in this Pull Request:

Code review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add order meta to prevent duplicate PayPal Standard API calls when we have already received a 404 response for a capture request on an authorised payment.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
