### PR TITLE
Add debugging for wp-env start failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,23 +186,28 @@ jobs:
       - name: 'Start Test Environment'
         id: 'prepare-test-environment'
         if: ${{ matrix.testEnv.shouldCreate }}
-        env: ${{ matrix.testEnv.envVars }}
         run: |
-          # randomized wp-env ports to reduce the number of ports usage conflicts in the range of 1024 - 49151
-          min=10
-          max=99
-          randomized=$(( $RANDOM % ( $max - $min + 1 ) + $min ))
-          httpport="${randomized}80"
-          mysqlport="${randomized}36"
+          # Explicitly set all wp-env ports
+          echo "WP_ENV_PORT=8888" >> "$GITHUB_ENV"
+          echo "WP_ENV_MYSQL_PORT=58888" >> "$GITHUB_ENV"
+          echo "WP_ENV_TESTS_PORT=8086" >> "$GITHUB_ENV"
+          echo "WP_ENV_TESTS_MYSQL_PORT=58086" >> "$GITHUB_ENV"
+          # WP_BASE_URL is set to satisfy blocks E2Es setup (setupRest)
+          echo "WP_BASE_URL=http://localhost:8086" >> "$GITHUB_ENV"
 
-          # provision the environment to propagate the randomized ports
-          echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
-          echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
-          # WP_BASE_URL is set only to satisfy blocks E2Es setup (setupRest).
-          echo "WP_BASE_URL=http://localhost:$httpport" >> "$GITHUB_ENV"
+          # Export for current step
+          export WP_ENV_PORT=8888
+          export WP_ENV_MYSQL_PORT=58888
+          export WP_ENV_TESTS_PORT=8086
+          export WP_ENV_TESTS_MYSQL_PORT=58086
 
           # Debug: Show current state before starting wp-env
           echo "::group::Pre-start diagnostics"
+          echo "=== wp-env ports ==="
+          echo "WP_ENV_PORT=$WP_ENV_PORT"
+          echo "WP_ENV_MYSQL_PORT=$WP_ENV_MYSQL_PORT"
+          echo "WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT"
+          echo "WP_ENV_TESTS_MYSQL_PORT=$WP_ENV_TESTS_MYSQL_PORT"
           echo "=== Docker containers ==="
           docker ps -a || true
           echo "=== Docker networks ==="
@@ -212,7 +217,7 @@ jobs:
           echo "::endgroup::"
 
           # Try to start wp-env, capture output for diagnostics on failure
-          if ! WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; then
+          if ! pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; then
             echo "::error::wp-env start failed"
             echo "::group::Post-failure diagnostics"
             echo "=== Docker containers after failure ==="
@@ -222,7 +227,7 @@ jobs:
             echo "=== Ports in use after failure ==="
             ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
             echo "=== Processes using common wp-env ports ==="
-            for port in 8888 8889 58888 58086 3306 $httpport $mysqlport; do
+            for port in $WP_ENV_PORT $WP_ENV_MYSQL_PORT $WP_ENV_TESTS_PORT $WP_ENV_TESTS_MYSQL_PORT 3306; do
               echo "--- Port $port ---"
               lsof -i :$port 2>/dev/null || ss -tlnp "sport = :$port" 2>/dev/null || true
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,35 @@ jobs:
           echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
           # WP_BASE_URL is set only to satisfy blocks E2Es setup (setupRest).
           echo "WP_BASE_URL=http://localhost:$httpport" >> "$GITHUB_ENV"
-          
-          WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+
+          # Debug: Show current state before starting wp-env
+          echo "::group::Pre-start diagnostics"
+          echo "=== Docker containers ==="
+          docker ps -a || true
+          echo "=== Docker networks ==="
+          docker network ls || true
+          echo "=== Ports in use ==="
+          ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+          echo "::endgroup::"
+
+          # Try to start wp-env, capture output for diagnostics on failure
+          if ! WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}; then
+            echo "::error::wp-env start failed"
+            echo "::group::Post-failure diagnostics"
+            echo "=== Docker containers after failure ==="
+            docker ps -a || true
+            echo "=== Docker logs from mysql containers ==="
+            docker ps -a --filter "name=mysql" --format "{{.Names}}" | xargs -I {} docker logs {} 2>&1 | tail -50 || true
+            echo "=== Ports in use after failure ==="
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "=== Processes using common wp-env ports ==="
+            for port in 8888 8889 58888 58086 3306 $httpport $mysqlport; do
+              echo "--- Port $port ---"
+              lsof -i :$port 2>/dev/null || ss -tlnp "sport = :$port" 2>/dev/null || true
+            done
+            echo "::endgroup::"
+            exit 1
+          fi
 
       - name: 'Determine BuildKite Analytics Message'
         env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Contributes to QAO-172

Adds diagnostics to debug intermittent wp-env port binding failures and explicitly sets all wp-env ports via environment variables.

### How to test the changes in this Pull Request:

- CI still green.
