### PR TITLE
Prevent `wc_add_notice` trying to add notices if session is not initialized

### DIFF
--- a/plugins/woocommerce/changelog/fix-check-session-before-accessing
+++ b/plugins/woocommerce/changelog/fix-check-session-before-accessing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent errors when plugins incorrectly call wc_add_notice before session is initialized

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -82,7 +82,7 @@ function wc_add_notice( $message, $notice_type = 'success', $data = array() ) {
 	// If this is called before the session is initialized, for example if a plugin includes this file incorrectly on
 	// the admin, skip doing anything to prevent errors.
 	if ( ! WC()->session ) {
-		wc_doing_it_wrong( __FUNCTION__, __( 'This function should not be called before the WooCommerce session is initialized, or places where there is no session, e.g. WordPress admin.', 'woocommerce' ), '2.3' );
+		wc_doing_it_wrong( __FUNCTION__, __( 'This function should not be called before the WooCommerce session is initialized, or places where there is no session, e.g. WordPress admin.', 'woocommerce' ), '10.5' );
 		return;
 	}
 

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -82,6 +82,7 @@ function wc_add_notice( $message, $notice_type = 'success', $data = array() ) {
 	// If this is called before the session is initialized, for example if a plugin includes this file incorrectly on
 	// the admin, skip doing anything to prevent errors.
 	if ( ! WC()->session ) {
+		wc_doing_it_wrong( __FUNCTION__, __( 'This function should not be called before the WooCommerce session is initialized, or places where there is no session, e.g. WordPress admin.', 'woocommerce' ), '2.3' );
 		return;
 	}
 

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -79,6 +79,12 @@ function wc_add_notice( $message, $notice_type = 'success', $data = array() ) {
 		return;
 	}
 
+	// If this is called before the session is initialized, for example if a plugin includes this file incorrectly on
+	// the admin, skip doing anything to prevent errors.
+	if ( ! WC()->session ) {
+		return;
+	}
+
 	$notices = WC()->session->get( 'wc_notices', array() );
 
 	// Backward compatibility.

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
@@ -255,11 +255,13 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 	 * Test wc_add_notice() with no session.
 	 */
 	public function test_wc_add_notice_no_session() {
+		$this->setExpectedIncorrectUsage( 'wc_add_notice' );
+
 		$original_session = WC()->session;
 
 		WC()->session = null;
 
-		// Should not throw an error when session is null.
+		// Should not throw an error when session is null, but should trigger doing_it_wrong.
 		wc_add_notice( 'Test Notice' );
 
 		WC()->session = $original_session;

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
@@ -250,4 +250,22 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 
 		WC()->session = $original_session;
 	}
+
+	/**
+	 * Test wc_add_notice() with no session.
+	 */
+	public function test_wc_add_notice_no_session() {
+		$original_session = WC()->session;
+
+		WC()->session = null;
+
+		// Should not throw an error when session is null.
+		wc_add_notice( 'Test Notice' );
+
+		WC()->session = $original_session;
+
+		// Notice should not have been added since there was no session.
+		$notices = wc_get_notices();
+		$this->assertEmpty( $notices );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a check to ensure `WC()->session` is available before accessing it to add notices.

This is useful if extensions try to call it in places where the session doesn't exist. Typically the method wouldn't be available, but there's nothing stopping extensions including the file where it is defined. This change is just an extra safety measure.

### How to test the changes in this Pull Request:

Add the following snippet, then go to the WC Admin (change the path in the first line to correct include `wc-notice-functions.php`

```php
include( __DIR__ . '/../woocommerce/includes/wc-notice-functions.php' );
add_action( 'woocommerce_init', function() {
	wc_add_notice( 'hello');
} );
add_action( 'woocommerce_loaded', 'custom_fields_tester_register_custom_checkout_fields' );
```

1. Visit the WC Admin and ensure no errors appear
2. Go to WC -> Settings -> Shipping -> Shipping Settings. Check `Enable debug mode`
3. Go to the front end, add an item to your cart and go to the shortcode cart and checkout, ensure the debug notices show for the shipping debug.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
