### PR TITLE
Remove WP_BASE_URL setting from CI test environment preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,7 @@ jobs:
       - name: 'Start Test Environment'
         id: 'prepare-test-environment'
         if: ${{ matrix.testEnv.shouldCreate }}
-        run: |
-          # WP_BASE_URL is set to satisfy blocks E2Es setup (setupRest)
-          echo "WP_BASE_URL=http://localhost:8086" >> "$GITHUB_ENV"
-
-          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+        run: pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
 
       - name: 'Determine BuildKite Analytics Message'
         env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix Blocks e2e URL setup in CI. #62316 removed the ports configuration but left the WP_BASE_URL which uses a different (wrong) port. This [breaks Blocks e2e setup](https://github.com/woocommerce/woocommerce/actions/runs/20034795362/job/57453326534#step:9:72).


### How to test the changes in this Pull Request:

- Blocks e2e tests start successfully in CI. Tested with https://github.com/woocommerce/woocommerce/actions/runs/20035926505/job/57457332534#step:9:78