### PR TITLE
Fix product permalinks to use deepest category instead of highest parent ID

### DIFF
--- a/plugins/woocommerce/changelog/62321-fix-WOOPLUG-5957-product-permalinks-deepest-category
+++ b/plugins/woocommerce/changelog/62321-fix-WOOPLUG-5957-product-permalinks-deepest-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product permalinks to use deepest category instead of highest parent term ID when product is assigned to multiple categories.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -304,7 +304,8 @@ function wc_product_post_type_link( $permalink, $post ) {
 		 * @param WP_Post   $post         The product post object.
 		 */
 		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $deepest_term, $terms, $post );
-		$product_cat     = ! $category_object instanceof WP_Term ? $deepest_term->slug : $category_object->slug;
+		$category_object = ! $category_object instanceof WP_Term ? $deepest_term : $category_object;
+		$product_cat     = $category_object->slug;
 
 		if ( $category_object->parent ) {
 			// Reuse cached ancestors if the filter didn't change the category, otherwise fetch them.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -271,7 +271,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 	// Get the custom taxonomy terms in use by this post.
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
-	if ( ! empty( $terms ) ) {
+	if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 		// Find the deepest category (most ancestors) for the permalink.
 		$deepest_term      = $terms[0];
 		$deepest_ancestors = $deepest_term->parent ? get_ancestors( $deepest_term->term_id, 'product_cat' ) : array();
@@ -344,7 +344,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 		date_i18n( 'H', strtotime( $post->post_date ) ),
 		date_i18n( 'i', strtotime( $post->post_date ) ),
 		date_i18n( 's', strtotime( $post->post_date ) ),
-		$post->ID,
+		(string) $post->ID,
 		$product_cat,
 		$product_cat,
 	);

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -294,12 +294,14 @@ function wc_product_post_type_link( $permalink, $post ) {
 		/**
 		 * Filter the product category used for the product permalink.
 		 *
-		 * By default, the deepest category (most ancestors) is selected. This filter allows
-		 * customization of which category is used in the product permalink.
+		 * By default, the deepest category (most ancestors) is selected. Prior to 9.9.0,
+		 * categories were sorted by parent term ID descending, then term ID ascending.
+		 * This filter allows customization of which category is used in the product permalink.
 		 *
 		 * @since 2.4.0
+		 * @since 9.9.0 Selection algorithm changed to use deepest category instead of sort order.
 		 *
-		 * @param WP_Term   $deepest_term The selected category term object.
+		 * @param WP_Term   $deepest_term The selected category term object (deepest category since 9.9.0).
 		 * @param WP_Term[] $terms        All category terms assigned to the product.
 		 * @param WP_Post   $post         The product post object.
 		 */

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -272,18 +272,45 @@ function wc_product_post_type_link( $permalink, $post ) {
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
 	if ( ! empty( $terms ) ) {
-		$terms           = wp_list_sort(
-			$terms,
-			array(
-				'parent'  => 'DESC',
-				'term_id' => 'ASC',
-			)
-		);
-		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $terms[0], $terms, $post );
+		// Find the deepest category (most ancestors) for the permalink.
+		$deepest_term      = $terms[0];
+		$deepest_ancestors = $deepest_term->parent ? get_ancestors( $deepest_term->term_id, 'product_cat' ) : array();
+
+		foreach ( $terms as $term ) {
+			if ( $term->term_id === $deepest_term->term_id ) {
+				continue;
+			}
+			// Skip root categories - they can't be deeper than current.
+			if ( ! $term->parent ) {
+				continue;
+			}
+			$ancestors = get_ancestors( $term->term_id, 'product_cat' );
+			if ( count( $ancestors ) > count( $deepest_ancestors ) ) {
+				$deepest_ancestors = $ancestors;
+				$deepest_term      = $term;
+			}
+		}
+
+		/**
+		 * Filter the product category used for the product permalink.
+		 *
+		 * By default, the deepest category (most ancestors) is selected. This filter allows
+		 * customization of which category is used in the product permalink.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param WP_Term   $deepest_term The selected category term object.
+		 * @param WP_Term[] $terms        All category terms assigned to the product.
+		 * @param WP_Post   $post         The product post object.
+		 */
+		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $deepest_term, $terms, $post );
 		$product_cat     = $category_object->slug;
 
 		if ( $category_object->parent ) {
-			$ancestors = get_ancestors( $category_object->term_id, 'product_cat' );
+			// Reuse cached ancestors if the filter didn't change the category, otherwise fetch them.
+			$ancestors = ( $category_object->term_id === $deepest_term->term_id )
+				? $deepest_ancestors
+				: get_ancestors( $category_object->term_id, 'product_cat' );
 			foreach ( $ancestors as $ancestor ) {
 				$ancestor_object = get_term( $ancestor, 'product_cat' );
 				if ( apply_filters( 'woocommerce_product_post_type_link_parent_category_only', false ) ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -297,7 +297,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 		 * By default, the deepest category (most ancestors) is selected. This filter allows
 		 * customization of which category is used in the product permalink.
 		 *
-		 * @since 2.5.0
+		 * @since 2.4.0
 		 *
 		 * @param WP_Term   $deepest_term The selected category term object.
 		 * @param WP_Term[] $terms        All category terms assigned to the product.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -304,7 +304,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 		 * @param WP_Post   $post         The product post object.
 		 */
 		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $deepest_term, $terms, $post );
-		$product_cat     = $category_object->slug;
+		$product_cat     = ! $category_object instanceof WP_Term ? $deepest_term->slug : $category_object->slug;
 
 		if ( $category_object->parent ) {
 			// Reuse cached ancestors if the filter didn't change the category, otherwise fetch them.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -52612,12 +52612,6 @@ parameters:
 			path: includes/wc-product-functions.php
 
 		-
-			message: '#^Parameter \#1 \$input_list of function wp_list_sort expects array, array\<WP_Term\>\|WP_Error given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/wc-product-functions.php
-
-		-
 			message: '#^Parameter \#1 \$maybeint of function absint expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -52705,12 +52699,6 @@ parameters:
 			message: '#^Parameter \#2 \$product of function wc_attribute_label expects WC_Product, WC_Product_Variation\|false given\.$#'
 			identifier: argument.type
 			count: 2
-			path: includes/wc-product-functions.php
-
-		-
-			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, array\<int, mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
 			path: includes/wc-product-functions.php
 
 		-

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -384,57 +384,33 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_wc_product_post_type_link_uses_deepest_category() {
 		/*
 		 * Reproduce the bug from WOOPLUG-5957:
-		 * 1. Create a 4-level deep hierarchy FIRST (gets lower term_ids)
-		 * 2. Create a shallow competing branch SECOND (gets higher term_ids)
-		 * 3. The shallow branch's parent will have a higher term_id than any category in the deep hierarchy
-		 * 4. Old buggy code sorted by parent DESC, so it would select the shallow category
-		 * 5. Fixed code should select the deepest category (level 4)
+		 * Create categories "out of sequence" so term_ids don't match hierarchy depth.
+		 * Per the issue: "Level 2 ID should be higher than all other levels."
+		 *
+		 * We create Level 2 LAST so it has the highest term_id. Then we update parent
+		 * relationships. This means Level 3's parent (Level 2) has a higher term_id
+		 * than Level 4's parent (Level 3).
+		 *
+		 * Old buggy code sorted by parent DESC, so it would select Level 3 (parent=Level 2
+		 * with high term_id) instead of Level 4 (the actual deepest category).
 		 */
 
-		// Create 4-level deep hierarchy first (these get lower term_ids).
+		// Create Level 1 first (gets lowest term_id).
 		$level1_term = wp_insert_term( 'Level 1', 'product_cat' );
-		$level2_term = wp_insert_term(
-			'Level 2',
-			'product_cat',
-			array( 'parent' => $level1_term['term_id'] )
-		);
-		$level3_term = wp_insert_term(
-			'Level 3',
-			'product_cat',
-			array( 'parent' => $level2_term['term_id'] )
-		);
-		$level4_term = wp_insert_term(
-			'Level 4 Deepest',
-			'product_cat',
-			array( 'parent' => $level3_term['term_id'] )
-		);
 
-		// Create shallow branch SECOND (gets higher term_ids).
-		// This simulates creating categories "out of sequence" as described in the issue.
-		$shallow_root_term  = wp_insert_term( 'Shallow Root', 'product_cat' );
-		$shallow_child_term = wp_insert_term(
-			'Shallow Child',
-			'product_cat',
-			array( 'parent' => $shallow_root_term['term_id'] )
-		);
+		// Create Level 3 and Level 4 without parents initially.
+		$level3_term = wp_insert_term( 'Level 3', 'product_cat' );
+		$level4_term = wp_insert_term( 'Level 4 Deepest', 'product_cat' );
 
-		// Verify test setup: shallow_root has higher term_id than all deep hierarchy categories.
-		// This means shallow_child's parent ID is higher than level4's parent ID.
-		$level4_obj        = get_term( $level4_term['term_id'], 'product_cat' );
-		$shallow_child_obj = get_term( $shallow_child_term['term_id'], 'product_cat' );
-		$this->assertGreaterThan(
-			$level4_obj->parent,
-			$shallow_child_obj->parent,
-			'Test setup: shallow category parent ID should be higher than level4 parent ID'
-		);
+		// Create Level 2 LAST (gets highest term_id).
+		$level2_term = wp_insert_term( 'Level 2', 'product_cat' );
 
-		// Verify depths.
-		$level4_ancestors  = get_ancestors( $level4_term['term_id'], 'product_cat' );
-		$shallow_ancestors = get_ancestors( $shallow_child_term['term_id'], 'product_cat' );
-		$this->assertCount( 3, $level4_ancestors, 'Level 4 should have 3 ancestors' );
-		$this->assertCount( 1, $shallow_ancestors, 'Shallow child should have 1 ancestor' );
+		// Set up hierarchy: Level 1 > Level 2 > Level 3 > Level 4.
+		wp_update_term( $level2_term['term_id'], 'product_cat', array( 'parent' => $level1_term['term_id'] ) );
+		wp_update_term( $level3_term['term_id'], 'product_cat', array( 'parent' => $level2_term['term_id'] ) );
+		wp_update_term( $level4_term['term_id'], 'product_cat', array( 'parent' => $level3_term['term_id'] ) );
 
-		// Assign product to ALL categories (as per issue reproduction steps).
+		// Assign product to all categories.
 		$product = WC_Helper_Product::create_simple_product();
 		wp_set_object_terms(
 			$product->get_id(),
@@ -443,8 +419,6 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 				$level2_term['term_id'],
 				$level3_term['term_id'],
 				$level4_term['term_id'],
-				$shallow_root_term['term_id'],
-				$shallow_child_term['term_id'],
 			),
 			'product_cat'
 		);
@@ -457,25 +431,18 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
 
 		// Get slugs for assertions.
-		$level1_slug       = get_term( $level1_term['term_id'], 'product_cat' )->slug;
-		$level2_slug       = get_term( $level2_term['term_id'], 'product_cat' )->slug;
-		$level3_slug       = get_term( $level3_term['term_id'], 'product_cat' )->slug;
-		$level4_slug       = get_term( $level4_term['term_id'], 'product_cat' )->slug;
-		$shallow_root_slug = get_term( $shallow_root_term['term_id'], 'product_cat' )->slug;
+		$level1_slug = get_term( $level1_term['term_id'], 'product_cat' )->slug;
+		$level2_slug = get_term( $level2_term['term_id'], 'product_cat' )->slug;
+		$level3_slug = get_term( $level3_term['term_id'], 'product_cat' )->slug;
+		$level4_slug = get_term( $level4_term['term_id'], 'product_cat' )->slug;
 
 		// The permalink should contain the full hierarchical path of the deepest category (level 4).
+		// The old buggy code would select Level 3 (parent=Level 2 with high term_id) instead of Level 4.
 		$expected_path = $level1_slug . '/' . $level2_slug . '/' . $level3_slug . '/' . $level4_slug;
 		$this->assertStringContainsString(
 			$expected_path,
 			$permalink,
 			'Permalink should contain the full path of the deepest category (level 4)'
-		);
-
-		// The shallow branch should NOT be in the permalink.
-		$this->assertStringNotContainsString(
-			$shallow_root_slug,
-			$permalink,
-			'Permalink should NOT contain the shallow branch with higher parent ID'
 		);
 
 		// Clean up (delete children before parents).
@@ -484,20 +451,17 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		wp_delete_term( $level3_term['term_id'], 'product_cat' );
 		wp_delete_term( $level2_term['term_id'], 'product_cat' );
 		wp_delete_term( $level1_term['term_id'], 'product_cat' );
-		wp_delete_term( $shallow_child_term['term_id'], 'product_cat' );
-		wp_delete_term( $shallow_root_term['term_id'], 'product_cat' );
 	}
 
 	/**
-	 * @testdox Product permalink works correctly when product has only root-level categories.
+	 * @testdox Product permalink uses first root category when product has only root-level categories.
 	 */
 	public function test_wc_product_post_type_link_with_only_root_categories() {
-		// Create multiple root-level categories (no parents).
+		// Create multiple root categories - first one (lowest term_id) should be selected.
 		$root1_term = wp_insert_term( 'Root Category One', 'product_cat' );
 		$root2_term = wp_insert_term( 'Root Category Two', 'product_cat' );
 		$root3_term = wp_insert_term( 'Root Category Three', 'product_cat' );
 
-		// Create product and assign to all root categories.
 		$product = WC_Helper_Product::create_simple_product();
 		wp_set_object_terms(
 			$product->get_id(),
@@ -505,40 +469,22 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			'product_cat'
 		);
 
-		// Set up permalink structure to include product_cat.
 		update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
 		$product_post = get_post( $product->get_id() );
 
-		// Call wc_product_post_type_link - should not error and should use one of the root categories.
 		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
 
-		// Get all root category slugs.
+		// First root category (lowest term_id) should be used.
 		$root1_slug = get_term( $root1_term['term_id'], 'product_cat' )->slug;
-		$root2_slug = get_term( $root2_term['term_id'], 'product_cat' )->slug;
-		$root3_slug = get_term( $root3_term['term_id'], 'product_cat' )->slug;
-
-		// Permalink should contain exactly one of the root category slugs (order depends on get_the_terms).
-		$contains_root1 = str_contains( $permalink, '/' . $root1_slug . '/' );
-		$contains_root2 = str_contains( $permalink, '/' . $root2_slug . '/' );
-		$contains_root3 = str_contains( $permalink, '/' . $root3_slug . '/' );
-
-		$this->assertTrue(
-			$contains_root1 || $contains_root2 || $contains_root3,
-			'Permalink should contain one of the root category slugs'
+		$this->assertStringContainsString(
+			'/' . $root1_slug . '/',
+			$permalink,
+			'Permalink should contain the first root category slug'
 		);
 
-		// Verify only ONE root category is used (not multiple).
-		$count = (int) $contains_root1 + (int) $contains_root2 + (int) $contains_root3;
-		$this->assertEquals(
-			1,
-			$count,
-			'Permalink should contain exactly one root category, not multiple'
-		);
-
-		// Clean up.
 		WC_Helper_Product::delete_product( $product->get_id() );
-		wp_delete_term( $root1_term['term_id'], 'product_cat' );
-		wp_delete_term( $root2_term['term_id'], 'product_cat' );
 		wp_delete_term( $root3_term['term_id'], 'product_cat' );
+		wp_delete_term( $root2_term['term_id'], 'product_cat' );
+		wp_delete_term( $root1_term['term_id'], 'product_cat' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -377,4 +377,168 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $related_product2->get_id() );
 		WC_Helper_Product::delete_product( $related_product3->get_id() );
 	}
+
+	/**
+	 * @testdox Product permalink should use deepest category, not the one with highest parent term ID.
+	 */
+	public function test_wc_product_post_type_link_uses_deepest_category() {
+		/*
+		 * Reproduce the bug from WOOPLUG-5957:
+		 * 1. Create a 4-level deep hierarchy FIRST (gets lower term_ids)
+		 * 2. Create a shallow competing branch SECOND (gets higher term_ids)
+		 * 3. The shallow branch's parent will have a higher term_id than any category in the deep hierarchy
+		 * 4. Old buggy code sorted by parent DESC, so it would select the shallow category
+		 * 5. Fixed code should select the deepest category (level 4)
+		 */
+
+		// Create 4-level deep hierarchy first (these get lower term_ids).
+		$level1_term = wp_insert_term( 'Level 1', 'product_cat' );
+		$level2_term = wp_insert_term(
+			'Level 2',
+			'product_cat',
+			array( 'parent' => $level1_term['term_id'] )
+		);
+		$level3_term = wp_insert_term(
+			'Level 3',
+			'product_cat',
+			array( 'parent' => $level2_term['term_id'] )
+		);
+		$level4_term = wp_insert_term(
+			'Level 4 Deepest',
+			'product_cat',
+			array( 'parent' => $level3_term['term_id'] )
+		);
+
+		// Create shallow branch SECOND (gets higher term_ids).
+		// This simulates creating categories "out of sequence" as described in the issue.
+		$shallow_root_term  = wp_insert_term( 'Shallow Root', 'product_cat' );
+		$shallow_child_term = wp_insert_term(
+			'Shallow Child',
+			'product_cat',
+			array( 'parent' => $shallow_root_term['term_id'] )
+		);
+
+		// Verify test setup: shallow_root has higher term_id than all deep hierarchy categories.
+		// This means shallow_child's parent ID is higher than level4's parent ID.
+		$level4_obj        = get_term( $level4_term['term_id'], 'product_cat' );
+		$shallow_child_obj = get_term( $shallow_child_term['term_id'], 'product_cat' );
+		$this->assertGreaterThan(
+			$level4_obj->parent,
+			$shallow_child_obj->parent,
+			'Test setup: shallow category parent ID should be higher than level4 parent ID'
+		);
+
+		// Verify depths.
+		$level4_ancestors  = get_ancestors( $level4_term['term_id'], 'product_cat' );
+		$shallow_ancestors = get_ancestors( $shallow_child_term['term_id'], 'product_cat' );
+		$this->assertCount( 3, $level4_ancestors, 'Level 4 should have 3 ancestors' );
+		$this->assertCount( 1, $shallow_ancestors, 'Shallow child should have 1 ancestor' );
+
+		// Assign product to ALL categories (as per issue reproduction steps).
+		$product = WC_Helper_Product::create_simple_product();
+		wp_set_object_terms(
+			$product->get_id(),
+			array(
+				$level1_term['term_id'],
+				$level2_term['term_id'],
+				$level3_term['term_id'],
+				$level4_term['term_id'],
+				$shallow_root_term['term_id'],
+				$shallow_child_term['term_id'],
+			),
+			'product_cat'
+		);
+
+		// Set up permalink structure to include product_cat.
+		update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
+		$product_post = get_post( $product->get_id() );
+
+		// Call wc_product_post_type_link directly to test the category selection.
+		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
+
+		// Get slugs for assertions.
+		$level1_slug       = get_term( $level1_term['term_id'], 'product_cat' )->slug;
+		$level2_slug       = get_term( $level2_term['term_id'], 'product_cat' )->slug;
+		$level3_slug       = get_term( $level3_term['term_id'], 'product_cat' )->slug;
+		$level4_slug       = get_term( $level4_term['term_id'], 'product_cat' )->slug;
+		$shallow_root_slug = get_term( $shallow_root_term['term_id'], 'product_cat' )->slug;
+
+		// The permalink should contain the full hierarchical path of the deepest category (level 4).
+		$expected_path = $level1_slug . '/' . $level2_slug . '/' . $level3_slug . '/' . $level4_slug;
+		$this->assertStringContainsString(
+			$expected_path,
+			$permalink,
+			'Permalink should contain the full path of the deepest category (level 4)'
+		);
+
+		// The shallow branch should NOT be in the permalink.
+		$this->assertStringNotContainsString(
+			$shallow_root_slug,
+			$permalink,
+			'Permalink should NOT contain the shallow branch with higher parent ID'
+		);
+
+		// Clean up (delete children before parents).
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wp_delete_term( $level4_term['term_id'], 'product_cat' );
+		wp_delete_term( $level3_term['term_id'], 'product_cat' );
+		wp_delete_term( $level2_term['term_id'], 'product_cat' );
+		wp_delete_term( $level1_term['term_id'], 'product_cat' );
+		wp_delete_term( $shallow_child_term['term_id'], 'product_cat' );
+		wp_delete_term( $shallow_root_term['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * @testdox Product permalink works correctly when product has only root-level categories.
+	 */
+	public function test_wc_product_post_type_link_with_only_root_categories() {
+		// Create multiple root-level categories (no parents).
+		$root1_term = wp_insert_term( 'Root Category One', 'product_cat' );
+		$root2_term = wp_insert_term( 'Root Category Two', 'product_cat' );
+		$root3_term = wp_insert_term( 'Root Category Three', 'product_cat' );
+
+		// Create product and assign to all root categories.
+		$product = WC_Helper_Product::create_simple_product();
+		wp_set_object_terms(
+			$product->get_id(),
+			array( $root1_term['term_id'], $root2_term['term_id'], $root3_term['term_id'] ),
+			'product_cat'
+		);
+
+		// Set up permalink structure to include product_cat.
+		update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
+		$product_post = get_post( $product->get_id() );
+
+		// Call wc_product_post_type_link - should not error and should use one of the root categories.
+		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
+
+		// Get all root category slugs.
+		$root1_slug = get_term( $root1_term['term_id'], 'product_cat' )->slug;
+		$root2_slug = get_term( $root2_term['term_id'], 'product_cat' )->slug;
+		$root3_slug = get_term( $root3_term['term_id'], 'product_cat' )->slug;
+
+		// Permalink should contain exactly one of the root category slugs (order depends on get_the_terms).
+		$contains_root1 = str_contains( $permalink, '/' . $root1_slug . '/' );
+		$contains_root2 = str_contains( $permalink, '/' . $root2_slug . '/' );
+		$contains_root3 = str_contains( $permalink, '/' . $root3_slug . '/' );
+
+		$this->assertTrue(
+			$contains_root1 || $contains_root2 || $contains_root3,
+			'Permalink should contain one of the root category slugs'
+		);
+
+		// Verify only ONE root category is used (not multiple).
+		$count = (int) $contains_root1 + (int) $contains_root2 + (int) $contains_root3;
+		$this->assertEquals(
+			1,
+			$count,
+			'Permalink should contain exactly one root category, not multiple'
+		);
+
+		// Clean up.
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wp_delete_term( $root1_term['term_id'], 'product_cat' );
+		wp_delete_term( $root2_term['term_id'], 'product_cat' );
+		wp_delete_term( $root3_term['term_id'], 'product_cat' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a product is assigned to multiple categories in a hierarchy, WooCommerce was selecting the category for permalinks based on the highest parent term ID (numeric value) rather than the deepest category in the hierarchy. This caused permalinks to use shallower categories instead of the most specific one.

For example, if a product was in:

-   `Electronics > Computers > Laptops` (depth 3, parent ID 50)
-   `Sale Items` (depth 2, parent ID 200)

The old code would select "Sale Items" because 200 > 50, even though "Laptops" is deeper and more specific.

**The fix:**

-   Replace `wp_list_sort()` by parent ID with explicit depth calculation using `get_ancestors()`
-   Find the category with the most ancestors (deepest in hierarchy)
-   Optimize by skipping root categories and caching ancestors for reuse

Closes #62274.

### How to test the changes in this Pull Request:

1. Set permalink structure to "Shop base with category" in Settings > Permalinks
2. Create a 4-level category hierarchy: `Level 1 > Level 2 > Level 3 > Level 4`. `Level 2` should be created first (so it has a higher term id). That sets the environment for reproducing the issue.
3. Create a separate shallow branch: `Shallow Root > Shallow Child` (create these AFTER the deep hierarchy so they have higher term IDs)
4. Create a product and assign it to ALL categories (all 4 levels + both shallow categories)
5. View the product permalink - it should use the full path of the deepest category: `/shop/level-1/level-2/level-3/level-4/product-name/`
6. Verify the shallow branch categories do NOT appear in the permalink

### Testing that has already taken place:

-   Unit tests added covering the fix and edge cases (root-only categories)
-   All 15 tests in `WC_Product_Functions_Tests` pass
-   PHP linting passes

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix product permalinks to use deepest category instead of highest parent term ID when product is assigned to multiple categories.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
