### PR TITLE
Add scheduled import for new installations and enable `analytics-scheduled-import` feature flag

### DIFF
--- a/plugins/woocommerce/changelog/wooa7s-843-rename-option-to-woocommerce_analytics_scheduled_import-new
+++ b/plugins/woocommerce/changelog/wooa7s-843-rename-option-to-woocommerce_analytics_scheduled_import-new
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add default scheduled import option for new installations

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -2,7 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
-		"analytics-scheduled-import": false,
+		"analytics-scheduled-import": true,
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": false,

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1187,8 +1187,10 @@ class WC_Install {
 	 * This ensures existing installations are not affected.
 	 *
 	 * @since 10.5.0
+	 *
+	 * @return void
 	 */
-	public static function enable_analytics_scheduled_import() {
+	public static function enable_analytics_scheduled_import(): void {
 		// add_option only sets if option doesn't exist, returns false if it already exists.
 		add_option( 'woocommerce_analytics_scheduled_import', 'yes' );
 	}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -355,6 +355,7 @@ class WC_Install {
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'add_coming_soon_option' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_email_improvements_for_newly_installed' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_customer_stock_notifications_signups' ), 20 );
+		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_analytics_scheduled_import' ), 20 );
 		add_action( 'woocommerce_updated', array( __CLASS__, 'enable_email_improvements_for_existing_merchants' ), 20 );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'woocommerce_update_db_to_current_version', array( __CLASS__, 'update_db_version' ) );
@@ -1177,6 +1178,19 @@ class WC_Install {
 	 */
 	public static function enable_customer_stock_notifications_signups() {
 		update_option( 'woocommerce_back_in_stock_allow_signups', 'yes' );
+	}
+
+	/**
+	 * Set scheduled import mode as the default for new installations.
+	 *
+	 * Uses add_option() which only sets the option if it doesn't already exist.
+	 * This ensures existing installations are not affected.
+	 *
+	 * @since 10.5.0
+	 */
+	public static function enable_analytics_scheduled_import() {
+		// add_option only sets if option doesn't exist, returns false if it already exists.
+		add_option( 'woocommerce_analytics_scheduled_import', 'yes' );
 	}
 
 	/**
@@ -2782,7 +2796,7 @@ $stock_notifications_table_schema;
 	 * @return string The content for the page
 	 */
 	private static function get_refunds_return_policy_page_content() {
-		return <<<EOT
+		return <<<'EOT'
 <!-- wp:paragraph -->
 <p><b>This is a sample page.</b></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -192,6 +192,38 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test scheduled import is set as default for new installations.
+	 *
+	 * @return void
+	 */
+	public function test_enable_analytics_scheduled_import_for_new_installation() {
+		// Ensure the option doesn't exist before testing.
+		delete_option( 'woocommerce_analytics_scheduled_import' );
+
+		// Call the method to set the default.
+		WC_Install::enable_analytics_scheduled_import();
+
+		// Verify the option was set to 'yes'.
+		$this->assertEquals( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
+	}
+
+	/**
+	 * Test scheduled import option is not overwritten if already exists.
+	 *
+	 * @return void
+	 */
+	public function test_enable_analytics_scheduled_import_preserves_existing_value() {
+		// Set the option to 'no' to simulate an existing installation with the option already set.
+		update_option( 'woocommerce_analytics_scheduled_import', 'no' );
+
+		// Call the method which should not overwrite the existing value.
+		WC_Install::enable_analytics_scheduled_import();
+
+		// Verify the option remains 'no' (not overwritten).
+		$this->assertEquals( 'no', get_option( 'woocommerce_analytics_scheduled_import' ) );
+	}
+
+	/**
 	 * Test migrate_options();
 	 * @return void
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR enables scheduled import mode as the default for **new WooCommerce installations only**, while maintaining backward compatibility for existing sites.

**Context:**

For new installations, scheduled mode provides better performance by batching analytics imports. Existing installations remain unaffected and will continue using their current settings (or fall back to the default defined in Settings.php).

**Implementation:**

- Hooks into `woocommerce_newly_installed` action in `WC_Install::init()`
- Sets `woocommerce_analytics_scheduled_import` option to `'yes'` using `add_option()`
- Enables `analytics-scheduled-import` feature flag in production
- Follows the same pattern as other installation defaults (HPOS, email improvements, etc.)


Closes WOOA7S-842


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions):

**Test Scenario 1: Fresh Installation**

1. Create a JN site using this branch
    - Install [`WooCommerce Live Branches User Script`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-beta-tester/userscripts)
    -  Click the `Create Jurassic Ninja site for this branch.` link in this PR description
    <img width="753" height="164" alt="Screenshot 2025-12-09 at 11 32 46" src="https://github.com/user-attachments/assets/c6f05456-3dc3-4453-9f5f-23b390627cf9" />
2. Check the option value: `wp option get woocommerce_analytics_scheduled_import`
3. Verify it returns `'yes'`
4. Navigate to `Analytics → Settings`
5. Verify "Scheduled (Recommended)" is pre-selected

**Test Scenario 2: Existing Installation (option not set)**

1. Create a new JN site using the latest WooCommerce (not this branch)
3. Update to this version 
4. Check the option: `wp option get woocommerce_analytics_scheduled_import`
5. Verify the option does not exist (no value returned)
6. Navigate to `Analytics → Settings`
7. Verify `Immediately` is selected 

### Testing that has already taken place:

- Unit tests added and passing for both new and existing installation scenarios
- Code follows the existing `WC_Install` pattern (same as HPOS, email improvements, etc.)
- PHP linting passed with no new issues
- Verified `add_option()` behavior prevents overwriting existing values

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
