### PR TITLE
Brands: Clear thumbnail after creating a brand

### DIFF
--- a/plugins/woocommerce/changelog/62333-fix-brands-clear-thumbnail-after-creation
+++ b/plugins/woocommerce/changelog/62333-fix-brands-clear-thumbnail-after-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Brands: Clear thumbnail after creating a brand
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -370,6 +370,23 @@ class WC_Brands_Admin {
 						jQuery('.remove_image_button').hide();
 						return false;
 					});
+
+					jQuery( document ).on( 'ajaxComplete', function( event, request, options ) {
+						if ( request && 4 === request.readyState && 200 === request.status
+							&& options.data && 0 <= options.data.indexOf( 'action=add-tag' ) ) {
+
+							var res = wpAjax.parseAjaxResponse( request.responseXML, 'ajax-response' );
+							if ( ! res || res.errors ) {
+								return;
+							}
+							// Clear Thumbnail fields on submit
+							jQuery( '#product_cat_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+							jQuery( '#product_cat_thumbnail_id' ).val( '' );
+							jQuery( '.remove_image_button' ).hide();
+
+							return;
+						}
+					} );
 				});
 
 			</script>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -332,6 +332,12 @@ class WC_Brands_Admin {
 					// Uploading files
 					var file_frame;
 
+					function clearThumbnailField() {
+						jQuery('#product_cat_thumbnail img').attr('src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>');
+						jQuery('#product_cat_thumbnail_id').val('');
+						jQuery('.remove_image_button').hide();
+					}
+
 					jQuery(document).on( 'click', '.upload_image_button', function( event ){
 
 						event.preventDefault();
@@ -365,9 +371,7 @@ class WC_Brands_Admin {
 					});
 
 					jQuery(document).on( 'click', '.remove_image_button', function( event ){
-						jQuery('#product_cat_thumbnail img').attr('src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>');
-						jQuery('#product_cat_thumbnail_id').val('');
-						jQuery('.remove_image_button').hide();
+						clearThumbnailField();
 						return false;
 					});
 
@@ -379,10 +383,8 @@ class WC_Brands_Admin {
 							if ( ! res || res.errors ) {
 								return;
 							}
-							// Clear Thumbnail fields on submit
-							jQuery( '#product_cat_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
-							jQuery( '#product_cat_thumbnail_id' ).val( '' );
-							jQuery( '.remove_image_button' ).hide();
+
+							clearThumbnailField();
 
 							return;
 						}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Resets the thumbnail field after creating a new brand.

This uses the same approach that we currently use for product categories. Note that the code still uses jQuery, so there are a few potential follow-up opportunities here:
- Unify the additional taxonomy management code with product categories
- Move away from jQuery

Closes #51576.
Closes WOOPLUG-2606.

### Screenshots or screen recordings:

Before:

https://github.com/user-attachments/assets/8c9cdd78-5c41-48c5-bad9-94d89ff457f2

After:

https://github.com/user-attachments/assets/0f7c248f-daa4-4b6c-954d-97f9bb6a0970

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Brands (`/wp-admin/edit-tags.php?taxonomy=product_brand&post_type=product`)
2. Create a new brand, choosing a thumbnail
3. Verify that the thumbnail is erased after creating the brand.

### Testing that has already taken place:

Manual testing as per the testing instructions. 

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>


#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Brands: Clear thumbnail after creating a brand

</details>
