### PR TITLE
Breadcrumbs: Remove taxonomy name item for brands

### DIFF
--- a/plugins/woocommerce/changelog/62334-remove-custom-taxonomy-breadcrumb-prefix
+++ b/plugins/woocommerce/changelog/62334-remove-custom-taxonomy-breadcrumb-prefix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Breadcrumbs: Remove taxonomy name item for custom taxonomies
+Comment: Breadcrumbs: Remove taxonomy name item for brands
 

--- a/plugins/woocommerce/changelog/62334-remove-custom-taxonomy-breadcrumb-prefix
+++ b/plugins/woocommerce/changelog/62334-remove-custom-taxonomy-breadcrumb-prefix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Breadcrumbs: Remove taxonomy name item for custom taxonomies
+

--- a/plugins/woocommerce/includes/class-wc-breadcrumb.php
+++ b/plugins/woocommerce/includes/class-wc-breadcrumb.php
@@ -309,6 +309,10 @@ class WC_Breadcrumb {
 		$this_term = $GLOBALS['wp_query']->get_queried_object();
 		$taxonomy  = get_taxonomy( $this_term->taxonomy );
 
+		if ( 'product_brand' !== $this_term->taxonomy ) {
+			$this->add_crumb( $taxonomy->labels->name );
+		}
+
 		if ( 0 !== intval( $this_term->parent ) ) {
 			$this->term_ancestors( $this_term->term_id, $this_term->taxonomy );
 		}

--- a/plugins/woocommerce/includes/class-wc-breadcrumb.php
+++ b/plugins/woocommerce/includes/class-wc-breadcrumb.php
@@ -309,8 +309,6 @@ class WC_Breadcrumb {
 		$this_term = $GLOBALS['wp_query']->get_queried_object();
 		$taxonomy  = get_taxonomy( $this_term->taxonomy );
 
-		$this->add_crumb( $taxonomy->labels->name );
-
 		if ( 0 !== intval( $this_term->parent ) ) {
 			$this->term_ancestors( $this_term->term_id, $this_term->taxonomy );
 		}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -15241,12 +15241,6 @@ parameters:
 			path: includes/class-wc-breadcrumb.php
 
 		-
-			message: '#^Cannot access property \$labels on WP_Taxonomy\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/class-wc-breadcrumb.php
-
-		-
 			message: '#^Cannot access property \$post_parent on WP_Post\|null\.$#'
 			identifier: property.nonObject
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -15241,6 +15241,12 @@ parameters:
 			path: includes/class-wc-breadcrumb.php
 
 		-
+			message: '#^Cannot access property \$labels on WP_Taxonomy\|false\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: includes/class-wc-breadcrumb.php
+
+		-
 			message: '#^Cannot access property \$post_parent on WP_Post\|null\.$#'
 			identifier: property.nonObject
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Removes the taxonomy name breadcrumb item for the Brands taxonomy.

This makes it consistent with how we're handling product categories:

<img width="163" height="38" alt="Screenshot 2025-12-09 at 10 57 06" src="https://github.com/user-attachments/assets/038bd58f-76cb-4922-afb1-c4d0961f2afb" />

We're keeping it for other taxonomies, as there are tests that expect this for product attributes.

Closes #51486.
Fixes WOOPLUG-100.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|<img width="190" height="40" alt="Screenshot 2025-12-09 at 10 57 21" src="https://github.com/user-attachments/assets/33cbd82e-769a-40f6-918e-0ab064eb0e99" />|<img width="136" height="41" alt="Screenshot 2025-12-09 at 10 57 11" src="https://github.com/user-attachments/assets/ff9a46ba-844e-4b22-9b91-da837089c10d" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Brands and create a brand
2. Assign products to that brand.
3. Go to the brand page
4. Verify you don't see `Brands / ` as part of the breadcrumb anymore. 

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing as provided in the testing instructions.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Breadcrumbs: Remove taxonomy name item for brands

</details>
