### PR TITLE
Admin Menu: Add lost password option only if endpoint is set

### DIFF
--- a/plugins/woocommerce/changelog/62335-fix-admin-menu-lost-password-endpoint-condition
+++ b/plugins/woocommerce/changelog/62335-fix-admin-menu-lost-password-endpoint-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Admin Menu: Add lost password option only if endpoint is set
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -414,8 +414,8 @@ class WC_Admin_Menus {
 			unset( $endpoints['dashboard'] );
 		}
 
-		// Include missing lost password endpoint, if set.
-		if ( get_option( 'woocommerce_myaccount_lost_password_endpoint' ) ) {
+		// Include missing lost password endpoint, if set in WooCommerce > Settings > Advanced > Account endpoints.
+		if ( ! empty( get_option( 'woocommerce_myaccount_lost_password_endpoint' ) ) ) {
 			$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -414,8 +414,10 @@ class WC_Admin_Menus {
 			unset( $endpoints['dashboard'] );
 		}
 
-		// Include missing lost password.
-		$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
+		// Include missing lost password endpoint, if set.
+		if ( get_option( 'woocommerce_myaccount_lost_password_endpoint' ) ) {
+			$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
+		}
 
 		$endpoints = apply_filters( 'woocommerce_custom_nav_menu_items', $endpoints );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Include a menu item for Lost Password only if the corresponding endpoint is set. 

Closes #48479.
Fixes WOOPLUG-2302.

### Screenshots or screen recordings:

Making sure the lost password endpoint is not set:

<img width="669" height="914" alt="Screenshot 2025-12-09 at 12 15 17" src="https://github.com/user-attachments/assets/b2125f4e-e01b-4909-8088-7da2041c1604" />

| Before | After |
| ------ | ----- |
|<img width="300" height="323" alt="Screenshot 2025-12-09 at 12 15 38" src="https://github.com/user-attachments/assets/fa85e894-7921-4502-853e-0178b82397f7" />| <img width="298" height="299" alt="Screenshot 2025-12-09 at 12 19 03" src="https://github.com/user-attachments/assets/e6d70a55-d67f-451e-b6a3-594be12779a1" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure you're using a classic theme that supports menus.
2. Go to WooCommerce > Settings > Advanced and delete "Lost Password" endpoint, then click "Save Changes".
3. Go to Appearance > Menus, create a menu if there's none
4. Expand "WooCommerce endpoints" and ensure there is no option for "Lost Password".
5. Go to WooCommerce > Settings > Advanced and restore the "Lost Password" endpoint to `lost-password`, then click "Save Changes".
6. Go back to Appearance > Menus
7. Expand "WooCommerce endpoints" and ensure there is an option for "Lost Password".

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing as per testing instructions. 

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Admin Menu: Add lost password option only if endpoint is set

</details>
