### PR TITLE
Ensure PRs generated as part of the release process are milestoned

### DIFF
--- a/.github/workflows/cherry-pick-milestoned-prs.yml
+++ b/.github/workflows/cherry-pick-milestoned-prs.yml
@@ -23,6 +23,7 @@ jobs:
       next_branch: ${{ steps.get-branches.outputs.next_branch }}
       pr_number: ${{ steps.set-vars.outputs.pr_number }}
       milestone: ${{ steps.set-vars.outputs.milestone }}
+      should_cherry_pick: ${{ steps.check-cherry-pick.outputs.should_cherry_pick }}
     steps:
       - name: debug
         run: |
@@ -36,6 +37,25 @@ jobs:
         run: |
           echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "milestone=${{ github.event.pull_request.milestone.title }}" >> $GITHUB_OUTPUT
+
+      # Check if cherry-pick should proceed.
+      # Behavior can be overridden using a hidden comment in HTML. By default, cherry-pick is disabled for PRs with the 'Release' label.
+      - name: Check if cherry-pick should proceed
+        id: check-cherry-pick
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            const body  = context.payload.pull_request.body || '';
+
+            // Check for override comment first (takes precedence over everything)
+            // Format: <!-- cherry-pick-milestoned-prs: yes --> or <!-- cherry-pick-milestoned-prs: no -->
+            const match = body.match(/^<!--\s*cherry-pick-milestoned-prs:\s*(yes|no)\s*-->$/m);
+            if ( match ) {
+              core.setOutput( 'should_cherry_pick', match[1] === 'yes' ? 'true' : 'false' );
+              return;
+            }
+
+            core.setOutput( 'should_cherry_pick', ${{ ! contains(github.event.pull_request.labels.*.name, 'Release') }} ? 'true' : 'false' );
 
       # Extract base version from milestone (e.g., 9.9 from 9.9.0)
       - name: Extract version from milestone
@@ -93,11 +113,11 @@ jobs:
 
             core.setOutput('milestoned_branch', milestonedExists ? milestonedBranch : '');
             core.setOutput('next_branch', nextExists ? nextBranch : '');
-  
+
   # Cherry-pick to milestoned branch
   cherry-pick-milestoned:
     needs: prepare
-    if: needs.prepare.outputs.milestoned_branch != ''
+    if: needs.prepare.outputs.milestoned_branch != '' && needs.prepare.outputs.should_cherry_pick == 'true'
     uses: ./.github/workflows/shared-cherry-pick.yml
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
@@ -107,7 +127,7 @@ jobs:
   # Cherry-pick to next branch
   cherry-pick-next:
     needs: prepare
-    if: needs.prepare.outputs.next_branch != ''
+    if: needs.prepare.outputs.next_branch != '' && needs.prepare.outputs.should_cherry_pick == 'true'
     uses: ./.github/workflows/shared-cherry-pick.yml
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
@@ -167,7 +187,7 @@ jobs:
               issue_number: parseInt('${{ needs.prepare.outputs.pr_number }}'),
               body
             });
-      
+
       # Notify Slack about successful cherry-pick to milestoned branch
       - name: Notify Slack on success
         if: always()
@@ -237,7 +257,7 @@ jobs:
               issue_number: parseInt('${{ needs.prepare.outputs.pr_number }}'),
               body
             });
-      
+
       # Notify Slack about successful cherry-pick to next branch
       - name: Notify Slack on success
         if: always()
@@ -299,7 +319,7 @@ jobs:
             const targetBranch = process.env.TARGET_BRANCH;
             const workflowLink = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-            const body = 
+            const body =
               (merger ? merger + ' ' : '') +
               '❌ **Cherry-pick to `' + targetBranch + '` failed.**\n\n' +
               '**Error:** ' + errorMsg + '\n\n' +
@@ -329,8 +349,8 @@ jobs:
           slack-optional-unfurl_links: false
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
           slack-text: |
-            :warning: *Cherry pick from `trunk` to `${{ env.TARGET_BRANCH }}` <${{ env.WORKFLOW_RUN_URL }}|failed>*  
-            Please resolve before releasing.  
+            :warning: *Cherry pick from `trunk` to `${{ env.TARGET_BRANCH }}` <${{ env.WORKFLOW_RUN_URL }}|failed>*
+            Please resolve before releasing.
             Source PR: _<${{ env.SOURCE_PR_URL }}|#${{ env.SOURCE_PR_NUMBER }} - ${{ env.SOURCE_PR_TITLE }}>_.
 
   # Handle failed cherry-pick to next branch
@@ -379,7 +399,7 @@ jobs:
             const targetBranch = process.env.TARGET_BRANCH;
             const workflowLink = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-            const body = 
+            const body =
               (merger ? merger + ' ' : '') +
               '❌ **Cherry-pick to `' + targetBranch + '` failed.**\n\n' +
               '**Error:** ' + errorMsg + '\n\n' +
@@ -409,6 +429,6 @@ jobs:
           slack-optional-unfurl_links: false
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
           slack-text: |
-            :warning: *Cherry pick from `trunk` to `${{ env.TARGET_BRANCH }}` <${{ env.WORKFLOW_RUN_URL }}|failed>*  
-            Please resolve before releasing.  
+            :warning: *Cherry pick from `trunk` to `${{ env.TARGET_BRANCH }}` <${{ env.WORKFLOW_RUN_URL }}|failed>*
+            Please resolve before releasing.
             Source PR: _<${{ env.SOURCE_PR_URL }}|#${{ env.SOURCE_PR_NUMBER }} - ${{ env.SOURCE_PR_TITLE }}>_.

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -184,7 +184,7 @@ jobs:
           # Create PR
           gh pr create \
             --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
-            --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
+            --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.'$'\n\n''<!-- [x] This Pull Request does not require a changelog -->' \
             --base ${{ inputs.branch }} \
             --head ${branch_name} \
             --label Release \

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -183,7 +183,7 @@ jobs:
 
           # Create PR
           gh pr create \
-            --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
+            --title 'Bump WooCommerce version to `${{ steps.compute-new-version.outputs.nextVersion }}` on `${{ inputs.branch }}`' \
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.'$'\n\n''<!-- [x] This Pull Request does not require a changelog -->' \
             --base ${{ inputs.branch }} \
             --head ${branch_name} \

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -27,10 +27,6 @@ on:
         description: Type of version bump to perform
         type: string
         required: true
-      milestone:
-        description: Milestone to set on the PR (optional)
-        type: string
-        required: false
 
 permissions:
   contents: write
@@ -119,6 +115,7 @@ jobs:
             core.setOutput( 'nextVersion', newVersion );
             core.setOutput( 'nextStable', newVersion.replace( /-(dev|(beta|rc)\.\d+)/, '' ) );
             core.setOutput( 'clearChangelog', '' === prerelease );
+            core.setOutput( 'prMilestone', `${ baseVersion }.0` );
 
       - name: Bump version in files
         env:
@@ -175,10 +172,13 @@ jobs:
             reviewer_arg="--reviewer ${{ github.actor }}"
           fi
 
-          # Set milestone argument (empty if not provided).
+          # Check milestone exists.
+          milestone="${{ steps.compute-new-version.outputs.prMilestone }}"
           milestone_arg=""
-          if [[ -n "${{ inputs.milestone }}" ]]; then
-            milestone_arg="--milestone ${{ inputs.milestone }}"
+          if [[ -n "$milestone" ]]; then
+            if [ "$(gh api repos/${{ github.repository }}/milestones --jq 'any(.[]; .title=="$milestone")')" = "true" ]; then
+              milestone_arg="--milestone $milestone"
+            fi
           fi
 
           # Create PR

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -176,7 +176,7 @@ jobs:
           milestone="${{ steps.compute-new-version.outputs.prMilestone }}"
           milestone_arg=""
           if [[ -n "$milestone" ]]; then
-            if [ "$(gh api repos/${{ github.repository }}/milestones --jq 'any(.[]; .title=="$milestone")')" = "true" ]; then
+            if [ "$(gh api repos/${{ github.repository }}/milestones --jq "any(.[]; .title==\"$milestone\")")" = "true" ]; then
               milestone_arg="--milestone $milestone"
             fi
           fi

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -210,7 +210,6 @@ jobs:
     with:
       branch: trunk
       bump-type: dev
-      milestone: ${{ needs.prepare-for-feature-freeze.outputs.nextReleaseVersion }}
 
   build-dev-release:
     name: 'Build WooCommerce -dev release'

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -82,6 +82,10 @@ jobs:
     name: 'Update changelog.txt after any stable release'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     if: ${{ github.event.action == 'published' && ! ( contains( inputs.release_tag_name, '-dev' ) || contains( inputs.release_tag_name, '-beta' ) || contains( inputs.release_tag_name, '-rc' ) ) }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: 'Fetch release readme.txt'
         env:
@@ -110,15 +114,15 @@ jobs:
           php ./trunk/.github/workflows/scripts/release-readme-to-changelog.php ./woocommerce/readme.txt ./trunk/changelog.txt
       - name: 'Push changes and open PR'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           # Determine milestone from release version.
           milestone=$( cat ./woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+$/.0/' )
 
           # Configure Git.
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "woocommercebot"
+          git config --global user.email "woocommercebot@users.noreply.github.com"
 
           # Push new changelog.txt.
           branch_name="update-changelog-${{ inputs.release_tag_name }}-$(date +%s)"

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -113,6 +113,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+          # Determine milestone from release version.
+          milestone=$( cat ./woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+$/.0/' )
+
           # Configure Git.
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -125,9 +128,6 @@ jobs:
             --all \
             --message 'Update changelog.txt after release ${{ inputs.release_tag_name }}'
           git push origin "$branch_name"
-
-          # Determine milestone from trunk version.
-          milestone=$( cat ./woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+$/.0/' )
 
           # Open a PR.
           gh pr create \

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -103,6 +103,7 @@ jobs:
           sparse-checkout: |
             /changelog.txt
             /.github/workflows/scripts/release-readme-to-changelog.php
+            /plugins/woocommerce/woocommerce.php
           sparse-checkout-cone-mode: false
           path: trunk
       - name: 'Update changelog.txt'
@@ -126,10 +127,14 @@ jobs:
             --message 'Update changelog.txt after release ${{ inputs.release_tag_name }}'
           git push origin "$branch_name"
 
+          # Determine milestone from trunk version.
+          milestone=$( cat ./trunk/plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+
           # Open a PR.
           gh pr create \
             --title 'Update changelog.txt after ${{ inputs.release_tag_name }}' \
             --body 'This PR updates the global changelog.txt file following the release of version ${{ inputs.release_tag_name }}.' \
             --base trunk \
             --head "$branch_name" \
-            --reviewer "${{ github.actor }}"
+            --reviewer "${{ github.actor }}" \
+            --milestone "$milestone"

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -56,10 +56,10 @@ jobs:
           git fetch origin ${BRANCH_NAME}
           git checkout ${BRANCH_NAME}
           current_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
-          
+
           echo "Current version from woocommerce.php: '$current_version'"
           echo "Release tag version: '$RELEASE_TAG'"
-          
+
           if [[ "$current_version" != "$RELEASE_TAG" ]]; then
             echo "::warning::The version in woocommerce.php ($current_version) does not match the release tag version ($RELEASE_TAG). Skipping notification."
             echo "versions_match=false" >> $GITHUB_OUTPUT
@@ -103,7 +103,6 @@ jobs:
           sparse-checkout: |
             /changelog.txt
             /.github/workflows/scripts/release-readme-to-changelog.php
-            /plugins/woocommerce/woocommerce.php
           sparse-checkout-cone-mode: false
           path: trunk
       - name: 'Update changelog.txt'
@@ -128,7 +127,7 @@ jobs:
           git push origin "$branch_name"
 
           # Determine milestone from trunk version.
-          milestone=$( cat ./trunk/plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+          milestone=$( cat ./woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+$/.0/' )
 
           # Open a PR.
           gh pr create \
@@ -137,4 +136,5 @@ jobs:
             --base trunk \
             --head "$branch_name" \
             --reviewer "${{ github.actor }}" \
+            --label "Release" \
             --milestone "$milestone"

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -288,7 +288,7 @@ jobs:
               --label Release \
               --milestone "$milestone"
 
-            echo "✅ Successfully created PR to update stable tag to $TARGET_VERSION on $BRANCH_NAME with milestone $MILESTONE"
+            echo "✅ Successfully created PR to update stable tag to $TARGET_VERSION on $BRANCH_NAME with milestone $milestone"
           fi
 
   notify-release:

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -275,15 +275,20 @@ jobs:
             git commit -m "Update stable tag to $TARGET_VERSION on $BRANCH_NAME"
             git push origin "$UPDATE_BRANCH"
 
+            # Determine milestone from woocommerce.php version.
+            milestone=$( cat ./plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+            echo "Using milestone: '$milestone'."
+
             gh pr create \
               --title "Update stable tag to $TARGET_VERSION ($BRANCH_NAME)" \
               --body "This PR updates the stable tag to $TARGET_VERSION." \
               --base "$BRANCH_NAME" \
               --head "$UPDATE_BRANCH" \
               --reviewer ${{ github.actor }} \
-              --label Release
+              --label Release \
+              --milestone "$milestone"
 
-            echo "✅ Successfully created PR to update stable tag to $TARGET_VERSION on $BRANCH_NAME"
+            echo "✅ Successfully created PR to update stable tag to $TARGET_VERSION on $BRANCH_NAME with milestone $MILESTONE"
           fi
 
   notify-release:

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -343,7 +343,10 @@ export const updateBranchChangelog = async (
 
 	// Read plugin file version in branch to determine milestone.
 	let milestone = '';
-	const pluginFile = readFileSync( path.join( tmpRepoPath, 'plugins/woocommerce/woocommerce.php' ), 'utf8' );
+	const pluginFile = readFileSync(
+		path.join( tmpRepoPath, 'plugins/woocommerce/woocommerce.php' ),
+		'utf8'
+	);
 	const m = pluginFile.match( /\*\s+Version:\s+(\d+\.\d+)\.\d+/ );
 
 	if ( m ) {
@@ -387,7 +390,7 @@ export const updateBranchChangelog = async (
 			}`,
 			head: branch,
 			base: releaseBranch,
-			reviewers: [ githubActor ]
+			reviewers: [ githubActor ],
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -348,18 +348,6 @@ export const updateBranchChangelog = async (
 		config: [ 'core.hooksPath=/dev/null' ],
 	} );
 
-	// Read plugin file version in branch to determine milestone.
-	let milestone = '';
-	const pluginFile = readFileSync(
-		path.join( tmpRepoPath, 'plugins/woocommerce/woocommerce.php' ),
-		'utf8'
-	);
-	const m = pluginFile.match( /\*\s+Version:\s+(\d+\.\d+)\.\d+/ );
-
-	if ( m ) {
-		milestone = `${ m[ 1 ] }.0`;
-	}
-
 	try {
 		await git.checkout( releaseBranch );
 		const branch = `delete/${ releaseBranch }-changelog-from-${ version }`;
@@ -370,6 +358,18 @@ export const updateBranchChangelog = async (
 			'-b': null,
 			[ branch ]: null,
 		} );
+
+		// Read plugin file version in branch to determine milestone.
+		let milestone = '';
+		const pluginFile = readFileSync(
+			path.join( tmpRepoPath, 'plugins/woocommerce/woocommerce.php' ),
+			'utf8'
+		);
+		const m = pluginFile.match( /\*\s+Version:\s+(\d+\.\d+)\.\d+/ );
+
+		if ( m ) {
+			milestone = `${ m[ 1 ] }.0`;
+		}
 
 		try {
 			await git.raw( [ 'cherry-pick', deletionCommitHash ] );

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -284,7 +284,6 @@ export const updateReleaseBranchChangelogs = async (
 			head: branch,
 			base: releaseBranch,
 			reviewers: [ githubActor ],
-			milestone: `${ mainVersion }.0`,
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
@@ -295,6 +294,14 @@ export const updateReleaseBranchChangelogs = async (
 		} catch {
 			Logger.warn(
 				`Could not add label "Release" to PR ${ pullRequest.number }`
+			);
+		}
+
+		try {
+			await addMilestoneToIssue( options, pullRequest.number, `${ mainVersion }.0` );
+		} catch {
+			Logger.warn(
+				`Could not add milestone "${ mainVersion }.0" to PR ${ pullRequest.number }`
 			);
 		}
 

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -14,6 +14,7 @@ import { Logger } from '../../../../core/logger';
 import { checkoutRemoteBranch } from '../../../../core/git';
 import {
 	addLabelsToIssue,
+	addMilestoneToIssue,
 	createPullRequest,
 } from '../../../../core/github/repo';
 import { Options } from '../types';
@@ -283,6 +284,7 @@ export const updateReleaseBranchChangelogs = async (
 			head: branch,
 			base: releaseBranch,
 			reviewers: [ githubActor ],
+			milestone: `${ mainVersion }.0`,
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
@@ -339,6 +341,15 @@ export const updateBranchChangelog = async (
 		config: [ 'core.hooksPath=/dev/null' ],
 	} );
 
+	// Read plugin file version in branch to determine milestone.
+	let milestone = '';
+	const pluginFile = readFileSync( path.join( tmpRepoPath, 'plugins/woocommerce/woocommerce.php' ), 'utf8' );
+	const m = pluginFile.match( /\*\s+Version:\s+(\d+\.\d+)\.\d+/ );
+
+	if ( m ) {
+		milestone = `${ m[ 1 ] }.0`;
+	}
+
 	try {
 		await git.checkout( releaseBranch );
 		const branch = `delete/${ releaseBranch }-changelog-from-${ version }`;
@@ -376,7 +387,7 @@ export const updateBranchChangelog = async (
 			}`,
 			head: branch,
 			base: releaseBranch,
-			reviewers: [ githubActor ],
+			reviewers: [ githubActor ]
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
@@ -387,6 +398,14 @@ export const updateBranchChangelog = async (
 		} catch {
 			Logger.warn(
 				`Could not add label "Release" to PR ${ pullRequest.number }`
+			);
+		}
+
+		try {
+			await addMilestoneToIssue( options, pullRequest.number, milestone );
+		} catch {
+			Logger.warn(
+				`Could not add milestone "${ milestone }" to PR ${ pullRequest.number }`
 			);
 		}
 

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -298,7 +298,11 @@ export const updateReleaseBranchChangelogs = async (
 		}
 
 		try {
-			await addMilestoneToIssue( options, pullRequest.number, `${ mainVersion }.0` );
+			await addMilestoneToIssue(
+				options,
+				pullRequest.number,
+				`${ mainVersion }.0`
+			);
 		} catch {
 			Logger.warn(
 				`Could not add milestone "${ mainVersion }.0" to PR ${ pullRequest.number }`

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -332,7 +332,7 @@ export const createPullRequest = async ( options: {
 				owner,
 				repo: name,
 				pull_number: pullRequest.data.number,
-				filteredReviewers,
+				reviewers: filteredReviewers,
 			}
 		);
 	}

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -321,7 +321,9 @@ export const createPullRequest = async ( options: {
 		}
 	);
 
-	const filteredReviewers = reviewers?.filter( ( reviewer ) => reviewer !== pullRequest.data.user.login );
+	const filteredReviewers = reviewers?.filter(
+		( reviewer ) => reviewer !== pullRequest.data.user.login
+	);
 
 	if ( filteredReviewers && filteredReviewers.length > 0 ) {
 		await octokitWithAuth().request(

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -321,14 +321,16 @@ export const createPullRequest = async ( options: {
 		}
 	);
 
-	if ( reviewers && reviewers.length > 0 ) {
+	const filteredReviewers = reviewers?.filter( ( reviewer ) => reviewer !== pullRequest.data.user.login );
+
+	if ( filteredReviewers && filteredReviewers.length > 0 ) {
 		await octokitWithAuth().request(
 			'POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers',
 			{
 				owner,
 				repo: name,
 				pull_number: pullRequest.data.number,
-				reviewers,
+				filteredReviewers,
 			}
 		);
 	}

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -249,6 +249,44 @@ export const addLabelsToIssue = async (
 	);
 };
 
+export const addMilestoneToIssue = async (
+	options: {
+		owner?: string;
+		name?: string;
+	},
+	issueNumber: number,
+	milestoneName: string
+): Promise< void > => {
+	const { owner, name } = options;
+
+	// Try to find milestone by name.
+	const { data } = await octokitWithAuth().request(
+		'GET /repos/{owner}/{repo}/milestones',
+		{
+			owner,
+			repo: name,
+			state: 'all',
+			direction: 'desc',
+			per_page: 100,
+		}
+	);
+
+	const milestone = data.find( ( m ) => m.title === milestoneName );
+
+	if ( milestone ) {
+		await octokitWithAuth().request(
+			'PATCH /repos/{owner}/{repo}/issues/{issue_number}',
+			{
+				owner,
+				repo: name,
+				issue_number: issueNumber,
+				milestone: milestone.number,
+			}
+		);
+	}
+
+}
+
 /**
  * Create a pull request from branches on GitHub.
  *
@@ -259,8 +297,8 @@ export const addLabelsToIssue = async (
  * @param {string} options.name  repository name.
  * @param {string} options.title pull request title.
  * @param {string} options.body  pull request body.
- * @return {Promise<object>}     pull request data.
  * @param {string[]} options.reviewers list of GitHub usernames to request a review from.
+ * @return {Promise<object>}     pull request data.
  */
 export const createPullRequest = async ( options: {
 	head: string;
@@ -271,7 +309,8 @@ export const createPullRequest = async ( options: {
 	body: string;
 	reviewers?: string[];
 } ): Promise< CreatePullRequestEndpointResponse[ 'data' ] > => {
-	const { head, base, owner, name, title, body, reviewers } = options;
+	const { head, base, owner, name, title, body, reviewers, milestone } =
+		options;
 	const pullRequest = await octokitWithAuth().request(
 		'POST /repos/{owner}/{repo}/pulls',
 		{

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -284,19 +284,18 @@ export const addMilestoneToIssue = async (
 			}
 		);
 	}
-
-}
+};
 
 /**
  * Create a pull request from branches on GitHub.
  *
- * @param {Object} options       pull request options.
- * @param {string} options.head  branch name containing the changes you want to merge.
- * @param {string} options.base  branch name you want the changes pulled into.
- * @param {string} options.owner repository owner.
- * @param {string} options.name  repository name.
- * @param {string} options.title pull request title.
- * @param {string} options.body  pull request body.
+ * @param {Object}   options           pull request options.
+ * @param {string}   options.head      branch name containing the changes you want to merge.
+ * @param {string}   options.base      branch name you want the changes pulled into.
+ * @param {string}   options.owner     repository owner.
+ * @param {string}   options.name      repository name.
+ * @param {string}   options.title     pull request title.
+ * @param {string}   options.body      pull request body.
  * @param {string[]} options.reviewers list of GitHub usernames to request a review from.
  * @return {Promise<object>}     pull request data.
  */
@@ -309,8 +308,7 @@ export const createPullRequest = async ( options: {
 	body: string;
 	reviewers?: string[];
 } ): Promise< CreatePullRequestEndpointResponse[ 'data' ] > => {
-	const { head, base, owner, name, title, body, reviewers, milestone } =
-		options;
+	const { head, base, owner, name, title, body, reviewers } = options;
 	const pullRequest = await octokitWithAuth().request(
 		'POST /repos/{owner}/{repo}/pulls',
 		{


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR ensures that PRs generated as part of releases have all the correct milestone so nothing gets missed. Normally, this milestone would be the same as the release being processed, except for `trunk`'s version bump at feature freeze time, which receives the milestone of the prior release (the one now frozen) so that it's addressed as part of the release cycle itself.

Part of #62072.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### 1. Setup
1. Fork the WooCommerce repo, including at least `trunk`, `release/10.4` and `release/10.3`.
1. In your fork, ensure that the label `Release` and milestones `10.4.0` and `10.5.0` and `10.6.0` exist.
1. Merge this branch (`fix/62072-milestones`) into `trunk` in your fork.
1. Go to **Settings > Secrets and variables > Actions** in your repo and add the following secrets / values:
   | Secret name | Value |
   | ---- | ------ |
   | `WC_BOT_PR_CREATE_TOKEN` | A fine-grained PAT for your account with permissions "Metadata" (ro), "Pull Requests" (r/w), "Contents" (r/w), "Issues" (r/w) and "Workflows" (r/w). |
   | `CODE_FREEZE_BOT_TOKEN` | Token from secret store item `Test Assistant bot` |
   | WOO_ANNOUNCEMENTS_SLACK_CHANNEL | `test-woo-core-release-notifications` |
   | `WOO_RELEASE_SLACK_CHANNEL` | `test-woo-core-release-notifications` |

   ⚠️ Ensure that your fork doesn't have secret `WPORG_SVN_URL` configured.
1. In your fork, use the GH UI to edit `.github/workflows/release-release-events-proxy.yml` [change line 11](https://github.com/woocommerce/woocommerce/blob/f23b5d0d8e73616421cf861285fbee2ee475c550/.github/workflows/release-release-events-proxy.yml#L11) to 
   ```
       uses: <your username>/woocommerce/.github/workflows/release-new-release-published.yml@trunk
   ```
1. Similarly, edit `.github/workflows/release-update-stable-tag.yml` in your fork, performing the following changes:
   - Comment out or remove [lines 120 to 186](https://github.com/woocommerce/woocommerce/blob/999849ad675ab8bc265df9df7e7dc134e29b2a8a/.github/workflows/release-update-stable-tag.yml#L120-L186).
   - Comment out or remove [lines 195 to 221](https://github.com/woocommerce/woocommerce/blob/999849ad675ab8bc265df9df7e7dc134e29b2a8a/.github/workflows/release-update-stable-tag.yml#L195-L221).
1. Edit trunk's `changelog.txt` in your fork by removing the section for `10.4.0` ([lines 3 to 184](https://github.com/woocommerce/woocommerce/blob/f23b5d0d8e73616421cf861285fbee2ee475c550/changelog.txt#L3-L184)).

#### 2. Test workflows

1. Stable tag update:
   1. Go to **Actions > Release: Update stable tag** and run the workflow with version "10.3.0" and check both checkboxes.
   1. Confirm that 3 PRs were created:
      - One targeting `release/10.3` with milestone `10.3.0`
      - One targeting `release/10.4` with milestone `10.4.0`
      - One targeting `trunk` with milestone `10.5.0`.
1. Bump version workflow:
   1. Go to **Actions > Release: Bump version number** and...
      1. Run the workflow with release branch `release/10.4` and bump type `stable`. Confirm that the resulting PR has label "Release" and milestone `10.4.0`. Do not merge the PR.
      1. Run the workflow with release branch `trunk` and bump type "dev". Confirm that the resulting PR has label "Release" and milestone `10.5.0`. Do not merge the PR.
      1. Merge the PR from the previous step (the one targeting `trunk`) and confirm that no backport / cherry pick occurs after merging. `trunk` should now be at `10.6.0-dev`.
1. Post-release changelog update:
   1. Go to **Code > Releases** and create a new release in your fork with title and tag `10.4.0` targeting `trunk`. Upload [WC's 10.4.0 zip](https://downloads.wordpress.org/plugin/woocommerce.10.4.0.zip) and rename it `woocommerce.zip` Save as draft.
   1. Publish the release and wait for a few mins until workflows finalize.
   1. Confirm that a PR "Update changelog.txt after 10.4.0" was created and has milestone `10.4.0`.
1. Changelog workflow:
   1. Go to **Code > Branches** and create a `release/10.5` branch based off of `trunk`.
   1. Use the GH UI to edit `woocommerce.php` and change the version header from `10.6.0-dev` to `10.5.0-dev`.
   1. Go to **Actions > Release: Compile changelog** and run the workflow with version `10.5`.
   1. Confirm that 2 PRs were generated:
      - One updating the changelog on `release/10.5` with milestone `10.5.0`.
      - One removing the changelog entries from `trunk` with milestone `10.6.0`.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.