### PR TITLE
Attempt to wait for template search to update before resetting templates

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -134,7 +134,7 @@ export class Editor extends CoreEditor {
 		// Using expect.poll() for a retrying assertion since toHaveCount
 		// requires an exact number.
 		await expect
-			.poll( () => templateCards.count(), { timeout: 10000 } )
+			.poll( () => templateCards.count(), { timeout: 3000 } )
 			.toBeLessThan( templatesBeforeSearch );
 	}
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -118,12 +118,24 @@ export class Editor extends CoreEditor {
 	 * Search for a template or template part in the Site Editor.
 	 */
 	async searchTemplate( { templateName }: { templateName: string } ) {
+		const templateCards = this.page.locator(
+			'.dataviews-view-grid > .dataviews-view-grid__card'
+		);
+		const templatesBeforeSearch = await templateCards.count();
+
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
 
 		await expect(
 			this.page.getByRole( 'button', { name: 'Reset Search' } )
 		).toBeVisible();
 		await expect( this.page.getByLabel( 'No results' ) ).toBeHidden();
+
+		// Wait for the grid to update with fewer items than before.
+		// Using expect.poll() for a retrying assertion since toHaveCount
+		// requires an exact number.
+		await expect
+			.poll( () => templateCards.count(), { timeout: 10000 } )
+			.toBeLessThan( templatesBeforeSearch );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some tests are flaky because the cleanup action to reset the modified templates attemps to click the "Actions" button on the first template in the list. There is a race condition here between the new results rendering after searching and the button being clicked.

This PR attempts to modify this by waiting until the number of templates in the view has decreased from the original amount before trying to click the "Actions" button.

Closes WOOPLUG-4981
Closes WOOPLUG-5404
Closes WOOPLUG-5573
Closes WOOPLUG-5708
Closes WOOPLUG-5973


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes and no flaky tests relating to templates are reported.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This change modifies test files only.

</details>
