### PR TITLE
Improve pre-build release checks

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -92,13 +92,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-            # No PRs by automated tools should remain open.
-            count=$( gh pr list --search "is:open label:Release" --limit 1 --json number | jq length )
-            if (( count > 0 )); then
-                echo "::error::Pre-build verification: there are release PRs still open."
-                exit 1
-            fi
-
             # Branch name must be 'release/*'.
             branch_name="${BRANCH#refs/heads/}"
             if  [[ $branch_name != release/* ]] ; then

--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -3,7 +3,7 @@
  *
  * @param {string} version
  * @param {{ github: Octokit, context: { repo: { owner: string, repo: string } } }} options
- * @returns {Promise<string>} The previous version.
+ * @returns {Promise<string> | null} The previous version.
  */
 const findPreviousVersion = async ( version, { github, context } ) => {
   if ( version.endsWith( '-dev' ) || version.endsWith( '-beta.1' ) ) {
@@ -40,7 +40,7 @@ const findPreviousVersion = async ( version, { github, context } ) => {
   );
 
   if ( 0 === allTags.length) {
-    throw new Error( `Cannot determine previous version for '${ version }'.` );
+    return null;
   }
 
   // Insert current version in array when necessary.
@@ -167,6 +167,11 @@ const run = async ( currentRef, { github, context } ) => {
 
   // Previous version.
   const previousRef = await findPreviousVersion( version, { github, context } );
+  if ( ! previousRef ) {
+    console.log( `No previous version for '${ version }'. Skipping db updates check.` );
+    return;
+  }
+
   const previousFile = await readFileFromRef( previousRef, 'plugins/woocommerce/includes/class-wc-install.php', { github, context } );
   const previousDbUpdates = readDbUpdatesFromString( previousFile );
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Currently, when building a WC release various checks are performed, including one where we check if there are any PRs open with the `Release` label. This is not necessarily what we want because it can prevent simultaneous releases from happening (for example a patch for 10.3.x while a beta or RC for 10.4.x is being built) given some of the auto-generated PRs have the `Release` label (this includes backports).

The build process already ensures that there are no open PRs targeting the release branch or have the release milestone, so we're already ensuring nothing that should go out with that release is missed.

This PR removes the unnecessary step and also makes a tiny change to the check where we ensure database updates are correctly versioned so that it works well in an empty repo, where there are no existing releases.

Related to #62072.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repository, including `trunk` and `release/10.4`.
1. Ensure your fork has milestones `10.5.0` and `10.4.0` and label `Release`.
1. Use the GH UI to make any changes on `trunk` and create a PR targeting `trunk`. Do not merge the PR.
1. Use the GH UI again to make any changes from within branch `release/10.4` and create a PR targeting `release/10.4`. Do not merge the PR.
1. In your fork, go to **Actions > Release: Build ZIP file** and run the workflow entering `release/10.4` as release branch.
1. The run should fail with error `Pre-build verification: there are PRs against the release branch (release/10.4) still open`.
1. Merge or close the PR created in step 4.
1. Run the workflow again.
1. This time, it should fail with error `Pre-build verification: there are PRs with milestone '10.4.0' still open.`.
1. Change milestone in the PR created in step 3 to `10.5.0` and add label `Release`.
1. Run the workflow again. This time it should complete successfully.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.