### PR TITLE
MiniCart: Fix price formatted with too many decimals

### DIFF
--- a/plugins/woocommerce/changelog/62355-wooplug-5941-interactivity-api-mini-cart-price-formatted-with-too-many
+++ b/plugins/woocommerce/changelog/62355-wooplug-5941-interactivity-api-mini-cart-price-formatted-with-too-many
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix minicart prices formatted with too many decimals

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -61,7 +61,11 @@ const scalePrice = ( {
 	price,
 	inputDecimals,
 	outputDecimals = 0,
-}: ScalePriceArgs ) => price * Math.pow( 10, outputDecimals - inputDecimals );
+}: ScalePriceArgs ) => {
+	const scaledPrice = price * Math.pow( 10, outputDecimals - inputDecimals );
+	// Remove extra decimals.
+	return scaledPrice.toFixed( 0 );
+};
 
 // Inject style tags for badge styles based on background colors of the document.
 setStyles();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -64,7 +64,7 @@ const scalePrice = ( {
 }: ScalePriceArgs ) => {
 	const scaledPrice = price * Math.pow( 10, outputDecimals - inputDecimals );
 	// Remove extra decimals.
-	return scaledPrice.toFixed( 0 );
+	return Math.round( scaledPrice );
 };
 
 // Inject style tags for badge styles based on background colors of the document.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #62230 .

(For Bug Fixes) Bug introduced in PR #61233 .

This PR properly formats the prices displayed in the minicart to include only the defined number of decimals.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="429" height="244" alt="Screenshot 2025-12-10 at 10 08 20" src="https://github.com/user-attachments/assets/49223eeb-018a-4700-b735-5208c0c9e859" />     |  <img width="429" height="273" alt="Screenshot 2025-12-10 at 10 07 38" src="https://github.com/user-attachments/assets/b29ad725-4fd9-4f66-806a-f126a0c37d61" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Following the testing instructions from the original issue: https://github.com/woocommerce/woocommerce/issues/62230

1. Go to WooCommerce > Settings > and check *Enable tax rates and calculations*.
2. Go to WooCommerce > Settings > Tax and select *Yes, I will enter prices inclusive of tax* and _Display prices during cart and checkout_ as *Excluding tax*.
3. Go to *Standard rates* and create a tax rate of 10%.
4. Now, go to the frontend, add any product on sale to your cart.
5. Open the Mini-Cart and notice the sale prices are displayed with too many decimals.
6. Change the Settings > General > Number of decimals and check it is properly displayed in the minicart.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix minicart prices formatted with too many decimals

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
