### PR TITLE
Use store title as default email "From" name instead of hardcoded WordPress site name

### DIFF
--- a/packages/js/settings-editor/typings/global.d.ts
+++ b/packages/js/settings-editor/typings/global.d.ts
@@ -30,6 +30,7 @@ declare global {
 		desc?: string;
 		description?: string;
 		desc_tip?: boolean | string;
+		skip_initial_save?: boolean;
 		default?: string | number | boolean | object;
 		value: string | number | boolean | object;
 		placeholder?: string;

--- a/plugins/woocommerce/changelog/stomail-7654-email-from-name-defaults-to-my-wordpress-site-instead-of
+++ b/plugins/woocommerce/changelog/stomail-7654-email-from-name-defaults-to-my-wordpress-site-instead-of
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Allow “Email FROM” to automatically use the “Store Title” as the value unless the merchant manually changes it.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -123,14 +123,15 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				),
 
 				array(
-					'title'    => __( '"From" name', 'woocommerce' ),
-					'desc'     => '',
-					'id'       => 'woocommerce_email_from_name',
-					'type'     => 'text',
-					'css'      => 'min-width:400px;',
-					'default'  => esc_attr( get_bloginfo( 'name', 'display' ) ),
-					'autoload' => false,
-					'desc_tip' => true,
+					'title'             => __( '"From" name', 'woocommerce' ),
+					'desc'              => '',
+					'id'                => 'woocommerce_email_from_name',
+					'type'              => 'text',
+					'css'               => 'min-width:400px;',
+					'default'           => esc_attr( get_bloginfo( 'name', 'display' ) ),
+					'autoload'          => false,
+					'desc_tip'          => true,
+					'skip_initial_save' => true,
 				),
 
 				array(

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -6,6 +6,8 @@
  * @version 2.1.0
  */
 
+declare(strict_types=1);
+
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\Email\EmailColors;
 use Automattic\WooCommerce\Internal\Email\EmailFont;
@@ -372,6 +374,13 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		// Remove empty elements that depend on the email_improvements feature flag.
 		$settings = array_filter( $settings );
 
+		/**
+		 * Filters the email settings array.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array $settings Array of email settings.
+		 */
 		return apply_filters( 'woocommerce_email_settings', $settings );
 	}
 
@@ -467,6 +476,13 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				<thead>
 					<tr>
 						<?php
+						/**
+						 * Filters the columns displayed in the email settings table.
+						 *
+						 * @since 2.1.0
+						 *
+						 * @param array $columns Array of column keys and labels.
+						 */
 						$columns = apply_filters(
 							'woocommerce_email_setting_columns',
 							array(
@@ -549,6 +565,13 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										</td>';
 										break;
 									default:
+										/**
+										 * Fires when rendering a custom column in the email settings table.
+										 *
+										 * @since 2.1.0
+										 *
+										 * @param WC_Email $email The email object.
+										 */
 										do_action( 'woocommerce_email_setting_column_' . $key, $email );
 										break;
 								}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -6,8 +6,6 @@
  * @version 2.1.0
  */
 
-declare(strict_types=1);
-
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\Email\EmailColors;
 use Automattic\WooCommerce\Internal\Email\EmailFont;

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -322,7 +322,7 @@ class WC_Emails {
 	 */
 	public function get_from_name() {
 		$default = get_bloginfo( 'name', 'display' );
-		return wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name', $default ) ), ENT_QUOTES );
+		return wp_specialchars_decode( get_option( 'woocommerce_email_from_name', $default ), ENT_QUOTES );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -321,7 +321,8 @@ class WC_Emails {
 	 * @return string
 	 */
 	public function get_from_name() {
-		return wp_specialchars_decode( get_option( 'woocommerce_email_from_name' ), ENT_QUOTES );
+		$default = get_bloginfo( 'name', 'display' );
+		return wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name', $default ) ), ENT_QUOTES );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -309,7 +309,7 @@ class WC_Emails {
 	/**
 	 * Return the email classes - used in admin to load settings.
 	 *
-	 * @return WC_Email[]
+	 * @return array<string, WC_Email> Email classes.
 	 */
 	public function get_emails() {
 		return $this->emails;

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1109,7 +1109,7 @@ class WC_Install {
 			foreach ( $subsections as $subsection ) {
 				foreach ( $section->get_settings( $subsection ) as $value ) {
 					if ( isset( $value['default'] ) && isset( $value['id'] ) ) {
-						$autoload = isset( $value['autoload'] ) ? (bool) $value['autoload'] : true;
+						$autoload          = isset( $value['autoload'] ) ? (bool) $value['autoload'] : true;
 						$skip_initial_save = isset( $value['skip_initial_save'] ) ? (bool) $value['skip_initial_save'] : false;
 						if ( ! $skip_initial_save ) {
 							add_option( $value['id'], $value['default'], '', ( $autoload ? 'yes' : 'no' ) );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1110,7 +1110,10 @@ class WC_Install {
 				foreach ( $section->get_settings( $subsection ) as $value ) {
 					if ( isset( $value['default'] ) && isset( $value['id'] ) ) {
 						$autoload = isset( $value['autoload'] ) ? (bool) $value['autoload'] : true;
-						add_option( $value['id'], $value['default'], '', ( $autoload ? 'yes' : 'no' ) );
+						$skip_initial_save = isset( $value['skip_initial_save'] ) ? (bool) $value['skip_initial_save'] : false;
+						if ( ! $skip_initial_save ) {
+							add_option( $value['id'], $value['default'], '', ( $autoload ? 'yes' : 'no' ) );
+						}
 					}
 				}
 			}

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -414,7 +414,7 @@ class WC_Email extends WC_Settings_API {
 		 * @since 6.8.0
 		 *
 		 * @param bool $default_value The default returned value.
-		 * @param WC_Email $this The WC_Email object.
+		 * @param WC_Email $email The WC_Email object.
 		 */
 		$switch_email_locale = apply_filters( 'woocommerce_allow_switching_email_locale', true, $this );
 
@@ -434,7 +434,7 @@ class WC_Email extends WC_Settings_API {
 		 * @since 6.8.0
 		 *
 		 * @param bool $default_value The default returned value.
-		 * @param WC_Email $this The WC_Email object.
+		 * @param WC_Email $email The WC_Email object.
 		 */
 		$restore_email_locale = apply_filters( 'woocommerce_allow_restoring_email_locale', true, $this );
 
@@ -888,7 +888,7 @@ class WC_Email extends WC_Settings_API {
 			 *
 			 * @param callable $style_inline_callback The default email inline styling callback.
 			 * @param string|null $content Content that will receive inline styles.
-			 * @param WC_Email $this The WC_Email object.
+			 * @param WC_Email $email The WC_Email object.
 			 */
 			$style_inline_callback = apply_filters( 'woocommerce_mail_style_inline_callback', array( $this, 'apply_inline_style' ), $content, $this );
 
@@ -941,7 +941,7 @@ class WC_Email extends WC_Settings_API {
 				 * @since 4.1.0
 				 *
 				 * @param CssInliner $css_inliner CssInliner instance.
-				 * @param WC_Email $this WC_Email instance.
+				 * @param WC_Email $email WC_Email instance.
 				 */
 				do_action( 'woocommerce_emogrifier', $css_inliner, $this );
 
@@ -1026,6 +1026,15 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function get_from_name( $from_name = '' ) {
 		$default = get_bloginfo( 'name', 'display' );
+		/**
+		 * Filters the "from" name for outgoing emails.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param string|mixed $from_name        The from name.
+		 * @param WC_Email     $email            Email object.
+		 * @param string       $default_from_name Default from name.
+		 */
 		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name', $default ), $this, $from_name );
 		return wp_specialchars_decode( esc_html( $from_name ), ENT_QUOTES );
 	}
@@ -1139,7 +1148,7 @@ class WC_Email extends WC_Settings_API {
 		 * @since 5.6.0
 		 * @param bool     $return Whether the email was sent successfully.
 		 * @param string   $id     Email ID.
-		 * @param WC_Email $this   WC_Email instance.
+		 * @param WC_Email $email  WC_Email instance.
 		 */
 		do_action( 'woocommerce_email_sent', $return, (string) $this->id, $this );
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1025,7 +1025,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_from_name( $from_name = '' ) {
-		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name' ), $this, $from_name );
+		$default = get_bloginfo( 'name', 'display' );
+		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name', $default ), $this, $from_name );
 		return wp_specialchars_decode( esc_html( $from_name ), ENT_QUOTES );
 	}
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -23947,12 +23947,6 @@ parameters:
 			path: includes/emails/class-wc-email.php
 
 		-
-			message: '#^@param tag must not be named \$this\. Choose a descriptive alias, for example \$instance\.$#'
-			identifier: phpDoc.parseError
-			count: 5
-			path: includes/emails/class-wc-email.php
-
-		-
 			message: '#^Access to property \$AltBody on an unknown class PHPMailer\.$#'
 			identifier: class.notFound
 			count: 4
@@ -24074,24 +24068,6 @@ parameters:
 
 		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Settings_API\)\: Unexpected token "\\n ", expected ''\<'' at offset 255 on line 9$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/emails/class-wc-email.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(WC_Email \$this The WC_Email object\.\)\: Unexpected token "\$this", expected variable at offset 161 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/emails/class-wc-email.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(WC_Email \$this The WC_Email object\.\)\: Unexpected token "\$this", expected variable at offset 162 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/emails/class-wc-email.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(WC_Email \$this The WC_Email object\.\)\: Unexpected token "\$this", expected variable at offset 300 on line 8$#'
 			identifier: phpDoc.parseError
 			count: 1
 			path: includes/emails/class-wc-email.php

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
@@ -28,7 +28,7 @@ class TemplateApiController {
 
 		return array(
 			'sender_settings' => array(
-				'from_name'    => get_option( 'woocommerce_email_from_name' ),
+				'from_name'    => get_option( 'woocommerce_email_from_name', get_bloginfo( 'name', 'display' ) ),
 				'from_address' => get_option( 'woocommerce_email_from_address' ),
 			),
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR addresses an issue where the email "From" name defaults to the generic "My WordPress Site" instead of using the store's configured title, creating a disconnect between the store branding and email communications.

**Why this change is needed:**
When merchants create a store (especially in a garden environment), they set up their store title in Settings → General → Store Details. However, outgoing emails use "My WordPress Site" as the sender name, which doesn't reflect their business branding and requires manual updates in Settings → Notifications → Email Settings. This creates a poor user experience and unnecessary friction.

**What this PR changes:**

1. **Introduces `skip_initial_save` setting option** - Adds a new optional parameter for settings that prevents the initial default value from being saved to the database during installation. This allows the setting to dynamically fall back to computed values (like the blog name) until explicitly set by the user.
2. **Updates email "From" name behavior** - Modifies `get_from_name()` methods in both `WC_Emails` and `WC_Email` classes to use `get_bloginfo('name', 'display')` as the default fallback when the option is not set in the database.
3. **Applies `skip_initial_save` to email settings** - Configures the `woocommerce_email_from_name` setting to use this new option, ensuring it automatically uses the store title until the merchant manually changes it.
4. **Updates installation logic** - Modifies `WC_Install::create_options()` to respect the `skip_initial_save` flag and skip saving options to the database when this flag is set.

Closes STOMAIL-7654

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh WordPress site with WooCommerce using this branch
2. Navigate to **Settings → General** and set a custom "Site Title" (e.g., "My Awesome Store")
3. Navigate to **WooCommerce → Settings → Emails**
4. Verify that the **"From" name** field shows "My Awesome Store" (matching the site title)
5. Send a test email (e.g., create an order and trigger an email notification)
6. Verify the email sender name shows "My Awesome Store"
7. Change the **"From" name** field to a custom value (e.g., "Custom Store Name") and save
8. Send another test email and verify it now uses "Custom Store Name"
9. Go back to **Settings → General** and change the site title
10. Verify that emails still use "Custom Store Name" (the manually set value should persist)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
