### PR TITLE
Fix BC Review Bot duplicate comments

### DIFF
--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -74,14 +74,32 @@ jobs:
               - PATH: the file path of the change
               - LINE: the target line number in the current diff
               - ORIGINAL_LINE: the stable original line if available; otherwise use LINE
-              - TOPIC: one of the predefined Topic values
-            - Query existing review comments and find a match using the hidden marker first, with path and topic, preferring `original_line` and falling back to `line`:
+              - TOPIC: use lowercase with hyphens, format: {category}-{specific}. Examples:
+                  hook-renamed, hook-removed, hook-bypassed
+                  method-visibility, method-signature, method-removed
+                  constant-renamed, constant-removed
+                  css-selector, css-layout, css-specificity
+                  api-response, api-timing, api-batching
+                  type-interface, type-export, type-prop
+                  data-contract, data-context
+                  exception-type, exception-code
+                  strict-types
+                  db-posttype, db-meta, db-schema
+            - Query existing review comments to find a match. First search by marker only (ignoring line numbers since they shift between pushes):
               gh api "repos/${REPO}/pulls/${PR}/comments?per_page=100" --paginate \
                 --jq \
-                "map(select(.path==\"${PATH}\" and ((.original_line==${ORIGINAL_LINE}) or (.line==${LINE})) and (.body|contains(\"wc-bc:path=${PATH};\") and (.body|contains(\"topic=${TOPIC}\")) ))) | first | .id"
-            - If an ID is returned, PATCH that comment to merge/append updated guidance instead of posting a new one:
+                "map(select(.body | contains(\"wc-bc:path=${PATH};\") and contains(\"topic=${TOPIC}\"))) | first | .id"
+            - If no match found by marker, fall back to path + line matching for comments without markers:
+              gh api "repos/${REPO}/pulls/${PR}/comments?per_page=100" --paginate \
+                --jq \
+                "map(select(.path==\"${PATH}\" and ((.original_line==${ORIGINAL_LINE}) or (.line==${LINE})))) | first | .id"
+            - If an ID is returned from either query, PATCH that comment to merge/append updated guidance instead of posting a new one:
               gh api repos/${REPO}/pulls/comments/${ID} -X PATCH -f body@updated_body.md
             - Otherwise, post a single merged comment for that (file, original_line, topic).
+
+            CRITICAL REQUIREMENT - MARKER INSERTION
+            You MUST include the hidden marker at the end of EVERY inline comment you create. This is essential for deduplication across pushes. Never omit it:
+            <!-- wc-bc:path={path};ol={original_line};topic={topic} -->
 
           claude_args: >
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*)"


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes the BC Review Bot creating duplicate comments instead of updating existing ones.

**Root Causes Identified:**

1. **Flawed jq query logic** - Required both line number match AND marker match. When lines shift between pushes, even comments with markers weren't found.

2. **Missing markers** - Only ~5% of bot comments had the deduplication marker. Claude wasn't reliably following the instruction.

3. **Undefined topic values** - The prompt referenced "predefined Topic values" without defining them, leading to inconsistent topic names that broke matching.

**Changes Made:**

1. **Fix jq query logic** - Search by marker first (path + topic only, ignoring lines), then fall back to path+line for comments without markers.

2. **Add topic naming convention** - Provides `{category}-{specific}` format with examples covering the variety of BC issues seen in real PRs.

3. **Add emphatic marker instruction** - Moved to end of prompt with "CRITICAL REQUIREMENT" header to improve marker insertion reliability.

Closes #62322.

### How to test the changes in this Pull Request:

~1. Create a test branch from this PR~
~2. Open a new PR against the test branch that includes BC-relevant code changes (e.g., changing a public method signature, renaming a hook)~
~3. Wait for the BC Review Bot workflow to complete and observe the inline comments created~
~4. Push an additional commit to the test PR (can be a minor change like adding a comment)~
~5. Wait for the BC Review Bot workflow to run again~
~6. Verify that existing BC comments were updated (check edit history) rather than new duplicate comments being created~
~7. Verify that the new comments include the hidden marker at the end: `<!-- wc-bc:path=...;ol=...;topic=... -->`~

I don't know of a way to test this because of security restrictions around running actions on PRs that change actions.  I attempted to do the above with #62379, but failed.  This would have be tested live.

### Testing that has already taken place:

- Reviewed existing PR #62041 comments via GitHub API to confirm root causes
- Analyzed 65+ bot comments: only 3 had markers, multiple duplicates per file
- Verified the jq query logic issue by examining the original vs proposed queries

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Change is focused on CI workflow configuration and is not merchant impacting.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
