### PR TITLE
Ensure A-S/WP/PHP version bumps run automatically and are tied to releases

### DIFF
--- a/.github/workflows/maintenance-bump-as-requirement.yml
+++ b/.github/workflows/maintenance-bump-as-requirement.yml
@@ -62,8 +62,6 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should-update == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      pr-number: ${{ steps.create-pr.outputs.pr-number }}
     steps:
     - name: Check out trunk
       uses: actions/checkout@v4

--- a/.github/workflows/maintenance-bump-as-requirement.yml
+++ b/.github/workflows/maintenance-bump-as-requirement.yml
@@ -86,14 +86,17 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd plugins/woocommerce
+        # Fetch all branches from origin.
+        git fetch origin
 
-        # Check if branch already exists.
-        branch_name="update/action-scheduler-${{ needs.check-version.outputs.version }}"
-        if git ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
-          echo "Branch $branch_name already exists. Skipping PR creation."
-          exit 0
-        fi
+        # Branch name hardcoded to avoid conflicts.
+        branch_name="update-action-scheduler-via-automation"
+
+        # Delete local branch if it exists and create fresh from trunk.
+        git branch -D "$branch_name" 2>/dev/null || true
+        git checkout -b "$branch_name" origin/trunk
+
+        cd plugins/woocommerce
 
         # Update A-S version.
         jq --tab -r ".require[\"woocommerce/action-scheduler\"] |= \"${{ needs.check-version.outputs.version }}\"" composer.json > composer.json.new
@@ -106,29 +109,48 @@ jobs:
 
         composer update woocommerce/action-scheduler --no-scripts
 
-        git checkout -b ${branch_name}
-
         composer exec -- changelogger add \
           --significance minor \
           --type update \
           --entry "Update the Action Scheduler package to version ${{ needs.check-version.outputs.version }}." \
           --no-interaction
 
-        # Push changes.
+        # Commit changes.
         git add composer.lock composer.json changelog/
         git commit \
           --message "Update Action Scheduler to '${{ needs.check-version.outputs.version }}'."
-        git push origin ${branch_name}
 
-        # Calculate milestone from trunk version.
-        milestone=$( cat woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+        # Push only if remote branch doesn't exist or differs from our changes.
+        if ! git ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1 || ! git diff --quiet HEAD origin/"$branch_name"; then
+          echo "Pushing changes to remote branch."
+          git push --force origin "$branch_name"
+        else
+          echo "No changes compared to remote branch. Skipping push."
+        fi
 
-        # Open PR and capture PR number.
-        gh pr create \
-          --title 'Bump Action Scheduler version to ${{ needs.check-version.outputs.version }}' \
-          --body 'This PR updates the Action Scheduler package requirement for WooCommerce core.' \
-          --base trunk \
-          --head ${branch_name} \
-          --reviewer "${{ github.actor }}" \
-          --label 'Release' \
-          --milestone "$milestone"
+        # Prepare PR content.
+        pr_title="Bump Action Scheduler version to ${{ needs.check-version.outputs.version }}"
+        pr_body="This PR updates the Action Scheduler package requirement for WooCommerce core."
+
+        # Check if PR already exists.
+        pr_number=$(gh pr list --head "$branch_name" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+        if [[ -n "$pr_number" ]]; then
+          echo "PR #$pr_number already exists. Updating title, body, and milestone."
+
+          gh pr edit "$pr_number" \
+            --title "$pr_title" \
+            --body "$pr_body"
+        else
+          # Get WooCommerce version for milestone from trunk.
+          milestone=$( git show origin/trunk:plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+
+          echo "Creating new PR."
+          gh pr create \
+            --title "$pr_title" \
+            --body "$pr_body" \
+            --base trunk \
+            --head "$branch_name" \
+            --label 'Release' \
+            --milestone "$milestone"
+        fi

--- a/.github/workflows/maintenance-bump-as-requirement.yml
+++ b/.github/workflows/maintenance-bump-as-requirement.yml
@@ -107,6 +107,7 @@ jobs:
 
         composer update woocommerce/action-scheduler --no-scripts
 
+        rm -f changelog/update-action-scheduler-via-automation
         composer exec -- changelogger add \
           --significance minor \
           --type update \

--- a/.github/workflows/maintenance-bump-as-requirement.yml
+++ b/.github/workflows/maintenance-bump-as-requirement.yml
@@ -1,5 +1,7 @@
 name: 'Maintenance: Bump Action Scheduler version'
 on:
+  schedule:
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
   workflow_dispatch:
     inputs:
       version:
@@ -8,9 +10,12 @@ on:
         default: ''
 
 jobs:
-  bump-version:
-    name: Bump Action Scheduler version
+  check-version:
+    name: Check Action Scheduler version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-as-version.outputs.version }}
+      should-update: ${{ steps.check-version.outputs.should-update }}
     steps:
     - name: Fetch Action Scheduler version
       id: get-as-version
@@ -34,52 +39,96 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: trunk
-    - name: Set up dev environment
+    - name: Check if version bump is needed
+      id: check-version
       run: |
         cd plugins/woocommerce
+        current_version=$(jq -r '.require["woocommerce/action-scheduler"]' composer.json)
+        target_version="${{ steps.get-as-version.outputs.version }}"
 
-        # Install dev packages. Required for changelogger use.
-        composer install --quiet
+        echo "Current Action Scheduler version: $current_version"
+        echo "Target Action Scheduler version: $target_version"
 
+        if [ "$current_version" = "$target_version" ]; then
+          echo "Action Scheduler is already at version $target_version. No update needed."
+          echo "should-update=false" >> $GITHUB_OUTPUT
+        else
+          echo "Action Scheduler needs to be updated from $current_version to $target_version."
+          echo "should-update=true" >> $GITHUB_OUTPUT
+        fi
+
+  bump-version:
+    name: Bump Action Scheduler version
+    needs: check-version
+    if: needs.check-version.outputs.should-update == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pr-number }}
+    steps:
+    - name: Check out trunk
+      uses: actions/checkout@v4
+      with:
+        ref: trunk
+    - name: Set up dev environment
+      run: |
         # Configure Git.
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Configure token for Composer.
+        composer config --global github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
+
+        # Install dev packages. Required for changelogger use.
+        cd plugins/woocommerce
+        composer install --quiet
     - name: Bump Action Scheduler requirement
+      id: create-pr
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd plugins/woocommerce
 
+        # Check if branch already exists.
+        branch_name="update/action-scheduler-${{ needs.check-version.outputs.version }}"
+        if git ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
+          echo "Branch $branch_name already exists. Skipping PR creation."
+          exit 0
+        fi
+
         # Update A-S version.
-        jq --tab -r ".require[\"woocommerce/action-scheduler\"] |= \"${{ steps.get-as-version.outputs.version }}\"" composer.json > composer.json.new
+        jq --tab -r ".require[\"woocommerce/action-scheduler\"] |= \"${{ needs.check-version.outputs.version }}\"" composer.json > composer.json.new
         mv composer.json.new composer.json
 
         if git diff --quiet; then
-          echo "::error::No changes to commit."
-          exit 1
+          echo "No changes to commit."
+          exit 0
         fi
 
         composer update woocommerce/action-scheduler --no-scripts
 
-        branch_name="update/action-scheduler-${{ steps.get-as-version.outputs.version }}"
         git checkout -b ${branch_name}
 
         composer exec -- changelogger add \
           --significance minor \
           --type update \
-          --entry "Update the Action Scheduler package to version ${{ steps.get-as-version.outputs.version }}." \
+          --entry "Update the Action Scheduler package to version ${{ needs.check-version.outputs.version }}." \
           --no-interaction
 
         # Push changes.
         git add composer.lock composer.json changelog/
         git commit \
-          --message "Update Action Scheduler to '${{ steps.get-as-version.outputs.version }}'."
+          --message "Update Action Scheduler to '${{ needs.check-version.outputs.version }}'."
         git push origin ${branch_name}
 
-        # Open PR.
+        # Calculate milestone from trunk version.
+        milestone=$( cat woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+
+        # Open PR and capture PR number.
         gh pr create \
-          --title 'Bump Action Scheduler version to ${{ steps.get-as-version.outputs.version }}' \
+          --title 'Bump Action Scheduler version to ${{ needs.check-version.outputs.version }}' \
           --body 'This PR updates the Action Scheduler package requirement for WooCommerce core.' \
           --base trunk \
           --head ${branch_name} \
-          --reviewer "${{ github.actor }}"
+          --reviewer "${{ github.actor }}" \
+          --label 'Release' \
+          --milestone "$milestone"

--- a/.github/workflows/maintenance-update-version-requirements.yml
+++ b/.github/workflows/maintenance-update-version-requirements.yml
@@ -97,6 +97,7 @@ jobs:
           fi
 
           # Add changelog entry.
+          rm -f changelog/update-version-requirements-wp-and-php-via-automation
           composer exec -- changelogger add \
             --significance minor \
             --type update \

--- a/.github/workflows/maintenance-update-version-requirements.yml
+++ b/.github/workflows/maintenance-update-version-requirements.yml
@@ -10,88 +10,84 @@ jobs:
     name: Update WordPress and PHP version requirements
     runs-on: ubuntu-latest
     steps:
-      - name: Install SVN
-        run: sudo apt-get -qq install -y subversion
-
-      - name: Get current WordPress version
-        id: wp-version
-        run: |
-          WP_VERSION=$(svn ls https://core.svn.wordpress.org/tags | sort -V | tail -n 1 | tr -d '/')
-          if [[ -z "$WP_VERSION" ]]; then
-            echo "Failed to get WordPress version"
-            exit 1
-          fi
-          
-          echo "wp_version=$WP_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest WordPress version is $WP_VERSION"
-
-      - name: Calculate L-1 WordPress version
-        id: wp-previous-version
-        uses: actions/github-script@v7
-        env:
-          WP_VERSION: ${{ steps.wp-version.outputs.wp_version }}
-        with:
-          script: |
-            const version = process.env.WP_VERSION;
-            
-            const parts = version.split('.').map(Number);
-            const [major, minor] = parts;
-            
-            let previousVersion;
-            if (minor > 0) {
-              previousVersion = `${major}.${minor - 1}`;
-            } else {
-              previousVersion = `${major - 1}.9`;
-            }
-            
-            core.info(`Previous WordPress version is ${previousVersion}`);
-            core.setOutput('wp_prev_version', previousVersion);
-
       - name: Check out trunk
         uses: actions/checkout@v4
         with:
           ref: trunk
 
-      - name: Get minimum PHP version from composer.json
-        id: php-version
+      - name: Compute WordPress and PHP versions
+        id: compute-env-versions
         run: |
-          REQUIRED_PHP=$(jq -r '.config.platform.php' plugins/woocommerce/composer.json)
-          if [[ -z "$REQUIRED_PHP" ]]; then
+          # Fetch latest WP version.
+          wp_version=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].current' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/' )
+          if [[ -z "$wp_version" ]]; then
+            echo "Failed to get WordPress version"
+            exit 1
+          fi
+
+          echo "wp_version=$wp_version" >> $GITHUB_OUTPUT
+          echo "Latest WordPress version is $wp_version."
+
+          # Calculate L-1 version.
+          wp_required_version=$(echo "$wp_version - 0.1" | bc)
+          echo "wp_required_version=$wp_required_version" >> $GITHUB_OUTPUT
+          echo "L-1 WordPress version is $wp_required_version."
+
+          # Get required PHP version.
+          php_version=$(jq -r '.config.platform.php' plugins/woocommerce/composer.json)
+          if [[ -z "$php_version" ]]; then
             echo "Failed to get PHP version from composer.json"
             exit 1
           fi
-          
-          echo "required_php_version=$REQUIRED_PHP" >> $GITHUB_OUTPUT
-          echo "Required PHP version from composer.json: $REQUIRED_PHP"
+
+          echo "php_version=$php_version" >> $GITHUB_OUTPUT
+          echo "Required PHP version from composer.json: $php_version"
 
       - name: Set up dev environment
         run: |
+          # Configure Git.
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Configure token for Composer.
+          composer config --global github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
+
           cd plugins/woocommerce
 
           # Install dev packages. Required for changelogger use.
           composer install --quiet
 
-          # Configure Git.
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Update version requirements and create PR
-        id: update-pr
+      - name: Update version requirements
+        id: update-versions
         env:
-          WP_PREV_VERSION: ${{ steps.wp-previous-version.outputs.wp_prev_version }}
-          PHP_VERSION: ${{ steps.php-version.outputs.required_php_version }}
+          PHP_VERSION: ${{ steps.compute-env-versions.outputs.php_version }}
+          WP_VERSION: ${{ steps.compute-env-versions.outputs.wp_version }}
+          WP_REQUIRED_VERSION: ${{ steps.compute-env-versions.outputs.wp_required_version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Fetch all branches from origin.
+          git fetch origin
+
+          # Branch name hardcoded to avoid conflicts.
+          branch_name="update-version-requirements-wp-and-php-via-automation"
+
+          # Delete local branch if it exists and create fresh from trunk.
+          git branch -D "$branch_name" 2>/dev/null || true
+          git checkout -b "$branch_name" origin/trunk
+
+          cd plugins/woocommerce
+
           # Update the version requirements in woocommerce.php
-          WOOCOMMERCE_FILE="plugins/woocommerce/woocommerce.php"
-          sed -i "s/\* Requires at least: [0-9.]*/\* Requires at least: $WP_PREV_VERSION/" "$WOOCOMMERCE_FILE"
+          WOOCOMMERCE_FILE="woocommerce.php"
+          sed -i "s/\* Requires at least: [0-9.]*/\* Requires at least: $WP_REQUIRED_VERSION/" "$WOOCOMMERCE_FILE"
           sed -i "s/\* Requires PHP: [0-9.]*/\* Requires PHP: $PHP_VERSION/" "$WOOCOMMERCE_FILE"
 
           # Update the version requirements in readme.txt
-          README_FILE="plugins/woocommerce/readme.txt"
-          sed -i "s/Requires at least: [0-9.]*/Requires at least: $WP_PREV_VERSION/" "$README_FILE"
+          README_FILE="readme.txt"
+          sed -i "s/Requires at least: [0-9.]*/Requires at least: $WP_REQUIRED_VERSION/" "$README_FILE"
+          sed -i "s/Tested up to: [0-9.]*/Tested up to: $WP_VERSION/" "$README_FILE"
           sed -i "s/Requires PHP: [0-9.]*/Requires PHP: $PHP_VERSION/" "$README_FILE"
-          sed -i "s/WordPress [0-9.]\+/WordPress $WP_PREV_VERSION/" "$README_FILE"
+          sed -i "s/WordPress [0-9.]\+/WordPress $WP_REQUIRED_VERSION/" "$README_FILE"
           sed -i "s/PHP [0-9.]\+ or greater is required/PHP $PHP_VERSION or greater is required/" "$README_FILE"
 
           # Check for changes and exit early if none
@@ -100,53 +96,69 @@ jobs:
             exit 0
           fi
 
-          # Create new branch with timestamp
-          BRANCH_NAME="update-version-requirements-$(date +%s)"
-          git checkout -b "$BRANCH_NAME"
-
-          cd plugins/woocommerce
+          # Add changelog entry.
           composer exec -- changelogger add \
             --significance minor \
             --type update \
-            --entry "Update version requirements to WordPress $WP_PREV_VERSION and PHP $PHP_VERSION in readme.txt and woocommerce.php." \
+            --entry "Update version requirements to WordPress $WP_REQUIRED_VERSION and PHP $PHP_VERSION in readme.txt and woocommerce.php." \
             --no-interaction
 
+          # Commit changes.
           git add .
-          git commit -m "Update version requirements to WP $WP_PREV_VERSION / PHP $PHP_VERSION"
+          git commit -m "Update version requirements to WP $WP_REQUIRED_VERSION / PHP $PHP_VERSION"
 
-          git push origin "$BRANCH_NAME"
+          # Push only if remote branch doesn't exist or differs from our changes.
+          if ! git ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1 || ! git diff --quiet HEAD origin/"$branch_name"; then
+            echo "Pushing changes to remote branch."
+            git push --force origin "$branch_name"
+          else
+            echo "No changes compared to remote branch. Skipping push."
+          fi
 
-          PR_URL=$(gh pr create \
-            --title "Update version requirements to WP $WP_PREV_VERSION / PHP $PHP_VERSION" \
-            --body "This PR automatically updates the version requirements in \`$WOOCOMMERCE_FILE\` and \`$README_FILE\`:
+          # Prepare PR content.
+          pr_title="Update version requirements to WP $WP_REQUIRED_VERSION / PHP $PHP_VERSION"
+          pr_body="This PR automatically updates the version requirements in \`$WOOCOMMERCE_FILE\` and \`$README_FILE\`:
 
           ## Changes
-          - **WordPress requirement**: $WP_PREV_VERSION
+          - **WordPress requirement**: $WP_REQUIRED_VERSION
           - **PHP requirement**: $PHP_VERSION
+          - **Tested up to**: $WP_VERSION
 
-          Auto-generated by the \`maintenance-update-version-requirements.yml\` workflow." \
-            --head "$BRANCH_NAME" \
-            --base trunk)
-          
-          echo "PR created successfully: $PR_URL"
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          ### ⚠️ Before merging
 
-      - name: Send Slack notification
-        if: steps.update-pr.outputs.pr_url != ''
-        uses: archive/github-actions-slack@v2.10.0
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-          slack-channel: ${{ secrets.WOO_DOCS_SLACK_CHANNEL }}
-          slack-optional-unfurl_links: false
-          slack-text: |
-            :woo: *WooCommerce Versions Requirements Updated*
+          Ensure that:
 
-            Version requirements for :woo: have been automatically updated and a PR has been created.
+          - [ ] **WordPress $WP_VERSION compatibility** has been tested and verified.
+          - [ ] **PHP $PHP_VERSION compatibility** has been tested and verified.
 
-            *WordPress Requirement:* ${{ steps.wp-previous-version.outputs.wp_prev_version }}
-            *PHP Requirement:* ${{ steps.php-version.outputs.required_php_version }}
-            *Pull Request:* <${{ steps.update-pr.outputs.pr_url }}|${{ steps.update-pr.outputs.pr_url }}>
+          ## ⚠️ After merging
 
-            <!subteam^S011VV34JTX> Please also update these documentation pages:
-            • <https://woocommerce.com/document/update-php-wordpress/|Update PHP and WordPress>
-            • <https://woocommerce.com/document/server-requirements/|WooCommerce Server Recommendations>
+          Please check with the Woo Docs team in \`#woo-docs\` to ensure the following documentation pages are updated:
+
+          - [ ] [Update PHP and WordPress](https://woocommerce.com/document/update-php-wordpress/)
+          - [ ] [WooCommerce Server Requirements](https://woocommerce.com/document/server-requirements/)
+
+          ---
+          _Auto-generated by the \`maintenance-update-version-requirements.yml\` workflow._"
+
+          # Check if PR already exists.
+          pr_number=$(gh pr list --head "$branch_name" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [[ -n "$pr_number" ]]; then
+            echo "PR #$pr_number already exists. Updating title, body, and milestone."
+            gh pr edit "$pr_number" \
+              --title "$pr_title" \
+              --body "$pr_body"
+          else
+            # Get WooCommerce version for milestone from trunk.
+            wc_milestone=$( git show origin/trunk:plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+
+            echo "Creating new PR."
+            gh pr create \
+              --title "$pr_title" \
+              --body "$pr_body" \
+              --head "$branch_name" \
+              --base trunk \
+              --label "Release" \
+              --milestone "$wc_milestone"
+          fi


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR makes various improvements to both the A-S bump version and WP/PHP update requirement workflows, which are used to bump the A-S requirement in core as well as the WordPress and PHP min. versions. The changes include:

- Previously each workflow used a unique brand name for pushing changes, but this could result in outdated branches or unnecessary PRs. In the case of the [_Maintenance: Update version requirements_](https://github.com/woocommerce/woocommerce/actions/workflows/maintenance-update-version-requirements.yml) workflow, it was creating a new branch and PR daily:
   <img width="1289" height="315" alt="Screenshot 2025-12-11 at 22 22 46" src="https://github.com/user-attachments/assets/53e0e0fb-3099-4140-acc0-95874b7b91a3" />
- The new code either creates or updates existing branches and PRs to reflect changes.
- Now, PRs are always milestoned using the last milestone so the updates always make it into the next release and aren't missed.
- Both workflows now use the GitHub token when running Composer commands to prevent issues from rate limits.

Related to #62358.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository, including `trunk`.
1. Ensure that your fork has at least the milestones `10.5.0`.
1. Push this branch (`fix/62358`) to your fork.
1. **Test _Maintenance: Update version requirements_**:
   1. Go to **Actions > Maintenance: Update version requirements** and run the workflow from the `fix/62358` branch.
   1. Run should be successful resulting in no PRs or new branches.
   1. Use the GH UI to commit directly to your fork's `trunk` changes to `plugins/woocommerce/readme.txt` and/or `plugins/woocommerce.php` modifying headers `Requires at least`, `Tested up to` and/or `Requires PHP` to older versions.
   1. Run the workflow again (from `fix/62358` and wait until it finishes.
   1. Confirm that a PR has been created updating the versions to the latest versions ("Tested up to" should be the latest WP version and "Requires at least" should be latest - 1). Confirm that this PR has milestone `10.5.0`.
      <img width="917" height="712" alt="Screenshot 2025-12-11 at 22 44 53" src="https://github.com/user-attachments/assets/c79af0e7-68d1-4858-81ce-5fe98b77e8b2" />
   1. Go to the created PR and use the GH UI to edit the changes and, once again, modify the headers from step iii.
      This is to "simulate" the branch/PR existing unmerged with outdated changes when the workflow runs again.
   1. Run the workflow once more.
   1. Confirm that no new PR is created but that the existing one has been updated with the latest versions again.
1. **Test _Maintenance: Bump Action Scheduler version_**:
   1. Go to **Actions > Maintenance: Bump Action Scheduler version** and run the workflow from branch `fix/62358` and enter `3.9.0` as input.
   1. Once the workflow finishes, a PR changing the A-S version in `composer.(json|lock)` to `3.9.0` should've been created, with milestone `10.5.0`:
      <img width="923" height="263" alt="Screenshot 2025-12-11 at 22 44 55" src="https://github.com/user-attachments/assets/2fcacb85-dea8-4e17-9c62-21b68b32b209" />
   1. Merge this PR into `trunk`.
   1. Run the workflow again from branch `fix/62358` and input `3.9.1`.
   1. Confirm that a new PR has been created, this time bumping the version to `3.9.1`. Do not merge the PR.
   1. Run the workflow one last time, again from branch `fix/62358` and **no input**. This simulates the automated daily run.
   1. Ensure that no new PR has been created but the existing PR has been updated to bump versions to `3.9.3` this time.


<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.