### PR TITLE
Spike: Improve build output

### DIFF
--- a/plugins/woocommerce/bin/build-pretty.js
+++ b/plugins/woocommerce/bin/build-pretty.js
@@ -8,7 +8,7 @@
  * - Showing a summary with timing per package
  * - Collecting warnings/errors at the end
  *
- * Usage: node scripts/build-pretty.js
+ * Usage: node bin/build-pretty.js
  */
 
 const { spawn } = require( 'child_process' );

--- a/plugins/woocommerce/bin/build-pretty.js
+++ b/plugins/woocommerce/bin/build-pretty.js
@@ -15,6 +15,7 @@ const { spawn } = require( 'child_process' );
 
 // Configuration
 const PROGRESS_BAR_WIDTH = 30;
+const IS_TTY = process.stdout.isTTY;
 
 // ANSI color codes
 const colors = {
@@ -43,6 +44,8 @@ let totalPackages = 0;
 let completedCount = 0;
 const startTime = Date.now();
 const currentlyBuilding = new Set();
+const lastProgressLine = '';
+let progressLineWritten = false;
 
 // Categorize package by path
 function getCategory( path ) {
@@ -140,8 +143,23 @@ function updateProgress() {
 		`${ colors.dim }${ elapsed }s${ colors.reset } ` +
 		currentDisplay;
 
-	// Clear line and write progress
-	process.stdout.write( '\r\x1b[K' + progressLine );
+	// Clear line and write progress (only in TTY mode)
+	if ( IS_TTY ) {
+		// Move cursor up if we've already written a progress line, then clear
+		if ( progressLineWritten ) {
+			process.stdout.write( '\x1b[1A\x1b[2K' ); // Move up 1 line, clear entire line
+		}
+		process.stdout.write( progressLine + '\n' );
+		progressLineWritten = true;
+	}
+}
+
+// Print completion message for non-TTY mode
+function printCompletion( packageName, cached ) {
+	if ( ! IS_TTY ) {
+		const status = cached ? '· (cached)' : '✓';
+		console.log( `${ status } ${ packageName }` );
+	}
 }
 
 // Process a line of output
@@ -193,7 +211,9 @@ function processLine( rawLine ) {
 		line.includes( 'DEPRECATION' )
 	) {
 		// Extract package name if present (format: "path/to/package task: message")
-		const packageMatch = line.match( /^([^\s]+)\s+build:project:[^:]+:\s*(.*)$/ );
+		const packageMatch = line.match(
+			/^([^\s]+)\s+build:project:[^:]+:\s*(.*)$/
+		);
 		let warningText;
 		if ( packageMatch ) {
 			const pkgName = getPackageName( packageMatch[ 1 ] );
@@ -203,10 +223,7 @@ function processLine( rawLine ) {
 		}
 
 		// Deduplicate by checking if we already have a similar warning
-		if (
-			warningText &&
-			! warnings.some( ( w ) => w === warningText )
-		) {
+		if ( warningText && ! warnings.some( ( w ) => w === warningText ) ) {
 			warnings.push( warningText );
 		}
 		return;
@@ -267,8 +284,14 @@ function processLine( rawLine ) {
 		// Check if cached (skipped > 0 means cached)
 		// Match "skipped N" where N > 0
 		const skippedMatch = line.match( /skipped (\d+)/ );
-		if ( skippedMatch && parseInt( skippedMatch[ 1 ], 10 ) > 0 ) {
+		const isCached = skippedMatch && parseInt( skippedMatch[ 1 ], 10 ) > 0;
+		if ( isCached ) {
 			pkg.cached = true;
+		}
+
+		// Print completion for non-TTY (only on first build type completion for this package)
+		if ( pkg.buildTypes.length === 1 ) {
+			printCompletion( packageName, isCached );
 		}
 
 		updateProgress();
@@ -279,8 +302,10 @@ function processLine( rawLine ) {
 function printSummary() {
 	const totalTime = ( Date.now() - startTime ) / 1000;
 
-	// Clear progress line
-	process.stdout.write( '\r\x1b[K' );
+	// Clear the last progress line if in TTY mode
+	if ( IS_TTY && progressLineWritten ) {
+		process.stdout.write( '\x1b[1A\x1b[2K' ); // Move up 1 line, clear entire line
+	}
 
 	console.log( '' );
 

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -10,7 +10,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"scripts": {
-		"build": "node scripts/build-pretty.js",
+		"build": "node bin/build-pretty.js",
 		"build:raw": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
 		"build:admin": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/admin-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:blocks": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/block-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -11,6 +11,7 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
+		"build:pretty": "node scripts/build-pretty.js",
 		"build:admin": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/admin-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:blocks": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/block-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:classic-assets": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/classic-assets...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -10,8 +10,8 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"scripts": {
-		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
-		"build:pretty": "node scripts/build-pretty.js",
+		"build": "node scripts/build-pretty.js",
+		"build:raw": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
 		"build:admin": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/admin-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:blocks": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/block-library...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:classic-assets": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/classic-assets...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -40,14 +40,6 @@ let completedCount = 0;
 const startTime = Date.now();
 const currentlyBuilding = new Set();
 
-// Packages that are in scope but don't have build:project scripts
-const NO_BUILD_PACKAGES = [
-	'dependency-extraction-webpack-plugin',
-	'eslint-plugin',
-	'eslint-plugin-woocommerce',
-	'internal-style-build',
-];
-
 // Categorize package by path
 function getCategory( path ) {
 	if ( path.startsWith( '../../packages/js/' ) ) {
@@ -259,8 +251,13 @@ function printSummary() {
 
 	console.log( '' );
 
+	const noBuildCount = totalPackages - packages.size;
+	const scopeInfo =
+		noBuildCount > 0
+			? `${ totalPackages } in scope, ${ noBuildCount } without build scripts`
+			: `${ totalPackages } in scope`;
 	console.log(
-		`${ colors.bold } WooCommerce Build - ${ packages.size } packages built${ colors.reset } ${ colors.dim }(${ totalPackages } in scope)${ colors.reset }`
+		`${ colors.bold } WooCommerce Build - ${ packages.size } packages built${ colors.reset } ${ colors.dim }(${ scopeInfo })${ colors.reset }`
 	);
 	console.log(
 		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
@@ -272,22 +269,8 @@ function printSummary() {
 		'packages/js': [],
 		client: [],
 		'plugins/woocommerce': [],
-		'packages/js (no build)': [],
 		other: [],
 	};
-
-	// Only add no-build packages if we actually built something
-	if ( packages.size > 0 ) {
-		for ( const name of NO_BUILD_PACKAGES ) {
-			categories[ 'packages/js (no build)' ].push( {
-				name,
-				category: 'packages/js (no build)',
-				buildTypes: [],
-				totalTime: 0,
-				noBuild: true,
-			} );
-		}
-	}
 
 	for ( const [ , pkg ] of packages ) {
 		categories[ pkg.category ].push( pkg );
@@ -306,9 +289,7 @@ function printSummary() {
 
 		for ( const pkg of pkgs ) {
 			let status;
-			if ( pkg.noBuild ) {
-				status = `${ colors.dim }·  (no build)${ colors.reset }`;
-			} else if ( packagesWithErrors.has( pkg.name ) ) {
+			if ( packagesWithErrors.has( pkg.name ) ) {
 				status = `${ colors.red }·  (error) ${ colors.reset }`;
 			} else if ( pkg.cached ) {
 				status = `${ colors.dim }·  (cached)${ colors.reset }`;
@@ -319,10 +300,7 @@ function printSummary() {
 				pkg.buildTypes.length > 0
 					? `(${ pkg.buildTypes.join( ', ' ) })`
 					: '';
-			const time =
-				pkg.cached || pkg.noBuild
-					? ''
-					: `${ pkg.totalTime.toFixed( 1 ) }s`;
+			const time = pkg.cached ? '' : `${ pkg.totalTime.toFixed( 1 ) }s`;
 
 			const namePadded = pkg.name.padEnd( 25 );
 			const typesPadded = types.padEnd( 20 );

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -13,6 +13,9 @@
 
 const { spawn } = require( 'child_process' );
 
+// Configuration
+const PROGRESS_BAR_WIDTH = 30;
+
 // ANSI color codes
 const colors = {
 	reset: '\x1b[0m',
@@ -23,6 +26,7 @@ const colors = {
 	red: '\x1b[31m',
 	cyan: '\x1b[36m',
 	magenta: '\x1b[35m',
+	bgGreen: '\x1b[42m',
 };
 
 // Strip ANSI codes from string
@@ -85,38 +89,59 @@ function parseTiming( line ) {
 	return 0;
 }
 
+// Create a progress bar string
+function createProgressBar( percent ) {
+	const clampedPercent = Math.min( 100, Math.max( 0, percent ) );
+	const filled = Math.round( ( clampedPercent / 100 ) * PROGRESS_BAR_WIDTH );
+	const empty = PROGRESS_BAR_WIDTH - filled;
+	const bar =
+		colors.bgGreen +
+		' '.repeat( filled ) +
+		colors.reset +
+		colors.dim +
+		'░'.repeat( empty ) +
+		colors.reset;
+	return bar;
+}
+
 // Update the progress line
 function updateProgress() {
 	const elapsed = ( ( Date.now() - startTime ) / 1000 ).toFixed( 1 );
 	const buildingList = [ ...currentlyBuilding ];
-	const building = buildingList.slice( 0, 5 ).join( ', ' );
+	const building = buildingList.slice( 0, 3 ).join( ', ' );
 	const more =
-		currentlyBuilding.size > 5
-			? ` +${ currentlyBuilding.size - 5 } more`
+		currentlyBuilding.size > 3
+			? ` +${ currentlyBuilding.size - 3 } more`
 			: '';
 
-	// Clear both lines and write progress
-	// Move up one line, clear it, then clear current line
-	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
+	// Calculate percentage
+	const percent =
+		totalPackages > 0
+			? Math.round( ( completedCount / totalPackages ) * 100 )
+			: 0;
+	const bar = createProgressBar( percent );
 
-	let statusLine;
+	// Build the current packages display
+	let currentDisplay;
 	if ( currentlyBuilding.size === 0 && completedCount === 0 ) {
-		statusLine = `${ colors.dim }Starting...${ colors.reset }`;
+		currentDisplay = `${ colors.dim }starting...${ colors.reset }`;
 	} else if ( currentlyBuilding.size > 0 ) {
-		statusLine = `${ colors.yellow }${ currentlyBuilding.size } active${ colors.reset } ${ colors.dim }(${ building }${ more })${ colors.reset }`;
+		currentDisplay = `${ colors.cyan }${ building }${ colors.reset }${ colors.dim }${ more }${ colors.reset }`;
 	} else {
-		statusLine = `${ colors.dim }Finishing...${ colors.reset }`;
+		currentDisplay = `${ colors.dim }finishing...${ colors.reset }`;
 	}
 
-	process.stdout.write(
-		`${ colors.dim }...${ colors.reset } ` +
-			`${ colors.bold }${ completedCount }/${
-				totalPackages || '?'
-			} done${ colors.reset } ` +
-			statusLine +
-			`\n` +
-			`   ${ colors.dim }Elapsed: ${ elapsed }s${ colors.reset }`
-	);
+	// Single line progress with bar
+	const progressLine =
+		`${ colors.bold }Building${ colors.reset } ` +
+		`${ bar } ` +
+		`${ colors.green }${ percent }%${ colors.reset } ` +
+		`(${ completedCount }/${ totalPackages || '?' }) ` +
+		`${ colors.dim }${ elapsed }s${ colors.reset } ` +
+		currentDisplay;
+
+	// Clear line and write progress
+	process.stdout.write( '\r\x1b[K' + progressLine );
 }
 
 // Process a line of output
@@ -167,14 +192,22 @@ function processLine( rawLine ) {
 		line.includes( 'Browserslist:' ) ||
 		line.includes( 'DEPRECATION' )
 	) {
-		const cleanWarning = line.split( ': ' ).slice( 1 ).join( ': ' ).trim();
+		// Extract package name if present (format: "path/to/package task: message")
+		const packageMatch = line.match( /^([^\s]+)\s+build:project:[^:]+:\s*(.*)$/ );
+		let warningText;
+		if ( packageMatch ) {
+			const pkgName = getPackageName( packageMatch[ 1 ] );
+			warningText = `[${ pkgName }] ${ packageMatch[ 2 ] }`;
+		} else {
+			warningText = line.trim();
+		}
+
+		// Deduplicate by checking if we already have a similar warning
 		if (
-			cleanWarning &&
-			! warnings.some( ( w ) =>
-				w.includes( cleanWarning.substring( 0, 50 ) )
-			)
+			warningText &&
+			! warnings.some( ( w ) => w === warningText )
 		) {
-			warnings.push( cleanWarning );
+			warnings.push( warningText );
 		}
 		return;
 	}
@@ -246,8 +279,8 @@ function processLine( rawLine ) {
 function printSummary() {
 	const totalTime = ( Date.now() - startTime ) / 1000;
 
-	// Clear both progress lines
-	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
+	// Clear progress line
+	process.stdout.write( '\r\x1b[K' );
 
 	console.log( '' );
 
@@ -367,10 +400,8 @@ function printSummary() {
 // Main
 function main() {
 	console.log(
-		`${ colors.cyan }🔨 Building WooCommerce...${ colors.reset }`
+		`${ colors.cyan }🔨 Building WooCommerce...${ colors.reset }\n`
 	);
-	console.log( '' );
-	console.log( '' ); // Extra line for two-line progress display
 
 	// Run the actual build command (same as the original "build" script)
 	const build = spawn(

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -34,6 +34,7 @@ function stripAnsi( str ) {
 const packages = new Map();
 const warnings = [];
 const errors = [];
+const packagesWithErrors = new Set();
 let totalPackages = 0;
 let completedCount = 0;
 const startTime = Date.now();
@@ -95,27 +96,32 @@ function parseTiming( line ) {
 // Update the progress line
 function updateProgress() {
 	const elapsed = ( ( Date.now() - startTime ) / 1000 ).toFixed( 1 );
-	const building = [ ...currentlyBuilding ].slice( 0, 3 ).join( ', ' );
+	const buildingList = [ ...currentlyBuilding ];
+	const building = buildingList.slice( 0, 5 ).join( ', ' );
 	const more =
-		currentlyBuilding.size > 3
-			? ` +${ currentlyBuilding.size - 3 } more`
+		currentlyBuilding.size > 5
+			? ` +${ currentlyBuilding.size - 5 } more`
 			: '';
 
 	// Clear both lines and write progress
 	// Move up one line, clear it, then clear current line
 	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
 
-	const buildingLabel =
-		building.length > 0
-			? `${ colors.dim }Building:${ colors.reset } ${ building }${ more }`
-			: `${ colors.dim }Starting...${ colors.reset }`;
+	let statusLine;
+	if ( currentlyBuilding.size === 0 && completedCount === 0 ) {
+		statusLine = `${ colors.dim }Starting...${ colors.reset }`;
+	} else if ( currentlyBuilding.size > 0 ) {
+		statusLine = `${ colors.yellow }${ currentlyBuilding.size } active${ colors.reset } ${ colors.dim }(${ building }${ more })${ colors.reset }`;
+	} else {
+		statusLine = `${ colors.dim }Finishing...${ colors.reset }`;
+	}
 
 	process.stdout.write(
-		`${ colors.cyan }⏳${ colors.reset } ` +
-			`${ colors.bold }${ completedCount }/${ totalPackages || '?' }${
-				colors.reset
-			} ` +
-			buildingLabel +
+		`${ colors.dim }...${ colors.reset } ` +
+			`${ colors.bold }${ completedCount }/${
+				totalPackages || '?'
+			} done${ colors.reset } ` +
+			statusLine +
 			`\n` +
 			`   ${ colors.dim }Elapsed: ${ elapsed }s${ colors.reset }`
 	);
@@ -187,13 +193,22 @@ function processLine( rawLine ) {
 		! line.includes( 'ERROR in breakpoint' )
 	) {
 		errors.push( line );
+		// Extract package name from error line (format: "../../packages/js/currency build:project:esm: ...")
+		const errorParts = line.split( ' ' );
+		if ( errorParts[ 0 ] ) {
+			const errorPackageName = getPackageName( errorParts[ 0 ] );
+			if ( errorPackageName ) {
+				packagesWithErrors.add( errorPackageName );
+			}
+		}
 		return;
 	}
 
-	// Parse completion lines - format: "path build:project:type: ✅ Ran X scripts..."
+	// Parse completion lines - format: "path build:project:type: ✅ Ran X script(s)..."
+	// Note: "script" (singular) when 1 script runs, "scripts" (plural) otherwise
 	if (
 		line.includes( 'Ran' ) &&
-		line.includes( 'scripts' ) &&
+		line.includes( 'script' ) &&
 		line.includes( ' in ' )
 	) {
 		const parts = line.split( ' ' );
@@ -224,8 +239,10 @@ function processLine( rawLine ) {
 		}
 		pkg.totalTime = Math.max( pkg.totalTime, timing );
 
-		// Check if cached (skipped means cached)
-		if ( line.includes( 'skipped' ) ) {
+		// Check if cached (skipped > 0 means cached)
+		// Match "skipped N" where N > 0
+		const skippedMatch = line.match( /skipped (\d+)/ );
+		if ( skippedMatch && parseInt( skippedMatch[ 1 ], 10 ) > 0 ) {
 			pkg.cached = true;
 		}
 
@@ -291,10 +308,12 @@ function printSummary() {
 			let status;
 			if ( pkg.noBuild ) {
 				status = `${ colors.dim }·  (no build)${ colors.reset }`;
+			} else if ( packagesWithErrors.has( pkg.name ) ) {
+				status = `${ colors.red }·  (error) ${ colors.reset }`;
 			} else if ( pkg.cached ) {
 				status = `${ colors.dim }·  (cached)${ colors.reset }`;
 			} else {
-				status = `${ colors.green }✅${ colors.reset }`;
+				status = `${ colors.green }·  (done)${ colors.reset }`;
 			}
 			const types =
 				pkg.buildTypes.length > 0
@@ -347,21 +366,9 @@ function printSummary() {
 		console.log(
 			`${ colors.yellow }⚠️  Warnings: ${ warnings.length }${ colors.reset }`
 		);
-		const uniqueWarnings = [ ...new Set( warnings ) ].slice( 0, 5 );
+		const uniqueWarnings = [ ...new Set( warnings ) ];
 		for ( const warning of uniqueWarnings ) {
-			const shortWarning = warning.substring( 0, 70 );
-			console.log(
-				`  ${ colors.dim }- ${ shortWarning }${
-					warning.length > 70 ? '...' : ''
-				}${ colors.reset }`
-			);
-		}
-		if ( warnings.length > 5 ) {
-			console.log(
-				`  ${ colors.dim }  ... and ${ warnings.length - 5 } more${
-					colors.reset
-				}`
-			);
+			console.log( `  ${ colors.dim }- ${ warning }${ colors.reset }` );
 		}
 	}
 
@@ -371,8 +378,7 @@ function printSummary() {
 		console.log(
 			`${ colors.red }❌ Errors: ${ errors.length }${ colors.reset }`
 		);
-		for ( const error of errors.slice( 0, 10 ) ) {
-			// Show more of the error message
+		for ( const error of errors ) {
 			console.log( `  ${ colors.red }- ${ error }${ colors.reset }` );
 		}
 	}

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+/**
+ * Build output formatter for WooCommerce
+ *
+ * Runs the build and formats the output to be more readable by:
+ * - Showing live progress as packages build
+ * - Grouping packages by area (packages/js, client, plugins)
+ * - Showing a summary with timing per package
+ * - Collecting warnings/errors at the end
+ *
+ * Usage: node scripts/build-pretty.js
+ */
+
+const { spawn } = require( 'child_process' );
+
+// ANSI color codes
+const colors = {
+	reset: '\x1b[0m',
+	bold: '\x1b[1m',
+	dim: '\x1b[2m',
+	green: '\x1b[32m',
+	yellow: '\x1b[33m',
+	red: '\x1b[31m',
+	cyan: '\x1b[36m',
+	magenta: '\x1b[35m',
+};
+
+// Strip ANSI codes from string
+function stripAnsi( str ) {
+	return str.replace( /\x1b\[[0-9;]*m/g, '' );
+}
+
+// Package tracking
+const packages = new Map();
+const warnings = [];
+const errors = [];
+let totalPackages = 0;
+let completedCount = 0;
+let startTime = Date.now();
+const currentlyBuilding = new Set();
+
+// Packages that are in scope but don't have build:project scripts
+const NO_BUILD_PACKAGES = [
+	'dependency-extraction-webpack-plugin',
+	'eslint-plugin',
+	'eslint-plugin-woocommerce',
+	'internal-style-build',
+];
+
+// Categorize package by path
+function getCategory( path ) {
+	if ( path.startsWith( '../../packages/js/' ) ) {
+		return 'packages/js';
+	}
+	if ( path.startsWith( 'client/' ) ) {
+		return 'client';
+	}
+	if ( path.includes( 'woocommerce' ) || path === '.' ) {
+		return 'plugins/woocommerce';
+	}
+	return 'other';
+}
+
+// Extract package name from path
+function getPackageName( path ) {
+	if ( path === '.' ) {
+		return 'woocommerce';
+	}
+	const clean = path.replace( '../../packages/js/', '' ).replace( 'client/', '' );
+	return clean.split( ' ' )[ 0 ];
+}
+
+// Parse build type from line
+function getBuildType( line ) {
+	if ( line.includes( 'build:project:esm' ) ) return 'esm';
+	if ( line.includes( 'build:project:cjs' ) ) return 'cjs';
+	if ( line.includes( 'build:project:bundle' ) ) return 'bundle';
+	if ( line.includes( 'build:project:assets' ) ) return 'assets';
+	return null;
+}
+
+// Parse timing from completion line
+function parseTiming( line ) {
+	const match = line.match( /in (\d+(?:\.\d+)?)(m?s)/ );
+	if ( match ) {
+		const value = parseFloat( match[ 1 ] );
+		const unit = match[ 2 ];
+		return unit === 'ms' ? value / 1000 : value;
+	}
+	return 0;
+}
+
+// Update the progress line
+function updateProgress() {
+	const elapsed = ( ( Date.now() - startTime ) / 1000 ).toFixed( 1 );
+	const building = [ ...currentlyBuilding ].slice( 0, 3 ).join( ', ' );
+	const more =
+		currentlyBuilding.size > 3
+			? ` +${ currentlyBuilding.size - 3 } more`
+			: '';
+
+	// Clear both lines and write progress
+	// Move up one line, clear it, then clear current line
+	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
+
+	const buildingLabel =
+		building.length > 0
+			? `${ colors.dim }Building:${ colors.reset } ${ building }${ more }`
+			: `${ colors.dim }Starting...${ colors.reset }`;
+
+	process.stdout.write(
+		`${ colors.cyan }⏳${ colors.reset } ` +
+			`${ colors.bold }${ completedCount }/${ totalPackages || '?' }${
+				colors.reset
+			} ` +
+			buildingLabel +
+			`\n` +
+			`   ${ colors.dim }Elapsed: ${ elapsed }s${ colors.reset }`
+	);
+}
+
+// Process a line of output
+function processLine( rawLine ) {
+	const line = stripAnsi( rawLine );
+
+	// Check for scope line
+	const scopeMatch = line.match( /Scope: (\d+) of (\d+) workspace projects/ );
+	if ( scopeMatch ) {
+		totalPackages = parseInt( scopeMatch[ 1 ], 10 );
+		updateProgress();
+		return;
+	}
+
+	// Track when a package starts building
+	if ( line.includes( '$ wireit' ) ) {
+		const parts = line.split( ' ' );
+		const packageName = getPackageName( parts[ 0 ] );
+		currentlyBuilding.add( packageName );
+		updateProgress();
+		return;
+	}
+
+	// Skip other noise lines
+	if (
+		line.includes( '0% [0 / 1]' ) ||
+		line.includes( '100% [1 / 1]' ) ||
+		line.includes( 'Analyzing' ) ||
+		line.match( /^\s*Done\s*$/ ) ||
+		line.includes( 'asset ' ) ||
+		line.includes( 'modules' ) ||
+		line.includes( 'Entrypoint' ) ||
+		line.includes( 'cacheable' ) ||
+		line.includes( 'orphan' ) ||
+		line.includes( 'runtime modules' ) ||
+		line.includes( 'webpack 5' ) ||
+		line.includes( 'css ' ) ||
+		line.includes( './src/' ) ||
+		line.match( /^\s*\+ \d+ assets/ ) ||
+		line.match( /^\d{4}-\d{2}-\d{2}/ )
+	) {
+		return;
+	}
+
+	// Capture warnings
+	if (
+		line.toLowerCase().includes( 'warning' ) ||
+		line.includes( 'Browserslist:' ) ||
+		line.includes( 'DEPRECATION' )
+	) {
+		const cleanWarning = line.split( ': ' ).slice( 1 ).join( ': ' ).trim();
+		if ( cleanWarning && ! warnings.some( ( w ) => w.includes( cleanWarning.substring( 0, 50 ) ) ) ) {
+			warnings.push( cleanWarning );
+		}
+		return;
+	}
+
+	// Capture errors
+	if ( line.toLowerCase().includes( 'error' ) && ! line.includes( 'ERROR in breakpoint' ) ) {
+		errors.push( line );
+		return;
+	}
+
+	// Parse completion lines - format: "path build:project:type: ✅ Ran X scripts..."
+	if ( line.includes( 'Ran' ) && line.includes( 'scripts' ) && line.includes( ' in ' ) ) {
+		const parts = line.split( ' ' );
+		const path = parts[ 0 ];
+		const buildInfo = parts[ 1 ] || '';
+		const timing = parseTiming( line );
+		const packageName = getPackageName( path );
+		const buildType = getBuildType( buildInfo );
+		const category = getCategory( path );
+
+		// Remove from currently building
+		currentlyBuilding.delete( packageName );
+
+		if ( ! packages.has( packageName ) ) {
+			packages.set( packageName, {
+				name: packageName,
+				category,
+				buildTypes: [],
+				totalTime: 0,
+				cached: false,
+			} );
+			completedCount++;
+		}
+
+		const pkg = packages.get( packageName );
+		if ( buildType && ! pkg.buildTypes.includes( buildType ) ) {
+			pkg.buildTypes.push( buildType );
+		}
+		pkg.totalTime = Math.max( pkg.totalTime, timing );
+
+		// Check if cached (skipped means cached)
+		if ( line.includes( 'skipped' ) ) {
+			pkg.cached = true;
+		}
+
+		updateProgress();
+		return;
+	}
+}
+
+// Print the formatted output
+function printSummary() {
+	const totalTime = ( Date.now() - startTime ) / 1000;
+
+	// Clear both progress lines
+	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
+
+	console.log( '' );
+	console.log(
+		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
+	);
+	console.log(
+		`${ colors.bold } WooCommerce Build - ${ packages.size } packages built${ colors.reset } ${ colors.dim }(${ totalPackages } in scope)${ colors.reset }`
+	);
+	console.log(
+		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
+	);
+	console.log( '' );
+
+	// Group by category
+	const categories = {
+		'packages/js': [],
+		client: [],
+		'plugins/woocommerce': [],
+		'packages/js (no build)': [],
+		other: [],
+	};
+
+	// Add no-build packages
+	for ( const name of NO_BUILD_PACKAGES ) {
+		categories[ 'packages/js (no build)' ].push( {
+			name,
+			category: 'packages/js (no build)',
+			buildTypes: [],
+			totalTime: 0,
+			noBuild: true,
+		} );
+	}
+
+	for ( const [ , pkg ] of packages ) {
+		categories[ pkg.category ].push( pkg );
+	}
+
+	// Print each category
+	for ( const [ category, pkgs ] of Object.entries( categories ) ) {
+		if ( pkgs.length === 0 ) continue;
+
+		// Sort by name
+		pkgs.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+
+		console.log(
+			`${ colors.magenta }📦 ${ category }/${ colors.reset } ${ colors.dim }(${ pkgs.length } packages)${ colors.reset }`
+		);
+
+		for ( const pkg of pkgs ) {
+			let status;
+			if ( pkg.noBuild ) {
+				status = `${ colors.dim }·  (no build)${ colors.reset }`;
+			} else if ( pkg.cached ) {
+				status = `${ colors.dim }·  (cached)${ colors.reset }`;
+			} else {
+				status = `${ colors.green }✅${ colors.reset }`;
+			}
+			const types =
+				pkg.buildTypes.length > 0
+					? `(${ pkg.buildTypes.join( ', ' ) })`
+					: '';
+			const time =
+				pkg.cached || pkg.noBuild
+					? ''
+					: `${ pkg.totalTime.toFixed( 1 ) }s`;
+
+			const namePadded = pkg.name.padEnd( 25 );
+			const typesPadded = types.padEnd( 20 );
+
+			console.log(
+				`  ${ status } ${ namePadded } ${ colors.dim }${ typesPadded }${ colors.reset } ${ time }`
+			);
+		}
+		console.log( '' );
+	}
+
+	console.log(
+		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
+	);
+
+	if ( errors.length > 0 ) {
+		console.log(
+			`${ colors.bold }${
+				colors.red
+			} ❌ Build failed after ${ totalTime.toFixed( 1 ) }s${
+				colors.reset
+			}`
+		);
+	} else {
+		console.log(
+			`${ colors.bold }${
+				colors.green
+			} ✅ Build completed in ${ totalTime.toFixed( 1 ) }s${
+				colors.reset
+			}`
+		);
+	}
+
+	console.log(
+		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
+	);
+
+	// Print warnings
+	if ( warnings.length > 0 ) {
+		console.log( '' );
+		console.log( `${ colors.yellow }⚠️  Warnings: ${ warnings.length }${ colors.reset }` );
+		const uniqueWarnings = [ ...new Set( warnings ) ].slice( 0, 5 );
+		for ( const warning of uniqueWarnings ) {
+			const shortWarning = warning.substring( 0, 70 );
+			console.log( `  ${ colors.dim }- ${ shortWarning }${ warning.length > 70 ? '...' : '' }${ colors.reset }` );
+		}
+		if ( warnings.length > 5 ) {
+			console.log( `  ${ colors.dim }  ... and ${ warnings.length - 5 } more${ colors.reset }` );
+		}
+	}
+
+	// Print errors
+	if ( errors.length > 0 ) {
+		console.log( '' );
+		console.log(
+			`${ colors.red }❌ Errors: ${ errors.length }${ colors.reset }`
+		);
+		for ( const error of errors.slice( 0, 10 ) ) {
+			// Show more of the error message
+			console.log( `  ${ colors.red }- ${ error }${ colors.reset }` );
+		}
+	}
+
+	console.log( '' );
+}
+
+// Main
+function main() {
+	console.log(
+		`${ colors.cyan }🔨 Building WooCommerce...${ colors.reset }`
+	);
+	console.log( '' );
+	console.log( '' ); // Extra line for two-line progress display
+
+	const build = spawn( 'pnpm', [ 'build' ], {
+		cwd: __dirname + '/..',
+		shell: true,
+		stdio: [ 'inherit', 'pipe', 'pipe' ],
+	} );
+
+	let buffer = '';
+
+	const processBuffer = ( data ) => {
+		buffer += data.toString();
+		const lines = buffer.split( '\n' );
+		buffer = lines.pop(); // Keep incomplete line in buffer
+
+		for ( const line of lines ) {
+			processLine( line );
+		}
+	};
+
+	build.stdout.on( 'data', processBuffer );
+	build.stderr.on( 'data', processBuffer );
+
+	build.on( 'close', ( code ) => {
+		// Process any remaining buffer
+		if ( buffer ) {
+			processLine( buffer );
+		}
+
+		printSummary();
+
+		process.exit( code );
+	} );
+}
+
+main();

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -36,7 +36,7 @@ const warnings = [];
 const errors = [];
 let totalPackages = 0;
 let completedCount = 0;
-let startTime = Date.now();
+const startTime = Date.now();
 const currentlyBuilding = new Set();
 
 // Packages that are in scope but don't have build:project scripts
@@ -66,7 +66,9 @@ function getPackageName( path ) {
 	if ( path === '.' ) {
 		return 'woocommerce';
 	}
-	const clean = path.replace( '../../packages/js/', '' ).replace( 'client/', '' );
+	const clean = path
+		.replace( '../../packages/js/', '' )
+		.replace( 'client/', '' );
 	return clean.split( ' ' )[ 0 ];
 }
 
@@ -168,20 +170,32 @@ function processLine( rawLine ) {
 		line.includes( 'DEPRECATION' )
 	) {
 		const cleanWarning = line.split( ': ' ).slice( 1 ).join( ': ' ).trim();
-		if ( cleanWarning && ! warnings.some( ( w ) => w.includes( cleanWarning.substring( 0, 50 ) ) ) ) {
+		if (
+			cleanWarning &&
+			! warnings.some( ( w ) =>
+				w.includes( cleanWarning.substring( 0, 50 ) )
+			)
+		) {
 			warnings.push( cleanWarning );
 		}
 		return;
 	}
 
 	// Capture errors
-	if ( line.toLowerCase().includes( 'error' ) && ! line.includes( 'ERROR in breakpoint' ) ) {
+	if (
+		line.toLowerCase().includes( 'error' ) &&
+		! line.includes( 'ERROR in breakpoint' )
+	) {
 		errors.push( line );
 		return;
 	}
 
 	// Parse completion lines - format: "path build:project:type: ✅ Ran X scripts..."
-	if ( line.includes( 'Ran' ) && line.includes( 'scripts' ) && line.includes( ' in ' ) ) {
+	if (
+		line.includes( 'Ran' ) &&
+		line.includes( 'scripts' ) &&
+		line.includes( ' in ' )
+	) {
 		const parts = line.split( ' ' );
 		const path = parts[ 0 ];
 		const buildInfo = parts[ 1 ] || '';
@@ -216,7 +230,6 @@ function processLine( rawLine ) {
 		}
 
 		updateProgress();
-		return;
 	}
 }
 
@@ -228,9 +241,7 @@ function printSummary() {
 	process.stdout.write( `\x1b[2K\x1b[1A\x1b[2K\r` );
 
 	console.log( '' );
-	console.log(
-		`${ colors.dim }───────────────────────────────────────────────────────────────${ colors.reset }`
-	);
+
 	console.log(
 		`${ colors.bold } WooCommerce Build - ${ packages.size } packages built${ colors.reset } ${ colors.dim }(${ totalPackages } in scope)${ colors.reset }`
 	);
@@ -331,14 +342,24 @@ function printSummary() {
 	// Print warnings
 	if ( warnings.length > 0 ) {
 		console.log( '' );
-		console.log( `${ colors.yellow }⚠️  Warnings: ${ warnings.length }${ colors.reset }` );
+		console.log(
+			`${ colors.yellow }⚠️  Warnings: ${ warnings.length }${ colors.reset }`
+		);
 		const uniqueWarnings = [ ...new Set( warnings ) ].slice( 0, 5 );
 		for ( const warning of uniqueWarnings ) {
 			const shortWarning = warning.substring( 0, 70 );
-			console.log( `  ${ colors.dim }- ${ shortWarning }${ warning.length > 70 ? '...' : '' }${ colors.reset }` );
+			console.log(
+				`  ${ colors.dim }- ${ shortWarning }${
+					warning.length > 70 ? '...' : ''
+				}${ colors.reset }`
+			);
 		}
 		if ( warnings.length > 5 ) {
-			console.log( `  ${ colors.dim }  ... and ${ warnings.length - 5 } more${ colors.reset }` );
+			console.log(
+				`  ${ colors.dim }  ... and ${ warnings.length - 5 } more${
+					colors.reset
+				}`
+			);
 		}
 	}
 
@@ -365,11 +386,22 @@ function main() {
 	console.log( '' );
 	console.log( '' ); // Extra line for two-line progress display
 
-	const build = spawn( 'pnpm', [ 'build' ], {
-		cwd: __dirname + '/..',
-		shell: true,
-		stdio: [ 'inherit', 'pipe', 'pipe' ],
-	} );
+	// Run the actual build command (same as the original "build" script)
+	const build = spawn(
+		'pnpm',
+		[
+			'--if-present',
+			'--workspace-concurrency=Infinity',
+			'--stream',
+			'--filter=@woocommerce/plugin-woocommerce...',
+			'/^build:project:.*$/',
+		],
+		{
+			cwd: __dirname + '/..',
+			shell: true,
+			stdio: [ 'inherit', 'pipe', 'pipe' ],
+		}
+	);
 
 	let buffer = '';
 

--- a/plugins/woocommerce/scripts/build-pretty.js
+++ b/plugins/woocommerce/scripts/build-pretty.js
@@ -259,15 +259,17 @@ function printSummary() {
 		other: [],
 	};
 
-	// Add no-build packages
-	for ( const name of NO_BUILD_PACKAGES ) {
-		categories[ 'packages/js (no build)' ].push( {
-			name,
-			category: 'packages/js (no build)',
-			buildTypes: [],
-			totalTime: 0,
-			noBuild: true,
-		} );
+	// Only add no-build packages if we actually built something
+	if ( packages.size > 0 ) {
+		for ( const name of NO_BUILD_PACKAGES ) {
+			categories[ 'packages/js (no build)' ].push( {
+				name,
+				category: 'packages/js (no build)',
+				buildTypes: [],
+				totalTime: 0,
+				noBuild: true,
+			} );
+		}
 	}
 
 	for ( const [ , pkg ] of packages ) {


### PR DESCRIPTION
The spike introduces a log wrapper `build-pretty.js` script that just formats the output: 

- Spawns the actual build command as a child process
- Captures stdout/stderr in real-time
- Parses and filters the output
- Displays a clean, updating progress view
- Collects warnings/errors for a summary at the end

The spike doesn't change configuration for the build tools, although I tried some things, and there is room for improvement. 

It also allows running the build with the full output, for debugging purposes using the pnpm build:raw command.