### PR TITLE
[TEST] BC Review Bot Workflow Validation

### DIFF
--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -74,14 +74,32 @@ jobs:
               - PATH: the file path of the change
               - LINE: the target line number in the current diff
               - ORIGINAL_LINE: the stable original line if available; otherwise use LINE
-              - TOPIC: one of the predefined Topic values
-            - Query existing review comments and find a match using the hidden marker first, with path and topic, preferring `original_line` and falling back to `line`:
+              - TOPIC: use lowercase with hyphens, format: {category}-{specific}. Examples:
+                  hook-renamed, hook-removed, hook-bypassed
+                  method-visibility, method-signature, method-removed
+                  constant-renamed, constant-removed
+                  css-selector, css-layout, css-specificity
+                  api-response, api-timing, api-batching
+                  type-interface, type-export, type-prop
+                  data-contract, data-context
+                  exception-type, exception-code
+                  strict-types
+                  db-posttype, db-meta, db-schema
+            - Query existing review comments to find a match. First search by marker only (ignoring line numbers since they shift between pushes):
               gh api "repos/${REPO}/pulls/${PR}/comments?per_page=100" --paginate \
                 --jq \
-                "map(select(.path==\"${PATH}\" and ((.original_line==${ORIGINAL_LINE}) or (.line==${LINE})) and (.body|contains(\"wc-bc:path=${PATH};\") and (.body|contains(\"topic=${TOPIC}\")) ))) | first | .id"
-            - If an ID is returned, PATCH that comment to merge/append updated guidance instead of posting a new one:
+                "map(select(.body | contains(\"wc-bc:path=${PATH};\") and contains(\"topic=${TOPIC}\"))) | first | .id"
+            - If no match found by marker, fall back to path + line matching for comments without markers:
+              gh api "repos/${REPO}/pulls/${PR}/comments?per_page=100" --paginate \
+                --jq \
+                "map(select(.path==\"${PATH}\" and ((.original_line==${ORIGINAL_LINE}) or (.line==${LINE})))) | first | .id"
+            - If an ID is returned from either query, PATCH that comment to merge/append updated guidance instead of posting a new one:
               gh api repos/${REPO}/pulls/comments/${ID} -X PATCH -f body@updated_body.md
             - Otherwise, post a single merged comment for that (file, original_line, topic).
+
+            CRITICAL REQUIREMENT - MARKER INSERTION
+            You MUST include the hidden marker at the end of EVERY inline comment you create. This is essential for deduplication across pushes. Never omit it:
+            <!-- wc-bc:path={path};ol={original_line};topic={topic} -->
 
           claude_args: >
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*)"

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -86,7 +86,7 @@ class WC_Product_Factory {
 	 * @param  int $product_id Product ID.
 	 * @return string|false
 	 */
-	public static function get_product_type( $product_id ) {
+	public static function get_product_type( int $product_id ): string|false {
 		// Allow the overriding of the lookup in this function. Return the product type here.
 		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
 		if ( ! $override ) {


### PR DESCRIPTION
## DO NOT MERGE - TEST PR

This PR is for testing the BC Review Bot workflow changes from #62370.

### What this tests:
1. The workflow should detect the type hint addition as a BC issue
2. Comments should include the hidden marker for deduplication
3. On subsequent pushes, existing comments should be updated (not duplicated)

### Test Changes:
- Added `int` type hint to `$product_id` parameter in `get_product_type()`
- Added `: string|false` return type to `get_product_type()`

This is a known BC issue that should be flagged by the bot.

### After testing:
This PR will be closed without merging.