### PR TITLE
Mini Cart: Add compatibility with Coming Soon

### DIFF
--- a/plugins/woocommerce/changelog/62388-update-mini-cart-coming-soon-compat
+++ b/plugins/woocommerce/changelog/62388-update-mini-cart-coming-soon-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Mini Cart: Add compatibility with Coming Soon
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Blocks\Utils\MiniCartUtils;
 use Automattic\WooCommerce\Blocks\Utils\BlockHooksTrait;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonHelper;
 use Automattic\Block_Delimiter;
 
 /**
@@ -471,6 +472,14 @@ class MiniCart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		/**
+		 * Do not render for logged-out users if the Coming Soon mode is enabled for store pages only.
+		 */
+		$coming_soon_helper = wc_get_container()->get( ComingSoonHelper::class );
+		if ( ! is_user_logged_in() && ! WC()->is_rest_api_request() && $coming_soon_helper->is_store_coming_soon() ) {
+			return '';
+		}
+
 		/**
 		 * In the cart and checkout pages, the block is either rendered hidden or removed.
 		 * It is not interactive, so it can fall back to the existing implementation.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -308,4 +308,98 @@ class MiniCart extends \WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * Test that mini-cart does not render for logged-out users when coming soon mode is enabled for store pages only.
+	 *
+	 * @return void
+	 */
+	public function test_mini_cart_does_not_render_for_logged_out_users_when_store_coming_soon() {
+		// Set up coming soon mode for store pages only.
+		update_option( 'woocommerce_coming_soon', 'yes' );
+		update_option( 'woocommerce_store_pages_only', 'yes' );
+
+		// Ensure user is logged out.
+		wp_set_current_user( 0 );
+
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart /-->' );
+		$output = render_block( $block[0] );
+
+		// Mini-cart should not render (empty output).
+		$this->assertEmpty( $output, 'Mini-cart should not render for logged-out users when store is in coming soon mode.' );
+
+		// Clean up.
+		update_option( 'woocommerce_coming_soon', 'no' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+	}
+
+	/**
+	 * Test that mini-cart renders for logged-in users when coming soon mode is enabled for store pages only.
+	 *
+	 * @return void
+	 */
+	public function test_mini_cart_renders_for_logged_in_users_when_store_coming_soon() {
+		// Set up coming soon mode for store pages only.
+		update_option( 'woocommerce_coming_soon', 'yes' );
+		update_option( 'woocommerce_store_pages_only', 'yes' );
+
+		// Create and log in a user.
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
+
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart /-->' );
+		$output = render_block( $block[0] );
+
+		// Mini-cart should render (non-empty output).
+		$this->assertNotEmpty( $output, 'Mini-cart should render for logged-in users even when store is in coming soon mode.' );
+
+		// Clean up.
+		wp_set_current_user( 0 );
+		update_option( 'woocommerce_coming_soon', 'no' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+	}
+
+	/**
+	 * Test that mini-cart renders for logged-out users when coming soon mode is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_mini_cart_renders_for_logged_out_users_when_coming_soon_disabled() {
+		// Ensure coming soon mode is disabled.
+		update_option( 'woocommerce_coming_soon', 'no' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+
+		// Ensure user is logged out.
+		wp_set_current_user( 0 );
+
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart /-->' );
+		$output = render_block( $block[0] );
+
+		// Mini-cart should render (non-empty output).
+		$this->assertNotEmpty( $output, 'Mini-cart should render for logged-out users when coming soon mode is disabled.' );
+	}
+
+	/**
+	 * Test that mini-cart renders for logged-out users when site-wide coming soon mode is enabled (not store pages only).
+	 *
+	 * @return void
+	 */
+	public function test_mini_cart_renders_when_site_wide_coming_soon_not_store_only() {
+		// Set up site-wide coming soon mode (not store pages only).
+		update_option( 'woocommerce_coming_soon', 'yes' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+
+		// Ensure user is logged out.
+		wp_set_current_user( 0 );
+
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart /-->' );
+		$output = render_block( $block[0] );
+
+		// Mini-cart should render (non-empty output) because the logic only checks for store pages coming soon.
+		$this->assertNotEmpty( $output, 'Mini-cart should render when site-wide coming soon is enabled but not store pages only.' );
+
+		// Clean up.
+		update_option( 'woocommerce_coming_soon', 'no' );
+		update_option( 'woocommerce_store_pages_only', 'no' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds compatibility to the iAPI Mini Cart with the Site Visibility feature, specifically when the site is in Coming Soon for store pages only. 

This way, when the site is in "Coming Soon" mode and users can access it, if they're logged out, they won't see a Mini Cart.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #50194.
Fixes WOOPLUG-2450.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Start with the TT4 theme with mini cart in the header (should be by default)
2. Go to WC Settings > Site Visibility
3. Turn on the Coming Soon mode with restriction to store only
4. Go to the frontend as a logged-in user.
5. Verify you can see the mini cart. 
6. Go to the frontend as a logged-out user.
7. Verify you don't see the mini cart. 
8. Verify the block still works well in the admin.

Note: This doesn't work with Storefront - it requires a patch there, which I'll work on separately.

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing with TT4, TT5, and Storefront themes.
Testing both with logged-in and logged-out user.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Mini Cart: Add compatibility with Coming Soon

</details>
