### PR TITLE
Prevent PHP notices about actions scheduler and translations on init

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5969-improve-translation-loading-to-avoid-wordpress-php-warning
+++ b/plugins/woocommerce/changelog/wooplug-5969-improve-translation-loading-to-avoid-wordpress-php-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent notice as_unschedule_all_actions() was called before the Action Scheduler data store was initialized

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -77464,12 +77464,6 @@ parameters:
 			path: src/Blocks/Patterns/PTKPatternsStore.php
 
 		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Blocks/Patterns/PTKPatternsStore.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Patterns\\PTKPatternsStore\:\:get_patterns\(\) should return array but returns mixed\.$#'
 			identifier: return.type
 			count: 1

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -187,13 +187,24 @@ class PTKPatternsStore {
 	/**
 	 * Reset the cached patterns to fetch them again from the PTK.
 	 *
+	 * @since 10.5.0 Unscheduling is deferred if Action Scheduler hasn't initialized yet.
 	 * @return void
 	 */
 	public function flush_cached_patterns() {
 		delete_option( self::OPTION_NAME );
 
 		// Unschedule any existing fetch_patterns actions.
-		as_unschedule_all_actions( self::FETCH_PATTERNS_ACTION, array(), 'woocommerce' );
+		// Defer unscheduling until Action Scheduler is ready to avoid errors during early initialization.
+		if ( did_action( 'action_scheduler_init' ) ) {
+			as_unschedule_all_actions( self::FETCH_PATTERNS_ACTION, array(), 'woocommerce' );
+		} else {
+			add_action(
+				'action_scheduler_init',
+				function () {
+					as_unschedule_all_actions( self::FETCH_PATTERNS_ACTION, array(), 'woocommerce' );
+				}
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -187,7 +187,7 @@ class PTKPatternsStore {
 	/**
 	 * Reset the cached patterns to fetch them again from the PTK.
 	 *
-	 * @since 10.5.0 Unscheduling is deferred if Action Scheduler hasn't initialized yet.
+	 * @since 10.4.1 Unscheduling is deferred if Action Scheduler hasn't initialized yet.
 	 * @return void
 	 */
 	public function flush_cached_patterns() {

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -193,6 +193,10 @@ class PTKPatternsStore {
 	public function flush_cached_patterns() {
 		delete_option( self::OPTION_NAME );
 
+		if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+			return;
+		}
+
 		// Unschedule any existing fetch_patterns actions.
 		// Defer unscheduling until Action Scheduler is ready to avoid errors during early initialization.
 		if ( did_action( 'action_scheduler_init' ) ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -471,4 +471,48 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 
 		$this->assertFalse( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'All fetch_patterns actions should be unscheduled after flush' );
 	}
+
+	/**
+	 * Test flush_cached_patterns defers unscheduling when called before action_scheduler_init.
+	 *
+	 * This test simulates the scenario where flush_cached_patterns is called during early
+	 * initialization, before Action Scheduler has been initialized.
+	 */
+	public function test_flush_cached_patterns_defers_unscheduling_before_action_scheduler_init() {
+		global $wp_actions;
+
+		// Schedule an action.
+		as_schedule_single_action( time(), 'fetch_patterns', array(), 'woocommerce' );
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'Action should be scheduled initially' );
+
+		// Save the original action_scheduler_init count.
+		$original_count = $wp_actions['action_scheduler_init'] ?? 0;
+
+		// Simulate that action_scheduler_init has not yet fired by unsetting it.
+		if ( isset( $wp_actions['action_scheduler_init'] ) ) {
+			unset( $wp_actions['action_scheduler_init'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		// Verify did_action returns 0 (not fired).
+		$this->assertEquals( 0, did_action( 'action_scheduler_init' ), 'action_scheduler_init should appear not fired' );
+
+		// Call flush_cached_patterns before action_scheduler_init has fired.
+		$this->pattern_store->flush_cached_patterns();
+
+		// The option should be deleted immediately.
+		$patterns = get_option( PTKPatternsStore::OPTION_NAME );
+		$this->assertFalse( $patterns, 'Patterns option should be deleted immediately' );
+
+		// The action should still be scheduled (unscheduling is deferred).
+		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'Action should still be scheduled before action_scheduler_init fires' );
+
+		// Now simulate action_scheduler_init firing.
+		do_action( 'action_scheduler_init' );
+
+		// After action_scheduler_init fires, the action should be unscheduled.
+		$this->assertFalse( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'Action should be unscheduled after action_scheduler_init fires' );
+
+		// Restore the original action count.
+		$wp_actions['action_scheduler_init'] = $original_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PTKPatternsStoreTest.php
@@ -506,7 +506,12 @@ class PTKPatternsStoreTest extends \WP_UnitTestCase {
 		// The action should still be scheduled (unscheduling is deferred).
 		$this->assertTrue( as_has_scheduled_action( 'fetch_patterns', array(), 'woocommerce' ), 'Action should still be scheduled before action_scheduler_init fires' );
 
-		// Now simulate action_scheduler_init firing.
+		/**
+		 * Simulate action_scheduler_init firing.
+		 *
+		 * @since 10.4.1
+		 * @return void
+		 */
 		do_action( 'action_scheduler_init' );
 
 		// After action_scheduler_init fires, the action should be unscheduled.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prevents PHP notices caused by running `as_unschedule_all_actions` too early. 

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6131 Notice: Function as_unschedule_all_actions was called incorrectly. as_unschedule_all_actions() was called before the Action Scheduler data store was initialized Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 3.1.6.) in /var/www/html/wp-includes/functions.php on line 6131 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6131) in /var/www/html/wp-includes/pluggable.php on line 1531 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6131) in /var/www/html/wp-includes/pluggable.php on line 1534
```

Related WOOPLUG-5969.

Bug introduced in PR #61749

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Replication

1. Install WooCommerce on a fresh environment.
2. Go to /wp-admin and observe the issue
<img width="1660" height="146" alt="Screenshot 2025-12-11 at 14 53 19" src="https://github.com/user-attachments/assets/f9350b08-9e34-46cc-8fe5-04857690a7ea" />

On this brach there should be no notice.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
