### PR TITLE
Address PHPStan errors in `LegacyDataHandler` and other order datastore classes

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpstan-errors
+++ b/plugins/woocommerce/changelog/fix-phpstan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Only PHPStan fixes.
+
+

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -187,6 +187,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		$order_id = $order->get_id();
+		/** @var WC_Logger_Interface $logger */
 		$logger   = WC()->call_function( 'wc_get_logger' );
 
 		foreach ( $errors->get_error_codes() as $error_code ) {
@@ -790,6 +791,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $order->get_id(), 'post_meta' );
+				/** @var WC_Logger_Interface $logger */
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID %d: "%s"', $order->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -176,8 +176,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	/**
 	 * Set the properties of an object and log the first error found while doing so.
 	 *
-	 * @param $order WC_Order $order Order object.
-	 * @param array $props The properties to set.
+	 * @param \WC_Order $order Order object.
+	 * @param array     $props The properties to set.
 	 */
 	private function set_order_props( &$order, array $props ) {
 		$errors = $order->set_props( $props );
@@ -187,8 +187,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		$order_id = $order->get_id();
-		/** @var WC_Logger_Interface $logger */
-		$logger   = WC()->call_function( 'wc_get_logger' );
+		/** @var WC_Logger_Interface $logger */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		$logger = WC()->call_function( 'wc_get_logger' );
 
 		foreach ( $errors->get_error_codes() as $error_code ) {
 			$property_name = $errors->get_error_data( $error_code )['property_name'] ?? '';
@@ -791,7 +791,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $order->get_id(), 'post_meta' );
-				/** @var WC_Logger_Interface $logger */
+				/** @var WC_Logger_Interface $logger */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `update_order_meta_from_object` in order with ID %d: "%s"', $order->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -27781,12 +27781,6 @@ parameters:
 			path: includes/data-stores/abstract-wc-order-data-store-cpt.php
 
 		-
-			message: '#^Cannot call method warning\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/data-stores/abstract-wc-order-data-store-cpt.php
-
-		-
 			message: '#^Cannot cast mixed to float\.$#'
 			identifier: cast.double
 			count: 2
@@ -27837,12 +27831,6 @@ parameters:
 		-
 			message: '#^Method Abstract_WC_Order_Data_Store_CPT\:\:set_order_props\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/data-stores/abstract-wc-order-data-store-cpt.php
-
-		-
-			message: '#^Method Abstract_WC_Order_Data_Store_CPT\:\:set_order_props\(\) has parameter \$order with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: includes/data-stores/abstract-wc-order-data-store-cpt.php
 
@@ -88354,6 +88342,12 @@ parameters:
 			path: src/Internal/DataStores/Orders/LegacyDataCleanup.php
 
 		-
+			message: '#^Access to protected property WC_Order\:\:\$data_store\.$#'
+			identifier: property.protected
+			count: 1
+			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
+
+		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -88367,18 +88361,6 @@ parameters:
 
 		-
 			message: '#^Call to an undefined method object\:\:get_current_class_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
-
-		-
-			message: '#^Call to an undefined method object\:\:read\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_id\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -88402,19 +88384,7 @@ parameters:
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:get_order_from_datastore\(\) should return WC_Order but returns WC_Abstract_Order\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:init\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:read_order_from_datastore\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -88426,13 +88396,13 @@ parameters:
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
 
 		-
-			message: '#^Parameter \#1 \$order of method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:is_order_newer_than_post\(\) expects WC_Abstract_Order, WC_Order\|WC_Order_Refund\|true given\.$#'
-			identifier: argument.type
+			message: '#^PHPDoc tag @var with type WC_Order is not subtype of native type \$this\(Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\)\.$#'
+			identifier: varTag.nativeType
 			count: 1
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
 
 		-
-			message: '#^Parameter \#1 \$order of method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:read_order_from_datastore\(\) expects WC_Abstract_Order, object given\.$#'
+			message: '#^Parameter \#1 \$order of method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:is_order_newer_than_post\(\) expects WC_Abstract_Order, WC_Order\|WC_Order_Refund\|true given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -88440,12 +88410,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$props of method WC_Data\:\:set_props\(\) expects array, array\|false given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
-
-		-
-			message: '#^Property WC_Data_Store\:\:\$instance \(WC_Data_Store\) does not accept object\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/Internal/DataStores/Orders/LegacyDataHandler.php
 
@@ -88928,12 +88892,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$order of method Abstract_WC_Order_Data_Store_CPT\:\:read\(\) expects WC_Order, WC_Abstract_Order given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/DataStores/Orders/OrdersTableDataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of method Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\LegacyDataHandler\:\:read_order_from_datastore\(\) expects WC_Abstract_Order, object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Internal/DataStores/Orders/OrdersTableDataStore.php

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -302,20 +302,20 @@ class LegacyDataHandler {
 		}
 
 		$classname = $order_type['class_name'];
-		/** @var \WC_Order $order */
-		$order     = new $classname();
+		/** @var \WC_Order $order */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		$order = new $classname();
 		$order->set_id( $order_id );
 
 		// Switch datastore if necessary.
 		$update_data_store_func = function ( $data_store ) {
-			/** @var \WC_Order $this */
+			/** @var \WC_Order $this */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			// Each order object contains a reference to its data store, but this reference is itself
 			// held inside of an instance of WC_Data_Store, so we create that first.
 			$data_store_wrapper = \WC_Data_Store::load( 'order' );
 
 			// Bind $data_store to our WC_Data_Store.
 			( function ( $data_store ) {
-				/** @var \WC_Data_Store $this */
+				/** @var \WC_Data_Store $this */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$this->current_class_name = (string) get_class( $data_store );
 				$this->instance           = $data_store;
 			} )->call( $data_store_wrapper, $data_store );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/LegacyDataHandler.php
@@ -302,18 +302,21 @@ class LegacyDataHandler {
 		}
 
 		$classname = $order_type['class_name'];
+		/** @var \WC_Order $order */
 		$order     = new $classname();
 		$order->set_id( $order_id );
 
 		// Switch datastore if necessary.
 		$update_data_store_func = function ( $data_store ) {
+			/** @var \WC_Order $this */
 			// Each order object contains a reference to its data store, but this reference is itself
 			// held inside of an instance of WC_Data_Store, so we create that first.
 			$data_store_wrapper = \WC_Data_Store::load( 'order' );
 
 			// Bind $data_store to our WC_Data_Store.
 			( function ( $data_store ) {
-				$this->current_class_name = get_class( $data_store );
+				/** @var \WC_Data_Store $this */
+				$this->current_class_name = (string) get_class( $data_store );
 				$this->instance           = $data_store;
 			} )->call( $data_store_wrapper, $data_store );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1676,12 +1676,12 @@ WHERE
 			$new_diff      = ArrayUtil::deep_assoc_array_diff( $order1_values, $order2_values );
 			if ( ! empty( $new_diff ) && $sync ) {
 				if ( count( $order2_values ) > 1 ) {
-					$sync && $order1->delete_meta_data( $key );
+					$order1->delete_meta_data( $key );
 					foreach ( $order2_values as $post_order_value ) {
-						$sync && $order1->add_meta_data( $key, $post_order_value, false );
+						$order1->add_meta_data( $key, $post_order_value, false );
 					}
 				} else {
-					$sync && $order1->update_meta_data( $key, $order2_values[0] );
+					$order1->update_meta_data( $key, $order2_values[0] );
 				}
 				$diff[ $key ] = $new_diff;
 				unset( $order2_meta_by_key[ $key ] );
@@ -3323,6 +3323,7 @@ CREATE TABLE $meta_table (
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $object->get_id(), 'post_meta' );
+				/** @var \WC_Logger_Interface $logger */
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID %d: "%s"', $object->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3323,7 +3323,7 @@ CREATE TABLE $meta_table (
 					array( '%d', '%s', '%s' )
 				);
 				wp_cache_delete( $object->get_id(), 'post_meta' );
-				/** @var \WC_Logger_Interface $logger */
+				/** @var \WC_Logger_Interface $logger */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 				$logger->warning( sprintf( 'encountered an order meta value of type __PHP_Incomplete_Class during `delete_meta` in order with ID %d: "%s"', $object->get_id(), var_export( $meta_value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->
Addresses a few PHPStan errors derived from #62402.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Make sure PHPStan check on this PR is green.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
