### PR TITLE
Add action before trashing an order due to privacy processes

### DIFF
--- a/plugins/woocommerce/changelog/62425-patch-17
+++ b/plugins/woocommerce/changelog/62425-patch-17
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New action hook to let third parties know about privacy-related order deletion

--- a/plugins/woocommerce/includes/class-wc-privacy.php
+++ b/plugins/woocommerce/includes/class-wc-privacy.php
@@ -301,6 +301,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
+				do_action( 'wc_privacy_before_trash_order', $order );
 				$order->delete( false );
 				++$count;
 			}

--- a/plugins/woocommerce/includes/class-wc-privacy.php
+++ b/plugins/woocommerce/includes/class-wc-privacy.php
@@ -301,6 +301,13 @@ class WC_Privacy extends WC_Abstract_Privacy {
 
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
+				/**
++				 * Fires before an order is trashed/deleted as part of WooCommerce privacy retention cleanup.
++				 *
++				 * @since x.y.z
++				 *
++				 * @param WC_Order $order Order object being trashed.
++				 */
 				do_action( 'wc_privacy_before_trash_order', $order );
 				$order->delete( false );
 				++$count;


### PR DESCRIPTION
Adding new action in order to allow other parties realizing that an order is about to be deleted due to privacy reasons

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The deletion of pending/failed orders due to privacy reasons is currently causing problems in other plugins, such as WooCommerce Subscriptions, where the consequences should vary depending on if a pending/failed order is deleted manually from the backend or via API, or if it is deleted due to privacy or cleaning-up reasons.

This PR just adds a new action launched just before an order is deleted by the WC_Privacy class, so third parties can make the proper decisions or changes when orders are deleted automatically.


Closes #62423 .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It's just an action hook. In order to test it, you should create a function linked to this new created hook, and check that it's being called with the expected orders.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

New action hook to let third parties know about privacy-related order deletion 

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
