### PR TITLE
PayPal Standard: Ensure the invoice ID is unique across stores

### DIFF
--- a/plugins/woocommerce/changelog/62427-fix-paypal-standard-duplicate-invoice-id-error
+++ b/plugins/woocommerce/changelog/62427-fix-paypal-standard-duplicate-invoice-id-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensure the PayPal Standard invoice ID is unique across stores.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -642,7 +642,7 @@ class WC_Gateway_Paypal_Request {
 				array(
 					'custom_id'  => $this->get_paypal_order_custom_id( $order ),
 					'amount'     => $this->get_paypal_order_purchase_unit_amount( $order ),
-					'invoice_id' => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), WC_Gateway_Paypal_Constants::PAYPAL_INVOICE_ID_MAX_LENGTH ),
+					'invoice_id' => $this->generate_paypal_invoice_id( $order ),
 					'items'      => $order_items,
 					'payee'      => array(
 						'email_address' => $payee_email,
@@ -756,6 +756,25 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return $custom_id;
+	}
+
+	/**
+	 * Generate a unique invoice ID for the order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return string
+	 */
+	private function generate_paypal_invoice_id( $order ) {
+		$prefix          = $this->gateway->get_option( 'invoice_prefix' );
+		$order_number    = $order->get_order_number();
+		$base_invoice_id = $prefix . $order_number;
+
+		// generate a unique ID for the site.
+		$site_id = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : '';
+		$unique_id = substr( md5( $site_id ), 0, 8 );
+
+		$invoice_id = $this->limit_length( $base_invoice_id . '-' . $unique_id, WC_Gateway_Paypal_Constants::PAYPAL_INVOICE_ID_MAX_LENGTH );
+		return $invoice_id;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added a random hash generated using the site ID at the end of the invoice ID to ensure the invoice ID is unique across multiple stores.

Closes PAYPAL-115


### How to test the changes in this Pull Request:
- Enable PayPal Standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`.
- Go to **WooCommerce > Settings > Payments > PayPal Standard** and set an `Invoice prefix`. (example: `WCLocal-`)
- As a shopper, complete a transaction using PayPal Standard.
- Verify that the transaction goes through without any errors.
- As an admin, go to the order edit page and click the transaction ID link.
- On the PayPal transaction page, verify that the invoice ID is set with the correct patterns.
    - For order ID 101 it should be `WCLocal-101-{random_hash}`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Ensure the PayPal Standard invoice ID is unique across stores.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
