### PR TITLE
Improve notification about open items in release milestones

### DIFF
--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -161,25 +161,47 @@ jobs:
                   repo: context.repo.repo,
                   branch: `release/${version}`
                 } );
-
-                releaseMilestones.push( {
-                  title: milestone.title,
-                  number: milestone.number,
-                  version: parseFloat( version )
-                } );
               } catch ( error ) {
                 if ( 404 === error.status ) {
                   console.log( `Skipping milestone ${milestone.title} - release branch does not exist.` );
+                  continue;
                 } else {
                   throw error;
                 }
               }
-            }
 
-            // Sort and filter milestones. Don't include the upcoming milestone unless it matches the upcoming release event.
-            releaseMilestones = releaseMilestones
-              .sort( (a, b) => b.version - a.version )
-              .filter( ( m, index ) => 0 !== index || ( releaseEventFound && m.title === upcomingMilestone ) );
+              // Check the plugin version on the release branch.
+              try {
+                const fileResponse = await github.rest.repos.getContent( {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: 'plugins/woocommerce/woocommerce.php',
+                  ref: `release/${version}`
+                } );
+
+                const content = Buffer.from( fileResponse.data.content, 'base64' ).toString( 'utf8' );
+                const versionMatch = content.match( /^\s*\*\s*Version:\s*(.+)$/m );
+
+                if ( versionMatch ) {
+                  const pluginVersion = versionMatch[1].trim().toLowerCase();
+                  const isPreRelease = /dev|rc|beta/.test( pluginVersion );
+
+                  // Skip pre-release versions unless they match the upcoming milestone.
+                  if ( isPreRelease && milestone.title !== upcomingMilestone ) {
+                    console.log( `Skipping milestone ${milestone.title} - pre-release version (${pluginVersion}) and not upcoming.` );
+                    continue;
+                  }
+                }
+              } catch ( error ) {
+                console.log( `Could not check plugin version for ${milestone.title}: ${error.message}` );
+              }
+
+              releaseMilestones.push( {
+                  title: milestone.title,
+                  number: milestone.number,
+                  version: parseFloat( version )
+              } );
+            }
 
             // Build report.
             const milestoneReports = [];
@@ -221,7 +243,12 @@ jobs:
               milestoneReports.push( reportLines.join( '\n' ) );
             }
 
-            core.setOutput( 'slack-message', milestoneReports.join( '\n\n' ) );
+            const fullReport = [];
+            fullReport.push( `:fyi: The following release milestones have open items:` );
+            fullReport.push( '\n\n' );
+            fullReport.push( milestoneReports.join( '\n\n' ) );
+
+            core.setOutput( 'slack-message', fullReport.join( '' ) );
 
       - name: Send Slack Message
         if: ${{ steps.process-milestones.outputs.slack-message != '' }}

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -134,74 +134,86 @@ jobs:
             const releaseEventTitle = '${{ needs.check-upcoming-release-events.outputs.release-event-title }}';
             const releaseEventDate  = '${{ needs.check-upcoming-release-events.outputs.release-event-date }}';
 
-            // Fetch all open milestones.
-            const milestones = await github.rest.issues.listMilestones( {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 10
-            } );
-
+            /**
+             * Fetches and filters milestones to only include those with a release branch and valid version.
+             *
+             * @returns {Array} The filtered milestones.
+             */
             const versionPattern = /^(\d+\.\d+)\.0$/;
-            let releaseMilestones = [];
+            const getReleaseMilestones = async () => {
+              const milestones = await github.rest.issues.listMilestones( {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 10
+              } );
 
-            for ( const milestone of milestones.data ) {
-              // Skip if not in format "X.Y.0".
-              if ( ! versionPattern.test( milestone.title ) ) {
-                continue;
-              }
+              const result = [];
 
-              // Extract X.Y from milestone title.
-              const version = milestone.title.match( versionPattern )[1];
-
-              // Skip if there isn't a release branch associated.
-              try {
-                await github.rest.repos.getBranch( {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  branch: `release/${version}`
-                } );
-              } catch ( error ) {
-                if ( 404 === error.status ) {
-                  console.log( `Skipping milestone ${milestone.title} - release branch does not exist.` );
+              for ( const milestone of milestones.data ) {
+                // Skip if not in format "X.Y.0".
+                if ( ! versionPattern.test( milestone.title ) ) {
                   continue;
-                } else {
-                  throw error;
                 }
-              }
 
-              // Check the plugin version on the release branch.
-              try {
-                const fileResponse = await github.rest.repos.getContent( {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path: 'plugins/woocommerce/woocommerce.php',
-                  ref: `release/${version}`
-                } );
+                // Extract X.Y from milestone title.
+                const version = milestone.title.match( versionPattern )[1];
 
-                const content = Buffer.from( fileResponse.data.content, 'base64' ).toString( 'utf8' );
-                const versionMatch = content.match( /^\s*\*\s*Version:\s*(.+)$/m );
-
-                if ( versionMatch ) {
-                  const pluginVersion = versionMatch[1].trim().toLowerCase();
-                  const isPreRelease = /dev|rc|beta/.test( pluginVersion );
-
-                  // Skip pre-release versions unless they match the upcoming milestone.
-                  if ( isPreRelease && milestone.title !== upcomingMilestone ) {
-                    console.log( `Skipping milestone ${milestone.title} - pre-release version (${pluginVersion}) and not upcoming.` );
+                // Skip if there isn't a release branch associated.
+                try {
+                  await github.rest.repos.getBranch( {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    branch: `release/${version}`
+                  } );
+                } catch ( error ) {
+                  if ( 404 === error.status ) {
+                    console.log( `Skipping milestone ${milestone.title} - release branch does not exist.` );
                     continue;
+                  } else {
+                    throw error;
                   }
                 }
-              } catch ( error ) {
-                console.log( `Could not check plugin version for ${milestone.title}: ${error.message}` );
-              }
 
-              releaseMilestones.push( {
+                // Check the plugin version on the release branch.
+                try {
+                  const fileResponse = await github.rest.repos.getContent( {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    path: 'plugins/woocommerce/woocommerce.php',
+                    ref: `release/${version}`
+                  } );
+
+                  const content = Buffer.from( fileResponse.data.content, 'base64' ).toString( 'utf8' );
+                  const versionMatch = content.match( /^\s*\*\s*Version:\s*(.+)$/m );
+
+                  if ( versionMatch ) {
+                    const pluginVersion = versionMatch[1].trim().toLowerCase();
+                    const isPreRelease = /dev|rc|beta/.test( pluginVersion );
+
+                    // Skip pre-release versions unless they match the upcoming milestone.
+                    if ( isPreRelease && milestone.title !== upcomingMilestone ) {
+                      console.log( `Skipping milestone ${milestone.title} - pre-release version (${pluginVersion}) and not upcoming.` );
+                      continue;
+                    }
+                  }
+                } catch ( error ) {
+                  console.log( `Could not check plugin version for ${milestone.title}: ${error.message}` );
+                }
+
+                result.push( {
                   title: milestone.title,
                   number: milestone.number,
                   version: parseFloat( version )
-              } );
-            }
+                } );
+              }
+
+              result.sort( (a, b) => b.version - a.version );
+
+              return result;
+            };
+
+            const releaseMilestones = await getReleaseMilestones();
 
             // Build report.
             const milestoneReports = [];
@@ -248,7 +260,10 @@ jobs:
             fullReport.push( '\n\n' );
             fullReport.push( milestoneReports.join( '\n\n' ) );
 
-            core.setOutput( 'slack-message', fullReport.join( '' ) );
+            console.log( fullReport.join( '' ) );
+
+            // core.setOutput( 'slack-message', fullReport.join( '' ) );
+            core.setOutput( 'slack-message', '' );
 
       - name: Send Slack Message
         if: ${{ steps.process-milestones.outputs.slack-message != '' }}

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -220,7 +220,7 @@ jobs:
             for ( const milestone of releaseMilestones ) {
               const milestoneResults = await github.rest.search.issuesAndPullRequests( {
                 q: `milestone:"${milestone.title}" state:open repo:${context.repo.owner}/${context.repo.repo}`,
-                per_page: 11 // Paginate to 11 items.
+                per_page: 6
               } );
 
               const totalCount = milestoneResults.data.total_count;
@@ -242,28 +242,30 @@ jobs:
                 reportLines.push( `  _*${releaseEventTitle}* coming up on *${formattedDate}*_` );
               }
 
-              const shouldPaginate = totalCount >= 12;
-              const itemsToShow    = shouldPaginate ? milestoneItems.slice( 0, 10 ) : milestoneItems;
+              const shouldPaginate = totalCount >= 6;
+              const itemsToShow    = shouldPaginate ? milestoneItems.slice( 0, 5 ) : milestoneItems;
               reportLines.push( ...( await Promise.all( itemsToShow.map( formatItem ) ) ) );
 
               if ( shouldPaginate ) {
-                const remainingCount = totalCount - 10;
+                const remainingCount = totalCount - 5;
                 const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${milestone.number}`;
-                reportLines.push( `<${milestoneUrl}|... and ${remainingCount} more>` );
+                reportLines.push( `• <${milestoneUrl}|... and *${remainingCount}* more items>.` );
               }
 
               milestoneReports.push( reportLines.join( '\n' ) );
             }
 
-            const fullReport = [];
-            fullReport.push( `:fyi: The following release milestones have open items:` );
-            fullReport.push( '\n\n' );
-            fullReport.push( milestoneReports.join( '\n\n' ) );
+            if ( milestoneReports.length > 0 ) {
+              const fullReport = [];
+              fullReport.push( `:fyi: The following release milestones have open items:` );
+              fullReport.push( '\n\n' );
+              fullReport.push( milestoneReports.join( '\n\n' ) );
 
-            console.log( fullReport.join( '' ) );
+              core.setOutput( 'slack-message', fullReport.join( '' ) );
+            } else {
+              core.setOutput( 'slack-message', '' );
+            }
 
-            // core.setOutput( 'slack-message', fullReport.join( '' ) );
-            core.setOutput( 'slack-message', '' );
 
       - name: Send Slack Message
         if: ${{ steps.process-milestones.outputs.slack-message != '' }}

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -72,109 +72,6 @@ jobs:
             } catch (error) {
               core.setFailed(`Failed to fetch calendar events: ${error.message}`);
             }
-      - name: Build Slack Message with Open Milestoned Issues
-        id: get-milestone-items
-        if: ${{ steps.check-upcoming-release-build.outputs.release-event-found == 'true' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          script: |
-            const milestone = '${{ steps.check-upcoming-release-build.outputs.milestone }}';
-
-            console.log(`Searching for open issues and PRs in milestone: ${milestone}`);
-
-            try {
-              // Search for issues in the milestone
-              const searchQuery = `milestone:"${milestone}" state:open repo:${context.repo.owner}/${context.repo.repo}`;
-
-              const searchResults = await github.rest.search.issuesAndPullRequests({
-                q: searchQuery,
-                per_page: 20,
-                advanced_search: true
-              });
-
-              console.log(`Found ${searchResults.data.total_count} open items in milestone ${milestone}`);
-
-              if (searchResults.data.total_count === 0) {
-                core.setOutput('slack-message', '');
-                core.setOutput('has-items', 'false');
-                return;
-              }
-
-              const items = [];
-
-              // Process each item to get detailed information
-              for (const item of searchResults.data.items) {
-                let waitingOn = [];
-
-                // Get assignees
-                if (item.assignees && item.assignees.length > 0) {
-                  waitingOn.push(...item.assignees.map(a => a.login));
-                }
-
-                // For PRs, also get requested reviewers
-                if (item.pull_request) {
-                  try {
-                    const reviewers = await github.rest.pulls.listRequestedReviewers({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      pull_number: item.number
-                    });
-
-                    if (reviewers.data.users && reviewers.data.users.length > 0) {
-                      waitingOn.push(...reviewers.data.users.map(r => r.login));
-                    }
-                  } catch (error) {
-                    console.log(`Failed to get reviewers for PR #${item.number}: ${error.message}`);
-                  }
-                }
-
-                const uniqueWaitingOn = [...new Set(waitingOn)];
-                const createdDate = new Date(item.created_at).toISOString().split('T')[0];
-                const author = item.user ? item.user.login : 'unknown';
-
-                const waitingOnText = uniqueWaitingOn.length > 0 ?
-                  `Waiting on ${uniqueWaitingOn.join(', ')}` :
-                  'No assignees/reviewers';
-
-                const itemUrl = item.pull_request
-                  ? `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${item.number}`
-                  : `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${item.number}`;
-
-                const formattedItem = `• [#${item.number}] <${itemUrl}|${item.title}> (${author})\n  Created ${createdDate} · ${waitingOnText}`;
-
-                items.push(formattedItem);
-              }
-
-              const releaseEventTitle = '${{ steps.check-upcoming-release-build.outputs.release-event-title }}';
-              const releaseEventDate = '${{ steps.check-upcoming-release-build.outputs.release-event-date }}';
-              const formattedDate = new Date(releaseEventDate).toISOString().split('T')[0];
-
-              // Build the complete Slack message
-              const slackMessage = [
-                `🚨 Milestone ${milestone} has ${searchResults.data.total_count} open items for ${releaseEventTitle} on ${formattedDate}\n`,
-                ...items
-              ].join('\n');
-
-              core.setOutput('slack-message', slackMessage);
-              core.setOutput('has-items', 'true');
-              console.log(`slack-message: ${slackMessage}`);
-
-            } catch (error) {
-              console.error(`Error fetching milestone items: ${error.message}`);
-              core.setFailed(`Failed to fetch milestone items: ${error.message}`);
-            }
-
-      - name: Send Slack Message
-        if: ${{ steps.get-milestone-items.outputs.has-items == 'true' }}
-        uses: archive/github-actions-slack@c643e5093620d65506466f2c9b317d5d29a5e517 # v2.10.1
-        env:
-          SLACK_MESSAGE: ${{ steps.get-milestone-items.outputs.slack-message }}
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-          slack-optional-unfurl_links: false
-          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
-          slack-text: |
-            ${{ env.SLACK_MESSAGE }}
 
   check-milestones:
     name: Check all open milestones
@@ -190,12 +87,12 @@ jobs:
             const formatItem = async (item, github, context) => {
               let waitingOn = [];
 
-              // Get assignees
+              // Get assignees.
               if (item.assignees && item.assignees.length > 0) {
                 waitingOn.push(...item.assignees.map(a => a.login));
               }
 
-              // For PRs, also get requested reviewers
+              // For PRs, also get requested reviewers.
               if (item.pull_request) {
                 try {
                   const reviewers = await github.rest.pulls.listRequestedReviewers({
@@ -302,4 +199,17 @@ jobs:
               milestoneReports.push( reportLines.join( '\n' ) );
             }
 
-            core.setOutput( 'slack-message', milestoneReports.join('\n\n') );
+            const fullReport = milestoneReports.join('\n\n');
+            core.setOutput( 'slack-message', fullReport );
+
+      - name: Send Slack Message
+        if: ${{ steps.process-milestones.outputs.slack-message != '' }}
+        uses: archive/github-actions-slack@c643e5093620d65506466f2c9b317d5d29a5e517 # v2.10.1
+        env:
+          SLACK_MESSAGE: ${{ steps.process-milestones.outputs.slack-message }}
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+          slack-optional-unfurl_links: false
+          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
+          slack-text: |
+            ${{ env.SLACK_MESSAGE }}

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -175,3 +175,121 @@ jobs:
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
           slack-text: |
             ${{ env.SLACK_MESSAGE }}
+
+  check-milestones:
+    name: Check all open milestones
+    needs: check-upcoming-release-events
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    steps:
+      - name: Get and process open milestones
+        id: process-milestones
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            // Helper function to format an item (issue or PR).
+            const formatItem = async (item, github, context) => {
+              let waitingOn = [];
+
+              // Get assignees
+              if (item.assignees && item.assignees.length > 0) {
+                waitingOn.push(...item.assignees.map(a => a.login));
+              }
+
+              // For PRs, also get requested reviewers
+              if (item.pull_request) {
+                try {
+                  const reviewers = await github.rest.pulls.listRequestedReviewers({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: item.number
+                  });
+
+                  if (reviewers.data.users && reviewers.data.users.length > 0) {
+                    waitingOn.push(...reviewers.data.users.map(r => r.login));
+                  }
+                } catch (error) {
+                  console.log(`Failed to get reviewers for PR #${item.number}: ${error.message}`);
+                }
+              }
+
+              const uniqueWaitingOn = [...new Set(waitingOn)];
+              const createdDate = new Date(item.created_at).toISOString().split('T')[0];
+              const author = item.user ? item.user.login : 'unknown';
+
+              const waitingOnText = uniqueWaitingOn.length > 0 ?
+                `Waiting on ${uniqueWaitingOn.join(', ')}` :
+                'No assignees/reviewers';
+
+              const itemUrl = item.pull_request
+                ? `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${item.number}`
+                : `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${item.number}`;
+
+              return `• [#${item.number}] <${itemUrl}|${item.title}> (${author})\n  Created ${createdDate} · ${waitingOnText}`;
+            }
+
+            const releaseEventFound = '${{ needs.check-upcoming-release-events.outputs.release-event-found }}' === 'true';
+            const upcomingMilestone = '${{ needs.check-upcoming-release-events.outputs.milestone }}';
+            const releaseEventTitle = '${{ needs.check-upcoming-release-events.outputs.release-event-title }}';
+            const releaseEventDate  = '${{ needs.check-upcoming-release-events.outputs.release-event-date }}';
+
+            // Fetch all open milestones.
+            const milestones = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 10
+            });
+
+            // Filter milestones matching X.Y.0 format.
+            const versionPattern = /^(\d+\.\d+)\.0$/;
+            const filteredMilestones = milestones.data
+              .filter(m => versionPattern.test(m.title))
+              .map(m => {
+                const match = m.title.match(versionPattern);
+                return {
+                  title: m.title,
+                  number: m.number,
+                  version: parseFloat(match[1])
+                };
+              })
+              .sort((a, b) => b.version - a.version);
+
+            const milestoneReports = [];
+            for (const milestone of filteredMilestones) {
+              // Search for issues and PRs in the milestone
+              const milestoneResults = await github.rest.search.issuesAndPullRequests({
+                q: `milestone:"${milestone.title}" state:open repo:${context.repo.owner}/${context.repo.repo}`,
+                per_page: 100
+              });
+
+              const milestoneItems = milestoneResults.data.items;
+              console.log(`Found ${milestoneItems.length} open items for milestone ${milestone.title}`);
+
+              if ( milestoneItems.length === 0 ) {
+                continue;
+              }
+
+              // Build the report for this milestone.
+              const formattedItems = [];
+
+              for (const item of milestoneItems) {
+                const formattedItem = await formatItem(item, github, context);
+                formattedItems.push(formattedItem);
+              }
+
+              const reportLines = [];
+              reportLines.push( `*_${milestone.title}_* (${milestoneItems.length} items)` );
+
+              // Milestone matches upcoming release.
+              if ( releaseEventFound && milestone.title === upcomingMilestone ) {
+                const formattedDate = new Date( releaseEventDate ).toISOString().split( 'T' )[0];
+                reportLines.push( `📅 ${releaseEventTitle} on ${formattedDate}` );
+              }
+
+              reportLines.push( '' ); // Empty line before items.
+              reportLines.push( ...formattedItems );
+
+              milestoneReports.push( reportLines.join( '\n' ) );
+            }
+
+            core.setOutput( 'slack-message', milestoneReports.join('\n\n') );

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -187,18 +187,22 @@ jobs:
                   const content = Buffer.from( fileResponse.data.content, 'base64' ).toString( 'utf8' );
                   const versionMatch = content.match( /^\s*\*\s*Version:\s*(.+)$/m );
 
-                  if ( versionMatch ) {
-                    const pluginVersion = versionMatch[1].trim().toLowerCase();
-                    const isPreRelease = /dev|rc|beta/.test( pluginVersion );
+                  if ( ! versionMatch ) {
+                    console.log( `Could not find version in ${milestone.title}` );
+                    continue;
+                  }
 
-                    // Skip pre-release versions unless they match the upcoming milestone.
-                    if ( isPreRelease && milestone.title !== upcomingMilestone ) {
-                      console.log( `Skipping milestone ${milestone.title} - pre-release version (${pluginVersion}) and not upcoming.` );
-                      continue;
-                    }
+                  const pluginVersion = versionMatch[1].trim().toLowerCase();
+                  const isPreRelease = /dev|rc|beta/.test( pluginVersion );
+
+                  // Skip pre-release versions unless they match the upcoming milestone.
+                  if ( isPreRelease && milestone.title !== upcomingMilestone ) {
+                    console.log( `Skipping milestone ${milestone.title} - pre-release version (${pluginVersion}) and not upcoming.` );
+                    continue;
                   }
                 } catch ( error ) {
                   console.log( `Could not check plugin version for ${milestone.title}: ${error.message}` );
+                  continue;
                 }
 
                 result.push( {

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -12,6 +12,12 @@ jobs:
   check-upcoming-release-events:
     name: Check for upcoming release events
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    outputs:
+      version: ${{ steps.check-upcoming-release-build.outputs.version }}
+      milestone: ${{ steps.check-upcoming-release-build.outputs.milestone }}
+      release-event-found: ${{ steps.check-upcoming-release-build.outputs.release-event-found }}
+      release-event-date: ${{ steps.check-upcoming-release-build.outputs.release-event-date }}
+      release-event-title: ${{ steps.check-upcoming-release-build.outputs.release-event-title }}
     steps:
       - name: Install node-ical
         run: npm install node-ical
@@ -33,15 +39,15 @@ jobs:
               const upcomingReleaseEvents = Object.values(events)
                 .filter(e => {
                   if (e.type !== 'VEVENT') return false;
-            
+
                   if (!e.start) return false;
-            
+
                   const startDate = new Date(e.start);
                   if (isNaN(startDate.getTime())) return false;
-            
+
                   const diff = startDate - now;
                   if (diff < 0 || diff > eventWindowInMs) return false; // Must be between now and 72h from now
-            
+
                   return pattern.test(e.summary || '');
                 })
                 .sort((a, b) => new Date(a.start) - new Date(b.start));
@@ -49,11 +55,14 @@ jobs:
               if (upcomingReleaseEvents.length > 0) {
                 const date = upcomingReleaseEvents[0].start.toISOString();
                 const version = upcomingReleaseEvents[0].summary.match(/\d+\.\d+/)[0];
+                const milestone = `${version}.0`;
                 console.log(`Found Release event: ${upcomingReleaseEvents[0].summary}`);
                 console.log(`Date: ${date}`);
                 console.log(`Version: ${version}`);
+                console.log(`Milestone: ${milestone}`);
                 core.setOutput('release-event-found', 'true');
                 core.setOutput('version', version);
+                core.setOutput('milestone', milestone);
                 core.setOutput('release-event-date', date);
                 core.setOutput('release-event-title', upcomingReleaseEvents[0].summary);
               } else {
@@ -69,40 +78,39 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
-            const version = '${{ steps.check-upcoming-release-build.outputs.version }}';
-            const milestone = `${version}.0`;
-            
+            const milestone = '${{ steps.check-upcoming-release-build.outputs.milestone }}';
+
             console.log(`Searching for open issues and PRs in milestone: ${milestone}`);
-            
+
             try {
               // Search for issues in the milestone
               const searchQuery = `milestone:"${milestone}" state:open repo:${context.repo.owner}/${context.repo.repo}`;
-            
+
               const searchResults = await github.rest.search.issuesAndPullRequests({
                 q: searchQuery,
                 per_page: 20,
                 advanced_search: true
               });
-            
+
               console.log(`Found ${searchResults.data.total_count} open items in milestone ${milestone}`);
-            
+
               if (searchResults.data.total_count === 0) {
                 core.setOutput('slack-message', '');
                 core.setOutput('has-items', 'false');
                 return;
               }
-            
+
               const items = [];
-            
+
               // Process each item to get detailed information
               for (const item of searchResults.data.items) {
                 let waitingOn = [];
-            
+
                 // Get assignees
                 if (item.assignees && item.assignees.length > 0) {
                   waitingOn.push(...item.assignees.map(a => a.login));
                 }
-            
+
                 // For PRs, also get requested reviewers
                 if (item.pull_request) {
                   try {
@@ -111,7 +119,7 @@ jobs:
                       repo: context.repo.repo,
                       pull_number: item.number
                     });
-            
+
                     if (reviewers.data.users && reviewers.data.users.length > 0) {
                       waitingOn.push(...reviewers.data.users.map(r => r.login));
                     }
@@ -119,38 +127,38 @@ jobs:
                     console.log(`Failed to get reviewers for PR #${item.number}: ${error.message}`);
                   }
                 }
-            
+
                 const uniqueWaitingOn = [...new Set(waitingOn)];
                 const createdDate = new Date(item.created_at).toISOString().split('T')[0];
                 const author = item.user ? item.user.login : 'unknown';
-            
-                const waitingOnText = uniqueWaitingOn.length > 0 ? 
-                  `Waiting on ${uniqueWaitingOn.join(', ')}` : 
+
+                const waitingOnText = uniqueWaitingOn.length > 0 ?
+                  `Waiting on ${uniqueWaitingOn.join(', ')}` :
                   'No assignees/reviewers';
-            
-                const itemUrl = item.pull_request 
+
+                const itemUrl = item.pull_request
                   ? `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${item.number}`
                   : `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${item.number}`;
 
                 const formattedItem = `• [#${item.number}] <${itemUrl}|${item.title}> (${author})\n  Created ${createdDate} · ${waitingOnText}`;
-            
+
                 items.push(formattedItem);
               }
 
               const releaseEventTitle = '${{ steps.check-upcoming-release-build.outputs.release-event-title }}';
               const releaseEventDate = '${{ steps.check-upcoming-release-build.outputs.release-event-date }}';
               const formattedDate = new Date(releaseEventDate).toISOString().split('T')[0];
-            
+
               // Build the complete Slack message
               const slackMessage = [
                 `🚨 Milestone ${milestone} has ${searchResults.data.total_count} open items for ${releaseEventTitle} on ${formattedDate}\n`,
                 ...items
               ].join('\n');
-            
+
               core.setOutput('slack-message', slackMessage);
               core.setOutput('has-items', 'true');
               console.log(`slack-message: ${slackMessage}`);
-            
+
             } catch (error) {
               console.error(`Error fetching milestone items: ${error.message}`);
               core.setFailed(`Failed to fetch milestone items: ${error.message}`);

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -83,8 +83,13 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
-            // Helper function to format an item (issue or PR).
-            const formatItem = async (item, github, context) => {
+            /**
+              * Formats an item (issue or PR) into a string for a Slack message.
+              *
+              * @param {Object} item - The item to format.
+              * @returns {string} The formatted item.
+              */
+            const formatItem = async (item) => {
               let waitingOn = [];
 
               // Get assignees.
@@ -121,7 +126,7 @@ jobs:
                 ? `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${item.number}`
                 : `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${item.number}`;
 
-              return `• [#${item.number}] <${itemUrl}|${item.title}> (${author})\n  Created ${createdDate} · ${waitingOnText}`;
+              return `• <${itemUrl}|#${item.number}: ${item.title}> (${author})\n  Created ${createdDate} · ${waitingOnText}`;
             }
 
             const releaseEventFound = '${{ needs.check-upcoming-release-events.outputs.release-event-found }}' === 'true';
@@ -130,33 +135,58 @@ jobs:
             const releaseEventDate  = '${{ needs.check-upcoming-release-events.outputs.release-event-date }}';
 
             // Fetch all open milestones.
-            const milestones = await github.rest.issues.listMilestones({
+            const milestones = await github.rest.issues.listMilestones( {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               per_page: 10
-            });
+            } );
 
-            // Filter milestones matching X.Y.0 format.
             const versionPattern = /^(\d+\.\d+)\.0$/;
-            const filteredMilestones = milestones.data
-              .filter(m => versionPattern.test(m.title))
-              .map(m => {
-                const match = m.title.match(versionPattern);
-                return {
-                  title: m.title,
-                  number: m.number,
-                  version: parseFloat(match[1])
-                };
-              })
-              .sort((a, b) => b.version - a.version);
+            let releaseMilestones = [];
 
+            for ( const milestone of milestones.data ) {
+              // Skip if not in format "X.Y.0".
+              if ( ! versionPattern.test( milestone.title ) ) {
+                continue;
+              }
+
+              // Extract X.Y from milestone title.
+              const version = milestone.title.match( versionPattern )[1];
+
+              // Skip if there isn't a release branch associated.
+              try {
+                await github.rest.repos.getBranch( {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: `release/${version}`
+                } );
+
+                releaseMilestones.push( {
+                  title: milestone.title,
+                  number: milestone.number,
+                  version: parseFloat( version )
+                } );
+              } catch ( error ) {
+                if ( 404 === error.status ) {
+                  console.log( `Skipping milestone ${milestone.title} - release branch does not exist.` );
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            // Sort and filter milestones. Don't include the upcoming milestone unless it matches the upcoming release event.
+            releaseMilestones = releaseMilestones
+              .sort( (a, b) => b.version - a.version )
+              .filter( ( m, index ) => 0 !== index || ( releaseEventFound && m.title === upcomingMilestone ) );
+
+            // Build report.
             const milestoneReports = [];
-            for ( const milestone of filteredMilestones ) {
-              // Search for issues and PRs in the milestone (fetch only 11 items).
+            for ( const milestone of releaseMilestones ) {
               const milestoneResults = await github.rest.search.issuesAndPullRequests( {
                 q: `milestone:"${milestone.title}" state:open repo:${context.repo.owner}/${context.repo.repo}`,
-                per_page: 11
+                per_page: 11 // Paginate to 11 items.
               } );
 
               const totalCount = milestoneResults.data.total_count;
@@ -168,39 +198,30 @@ jobs:
               }
 
               // Build the report for this milestone.
-              const formattedItems = [];
-              const shouldPaginate = totalCount >= 12;
-              const itemsToShow = shouldPaginate ? milestoneItems.slice( 0, 10 ) : milestoneItems;
+              let reportLines = [];
 
-              for (const item of itemsToShow) {
-                const formattedItem = await formatItem( item, github, context );
-                formattedItems.push( formattedItem );
+              reportLines.push( `*${milestone.title}*` );
+
+              if ( releaseEventFound && milestone.title === upcomingMilestone ) {
+                // Milestone matches upcoming release.
+                const formattedDate = new Date( releaseEventDate ).toISOString().split( 'T' )[0];
+                reportLines.push( `  _*${releaseEventTitle}* coming up on *${formattedDate}*_` );
               }
 
-              // Add "... and X more" link if there are more items.
-              if (shouldPaginate) {
+              const shouldPaginate = totalCount >= 12;
+              const itemsToShow    = shouldPaginate ? milestoneItems.slice( 0, 10 ) : milestoneItems;
+              reportLines.push( ...( await Promise.all( itemsToShow.map( formatItem ) ) ) );
+
+              if ( shouldPaginate ) {
                 const remainingCount = totalCount - 10;
                 const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${milestone.number}`;
-                formattedItems.push(`<${milestoneUrl}|... and ${remainingCount} more>`);
+                reportLines.push( `<${milestoneUrl}|... and ${remainingCount} more>` );
               }
-
-              const reportLines = [];
-              reportLines.push( `*_${milestone.title}_* (${totalCount} items)` );
-
-              // Milestone matches upcoming release.
-              if ( releaseEventFound && milestone.title === upcomingMilestone ) {
-                const formattedDate = new Date( releaseEventDate ).toISOString().split( 'T' )[0];
-                reportLines.push( `📅 ${releaseEventTitle} on ${formattedDate}` );
-              }
-
-              reportLines.push( '' ); // Empty line before items.
-              reportLines.push( ...formattedItems );
 
               milestoneReports.push( reportLines.join( '\n' ) );
             }
 
-            const fullReport = milestoneReports.join('\n\n');
-            core.setOutput( 'slack-message', fullReport );
+            core.setOutput( 'slack-message', milestoneReports.join( '\n\n' ) );
 
       - name: Send Slack Message
         if: ${{ steps.process-milestones.outputs.slack-message != '' }}

--- a/.github/workflows/release-open-issue-warning.yml
+++ b/.github/workflows/release-open-issue-warning.yml
@@ -255,30 +255,40 @@ jobs:
               .sort((a, b) => b.version - a.version);
 
             const milestoneReports = [];
-            for (const milestone of filteredMilestones) {
-              // Search for issues and PRs in the milestone
-              const milestoneResults = await github.rest.search.issuesAndPullRequests({
+            for ( const milestone of filteredMilestones ) {
+              // Search for issues and PRs in the milestone (fetch only 11 items).
+              const milestoneResults = await github.rest.search.issuesAndPullRequests( {
                 q: `milestone:"${milestone.title}" state:open repo:${context.repo.owner}/${context.repo.repo}`,
-                per_page: 100
-              });
+                per_page: 11
+              } );
 
+              const totalCount = milestoneResults.data.total_count;
               const milestoneItems = milestoneResults.data.items;
-              console.log(`Found ${milestoneItems.length} open items for milestone ${milestone.title}`);
+              console.log( `Found ${totalCount} open items for milestone ${milestone.title}` );
 
-              if ( milestoneItems.length === 0 ) {
+              if ( totalCount === 0 ) {
                 continue;
               }
 
               // Build the report for this milestone.
               const formattedItems = [];
+              const shouldPaginate = totalCount >= 12;
+              const itemsToShow = shouldPaginate ? milestoneItems.slice( 0, 10 ) : milestoneItems;
 
-              for (const item of milestoneItems) {
-                const formattedItem = await formatItem(item, github, context);
-                formattedItems.push(formattedItem);
+              for (const item of itemsToShow) {
+                const formattedItem = await formatItem( item, github, context );
+                formattedItems.push( formattedItem );
+              }
+
+              // Add "... and X more" link if there are more items.
+              if (shouldPaginate) {
+                const remainingCount = totalCount - 10;
+                const milestoneUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/milestone/${milestone.number}`;
+                formattedItems.push(`<${milestoneUrl}|... and ${remainingCount} more>`);
               }
 
               const reportLines = [];
-              reportLines.push( `*_${milestone.title}_* (${milestoneItems.length} items)` );
+              reportLines.push( `*_${milestone.title}_* (${totalCount} items)` );
 
               // Milestone matches upcoming release.
               if ( releaseEventFound && milestone.title === upcomingMilestone ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Currently, we run a daily workflow to notify in Slack if there are any open items (issues or PRs) against a milestone that has a release in the next 72 hours (per the release calendar).

This PR adds old milestone to the notification, ensuring we don't lose track of pending items on release branches that have been already released. It also improves the formatting of the notification.

The new logic is as follows: only open milestones with a corresponding release branch are considered (so work happening on `trunk` is not) and, of those, we consider only release branches that correspond to stable releases or that have an upcoming pre-release (beta, dev, RC) coming up in the next 72 hours.

Closes #62359.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository. Include at least the `trunk` and `release/10.4` branches.
1. 
1. Ensure your fork has milestones `10.6.0`, `10.5.0` and `10.4.0`.
1. In your forked repo, go to **Settings > Secrets and variables > Actions** and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
- `RELEASE_CALENDAR_ID`: `46e4204b5406a5c6df48addc0dfd3a29e5e69ad7e991b165fa4e331f03ede0e0@group.calendar.google.com` (it already has the event necessary for this workflow to run properly).
1. Merge this branch (`fix/62359`) into your fork's `trunk`.
1. Go to **Code > Branches** in your fork, and create a new branch `release/10.5` based off `trunk`.
1. Use the GH UI to open a couple of PRs with any change against `trunk` (with milestone `10.5.0`) and one against `release/10.4` (with milestone `10.4.0`).
1. Similarly, ensure at least one release event related to 10.5.0 is scheduled in the next 72 hours on the "Test Releases" calendar.
   Currently, the calendar has "WooCommerce 10.5 Beta 1" on Friday.
1. Go to **Workflows > Release: Open Issue Warning** and run the workflow.
1. Once it completes, a notification should've been sent to `#test-woo-core-release-notifications` in Slack, listing both of the PRs you've created. It should look something like this:
   <img width="624" height="393" alt="Screenshot 2026-01-06 at 14 17 33" src="https://github.com/user-attachments/assets/83aaa261-f960-4fdf-97ed-6354e7aa9393" />
1. Now, move the event calendar to next week and run the workflow again. Confirm that the "10.5.0" milestone is no longer included.
1. Move back the event calendar to the next 72 hours but remove the `release/10.5` branch from your fork. Run the workflow again and confirm that the "10.5.0" milestone is not included.
1. Remove the milestone on your PR currently with milestone `10.4.0` or change it to `10.5.0` (which no longer has an associated release branch).
1. Run the workflow again and confirm that it completes successfully but no notification is sent to Slack as there aren't any open items against a stable release branch or a release branch with upcoming events.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.