### PR TITLE
Add new email pattern categories and load them dynamically from block patterns

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add category tabs navigation to email template selection modal

--- a/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add category tabs navigation to email template selection modal. The TemplateCategory type is now a string (previously 'recent' | 'basic') to support dynamic categories loaded from block patterns.
+Add category tabs navigation to email template selection modal. The TemplateCategory type is now a string to support dynamic categories loaded from block patterns.

--- a/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/js/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add category tabs navigation to email template selection modal
+Add category tabs navigation to email template selection modal. The TemplateCategory type is now a string (previously 'recent' | 'basic') to support dynamic categories loaded from block patterns.

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -4,6 +4,7 @@
 import { useState, useEffect, useMemo, memo } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
+import type { UserPatternCategory } from '@wordpress/core-data/build-types/selectors';
 import { dispatch, useSelect } from '@wordpress/data';
 import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -22,14 +23,9 @@ import { TemplateList } from './template-list';
 import { TemplateCategoriesListSidebar } from './template-categories-list-sidebar';
 import { recordEvent, recordEventOnce } from '../../events';
 
-type PatternCategory = {
-	name: string;
-	label: string;
-};
-
 function getCategoriesFromTemplates(
 	templates: TemplatePreview[],
-	patternCategories: PatternCategory[]
+	patternCategories: UserPatternCategory[]
 ): Array< { name: TemplateCategory; label: string } > {
 	const categoryLabels = new Map< string, string >(
 		patternCategories.map( ( cat ) => [ cat.name, cat.label ] )
@@ -59,7 +55,7 @@ function SelectTemplateBody( {
 		( select ) =>
 			select(
 				coreStore
-			).getBlockPatternCategories() as PatternCategory[],
+			).getBlockPatternCategories() as UserPatternCategory[],
 		[]
 	);
 
@@ -93,7 +89,7 @@ function SelectTemplateBody( {
 
 	useEffect( () => {
 		if ( selectedCategory !== null || displayCategories.length === 0 ) {
-			return;
+			return undefined;
 		}
 
 		const timeoutId = setTimeout( () => {

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -96,12 +96,14 @@ function SelectTemplateBody( {
 			return;
 		}
 
-		setTimeout( () => {
+		const timeoutId = setTimeout( () => {
 			const defaultCategory =
 				displayCategories.find( ( cat ) => cat.name !== 'recent' )
 					?.name ?? displayCategories[ 0 ]?.name;
 			setSelectedCategory( defaultCategory );
 		}, 1000 ); // using setTimeout to ensure the template styles are available before block preview
+
+		return () => clearTimeout( timeoutId );
 	}, [ displayCategories, selectedCategory ] );
 
 	return (

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -24,11 +24,11 @@ import { recordEvent, recordEventOnce } from '../../events';
 const TemplateCategories: Array< { name: TemplateCategory; label: string } > = [
 	{
 		name: 'recent',
-		label: 'Recent',
+		label: __( 'Recent', 'woocommerce' ),
 	},
 	{
 		name: 'basic',
-		label: 'Basic',
+		label: __( 'Basic', 'woocommerce' ),
 	},
 ];
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { useState, useEffect, memo } from '@wordpress/element';
+import { useState, useEffect, useMemo, memo } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
-import { dispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { dispatch, useSelect } from '@wordpress/data';
 import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -21,32 +22,69 @@ import { TemplateList } from './template-list';
 import { TemplateCategoriesListSidebar } from './template-categories-list-sidebar';
 import { recordEvent, recordEventOnce } from '../../events';
 
-const TemplateCategories: Array< { name: TemplateCategory; label: string } > = [
-	{
-		name: 'recent',
-		label: __( 'Recent', 'woocommerce' ),
-	},
-	{
-		name: 'basic',
-		label: __( 'Basic', 'woocommerce' ),
-	},
-];
+type PatternCategory = {
+	name: string;
+	label: string;
+};
+
+function getCategoriesFromTemplates(
+	templates: TemplatePreview[],
+	patternCategories: PatternCategory[]
+): Array< { name: TemplateCategory; label: string } > {
+	const categoryLabels = new Map< string, string >(
+		patternCategories.map( ( cat ) => [ cat.name, cat.label ] )
+	);
+	// Add localized label for 'recent' category (used by email posts)
+	categoryLabels.set( 'recent', __( 'Recent', 'woocommerce' ) );
+
+	const uniqueCategories = new Set< string >();
+	for ( const template of templates ) {
+		if ( template.category ) {
+			uniqueCategories.add( template.category );
+		}
+	}
+
+	return [ ...uniqueCategories ].map( ( category ) => ( {
+		name: category as TemplateCategory,
+		label: categoryLabels.get( category ) ?? category,
+	} ) );
+}
 
 function SelectTemplateBody( {
-	hasEmailPosts,
 	templates,
 	handleTemplateSelection,
 	templateSelectMode,
 } ) {
-	const [ selectedCategory, setSelectedCategory ] = useState(
-		TemplateCategories[ 1 ].name // Show the “Basic” category by default
+	const patternCategories = useSelect(
+		( select ) =>
+			select(
+				coreStore
+			).getBlockPatternCategories() as PatternCategory[],
+		[]
 	);
 
 	const hideRecentCategory = templateSelectMode === 'swap';
 
-	const displayCategories = TemplateCategories.filter(
-		( { name } ) => name !== 'recent' || ! hideRecentCategory
-	);
+	const displayCategories = useMemo( () => {
+		const allCategories = getCategoriesFromTemplates(
+			templates,
+			patternCategories ?? []
+		);
+
+		if ( hideRecentCategory ) {
+			return allCategories.filter( ( cat ) => cat.name !== 'recent' );
+		}
+
+		// Put 'recent' category first
+		return allCategories.sort( ( a, b ) => {
+			if ( a.name === 'recent' ) return -1;
+			if ( b.name === 'recent' ) return 1;
+			return 0;
+		} );
+	}, [ templates, patternCategories, hideRecentCategory ] );
+
+	const [ selectedCategory, setSelectedCategory ] =
+		useState< TemplateCategory | null >( null );
 
 	const handleCategorySelection = ( category: TemplateCategory ) => {
 		recordEvent( 'template_select_modal_category_change', { category } );
@@ -54,12 +92,17 @@ function SelectTemplateBody( {
 	};
 
 	useEffect( () => {
+		if ( selectedCategory !== null || displayCategories.length === 0 ) {
+			return;
+		}
+
 		setTimeout( () => {
-			if ( hasEmailPosts && ! hideRecentCategory ) {
-				setSelectedCategory( TemplateCategories[ 0 ].name );
-			}
+			const defaultCategory =
+				displayCategories.find( ( cat ) => cat.name !== 'recent' )
+					?.name ?? displayCategories[ 0 ]?.name;
+			setSelectedCategory( defaultCategory );
 		}, 1000 ); // using setTimeout to ensure the template styles are available before block preview
-	}, [ hasEmailPosts, hideRecentCategory ] );
+	}, [ displayCategories, selectedCategory ] );
 
 	return (
 		<div className="block-editor-block-patterns-explorer">
@@ -89,8 +132,7 @@ export function SelectTemplateModal( {
 	const templateSelectMode = previewContent ? 'swap' : 'new';
 	recordEventOnce( 'template_select_modal_opened', { templateSelectMode } );
 
-	const [ templates, emailPosts, hasEmailPosts ] =
-		usePreviewTemplates( previewContent );
+	const [ templates, emailPosts ] = usePreviewTemplates( previewContent );
 
 	const hasTemplates = templates?.length > 0;
 
@@ -147,7 +189,6 @@ export function SelectTemplateModal( {
 			isFullScreen
 		>
 			<MemorizedSelectTemplateBody
-				hasEmailPosts={ hasEmailPosts }
 				templates={ [ ...templates, ...emailPosts ] }
 				handleTemplateSelection={ handleTemplateSelection }
 				templateSelectMode={ templateSelectMode }

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -156,7 +156,7 @@ export function usePreviewTemplates(
 						previewContentParsed: parsedTemplate,
 						emailParsed: contentPattern.blocks,
 						template,
-						category: 'basic', // TODO: This will be updated once template category is implemented
+						category: contentPattern.categories?.[ 0 ],
 						type: template.type,
 						displayName: contentPattern.title
 							? `${ template.title.rendered } - ${ contentPattern.title }`

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -167,7 +167,7 @@ export type TemplatePreview = {
 	type: string;
 };
 
-export type TemplateCategory = 'recent' | 'basic';
+export type TemplateCategory = string;
 
 export type Feature =
 	| 'fullscreenMode'

--- a/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add method to retrieve email pattern categories from block patterns
+Add method to retrieve email pattern categories from block patterns. Renamed 'basic' email pattern category to 'newsletter'.

--- a/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add method to retrieve email pattern categories from block patterns

--- a/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
+++ b/packages/php/email-editor/changelog/wooprd-1118-add-category-tabs-navigation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add method to retrieve email pattern categories from block patterns. Renamed 'basic' email pattern category to 'newsletter'.
+Add category tabs navigation to email template selection modal.

--- a/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
+++ b/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
@@ -33,21 +33,6 @@ class Patterns {
 				'label'       => _x( 'Email Contents', 'Block pattern category', 'woocommerce' ),
 				'description' => __( 'A collection of email content layouts.', 'woocommerce' ),
 			),
-			array(
-				'name'        => 'newsletter',
-				'label'       => _x( 'Newsletter', 'Block pattern category', 'woocommerce' ),
-				'description' => __( 'A collection of newsletter email layouts.', 'woocommerce' ),
-			),
-			array(
-				'name'        => 'welcome',
-				'label'       => _x( 'Welcome', 'Block pattern category', 'woocommerce' ),
-				'description' => __( 'A collection of welcome email layouts.', 'woocommerce' ),
-			),
-			array(
-				'name'        => 'abandoned-cart',
-				'label'       => _x( 'Abandoned cart', 'Block pattern category', 'woocommerce' ),
-				'description' => __( 'A collection of abandoned cart email layouts.', 'woocommerce' ),
-			),
 		);
 		foreach ( $categories as $category ) {
 			register_block_pattern_category(

--- a/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
+++ b/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
@@ -33,6 +33,21 @@ class Patterns {
 				'label'       => _x( 'Email Contents', 'Block pattern category', 'woocommerce' ),
 				'description' => __( 'A collection of email content layouts.', 'woocommerce' ),
 			),
+			array(
+				'name'        => 'basic',
+				'label'       => _x( 'Basic', 'Block pattern category', 'woocommerce' ),
+				'description' => __( 'A collection of basic email layouts.', 'woocommerce' ),
+			),
+			array(
+				'name'        => 'welcome',
+				'label'       => _x( 'Welcome', 'Block pattern category', 'woocommerce' ),
+				'description' => __( 'A collection of welcome email layouts.', 'woocommerce' ),
+			),
+			array(
+				'name'        => 'abandoned-cart',
+				'label'       => _x( 'Abandoned cart', 'Block pattern category', 'woocommerce' ),
+				'description' => __( 'A collection of abandoned cart email layouts.', 'woocommerce' ),
+			),
 		);
 		foreach ( $categories as $category ) {
 			register_block_pattern_category(

--- a/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
+++ b/packages/php/email-editor/src/Engine/Patterns/class-patterns.php
@@ -34,9 +34,9 @@ class Patterns {
 				'description' => __( 'A collection of email content layouts.', 'woocommerce' ),
 			),
 			array(
-				'name'        => 'basic',
-				'label'       => _x( 'Basic', 'Block pattern category', 'woocommerce' ),
-				'description' => __( 'A collection of basic email layouts.', 'woocommerce' ),
+				'name'        => 'newsletter',
+				'label'       => _x( 'Newsletter', 'Block pattern category', 'woocommerce' ),
+				'description' => __( 'A collection of newsletter email layouts.', 'woocommerce' ),
 			),
 			array(
 				'name'        => 'welcome',

--- a/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
@@ -39,9 +39,9 @@ class Patterns_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertEquals( 'Email Contents', $categories_by_name['email-contents']['label'] );
 		$this->assertEquals( 'A collection of email content layouts.', $categories_by_name['email-contents']['description'] );
 
-		$this->assertArrayHasKey( 'basic', $categories_by_name );
-		$this->assertEquals( 'Basic', $categories_by_name['basic']['label'] );
-		$this->assertEquals( 'A collection of basic email layouts.', $categories_by_name['basic']['description'] );
+		$this->assertArrayHasKey( 'newsletter', $categories_by_name );
+		$this->assertEquals( 'Newsletter', $categories_by_name['newsletter']['label'] );
+		$this->assertEquals( 'A collection of newsletter email layouts.', $categories_by_name['newsletter']['description'] );
 
 		$this->assertArrayHasKey( 'welcome', $categories_by_name );
 		$this->assertEquals( 'Welcome', $categories_by_name['welcome']['label'] );

--- a/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
@@ -38,18 +38,6 @@ class Patterns_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertArrayHasKey( 'email-contents', $categories_by_name );
 		$this->assertEquals( 'Email Contents', $categories_by_name['email-contents']['label'] );
 		$this->assertEquals( 'A collection of email content layouts.', $categories_by_name['email-contents']['description'] );
-
-		$this->assertArrayHasKey( 'newsletter', $categories_by_name );
-		$this->assertEquals( 'Newsletter', $categories_by_name['newsletter']['label'] );
-		$this->assertEquals( 'A collection of newsletter email layouts.', $categories_by_name['newsletter']['description'] );
-
-		$this->assertArrayHasKey( 'welcome', $categories_by_name );
-		$this->assertEquals( 'Welcome', $categories_by_name['welcome']['label'] );
-		$this->assertEquals( 'A collection of welcome email layouts.', $categories_by_name['welcome']['description'] );
-
-		$this->assertArrayHasKey( 'abandoned-cart', $categories_by_name );
-		$this->assertEquals( 'Abandoned cart', $categories_by_name['abandoned-cart']['label'] );
-		$this->assertEquals( 'A collection of abandoned cart email layouts.', $categories_by_name['abandoned-cart']['description'] );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Patterns/Patterns_Test.php
@@ -32,12 +32,24 @@ class Patterns_Test extends \Email_Editor_Integration_Test_Case {
 	 */
 	public function testItRegistersPatternCategories(): void {
 		$this->patterns->initialize();
-		$categories = \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
-		/** @var array{name: string, label: string, description: string} $category */ // phpcs:ignore
-		$category = array_pop( $categories );
-		$this->assertEquals( 'email-contents', $category['name'] );
-		$this->assertEquals( 'Email Contents', $category['label'] );
-		$this->assertEquals( 'A collection of email content layouts.', $category['description'] );
+		$categories         = \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+		$categories_by_name = array_column( $categories, null, 'name' );
+
+		$this->assertArrayHasKey( 'email-contents', $categories_by_name );
+		$this->assertEquals( 'Email Contents', $categories_by_name['email-contents']['label'] );
+		$this->assertEquals( 'A collection of email content layouts.', $categories_by_name['email-contents']['description'] );
+
+		$this->assertArrayHasKey( 'basic', $categories_by_name );
+		$this->assertEquals( 'Basic', $categories_by_name['basic']['label'] );
+		$this->assertEquals( 'A collection of basic email layouts.', $categories_by_name['basic']['description'] );
+
+		$this->assertArrayHasKey( 'welcome', $categories_by_name );
+		$this->assertEquals( 'Welcome', $categories_by_name['welcome']['label'] );
+		$this->assertEquals( 'A collection of welcome email layouts.', $categories_by_name['welcome']['description'] );
+
+		$this->assertArrayHasKey( 'abandoned-cart', $categories_by_name );
+		$this->assertEquals( 'Abandoned cart', $categories_by_name['abandoned-cart']['label'] );
+		$this->assertEquals( 'A collection of abandoned cart email layouts.', $categories_by_name['abandoned-cart']['description'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

 This PR adds category tabs navigation to the email template selection modal, allowing users to filter templates by category.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR adds category tabs navigation to the email template selection modal, improving the user experience when browsing and selecting email templates.

  Key changes:
  - Added dynamic category tabs to the template selection modal that are populated from block pattern categories
  - Categories are now loaded dynamically from registered block patterns instead of being hardcoded
  - Added new email pattern categories: Newsletter, Welcome, and Abandoned Cart
  - Template category is now derived from the first category of its content pattern
  - Localized "Recent" category label for internationalization support

  Related to WOOPRD-1118.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1679" height="1211" alt="Screenshot 2025-12-12 at 20 49 08" src="https://github.com/user-attachments/assets/15c78c5a-ee1d-4e80-94c6-13763f8bebd9" />|<img width="1678" height="1216" alt="Screenshot 2025-12-12 at 18 56 07" src="https://github.com/user-attachments/assets/7bedba3d-e82b-4cf8-a424-b233e438fad7" />|



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use those new packages in MailPoet
2. Visit MailPoet > Newsletters page
3. Click on the button for creating a new email in the block email editor 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
