### PR TITLE
e2e tests: fix unstable monitor js files count checks

### DIFF
--- a/plugins/woocommerce/changelog/qao-187-woocommerce-unstable-tests-fix-monitor-js-files-count
+++ b/plugins/woocommerce/changelog/qao-187-woocommerce-unstable-tests-fix-monitor-js-files-count
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: e2e tests: fix js-count tests
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
@@ -1,98 +1,86 @@
 const { test, expect } = require( '@playwright/test' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 
-// add any non-authenticated pages here (that don't require a login)
-const shopperPages = [
-	{ name: 'Shop page', url: 'shop/', expectedCount: 50 },
-	{ name: 'Cart', url: 'cart/', expectedCount: 54 },
-	{ name: 'Checkout', url: 'checkout/', expectedCount: 54 },
+const pageGroups = [
+	{
+		name: 'shopper pages',
+		storageState: undefined,
+		pages: [
+			{ name: 'Shop page', url: 'shop/', expectedCount: 50 },
+			{ name: 'Cart', url: 'cart/', expectedCount: 54 },
+			{ name: 'Checkout', url: 'checkout/', expectedCount: 54 },
+		],
+	},
+	{
+		name: 'admin pages',
+		storageState: ADMIN_STATE_PATH,
+		pages: [
+			{
+				name: 'WC Dashboard',
+				url: 'wp-admin/admin.php?page=wc-admin',
+				expectedCount: 83,
+			},
+			{
+				name: 'Reports',
+				url: 'wp-admin/admin.php?page=wc-reports',
+				expectedCount: 150,
+			},
+			{
+				name: 'Orders page',
+				url: 'wp-admin/admin.php?page=wc-orders',
+				expectedCount: 150,
+			},
+			{
+				name: 'Products page',
+				url: 'wp-admin/edit.php?post_type=product',
+				expectedCount: 150,
+			},
+			{
+				name: 'Add new product',
+				url: 'wp-admin/post-new.php?post_type=product',
+				expectedCount: 150,
+			},
+			{
+				name: 'Analytics page',
+				url: 'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview',
+				expectedCount: 120,
+			},
+			{
+				name: 'Marketing Overview',
+				url: 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing',
+				expectedCount: 120,
+			},
+		],
+	},
 ];
 
-// add any pages that require an admin login here
-const merchantPages = [
-	{
-		name: 'WC Dashboard',
-		url: 'wp-admin/admin.php?page=wc-admin',
-		expectedCount: 83,
-	},
-	{
-		name: 'Reports',
-		url: 'wp-admin/admin.php?page=wc-reports',
-		expectedCount: 150,
-	},
-	{
-		name: 'Orders page',
-		url: 'wp-admin/admin.php?page=wc-orders',
-		expectedCount: 150,
-	},
-	{
-		name: 'Products page',
-		url: 'wp-admin/edit.php?post_type=product',
-		expectedCount: 150,
-	},
-	{
-		name: 'Add new product',
-		url: 'wp-admin/post-new.php?post_type=product',
-		expectedCount: 150,
-	},
-	{
-		name: 'Analytics page',
-		url: 'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview',
-		expectedCount: 120,
-	},
-	{
-		name: 'Marketing Overview',
-		url: 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing',
-		expectedCount: 120,
-	},
-];
+for ( const group of pageGroups ) {
+	test.describe( `JS file count on ${ group.name }`, () => {
+		test.use( { storageState: group.storageState } );
 
-test.describe( 'Keeps track of the number of JS files included on key shopper pages', () => {
-	for ( const row of shopperPages ) {
-		const url = row.url;
-		const name = row.name;
-		const expectedCount = parseInt( row.expectedCount, 10 );
+		for ( const { name, url, expectedCount } of group.pages ) {
+			test( `${ name } should load at most ${ expectedCount } JS files`, async ( {
+				page,
+			} ) => {
+				// networkidle is needed to ensure all JS files are loaded and avoid race conditions
+				// eslint-disable-next-line playwright/no-networkidle
+				await page.goto( url, { waitUntil: 'networkidle' } );
+				const javascriptFiles = await page.$$eval(
+					'script[src]',
+					( scripts ) => scripts.map( ( s ) => s.src )
+				);
 
-		test( `Check that ${ name } has ${ expectedCount } JS files`, async ( {
-			page,
-		} ) => {
-			await page.goto( url );
-			const javascriptFiles = await page.$$eval(
-				'script[src]',
-				( scripts ) => scripts.length
-			);
-
-			await expect
-				.soft(
-					javascriptFiles,
-					`${ url } loaded ${ javascriptFiles }, expected ${ expectedCount }`
-				)
-				.toBeLessThanOrEqual( expectedCount );
-		} );
-	}
-} );
-
-test.describe( 'Keeps track of the number of JS files on key admin pages', () => {
-	test.use( { storageState: ADMIN_STATE_PATH } );
-	for ( const row of merchantPages ) {
-		const url = row.url;
-		const name = row.name;
-		const expectedCount = parseInt( row.expectedCount, 10 );
-
-		test( `Check that ${ name } has ${ expectedCount } JS files`, async ( {
-			page,
-		} ) => {
-			await page.goto( url );
-			const javascriptFiles = await page.$$eval(
-				'script[src]',
-				( scripts ) => scripts.length
-			);
-			await expect
-				.soft(
-					javascriptFiles,
-					`${ url } loaded ${ javascriptFiles }, expected ${ expectedCount }`
-				)
-				.toBeLessThanOrEqual( expectedCount );
-		} );
-	}
-} );
+				expect
+					.soft(
+						javascriptFiles.length,
+						`${ url } loaded ${
+							javascriptFiles.length
+						} JS files, expected max ${ expectedCount }:\n${ javascriptFiles.join(
+							'\n'
+						) }`
+					)
+					.toBeLessThanOrEqual( expectedCount );
+			} );
+		}
+	} );
+}

--- a/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
@@ -7,8 +7,8 @@ const pageGroups = [
 		storageState: undefined,
 		pages: [
 			{ name: 'Shop page', url: 'shop/', expectedCount: 50 },
-			{ name: 'Cart', url: 'cart/', expectedCount: 54 },
-			{ name: 'Checkout', url: 'checkout/', expectedCount: 54 },
+			{ name: 'Cart', url: 'cart/', expectedCount: 55 },
+			{ name: 'Checkout', url: 'checkout/', expectedCount: 55 },
 		],
 	},
 	{


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes QAO-187

Fixed JS file monitoring tests: 
- consolidate test data and merge test logic into a single test
- add `waitUntil: 'networkidle'` to avoid race conditions 
- print the list of files in the expect message in case of failure
- Update expected JS file counts for Cart and Checkout pages

Closes #61929
Closes #61928

### How to test the changes in this Pull Request:

```
pnpm test:e2e js-file-monitor/monitor-js-file-number.spec.js
```

