### PR TITLE
Update summary title to "Discount" instead of coupon(s) and ensure negative fees are reflected in order details

### DIFF
--- a/plugins/woocommerce/changelog/2025-12-15-17-18-50-141498
+++ b/plugins/woocommerce/changelog/2025-12-15-17-18-50-141498
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure discount fees are included in the order subtotal calculation on the admin order view

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -183,7 +183,7 @@ if ( wc_tax_enabled() ) {
 				</td>
 			</tr>
 		<?php endif; ?>
-		<?php if ( 0 < $order->get_total_fees() ) : ?>
+		<?php if ( abs( $order->get_total_fees() ) > 0 ) : ?>
 			<tr>
 				<td class="label"><?php esc_html_e( 'Fees:', 'woocommerce' ); ?></td>
 				<td width="1%"></td>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -176,7 +176,7 @@ if ( wc_tax_enabled() ) {
 			</tr>
 		<?php if ( 0 < $order->get_total_discount() ) : ?>
 			<tr>
-				<td class="label"><?php esc_html_e( 'Coupon(s):', 'woocommerce' ); ?></td>
+				<td class="label"><?php esc_html_e( 'Discount:', 'woocommerce' ); ?></td>
 				<td width="1%"></td>
 				<td class="total">-
 					<?php echo wc_price( $order->get_total_discount(), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/order-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/order-coupon.spec.js
@@ -108,7 +108,7 @@ test.describe(
 					.filter( { hasText: couponCode } )
 			).toBeVisible();
 			await expect(
-				page.getByRole( 'cell', { name: 'Coupon(s)' } )
+				page.getByRole( 'cell', { name: 'Discount:', exact: true } )
 			).toBeVisible();
 			await expect(
 				page.getByRole( 'cell', { name: `- $${ couponAmount }.00` } )
@@ -132,7 +132,7 @@ test.describe(
 					.filter( { hasText: couponCode } )
 			).toBeVisible();
 			await expect(
-				page.getByRole( 'cell', { name: 'Coupon(s)' } )
+				page.getByRole( 'cell', { name: 'Discount:', exact: true } )
 			).toBeVisible();
 			await expect(
 				page.getByRole( 'cell', {

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -2100,4 +2100,45 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 110.06, $order->get_total_fees() );
 	}
+
+	/**
+	 * Test that WC_Order::get_total_fees() returns negative values for discount fees.
+	 */
+	public function test_get_total_fees_should_return_negative_fees() {
+		$order = WC_Helper_Order::create_order();
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'       => 'Discount Fee',
+				'tax_status' => ProductTaxStatus::NONE,
+				'total'      => -10,
+			)
+		);
+		$order->add_item( $fee );
+
+		$this->assertEquals( -10, $order->get_total_fees() );
+	}
+
+	/**
+	 * Test that WC_Order::get_total_fees() correctly sums mixed positive and negative fees.
+	 */
+	public function test_get_total_fees_should_sum_mixed_positive_and_negative_fees() {
+		$order      = WC_Helper_Order::create_order();
+		$fee_totals = array( 25, -10, 5.50 ); // Net: 20.50
+
+		foreach ( $fee_totals as $total ) {
+			$fee = new WC_Order_Item_Fee();
+			$fee->set_props(
+				array(
+					'name'       => $total < 0 ? 'Discount Fee' : 'Regular Fee',
+					'tax_status' => ProductTaxStatus::NONE,
+					'total'      => $total,
+				)
+			);
+			$order->add_item( $fee );
+		}
+
+		$this->assertEquals( 20.50, $order->get_total_fees() );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -2125,7 +2125,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 */
 	public function test_get_total_fees_should_sum_mixed_positive_and_negative_fees() {
 		$order      = WC_Helper_Order::create_order();
-		$fee_totals = array( 25, -10, 5.50 ); // Net: 20.50
+		$fee_totals = array( 25, -10, 5.50 ); // Net: 20.50.
 
 		foreach ( $fee_totals as $total ) {
 			$fee = new WC_Order_Item_Fee();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the admin order view when the total calculation is shown, discounts are named Coupon(s) which is not consistent with the email sent to customers where it is named _Discount_.

Also, negative fees are not shown in this calculation resulting in discrepencies when they are applied, meaning the _Total_ (which is correct) does not actually match the sum of all the displayed components. Below is an example of an order with a £1 negative fee added.

<img width="1179" height="171" alt="image" src="https://github.com/user-attachments/assets/fd631d5d-7669-4583-8add-1197266af767" />

The total sum of the components here adds up to £2.55 but the total is actually £1.55 because of the negative fee.

Closes WOOPLUG-5995
Closes #[62386](https://github.com/woocommerce/woocommerce/issues/62386)
Closes WOOPLUG-5989

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1179" height="171" alt="image" src="https://github.com/user-attachments/assets/ca759c38-aa03-462c-bbb3-6a291c692890" /> | <img width="1181" height="203" alt="image" src="https://github.com/user-attachments/assets/0e0f0b00-2f61-42b1-b494-5af027cb9aa4" />  |

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Place an order using a coupon, then go to edit it in the admin
2. You could use this one-liner to update the order: `wp eval '$o = wc_get_order(123); $f = new WC_Order_Item_Fee(); $f->set_name("Test Discount"); $f->set_total(-1); $o->add_item($f); $o->calculate_totals(); $o->save();'` (update the order ID)
3. If the above doesn't work, put it in an `mu-plugin` and run it once.
4. Ensure the entry for "Fees" is shown and that it contains the correct negative amount.
5. Note, the fee _name_ does not need to show in the subtotals section, as it is listed in the line items.
6. Re-send both the "New order notification" email and "Send order details to customer" from the order actions panel on the sidebar:

<img width="333" height="193" alt="image" src="https://github.com/user-attachments/assets/764c3733-20c3-48f8-915a-31e33543b31c" />

View these emails and ensure the discounts for coupons show correctly, and that the negative fee, named "Test fee" is shown correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
