### PR TITLE
DO NOT MERGE: Store API support for POS

### DIFF
--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -87,6 +87,7 @@ class WC_Payment_Gateways {
 			'WC_Gateway_COD',
 			'WC_Gateway_Paypal',
 			'WC_Gateway_POS_Cash',
+			'WC_Gateway_POS_Card',
 		);
 
 		// Filter.

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -86,6 +86,7 @@ class WC_Payment_Gateways {
 			'WC_Gateway_Cheque',
 			'WC_Gateway_COD',
 			'WC_Gateway_Paypal',
+			'WC_Gateway_POS_Cash',
 		);
 
 		// Filter.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -555,8 +555,15 @@ final class WooCommerce {
 			return false;
 		}
 
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
-		$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
+
+		// Also check for ?rest_route= query parameter format.
+		if ( ! $is_rest_api_request && isset( $_GET['rest_route'] ) ) {
+			$is_rest_api_request = true;
+		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		/**
 		 * Whether this is a REST API request.
@@ -576,7 +583,16 @@ final class WooCommerce {
 			return false;
 		}
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
+		// Check for /wp-json/wc/store/ format.
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' ) ) {
+			return true;
+		}
+		// Also check for ?rest_route=/wc/store/ query parameter format.
+		if ( isset( $_GET['rest_route'] ) && 0 === strpos( $_GET['rest_route'], '/wc/store/' ) ) {
+			return true;
+		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -167,7 +167,9 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				$customer->set_shipping_state( $customer->get_billing_state() );
 			}
 
-			if ( ! $customer->get_billing_email() && is_user_logged_in() ) {
+			// Don't auto-fill billing email from logged-in user for POS sessions.
+			// In POS, the logged-in user is the store operator, not the customer.
+			if ( ! $customer->get_billing_email() && is_user_logged_in() && ! wc_is_pos_session() ) {
 				$current_user = wp_get_current_user();
 				$customer->set_billing_email( $current_user->user_email );
 			}

--- a/plugins/woocommerce/includes/gateways/pos-card/class-wc-gateway-pos-card.php
+++ b/plugins/woocommerce/includes/gateways/pos-card/class-wc-gateway-pos-card.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Class WC_Gateway_POS_Card file.
+ *
+ * @package WooCommerce\Gateways
+ */
+
+use Automattic\WooCommerce\StoreApi\POSSessionHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * POS Card Payment Gateway.
+ *
+ * A payment gateway for Point of Sale card-present transactions. This gateway
+ * handles a two-step flow:
+ * 1. First checkout call creates the order (no payment_intent_id) - order stays pending
+ * 2. Second checkout call captures payment (with payment_intent_id) - order completed
+ *
+ * Payment capture is delegated to WooPayments via its capture_terminal_payment endpoint.
+ *
+ * @class       WC_Gateway_POS_Card
+ * @extends     WC_Payment_Gateway
+ * @package     WooCommerce\Classes\Payment
+ */
+class WC_Gateway_POS_Card extends WC_Payment_Gateway {
+
+	/**
+	 * Unique ID for this gateway.
+	 *
+	 * @var string
+	 */
+	const ID = 'pos_card';
+
+	/**
+	 * Constructor for the gateway.
+	 */
+	public function __construct() {
+		$this->id                 = self::ID;
+		$this->icon               = '';
+		$this->has_fields         = false;
+		$this->method_title       = __( 'POS Card', 'woocommerce' );
+		$this->method_description = __( 'Accept card payments at Point of Sale via Stripe Terminal. This gateway is only available for POS checkout sessions.', 'woocommerce' );
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+
+		$this->title       = $this->get_option( 'title', __( 'Card', 'woocommerce' ) );
+		$this->description = $this->get_option( 'description', '' );
+
+		// This gateway doesn't need to be enabled in settings - it's auto-available for POS.
+		$this->enabled = 'yes';
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'title'       => array(
+				'title'       => __( 'Title', 'woocommerce' ),
+				'type'        => 'safe_text',
+				'description' => __( 'Payment method title shown during POS checkout.', 'woocommerce' ),
+				'default'     => __( 'Card', 'woocommerce' ),
+				'desc_tip'    => true,
+			),
+			'description' => array(
+				'title'       => __( 'Description', 'woocommerce' ),
+				'type'        => 'textarea',
+				'description' => __( 'Payment method description shown during POS checkout.', 'woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+		);
+	}
+
+	/**
+	 * Check if the gateway is available for use.
+	 *
+	 * This gateway is ONLY available for POS sessions.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return wc_is_pos_session();
+	}
+
+	/**
+	 * Process the payment and return the result.
+	 *
+	 * This method handles a two-step payment flow:
+	 * - Step 1 (no payment_intent_id): Create order, return success without capturing
+	 * - Step 2 (with payment_intent_id): Capture payment via WooPayments
+	 *
+	 * @param int $order_id Order ID.
+	 * @return array
+	 */
+	public function process_payment( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce handled by Store API.
+		$payment_intent_id = isset( $_POST['payment_intent_id'] )
+			? wc_clean( wp_unslash( $_POST['payment_intent_id'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			: null;
+
+		if ( ! $payment_intent_id ) {
+			// Step 1: Order created, waiting for card collection.
+			// Return success without processing payment - order stays pending, cart intact.
+			return array(
+				'result'   => 'success',
+				'redirect' => '',
+			);
+		}
+
+		// Step 2: Capture the payment via WooPayments.
+		$capture_result = $this->capture_payment_intent( $order, $payment_intent_id );
+
+		if ( is_wp_error( $capture_result ) ) {
+			// Pass through the full error from WooPayments for app compatibility.
+			return array(
+				'result'  => 'failure',
+				'message' => $capture_result->get_error_message(),
+				'code'    => $capture_result->get_error_code(),
+				'data'    => $capture_result->get_error_data(),
+			);
+		}
+
+		// WooPayments handles payment_complete() and order status.
+		// Start a fresh transaction for the next POS customer.
+		$this->start_new_pos_transaction();
+
+		return array(
+			'result'   => 'success',
+			'redirect' => $this->get_return_url( $order ),
+		);
+	}
+
+	/**
+	 * Capture a payment intent via WooPayments.
+	 *
+	 * Delegates to WooPayments' capture_terminal_payment endpoint which handles
+	 * all the Stripe interaction, order status updates, and fulfillment triggers.
+	 *
+	 * @param WC_Order $order     The order to capture payment for.
+	 * @param string   $intent_id The Stripe payment intent ID.
+	 * @return array|WP_Error Response data on success, WP_Error on failure.
+	 */
+	private function capture_payment_intent( $order, $intent_id ) {
+		$request = new WP_REST_Request(
+			'POST',
+			"/wc/v3/payments/orders/{$order->get_id()}/capture_terminal_payment"
+		);
+		$request->set_body_params( array( 'payment_intent_id' => $intent_id ) );
+
+		$response = rest_do_request( $request );
+		$status   = $response->get_status();
+		$data     = $response->get_data();
+
+		// Check for HTTP error status codes (4xx, 5xx).
+		if ( $status >= 400 ) {
+			// Pass through full error from WooPayments for app compatibility.
+			return new WP_Error(
+				$data['code'] ?? 'capture_failed',
+				$data['message'] ?? __( 'Payment capture failed', 'woocommerce' ),
+				$data['data'] ?? array( 'status' => $status )
+			);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Start a new POS transaction by clearing the cart.
+	 *
+	 * This ensures that cart data from one transaction doesn't carry over
+	 * to the next. In POS, each transaction serves a different customer.
+	 *
+	 * The next POS request will get a fresh session with a new transaction ID
+	 * because POSSessionHandler checks if the cart is empty when initializing.
+	 */
+	private function start_new_pos_transaction() {
+		WC()->cart->empty_cart();
+	}
+}

--- a/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
+++ b/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
@@ -104,12 +104,27 @@ class WC_Gateway_POS_Cash extends WC_Payment_Gateway {
 		// Add order note indicating POS cash payment.
 		$order->add_order_note( __( 'Payment received via POS cash transaction.', 'woocommerce' ) );
 
-		// Clear the cart.
-		WC()->cart->empty_cart();
+		// Start a fresh transaction for the next POS customer.
+		$this->start_new_pos_transaction();
 
 		return array(
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		);
+	}
+
+	/**
+	 * Start a new POS transaction by clearing the transaction ID.
+	 *
+	 * This ensures that customer data from one transaction doesn't carry over
+	 * to the next. In POS, each transaction serves a different customer.
+	 *
+	 * The next POS request will get a fresh session with a new transaction ID
+	 * because POSSessionHandler checks if the cart is empty when initializing.
+	 */
+	private function start_new_pos_transaction() {
+		// Simply empty the cart. The POSSessionHandler will detect an empty cart
+		// on the next request and create a fresh session with a new transaction ID.
+		WC()->cart->empty_cart();
 	}
 }

--- a/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
+++ b/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
@@ -104,6 +104,9 @@ class WC_Gateway_POS_Cash extends WC_Payment_Gateway {
 		// Mark the order as paid - cash has been received at the point of sale.
 		$order->payment_complete();
 
+		// Remove the filter to avoid affecting other orders in the same request.
+		remove_filter( 'woocommerce_payment_complete_order_status', array( $this, 'set_completed_order_status' ) );
+
 		// Add order note indicating POS cash payment.
 		$order->add_order_note( __( 'Payment received via POS cash transaction.', 'woocommerce' ) );
 

--- a/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
+++ b/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
@@ -98,6 +98,9 @@ class WC_Gateway_POS_Cash extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
+		// POS orders go directly to 'completed' - the customer takes items in-person.
+		add_filter( 'woocommerce_payment_complete_order_status', array( $this, 'set_completed_order_status' ) );
+
 		// Mark the order as paid - cash has been received at the point of sale.
 		$order->payment_complete();
 
@@ -111,6 +114,19 @@ class WC_Gateway_POS_Cash extends WC_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		);
+	}
+
+	/**
+	 * Set the order status to completed for POS orders.
+	 *
+	 * POS orders go directly to 'completed' because the customer takes items
+	 * in-person - there's no shipping to process.
+	 *
+	 * @param string $status Default order status.
+	 * @return string Order status.
+	 */
+	public function set_completed_order_status( $status ) {
+		return OrderStatus::COMPLETED;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
+++ b/plugins/woocommerce/includes/gateways/pos-cash/class-wc-gateway-pos-cash.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Class WC_Gateway_POS_Cash file.
+ *
+ * @package WooCommerce\Gateways
+ */
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * POS Cash Payment Gateway.
+ *
+ * A payment gateway for Point of Sale cash transactions. This gateway is only
+ * available during POS checkout sessions and immediately marks orders as paid.
+ *
+ * @class       WC_Gateway_POS_Cash
+ * @extends     WC_Payment_Gateway
+ * @package     WooCommerce\Classes\Payment
+ */
+class WC_Gateway_POS_Cash extends WC_Payment_Gateway {
+
+	/**
+	 * Unique ID for this gateway.
+	 *
+	 * @var string
+	 */
+	const ID = 'pos_cash';
+
+	/**
+	 * Constructor for the gateway.
+	 */
+	public function __construct() {
+		$this->id                 = self::ID;
+		$this->icon               = '';
+		$this->has_fields         = false;
+		$this->method_title       = __( 'POS Cash', 'woocommerce' );
+		$this->method_description = __( 'Accept cash payments at Point of Sale. This gateway is only available for POS checkout sessions.', 'woocommerce' );
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+
+		$this->title       = $this->get_option( 'title', __( 'Cash', 'woocommerce' ) );
+		$this->description = $this->get_option( 'description', '' );
+
+		// This gateway doesn't need to be enabled in settings - it's auto-available for POS.
+		$this->enabled = 'yes';
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'title'       => array(
+				'title'       => __( 'Title', 'woocommerce' ),
+				'type'        => 'safe_text',
+				'description' => __( 'Payment method title shown during POS checkout.', 'woocommerce' ),
+				'default'     => __( 'Cash', 'woocommerce' ),
+				'desc_tip'    => true,
+			),
+			'description' => array(
+				'title'       => __( 'Description', 'woocommerce' ),
+				'type'        => 'textarea',
+				'description' => __( 'Payment method description shown during POS checkout.', 'woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+		);
+	}
+
+	/**
+	 * Check if the gateway is available for use.
+	 *
+	 * This gateway is ONLY available for POS sessions.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return wc_is_pos_session();
+	}
+
+	/**
+	 * Process the payment and return the result.
+	 *
+	 * For POS cash payments, we trust that the cash has been received
+	 * and immediately mark the order as complete.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return array
+	 */
+	public function process_payment( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		// Mark the order as paid - cash has been received at the point of sale.
+		$order->payment_complete();
+
+		// Add order note indicating POS cash payment.
+		$order->add_order_note( __( 'Payment received via POS cash transaction.', 'woocommerce' ) );
+
+		// Clear the cart.
+		WC()->cart->empty_cart();
+
+		return array(
+			'result'   => 'success',
+			'redirect' => $this->get_return_url( $order ),
+		);
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -61,7 +61,14 @@ class Legacy {
 		// If the payment failed with a message, throw an exception.
 		if ( isset( $gateway_result['result'] ) && 'failure' === $gateway_result['result'] ) {
 			if ( isset( $gateway_result['message'] ) ) {
-				throw new RouteException( 'woocommerce_rest_payment_error', esc_html( wp_strip_all_tags( $gateway_result['message'] ) ), 400 );
+				// Use gateway's error code if provided, otherwise use generic code.
+				$error_code = $gateway_result['code'] ?? 'woocommerce_rest_payment_error';
+				$error_data = $gateway_result['data'] ?? array();
+
+				// Get HTTP status from error data, default to 400.
+				$http_status = $error_data['status'] ?? 400;
+
+				throw new RouteException( $error_code, esc_html( wp_strip_all_tags( $gateway_result['message'] ) ), $http_status, $error_data );
 			} else {
 				NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
 			}

--- a/plugins/woocommerce/src/StoreApi/POS-IOS-INTEGRATION-GUIDE.md
+++ b/plugins/woocommerce/src/StoreApi/POS-IOS-INTEGRATION-GUIDE.md
@@ -1,0 +1,278 @@
+# Integrating POS Store API in iOS WooCommerce App
+
+Guide for migrating the iOS WooCommerce app's POS checkout from REST API to Store API.
+
+## Current State
+
+The iOS app currently:
+- Uses WooCommerce REST API (`/wc/v3/`) for all operations
+- Cannot provide billing customer email at checkout
+- Cannot provide required gift card fields
+- Creates orders directly via REST API
+
+## Target State
+
+Migrate to Store API (`/wc/store/v1/`) for POS checkout:
+- Cart-based checkout flow
+- Email optional (POS bypass)
+- Gift cards handled via cart/checkout flow
+- Same endpoints as web checkout block
+
+## Required Headers
+
+All POS requests must include:
+```
+Authorization: Basic <base64(ck_xxx:cs_xxx)>
+X-WC-POS: 1
+```
+
+Use the existing WooCommerce API key authentication (same as REST API).
+
+## API Endpoints
+
+### Cart Operations
+
+| Operation | Method | Endpoint | Body |
+|-----------|--------|----------|------|
+| Get cart | GET | `/wc/store/v1/cart` | - |
+| Add item | POST | `/wc/store/v1/cart/add-item` | `{id, quantity, variation?, ...extras}` |
+| Update quantity | POST | `/wc/store/v1/cart/update-item` | `{key, quantity}` |
+| Remove item | POST | `/wc/store/v1/cart/remove-item` | `{key}` |
+| Clear cart | DELETE | `/wc/store/v1/cart/items` | - |
+
+### Coupons
+
+| Operation | Method | Endpoint | Body |
+|-----------|--------|----------|------|
+| Apply coupon | POST | `/wc/store/v1/cart/apply-coupon` | `{code}` |
+| Remove coupon | POST | `/wc/store/v1/cart/remove-coupon` | `{code}` |
+| List coupons | GET | `/wc/store/v1/cart/coupons` | - |
+
+### Checkout
+
+| Operation | Method | Endpoint | Body |
+|-----------|--------|----------|------|
+| Get checkout state | GET | `/wc/store/v1/checkout` | - |
+| Process payment | POST | `/wc/store/v1/checkout` | See below |
+
+## Checkout Flow
+
+### Cash Payment (Single Step)
+
+```swift
+// 1. Build cart
+POST /wc/store/v1/cart/add-item
+{"id": 123, "quantity": 1}
+
+// 2. Apply coupon (optional)
+POST /wc/store/v1/cart/apply-coupon
+{"code": "DISCOUNT10"}
+
+// 3. Checkout
+POST /wc/store/v1/checkout
+{
+  "payment_method": "pos_cash",
+  "billing_address": {},  // Empty object OK for POS
+  "payment_data": []
+}
+// → Order created with status: completed
+```
+
+### Card Payment (Two Step)
+
+```swift
+// 1. Build cart (same as cash)
+
+// 2. Create pending order
+POST /wc/store/v1/checkout
+{
+  "payment_method": "pos_card",
+  "billing_address": {},
+  "payment_data": []
+}
+// → Order created with status: pending
+// → Response includes order_id
+
+// 3. Collect card via Stripe Terminal SDK
+// ... Terminal SDK returns payment_intent_id ...
+
+// 4. Capture payment
+POST /wc/store/v1/checkout
+{
+  "payment_method": "pos_card",
+  "billing_address": {},
+  "payment_data": [
+    {"key": "payment_intent_id", "value": "pi_xxx"}
+  ]
+}
+// → Order status: completed
+```
+
+## Response Handling
+
+### Cart Response Structure
+
+```swift
+struct StoreAPICart: Codable {
+    let items: [CartItem]
+    let itemsCount: Int
+    let coupons: [CartCoupon]
+    let totals: CartTotals
+    let needsPayment: Bool
+    let needsShipping: Bool
+    let errors: [CartError]
+}
+
+struct CartItem: Codable {
+    let key: String          // Use for update/remove
+    let id: Int              // Product ID
+    let quantity: Int
+    let name: String
+    let prices: ItemPrices
+    let totals: ItemTotals
+}
+
+struct CartTotals: Codable {
+    let currencyCode: String
+    let totalItems: String      // Subtotal in minor units
+    let totalDiscount: String   // Coupon discount
+    let totalPrice: String      // Final total
+}
+```
+
+### Checkout Response Structure
+
+```swift
+struct CheckoutResponse: Codable {
+    let orderId: Int
+    let status: String           // "pending", "completed", etc.
+    let orderKey: String
+    let paymentResult: PaymentResult
+}
+
+struct PaymentResult: Codable {
+    let paymentStatus: String    // "success", "pending", "failure"
+    let redirectUrl: String?
+}
+```
+
+## Error Handling
+
+### HTTP Status Codes
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 200 | Success | Process response |
+| 201 | Created | Item added / order created |
+| 400 | Bad request | Check error message |
+| 401 | Unauthorized | Re-authenticate |
+| 404 | Not found | Item/coupon doesn't exist |
+| 409 | Conflict | Cart changed; resync from response |
+
+### Error Response
+
+```swift
+struct StoreAPIError: Codable {
+    let code: String      // e.g., "woocommerce_rest_cart_invalid_key"
+    let message: String
+    let data: ErrorData?
+}
+```
+
+All cart-modifying endpoints return updated cart on error, allowing state reconciliation.
+
+## Migration Steps
+
+### 1. Add Store API Client
+
+Create parallel networking layer for Store API:
+- Base URL: `/wc/store/v1/`
+- Add `X-WC-POS: 1` header to all requests
+- Use existing Application Password auth
+
+### 2. Implement Cart State Management
+
+Replace direct order creation with cart-based flow:
+- Local cart model synced with server
+- Handle 409 conflicts by accepting server state
+- Clear cart after successful checkout
+
+### 3. Update Checkout Flow
+
+```swift
+// Before (REST API)
+func checkout() {
+    let order = createOrderRequest(items: localItems)
+    restAPI.createOrder(order) { ... }
+}
+
+// After (Store API)
+func checkout() {
+    // Cart already populated via add-item calls
+    let checkout = CheckoutRequest(
+        paymentMethod: selectedMethod,
+        billingAddress: [:],  // Empty for POS
+        paymentData: paymentData
+    )
+    storeAPI.checkout(checkout) { ... }
+}
+```
+
+### 4. Handle Two-Step Card Payments
+
+For Stripe Terminal integration:
+1. Call checkout without `payment_intent_id` → pending order
+2. Collect card via Terminal SDK
+3. Call checkout again with `payment_intent_id` → capture
+
+## Gift Cards
+
+Gift card products (WooCommerce Gift Cards plugin) require extra fields when adding to cart:
+
+```swift
+POST /wc/store/v1/cart/add-item
+{
+  "id": 92,
+  "quantity": 1,
+  "wc_gc_giftcard_to": "recipient@example.com",
+  "wc_gc_giftcard_from": "Sender Name"
+}
+```
+
+Extra fields beyond `id`, `quantity`, and `variation` are automatically passed through to `cart_item_data`, where plugins can access them via the `woocommerce_add_cart_item_data` filter.
+
+**For redeeming gift cards** (applying as payment):
+- If gift cards work as coupon codes, use `/cart/apply-coupon`
+- Discount appears in `totals.total_discount`
+
+## Known Limitations
+
+1. **User-scoped sessions**: One cart per authenticated user. Multiple devices share state.
+2. **No explicit transaction start**: Cart persists until checkout completes or explicit clear.
+3. **WooPayments required**: Card capture requires WooPayments plugin for `payment_intent_id` handling.
+
+## Technical Notes
+
+### URL Format Support
+
+Both URL formats are supported:
+
+- Pretty permalinks: `/wp-json/wc/store/v1/cart`
+- Query parameter: `/?rest_route=/wc/store/v1/cart`
+
+The iOS app typically uses the `?rest_route=` format when pretty permalinks are unavailable. Both formats now work correctly with POS sessions.
+
+## Testing Checklist
+
+- [ ] Add single item to cart
+- [ ] Add variable product with attributes
+- [ ] Update item quantity
+- [ ] Remove item
+- [ ] Apply valid coupon
+- [ ] Apply invalid coupon (expect 400)
+- [ ] Cash checkout (single step)
+- [ ] Card checkout step 1 (pending order)
+- [ ] Card checkout step 2 (capture)
+- [ ] Handle 409 conflict response
+- [ ] Clear cart after checkout
+- [ ] Verify order appears in WooCommerce admin

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -51,21 +51,74 @@ final class POSSessionHandler extends WC_Session {
 	/**
 	 * Initialize session for POS.
 	 *
-	 * For POS sessions, we use the authenticated user's ID directly
-	 * rather than relying on a cart token from headers.
+	 * POS sessions use a transaction-based approach: each transaction gets a fresh
+	 * session when the cart is empty. This prevents customer data (email, addresses)
+	 * from carrying over between different customers' transactions.
+	 *
+	 * The session key includes a transaction ID that changes when:
+	 * - The cart is empty (starting a new transaction)
+	 * - No existing transaction ID exists
 	 */
 	protected function init_session_for_pos() {
-		// Use the authenticated user's ID for the session.
 		$user_id = get_current_user_id();
 
-		// Generate a unique session key for this POS user to avoid conflicts with their web cart.
-		$this->_customer_id = 'pos_' . $user_id;
+		// Check if we have an existing transaction ID for this user.
+		$transaction_id = $this->get_existing_transaction_id( $user_id );
 
-		// Set expiration to 48 hours from now (same as default cart token).
-		$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
+		// Load the existing session to check if cart is empty.
+		if ( $transaction_id ) {
+			$this->_customer_id       = 'pos_' . $user_id . '_' . $transaction_id;
+			$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
+			$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
 
-		// Load existing session data if any.
-		$this->_data = (array) $this->get_session( $this->get_customer_id(), array() );
+			// If cart is empty, start a fresh transaction.
+			$cart = $this->_data['cart'] ?? '';
+			if ( empty( $cart ) || maybe_unserialize( $cart ) === array() ) {
+				// Delete the old session from database to clean up.
+				$this->delete_session( $this->get_customer_id() );
+				$transaction_id = null; // Will generate new ID below.
+			}
+		}
+
+		// Generate a new transaction ID if needed (new transaction).
+		if ( ! $transaction_id ) {
+			$transaction_id           = $this->generate_transaction_id();
+			$this->_customer_id       = 'pos_' . $user_id . '_' . $transaction_id;
+			$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
+			$this->_data              = array(); // Fresh session data - no cart, no customer.
+
+			// Store the transaction ID so subsequent requests can find it.
+			$this->save_transaction_id( $user_id, $transaction_id );
+		}
+	}
+
+	/**
+	 * Get an existing transaction ID for a user, if one exists.
+	 *
+	 * @param int $user_id The user ID.
+	 * @return string|null The transaction ID or null if none exists.
+	 */
+	private function get_existing_transaction_id( int $user_id ): ?string {
+		return get_transient( 'wc_pos_transaction_' . $user_id ) ?: null;
+	}
+
+	/**
+	 * Save a transaction ID for a user.
+	 *
+	 * @param int    $user_id        The user ID.
+	 * @param string $transaction_id The transaction ID.
+	 */
+	private function save_transaction_id( int $user_id, string $transaction_id ): void {
+		set_transient( 'wc_pos_transaction_' . $user_id, $transaction_id, DAY_IN_SECONDS * 2 );
+	}
+
+	/**
+	 * Generate a unique transaction ID.
+	 *
+	 * @return string A unique transaction ID.
+	 */
+	private function generate_transaction_id(): string {
+		return wp_generate_uuid4();
 	}
 
 	/**
@@ -119,6 +172,41 @@ final class POSSessionHandler extends WC_Session {
 
 			$this->_dirty = false;
 		}
+	}
+
+	/**
+	 * Destroy the current session and clear the transaction ID.
+	 *
+	 * This allows starting a fresh transaction for the next POS customer.
+	 */
+	public function destroy_session(): void {
+		$this->delete_session( $this->get_customer_id() );
+
+		// Clear the transaction ID so the next request gets a fresh session.
+		$user_id = get_current_user_id();
+		delete_transient( 'wc_pos_transaction_' . $user_id );
+
+		// Reset session data and mark as not dirty.
+		$this->_data  = array();
+		$this->_dirty = false;
+
+		// Remove the shutdown hook so save_data() won't recreate the session.
+		remove_action( 'shutdown', array( $this, 'save_data' ), 20 );
+	}
+
+	/**
+	 * Delete a session from the database.
+	 *
+	 * @param string $customer_id Customer ID.
+	 */
+	public function delete_session( $customer_id ): void {
+		global $wpdb;
+
+		if ( ! $customer_id ) {
+			return;
+		}
+
+		$wpdb->delete( $this->table, array( 'session_key' => $customer_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -217,4 +217,19 @@ final class POSSessionHandler extends WC_Session {
 	public function is_pos_session(): bool {
 		return true;
 	}
+
+	/**
+	 * Check if we have an active session.
+	 *
+	 * POS sessions are always active - if this handler is in use, the user
+	 * is authenticated and has a valid session.
+	 *
+	 * Note: If we implement transaction-scoped sessions in the future, we may
+	 * need to reconsider this and check for an active transaction instead.
+	 *
+	 * @return bool Always returns true for POS sessions.
+	 */
+	public function has_session(): bool {
+		return true;
+	}
 }

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -3,17 +3,123 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\StoreApi;
 
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
+use WC_Session;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * POSSessionHandler class
  *
- * A session handler for Point of Sale (POS) requests. This extends the standard
+ * A session handler for Point of Sale (POS) requests. This is based on the
  * Store API SessionHandler but can be identified as a POS session, allowing
  * the checkout flow to apply different validation rules (e.g., skipping
  * address requirements) for trusted POS clients.
+ *
+ * Note: This duplicates SessionHandler because that class is marked final.
  */
-final class POSSessionHandler extends SessionHandler {
+final class POSSessionHandler extends WC_Session {
+	/**
+	 * Token from HTTP headers.
+	 *
+	 * @var string
+	 */
+	protected $token = '';
+
+	/**
+	 * Table name for session data.
+	 *
+	 * @var string Custom session table name
+	 */
+	protected $table = '';
+
+	/**
+	 * Expiration timestamp.
+	 *
+	 * @var int
+	 */
+	protected $session_expiration = 0;
+
+	/**
+	 * Constructor for the session class.
+	 */
+	public function __construct() {
+		$this->token = wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
+		$this->table = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
+	}
+
+	/**
+	 * Init hooks and session data.
+	 */
+	public function init() {
+		$this->init_session_from_token();
+		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
+	}
+
+	/**
+	 * Process the token header to load the correct session.
+	 */
+	protected function init_session_from_token() {
+		$payload = CartTokenUtils::get_cart_token_payload( $this->token );
+
+		$this->_customer_id       = $payload['user_id'];
+		$this->session_expiration = $payload['exp'];
+		$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
+	}
+
+	/**
+	 * Returns the session.
+	 *
+	 * @param string $customer_id Customer ID.
+	 * @param mixed  $default_value Default session value.
+	 *
+	 * @return mixed Returns either the session data or the default value. Returns false if WP setup is in progress.
+	 */
+	public function get_session( $customer_id, $default_value = false ) {
+		global $wpdb;
+
+		// This mimics behaviour from default WC_Session_Handler class. There will be no sessions retrieved while WP setup is due.
+		if ( Constants::is_defined( 'WP_SETUP_CONFIG' ) ) {
+			return $default_value;
+		}
+
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT session_value FROM %i WHERE session_key = %s',
+				$this->table,
+				$customer_id
+			)
+		);
+
+		if ( is_null( $value ) ) {
+			$value = $default_value;
+		}
+
+		return maybe_unserialize( $value );
+	}
+
+	/**
+	 * Save data and delete user session.
+	 */
+	public function save_data() {
+		// Dirty if something changed - prevents saving nothing new.
+		if ( $this->_dirty ) {
+			global $wpdb;
+
+			$wpdb->query(
+				$wpdb->prepare(
+					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
+					$this->table,
+					$this->get_customer_id(),
+					maybe_serialize( $this->_data ),
+					$this->session_expiration
+				)
+			);
+
+			$this->_dirty = false;
+		}
+	}
 
 	/**
 	 * Check if this is a POS session.

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\StoreApi;
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
 use WC_Session;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,13 +19,6 @@ defined( 'ABSPATH' ) || exit;
  * Note: This duplicates SessionHandler because that class is marked final.
  */
 final class POSSessionHandler extends WC_Session {
-	/**
-	 * Token from HTTP headers.
-	 *
-	 * @var string
-	 */
-	protected $token = '';
-
 	/**
 	 * Table name for session data.
 	 *
@@ -45,7 +37,6 @@ final class POSSessionHandler extends WC_Session {
 	 * Constructor for the session class.
 	 */
 	public function __construct() {
-		$this->token = wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
 		$this->table = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
 	}
 
@@ -53,19 +44,28 @@ final class POSSessionHandler extends WC_Session {
 	 * Init hooks and session data.
 	 */
 	public function init() {
-		$this->init_session_from_token();
+		$this->init_session_for_pos();
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 	}
 
 	/**
-	 * Process the token header to load the correct session.
+	 * Initialize session for POS.
+	 *
+	 * For POS sessions, we use the authenticated user's ID directly
+	 * rather than relying on a cart token from headers.
 	 */
-	protected function init_session_from_token() {
-		$payload = CartTokenUtils::get_cart_token_payload( $this->token );
+	protected function init_session_for_pos() {
+		// Use the authenticated user's ID for the session.
+		$user_id = get_current_user_id();
 
-		$this->_customer_id       = $payload['user_id'];
-		$this->session_expiration = $payload['exp'];
-		$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
+		// Generate a unique session key for this POS user to avoid conflicts with their web cart.
+		$this->_customer_id = 'pos_' . $user_id;
+
+		// Set expiration to 48 hours from now (same as default cart token).
+		$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
+
+		// Load existing session data if any.
+		$this->_data = (array) $this->get_session( $this->get_customer_id(), array() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -11,12 +11,12 @@ defined( 'ABSPATH' ) || exit;
 /**
  * POSSessionHandler class
  *
- * A session handler for Point of Sale (POS) requests. This is based on the
- * Store API SessionHandler but can be identified as a POS session, allowing
- * the checkout flow to apply different validation rules (e.g., skipping
- * address requirements) for trusted POS clients.
+ * A simple session handler for Point of Sale (POS) requests. Uses the user ID
+ * as the session key, similar to how WC_Session_Handler works for logged-in users.
  *
- * Note: This duplicates SessionHandler because that class is marked final.
+ * This can be identified as a POS session, allowing the checkout flow to apply
+ * different validation rules (e.g., skipping address requirements) for trusted
+ * POS clients.
  */
 final class POSSessionHandler extends WC_Session {
 	/**
@@ -51,74 +51,15 @@ final class POSSessionHandler extends WC_Session {
 	/**
 	 * Initialize session for POS.
 	 *
-	 * POS sessions use a transaction-based approach: each transaction gets a fresh
-	 * session when the cart is empty. This prevents customer data (email, addresses)
-	 * from carrying over between different customers' transactions.
-	 *
-	 * The session key includes a transaction ID that changes when:
-	 * - The cart is empty (starting a new transaction)
-	 * - No existing transaction ID exists
+	 * Simple approach: use user ID as session key, prefixed with 'pos_'.
+	 * This keeps POS sessions separate from regular web sessions.
 	 */
 	protected function init_session_for_pos() {
 		$user_id = get_current_user_id();
 
-		// Check if we have an existing transaction ID for this user.
-		$transaction_id = $this->get_existing_transaction_id( $user_id );
-
-		// Load the existing session to check if cart is empty.
-		if ( $transaction_id ) {
-			$this->_customer_id       = 'pos_' . $user_id . '_' . $transaction_id;
-			$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
-			$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
-
-			// If cart is empty, start a fresh transaction.
-			$cart = $this->_data['cart'] ?? '';
-			if ( empty( $cart ) || maybe_unserialize( $cart ) === array() ) {
-				// Delete the old session from database to clean up.
-				$this->delete_session( $this->get_customer_id() );
-				$transaction_id = null; // Will generate new ID below.
-			}
-		}
-
-		// Generate a new transaction ID if needed (new transaction).
-		if ( ! $transaction_id ) {
-			$transaction_id           = $this->generate_transaction_id();
-			$this->_customer_id       = 'pos_' . $user_id . '_' . $transaction_id;
-			$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
-			$this->_data              = array(); // Fresh session data - no cart, no customer.
-
-			// Store the transaction ID so subsequent requests can find it.
-			$this->save_transaction_id( $user_id, $transaction_id );
-		}
-	}
-
-	/**
-	 * Get an existing transaction ID for a user, if one exists.
-	 *
-	 * @param int $user_id The user ID.
-	 * @return string|null The transaction ID or null if none exists.
-	 */
-	private function get_existing_transaction_id( int $user_id ): ?string {
-		return get_transient( 'wc_pos_transaction_' . $user_id ) ?: null;
-	}
-
-	/**
-	 * Save a transaction ID for a user.
-	 *
-	 * @param int    $user_id        The user ID.
-	 * @param string $transaction_id The transaction ID.
-	 */
-	private function save_transaction_id( int $user_id, string $transaction_id ): void {
-		set_transient( 'wc_pos_transaction_' . $user_id, $transaction_id, DAY_IN_SECONDS * 2 );
-	}
-
-	/**
-	 * Generate a unique transaction ID.
-	 *
-	 * @return string A unique transaction ID.
-	 */
-	private function generate_transaction_id(): string {
-		return wp_generate_uuid4();
+		$this->_customer_id       = 'pos_' . $user_id;
+		$this->session_expiration = time() + ( DAY_IN_SECONDS * 2 );
+		$this->_data              = (array) $this->get_session( $this->_customer_id, array() );
 	}
 
 	/**
@@ -137,10 +78,10 @@ final class POSSessionHandler extends WC_Session {
 			return $default_value;
 		}
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $this->table is set in constructor from wpdb prefix.
 		$value = $wpdb->get_var(
 			$wpdb->prepare(
-				'SELECT session_value FROM %i WHERE session_key = %s',
-				$this->table,
+				"SELECT session_value FROM {$this->table} WHERE session_key = %s",
 				$customer_id
 			)
 		);
@@ -160,11 +101,11 @@ final class POSSessionHandler extends WC_Session {
 		if ( $this->_dirty ) {
 			global $wpdb;
 
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $this->table is set in constructor from wpdb prefix.
 			$wpdb->query(
 				$wpdb->prepare(
-					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
-					$this->table,
-					$this->get_customer_id(),
+					"INSERT INTO {$this->table} (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
+					$this->_customer_id,
 					maybe_serialize( $this->_data ),
 					$this->session_expiration
 				)
@@ -175,16 +116,12 @@ final class POSSessionHandler extends WC_Session {
 	}
 
 	/**
-	 * Destroy the current session and clear the transaction ID.
+	 * Destroy the current session.
 	 *
 	 * This allows starting a fresh transaction for the next POS customer.
 	 */
 	public function destroy_session(): void {
-		$this->delete_session( $this->get_customer_id() );
-
-		// Clear the transaction ID so the next request gets a fresh session.
-		$user_id = get_current_user_id();
-		delete_transient( 'wc_pos_transaction_' . $user_id );
+		$this->delete_session( $this->_customer_id );
 
 		// Reset session data and mark as not dirty.
 		$this->_data  = array();
@@ -220,12 +157,6 @@ final class POSSessionHandler extends WC_Session {
 
 	/**
 	 * Check if we have an active session.
-	 *
-	 * POS sessions are always active - if this handler is in use, the user
-	 * is authenticated and has a valid session.
-	 *
-	 * Note: If we implement transaction-scoped sessions in the future, we may
-	 * need to reconsider this and check for an active transaction instead.
 	 *
 	 * @return bool Always returns true for POS sessions.
 	 */

--- a/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/POSSessionHandler.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\StoreApi;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * POSSessionHandler class
+ *
+ * A session handler for Point of Sale (POS) requests. This extends the standard
+ * Store API SessionHandler but can be identified as a POS session, allowing
+ * the checkout flow to apply different validation rules (e.g., skipping
+ * address requirements) for trusted POS clients.
+ */
+final class POSSessionHandler extends SessionHandler {
+
+	/**
+	 * Check if this is a POS session.
+	 *
+	 * @return bool Always returns true for POS sessions.
+	 */
+	public function is_pos_session(): bool {
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/README-POS.md
+++ b/plugins/woocommerce/src/StoreApi/README-POS.md
@@ -1,0 +1,157 @@
+# POS Checkout via Store API
+
+Point of Sale (POS) checkout functionality for the WooCommerce Store API. Built as a Hack Week proof-of-concept.
+
+## Overview
+
+POS checkout allows authenticated store operators to process in-person sales using the same Store API endpoints used by the checkout block. POS sessions skip validation requirements that don't apply to in-person transactions (addresses, email, nonces).
+
+## Authentication
+
+POS requests require:
+1. **Authentication** via Application Passwords (Basic or Bearer)
+2. **`X-WC-POS: 1` header** on all requests
+3. **`manage_woocommerce` capability** on the authenticated user
+
+Requests with `X-WC-POS` header but without valid authentication return 401.
+
+### Supported Auth Methods
+
+```http
+# WooCommerce API keys (iOS app)
+Authorization: Basic <base64(ck_xxx:cs_xxx)>
+
+# WordPress Application Passwords
+Authorization: Basic <base64(username:app_password)>
+```
+
+Both are handled by WooCommerce's existing `WC_REST_Authentication` class.
+
+## Key Components
+
+### POSSessionHandler
+`src/StoreApi/POSSessionHandler.php`
+
+Session handler for POS requests. Uses the authenticated user ID as the session key (prefixed with `pos_`), keeping POS cart state separate from the user's web cart.
+
+### POSUtils
+`src/StoreApi/Utilities/POSUtils.php`
+
+- `is_pos_session()` - Check if current request is a POS session
+- `current_user_can_pos()` - Check if user has POS permissions
+
+### wc_is_pos_session()
+Global helper function in `src/StoreApi/functions.php`.
+
+### Payment Gateways
+
+**POS Cash** (`includes/gateways/pos-cash/`)
+- Single-step cash payment
+- Orders marked completed immediately
+
+**POS Card** (`includes/gateways/pos-card/`)
+- Two-step card payment for Stripe Terminal
+- Step 1: Create pending order (no `payment_intent_id`)
+- Step 2: Capture payment (with `payment_intent_id` from Terminal)
+
+## Validation Bypasses
+
+When `wc_is_pos_session()` returns true:
+
+| Validation | Location |
+|------------|----------|
+| Address validation | `Checkout.php`, `OrderController.php` |
+| Billing address required | Schema filter |
+| Email required | `BillingAddressSchema.php`, `OrderController.php` |
+| Nonce check | `AbstractCartRoute.php`, `Checkout.php` |
+| Cart hash for pending orders | `DraftOrderTrait.php` |
+
+## API Usage
+
+### Cash Payment
+```http
+POST /wc/store/v1/cart/add-item
+X-WC-POS: 1
+Authorization: Basic xxx
+
+POST /wc/store/v1/checkout
+X-WC-POS: 1
+{"payment_method": "pos_cash"}
+```
+
+### Card Payment
+```http
+POST /wc/store/v1/checkout
+X-WC-POS: 1
+{"payment_method": "pos_card"}
+# → Order created, status: pending
+
+# [Collect card via Stripe Terminal]
+
+POST /wc/store/v1/checkout
+X-WC-POS: 1
+{
+  "payment_method": "pos_card",
+  "payment_data": [{"key": "payment_intent_id", "value": "pi_xxx"}]
+}
+# → Payment captured, order completed
+```
+
+## Known Limitations
+
+1. **User-scoped sessions**: One active transaction per user. Multiple devices with same user share cart state.
+2. **No transaction isolation**: Abandoned carts persist until next successful checkout.
+3. **WooPayments dependency**: Card payments require WooPayments for capture endpoint.
+4. **Guest orders**: POS orders created with customer_id = 0 to avoid polluting operator's order history.
+
+## Technical Notes
+
+### REST API URL Format Fix
+
+The `?rest_route=` query parameter format (e.g., `/?rest_route=/wc/store/v1/cart`) is commonly used by mobile apps when pretty permalinks are not available. This format was not being recognized as a Store API request by `WC()->is_store_api_request()`, which caused the cart to be loaded with the wrong session handler before the POS session filter could be applied.
+
+**Root cause**: `is_rest_api_request()` and `is_store_api_request()` in `class-woocommerce.php` only checked for `/wp-json/` in `REQUEST_URI`, not the `?rest_route=` query parameter.
+
+**Fix**: Both methods now also check for the `rest_route` query parameter (see `includes/class-woocommerce.php`).
+
+**Impact**: Without this fix, POS sessions fail when using `?rest_route=` URLs because `wc_load_cart()` is called early (treating it as a frontend request), initializing the wrong session handler before the Store API route can set up `POSSessionHandler`.
+
+This is a general WooCommerce bug that affects any Store API functionality relying on early detection of Store API requests, not just POS.
+
+### Extra Cart Item Data for Plugins
+
+Plugins like Gift Cards expect additional fields when adding products to cart (e.g., `wc_gc_giftcard_to`, `wc_gc_giftcard_from`). These plugins typically read from `$_POST`, which isn't populated for JSON requests.
+
+**Fix**: The `cart/add-item` endpoint now passes unknown request parameters through to `cart_item_data`, allowing plugins to receive extra fields from JSON requests via the `woocommerce_add_cart_item_data` filter.
+
+**Example**:
+```json
+POST /wc/store/v1/cart/add-item
+{
+  "id": 92,
+  "quantity": 1,
+  "wc_gc_giftcard_to": "recipient@example.com",
+  "wc_gc_giftcard_from": "Josh"
+}
+```
+
+## Files Changed
+
+Key files:
+
+- `src/StoreApi/POSSessionHandler.php` - Session handling
+- `src/StoreApi/Utilities/POSUtils.php` - Utility functions
+- `src/StoreApi/functions.php` - Global helper
+- `src/StoreApi/Routes/V1/Checkout.php` - Validation bypasses
+- `src/StoreApi/Routes/V1/AbstractCartRoute.php` - Nonce bypass, session init
+- `src/StoreApi/Utilities/OrderController.php` - Address/email validation
+- `src/StoreApi/Utilities/DraftOrderTrait.php` - Pending order reuse
+- `src/StoreApi/Schemas/V1/BillingAddressSchema.php` - Optional email
+- `src/StoreApi/Legacy.php` - Error passthrough
+- `src/StoreApi/Utilities/CheckoutTrait.php` - Error passthrough
+- `src/StoreApi/Routes/V1/CartAddItem.php` - Extra cart item data passthrough
+- `includes/gateways/pos-cash/` - Cash gateway
+- `includes/gateways/pos-card/` - Card gateway
+- `includes/class-wc-payment-gateways.php` - Gateway registration
+- `includes/data-stores/class-wc-customer-data-store-session.php` - Email autofill skip
+- `includes/class-woocommerce.php` - REST API URL format detection fix

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -191,6 +191,37 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		}
 		$this->cart_controller->load_cart();
 		$this->cart_controller->normalize_cart();
+
+		// For POS sessions, clear the store operator's data from the customer object.
+		// The customer being served is not the logged-in user (the store operator).
+		$this->maybe_clear_pos_customer_data();
+	}
+
+	/**
+	 * Clear customer data that was auto-populated from the store operator's account.
+	 *
+	 * In POS, the logged-in user is the store operator, not the customer. If the
+	 * session has no customer data (fresh transaction), we need to clear any data
+	 * that was loaded from the operator's WordPress user account.
+	 */
+	protected function maybe_clear_pos_customer_data(): void {
+		if ( ! wc_is_pos_session() ) {
+			return;
+		}
+
+		// Check if this is a fresh transaction (no customer data in session).
+		$session_customer = wc()->session->get( 'customer' );
+		if ( ! empty( $session_customer ) ) {
+			// Session has customer data, don't override it.
+			return;
+		}
+
+		// Clear the billing email that was loaded from the store operator's account.
+		// The WC_Customer was created with the logged-in user's ID, which loads their email.
+		$customer = wc()->customer;
+		if ( $customer && $customer->get_id() > 0 ) {
+			$customer->set_billing_email( '' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -262,11 +262,19 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Checks if a nonce is required for the route.
 	 *
+	 * Nonce is required for update requests (POST, PUT, PATCH, DELETE) to prevent CSRF attacks,
+	 * unless the request has a valid cart token or is an authenticated POS session.
+	 *
 	 * @param \WP_REST_Request $request Request.
 	 *
 	 * @return bool
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
+		// POS sessions are authenticated via Application Passwords, so they don't need CSRF protection.
+		if ( wc_is_pos_session() ) {
+			return false;
+		}
+
 		return $this->is_update_request( $request ) && ! $this->has_cart_token( $request );
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -113,13 +113,20 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->load_cart_session( $request );
+		$response = null;
 
-		$response    = null;
-		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
+		try {
+			$this->load_cart_session( $request );
+		} catch ( RouteException $error ) {
+			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
+		}
 
-		if ( is_wp_error( $nonce_check ) ) {
-			$response = $nonce_check;
+		if ( ! $response ) {
+			$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
+
+			if ( is_wp_error( $nonce_check ) ) {
+				$response = $nonce_check;
+			}
 		}
 
 		if ( ! $response ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -167,18 +167,13 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Load the cart session before handling responses.
 	 *
+	 * @throws RouteException If POS header is present but user is not authorized.
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	protected function load_cart_session( \WP_REST_Request $request ) {
-		if ( $this->should_use_pos_session( $request ) ) {
-			// Use POS session handler for authenticated POS requests.
-			add_filter(
-				'woocommerce_session_handler',
-				function () {
-					return POSSessionHandler::class;
-				}
-			);
-		} elseif ( $this->has_cart_token( $request ) ) {
+		$this->maybe_use_pos_session( $request );
+
+		if ( $this->has_cart_token( $request ) ) {
 			// Overrides the core session class.
 			add_filter(
 				'woocommerce_session_handler',
@@ -192,23 +187,37 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	}
 
 	/**
-	 * Check if this request should use a POS session.
+	 * Check if this request should use a POS session and set up the handler.
 	 *
 	 * POS sessions require:
 	 * 1. The X-WC-POS header to be present
 	 * 2. An authenticated user with the manage_woocommerce capability
 	 *
+	 * @throws RouteException If POS header is present but user is not authorized.
 	 * @param \WP_REST_Request $request Request object.
-	 * @return bool
 	 */
-	protected function should_use_pos_session( \WP_REST_Request $request ): bool {
+	protected function maybe_use_pos_session( \WP_REST_Request $request ): void {
 		$pos_header = $request->get_header( 'X-WC-POS' );
 
 		if ( ! $pos_header ) {
-			return false;
+			return;
 		}
 
-		return POSUtils::current_user_can_pos();
+		if ( ! POSUtils::current_user_can_pos() ) {
+			throw new RouteException(
+				'woocommerce_rest_pos_unauthorized',
+				__( 'POS requests require authentication with a user that has the manage_woocommerce capability.', 'woocommerce' ),
+				401
+			);
+		}
+
+		// Use POS session handler for authenticated POS requests.
+		add_filter(
+			'woocommerce_session_handler',
+			function () {
+				return POSSessionHandler::class;
+			}
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -10,10 +10,12 @@ use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CartItemSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema;
 use Automattic\WooCommerce\StoreApi\SessionHandler;
+use Automattic\WooCommerce\StoreApi\POSSessionHandler;
 use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
+use Automattic\WooCommerce\StoreApi\Utilities\POSUtils;
 
 /**
  * Abstract Cart Route
@@ -168,7 +170,15 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	protected function load_cart_session( \WP_REST_Request $request ) {
-		if ( $this->has_cart_token( $request ) ) {
+		if ( $this->should_use_pos_session( $request ) ) {
+			// Use POS session handler for authenticated POS requests.
+			add_filter(
+				'woocommerce_session_handler',
+				function () {
+					return POSSessionHandler::class;
+				}
+			);
+		} elseif ( $this->has_cart_token( $request ) ) {
 			// Overrides the core session class.
 			add_filter(
 				'woocommerce_session_handler',
@@ -179,6 +189,26 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		}
 		$this->cart_controller->load_cart();
 		$this->cart_controller->normalize_cart();
+	}
+
+	/**
+	 * Check if this request should use a POS session.
+	 *
+	 * POS sessions require:
+	 * 1. The X-WC-POS header to be present
+	 * 2. An authenticated user with the manage_woocommerce capability
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	protected function should_use_pos_session( \WP_REST_Request $request ): bool {
+		$pos_header = $request->get_header( 'X-WC-POS' );
+
+		if ( ! $pos_header ) {
+			return false;
+		}
+
+		return POSUtils::current_user_can_pos();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -178,8 +178,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	protected function load_cart_session( \WP_REST_Request $request ) {
-		$this->maybe_use_pos_session( $request );
-
+		// Check for cart token first (for non-POS requests).
 		if ( $this->has_cart_token( $request ) ) {
 			// Overrides the core session class.
 			add_filter(
@@ -189,6 +188,10 @@ abstract class AbstractCartRoute extends AbstractRoute {
 				}
 			);
 		}
+
+		// POS session setup runs after and takes precedence over cart token.
+		$this->maybe_use_pos_session( $request );
+
 		$this->cart_controller->load_cart();
 		$this->cart_controller->normalize_cart();
 
@@ -302,11 +305,27 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
 		// POS sessions are authenticated via Application Passwords, so they don't need CSRF protection.
-		if ( wc_is_pos_session() ) {
+		// Check both wc_is_pos_session() (if session is already initialized) and the request header
+		// (in case session was initialized before our filter was added).
+		if ( wc_is_pos_session() || $this->is_pos_request( $request ) ) {
 			return false;
 		}
 
 		return $this->is_update_request( $request ) && ! $this->has_cart_token( $request );
+	}
+
+	/**
+	 * Check if this is an authenticated POS request.
+	 *
+	 * This checks the X-WC-POS header and verifies the user has POS permissions.
+	 * Used as a fallback when wc_is_pos_session() might return false due to
+	 * session initialization timing.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool
+	 */
+	protected function is_pos_request( \WP_REST_Request $request ): bool {
+		return $request->get_header( 'X-WC-POS' ) && POSUtils::current_user_can_pos();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -98,6 +98,17 @@ class CartAddItem extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_item_exists', esc_html__( 'Cannot create an existing cart item.', 'woocommerce' ), 400 );
 		}
 
+		// Collect extra fields from the request that aren't part of the schema.
+		// These are passed to cart_item_data for plugins like Gift Cards that expect
+		// additional product-specific data (e.g., wc_gc_giftcard_to, wc_gc_giftcard_from).
+		$known_keys     = array( 'id', 'quantity', 'variation', 'key' );
+		$cart_item_data = array();
+		foreach ( $request->get_params() as $key => $value ) {
+			if ( ! in_array( $key, $known_keys, true ) ) {
+				$cart_item_data[ $key ] = $value;
+			}
+		}
+
 		/**
 		 * Filters cart item data sent via the API before it is passed to the cart controller.
 		 *
@@ -119,7 +130,7 @@ class CartAddItem extends AbstractCartRoute {
 				'id'             => $request['id'],
 				'quantity'       => $request['quantity'],
 				'variation'      => $request['variation'],
-				'cart_item_data' => [],
+				'cart_item_data' => $cart_item_data,
 			),
 			$request
 		);

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -58,10 +58,17 @@ class Checkout extends AbstractCartRoute {
 	/**
 	 * Checks if a nonce is required for the route.
 	 *
+	 * Nonce is required unless the request has a valid cart token or is an authenticated POS session.
+	 *
 	 * @param \WP_REST_Request $request Request.
 	 * @return bool
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
+		// POS sessions are authenticated via Application Passwords, so they don't need CSRF protection.
+		if ( wc_is_pos_session() ) {
+			return false;
+		}
+
 		return ! $this->has_cart_token( $request );
 	}
 
@@ -239,6 +246,12 @@ class Checkout extends AbstractCartRoute {
 				'param'    => 'additional_fields',
 			],
 		];
+
+		// POS sessions don't require customer addresses - skip address validation.
+		if ( wc_is_pos_session() ) {
+			unset( $validate_contexts['shipping_address'] );
+			unset( $validate_contexts['billing_address'] );
+		}
 
 		if ( ! WC()->cart->needs_shipping() ) {
 			unset( $validate_contexts['shipping_address'] );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -65,7 +65,9 @@ class Checkout extends AbstractCartRoute {
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
 		// POS sessions are authenticated via Application Passwords, so they don't need CSRF protection.
-		if ( wc_is_pos_session() ) {
+		// Check both wc_is_pos_session() (if session is already initialized) and the request header
+		// (in case session was initialized before our filter was added).
+		if ( wc_is_pos_session() || $this->is_pos_request( $request ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -31,6 +31,10 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	 */
 	public function get_properties() {
 		$properties = parent::get_properties();
+
+		// POS sessions don't require email - it's optional for in-person sales.
+		$email_required = ! wc_is_pos_session();
+
 		return array_merge(
 			$properties,
 			[
@@ -38,7 +42,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 					'description' => __( 'Email', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => [ 'view', 'edit' ],
-					'required'    => true,
+					'required'    => $email_required,
 				],
 			]
 		);

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -42,6 +42,15 @@ final class StoreApi {
 			11
 		);
 
+		// Make billing_address optional for POS checkout requests.
+		// This filter runs before validation, allowing us to provide a default.
+		add_filter(
+			'rest_pre_dispatch',
+			array( $this, 'maybe_default_pos_billing_address' ),
+			10,
+			3
+		);
+
 		add_action(
 			'woocommerce_blocks_pre_get_routes_from_namespace',
 			function ( $routes, $ns ) {
@@ -129,5 +138,43 @@ final class StoreApi {
 			}
 		);
 		return $container;
+	}
+
+	/**
+	 * Provide a default empty billing_address for POS checkout requests.
+	 *
+	 * POS sessions don't require billing address, but the REST API schema marks it
+	 * as required. This filter runs before validation, allowing us to provide a
+	 * default so the request passes validation. The actual address validation is
+	 * already bypassed for POS in Checkout.php.
+	 *
+	 * @param mixed            $result  Response to replace the requested version with.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 * @return mixed
+	 */
+	public function maybe_default_pos_billing_address( $result, $server, $request ) {
+		// Only apply to checkout POST requests.
+		$route = $request->get_route();
+		if ( ! preg_match( '#^/wc/store(/v1)?/checkout$#', $route ) ) {
+			return $result;
+		}
+
+		if ( 'POST' !== $request->get_method() ) {
+			return $result;
+		}
+
+		// Only apply to POS sessions (requires X-WC-POS header).
+		$pos_header = $request->get_header( 'X-WC-POS' );
+		if ( ! $pos_header ) {
+			return $result;
+		}
+
+		// Provide default empty billing_address if not set.
+		if ( null === $request->get_param( 'billing_address' ) ) {
+			$request->set_param( 'billing_address', array() );
+		}
+
+		return $result;
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -84,6 +84,9 @@ trait CheckoutTrait {
 			if ( ! $payment_result instanceof PaymentResult ) {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woocommerce' ), 500 );
 			}
+		} catch ( RouteException $e ) {
+			// Re-throw RouteExceptions as-is to preserve error code and data from payment gateways.
+			throw $e;
 		} catch ( \Exception $e ) {
 			$additional_data = [];
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -60,6 +60,12 @@ trait DraftOrderTrait {
 			return true;
 		}
 
+		// POS pending orders can be retried without cart hash validation.
+		// POS sessions are transaction-scoped, providing isolation between customers.
+		if ( wc_is_pos_session() && $order_object->needs_payment() && $order_object->has_status( 'pending' ) ) {
+			return true;
+		}
+
 		// Pending and failed orders can be retried if the cart hasn't changed.
 		if ( $order_object->needs_payment() && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
 			return true;

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -341,6 +341,12 @@ class OrderController {
 	protected function validate_email( \WC_Order $order ) {
 		$email = $order->get_billing_email();
 
+		// POS sessions don't require an email address for most orders.
+		// Email is only needed for products that require delivery (downloads, gift cards).
+		if ( wc_is_pos_session() && empty( $email ) ) {
+			return;
+		}
+
 		if ( empty( $email ) ) {
 			throw new RouteException(
 				'woocommerce_rest_missing_email_address',

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -112,7 +112,9 @@ class OrderController {
 		$this->update_addresses_from_cart( $order );
 		$order->set_currency( get_woocommerce_currency() );
 		$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
-		$order->set_customer_id( get_current_user_id() );
+		// For POS sessions, create guest orders (customer_id = 0).
+		// The logged-in user is the store operator, not the customer.
+		$order->set_customer_id( wc_is_pos_session() ? 0 : get_current_user_id() );
 		$order->set_customer_ip_address( \WC_Geolocation::get_ip_address() );
 		$order->set_customer_user_agent( wc_get_user_agent() );
 		$order->set_payment_method( PaymentUtils::get_default_payment_method() );

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -368,6 +368,11 @@ class OrderController {
 	 * @param bool      $needs_shipping Whether the order needs shipping.
 	 */
 	protected function validate_addresses( \WC_Order $order, bool $needs_shipping ) {
+		// POS sessions don't require customer addresses - skip address validation entirely.
+		if ( wc_is_pos_session() ) {
+			return;
+		}
+
 		$errors           = new \WP_Error();
 		$billing_country  = $order->get_billing_country();
 		$shipping_country = $order->get_shipping_country();

--- a/plugins/woocommerce/src/StoreApi/Utilities/POSUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/POSUtils.php
@@ -1,0 +1,40 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\StoreApi\Utilities;
+
+use Automattic\WooCommerce\StoreApi\POSSessionHandler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * POSUtils class
+ *
+ * Utility functions for Point of Sale (POS) functionality in the Store API.
+ */
+class POSUtils {
+
+	/**
+	 * Check if the current request is using a POS session.
+	 *
+	 * @return bool True if the current session is a POS session.
+	 */
+	public static function is_pos_session(): bool {
+		if ( ! function_exists( 'WC' ) || is_null( WC()->session ) ) {
+			return false;
+		}
+
+		return WC()->session instanceof POSSessionHandler;
+	}
+
+	/**
+	 * Check if the current user has permission to use POS checkout.
+	 *
+	 * Requires the user to be authenticated and have the manage_woocommerce capability.
+	 *
+	 * @return bool True if the current user can use POS checkout.
+	 */
+	public static function current_user_can_pos(): bool {
+		return is_user_logged_in() && current_user_can( 'manage_woocommerce' );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/functions.php
+++ b/plugins/woocommerce/src/StoreApi/functions.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\POSUtils;
 
 if ( ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
 
@@ -83,5 +84,20 @@ if ( ! function_exists( 'woocommerce_store_api_get_formatter' ) ) {
 	 */
 	function woocommerce_store_api_get_formatter( $name ) {
 		return StoreApi::container()->get( ExtendSchema::class )->get_formatter( $name );
+	}
+}
+
+if ( ! function_exists( 'wc_is_pos_session' ) ) {
+
+	/**
+	 * Check if the current request is using a POS session.
+	 *
+	 * POS sessions are authenticated Store API requests that allow
+	 * different validation rules (e.g., skipping address requirements).
+	 *
+	 * @return bool True if the current session is a POS session.
+	 */
+	function wc_is_pos_session() {
+		return POSUtils::is_pos_session();
 	}
 }


### PR DESCRIPTION
This is a HACK week project and should not be merged.

It adds authenticated session handlers to the Store API, as a proof of concept for using the Store API from Point of Sale.

Two payment methods are supported:
- a trusted `pos_cash` payment method which just marks the order as paid
- a two-step `pos_card` method which creates a pending order on the first call, then proxies the second call (with the payment_intent_id) to WooPayments' `capture_terminal_payment` endpoint.

Various restrictions are removed due to the authentication
- Nonce
- Billing address
- Email (except for downloadable products)

Some issues are also fixed along the way, but not necessarily in a production-appropriate way!