### PR TITLE
Include WooCommerce `src` Directory in Code Coverage

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpunit-coverage-excludes
+++ b/plugins/woocommerce/changelog/fix-phpunit-coverage-excludes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Only updating PHPUnit's code coverage include/exclude to add ./src directory support.
+
+

--- a/plugins/woocommerce/phpunit.xml
+++ b/plugins/woocommerce/phpunit.xml
@@ -35,8 +35,9 @@
 	<coverage includeUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./includes</directory>
-		<file>woocommerce.php</file>
-		<file>uninstall.php</file>
+			<directory suffix=".php">./src</directory>
+			<file>woocommerce.php</file>
+			<file>uninstall.php</file>
 		</include>
 		<exclude>
 			<directory suffix=".php">./includes/admin/helper/views</directory>
@@ -57,7 +58,6 @@
 			<directory suffix=".php">./includes/vendor</directory>
 			<directory suffix=".php">./includes/widgets</directory>
 			<directory suffix=".php">./packages</directory>
-			<directory suffix=".php">./src</directory>
 			<directory suffix=".php">./vendor</directory>
 			<file>./includes/wc-deprecated-functions.php</file>
 			<file>./includes/wc-template-hooks.php</file>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In trying to generate a code coverage report I found that the `src` directory is explicitly excluded from code coverage. Since most of the modern code we write is here, it seems reasonable to include it in the code coverage report. This pull request does just that.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Xdebug`'s "coverage" mode. If you're using `wp-env`, this can be done via `pnpm --filter='@woocommerce/plugin-woocommerce' env:dev --xdebug=coverage`.
2. Run the unit test suite with coverage. `pnpm --filter='@woocommerce/plugin-woocommerce' wp-env run tests-cli bash -c "cd wp-content/plugins/woocommerce && ./vendor/bin/phpunit -c phpunit.xml --group fast --verbose --coverage-html reports/html"` (Runs a subset just to demonstrate the generation more quickly.)
3. Review the report in `plugins/woocommerce/reports/html` ton confirm they were generated correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

- Generated coverage report for full suite

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
