### PR TITLE
[Fraud Protection] POC Add fraud protection implementation

### DIFF
--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -602,6 +602,12 @@ class FeaturesController {
 						'title' => __( 'Reset Session Clearances', 'woocommerce' ),
 						'desc'  => __( 'Reset all data about session fraud protection clearance. This will require all users to validate their sessions again.', 'woocommerce' ),
 					),
+					array(
+						'type'  => 'jetpack_connection',
+						'id'    => 'jetpack_connection_button',
+						'title' => __( 'Connect to Jetpack', 'woocommerce' ),
+						'desc'  => __( 'A Jetpack connection is required to use fraud protection.', 'woocommerce' ),
+					),
 				),
 			),
 		);

--- a/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
@@ -7,6 +7,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\FraudProtection;
 
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\WooCommerce\Admin\API\OnboardingPlugins;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -21,6 +24,7 @@ class AdminSettingsHandler {
 	 */
 	public function __construct() {
 		add_action( 'woocommerce_admin_field_fraud_protection_reset_sessions', array( $this, 'handle_output_reset_button' ), 10, 1 );
+		add_action( 'woocommerce_admin_field_jetpack_connection', array( $this, 'handle_output_jetpack_connection_button' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'handle_reset_sessions_action' ), 10, 0 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'handle_enqueue_admin_scripts' ), 10, 1 );
 	}
@@ -60,6 +64,76 @@ class AdminSettingsHandler {
 			</td>
 		</tr>
 		<?php
+	}
+
+	/**
+	 * Output the reset sessions button field.
+	 *
+	 * @internal
+	 *
+	 * @param array $value Field configuration.
+	 * @return void
+	 */
+	public function handle_output_jetpack_connection_button( $value ): void {
+		$field_id          = esc_attr( $value['id'] );
+		$field_title       = esc_html( $value['title'] );
+		$field_description = esc_html( $value['desc'] );
+
+
+		$manager = new Manager( 'woocommerce' );
+		if ( ! $manager->is_connected() ) {
+			$request = new \WP_REST_Request();
+			$request->set_param( 'redirect_url', admin_url() );
+			$plugin_onboarding = new OnboardingPlugins();
+			$result = $plugin_onboarding->get_jetpack_authorization_url( $request );
+
+			// Todo: change parameters
+			if ( ! empty( $result['url'] ) ) {
+				$result['url'] = add_query_arg(
+					array(
+						'redirect_uri' => urlencode( admin_url() . 'admin.php/?page=wc-settings&tab=advanced&section=features' ),
+						// We use the new WooDNA value.
+						'from'         => 'woocommerce-setup-wizard',
+						// We inform Calypso that this is a WooPayments onboarding flow.
+						'plugin_name'  => 'woocommerce',
+						// Use the current user's WP admin color scheme.
+						'color_scheme' => $result['color_scheme'],
+					),
+					$result['url']
+				);
+				$connection_url = $result['url'];
+			}
+
+			?>
+			<tr valign="top">
+				<th scope="row" class="titledesc">
+					<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+				</th>
+				<td class="forminp forminp-button">
+					<button
+						type="button"
+						id="<?php echo $field_id; ?>"
+						class="button button-secondary jetpack_connection_button"
+						data-reset-url="<?php echo esc_url( $connection_url ); ?>"
+					>
+						<?php esc_html_e( 'Connect to Jetpack', 'woocommerce' ); ?>
+					</button>
+					<p class="description"><?php echo $field_description; ?></p>
+				</td>
+			</tr>
+			<?php
+		} else {
+			?>
+			<tr valign="top">
+				<th scope="row" class="titledesc">
+					<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+				</th>
+				<td class="forminp forminp-button">
+					<p class="description"><?php _e( 'Already connected to Jetpack', 'woocommerce' )  ?></p>
+				</td>
+			</tr>
+			<?php
+		}
 	}
 
 	/**
@@ -136,6 +210,12 @@ class AdminSettingsHandler {
 				if (!confirm('" . esc_js( __( 'Are you sure you want to reset all session clearances? This will require all users to clear their sessions again.', 'woocommerce' ) ) . "')) {
 					return;
 				}
+
+				var resetUrl = $(this).data('reset-url');
+				window.location.href = resetUrl;
+			});
+			$('.jetpack_connection_button').on('click', function(e) {
+				e.preventDefault();
 
 				var resetUrl = $(this).data('reset-url');
 				window.location.href = resetUrl;

--- a/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
@@ -60,18 +60,18 @@ class AdminSettingsHandler {
 		?>
 		<tr valign="top">
 			<th scope="row" class="titledesc">
-				<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+				<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field_title ); ?></label>
 			</th>
 			<td class="forminp forminp-button">
 				<button
 					type="button"
-					id="<?php echo $field_id; ?>"
+					id="<?php echo esc_attr( $field_id ); ?>"
 					class="button button-secondary wc-fraud-protection-reset-button"
 					data-reset-url="<?php echo esc_url( $reset_url ); ?>"
 				>
 					<?php esc_html_e( 'Reset All Sessions', 'woocommerce' ); ?>
 				</button>
-				<p class="description"><?php echo $field_description; ?></p>
+				<p class="description"><?php echo esc_html( $field_description ); ?></p>
 			</td>
 		</tr>
 		<?php
@@ -103,7 +103,7 @@ class AdminSettingsHandler {
 				?>
 				<tr valign="top">
 					<th scope="row" class="titledesc">
-						<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+						<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field_title ); ?></label>
 					</th>
 					<td class="forminp forminp-button">
 						<p class="description" style="color: #dc3232;">
@@ -118,18 +118,18 @@ class AdminSettingsHandler {
 			?>
 			<tr valign="top">
 				<th scope="row" class="titledesc">
-					<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+					<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field_title ); ?></label>
 				</th>
 				<td class="forminp forminp-button">
 					<button
 						type="button"
-						id="<?php echo $field_id; ?>"
+						id="<?php echo esc_attr( $field_id ); ?>"
 						class="button button-secondary jetpack_connection_button"
 						data-connection-url="<?php echo esc_url( $connection_url ); ?>"
 					>
 						<?php esc_html_e( 'Connect to Jetpack', 'woocommerce' ); ?>
 					</button>
-					<p class="description"><?php echo $field_description; ?></p>
+					<p class="description"><?php echo esc_html( $field_description ); ?></p>
 				</td>
 			</tr>
 			<?php
@@ -137,7 +137,7 @@ class AdminSettingsHandler {
 			?>
 			<tr valign="top">
 				<th scope="row" class="titledesc">
-					<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+					<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $field_title ); ?></label>
 				</th>
 				<td class="forminp forminp-button">
 					<span class="dashicons dashicons-yes-alt" style="color: #46b450;"></span>

--- a/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
@@ -7,9 +7,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\FraudProtection;
 
-use Automattic\Jetpack\Connection\Manager;
-use Automattic\WooCommerce\Admin\API\OnboardingPlugins;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -20,9 +17,20 @@ defined( 'ABSPATH' ) || exit;
 class AdminSettingsHandler {
 
 	/**
-	 * Constructor. Sets up hooks on instantiation.
+	 * Jetpack connection manager instance.
+	 *
+	 * @var JetpackConnectionManager
 	 */
-	public function __construct() {
+	private $connection_manager;
+
+	/**
+	 * Constructor. Sets up hooks on instantiation.
+	 *
+	 * @param JetpackConnectionManager $connection_manager Jetpack connection manager instance.
+	 */
+	public function __construct( JetpackConnectionManager $connection_manager ) {
+		$this->connection_manager = $connection_manager;
+
 		add_action( 'woocommerce_admin_field_fraud_protection_reset_sessions', array( $this, 'handle_output_reset_button' ), 10, 1 );
 		add_action( 'woocommerce_admin_field_jetpack_connection', array( $this, 'handle_output_jetpack_connection_button' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'handle_reset_sessions_action' ), 10, 0 );
@@ -79,29 +87,29 @@ class AdminSettingsHandler {
 		$field_title       = esc_html( $value['title'] );
 		$field_description = esc_html( $value['desc'] );
 
+		// Get connection status from connection manager.
+		$connection_status = $this->connection_manager->get_connection_status();
 
-		$manager = new Manager( 'woocommerce' );
-		if ( ! $manager->is_connected() ) {
-			$request = new \WP_REST_Request();
-			$request->set_param( 'redirect_url', admin_url() );
-			$plugin_onboarding = new OnboardingPlugins();
-			$result = $plugin_onboarding->get_jetpack_authorization_url( $request );
+		if ( ! $connection_status['connected'] ) {
+			// Get authorization URL for connecting.
+			$redirect_url   = admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
+			$connection_url = $this->connection_manager->get_authorization_url( $redirect_url );
 
-			// Todo: change parameters
-			if ( ! empty( $result['url'] ) ) {
-				$result['url'] = add_query_arg(
-					array(
-						'redirect_uri' => urlencode( admin_url() . 'admin.php/?page=wc-settings&tab=advanced&section=features' ),
-						// We use the new WooDNA value.
-						'from'         => 'woocommerce-setup-wizard',
-						// We inform Calypso that this is a WooPayments onboarding flow.
-						'plugin_name'  => 'woocommerce',
-						// Use the current user's WP admin color scheme.
-						'color_scheme' => $result['color_scheme'],
-					),
-					$result['url']
-				);
-				$connection_url = $result['url'];
+			// If we couldn't get authorization URL, show error message.
+			if ( ! $connection_url ) {
+				?>
+				<tr valign="top">
+					<th scope="row" class="titledesc">
+						<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
+					</th>
+					<td class="forminp forminp-button">
+						<p class="description" style="color: #dc3232;">
+							<?php echo esc_html( $connection_status['error'] ); ?>
+						</p>
+					</td>
+				</tr>
+				<?php
+				return;
 			}
 
 			?>
@@ -114,7 +122,7 @@ class AdminSettingsHandler {
 						type="button"
 						id="<?php echo $field_id; ?>"
 						class="button button-secondary jetpack_connection_button"
-						data-reset-url="<?php echo esc_url( $connection_url ); ?>"
+						data-connection-url="<?php echo esc_url( $connection_url ); ?>"
 					>
 						<?php esc_html_e( 'Connect to Jetpack', 'woocommerce' ); ?>
 					</button>
@@ -129,7 +137,17 @@ class AdminSettingsHandler {
 					<label for="<?php echo $field_id; ?>"><?php echo $field_title; ?></label>
 				</th>
 				<td class="forminp forminp-button">
-					<p class="description"><?php _e( 'Already connected to Jetpack', 'woocommerce' )  ?></p>
+					<span class="dashicons dashicons-yes-alt" style="color: #46b450;"></span>
+					<span><?php esc_html_e( 'Connected to Jetpack', 'woocommerce' ); ?></span>
+					<p class="description">
+						<?php
+						printf(
+							/* translators: %d: Blog ID */
+							esc_html__( 'Site ID: %d', 'woocommerce' ),
+							(int) $connection_status['blog_id']
+						);
+						?>
+					</p>
 				</td>
 			</tr>
 			<?php
@@ -217,8 +235,8 @@ class AdminSettingsHandler {
 			$('.jetpack_connection_button').on('click', function(e) {
 				e.preventDefault();
 
-				var resetUrl = $(this).data('reset-url');
-				window.location.href = resetUrl;
+				var connectionUrl = $(this).data('connection-url');
+				window.location.href = connectionUrl;
 			});
 		});
 		";

--- a/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/AdminSettingsHandler.php
@@ -24,11 +24,14 @@ class AdminSettingsHandler {
 	private $connection_manager;
 
 	/**
-	 * Constructor. Sets up hooks on instantiation.
+	 * Initialize the class with dependencies.
+	 *
+	 * @internal
 	 *
 	 * @param JetpackConnectionManager $connection_manager Jetpack connection manager instance.
+	 * @return void
 	 */
-	public function __construct( JetpackConnectionManager $connection_manager ) {
+	final public function init( JetpackConnectionManager $connection_manager ): void {
 		$this->connection_manager = $connection_manager;
 
 		add_action( 'woocommerce_admin_field_fraud_protection_reset_sessions', array( $this, 'handle_output_reset_button' ), 10, 1 );

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
@@ -43,6 +43,13 @@ class FraudProtectionController {
 	private $data_collector;
 
 	/**
+	 * Jetpack connection manager instance.
+	 *
+	 * @var JetpackConnectionManager
+	 */
+	private $connection_manager;
+
+	/**
 	 * Constructor. Sets up hooks on instantiation.
 	 */
 	public function __construct() {
@@ -50,7 +57,8 @@ class FraudProtectionController {
 		$container = wc_get_container();
 		$this->session_manager     = $container->get( SessionClearanceManager::class );
 		$this->features_controller = $container->get( FeaturesController::class );
-		$this->data_collector    = $container->get( SessionDataCollector::class );
+		$this->data_collector      = $container->get( SessionDataCollector::class );
+		$this->connection_manager  = $container->get( JetpackConnectionManager::class );
 
 		// Register Store API routes.
 		add_action( 'rest_api_init', array( $this, 'handle_register_store_api_routes' ), 10, 0 );
@@ -77,8 +85,77 @@ class FraudProtectionController {
 	 */
 	public function maybe_init_hooks(): void {
 		if ( $this->is_fraud_protection_enabled() ) {
+			// Check Jetpack connection and log warning if not connected.
+			$this->check_jetpack_connection();
+
 			$this->init_hooks();
 		}
+	}
+
+	/**
+	 * Check Jetpack connection status and log warning if not connected.
+	 *
+	 * This implements the fail-open pattern: the feature will continue to work
+	 * even if Jetpack is not connected, but fraud protection API calls will fail
+	 * gracefully and allow all sessions through.
+	 *
+	 * @return void
+	 */
+	private function check_jetpack_connection(): void {
+		$connection_status = $this->connection_manager->get_connection_status();
+
+		if ( ! $connection_status['connected'] ) {
+			$logger = wc_get_logger();
+			$logger->warning(
+				sprintf(
+					'Fraud Protection is enabled but Jetpack connection is not available: %s (Error: %s). Fraud protection will fail open and allow all sessions.',
+					$connection_status['error'],
+					$connection_status['error_code']
+				),
+				array( 'source' => 'woo-fraud-protection' )
+			);
+
+			// Add admin notice if in admin area.
+			if ( is_admin() ) {
+				add_action( 'admin_notices', array( $this, 'handle_connection_warning_notice' ) );
+			}
+		}
+	}
+
+	/**
+	 * Display admin notice when Jetpack connection is not available.
+	 *
+	 * @internal
+	 *
+	 * @return void
+	 */
+	public function handle_connection_warning_notice(): void {
+		// Only show on WooCommerce settings page.
+		$screen = get_current_screen();
+		if ( ! $screen || 'woocommerce_page_wc-settings' !== $screen->id ) {
+			return;
+		}
+
+		$connection_status = $this->connection_manager->get_connection_status();
+		$settings_url      = admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
+
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p>
+				<strong><?php esc_html_e( 'Fraud Protection Warning:', 'woocommerce' ); ?></strong>
+				<?php echo esc_html( $connection_status['error'] ); ?>
+			</p>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: Settings page URL */
+					wp_kses_post( __( 'Fraud protection will fail open and allow all sessions until connected. <a href="%s">Connect to Jetpack</a>', 'woocommerce' ) ),
+					esc_url( $settings_url )
+				);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionServiceApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionServiceApiClient.php
@@ -65,11 +65,14 @@ class FraudProtectionServiceApiClient {
 	private $connection_manager;
 
 	/**
-	 * Constructor.
+	 * Initialize the class with dependencies.
+	 *
+	 * @internal
 	 *
 	 * @param JetpackConnectionManager $connection_manager Jetpack connection manager instance.
+	 * @return void
 	 */
-	public function __construct( JetpackConnectionManager $connection_manager ) {
+	final public function init( JetpackConnectionManager $connection_manager ): void {
 		$this->connection_manager = $connection_manager;
 	}
 

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionServiceApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionServiceApiClient.php
@@ -58,6 +58,22 @@ class FraudProtectionServiceApiClient {
 	public const DECISION_CHALLENGE = 'challenge';
 
 	/**
+	 * Jetpack connection manager instance.
+	 *
+	 * @var JetpackConnectionManager
+	 */
+	private $connection_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param JetpackConnectionManager $connection_manager Jetpack connection manager instance.
+	 */
+	public function __construct( JetpackConnectionManager $connection_manager ) {
+		$this->connection_manager = $connection_manager;
+	}
+
+	/**
 	 * Track a session event and get fraud decision from WPCOM endpoint.
 	 *
 	 * Implements fail-open pattern: if the endpoint is unreachable or times out,
@@ -106,20 +122,23 @@ class FraudProtectionServiceApiClient {
 	private function make_request( array $payload ) {
 		$this->log_request( $payload );
 
-		// Check if Jetpack Connection is available.
-		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
+		// Check connection status using connection manager.
+		$connection_status = $this->connection_manager->get_connection_status();
+		if ( ! $connection_status['connected'] ) {
 			return new \WP_Error(
-				'jetpack_not_available',
-				'Jetpack Connection is not available'
+				$connection_status['error_code'],
+				$connection_status['error']
 			);
 		}
 
-		// Get the Jetpack blog ID for site-specific endpoint.
-		$blog_id = \Jetpack_Options::get_option( 'id' );
-		if ( ! $blog_id ) {
+		// Get blog ID from connection manager.
+		$blog_id = $connection_status['blog_id'];
+
+		// Check if Jetpack Connection Client is available.
+		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
 			return new \WP_Error(
-				'no_blog_id',
-				'Jetpack blog ID not found. Is the site connected to WordPress.com?'
+				'jetpack_not_available',
+				'Jetpack Connection Client class is not available'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/FraudProtection/JetpackConnectionManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/JetpackConnectionManager.php
@@ -192,7 +192,7 @@ class JetpackConnectionManager {
 					// Customize the URL parameters for fraud protection.
 					$url = add_query_arg(
 						array(
-							'redirect_uri' => urlencode( $redirect_url ),
+							'redirect_uri' => rawurlencode( $redirect_url ),
 							'from'         => 'woocommerce-fraud-protection',
 							'plugin_name'  => 'woocommerce',
 						),

--- a/plugins/woocommerce/src/Internal/FraudProtection/JetpackConnectionManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/JetpackConnectionManager.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * JetpackConnectionManager class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\FraudProtection;
+
+use Automattic\Jetpack\Connection\Manager;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages Jetpack connection status and validation for fraud protection.
+ *
+ * Provides centralized methods to check connection status, validate requirements,
+ * and handle connection-related errors gracefully.
+ *
+ * @since 10.4.0
+ */
+class JetpackConnectionManager {
+
+	/**
+	 * Logger source identifier.
+	 */
+	private const LOGGER_SOURCE = 'woo-fraud-protection';
+
+	/**
+	 * Check if Jetpack Connection is available and properly configured.
+	 *
+	 * This method checks:
+	 * 1. If Jetpack Connection class exists
+	 * 2. If the site is connected to WordPress.com
+	 * 3. If we can retrieve the blog ID
+	 *
+	 * @return bool True if connection is available and valid.
+	 */
+	public function is_connected(): bool {
+		// Check if Jetpack Connection is available.
+		if ( ! $this->is_jetpack_connection_available() ) {
+			return false;
+		}
+
+		// Get connection manager instance.
+		$manager = $this->get_connection_manager();
+		if ( ! $manager ) {
+			return false;
+		}
+
+		// Check if site is connected.
+		return $manager->is_connected();
+	}
+
+	/**
+	 * Check if Jetpack Connection class is available.
+	 *
+	 * @return bool True if Jetpack Connection class exists.
+	 */
+	public function is_jetpack_connection_available(): bool {
+		return class_exists( Manager::class );
+	}
+
+	/**
+	 * Get the Jetpack blog ID.
+	 *
+	 * @return int|null Blog ID if available, null otherwise.
+	 */
+	public function get_blog_id(): ?int {
+		if ( ! $this->is_jetpack_connection_available() ) {
+			return null;
+		}
+
+		// Get blog ID from Jetpack options.
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+
+		return $blog_id ? (int) $blog_id : null;
+	}
+
+	/**
+	 * Get connection manager instance.
+	 *
+	 * @return Manager|null Connection manager instance or null if not available.
+	 */
+	private function get_connection_manager(): ?Manager {
+		if ( ! $this->is_jetpack_connection_available() ) {
+			return null;
+		}
+
+		try {
+			return new Manager( 'woocommerce' );
+		} catch ( \Exception $e ) {
+			$this->log_error(
+				sprintf(
+					'Failed to initialize Jetpack Connection Manager: %s',
+					$e->getMessage()
+				)
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Get connection status with detailed error information.
+	 *
+	 * Returns an array with connection status and any error details.
+	 *
+	 * @return array {
+	 *     Connection status information.
+	 *
+	 *     @type bool   $connected    Whether the site is connected.
+	 *     @type string $error        Error message if not connected.
+	 *     @type string $error_code   Error code if not connected.
+	 *     @type int    $blog_id      Blog ID if available.
+	 * }
+	 */
+	public function get_connection_status(): array {
+		$status = array(
+			'connected'  => false,
+			'error'      => '',
+			'error_code' => '',
+			'blog_id'    => null,
+		);
+
+		// Check if Jetpack Connection class exists.
+		if ( ! $this->is_jetpack_connection_available() ) {
+			$status['error']      = __( 'Jetpack Connection is not available. Please install and activate Jetpack.', 'woocommerce' );
+			$status['error_code'] = 'jetpack_not_available';
+			return $status;
+		}
+
+		// Get connection manager.
+		$manager = $this->get_connection_manager();
+		if ( ! $manager ) {
+			$status['error']      = __( 'Failed to initialize Jetpack Connection Manager.', 'woocommerce' );
+			$status['error_code'] = 'manager_init_failed';
+			return $status;
+		}
+
+		// Check if connected.
+		if ( ! $manager->is_connected() ) {
+			$status['error']      = __( 'Site is not connected to WordPress.com. Please connect your site to enable fraud protection.', 'woocommerce' );
+			$status['error_code'] = 'not_connected';
+			return $status;
+		}
+
+		// Get blog ID.
+		$blog_id = $this->get_blog_id();
+		if ( ! $blog_id ) {
+			$status['error']      = __( 'Jetpack blog ID not found. Please reconnect your site to WordPress.com.', 'woocommerce' );
+			$status['error_code'] = 'no_blog_id';
+			return $status;
+		}
+
+		// All checks passed.
+		$status['connected'] = true;
+		$status['blog_id']   = $blog_id;
+
+		return $status;
+	}
+
+	/**
+	 * Get the Jetpack authorization URL for connecting the site.
+	 *
+	 * @param string $redirect_url URL to redirect to after authorization.
+	 * @return string|null Authorization URL or null on error.
+	 */
+	public function get_authorization_url( string $redirect_url = '' ): ?string {
+		if ( ! $this->is_jetpack_connection_available() ) {
+			return null;
+		}
+
+		$manager = $this->get_connection_manager();
+		if ( ! $manager ) {
+			return null;
+		}
+
+		// If no redirect URL provided, use current admin URL.
+		if ( empty( $redirect_url ) ) {
+			$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
+		}
+
+		try {
+			// Use the OnboardingPlugins class to get authorization URL.
+			if ( class_exists( '\Automattic\WooCommerce\Admin\API\OnboardingPlugins' ) ) {
+				$request = new \WP_REST_Request();
+				$request->set_param( 'redirect_url', $redirect_url );
+				$plugin_onboarding = new \Automattic\WooCommerce\Admin\API\OnboardingPlugins();
+				$result            = $plugin_onboarding->get_jetpack_authorization_url( $request );
+
+				if ( ! empty( $result['url'] ) ) {
+					// Customize the URL parameters for fraud protection.
+					$url = add_query_arg(
+						array(
+							'redirect_uri' => urlencode( $redirect_url ),
+							'from'         => 'woocommerce-fraud-protection',
+							'plugin_name'  => 'woocommerce',
+						),
+						$result['url']
+					);
+					return $url;
+				}
+			}
+
+			return null;
+		} catch ( \Exception $e ) {
+			$this->log_error(
+				sprintf(
+					'Failed to get Jetpack authorization URL: %s',
+					$e->getMessage()
+				)
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Log an error message.
+	 *
+	 * @param string $message Error message.
+	 * @return void
+	 */
+	private function log_error( string $message ): void {
+		$logger = wc_get_logger();
+		$logger->error( $message, array( 'source' => self::LOGGER_SOURCE ) );
+	}
+
+	/**
+	 * Log an info message.
+	 *
+	 * @param string $message Info message.
+	 * @return void
+	 */
+	private function log_info( string $message ): void {
+		$logger = wc_get_logger();
+		$logger->info( $message, array( 'source' => self::LOGGER_SOURCE ) );
+	}
+}


### PR DESCRIPTION
A new button to connect to jetpack was added to /wp-admin > WooCommerce > Settings > Advanced > Feature > Connect to Jetpack. This connection will be used by the fraud protection code

Before connecting:
<img width="698" height="270" alt="Screenshot 2025-12-17 at 17 50 28" src="https://github.com/user-attachments/assets/a8b80091-c117-4aae-90b2-e97579c76fad" />

After connecting:
<img width="1178" height="457" alt="Screenshot 2025-12-16 at 13 55 58" src="https://github.com/user-attachments/assets/22add455-6e3e-4f9d-b710-07fb9ebb8c68" />


**Testing instructions**
- Checkout to this branch
- Make sure you don't have any jetpack connections active. This can be done by installing the jetpack plugin and then disconnecting
- Make your local site public. You can use ngrok or jurassic tunnel for that
- Go to /wp-admin > WooCommerce > Settings > Advanced > Feature
- Click Connect to Jetpack
- You'll get forwarded to the Jetpack login page
- Authorize the connection
- You'll get forwarded back to your site

Closes [WOOSUBS-1313](https://linear.app/a8c/issue/WOOSUBS-1313/woofraudprotection-jetpack-connection-integration)