### PR TITLE
Minicart: Fix wrong focus when multiple minicarts are in the page

### DIFF
--- a/plugins/woocommerce/changelog/62494-wooplug-6029-minicart-incorrect-focus-when-having-multiple-minicarts
+++ b/plugins/woocommerce/changelog/62494-wooplug-6029-minicart-incorrect-focus-when-having-multiple-minicarts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix minicart focus when multiple minicarts are in the page

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -255,6 +255,8 @@ store< MiniCart >(
 					window.location.href = checkoutUrl;
 					return;
 				}
+				const { ref } = getElement();
+				state.miniCartButtonRef = ref;
 				state.isOpen = true;
 			},
 
@@ -382,11 +384,6 @@ store< MiniCart >(
 					// Focus first element when the minicart is opened.
 					getFocusableElements( ref )[ 0 ]?.focus();
 				}
-			},
-
-			saveMiniCartButtonRef() {
-				const { ref } = getElement();
-				state.miniCartButtonRef = ref;
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -98,7 +98,6 @@ type MiniCart = {
 		setupEventListeners: () => void;
 		disableScrollingOnBody: () => void;
 		focusFirstElement: () => void;
-		saveMiniCartButtonRef: () => void;
 	};
 };
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -610,7 +610,6 @@ class MiniCart extends AbstractBlock {
 				style="<?php echo esc_attr( $wrapper_styles ); ?>"
 			>
 				<button 
-					data-wp-init="callbacks.saveMiniCartButtonRef"
 					data-wp-on--click="actions.openDrawer"
 					data-wp-bind--aria-label="state.buttonAriaLabel"
 					class="wc-block-mini-cart__button"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #62493 .

This PR sets the correct focus after closing when there are multiple minicarts in the page. 

### Screenshots or screen recordings:

**Before**

https://github.com/user-attachments/assets/af89d9f0-6c73-464d-9a65-16d2a9965624

**After**

https://github.com/user-attachments/assets/c9cb1c44-6155-4304-8860-51bfd275bacf

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add two minicarts to the header. You need to use the Code Editor for that and adding the minicart twice.

```
<!-- wp:woocommerce/mini-cart /-->
```
2. Go to the frontend and open the first minicart.
3. Close the minicart and see the focus is correct.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix minicart focus when multiple minicarts are in the page

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
