### PR TITLE
e2e tests: Fix expected count in JS file monitor test

### DIFF
--- a/plugins/woocommerce/changelog/fix-62462-flaky-js-file-monitor-test
+++ b/plugins/woocommerce/changelog/fix-62462-flaky-js-file-monitor-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix unstable monitor js count e2e test
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/js-file-monitor/monitor-js-file-number.spec.js
@@ -18,7 +18,7 @@ const pageGroups = [
 			{
 				name: 'WC Dashboard',
 				url: 'wp-admin/admin.php?page=wc-admin',
-				expectedCount: 83,
+				expectedCount: 84,
 			},
 			{
 				name: 'Reports',


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Closes #62462

Bumped the expected JS file count for WC Dashboard from 83 to 84.

### How to test the changes in this Pull Request:

```
pnpm test:e2e js-file-monitor/monitor-js-file-number.spec.js
```
