### PR TITLE
Fix handling of order modified date during HPOS sync-on-read

### DIFF
--- a/plugins/woocommerce/changelog/fix-62492
+++ b/plugins/woocommerce/changelog/fix-62492
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve handling of order modified date during HPOS sync on read to prevent infinite loops.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1372,7 +1372,10 @@ WHERE
 			 *
 			 * @since 8.1.0
 			 */
-			$data_sync_enabled = apply_filters( 'woocommerce_hpos_enable_sync_on_read', $data_sync_enabled );
+			$data_sync_enabled = apply_filters(
+				'woocommerce_hpos_enable_sync_on_read',
+				$data_sync_enabled && ! doing_action( 'woocommerce_deliver_webhook_async' ) && ! doing_action( 'wc-admin_import_orders' )
+			);
 		}
 
 		$load_posts_for = array_diff( $order_ids, array_merge( self::$reading_order_ids, self::$backfilling_order_ids ) );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -45,7 +45,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	private static $backfilling_order_ids = array();
 
 	/**
-	 * Keep track of order IDs that are being synced on read. This is used to prevent backfilling to posts of an order being updated
+	 * Keep track of order IDs (as keys) that are being synced on read. This is used to prevent backfilling to posts of an order being updated
 	 * from posts.
 	 *
 	 * @var array
@@ -1721,7 +1721,7 @@ WHERE
 	 * @return void
 	 */
 	private function migrate_post_record( \WC_Abstract_Order &$order, \WC_Abstract_Order $post_order ): void {
-		self::$sync_on_read_order_ids[] = $order->get_id();
+		self::$sync_on_read_order_ids[ $order->get_id() ] = true;
 
 		$diff                 = $this->migrate_meta_data_from_post_order( $order, $post_order );
 		$post_order_base_data = $post_order->get_base_data();
@@ -1738,7 +1738,7 @@ WHERE
 		}
 		$this->persist_updates( $order, false );
 
-		self::$sync_on_read_order_ids = array_diff( self::$sync_on_read_order_ids, array( $order->get_id() ) );
+		unset( self::$sync_on_read_order_ids[ $order->get_id() ] );
 
 		/**
 		 * Fired when an HPOS order is updated from its corresponding post record on read due to a difference in the data.
@@ -2894,7 +2894,7 @@ FROM $order_meta_table
 		$changes = $order->get_changes();
 
 		// Does not make much sense to backfill to posts an order being sync-on-read from posts.
-		$should_backfill = ! in_array( $order->get_id(), self::$sync_on_read_order_ids, true );
+		$should_backfill = ! isset( self::$sync_on_read_order_ids[ $order->get_id() ] );
 
 		$this->persist_updates( $order, $should_backfill );
 
@@ -3440,7 +3440,7 @@ CREATE TABLE $meta_table (
 
 		$should_save =
 			$order->get_id() > 0
-			&& ! in_array( $order->get_id(), self::$sync_on_read_order_ids, true )
+			&& ! isset( self::$sync_on_read_order_ids[ $order->get_id() ] )
 			&& $order->get_date_modified() < $current_date_time && empty( $order->get_changes() )
 			&& ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1374,7 +1374,7 @@ WHERE
 			 */
 			$data_sync_enabled = apply_filters(
 				'woocommerce_hpos_enable_sync_on_read',
-				$data_sync_enabled && ! doing_action( 'woocommerce_deliver_webhook_async' ) && ! doing_action( 'wc-admin_import_orders' )
+				! doing_action( 'woocommerce_deliver_webhook_async' ) && ! doing_action( 'wc-admin_import_orders' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -45,6 +45,14 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	private static $backfilling_order_ids = array();
 
 	/**
+	 * Keep track of order IDs that are being synced on read. This is used to prevent backfilling to posts of an order being updated
+	 * from posts.
+	 *
+	 * @var array
+	 */
+	private static $sync_on_read_order_ids = array();
+
+	/**
 	 * Data stored in meta keys, but not considered "meta" for an order.
 	 *
 	 * @since 7.0.0
@@ -1710,6 +1718,8 @@ WHERE
 	 * @return void
 	 */
 	private function migrate_post_record( \WC_Abstract_Order &$order, \WC_Abstract_Order $post_order ): void {
+		self::$sync_on_read_order_ids[] = $order->get_id();
+
 		$diff                 = $this->migrate_meta_data_from_post_order( $order, $post_order );
 		$post_order_base_data = $post_order->get_base_data();
 		foreach ( $post_order_base_data as $key => $value ) {
@@ -1724,6 +1734,8 @@ WHERE
 			$this->set_order_prop( $order, $key, $value );
 		}
 		$this->persist_updates( $order, false );
+
+		self::$sync_on_read_order_ids = array_diff( self::$sync_on_read_order_ids, array( $order->get_id() ) );
 
 		/**
 		 * Fired when an HPOS order is updated from its corresponding post record on read due to a difference in the data.
@@ -2877,7 +2889,11 @@ FROM $order_meta_table
 
 		// Fetch changes.
 		$changes = $order->get_changes();
-		$this->persist_updates( $order );
+
+		// Does not make much sense to backfill to posts an order being sync-on-read from posts.
+		$should_backfill = ! in_array( $order->get_id(), self::$sync_on_read_order_ids, true );
+
+		$this->persist_updates( $order, $should_backfill );
 
 		// Update download permissions if necessary.
 		if ( array_key_exists( 'billing_email', $changes ) || array_key_exists( 'customer_id', $changes ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3437,6 +3437,7 @@ CREATE TABLE $meta_table (
 
 		$should_save =
 			$order->get_id() > 0
+			&& ! in_array( $order->get_id(), self::$sync_on_read_order_ids, true )
 			&& $order->get_date_modified() < $current_date_time && empty( $order->get_changes() )
 			&& ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1364,6 +1364,10 @@ WHERE
 
 		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled();
 		if ( $data_sync_enabled ) {
+			// We prefer not syncing-on-read if we are inside a webhook delivery or importing orders, as those events are likely triggered after the order is written
+			// and we don't want to possibly create loops of sync-on-read.
+			$should_sync_on_read = ! doing_action( 'woocommerce_deliver_webhook_async' ) && ! doing_action( 'wc-admin_import_orders' );
+
 			/**
 			 * Allow opportunity to disable sync on read, while keeping sync on write enabled. This adds another step as a large shop progresses from full sync to no sync with HPOS authoritative.
 			 * This filter is only executed if data sync is enabled from settings in the first place as it's meant to be a step between full sync -> no sync, rather than be a control for enabling just the sync on read. Sync on read without sync on write is problematic as any update will reset on the next read, but sync on write without sync on read is fine.
@@ -1372,10 +1376,7 @@ WHERE
 			 *
 			 * @since 8.1.0
 			 */
-			$data_sync_enabled = apply_filters(
-				'woocommerce_hpos_enable_sync_on_read',
-				! doing_action( 'woocommerce_deliver_webhook_async' ) && ! doing_action( 'wc-admin_import_orders' )
-			);
+			$data_sync_enabled = apply_filters( 'woocommerce_hpos_enable_sync_on_read', $should_sync_on_read );
 		}
 
 		$load_posts_for = array_diff( $order_ids, array_merge( self::$reading_order_ids, self::$backfilling_order_ids ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
As described in #62492, when an order is updated via HPOS sync-on-read, it triggers events such as webhooks and Analytics events related to the update. Under certain circumstances (when the modified date in the posts version is ahead of the HPOS one) processing of those events triggers sync-on-read again, enqueuing those same events over and over again.

While this bug has been present in HPOS sync-on-read since it was initially rolled out, it was only now that some related changes made it visible. See below for the details on why this happens.

This PR addresses the main issue and ensures that:

- Sync-on-read doesn't trigger changes to the "modified" date of HPOS orders when metadata is updated as part of the sync.
- Skips backfilling the posts version of an order when the save is happening as part of a sync-on-read, given the posts version is actually what we're copying from.
- Entirely disables sync-on-read during Analytics import and webhook processing.

Closes #62492.

<details>
<summary>Why this happens? (click for details)</summary>

While updating the HPOS order from the posts version, [metadata is updated first](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1713) and then the base properties. As part of updating metadata, HPOS sets the "modified" date [to the current time](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L3394-L3395) and also [writes the changes](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L2880) back to the [posts version](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L2959).

When [the rest of the base properties are processed](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1714-L1725), the modified date gets set to that of the order that originally triggered the sync-on-read, which is the same timestamp the posts version had initially.

When those new changes are persisted, the posts versions is no longer backfilled ([on purpose](https://github.com/woocommerce/woocommerce/blob/8e9b868158947b84e5b1bf09deeb49cc51138911/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1726)) as we're actually copying data from it.

In the end, the HPOS version gets the _intended_ modified date, but the posts version gets the current time, so they are never in agreement.

</details>

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Pre-requisites
We're going to disable automatic processing of the A-S queue for testing, to make things more manageable (otherwise tons of events will occur while we test).

1. Enable the following snippet on your test site, which disabled A-S processing and also takes care of logging certain events of interest:
   ```php
   <?php

   add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
   add_action( 'init', fn () => remove_action( ActionScheduler_QueueRunner::WP_CRON_HOOK, [ ActionScheduler_QueueRunner::instance(), 'run' ] ) );
   add_filter( 'woocommerce_hpos_enable_sync_on_read', '__return_true' );
   
   add_action(
       'woocommerce_hpos_post_record_migrated_on_read',
       function( $order, $diff ) {
           error_log( 'woocommerce_hpos_post_record_migrated_on_read: ' . $order->get_id() );

       },
       10,
       2
   );
   
   add_action(
       'woocommerce_hpos_post_record_backfilled',
       function( $order ) {
           error_log( 'woocommerce_hpos_post_record_backfilled: ' . $order->get_id() );
       }
   );
   ```
1. Enable Analytics in **WooCommerce > Settings > Advanced > Features**.
1. Ensure that HPOS data storage and compatibility mode are both enabled in **WooCommerce > Settings > Advanced > Features > Order data storage**.
1. Go to **WooCommerce > Orders** and create a new order with any details. Take note of the order ID.
1. Add some 'complex' metadata to your order:
   ```
   $o = wc_get_order( <order_id> )
   $o->add_meta_data( 'complex_meta', array( 'x' => 'y', 'z' => new stdClass() ) );
   $o->save();
   ```
1. Close any admin order screen you might have open. This is to prevent the heartbeat and edit lock pings that could include your order from adding noise to the logs.

#### Test the fix
1. Change the "modified" date in the posts version of your order to be a bit ahead of the HPOS version:
   ```
   wp db query "UPDATE wp_wc_orders o JOIN wp_posts p ON p.ID = o.id SET o.date_updated_gmt = DATE_SUB(p.post_modified_gmt, INTERVAL 1 MINUTE) WHERE o.id  <order_id>"
   ```
1. Run `wp eval 'wc_get_order( <order_id> );'` to trigger read-on-sync.
1. Confirm that your logs show an entry:
   ```
   woocommerce_hpos_post_record_migrated_on_read: <order_id>
   ```

   **No** `woocommerce_hpos_post_record_backfilled` entries should be logged.
1. Confirm, again, that both versions of the order have the same modified date:
   ```
   wp db query "SELECT p.post_modified_gmt, o.date_updated_gmt FROM wp_posts p JOIN wp_wc_orders o ON o.id = p.ID WHERE p.ID = <order_id>"
   ```
1. Run `wp eval 'wc_get_order( <order_id> );'` again and confirm that this time no entries are logged.
1. Add some metadata to the posts version of your order:
   ```
   wp post meta add <order_id> foo bar
   ```
1. Run `wp eval 'wc_get_order( <order_id> );'` to trigger read-on-sync. Confirm `woocommerce_hpos_post_record_migrated_on_read` is again logged.
1. Confirm that both modified dates are identical:
   ```
   wp db query "SELECT p.post_modified_gmt, o.date_updated_gmt FROM wp_posts p JOIN wp_wc_orders o ON o.id = p.ID WHERE p.ID = <order_id>"
   ```
1. Now mix both types of change: differences in metadata and modified date.
   ```
   wp db query "UPDATE wp_wc_orders o JOIN wp_posts p ON p.ID = o.id SET o.date_updated_gmt = DATE_SUB(p.post_modified_gmt, INTERVAL 1 MINUTE) WHERE o.id =<order_id>"

   wp post meta add <order_id> another_meta no
   ```
1. Run `wp eval 'wc_get_order( <order_id> );'` to trigger read-on-sync. Confirm `woocommerce_hpos_post_record_migrated_on_read` is again logged and that both versions have the same "modified" date.
1. Run `wp eval 'wc_get_order( <order_id> )->save();'` to simulate a normal order edit. Confirm that there's a pending A-S job for the Analytics related to your order:

   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"
   ```

   Make a note of the action ID that has your order id in args.
1. Run the job from the previous step:

   ```
   wp action-scheduler action run <action_id>
   ```

   Confirm that no job with your order in args remains:

   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"
   ```

#### Confirm the issue on `trunk` and that updating will address it
1. Check out `trunk`.
1. Change the "modified" date in the posts version of your order to be a bit ahead of the HPOS version:
   ```
   wp db query "UPDATE wp_wc_orders o JOIN wp_posts p ON p.ID = o.id SET o.date_updated_gmt = DATE_SUB(p.post_modified_gmt, INTERVAL 1 MINUTE) WHERE o.id  <order_id>"
   ```
1. Run `wp eval 'wc_get_order( <order_id> );'` to trigger read-on-sync. Confirm that both `woocommerce_hpos_post_record_backfilled` and `wocommerce_hpos_post_record_migrated_on_read` entries are logged.
1. Repeat `wp eval 'wc_get_order( <order_id> );'` to trigger read-on-sync a few times and confirm that each time `woocommerce_hpos_post_record_backfilled` and `wocommerce_hpos_post_record_migrated_on_read` entries are logged, indicating that sync-on-read is already in a loop.
1. Confirm that the "modified" date in both versions is different:
   ```
   wp db query "SELECT p.post_modified_gmt, o.date_updated_gmt FROM wp_posts p JOIN wp_wc_orders o ON o.id = p.ID WHERE p.ID = <order_id>"
   ```
1. Confirm that there's an A-S job associated to your order:
   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"
   ```
1. Run the job:
   ```
   wp action-scheduler action run <action_id>
   ```
1. Confirm that there's a new A-S job still associated to your order (demonstrating the "infinite loop" situation):
   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"
   ```
1. Check out this branch (`fix/62492`) to simulate an upgrade.
1. Run the pending A-S job:
   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"

   wp action-scheduler action run <order_id>
   ```
1. Confirm that no new job has been enqueued, demonstrating the infinite loop ending:
   ```
   wp action-scheduler action list --hook=wc-admin_import_orders --status=pending --fields=id,hook,args --args="[<order_id>]"
   ```
   


<!-- End testing instructions -->