### PR TITLE
Email Editor: fix block width preprocessor

### DIFF
--- a/packages/php/email-editor/changelog/62524-fix-block-width-preprocessor
+++ b/packages/php/email-editor/changelog/62524-fix-block-width-preprocessor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Email Editor: prevent fatal type errors in Blocks_Width_Preprocessor

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-blocks-width-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-blocks-width-preprocessor.php
@@ -36,6 +36,7 @@ class Blocks_Width_Preprocessor implements Preprocessor {
 			// Currently we support only % and px units in case only the number is provided we assume it's %
 			// because editor saves percent values as a number.
 			$width_input = is_numeric( $width_input ) ? "$width_input%" : $width_input;
+			$width_input = is_string( $width_input ) ? $width_input : '100%';
 			$width       = $this->convert_width_to_pixels( $width_input, $layout_width );
 
 			if ( 'core/columns' === $block['blockName'] ) {

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Blocks_Width_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Blocks_Width_Preprocessor_Test.php
@@ -539,4 +539,56 @@ class Blocks_Width_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$image_block = $result[0]['innerBlocks'][2]['innerBlocks'][0];
 		$this->assertEquals( '215px', $image_block['email_attrs']['width'] );
 	}
+
+	/**
+	 * Test it handles non-string width values
+	 */
+	public function testItHandlesNonStringWidthValues(): void {
+		$styles                       = $this->styles;
+		$styles['spacing']['padding'] = array(
+			'left'   => '0px',
+			'right'  => '0px',
+			'top'    => '0px',
+			'bottom' => '0px',
+		);
+
+		// Test numeric width (should be treated as percentage).
+		$blocks = array(
+			array(
+				'blockName'   => 'core/paragraph',
+				'attrs'       => array(
+					'width' => 50,
+				),
+				'innerBlocks' => array(),
+			),
+		);
+		$result = $this->preprocessor->preprocess( $blocks, $this->layout, $styles );
+		$this->assertEquals( '330px', $result[0]['email_attrs']['width'] ); // 660 * 0.5
+
+		// Test array width (should default to 100%).
+		$blocks = array(
+			array(
+				'blockName'   => 'core/paragraph',
+				'attrs'       => array(
+					'width' => array( 'value' => 50 ),
+				),
+				'innerBlocks' => array(),
+			),
+		);
+		$result = $this->preprocessor->preprocess( $blocks, $this->layout, $styles );
+		$this->assertEquals( '660px', $result[0]['email_attrs']['width'] ); // 100% of 660
+
+		// Test boolean width (should default to 100%).
+		$blocks = array(
+			array(
+				'blockName'   => 'core/paragraph',
+				'attrs'       => array(
+					'width' => true,
+				),
+				'innerBlocks' => array(),
+			),
+		);
+		$result = $this->preprocessor->preprocess( $blocks, $this->layout, $styles );
+		$this->assertEquals( '660px', $result[0]['email_attrs']['width'] ); // 100% of 660
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Check the type of the width attribute before attempting to convert it to a percentage.
2. Extend test to handle this case.

There are some blocks such as `html5-player/video` that set the width as a type other than a string. This block is setting an array like this:

```
Array
(
    [deprecated] => 1
    [number] => 100
    [unit] => %
    [isDeprecated] => 1
)
```

This causes a type error when passing it to `convert_width_to_pixels` since it is expecting a string. By checking the type of the width attribute and setting it to `100%` if it's not a string we avoid this type error failure. 100% is the value we default to in the event that there is no width input set so this is consistent.

Closes https://linear.app/a8c/issue/NL-316/handle-non-string-width-attrs-in-email-editor

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a post using a block that has a width attribute other than a string.
2. Preview the email
3. Send a post

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Email Editor: prevent fatal type errors in Blocks_Width_Preprocessor
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
