### PR TITLE
Update AI backend skill to always be invoked before writing tests

### DIFF
--- a/.ai/skills/woocommerce-backend-dev/SKILL.md
+++ b/.ai/skills/woocommerce-backend-dev/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: woocommerce-backend-dev
-description: Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code.
+description: Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code. **MUST be invoked before writing any PHP unit tests.**
 ---
 
 # WooCommerce Backend Development
 
 This skill provides guidance for developing WooCommerce backend PHP code according to project standards and conventions.
+
+## When to Use This Skill
+
+**ALWAYS invoke this skill before:**
+
+- Writing new PHP unit tests (`*Test.php` files)
+- Creating new PHP classes
+- Modifying existing backend PHP code
+- Adding hooks or filters
 
 ## Instructions
 

--- a/.ai/skills/woocommerce-backend-dev/unit-tests.md
+++ b/.ai/skills/woocommerce-backend-dev/unit-tests.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [Complete Test File Template](#complete-test-file-template)
 - [Test File Naming and Location](#test-file-naming-and-location)
 - [System Under Test Variable](#system-under-test-variable)
 - [Test Method Documentation](#test-method-documentation)
@@ -10,6 +11,80 @@
 - [Example: Payment Extension Suggestions Tests](#example-payment-extension-suggestions-tests)
 - [Mocking the WooCommerce Logger](#mocking-the-woocommerce-logger)
 - [General Testing Best Practices](#general-testing-best-practices)
+
+## Complete Test File Template
+
+Use this template when creating new test files. It shows all conventions applied together:
+
+```php
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\OrderProcessor;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the OrderProcessor class.
+ */
+class OrderProcessorTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var OrderProcessor
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new OrderProcessor();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should return true when order is valid.
+	 */
+	public function test_returns_true_for_valid_order(): void {
+		$order = wc_create_order();
+
+		$result = $this->sut->is_valid( $order );
+
+		$this->assertTrue( $result, 'Valid orders should return true' );
+	}
+
+	/**
+	 * @testdox Should throw exception when order ID is negative.
+	 */
+	public function test_throws_exception_for_negative_order_id(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->sut->process( -1 );
+	}
+}
+```
+
+### Key Elements
+
+| Element | Requirement |
+| ------- | ----------- |
+| `declare( strict_types = 1 )` | Required at file start |
+| Namespace | Match source location: `Automattic\WooCommerce\Tests\{path}` |
+| Base class | Extend `WC_Unit_Test_Case` |
+| SUT variable | Use `$sut` with docblock "The System Under Test." |
+| Test docblock | Use `@testdox` with sentence ending in `.` |
+| Return type | Use `void` for test methods |
+| Assertion messages | Include helpful context for failures |
 
 ## Test File Naming and Location
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ WooCommerce is a WordPress e-commerce plugin organized as a monorepo with:
 
 The `.ai/skills/` directory contains procedural HOW-TO instructions:
 
-- **`woocommerce-backend-dev`** - Backend PHP conventions (classes, methods, hooks, DI, testing)
+- **`woocommerce-backend-dev`** - Backend PHP conventions and unit tests. **Invoke before writing any PHP test files.**
 - **`woocommerce-dev-cycle`** - Testing and linting workflows (PHP, JS, markdown)
 - **`woocommerce-copy-guidelines`** - UI text standards (sentence case rules)
 - **`woocommerce-code-review`** - Code review standards and critical violations to flag

--- a/plugins/woocommerce/changelog/update-skill-for-backend
+++ b/plugins/woocommerce/changelog/update-skill-for-backend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update AI backend skill to always be invoked before writing tests


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the back-end skills and the Claude.md file to ensure the skills are accessed before writing PHP unit tests.
- Adds a complete test file template to `unit-tests.md`
- Updated the CLAUDE.md skill description

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:
<img width="474" height="190" alt="Screenshot 2025-12-19 at 11 02 17" src="https://github.com/user-attachments/assets/6a72e27b-26f5-4186-856b-c6f1bd2abd90" />


### How to test the changes in this Pull Request:

Try to generate a PHP unit test with Claude. Notice the skill gets invoked before proceeding with the task.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
