### PR TITLE
Fix 404 error on order-received endpoint after checkout

### DIFF
--- a/plugins/woocommerce/changelog/62542-fix-order-received-404
+++ b/plugins/woocommerce/changelog/62542-fix-order-received-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 404 error on order-received endpoint after checkout completion

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -57,7 +57,7 @@ function wc_template_redirect() {
 	}
 
 	// Trigger 404 if trying to access an endpoint on wrong page.
-	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && apply_filters( 'woocommerce_account_endpoint_page_not_found', true ) ) {
+	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && ! is_order_received_page() && ! is_checkout_pay_page() && apply_filters( 'woocommerce_account_endpoint_page_not_found', true ) ) {
 		$wp_query->set_404();
 		status_header( 404 );
 

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 /**
  * Unit tests for wc_template_redirect function.
  *

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -74,6 +74,7 @@ class WC_Template_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertFalse( $would_trigger_404, 'Order received endpoint should not trigger 404' );
 		$this->assertTrue( $is_order_received, 'is_order_received_page() should return true' );
 		$this->assertTrue( $is_wc_endpoint, 'is_wc_endpoint_url() should return true for order-received' );
+		$this->assertTrue( $is_checkout, 'is_checkout() should return true when on order-received page (same checkout page)' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Unit tests for wc_template_redirect function.
+ *
+ * @package WooCommerce\Tests\TemplateFunctions
+ */
+
+/**
+ * Class WC_Template_Functions_Test
+ */
+class WC_Template_Functions_Test extends \WC_Unit_Test_Case {
+
+	public function setUp(): void {
+		parent::setUp();
+		
+		WC()->init();
+
+		flush_rewrite_rules();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		global $wp_query, $wp;
+		$wp_query = new WP_Query();
+		$wp->query_vars = array();
+
+		remove_all_filters( 'woocommerce_account_endpoint_page_not_found' );
+		remove_all_filters( 'woocommerce_is_checkout' );
+		remove_all_filters( 'woocommerce_is_order_received_page' );
+	}
+
+	/**
+	 * @testdox Order received endpoint should not trigger 404 error.
+	 */
+	public function test_order_received_endpoint_does_not_trigger_404() {
+		global $wp_query, $wp;
+
+		$checkout_page_id = wc_create_page( 'checkout', 'woocommerce_checkout_page_id', 'Checkout', '[woocommerce_checkout]' );
+		
+		$order = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+		$order_key = $order->get_order_key();
+
+		$wp->query_vars['order-received'] = $order_id;
+		$_GET['key'] = $order_key;
+
+		$wp_query->is_page = true;
+		$wp_query->is_404 = false;
+		$wp_query->queried_object_id = $checkout_page_id;
+		$wp_query->queried_object = get_post( $checkout_page_id );
+		$wp_query->post = get_post( $checkout_page_id );
+
+		ob_start();
+		
+		$is_wc_endpoint = is_wc_endpoint_url();
+		$is_account_page = is_account_page();
+		$is_checkout = is_checkout();
+		$is_order_received = is_order_received_page();
+		$is_checkout_pay = is_checkout_pay_page();
+		$should_trigger_404 = apply_filters( 'woocommerce_account_endpoint_page_not_found', true );
+
+		$would_trigger_404 = $is_wc_endpoint 
+			&& ! $is_account_page 
+			&& ! $is_checkout 
+			&& ! $is_order_received 
+			&& ! $is_checkout_pay 
+			&& $should_trigger_404;
+
+		ob_end_clean();
+
+		$this->assertFalse( $would_trigger_404, 'Order received endpoint should not trigger 404' );
+		$this->assertTrue( $is_order_received, 'is_order_received_page() should return true' );
+		$this->assertTrue( $is_wc_endpoint, 'is_wc_endpoint_url() should return true for order-received' );
+	}
+
+	/**
+	 * @testdox Order pay endpoint should not trigger 404 error.
+	 */
+	public function test_order_pay_endpoint_does_not_trigger_404() {
+		global $wp_query, $wp;
+
+		$checkout_page_id = wc_create_page( 'checkout', 'woocommerce_checkout_page_id', 'Checkout', '[woocommerce_checkout]' );
+		
+		$order = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+
+		$wp->query_vars['order-pay'] = $order_id;
+
+		$wp_query->is_page = true;
+		$wp_query->is_404 = false;
+		$wp_query->queried_object_id = $checkout_page_id;
+		$wp_query->queried_object = get_post( $checkout_page_id );
+		$wp_query->post = get_post( $checkout_page_id );
+
+		ob_start();
+		
+		$is_wc_endpoint = is_wc_endpoint_url();
+		$is_account_page = is_account_page();
+		$is_checkout = is_checkout();
+		$is_order_received = is_order_received_page();
+		$is_checkout_pay = is_checkout_pay_page();
+		$should_trigger_404 = apply_filters( 'woocommerce_account_endpoint_page_not_found', true );
+
+		$would_trigger_404 = $is_wc_endpoint 
+			&& ! $is_account_page 
+			&& ! $is_checkout 
+			&& ! $is_order_received 
+			&& ! $is_checkout_pay 
+			&& $should_trigger_404;
+
+		ob_end_clean();
+
+		$this->assertFalse( $would_trigger_404 );
+		$this->assertTrue( $is_checkout_pay || $is_checkout );
+	}
+
+	/**
+	 * @testdox Invalid endpoint on wrong page should still trigger 404.
+	 */
+	public function test_invalid_endpoint_on_wrong_page_triggers_404() {
+		global $wp_query, $wp;
+
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Page',
+			)
+		);
+
+		$wp->query_vars['orders'] = 1;
+
+		$wp_query->is_page = true;
+		$wp_query->is_404 = false;
+		$wp_query->queried_object_id = $page_id;
+		$wp_query->queried_object = get_post( $page_id );
+		$wp_query->post = get_post( $page_id );
+
+		ob_start();
+		
+		$is_wc_endpoint = is_wc_endpoint_url();
+		$is_order_received = is_order_received_page();
+		$is_checkout_pay = is_checkout_pay_page();
+		$should_trigger_404 = apply_filters( 'woocommerce_account_endpoint_page_not_found', true );
+
+		$this->assertFalse( $is_order_received, 'is_order_received_page() should return false for orders endpoint' );
+		$this->assertFalse( $is_checkout_pay, 'is_checkout_pay_page() should return false for orders endpoint' );
+		$this->assertTrue( $is_wc_endpoint, 'is_wc_endpoint_url() should return true for orders endpoint' );
+
+		ob_end_clean();
+
+		wp_delete_post( $page_id, true );
+
+		$this->assertFalse( $is_order_received );
+		$this->assertFalse( $is_checkout_pay );
+		$this->assertTrue( $is_wc_endpoint );
+	}
+
+	/**
+	 * @testdox Order received page should be accessible with valid order key.
+	 */
+	public function test_order_received_page_accessible_with_valid_key() {
+		global $wp_query, $wp;
+
+		$checkout_page_id = wc_create_page( 'checkout', 'woocommerce_checkout_page_id', 'Checkout', '[woocommerce_checkout]' );
+		
+		$order = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+		$order_key = $order->get_order_key();
+
+		$wp->query_vars['order-received'] = $order_id;
+		$_GET['key'] = $order_key;
+
+		$wp_query->is_page = true;
+		$wp_query->is_404 = false;
+		$wp_query->queried_object_id = $checkout_page_id;
+		$wp_query->queried_object = get_post( $checkout_page_id );
+
+		$this->assertTrue( is_order_received_page(), 'is_order_received_page() should return true for valid order-received endpoint' );
+		
+		$retrieved_order = wc_get_order( $order_id );
+		$this->assertInstanceOf( 'WC_Order', $retrieved_order, 'Order should be retrievable' );
+		$this->assertEquals( $order_key, $retrieved_order->get_order_key(), 'Order key should match' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a bug where customers receive a 404 error page instead of the order confirmation page after completing checkout.

The issue occurs when customers are redirected to the order-received endpoint (`/checkout/order-received/{order_id}/?key={order_key}`). The `wc_template_redirect()` function was incorrectly triggering a 404 error for this valid checkout endpoint.

Closes #58710.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a product to the cart and proceed to checkout
2. Complete an order by clicking "Place Order"
3. Verify you are redirected to the order confirmation page (not a 404 error)
4. Check that the order details are displayed correctly
5. Verify the cart is empty after order completion

### Testing that has already taken place:

- Tested with guest checkout
- Tested with logged-in customer checkout
- Verified that invalid endpoints still correctly trigger 404 errors

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix 404 error on order-received endpoint after checkout completion

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>