### PR TITLE
Fix URL decoding for product variation attributes in REST API

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-special-char-follow-up
+++ b/plugins/woocommerce/changelog/fix-variation-special-char-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix decoding attribute option name

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -497,7 +497,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 				}
 
 				$attribute_key   = sanitize_title( $parent_attributes[ $attribute_name ]->get_name() );
-				$attribute_value = isset( $attribute['option'] ) ? wc_clean( stripslashes( $attribute['option'] ) ) : '';
+				$attribute_value = isset( $attribute['option'] ) ? wc_clean( rawurldecode( stripslashes( $attribute['option'] ) ) ) : '';
 
 				if ( $parent_attributes[ $attribute_name ]->is_taxonomy() ) {
 					// If dealing with a taxonomy, we need to get the slug from the name posted to the API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -689,7 +689,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 						'id'     => wc_attribute_taxonomy_id_by_name( $name ),
 						'name'   => $this->get_attribute_taxonomy_name( $name, $_product ),
 						'slug'   => rawurldecode( $name ),
-						'option' => $option_term && ! is_wp_error( $option_term ) ? $option_term->name : $attribute,
+						'option' => $option_term && ! is_wp_error( $option_term ) ? rawurldecode( $option_term->name ) : rawurldecode( $attribute ),
 					);
 				} else {
 					$attributes[] = array(
@@ -1631,7 +1631,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 					$_attribute = $attributes[ $attribute_name ];
 
 					if ( $_attribute['is_variation'] ) {
-						$value = isset( $attribute['option'] ) ? wc_clean( stripslashes( $attribute['option'] ) ) : '';
+						$value = isset( $attribute['option'] ) ? wc_clean( rawurldecode( stripslashes( $attribute['option'] ) ) ) : '';
 
 						if ( ! empty( $_attribute['is_taxonomy'] ) ) {
 							// If dealing with a taxonomy, we need to get the slug from the name posted to the API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -364,7 +364,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				}
 
 				$attribute_key   = sanitize_title( $parent_attributes[ $attribute_name ]->get_name() );
-				$attribute_value = isset( $attribute['option'] ) ? wc_clean( stripslashes( $attribute['option'] ) ) : '';
+				$attribute_value = isset( $attribute['option'] ) ? wc_clean( rawurldecode( stripslashes( $attribute['option'] ) ) ) : '';
 
 				if ( $parent_attributes[ $attribute_name ]->is_taxonomy() ) {
 					// If dealing with a taxonomy, we need to get the slug from the name posted to the API.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller-tests.php
@@ -227,6 +227,65 @@ class WC_REST_Product_Variations_Controller_Tests extends WC_REST_Unit_Test_Case
 	}
 
 	/**
+	 * Test that creating a variation with URL-encoded attribute option values
+	 * properly decodes and saves the attributes.
+	 *
+	 * This test verifies the fix for URL-encoded attribute options (e.g., special characters
+	 * like Persian/unicode) are properly decoded when sent via the REST API.
+	 */
+	public function test_create_variation_with_url_encoded_attribute_option() {
+		// Create a variable product with a Persian attribute name and options.
+		$product         = WC_Helper_Product::create_variation_product();
+		$color_attribute = WC_Helper_Product::create_product_attribute_object( 'رنگ', array( 'آبی', 'سبز' ) );
+		$product->set_attributes( array( $color_attribute ) );
+		$product->save();
+
+		// Create a variation via REST API with URL-encoded attribute option.
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products/' . $product->get_id() . '/variations' );
+		$request->set_body_params(
+			array(
+				'regular_price'  => '0',
+				'sale_price'     => '0',
+				'manage_stock'   => true,
+				'stock_quantity' => 0,
+				'attributes'     => array(
+					array(
+						'id'     => $color_attribute->get_id(),
+						'option' => 'سبز', // URL-encoded Persian word for "green".
+					),
+				),
+			)
+		);
+
+		$response  = $this->server->dispatch( $request );
+		$variation = $response->get_data();
+
+		// Verify the variation was created successfully.
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertNotEmpty( $variation['id'] );
+		$this->assertEquals( 'variation', $variation['type'] );
+		$this->assertEquals( $product->get_id(), $variation['parent_id'] );
+
+		// Verify the attribute is properly set with decoded option.
+		$this->assertNotEmpty( $variation['attributes'], 'Attributes array should not be empty' );
+		$this->assertCount( 1, $variation['attributes'], 'Variation should have 1 attribute' );
+		$this->assertEquals( 'رنگ', $variation['attributes'][0]['name'], 'Variation should contain color attribute' );
+		$this->assertEquals( 'سبز', $variation['attributes'][0]['option'], 'Attribute option should be decoded from URL encoding' );
+
+		// Verify the variation can be retrieved and has the attribute data.
+		$get_request         = new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() . '/variations/' . $variation['id'] );
+		$get_response        = $this->server->dispatch( $get_request );
+		$retrieved_variation = $get_response->get_data();
+
+		$this->assertEquals( 200, $get_response->get_status() );
+		$this->assertNotEmpty( $retrieved_variation['attributes'], 'Retrieved variation should have attributes' );
+		$this->assertCount( 1, $retrieved_variation['attributes'], 'Retrieved variation should have 1 attribute' );
+		$this->assertEquals( 'رنگ', $retrieved_variation['attributes'][0]['name'], 'Variation should contain color attribute' );
+		$this->assertEquals( 'pa_رنگ', $retrieved_variation['attributes'][0]['slug'], 'Variation should contain color attribute slug' );
+		$this->assertEquals( 'سبز', $retrieved_variation['attributes'][0]['option'], 'Retrieved attribute option should be decoded' );
+	}
+
+	/**
 	 * Test that the products endpoint can filter by global_unique_id and also return matched variations.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up of https://github.com/woocommerce/woocommerce/pull/61939

This PR is a follow-up to #61939, extending the rawurldecode() fix for attribute options value. 


### How to test the changes in this Pull Request:

1. Go to `/wp-admin/edit.php?post_type=product&page=product_attributes`
2. Edit an attribute and add `ارسی` as term.
3. Edit or create a variable product so it uses this attribute for variations.
4. Make a POST call to `/wp-json/wc/v3/products/<product_id>/variations` with this in the body (in this case, the attribute we updated is the attribute with id `1`):

```JSON
{
  "regular_price": "20",
  "sale_price": "10",
  "manage_stock": true,
  "stock_quantity": 1,
  "attributes": [
    { "id": 1, "option": "ارسی" },
  ]
}
```

5. Verify the response contains an `attributes` property with the attribute encoded correctly.
6. Edit the product from step 2 and verify the attribute was created properly with correct attributes.