### PR TITLE
Fix: performance issue with filter data cache

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6049-performance-slow-wp_load_alloptions-dp-call-200000
+++ b/plugins/woocommerce/changelog/wooplug-6049-performance-slow-wp_load_alloptions-dp-call-200000
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Fix: Set expiration time for filter data cache to avoid autoloading all cache data

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -532,7 +532,7 @@ class FilterData {
 			'value'   => $value,
 		);
 
-		$result = set_transient( $key, $transient_value );
+		$result = set_transient( $key, $transient_value, DAY_IN_SECONDS );
 
 		return $result;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Set expiration time for filter data cache transients to prevent them from being autoloaded by WordPress. Without an expiration time, transients are stored in the options table with `autoload = 'yes'`, causing all cache data to be loaded on every request via `wp_load_alloptions()`.

Closes #6049.

### How to test the changes in this Pull Request:

1. Create products with various attributes and categories
2. Navigate to a shop page that uses product filters
3. Verify filters work correctly
4. Check that filter data cache entries have expiration times set in the database.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.