### PR TITLE
use get_terms instead of WP_Terms_Query to better respect visibility settings

### DIFF
--- a/plugins/woocommerce/changelog/62581-fix-use-get-terms-instead-of-query
+++ b/plugins/woocommerce/changelog/62581-fix-use-get-terms-instead-of-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect stock visibility and product visibility when counting term products in Store API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -326,7 +326,10 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$query_result = $this->get_terms_for_product( $prepared_args, $request );
 			$total_terms  = $this->total_terms;
 		} else {
-			$query_result = get_terms( $taxonomy, $prepared_args );
+			// Use WP_Term_Query directly to bypass wc_change_term_counts filter,
+			// ensuring REST API returns actual term counts for admin use.
+			$term_query   = new WP_Term_Query( array_merge( $prepared_args, array( 'taxonomy' => $taxonomy ) ) );
+			$query_result = $term_query->get_terms();
 
 			$count_args = $prepared_args;
 			unset( $count_args['number'] );
@@ -462,10 +465,21 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$taxonomy = $this->get_taxonomy( $request );
-		$term     = get_term( (int) $request['id'], $taxonomy );
 
-		if ( is_wp_error( $term ) ) {
-			return $term;
+		// Use WP_Term_Query directly to bypass wc_change_term_count filter,
+		// ensuring REST API returns actual term counts for admin use.
+		$term_query = new WP_Term_Query(
+			array(
+				'taxonomy'   => $taxonomy,
+				'include'    => array( (int) $request['id'] ),
+				'hide_empty' => false,
+			)
+		);
+		$terms      = $term_query->get_terms();
+		$term       = ! empty( $terms ) ? $terms[0] : null;
+
+		if ( ! $term ) {
+			return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$response = $this->prepare_item_for_response( $term, $request );

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -564,8 +564,8 @@ add_action( 'woocommerce_product_set_stock_status', 'wc_recount_after_stock_chan
 
 
 /**
- * Overrides the original term count for product categories and tags with the product count.
- * that takes catalog visibility into account.
+ * Overrides the original term count for product categories, tags, and brands with the product count.
+ * that takes catalog visibility and out of stock status into account.
  *
  * @param array        $terms      List of terms.
  * @param string|array $taxonomies Single taxonomy or list of taxonomies.
@@ -614,6 +614,62 @@ function wc_change_term_counts( $terms, $taxonomies ) {
 	return $terms;
 }
 add_filter( 'get_terms', 'wc_change_term_counts', 10, 2 );
+
+/**
+ * Overrides the original term count for a single term with the product count.
+ * that takes catalog visibility and out of stock status into account.
+ *
+ * Similar to wc_change_term_counts, but for a single term.
+ *
+ * @param WP_Term $term Term object.
+ * @param string  $taxonomy Taxonomy.
+ * @return WP_Term
+ */
+function wc_change_term_count( $term, $taxonomy ) {
+	if ( is_admin() || wp_doing_ajax() ) {
+		return $term;
+	}
+
+	/**
+	 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array $valid_taxonomies List of taxonomy slugs.
+	 */
+	$valid_taxonomies = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
+	if ( ! in_array( $taxonomy, $valid_taxonomies, true ) ) {
+		return $term;
+	}
+
+	if ( ! $term instanceof WP_Term ) {
+		return $term;
+	}
+
+	// Check the transient cache first (shared with wc_change_term_counts) to avoid redundant meta lookups.
+	$key         = $term->term_id . '_' . $taxonomy;
+	$term_counts = get_transient( 'wc_term_counts' );
+
+	if ( false !== $term_counts && isset( $term_counts[ $key ] ) ) {
+		$term->count = $term_counts[ $key ];
+		return $term;
+	}
+
+	$count       = get_term_meta( $term->term_id, 'product_count_' . $taxonomy, true );
+	$count       = '' !== $count ? absint( $count ) : 0;
+	$term->count = $count;
+
+	// Update the transient cache.
+	if ( false === $term_counts ) {
+		$term_counts = array();
+	}
+	$term_counts[ $key ] = $count;
+	set_transient( 'wc_term_counts', $term_counts, MONTH_IN_SECONDS );
+
+	return $term;
+}
+
+add_filter( 'get_term', 'wc_change_term_count', 10, 2 );
 
 /**
  * Return products in a given term, and cache value.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58954,12 +58954,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductCategories.php
 
 		-
-			message: '#^Parameter \#1 \$args of function get_terms expects array\{taxonomy\?\: array\<string\>\|string, object_ids\?\: array\<int\>\|int, orderby\?\: string, order\?\: string, hide_empty\?\: bool\|int, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, exclude_tree\?\: array\<int\>\|string, \.\.\.\}, ''product_cat'' given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Blocks/BlockTypes/ProductCategories.php
-
-		-
 			message: '#^Parameter \#1 \$default of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AbstractDynamicBlock\:\:get_schema_boolean\(\) expects string, false given\.$#'
 			identifier: argument.type
 			count: 4
@@ -78577,12 +78571,6 @@ parameters:
 			path: src/StoreApi/Routes/V1/AbstractRoute.php
 
 		-
-			message: '#^Argument of an invalid type array\<int\|string\|WP_Term\>\|string supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/StoreApi/Routes/V1/AbstractTermsRoute.php
-
-		-
 			message: '#^Cannot cast numeric\-string\|WP_Error to int\.$#'
 			identifier: cast.int
 			count: 1
@@ -78596,12 +78584,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$args of function wp_count_terms expects array\{taxonomy\?\: array\<string\>\|string, object_ids\?\: array\<int\>\|int, orderby\?\: string, order\?\: string, hide_empty\?\: bool\|int, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, exclude_tree\?\: array\<int\>\|string, \.\.\.\}, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/StoreApi/Routes/V1/AbstractTermsRoute.php
-
-		-
-			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\<int\|string\|WP_Term\>\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/StoreApi/Routes/V1/AbstractTermsRoute.php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
@@ -138,8 +138,8 @@ class ProductCategories extends AbstractDynamicBlock {
 		if ( $children_only ) {
 			$term_id    = get_queried_object_id();
 			$categories = get_terms(
-				'product_cat',
 				[
+					'taxonomy'     => 'product_cat',
 					'hide_empty'   => ! $attributes['hasEmpty'],
 					'pad_counts'   => true,
 					'hierarchical' => true,
@@ -148,8 +148,8 @@ class ProductCategories extends AbstractDynamicBlock {
 			);
 		} else {
 			$categories = get_terms(
-				'product_cat',
 				[
+					'taxonomy'     => 'product_cat',
 					'hide_empty'   => ! $attributes['hasEmpty'],
 					'pad_counts'   => true,
 					'hierarchical' => true,
@@ -165,7 +165,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		if ( ! $attributes['hasEmpty'] ) {
 			$categories = array_filter(
 				$categories,
-				function( $category ) {
+				function ( $category ) {
 					return 0 !== $category->count;
 				}
 			);

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractTermsRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractTermsRoute.php
@@ -1,8 +1,8 @@
 <?php
+declare(strict_types=1);
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\StoreApi\Utilities\Pagination;
-use WP_Term_Query;
 
 /**
  * AbstractTermsRoute class.
@@ -133,9 +133,8 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 			$prepared_args['parent'] = (int) $request['parent'];
 		}
 
-		$term_query = new WP_Term_Query();
-		$objects    = $term_query->query( $prepared_args );
-		$return     = [];
+		$objects = get_terms( $prepared_args );
+		$return  = [];
 
 		foreach ( $objects as $object ) {
 			$data     = $this->prepare_item_for_response( $object, $request );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractTermsRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractTermsRoute.php
@@ -134,7 +134,12 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 		}
 
 		$objects = get_terms( $prepared_args );
-		$return  = [];
+
+		if ( is_wp_error( $objects ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$return = [];
 
 		foreach ( $objects as $object ) {
 			$data     = $this->prepare_item_for_response( $object, $request );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
@@ -172,19 +172,19 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 		$product->set_stock_status( 'outofstock' );
 		$product->save();
 
-		// Now should have count of 0.
+		// REST API should still show count of 1 (full count for admins, visibility not applied).
 		$response = $this->make_categories_request();
 		$data     = $response->get_data();
 
 		// Find our test category in the response.
 		$test_category_data = $this->find_category_in_response( $data, $category['term_id'] );
 		$this->assertNotNull( $test_category_data, 'Test category should be found in response' );
-		$this->assertEquals( 0, $test_category_data['count'], 'Category should have count of 0 when product is out of stock and hidden' );
+		$this->assertEquals( 1, $test_category_data['count'], 'REST API should show full count of 1 for admins even when product is hidden' );
 
-		// Category specific request should have count of 1.
+		// Category specific request should have count of 1 (REST API shows full count for admins).
 		$response = $this->make_categories_request( $category['term_id'] );
 		$data     = $response->get_data();
-		$this->assertEquals( 1, $data['count'], 'Category should have count of 1 when product is out of stock and hidden' );
+		$this->assertEquals( 1, $data['count'], 'REST API should show full count of 1 for admins even when product is hidden' );
 
 		// Reset the setting.
 		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCategories.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCategories.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Controller Tests.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Product Categories Controller Tests.
+ */
+class ProductCategories extends ControllerTestCase {
+
+	/**
+	 * The product category term.
+	 *
+	 * @var array
+	 */
+	private $product_category;
+
+	/**
+	 * The products.
+	 *
+	 * @var array
+	 */
+	private $products;
+
+	/**
+	 * Setup test product data. Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$fixtures = new FixtureData();
+
+		$this->product_category = $fixtures->get_product_category(
+			array(
+				'name' => 'Test Category',
+			)
+		);
+
+		$this->products = array(
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 1',
+					'regular_price' => 10,
+					'stock_status'  => 'instock',
+					'category_ids'  => array( $this->product_category['term_id'] ),
+				)
+			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 2',
+					'regular_price' => 20,
+					'stock_status'  => 'instock',
+					'category_ids'  => array( $this->product_category['term_id'] ),
+				)
+			),
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		delete_option( 'woocommerce_hide_out_of_stock_items' );
+	}
+
+	/**
+	 * @testdox Should return correct category data.
+	 */
+	public function test_get_items(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories' );
+		$request->set_param( 'hide_empty', false );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertGreaterThanOrEqual( 1, count( $data ), 'Expected at least one category.' );
+
+		$test_category = null;
+		foreach ( $data as $category ) {
+			if ( $category['id'] === $this->product_category['term_id'] ) {
+				$test_category = $category;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $test_category, 'Test category not found in response.' );
+		$this->assertArrayHasKey( 'id', $test_category );
+		$this->assertArrayHasKey( 'name', $test_category );
+		$this->assertArrayHasKey( 'slug', $test_category );
+		$this->assertArrayHasKey( 'description', $test_category );
+		$this->assertArrayHasKey( 'count', $test_category );
+	}
+
+	/**
+	 * @testdox Should return a single category.
+	 */
+	public function test_get_item(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 'Test Category', $data['name'] );
+	}
+
+	/**
+	 * @testdox Should exclude out of stock products from category count when hide out of stock option is enabled.
+	 */
+	public function test_category_count_excludes_out_of_stock_when_visibility_option_enabled(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 2, $data['count'], 'Expected count of 2 when both products are in stock.' );
+
+		$this->products[0]->set_stock_status( 'outofstock' );
+		$this->products[0]->save();
+
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+		wc_recount_all_terms();
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 1, $data['count'], 'Expected count of 1 when one product is out of stock and visibility option is enabled.' );
+	}
+
+	/**
+	 * @testdox Should include out of stock products in category count when hide out of stock option is disabled.
+	 */
+	public function test_category_count_includes_out_of_stock_when_visibility_option_disabled(): void {
+		$this->products[0]->set_stock_status( 'outofstock' );
+		$this->products[0]->save();
+
+		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );
+		wc_recount_all_terms();
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 2, $data['count'], 'Expected count of 2 when visibility option is disabled, even if one product is out of stock.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCategories.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCategories.php
@@ -68,90 +68,54 @@ class ProductCategories extends ControllerTestCase {
 	 */
 	protected function tearDown(): void {
 		parent::tearDown();
-
 		delete_option( 'woocommerce_hide_out_of_stock_items' );
+		delete_transient( 'wc_term_counts' );
 	}
 
 	/**
-	 * @testdox Should return correct category data.
+	 * @testdox Category list count should reflect visibility-aware product count.
 	 */
-	public function test_get_items(): void {
+	public function test_category_list_count_uses_visibility_aware_count(): void {
+		$term_id = $this->product_category['term_id'];
+
+		$this->products[0]->set_stock_status( 'outofstock' );
+		$this->products[0]->save();
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+		wc_recount_all_terms();
+
 		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories' );
 		$request->set_param( 'hide_empty', false );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertGreaterThanOrEqual( 1, count( $data ), 'Expected at least one category.' );
-
-		$test_category = null;
-		foreach ( $data as $category ) {
-			if ( $category['id'] === $this->product_category['term_id'] ) {
-				$test_category = $category;
+		$category = null;
+		foreach ( $data as $cat ) {
+			if ( $cat['id'] === $term_id ) {
+				$category = $cat;
 				break;
 			}
 		}
 
-		$this->assertNotNull( $test_category, 'Test category not found in response.' );
-		$this->assertArrayHasKey( 'id', $test_category );
-		$this->assertArrayHasKey( 'name', $test_category );
-		$this->assertArrayHasKey( 'slug', $test_category );
-		$this->assertArrayHasKey( 'description', $test_category );
-		$this->assertArrayHasKey( 'count', $test_category );
+		$this->assertNotNull( $category, 'Category should exist in response.' );
+		$this->assertSame( 1, $category['count'], 'Count should reflect visibility-aware value.' );
 	}
 
 	/**
-	 * @testdox Should return a single category.
+	 * @testdox Single category count should reflect visibility-aware product count.
 	 */
-	public function test_get_item(): void {
-		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertSame( 'Test Category', $data['name'] );
-	}
-
-	/**
-	 * @testdox Should exclude out of stock products from category count when hide out of stock option is enabled.
-	 */
-	public function test_category_count_excludes_out_of_stock_when_visibility_option_enabled(): void {
-		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertSame( 2, $data['count'], 'Expected count of 2 when both products are in stock.' );
+	public function test_single_category_count_uses_visibility_aware_count(): void {
+		$term_id = $this->product_category['term_id'];
 
 		$this->products[0]->set_stock_status( 'outofstock' );
 		$this->products[0]->save();
-
 		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
 		wc_recount_all_terms();
 
-		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $term_id );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertSame( 1, $data['count'], 'Expected count of 1 when one product is out of stock and visibility option is enabled.' );
-	}
-
-	/**
-	 * @testdox Should include out of stock products in category count when hide out of stock option is disabled.
-	 */
-	public function test_category_count_includes_out_of_stock_when_visibility_option_disabled(): void {
-		$this->products[0]->set_stock_status( 'outofstock' );
-		$this->products[0]->save();
-
-		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );
-		wc_recount_all_terms();
-
-		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/categories/' . $this->product_category['term_id'] );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertSame( 2, $data['count'], 'Expected count of 2 when visibility option is disabled, even if one product is out of stock.' );
+		$this->assertSame( 200, $response->get_status(), 'Response should be successful.' );
+		$this->assertSame( 1, $data['count'], 'Single category count should reflect visibility-aware value.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR moves Store API to use `get_terms` instead of `WP_Term_Query` to better respect visibility count in products.

Closes WOOPLUG-6071

(For Bug Fixes) Bug introduced in PR # .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create 2 products, in stock, assign them to category A (keep note of category ID).
2. Call `/wp-json/wc/store/products/categories?include=$category_id` note that count says 2.
3. Modify one product to make it out of count.
4. In WooCommerce -> Settings -> Products -> Inventory, toggle Out of stock visibility option to force recount, but make sure it is checked.
5. Hit the endpoint again, notice that count says 1 now.
6. Visit the permalink of said category, it would show only 1 product.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Respect stock visibility and product visibility when counting term products in Store API.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
