### PR TITLE
`wc-ajax` endpoint for product variations (`get_variations`)

### DIFF
--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -147,6 +147,7 @@ class WC_AJAX {
 			'remove_from_cart',
 			'checkout',
 			'get_variation',
+			'get_variations',
 			'get_customer_location',
 		);
 
@@ -621,6 +622,30 @@ class WC_AJAX {
 		$variation_id = $data_store->find_matching_product_variation( $variable_product, wp_unslash( $_POST ) );
 		$variation    = $variation_id ? $variable_product->get_available_variation( $variation_id ) : false;
 		wp_send_json( $variation );
+		// phpcs:enable
+	}
+
+	/**
+	 * Get matching variations based on posted attributes.
+	 */
+	public static function get_variations() {
+		ob_start();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( empty( $_POST['product_id'] ) ) {
+			wp_die();
+		}
+
+		$variable_product = wc_get_product( absint( $_POST['product_id'] ) );
+
+		if ( ! $variable_product ) {
+			wp_die();
+		}
+
+		$data_store    = WC_Data_Store::load( 'product' );
+		$variation_ids = $data_store->find_matching_product_variations( $variable_product, wp_unslash( $_POST ) );
+		$variations    = array_values( array_filter( array_map( array( $variable_product, 'get_available_variation' ), $variation_ids ), 'is_array' ) );
+		wp_send_json( $variations );
 		// phpcs:enable
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1438,17 +1438,20 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	}
 
 	/**
-	 * Find a matching (enabled) variation within a variable product.
+	 * Returns an array of available product variations.
 	 *
-	 * @since  3.0.0
+	 * @since 10.4.0
 	 * @param  WC_Product $product Variable product.
-	 * @param  array      $match_attributes Array of attributes we want to try to match.
-	 * @return int Matching variation ID or 0.
+	 * @return array
 	 */
-	public function find_matching_product_variation( $product, $match_attributes = array() ) {
+	public function get_product_variations( $product ) {
+		if ( ! $product instanceof WC_Product ) {
+			return array();
+		}
+
 		if ( ProductType::VARIATION === $product->get_type() ) {
 			// Can't get a variation of a variation.
-			return 0;
+			return array();
 		}
 
 		global $wpdb;
@@ -1482,8 +1485,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$query .= ' ORDER BY posts.menu_order ASC, postmeta.post_id ASC;';
 
-		$attributes = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
 
+	/**
+	 * Find a matching (enabled) variation within a variable product.
+	 *
+	 * @since  3.0.0
+	 * @param  WC_Product $product Variable product.
+	 * @param  array      $match_attributes Array of attributes we want to try to match.
+	 * @return int Matching variation ID or 0.
+	 */
+	public function find_matching_product_variation( $product, $match_attributes = array() ) {
+		$attributes = self::get_product_variations( $product );
 		if ( ! $attributes ) {
 			return 0;
 		}
@@ -1500,26 +1514,22 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		 * Note: Not all meta fields will be set which is why we check existence.
 		 */
 		foreach ( $sorted_meta as $variation_id => $variation ) {
-			$match = true;
-
 			// Loop over the variation meta keys and values i.e. what is saved to the products. Note: $attribute_value is empty when 'any' is in use.
 			foreach ( $variation as $attribute_key => $attribute_value ) {
-				$match_any_value = '' === $attribute_value;
-
-				if ( ! $match_any_value && ! array_key_exists( $attribute_key, $match_attributes ) ) {
-					$match = false; // Requires a selection but no value was provide.
+				if ( '' === $attribute_value ) {
+					continue;
 				}
 
-				if ( array_key_exists( $attribute_key, $match_attributes ) ) { // Value to match was provided.
-					if ( ! $match_any_value && $match_attributes[ $attribute_key ] !== $attribute_value ) {
-						$match = false; // Provided value does not match variation.
-					}
+				if ( ! array_key_exists( $attribute_key, $match_attributes ) ) {
+					continue 2; // Requires a selection but no value was provide.
+				}
+
+				if ( $match_attributes[ $attribute_key ] !== $attribute_value ) {
+					continue 2; // Provided value does not match variation.
 				}
 			}
 
-			if ( true === $match ) {
-				return $variation_id;
-			}
+			return $variation_id;
 		}
 
 		if ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
@@ -1531,6 +1541,66 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Find matching (enabled) variations within a variable product.
+	 *
+	 * @since 10.4.0
+	 * @param  WC_Product $product Variable product.
+	 * @param  array      $match_attributes Array of attributes we want to try to match.
+	 * @return int[] Matching variation IDs or empty array if none found.
+	 */
+	public function find_matching_product_variations( $product, $match_attributes = array() ) {
+		$attributes = self::get_product_variations( $product );
+		if ( ! $attributes ) {
+			return [];
+		}
+
+		$sorted_meta = array();
+
+		foreach ( $attributes as $m ) {
+			$sorted_meta[ $m->post_id ][ $m->meta_key ] = $m->meta_value; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		}
+
+		/**
+		 * Check each variation to find the one that matches the $match_attributes.
+		 *
+		 * Note: Not all meta fields will be set which is why we check existence.
+		 */
+		$variation_ids = array();
+		foreach ( $sorted_meta as $variation_id => $variation ) {
+			// Loop over the variation meta keys and values i.e. what is saved to the products. Note: $attribute_value is empty when 'any' is in use.
+			foreach ( $variation as $attribute_key => $attribute_value ) {
+				if ( '' === $attribute_value ) {
+					continue;
+				}
+
+				if ( ! array_key_exists( $attribute_key, $match_attributes ) ) {
+					continue;
+				}
+
+				if ( '' === $match_attributes[$attribute_key] ) {
+					continue;
+				}
+
+				if ( $match_attributes[ $attribute_key ] !== $attribute_value ) {
+					continue 2;
+				}
+			}
+
+			$variation_ids[] = $variation_id;
+		}
+
+		if ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
+			/**
+			 * Pre 2.4 handling where 'slugs' were saved instead of the full text attribute.
+			 * Fallback is here because there are cases where data will be 'synced' but the product version will remain the same.
+			 */
+			return ( array_map( 'sanitize_title', $match_attributes ) === $match_attributes ) ? array() : $this->find_matching_product_variations( $product, array_map( 'sanitize_title', $match_attributes ) );
+		}
+
+		return $variation_ids;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/interfaces/class-wc-product-data-store-interface.php
+++ b/plugins/woocommerce/includes/interfaces/class-wc-product-data-store-interface.php
@@ -65,6 +65,15 @@ interface WC_Product_Data_Store_Interface {
 	public function get_ending_sales();
 
 	/**
+	 * Returns an array of available product variations.
+	 *
+	 * @since 10.4.0
+	 * @param WC_Product $product Variable product object.
+	 * @return array
+	 */
+	public function get_product_variations( $product );
+
+	/**
 	 * Find a matching (enabled) variation within a variable product.
 	 *
 	 * @param WC_Product $product Variable product object.
@@ -72,6 +81,16 @@ interface WC_Product_Data_Store_Interface {
 	 * @return int Matching variation ID or 0.
 	 */
 	public function find_matching_product_variation( $product, $match_attributes = array() );
+
+	/**
+	 * Find matching (enabled) variations within a variable product.
+	 *
+	 * @since 10.4.0
+	 * @param WC_Product $product Variable product object.
+	 * @param array      $match_attributes Array of attributes we want to try to match.
+	 * @return int[] Matching variation IDs or empty array if none found.
+	 */
+	public function find_matching_product_variations( $product, $match_attributes = array() );
 
 	/**
 	 * Make sure all variations have a sort order set so they can be reordered correctly.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Refactoring of the function `find_matching_product_variation()` (some splitting & improvements with `continue`)
- Additional method + endpoint for matching variations ('get_variations').

I can remove the new `?wc-ajax=get_variations` endpoint from this PR if you don't want to have new endpoints. I just need the refactoring of the main function (move some parts in `find_matching_product_variation()` to new `get_product_variations` function), so I can re-use it for an own endpoint :-)

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Instead of `?wc-ajax=get_variation` send same request with less attributes to `?wc-ajax=get_variations`. The endpoint can be triggered on frontend -> single variable product -> add-to-cart/variations area -> select attributes
2. As response you'll get all possible variations to attributes which were requested/selected

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [X] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [X] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [X] Performance - Address performance issues
-   [X] Enhancement - Improvement to existing functionality

#### `wc-ajax` endpoint for product variations (`get_variations`)

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

