### PR TITLE
Email Editor: fix classic block

### DIFF
--- a/packages/php/email-editor/changelog/62605-fix-email-editor-classic-content
+++ b/packages/php/email-editor/changelog/62605-fix-email-editor-classic-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Email Editor: make Cleanup_Preprocessor only remove truly empty blocks.
+

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-cleanup-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-cleanup-preprocessor.php
@@ -25,7 +25,7 @@ class Cleanup_Preprocessor implements Preprocessor {
 			// https://core.trac.wordpress.org/ticket/45312
 			// \WP_Block_Parser::parse_blocks() sometimes add a block with name null that can cause unexpected spaces in rendered content
 			// This behavior was reported as an issue, but it was closed as won't fix.
-			if ( null === $block['blockName'] && empty( trim( $block['innerHTML'] ?? '' ) ) ) {
+			if ( null === $block['blockName'] && '' === trim( $block['innerHTML'] ?? '' ) ) {
 				unset( $parsed_blocks[ $key ] );
 			}
 		}

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-cleanup-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-cleanup-preprocessor.php
@@ -25,7 +25,7 @@ class Cleanup_Preprocessor implements Preprocessor {
 			// https://core.trac.wordpress.org/ticket/45312
 			// \WP_Block_Parser::parse_blocks() sometimes add a block with name null that can cause unexpected spaces in rendered content
 			// This behavior was reported as an issue, but it was closed as won't fix.
-			if ( null === $block['blockName'] ) {
+			if ( null === $block['blockName'] && empty( trim( $block['innerHTML'] ?? '' ) ) ) {
 				unset( $parsed_blocks[ $key ] );
 			}
 		}

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Cleanup_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Cleanup_Preprocessor_Test.php
@@ -108,4 +108,25 @@ class Cleanup_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$this->assertEquals( self::PARAGRAPH_BLOCK, $result[1] );
 		$this->assertEquals( self::COLUMNS_BLOCK, $result[2] );
 	}
+
+	/**
+	 * Test it preserves blocks with null blockName but non-empty innerHTML
+	 */
+	public function testItPreservesBlocksWithNullBlockNameButWithInnerHtml(): void {
+		$block_with_content = array(
+			'blockName' => null,
+			'attrs'     => array(),
+			'innerHTML' => '<p>Some content</p>',
+		);
+		$blocks             = array(
+			self::COLUMNS_BLOCK,
+			$block_with_content,
+			self::PARAGRAPH_BLOCK,
+		);
+		$result             = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$this->assertCount( 3, $result );
+		$this->assertEquals( self::COLUMNS_BLOCK, $result[0] );
+		$this->assertEquals( $block_with_content, $result[1] );
+		$this->assertEquals( self::PARAGRAPH_BLOCK, $result[2] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/CM-502/allow-non-block-content

The current `Cleanup_Preprocessor` strips any blocks that do not have `blockName`s. This helps remove any empty blocks. However the classic block (`core/freeform`) also gets returned as a block without a `blockName` this results in stripping all classic block content.

By checking if there is an innerHTML before unsetting it we prevent losing any valid HTML content that should be kept in the email content.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="726" height="405" alt="Screen Shot 2025-12-26 at 13 06 31" src="https://github.com/user-attachments/assets/25f830e6-702b-4dc7-b17b-d0f4d98ee5bc" /> | <img width="773" height="589" alt="Screen Shot 2025-12-26 at 13 04 50" src="https://github.com/user-attachments/assets/94c0d75f-3f59-4662-965d-b74a33994876" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a post using the Classic Block and add content to the classic block
2. Preview the email and ensure the content is displayed in the email

To test on WordPress.com: PCYsg-19om-p2

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Email Editor: make Cleanup_Preprocessor only remove truly empty blocks.

</details>