### PR TITLE
Replace admin bar height with css variable

### DIFF
--- a/plugins/woocommerce/changelog/62608-admin-bar-variable
+++ b/plugins/woocommerce/changelog/62608-admin-bar-variable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Replace admin bar height with css variable

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/user-interface/fulfillment-drawer/fulfillment-drawer.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/user-interface/fulfillment-drawer/fulfillment-drawer.scss
@@ -1,9 +1,9 @@
 .woocommerce-fulfillment-drawer {
 	position: fixed;
 	inset: 0;
-	top: 32px;
+	top: var(--wp-admin--admin-bar--height, 0px);
 	left: auto;
-	height: calc(100vh - 32px);
+	height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 	z-index: 9999;
 	width: calc(27.7778vw + 1px);
 	min-width: 401px;
@@ -107,8 +107,6 @@
 
 @media screen and (max-width: 782px) {
 	.woocommerce-fulfillment-drawer {
-		top: 46px;
-		height: calc(100vh - 46px);
 		width: 100%;
 		min-width: 100%;
 		max-width: 100%;
@@ -118,7 +116,7 @@
 			max-width: 100%;
 		}
 		&__body {
-			height: calc(100% - 73px);
+			height: calc(100% - var(--wp-admin--admin-bar--height, 0px) - 27px);
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/drawer/style.scss
@@ -151,13 +151,6 @@ $drawer-animation-duration: 0.3s;
 }
 
 .admin-bar .wc-block-components-drawer__content {
-	margin-top: 46px;
-	height: calc(100dvh - 46px);
-}
-
-@media only screen and (min-width: 783px) {
-	.admin-bar .wc-block-components-drawer__content {
-		margin-top: 32px;
-		height: calc(100dvh - 32px);
-	}
+	margin-top: var(--wp-admin--admin-bar--height, 0px);
+	height: calc(100dvh - var(--wp-admin--admin-bar--height, 0px));
 }

--- a/plugins/woocommerce/client/legacy/css/photoswipe/photoswipe.css
+++ b/plugins/woocommerce/client/legacy/css/photoswipe/photoswipe.css
@@ -58,14 +58,8 @@ button.pswp__button--zoom:hover {
 
   /* adjust for admin bar */
   .admin-bar .pswp {
-    height: calc(100% - 32px);
-    top: 32px;
-  }
-  @media screen and (max-width: 782px) {
-    .admin-bar .pswp {
-      height: calc(100% - 46px);
-      top: 46px;
-    }
+    height: calc(100% - var(--wp-admin--admin-bar--height, 0px));
+    top: var(--wp-admin--admin-bar--height, 0px);
   }
 
 /* style is added when JS option showHideOpacity is set to true */


### PR DESCRIPTION
It's not required to hardcode the admin bar height, you can use the css variable instead.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Replace admin bar height with css variable

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>