### PR TITLE
Checkout: Fix shipping method label when free

### DIFF
--- a/plugins/woocommerce/changelog/62617-update-free-shipping-labeling
+++ b/plugins/woocommerce/changelog/62617-update-free-shipping-labeling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Checkout: Fix shipping method label when free
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
@@ -28,7 +28,7 @@ export const RatePrice = ( {
 		? parseInt( maxRate.price, 10 ) + parseInt( maxRate.taxes, 10 )
 		: parseInt( maxRate.price, 10 );
 	const priceElement =
-		minRatePrice === 0 ? (
+		minRatePrice === 0 && maxRatePrice === 0 ? (
 			<em>{ __( 'free', 'woocommerce' ) }</em>
 		) : (
 			<FormattedMonetaryAmount


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR changes the shipping method labeling when there is a "Free" rate and at least one paid rate. The previous "From FREE" was awkward and difficult to translate in some languages.

Fixes #62611.
Fixes WOOPLUG-6080.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

One free method and one paid method enabled in the zone:

| Before | After |
| ------ | ----- |
|<img width="503" height="139" alt="Screenshot 2025-12-29 at 17 57 34" src="https://github.com/user-attachments/assets/a2c6c0f3-50b9-4cb7-bb82-ba89c946bf2a" />|<img width="501" height="138" alt="Screenshot 2025-12-29 at 17 57 45" src="https://github.com/user-attachments/assets/96eb62da-a8d1-43ce-b5a5-bc6abf68c41f" />|

Only one free method enabled in the zone (unchanged from `trunk`):
<img width="501" height="138" alt="Screenshot 2025-12-29 at 17 57 52" src="https://github.com/user-attachments/assets/629b29d5-b864-45bc-9871-264ca4a4ce82" />

Multiple paid methods enabled in the zone (unchanged from `trunk`):
<img width="500" height="135" alt="Screenshot 2025-12-29 at 18 00 04" src="https://github.com/user-attachments/assets/48991972-edb9-4b11-9adb-ae5335a14de8" />

Single paid method enabled in the zone (unchanged from `trunk`):
<img width="498" height="134" alt="Screenshot 2025-12-29 at 17 58 09" src="https://github.com/user-attachments/assets/bb2d603a-127e-486c-8831-f21e0b5b7cfa" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have at least one FREE shipping method and one paid shipping method.
2. Make sure local pickup is enabled.
3. Add some products to the cart.
4. Go to the checkout page.
5. Verify the shipping method label no longer says "From FREE" but rather says "From $0.00"
6. Disable the FREE method in the admin. Verify it now shows the price of the paid method "$5.00".
7. Add another paid shipping rate to that shipping zone. Verify it now shows "From $5.00" where "$5.00" is the price of the cheaper rate.
8. Disable all paid methods and enable "Free". Verify it now says "Free".

<!-- End testing instructions -->

### Testing that has already taken place:

Manual testing with the steps above. 

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Checkout: Fix shipping method label when free

</details>
