### PR TITLE
Apply consistent form spacing in Checkout block fields

### DIFF
--- a/plugins/woocommerce/changelog/62622-fix-proper-gaps-in-checkout
+++ b/plugins/woocommerce/changelog/62622-fix-proper-gaps-in-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix checkout block input spacing when country is not the first element.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/style.scss
@@ -3,7 +3,6 @@ This file is part of the WooCommerce Blocks autocomplete. If editing shortcode, 
 */
 .wc-block-components-address-autocomplete-container {
 	width: 100%;
-	margin-top: $gap;
 	position: relative;
 
 	.wc-block-components-address-autocomplete-icon {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
@@ -9,7 +9,7 @@ import { Fragment, forwardRef } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { checkoutStore } from '@woocommerce/block-data';
+import { checkoutStore, validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -30,7 +30,12 @@ const EmailField = forwardRef(
 			} ),
 			[]
 		);
-
+		const hasVisibleError = useSelect(
+			( select ) =>
+				select( validationStore ).getValidationError( 'billing_email' )
+					?.hidden === false,
+			[]
+		);
 		return (
 			<Fragment>
 				<ValidatedTextInput
@@ -39,7 +44,7 @@ const EmailField = forwardRef(
 					onChange={ onChange }
 					value={ value }
 				/>
-				{ allowGuestCheckout && ! customerId ? (
+				{ allowGuestCheckout && ! customerId && ! hasVisibleError ? (
 					<p
 						id={ guestCheckoutNoticeId }
 						className="wc-block-checkout__guest-checkout-notice"

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
@@ -1,10 +1,15 @@
 /**
  * External dependencies
  */
-import { ValidatedTextInput } from '@woocommerce/blocks-components';
-import { Fragment } from '@wordpress/element';
+import {
+	ValidatedTextInput,
+	ValidatedTextInputHandle,
+} from '@woocommerce/blocks-components';
+import { Fragment, forwardRef } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -13,33 +18,41 @@ import { ValidatedTextInputProps } from '../../../../../../packages/components/t
 
 const guestCheckoutNoticeId = 'wc-guest-checkout-notice';
 
-const EmailField = ( {
-	onChange,
-	value,
-	...props
-}: ValidatedTextInputProps ): JSX.Element => {
-	const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
+const EmailField = forwardRef(
+	(
+		{ onChange, value, ...props }: ValidatedTextInputProps,
+		ref: React.Ref< ValidatedTextInputHandle >
+	): JSX.Element => {
+		const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
+		const { customerId } = useSelect(
+			( select ) => ( {
+				customerId: select( checkoutStore ).getCustomerId(),
+			} ),
+			[]
+		);
 
-	return (
-		<Fragment>
-			<ValidatedTextInput
-				{ ...props }
-				onChange={ onChange }
-				value={ value }
-			/>
-			{ allowGuestCheckout ? (
-				<p
-					id={ guestCheckoutNoticeId }
-					className="wc-block-checkout__guest-checkout-notice"
-				>
-					{ __(
-						'You are currently checking out as a guest.',
-						'woocommerce'
-					) }
-				</p>
-			) : null }
-		</Fragment>
-	);
-};
+		return (
+			<Fragment>
+				<ValidatedTextInput
+					{ ...props }
+					ref={ ref }
+					onChange={ onChange }
+					value={ value }
+				/>
+				{ allowGuestCheckout && ! customerId ? (
+					<p
+						id={ guestCheckoutNoticeId }
+						className="wc-block-checkout__guest-checkout-notice"
+					>
+						{ __(
+							'You are currently checking out as a guest.',
+							'woocommerce'
+						) }
+					</p>
+				) : null }
+			</Fragment>
+		);
+	}
+);
 
 export { EmailField };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/email-field.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { ValidatedTextInput } from '@woocommerce/blocks-components';
+import { Fragment } from '@wordpress/element';
+import { getSetting } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ValidatedTextInputProps } from '../../../../../../packages/components/text-input/types';
+
+const guestCheckoutNoticeId = 'wc-guest-checkout-notice';
+
+const EmailField = ( {
+	onChange,
+	value,
+	...props
+}: ValidatedTextInputProps ): JSX.Element => {
+	const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
+
+	return (
+		<Fragment>
+			<ValidatedTextInput
+				{ ...props }
+				onChange={ onChange }
+				value={ value }
+			/>
+			{ allowGuestCheckout ? (
+				<p
+					id={ guestCheckoutNoticeId }
+					className="wc-block-checkout__guest-checkout-notice"
+				>
+					{ __(
+						'You are currently checking out as a guest.',
+						'woocommerce'
+					) }
+				</p>
+			) : null }
+		</Fragment>
+	);
+};
+
+export { EmailField };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -47,6 +47,8 @@ import {
 } from './utils';
 import validateCountry from './validate-country';
 import { validateState } from './validate-state';
+import { EmailField } from './email-field';
+
 /**
  * Checkout form.
  */
@@ -251,6 +253,22 @@ const Form = <
 				if ( field.key === 'email' ) {
 					fieldProps.id = 'email';
 					fieldProps.errorId = 'billing_email';
+
+					return (
+						<EmailField
+							{ ...fieldProps }
+							key={ field.key }
+							onChange={ ( value: string ) =>
+								onChange( {
+									...values,
+									email: value,
+								} as T )
+							}
+							value={
+								( values as ContactFormValues )?.email || ''
+							}
+						/>
+					);
 				}
 
 				if ( field.type === 'checkbox' ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -258,6 +258,10 @@ const Form = <
 						<EmailField
 							{ ...fieldProps }
 							key={ field.key }
+							ref={ ( el ) =>
+								( inputsRef.current[ field.key ] = el )
+							}
+							ariaDescribedBy={ ariaDescribedBy }
 							onChange={ ( value: string ) =>
 								onChange( {
 									...values,

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -93,28 +93,27 @@ const Form = <
 
 	const { errors, previousErrors } = useFormValidation(
 		formFields,
-		addressType,
-		// Temporary override for shipping calculator address form.
-		addressType === 'shipping' ? ( values as AddressFormValues ) : undefined
+		addressType
 	);
 
 	useEffect( () => {
 		Object.entries( errors ).forEach( ( [ key, error ] ) => {
+			const errorKey =
+				key === 'email' ? 'billing_email' : `${ addressType }_${ key }`;
 			const inputRef = inputsRef.current[ key ];
 			if ( ! error ) {
 				return;
 			}
 			inputRef?.setErrorMessage( error );
-			const hasValidationError = select(
-				validationStore
-			).getValidationError( `${ addressType }_${ key }` );
+			const hasValidationError =
+				select( validationStore ).getValidationError( errorKey );
 
 			// Check if this field already has a validation error, prevents up from surfacing already hidden errors.
 			if ( hasValidationError ) {
 				return;
 			}
 			dispatch( validationStore ).setValidationErrors( {
-				[ `${ addressType }_${ key }` ]: {
+				[ errorKey ]: {
 					message: error,
 					hidden: !! inputRef?.isFocused(),
 				},
@@ -125,11 +124,15 @@ const Form = <
 		if ( previousErrors ) {
 			const errorsToClear: string[] = [];
 			Object.entries( previousErrors ).forEach( ( [ key ] ) => {
+				const errorKey =
+					key === 'email'
+						? 'billing_email'
+						: `${ addressType }_${ key }`;
 				const inputRef = inputsRef.current[ key ];
 
 				// If error was previously set but no longer exists, clear it.
 				if ( ! ( key in errors ) ) {
-					errorsToClear.push( `${ addressType }_${ key }` );
+					errorsToClear.push( errorKey );
 					inputRef?.setErrorMessage( '' );
 				}
 			} );
@@ -258,18 +261,21 @@ const Form = <
 						<EmailField
 							{ ...fieldProps }
 							key={ field.key }
+							type="email"
 							ref={ ( el ) =>
 								( inputsRef.current[ field.key ] = el )
 							}
 							ariaDescribedBy={ ariaDescribedBy }
+							value={
+								decodeEntities(
+									values[ field.key as keyof T ] as string
+								) ?? ''
+							}
 							onChange={ ( value: string ) =>
 								onChange( {
 									...values,
 									email: value,
 								} as T )
-							}
-							value={
-								( values as ContactFormValues )?.email || ''
 							}
 						/>
 					);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -118,7 +118,6 @@ export const useFormValidation = (
 	let values:
 		| BillingAddress
 		| ShippingAddress
-		| BillingAddress
 		| ContactFormValues
 		| OrderFormValues
 		| Record< string, never >;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -143,8 +143,8 @@ export const useFormValidation = (
 
 	// Only set email on values if formFields contains 'email' and values supports 'email'.
 	if ( formFields.some( ( field ) => field.key === 'email' ) ) {
-		// @ts-expect-error values is a BillingAddress, but TS can't seem to figure that out.
-		values.email = data.customer.billing_address.email || '';
+		( values as ContactFormValues & { email: string } ).email =
+			data.customer.billing_address.email || '';
 	}
 
 	const partialSchema = formFields.reduce<

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -9,6 +9,8 @@ import {
 import { getFieldLabel, isPostcode } from '@woocommerce/blocks-checkout';
 import {
 	AddressFormValues,
+	BillingAddress,
+	ShippingAddress,
 	ContactFormValues,
 	FormFields,
 	FormType,
@@ -114,7 +116,9 @@ export const useFormValidation = (
 	}
 
 	let values:
-		| AddressFormValues
+		| BillingAddress
+		| ShippingAddress
+		| BillingAddress
 		| ContactFormValues
 		| OrderFormValues
 		| Record< string, never >;
@@ -135,6 +139,12 @@ export const useFormValidation = (
 				values = {};
 				break;
 		}
+	}
+
+	// Only set email on values if formFields contains 'email' and values supports 'email'.
+	if ( formFields.some( ( field ) => field.key === 'email' ) ) {
+		// @ts-expect-error values is a BillingAddress, but TS can't seem to figure that out.
+		values.email = data.customer.billing_address.email || '';
 	}
 
 	const partialSchema = formFields.reduce<

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import type { CountryInputWithCountriesProps } from './CountryInputProps';
 import { Select, SelectOption } from '../select';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/style.scss
@@ -1,6 +1,0 @@
-@import "node_modules/@wordpress/base-styles/breakpoints";
-@import "node_modules/@wordpress/base-styles/mixins";
-
-.wc-block-components-country-input {
-	margin-top: $gap;
-}

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
@@ -6,9 +6,10 @@ import { useSelect } from '@wordpress/data';
 import { snakeCaseKeys } from '@woocommerce/base-utils';
 import type {
 	OrderFormValues,
-	AddressFormValues,
 	FormType,
 	ContactFormValues,
+	BillingAddress,
+	ShippingAddress,
 } from '@woocommerce/settings';
 import {
 	ORDER_FORM_KEYS,
@@ -229,13 +230,13 @@ export interface DocumentObject< T extends FormType | 'global' > {
 	customer:
 		| {
 				id: number;
-				billing_address: AddressFormValues;
-				shipping_address: AddressFormValues;
+				billing_address: BillingAddress;
+				shipping_address: ShippingAddress;
 				additional_fields: ContactFormValues;
 				address: T extends 'billing'
-					? AddressFormValues
+					? BillingAddress
 					: T extends 'shipping'
-					? AddressFormValues
+					? ShippingAddress
 					: null;
 		  }
 		| Record< string, never >;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -7,16 +7,6 @@
 .wc-block-cart {
 	padding-top: $gap;
 
-	.wc-block-components-address-form {
-		.wc-block-components-text-input,
-		.wc-block-components-country-input,
-		.wc-block-components-state-input {
-			&:first-of-type {
-				margin-top: 0;
-			}
-		}
-	}
-
 	.wc-block-components-totals-taxes,
 	.wc-block-components-totals-footer-item {
 		margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/edit.tsx
@@ -39,7 +39,7 @@ export const Edit = ( {
 			setAttributes={ setAttributes }
 			attributes={ attributes }
 			className={ clsx(
-				'wc-block-checkout__additional-information-fields',
+				'wc-block-checkout__order-fields',
 				attributes?.className
 			) }
 		>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
@@ -54,17 +54,6 @@ const CreateAccountUI = (): React.ReactElement | null => {
 
 	return (
 		<>
-			{ allowGuestCheckout && (
-				<p
-					id={ guestCheckoutNoticeId }
-					className="wc-block-checkout__guest-checkout-notice"
-				>
-					{ __(
-						'You are currently checking out as a guest.',
-						'woocommerce'
-					) }
-				</p>
-			) }
 			{ showCreateAccountCheckbox && (
 				<CheckboxControl
 					className="wc-block-checkout__create-account"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -8,51 +8,54 @@
 		order: 1;
 	}
 }
-@mixin address-form-layout {
+
+.wc-block-checkout__shipping-fields,
+.wc-block-checkout__billing-fields,
+.wc-block-checkout__contact-fields {
+	.wc-block-components-address-form {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: $gap-small; // Required for spacing especially when using flex-grow
+
+		.wc-block-components-text-input,
+		.wc-block-components-state-input,
+		.wc-block-components-select-input {
+			flex: 1 0 calc(50% - #{$gap-small}); // "flex-grow = 1" allows the input to grow to fill the space
+			box-sizing: border-box;
+		}
+
+		.wc-block-components-address-form__company,
+		.wc-block-components-address-form__address_1,
+		.wc-block-components-address-form__address_2,
+		.wc-block-components-country-input,
+		.wc-block-components-checkbox {
+			flex: 0 0 100%;
+		}
+	}
+}
+
+.wc-block-checkout__contact-fields {
+	.wc-block-components-address-form {
+		.wc-block-components-select-input,
+		.wc-block-components-text-input {
+			flex: 0 0 100%; // Forcing all inputs in the contact step to be full width.
+		}
+	}
+}
+
+@include cart-checkout-mobile-container {
 	.wc-block-checkout__shipping-fields,
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__contact-fields {
 		.wc-block-components-address-form {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: space-between;
-			gap: $gap-small; // Required for spacing especially when using flex-grow
-
 			.wc-block-components-text-input,
 			.wc-block-components-state-input,
 			.wc-block-components-select-input {
-				flex: 1 0 calc(50% - #{$gap-small}); // "flex-grow = 1" allows the input to grow to fill the space
-				box-sizing: border-box;
-			}
-
-			.wc-block-components-address-form__company,
-			.wc-block-components-address-form__address_1,
-			.wc-block-components-address-form__address_2,
-			.wc-block-components-country-input,
-			.wc-block-components-checkbox {
 				flex: 0 0 100%;
 			}
 		}
 	}
-
-	.wc-block-checkout__contact-fields {
-		.wc-block-components-address-form {
-			.wc-block-components-select-input,
-			.wc-block-components-text-input {
-				flex: 0 0 100%; // Forcing all inputs in the contact step to be full width.
-			}
-		}
-	}
-}
-
-@include cart-checkout-large-container {
-	@include address-form-layout;
-}
-@include cart-checkout-small-container {
-	@include address-form-layout;
-}
-@include cart-checkout-medium-container {
-	@include address-form-layout;
 }
 
 .wc-block-components-address-form__address_2-toggle {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -1,23 +1,8 @@
 .wc-block-checkout__form {
 	margin: 0;
 	max-width: 100%;
-
-	// This margin is aligned with text-input margin-top, making it positioned
-	// correctly when two are placed next to each other.
-	// Please don't change unless you plan to apply the same change
-	// in text-input/style.scss
-	.wc-blocks-components-select {
-		margin-top: $gap-small;
-	}
-
-	// No need for this margin in default country select, which sits at the top
-	// of the form
-	.wc-block-components-address-form__country {
-		.wc-blocks-components-select {
-			margin-top: 0;
-		}
-	}
 }
+
 @include cart-checkout-below-large-container {
 	.wc-block-checkout__main {
 		order: 1;
@@ -25,49 +10,28 @@
 }
 @mixin address-form-layout {
 	.wc-block-checkout__shipping-fields,
-	.wc-block-checkout__billing-fields {
+	.wc-block-checkout__billing-fields,
+	.wc-block-checkout__contact-fields {
 		.wc-block-components-address-form {
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
-			gap: 0 $gap-small; // Required for spacing especially when using flex-grow
+			gap: $gap-small; // Required for spacing especially when using flex-grow
 
 			.wc-block-components-text-input,
 			.wc-block-components-state-input,
 			.wc-block-components-select-input {
 				flex: 1 0 calc(50% - #{$gap-small}); // "flex-grow = 1" allows the input to grow to fill the space
 				box-sizing: border-box;
-
-				&:first-child {
-					margin-top: 0;
-				}
-
-				&:first-child + .wc-block-components-text-input {
-					margin-top: 0;
-				}
 			}
 
 			.wc-block-components-address-form__company,
 			.wc-block-components-address-form__address_1,
 			.wc-block-components-address-form__address_2,
+			.wc-block-components-address-form__email,
 			.wc-block-components-country-input,
 			.wc-block-components-checkbox {
 				flex: 0 0 100%;
-
-				&:first-child {
-					margin-top: 0;
-				}
-			}
-		}
-	}
-	.wc-block-components-address-form {
-		.wc-block-components-checkbox {
-			margin-top: $gap;
-		}
-
-		.wc-block-components-text-input.wc-block-components-address-form__email {
-			&:only-child {
-				margin-top: 0;
 			}
 		}
 	}
@@ -90,7 +54,6 @@
 	border: none;
 	color: inherit;
 	cursor: pointer;
-	margin-top: $gap-small;
 	text-align: left;
 	width: 100%;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -11,7 +11,8 @@
 
 .wc-block-checkout__shipping-fields,
 .wc-block-checkout__billing-fields,
-.wc-block-checkout__contact-fields {
+.wc-block-checkout__contact-fields,
+.wc-block-checkout__order-fields {
 	.wc-block-components-address-form {
 		display: flex;
 		flex-wrap: wrap;
@@ -35,12 +36,24 @@
 	}
 }
 
-.wc-block-checkout__contact-fields {
+.wc-block-checkout__contact-fields,
+.wc-block-checkout__order-fields {
 	.wc-block-components-address-form {
 		.wc-block-components-select-input,
 		.wc-block-components-text-input {
-			flex: 0 0 100%; // Forcing all inputs in the contact step to be full width.
+			flex: 0 0 100%; // Forcing all inputs in the contact and order steps to be full width.
 		}
+	}
+}
+
+.wc-block-components-form {
+	.wc-block-checkout__order-fields:has(+ .wc-block-checkout__order-notes),
+	.wc-block-checkout__order-notes:has(
+			+ .wc-block-checkout__terms:not(
+					.wc-block-checkout__terms--with-separator
+				)
+		) {
+		margin-bottom: $gap-small;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -48,7 +48,7 @@
 
 .wc-block-components-form {
 	.wc-block-checkout__order-fields:has(+ .wc-block-checkout__order-notes),
-	.wc-block-checkout__order-notes:has(
+	:is(.wc-block-checkout__order-notes, .wc-block-checkout__order-fields):has(
 			+ .wc-block-checkout__terms:not(
 					.wc-block-checkout__terms--with-separator
 				)

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -49,11 +49,23 @@
 .wc-block-components-form {
 	.wc-block-checkout__order-fields:has(+ .wc-block-checkout__order-notes),
 	:is(.wc-block-checkout__order-notes, .wc-block-checkout__order-fields):has(
-			+ .wc-block-checkout__terms:not(
-					.wc-block-checkout__terms--with-separator
-				)
+			+ .wc-block-checkout__terms
 		) {
 		margin-bottom: $gap-small;
+	}
+}
+
+@include cart-checkout-large-container {
+	.wc-block-components-form {
+		// Apply a different style when the terms block has the --with-separator modifier
+		:is(
+				.wc-block-checkout__order-notes,
+				.wc-block-checkout__order-fields
+			):has(
+				+ .wc-block-checkout__terms.wc-block-checkout__terms--with-separator
+			) {
+			margin-bottom: $gap-large;
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -28,10 +28,18 @@
 			.wc-block-components-address-form__company,
 			.wc-block-components-address-form__address_1,
 			.wc-block-components-address-form__address_2,
-			.wc-block-components-address-form__email,
 			.wc-block-components-country-input,
 			.wc-block-components-checkbox {
 				flex: 0 0 100%;
+			}
+		}
+	}
+
+	.wc-block-checkout__contact-fields {
+		.wc-block-components-address-form {
+			.wc-block-components-select-input,
+			.wc-block-components-text-input {
+				flex: 0 0 100%; // Forcing all inputs in the contact step to be full width.
 			}
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/editor.scss
@@ -1,4 +1,4 @@
-// Adjust padding and margins in the editor to improve selected block outlines.
+// Add a small padding to the order so that margin doesn't collapse, this allows the block selector outline to include the margin so it's not too tight around the block.
 .wp-block-woocommerce-checkout-order-note-block {
-	padding: 4px 0;
+	padding: 1px 0;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/editor.scss
@@ -1,12 +1,12 @@
 .edit-post-visual-editor {
 	@include cart-checkout-small-container {
 		.wc-block-checkout__terms {
-			padding: 4px;
+			padding: 1px 4px;
 		}
 	}
 	@include cart-checkout-medium-container {
 		.wc-block-checkout__terms {
-			padding: 4px;
+			padding: 1px 4px;
 		}
 	}
 }
@@ -14,8 +14,8 @@
 // Adjust padding and margins in the editor to improve selected block outlines.
 .wc-block-checkout__terms {
 	margin: 0 0 $gap-larger 0;
-	padding-top: 4px;
-	padding-bottom: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
 	display: flex;
 	align-items: flex-start;
 }
@@ -27,7 +27,7 @@
 .wc-block-checkout__terms_notice {
 	margin: 0;
 	.components-notice__content {
-		margin: 4px 0;
+		margin: 1px 0;
 	}
 	.components-notice__actions {
 		button {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/style.scss
@@ -1,5 +1,5 @@
 .wc-block-checkout__add-note {
 	display: flex;
 	flex-direction: column;
-	gap: $gap;
+	gap: $gap-small;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
@@ -41,6 +41,32 @@
 			top: 0;
 		}
 	}
+
+	.wc-block-components-form {
+		.wc-block-checkout__order-fields:has(
+				+ .wp-block-woocommerce-checkout-order-note-block
+			) {
+			margin-bottom: $gap-small;
+		}
+
+		// Would have been a lot easier to do if those blocks aren't nested from what we have in the frontend.
+		// @TODO: Refactor the block to remove the extra parent in the editor.
+		.wp-block-woocommerce-checkout-order-note-block:has(
+				+ .wp-block-woocommerce-checkout-terms-block
+			)
+			.wc-block-checkout__order-notes {
+			margin-bottom: $gap-small;
+		}
+
+		// Reset when the terms block has a separator
+		.wp-block-woocommerce-checkout-order-note-block:has(
+				+ .wp-block-woocommerce-checkout-terms-block
+					.wc-block-checkout__terms--with-separator
+			)
+			.wc-block-checkout__order-notes {
+			margin-bottom: $gap-large;
+		}
+	}
 }
 
 body.wc-lock-selected-block--move {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
@@ -43,14 +43,14 @@
 	}
 
 	.wc-block-components-form {
+		// Would have been a lot easier to do if those blocks aren't nested from what we have in the frontend.
+		// @TODO: Refactor the block to remove the extra parent in the editor.
 		.wc-block-checkout__order-fields:has(
-				+ .wp-block-woocommerce-checkout-order-note-block
+				+ .wp-block-woocommerce-checkout-order-note-block,
+				+ .wp-block-woocommerce-checkout-terms-block
 			) {
 			margin-bottom: $gap-small;
 		}
-
-		// Would have been a lot easier to do if those blocks aren't nested from what we have in the frontend.
-		// @TODO: Refactor the block to remove the extra parent in the editor.
 		.wp-block-woocommerce-checkout-order-note-block:has(
 				+ .wp-block-woocommerce-checkout-terms-block
 			)
@@ -64,6 +64,12 @@
 					.wc-block-checkout__terms--with-separator
 			)
 			.wc-block-checkout__order-notes {
+			margin-bottom: $gap-large;
+		}
+		.wc-block-checkout__order-fields:has(
+				+ .wp-block-woocommerce-checkout-terms-block
+					.wc-block-checkout__terms--with-separator
+			) {
 			margin-bottom: $gap-large;
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/editor.scss
@@ -57,20 +57,25 @@
 			.wc-block-checkout__order-notes {
 			margin-bottom: $gap-small;
 		}
+	}
 
-		// Reset when the terms block has a separator
-		.wp-block-woocommerce-checkout-order-note-block:has(
-				+ .wp-block-woocommerce-checkout-terms-block
-					.wc-block-checkout__terms--with-separator
-			)
-			.wc-block-checkout__order-notes {
-			margin-bottom: $gap-large;
-		}
-		.wc-block-checkout__order-fields:has(
-				+ .wp-block-woocommerce-checkout-terms-block
-					.wc-block-checkout__terms--with-separator
-			) {
-			margin-bottom: $gap-large;
+	// Terms and conditions seperator is only visible on large screens, we account for it only there.
+	@include cart-checkout-large-container {
+		.wc-block-components-form {
+			// Reset when the terms block has a separator, but only in the large container
+			.wp-block-woocommerce-checkout-order-note-block:has(
+					+ .wp-block-woocommerce-checkout-terms-block
+						.wc-block-checkout__terms--with-separator
+				)
+				.wc-block-checkout__order-notes {
+				margin-bottom: $gap-large;
+			}
+			.wc-block-checkout__order-fields:has(
+					+ .wp-block-woocommerce-checkout-terms-block
+						.wc-block-checkout__terms--with-separator
+				) {
+				margin-bottom: $gap-large;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
@@ -34,12 +34,11 @@
 		line-height: $gap * 1.25;
 		@include font-small-locked;
 	}
-	.wc-block-checkout__create-account {
-		margin-top: $gap !important;
-	}
+
 	.wc-block-checkout__guest-checkout-notice {
 		@include font-small-locked;
-		margin: $gap-smallest 0 0;
+		// $gap-small is the gap between form elements, we want to shift this notice up by that gap minus the smallest gap (similar to having no parent gap and margin top of $gap-smallest).
+		margin: ($gap-smallest - $gap-small) 0 0;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
@@ -8,11 +8,6 @@
 	padding: 0;
 	background: none;
 	margin: 0 0 $gap-large 0;
-
-	.wc-block-components-text-input:first-of-type,
-	.wc-block-components-country-input {
-		margin-top: 0;
-	}
 }
 
 .wc-block-components-checkout-step--disabled {

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -1,7 +1,6 @@
 .wc-block-components-form .wc-block-components-text-input,
 .wc-block-components-text-input {
 	position: relative;
-	margin-top: $gap-small;
 	white-space: nowrap;
 	// Resetting line-height to avoid any unnecessary space around the input
 	line-height: 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR moves Checkout block form spacing from using margin-tops and overrides all over the place to using consistent flex gap between all items.

It also moves the email "you're currently checking out as guest" to be always under email, since that value is relevant to it, and hides it if there's an error visible.


Closes https://github.com/woocommerce/woocommerce/issues/52619
Closes WOOPLUG-6086

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59518

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="330" height="776" alt="image" src="https://github.com/user-attachments/assets/c9c13d20-966b-4517-8b9f-e68606350df6" />|<img width="318" height="711" alt="image" src="https://github.com/user-attachments/assets/d1446414-e4af-4cc0-9e93-deba12fd5644" />|
|<img width="851" height="239" alt="image" src="https://github.com/user-attachments/assets/a74b7d1f-5dda-4461-beb1-f65764a935a9" />|<img width="839" height="207" alt="image" src="https://github.com/user-attachments/assets/3d3b3f0e-33ec-4520-8549-6996f50dbf96" />|
|<img width="636" height="455" alt="image" src="https://github.com/user-attachments/assets/77270989-6b6e-41e1-8b6c-f202fae8a081" />|<img width="648" height="438" alt="Screenshot 2026-01-02 at 12 56 30 PM" src="https://github.com/user-attachments/assets/2dc7cdb8-1759-4e86-91c6-b9ef5a1109e5" />|
|<img width="634" height="426" alt="image" src="https://github.com/user-attachments/assets/a07bd7a0-035e-4e54-bca6-3ea90380950b" />|<img width="649" height="400" alt="image" src="https://github.com/user-attachments/assets/e2da67f6-341c-4c57-8e33-9a178aa6789b" />|
|<img width="642" height="384" alt="image" src="https://github.com/user-attachments/assets/473dcdd2-09e9-4c19-bbc4-9a58659920cf" />|<img width="658" height="359" alt="image" src="https://github.com/user-attachments/assets/dbef943a-a2c5-4a3c-9255-ce515f5b364b" />|
|<img width="647" height="392" alt="image" src="https://github.com/user-attachments/assets/85b80ace-4a19-49e2-8e63-fe16e959bf20" />|<img width="643" height="397" alt="image" src="https://github.com/user-attachments/assets/44cea3e4-61de-4c9f-a482-ce06ec64c239" />|
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Guest Checkout Notice

  | Scenario                        | Expected                      |
  |---------------------------------|-------------------------------|
  | Guest + guest checkout enabled  | ✅ Notice appears below email |
  | Logged-in user                  | ✅ No notice                  |
  | Guest + guest checkout disabled | ✅ No notice                  |

  2. Field Spacing (Country Priority)
```php
  add_filter('woocommerce_get_country_locale', function( $locale ) {
      $locale['US']['country']['priority'] = 30;
      return $locale;
  });
```
  - Switch to US → ✅ No broken spacing

  3. Order Notes + Terms Combinations

  Test these block configurations in the editor with desktop view (wide), (remove/add blocks, toggle settings):

  | Order Fields | Order Notes | Terms | Terms Separator | Expected                          |
  |--------------|-------------|-------|-----------------|-----------------------------------|
  | ✅           | ✅          | ✅    | Off             | Even gaps throughout              |
  | ✅           | ✅          | ✅    | On              | Larger gap before terms separator |
  | ✅           | ❌          | ✅    | Off             | Even gaps                         |
  | ✅           | ❌          | ✅    | On              | Larger gap before terms separator |
  | ✅           | ✅          | ❌    | -               | Even gaps                         |
  | ❌           | ✅          | ✅    | Off             | Even gaps                         |

  For each combination, verify:
  - Spacing in editor matches frontend
  - Gaps are consistent, no collapsing or doubling
  - On table and mobile, Separator is always collapsed.
 
  4. Terms Checkbox vs Text

  In Terms block settings, toggle "Require checkbox":
  - ✅ Checkbox mode: proper spacing
  - ✅ Text-only mode: proper spacing

  5. Responsive

  - Test all above at mobile/tablet/desktop
  - ✅ Fields stack properly, gaps remain even

  6. Additional Fields (Optional)

  - Install https://github.com/woocommerce/additional-checkout-fields-tester
  - ✅ Custom fields in order step have consistent spacing

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix checkout block input spacing when country is not the first element.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
