### PR TITLE
Fix the margin for country input when position changes for fields on checkout form via filters.

### DIFF
--- a/plugins/woocommerce/changelog/fix-62621
+++ b/plugins/woocommerce/changelog/fix-62621
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the margin for country dropdown when position changes via filters.

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
@@ -9,9 +9,15 @@
 	background: none;
 	margin: 0 0 $gap-large 0;
 
-	.wc-block-components-text-input:first-of-type,
+	.wc-block-components-text-input,
 	.wc-block-components-country-input {
-		margin-top: 0;
+		&:first-of-type {
+			margin-top: 0;
+		}
+	}
+
+	.wc-block-components-country-input {
+		margin-top: $gap-small;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request tries to fix the issue where when we change the position of Country field on the checkout form the margin top is still `0` which cause the field to stick to the fields above it as shown in the issue.

Here we are fixing the approach where when the field is the first field of the form, only then the margin is `0` else we apply `$gap-small` as done with other fields.

Closes #62621 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ------ |
| <img width="423" height="520" alt="Screenshot 2025-12-31 at 12:26:53 PM" src="https://github.com/user-attachments/assets/a71a18cb-d38a-4adc-af57-ca5df766ae1e" /><br><br><img width="1114" height="740" alt="Screenshot 2025-12-31 at 12:26:24 PM" src="https://github.com/user-attachments/assets/93d74fd2-9888-470f-b3f6-98a4c312cc6c" /> | <img width="1077" height="778" alt="Screenshot 2025-12-31 at 12:27:50 PM" src="https://github.com/user-attachments/assets/a2674837-2c32-407e-bb42-795c6e0fdafd" /><br><br><img width="423" height="520" alt="Screenshot 2025-12-31 at 12:27:30 PM" src="https://github.com/user-attachments/assets/b5127a14-b00a-4889-8acb-c806dbcd6d2d" /><br><br><img width="1077" height="778" alt="Screenshot 2025-12-31 at 12:27:59 PM" src="https://github.com/user-attachments/assets/11830eb4-cfe1-4d26-884a-b20941a3c44f" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Firstly to change the position of the the fields on the checkout form, use this code snippet.
```
add_filter('woocommerce_get_country_locale', function( $locale ) {
    $locale['US']['country']['priority'] = 30;
    return $locale;
} );
```
2. Not verify that the position is changed and looks something like the screenshot should in the before column of the description.
3. Now apply the patch and build the code and verify the fix works properly and there is uniform spacing as other fields as well.
4. Test the fix for responsive screens as well.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
