### PR TITLE
Mini Cart: Avoid UI flicker when removing cart items rapidly.

### DIFF
--- a/plugins/woocommerce/changelog/62643-wooplug-6089-woocommerce-mini-cart-bug-race-condition-causing-removed
+++ b/plugins/woocommerce/changelog/62643-wooplug-6089-woocommerce-mini-cart-bug-race-condition-causing-removed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Mini Cart: Avoid stale cart items returning when removing cart items rapidly.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -252,6 +252,8 @@ function emitSyncEvent( {
 	);
 }
 
+const pendingDeletes = new Set< string >();
+
 // Todo: export this store once the store is public.
 const { state, actions } = store< Store >(
 	'woocommerce',
@@ -259,6 +261,7 @@ const { state, actions } = store< Store >(
 		actions: {
 			*removeCartItem( key: string ) {
 				const previousCart = JSON.stringify( state.cart );
+				pendingDeletes.add( key );
 
 				// optimistically update the cart
 				state.cart.items = state.cart.items.filter(
@@ -280,6 +283,7 @@ const { state, actions } = store< Store >(
 					);
 
 					const json: Cart | ApiErrorResponse = yield res.json();
+					pendingDeletes.delete( key );
 
 					if ( isApiErrorResponse( res, json ) ) {
 						throw generateError( json );
@@ -296,9 +300,15 @@ const { state, actions } = store< Store >(
 						true
 					);
 
-					state.cart = json;
+					state.cart = {
+						...json,
+						items: json.items.filter(
+							( item ) => ! pendingDeletes.has( item.key )
+						),
+					};
 					emitSyncEvent( { quantityChanges } );
 				} catch ( error ) {
+					pendingDeletes.delete( key );
 					state.cart = JSON.parse( previousCart );
 
 					// Shows the error notice.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When removing items, we used to take the full server response and overwrite the cart state. What this means is that if you fire multiple `remove-item` requests and they don't resolve in the order they were sent, the returned cart state will be out of date and items you already removed will return in the UI. You can see a screen recording of that behaviour in #62632.

We need a more wholistic approach to optimistic updates and there is a related issue for that in #61793 

But this could be considered as an interim step to improve the experience of removing cart items. It could be argued this is a more likely bug for users to encounter as they go about clearing their cart of items.

Closes #62632

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The best way to reliably reproduce this is to use the browser dev tools network throttling feature in slow 4G or 3G mode:

<img width="576" height="283" alt="Screenshot 2026-01-01 at 2 31 35 PM" src="https://github.com/user-attachments/assets/d4d1e659-1aa4-45df-b6d9-e76b01387161" />

1. Add 3 items to your cart
2. Open the mini cart
3. Rapidly click remove item on each cart item
4. See that they vanish but they do not return even after all the network requests have resolved

<!-- End testing instructions -->

### Testing that has already taken place:

I've manually tested the steps above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Mini Cart: Avoid stale cart items returning when removing cart items rapidly.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
