### PR TITLE
Fix Analytics Products report compatibility for extended variable product types

### DIFF
--- a/plugins/woocommerce/changelog/fix-variable-product-types-analytics-compatibility
+++ b/plugins/woocommerce/changelog/fix-variable-product-types-analytics-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Analytics Products report to support product types extending WC_Product_Variable by checking variations array as fallback.

--- a/plugins/woocommerce/client/admin/client/analytics/report/products/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/products/index.js
@@ -153,10 +153,12 @@ export default compose(
 			const includeArgs = { include: productId };
 			// TODO Look at similar usage to populate tags in the Search component.
 			const products = getItems( 'products', includeArgs );
+			const product = products?.get( productId );
 			const isVariable =
-				products &&
-				products.get( productId ) &&
-				products.get( productId ).type === 'variable';
+				product &&
+				( product.type === 'variable' ||
+					( Array.isArray( product.variations ) &&
+						product.variations.length > 0 ) );
 			const isProductsRequesting = isResolving( 'getItems', [
 				'products',
 				includeArgs,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Issue:** Products extending `WC_Product_Variable` (like `variable-subscription` from **WooCommerce Subscriptions** or custom product types from ATUM Product Levels) were not showing variations breakdown in `Analytics > Products` report.

**Root cause:** The `isVariable` check in the Products report only matched `type === 'variable'`, which fails for extended product types that have different type strings (e.g., `variable-subscription`).

**Solution:** Added a fallback check for `variations.length > 0` to correctly identify all variable-like products regardless of their specific type string. This works because extended variable product types properly include variations in their API response.


<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-6092

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before:
<img width="1026" height="196" alt="Screenshot 2026-01-02 at 18 07 43" src="https://github.com/user-attachments/assets/4f0a851c-a0cc-4dda-a8d8-a27d36a06238" />

After:
<img width="1046" height="189" alt="Screenshot 2026-01-02 at 18 07 47" src="https://github.com/user-attachments/assets/20e1ea21-2921-491f-be81-153c55a98a4c" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install **WooCommerce Subscriptions** plugin
2. Create a variable subscription product with multiple variations
3. Create some test orders containing these variations
4. Navigate to **Analytics > Products**
5. Click on the created product name
6. **Expected:** The variations breakdown should be displayed (showing individual variation sales)
7. **Before fix:** Only the parent product would show, no variations breakdown



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified that the REST API returns `variations` array for extended variable product types
- Code review confirmed the logic correctly handles both standard `variable` type and extended types with variations

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry already added manually in this PR.

</details>