### PR TITLE
Add PHPStan conditional return type to get_available_variations

### DIFF
--- a/plugins/woocommerce/changelog/phpstan-variable-product-return-type
+++ b/plugins/woocommerce/changelog/phpstan-variable-product-return-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add PHPStan conditional return type to WC_Product_Variable::get_available_variations().

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -304,6 +304,8 @@ class WC_Product_Variable extends WC_Product {
 	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
 	 *
 	 * @return array[]|WC_Product_Variation[]
+	 * @phpstan-param 'array'|'objects' $return
+	 * @phpstan-return ($return is 'array' ? array[] : WC_Product_Variation[])
 	 */
 	public function get_available_variations( $return = 'array' ) {
 		$variation_ids           = $this->get_children();

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58408,18 +58408,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
 
 		-
-			message: '#^Cannot call method get_description\(\) on array\|WC_Product_Variation\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationDescription.php
-
-		-
-			message: '#^Cannot call method get_id\(\) on array\|WC_Product_Variation\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationDescription.php
-
-		-
 			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\VariationDescription\:\:render\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
Fixes WOOPLUG-6097

## Summary

Adds `@phpstan-param` and `@phpstan-return` annotations to `WC_Product_Variable::get_available_variations()` to enable PHPStan to infer the correct return type based on the `$return` parameter value.

**Before:** PHPStan couldn't distinguish between the two return types, causing false positives when calling methods on `WC_Product_Variation` objects.

**After:** When called with `'objects'`, PHPStan correctly understands the return type is `WC_Product_Variation[]` rather than `array[]`.

## Changes

```php
 * @return array[]|WC_Product_Variation[]
+* @phpstan-param 'array'|'objects' $return
+* @phpstan-return ($return is 'array' ? array[] : WC_Product_Variation[])
```

## Test plan

- [ ] PHPStan passes without new errors
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)