### PR TITLE
Pass callbacks instead of strings for name and description when registering features

### DIFF
--- a/plugins/woocommerce/changelog/pr-62662
+++ b/plugins/woocommerce/changelog/pr-62662
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Pass callbacks instead of strings for name and description when registering features

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -54,7 +54,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 	 */
 	public function add_feature_definition( $features_controller ) {
 		$definition = array(
-			'description'                  => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
+			'description'                  => fn() => __( 'Allows entering cost of goods sold information for products.', 'woocommerce' ),
 			'is_experimental'              => false,
 			'enabled_by_default'           => false,
 			'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
@@ -62,7 +62,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 
 		$features_controller->add_feature_definition(
 			'cost_of_goods_sold',
-			__( 'Cost of Goods Sold', 'woocommerce' ),
+			fn() => __( 'Cost of Goods Sold', 'woocommerce' ),
 			$definition
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -590,7 +590,7 @@ class CustomOrdersTableController {
 
 		$features_controller->add_feature_definition(
 			'custom_order_tables',
-			__( 'High-Performance order storage', 'woocommerce' ),
+			fn() => __( 'High-Performance order storage', 'woocommerce' ),
 			$definition
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -129,6 +129,14 @@ class FeaturesController {
 	private bool $lazy = true;
 
 	/**
+	 * Flag indicating if translatable strings (name, description) have been
+	 * resolved from callbacks in the feature definitions.
+	 *
+	 * @var bool
+	 */
+	private bool $strings_initialized = false;
+
+	/**
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
@@ -174,40 +182,65 @@ class FeaturesController {
 	 * This used to be called during the `woocommerce_register_feature_definitions` action hook,
 	 * now it's called directly from get_feature_definitions as needed.
 	 *
-	 * @param string $slug The ID slug of the feature.
-	 * @param string $name The name of the feature that will appear on the Features screen and elsewhere.
-	 * @param array  $args {
+	 * @param string          $slug The ID slug of the feature.
+	 * @param callable|string $name A callback that returns the translated name of the feature,
+	 *                              or the name directly (deprecated, triggers doing_it_wrong).
+	 * @param array           $args {
 	 *     Properties that make up the feature definition. Each of these properties can also be set as a
 	 *     callback function, as long as that function returns the specified type.
 	 *
-	 *     @type string  $default_plugin_compatibility The default plugin compatibility for the feature: either 'compatible' or 'incompatible'. Required.
-	 *     @type array[] $additional_settings          An array of definitions for additional settings controls related to
-	 *                                                 the feature that will display on the Features screen. See the Settings API
-	 *                                                 for the schema of these props.
-	 *     @type string  $description                  A brief description of the feature, used as an input label if the feature
-	 *                                                 setting is a checkbox.
-	 *     @type bool    $disabled                     True to disable the setting field for this feature on the Features screen,
-	 *                                                 so it can't be changed.
-	 *     @type bool    $disable_ui                   Set to true to hide the setting field for this feature on the
-	 *                                                 Features screen. Defaults to false.
-	 *     @type bool    $enabled_by_default           Set to true to have this feature by opt-out instead of opt-in.
-	 *                                                 Defaults to false.
-	 *     @type bool    $is_experimental              Set to true to display this feature under the "Experimental" heading on
-	 *                                                 the Features screen. Features set to experimental are also omitted from
-	 *                                                 the features list in some cases. Defaults to true.
-	 *     @type bool    $skip_compatibility_checks    Set to true if the feature should not produce warnings about incompatible plugins.
-	 *                                                 Defaults to false.
-	 *     @type string  $learn_more_url               The URL to the learn more page for the feature.
-	 *     @type string  $option_key                   The key name for the option that enables/disables the feature.
-	 *     @type int     $order                        The order that the feature will appear in the list on the Features screen.
-	 *                                                 Higher number = higher in the list. Defaults to 10.
-	 *     @type array   $setting                      The properties used by the Settings API to render the setting control on
-	 *                                                 the Features screen. See the Settings API for the schema of these props.
+	 *     @type string   $default_plugin_compatibility The default plugin compatibility for the feature: either 'compatible' or 'incompatible'. Required.
+	 *     @type array[]  $additional_settings          An array of definitions for additional settings controls related to
+	 *                                                  the feature that will display on the Features screen. See the Settings API
+	 *                                                  for the schema of these props.
+	 *     @type callable|string $description           A callback that returns the translated description, or the description
+	 *                                                  directly (deprecated). Used as an input label if the feature setting is a checkbox.
+	 *     @type bool     $disabled                     True to disable the setting field for this feature on the Features screen,
+	 *                                                  so it can't be changed.
+	 *     @type bool     $disable_ui                   Set to true to hide the setting field for this feature on the
+	 *                                                  Features screen. Defaults to false.
+	 *     @type bool     $enabled_by_default           Set to true to have this feature by opt-out instead of opt-in.
+	 *                                                  Defaults to false.
+	 *     @type bool     $is_experimental              Set to true to display this feature under the "Experimental" heading on
+	 *                                                  the Features screen. Features set to experimental are also omitted from
+	 *                                                  the features list in some cases. Defaults to true.
+	 *     @type bool     $skip_compatibility_checks    Set to true if the feature should not produce warnings about incompatible plugins.
+	 *                                                  Defaults to false.
+	 *     @type string   $learn_more_url               The URL to the learn more page for the feature.
+	 *     @type string   $option_key                   The key name for the option that enables/disables the feature.
+	 *     @type int      $order                        The order that the feature will appear in the list on the Features screen.
+	 *                                                  Higher number = higher in the list. Defaults to 10.
+	 *     @type array    $setting                      The properties used by the Settings API to render the setting control on
+	 *                                                  the Features screen. See the Settings API for the schema of these props.
 	 * }
 	 *
 	 * @return void
 	 */
 	public function add_feature_definition( $slug, $name, array $args = array() ) {
+		if ( is_string( $name ) ) {
+			$this->proxy->call_function(
+				'wc_doing_it_wrong',
+				__FUNCTION__,
+				sprintf(
+					'Passing a string for the feature name is deprecated. Pass a callback that returns the translated name instead for feature "%s".',
+					esc_html( $slug )
+				),
+				'10.5.0'
+			);
+		}
+
+		if ( is_string( $args['description'] ?? null ) ) {
+			$this->proxy->call_function(
+				'wc_doing_it_wrong',
+				__FUNCTION__,
+				sprintf(
+					'Passing a string for the feature description is deprecated. Pass a callback that returns the translated description instead for feature "%s".',
+					esc_html( $slug )
+				),
+				'10.5.0'
+			);
+		}
+
 		$defaults = array(
 			'disable_ui'                   => false,
 			'enabled_by_default'           => false,
@@ -220,7 +253,8 @@ class FeaturesController {
 		);
 
 		if ( empty( $args['default_plugin_compatibility'] ) ) {
-			wc_doing_it_wrong(
+			$this->proxy->call_function(
+				'wc_doing_it_wrong',
 				__FUNCTION__,
 				sprintf(
 					'Assuming positive compatibility by default will be deprecated in the future. Please set \'default_plugin_compatibility\' for feature "%s".',
@@ -270,6 +304,20 @@ class FeaturesController {
 			$this->init_compatibility_info_by_feature();
 		}
 
+		// Resolve name and description callbacks to strings after the init hook.
+		// This allows feature_is_enabled() to be called early without triggering translation loading.
+		if ( ! $this->strings_initialized && did_action( 'init' ) ) {
+			$this->strings_initialized = true;
+			foreach ( $this->features as $slug => &$feature ) {
+				if ( is_callable( $feature['name'] ) ) {
+					$feature['name'] = call_user_func( $feature['name'] );
+				}
+				if ( is_callable( $feature['description'] ?? null ) ) {
+					$feature['description'] = call_user_func( $feature['description'] );
+				}
+			}
+		}
+
 		return $this->features;
 	}
 
@@ -286,8 +334,8 @@ class FeaturesController {
 
 		$legacy_features = array(
 			'analytics'                          => array(
-				'name'                         => __( 'Analytics', 'woocommerce' ),
-				'description'                  => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
+				'name'                         => fn() => __( 'Analytics', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 				'option_key'                   => Analytics::TOGGLE_OPTION_NAME,
 				'is_experimental'              => false,
 				'enabled_by_default'           => true,
@@ -296,27 +344,24 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'product_block_editor'               => array(
-				'name'                         => __( 'New product editor', 'woocommerce' ),
-				'description'                  => __( 'Try the new product editor (Beta)', 'woocommerce' ),
+				'name'                         => fn() => __( 'New product editor', 'woocommerce' ),
+				'description'                  => fn() => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 				'is_experimental'              => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'cart_checkout_blocks'               => array(
-				'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-				'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+				'name'                         => fn() => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+				'description'                  => fn() => __( 'Optimize for faster checkout', 'woocommerce' ),
 				'is_experimental'              => false,
 				'disable_ui'                   => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'rate_limit_checkout'                => array(
-				'name'                         => __( 'Rate limit Checkout', 'woocommerce' ),
-				'description'                  => sprintf(
-					// translators: %s is the URL to the rate limiting documentation.
-					__( 'Enables rate limiting for Checkout place order and Store API /checkout endpoint. To further control this, refer to <a href="%s" target="_blank">rate limiting documentation</a>.', 'woocommerce' ),
-					'https://developer.woocommerce.com/docs/apis/store-api/rate-limiting/'
-				),
+				'name'                         => fn() => __( 'Rate limit Checkout', 'woocommerce' ),
+				// translators: %s is the URL to the rate limiting documentation.
+				'description'                  => fn() => sprintf( __( 'Enables rate limiting for Checkout place order and Store API /checkout endpoint. To further control this, refer to <a href="%s" target="_blank">rate limiting documentation</a>.', 'woocommerce' ), 'https://developer.woocommerce.com/docs/apis/store-api/rate-limiting/' ),
 				'is_experimental'              => false,
 				'disable_ui'                   => false,
 				'enabled_by_default'           => false,
@@ -324,11 +369,8 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'marketplace'                        => array(
-				'name'                         => __( 'Marketplace', 'woocommerce' ),
-				'description'                  => __(
-					'New, faster way to find extensions and themes for your WooCommerce store',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Marketplace', 'woocommerce' ),
+				'description'                  => fn() => __( 'New, faster way to find extensions and themes for your WooCommerce store', 'woocommerce' ),
 				'is_experimental'              => false,
 				'enabled_by_default'           => true,
 				'disable_ui'                   => true,
@@ -338,11 +380,8 @@ class FeaturesController {
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
 			'order_attribution'                  => array(
-				'name'                         => __( 'Order Attribution', 'woocommerce' ),
-				'description'                  => __(
-					'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Order Attribution', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable this feature to track and credit channels and campaigns that contribute to orders on your site', 'woocommerce' ),
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
@@ -350,11 +389,8 @@ class FeaturesController {
 				'is_experimental'              => false,
 			),
 			'site_visibility_badge'              => array(
-				'name'                         => __( 'Site visibility badge', 'woocommerce' ),
-				'description'                  => __(
-					'Enable the site visibility badge in the WordPress admin bar',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Site visibility badge', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable the site visibility badge in the WordPress admin bar', 'woocommerce' ),
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 				'skip_compatibility_checks'    => true,
@@ -363,11 +399,8 @@ class FeaturesController {
 				'disabled'                     => false,
 			),
 			'hpos_fts_indexes'                   => array(
-				'name'                         => __( 'HPOS Full text search indexes', 'woocommerce' ),
-				'description'                  => __(
-					'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'HPOS Full text search indexes', 'woocommerce' ),
+				'description'                  => fn() => __( 'Create and use full text search indexes for orders. This feature only works with high-performance order storage.', 'woocommerce' ),
 				'is_experimental'              => true,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
@@ -375,11 +408,8 @@ class FeaturesController {
 				'option_key'                   => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
 			'hpos_datastore_caching'             => array(
-				'name'                         => __( 'HPOS Data Caching', 'woocommerce' ),
-				'description'                  => __(
-					'Enable order data caching in the datastore. This feature only works with high-performance order storage and is recommended for stores using object caching.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'HPOS Data Caching', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable order data caching in the datastore. This feature only works with high-performance order storage and is recommended for stores using object caching.', 'woocommerce' ),
 				'is_experimental'              => false,
 				'enabled_by_default'           => false,
 				'skip_compatibility_checks'    => true,
@@ -388,13 +418,9 @@ class FeaturesController {
 				'option_key'                   => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
 			'remote_logging'                     => array(
-				'name'                         => __( 'Remote Logging', 'woocommerce' ),
-				'description'                  => sprintf(
-					/* translators: %1$s: opening link tag, %2$s: closing link tag */
-					__( 'Allow WooCommerce to send error logs and non-sensitive diagnostic data to help improve WooCommerce. This feature requires %1$susage tracking%2$s to be enabled.', 'woocommerce' ),
-					'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
-					'</a>'
-				),
+				'name'                         => fn() => __( 'Remote Logging', 'woocommerce' ),
+				/* translators: %1$s: opening link tag, %2$s: closing link tag */
+				'description'                  => fn() => sprintf( __( 'Allow WooCommerce to send error logs and non-sensitive diagnostic data to help improve WooCommerce. This feature requires %1$susage tracking%2$s to be enabled.', 'woocommerce' ), '<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">', '</a>' ),
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 
@@ -423,11 +449,8 @@ class FeaturesController {
 				),
 			),
 			'email_improvements'                 => array(
-				'name'                         => __( 'Email improvements', 'woocommerce' ),
-				'description'                  => __(
-					'Enable modern email design for transactional emails',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Email improvements', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable modern email design for transactional emails', 'woocommerce' ),
 
 				/*
 				 * This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -443,11 +466,8 @@ class FeaturesController {
 				'is_experimental'              => false,
 			),
 			'blueprint'                          => array(
-				'name'                         => __( 'Blueprint (beta)', 'woocommerce' ),
-				'description'                  => __(
-					'Enable blueprint to import and export settings in bulk',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Blueprint (beta)', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable blueprint to import and export settings in bulk', 'woocommerce' ),
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 
@@ -464,11 +484,8 @@ class FeaturesController {
 				'is_experimental'              => false,
 			),
 			'block_email_editor'                 => array(
-				'name'                         => __( 'Block Email Editor (alpha)', 'woocommerce' ),
-				'description'                  => __(
-					'Enable the block-based email editor for transactional emails.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Block Email Editor (alpha)', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable the block-based email editor for transactional emails.', 'woocommerce' ),
 				'learn_more_url'               => 'https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256',
 
 				/*
@@ -484,11 +501,8 @@ class FeaturesController {
 				'enabled_by_default'           => false,
 			),
 			'point_of_sale'                      => array(
-				'name'                         => __( 'Point of Sale', 'woocommerce' ),
-				'description'                  => __(
-					'Enable Point of Sale functionality in the WooCommerce mobile apps.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Point of Sale', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable Point of Sale functionality in the WooCommerce mobile apps.', 'woocommerce' ),
 				'enabled_by_default'           => true,
 				'disable_ui'                   => false,
 
@@ -505,19 +519,16 @@ class FeaturesController {
 				'is_experimental'              => true,
 			),
 			'fulfillments'                       => array(
-				'name'                         => __( 'Order Fulfillments', 'woocommerce' ),
-				'description'                  => __(
-					'Enable the Order Fulfillments feature to manage order fulfillment and shipping.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Order Fulfillments', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable the Order Fulfillments feature to manage order fulfillment and shipping.', 'woocommerce' ),
 				'enabled_by_default'           => false,
 				'disable_ui'                   => true,
 				'is_experimental'              => false,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'mcp_integration'                    => array(
-				'name'                         => __( 'WooCommerce MCP', 'woocommerce' ),
-				'description'                  => $this->get_mcp_integration_description(),
+				'name'                         => fn() => __( 'WooCommerce MCP', 'woocommerce' ),
+				'description'                  => fn() => $this->get_mcp_integration_description(),
 				'enabled_by_default'           => false,
 				'disable_ui'                   => false,
 				'is_experimental'              => true,
@@ -525,22 +536,16 @@ class FeaturesController {
 				'is_legacy'                    => false,
 			),
 			'destroy-empty-sessions'             => array(
-				'name'                         => __( 'Clear Customer Sessions When Empty', 'woocommerce' ),
-				'description'                  => __(
-					'[Performance] Removes session cookies for non-logged in customers when session data is empty, improving page caching performance. May cause compatibility issues with extensions that depend on the session cookie without using session data.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Clear Customer Sessions When Empty', 'woocommerce' ),
+				'description'                  => fn() => __( '[Performance] Removes session cookies for non-logged in customers when session data is empty, improving page caching performance. May cause compatibility issues with extensions that depend on the session cookie without using session data.', 'woocommerce' ),
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
 				'disable_ui'                   => false,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'agentic_checkout'                   => array(
-				'name'                         => __( 'Agentic Checkout API', 'woocommerce' ),
-				'description'                  => __(
-					'Enable the Agentic Checkout API for AI-powered checkout experiences (e.g., ChatGPT). This adds REST API endpoints that allow AI agents to create and manage checkout sessions.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Agentic Checkout API', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable the Agentic Checkout API for AI-powered checkout experiences (e.g., ChatGPT). This adds REST API endpoints that allow AI agents to create and manage checkout sessions.', 'woocommerce' ),
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
 				'disable_ui'                   => true,
@@ -548,11 +553,8 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			PushNotifications::FEATURE_NAME      => array(
-				'name'                         => __( 'Push Notifications', 'woocommerce' ),
-				'description'                  => __(
-					'Enable push notifications for the WooCommerce mobile apps to receive order notifications and store updates.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Push Notifications', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable push notifications for the WooCommerce mobile apps to receive order notifications and store updates.', 'woocommerce' ),
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
 				'disable_ui'                   => true,
@@ -560,13 +562,9 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			'rest_api_caching'                   => array(
-				'name'                         => __( 'REST API Caching', 'woocommerce' ),
-				'description'                  => sprintf(
-					/* translators: %1$s and %2$s are opening and closing <a> tags */
-					__( 'Enable backend caching and cache control headers for REST API responses via the <code>RestApiCache</code> trait. ⚙️ %1$sConfiguration%2$s', 'woocommerce' ),
-					'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=rest_api_caching' ) . '">',
-					'</a>'
-				),
+				'name'                         => fn() => __( 'REST API Caching', 'woocommerce' ),
+				/* translators: %1$s and %2$s are opening and closing <a> tags */
+				'description'                  => fn() => sprintf( __( 'Enable backend caching and cache control headers for REST API responses via the <code>RestApiCache</code> trait. ⚙️ %1$sConfiguration%2$s', 'woocommerce' ), '<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=rest_api_caching' ) . '">', '</a>' ),
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
 				'disable_ui'                   => false,
@@ -574,8 +572,8 @@ class FeaturesController {
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
 			ProductCacheController::FEATURE_NAME => array(
-				'name'                         => __( 'Cache Product Objects', 'woocommerce' ),
-				'description'                  => __(
+				'name'                         => fn() => __( 'Cache Product Objects', 'woocommerce' ),
+				'description'                  => fn() => __(
 					'[Performance] Speeds up your store by caching product objects during each request, preventing duplicate product loads. Can improve page load times on product-heavy pages.',
 					'woocommerce'
 				),
@@ -585,11 +583,8 @@ class FeaturesController {
 				'disable_ui'                   => false,
 			),
 			'fraud_protection'                   => array(
-				'name'                         => __( 'Fraud protection', 'woocommerce' ),
-				'description'                  => __(
-					'Enable fraud protection features for your store.',
-					'woocommerce'
-				),
+				'name'                         => fn() => __( 'Fraud protection', 'woocommerce' ),
+				'description'                  => fn() => __( 'Enable fraud protection features for your store.', 'woocommerce' ),
 				'enabled_by_default'           => false,
 				'disable_ui'                   => false,
 				'is_experimental'              => true,
@@ -1347,12 +1342,21 @@ class FeaturesController {
 	 * @return array The parameters to add to the settings array.
 	 */
 	private function get_setting_for_feature( string $feature_id, array $feature ): array {
+		$name               = $feature['name'] ?? '';
 		$description        = $feature['description'] ?? '';
 		$disabled           = false;
 		$desc_tip           = '';
 		$tooltip            = $feature['tooltip'] ?? '';
 		$type               = $feature['type'] ?? 'checkbox';
 		$setting_definition = $feature['setting'] ?? array();
+
+		// Resolve callbacks if they haven't been resolved yet.
+		if ( is_callable( $name ) ) {
+			$name = $name();
+		}
+		if ( is_callable( $description ) ) {
+			$description = $description();
+		}
 
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		/**
@@ -1412,7 +1416,7 @@ class FeaturesController {
 		$desc_tip = apply_filters( 'woocommerce_feature_description_tip', $desc_tip, $feature_id, $disabled );
 
 		$feature_setting_defaults = array(
-			'title'    => $feature['name'],
+			'title'    => $name,
 			'desc'     => $description,
 			'type'     => $type,
 			'id'       => $this->feature_enable_option_name( $feature_id ),

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -74,26 +74,26 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	public function register_dummy_features( $features_controller ) {
 		$features = array(
 			'mature1'       => array(
-				'name'                         => 'Mature feature 1',
-				'description'                  => 'The mature feature number 1',
+				'name'                         => fn() => 'Mature feature 1',
+				'description'                  => fn() => 'The mature feature number 1',
 				'is_experimental'              => false,
 				'default_plugin_compatibility' => 'compatible',
 			),
 			'mature2'       => array(
-				'name'                         => 'Mature feature 2',
-				'description'                  => 'The mature feature number 2',
+				'name'                         => fn() => 'Mature feature 2',
+				'description'                  => fn() => 'The mature feature number 2',
 				'is_experimental'              => false,
 				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental1' => array(
-				'name'                         => 'Experimental feature 1',
-				'description'                  => 'The experimental feature number 1',
+				'name'                         => fn() => 'Experimental feature 1',
+				'description'                  => fn() => 'The experimental feature number 1',
 				'is_experimental'              => true,
 				'default_plugin_compatibility' => 'compatible',
 			),
 			'experimental2' => array(
-				'name'                         => 'Experimental feature 2',
-				'description'                  => 'The experimental feature number 2',
+				'name'                         => fn() => 'Experimental feature 2',
+				'description'                  => fn() => 'The experimental feature number 2',
 				'is_experimental'              => true,
 				'default_plugin_compatibility' => 'compatible',
 			),
@@ -170,6 +170,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$compat_property = $reflection_class->getProperty( 'compatibility_info_by_feature' );
 		$compat_property->setAccessible( true );
 		$compat_property->setValue( $sut, array() );
+
+		$strings_initialized_property = $reflection_class->getProperty( 'strings_initialized' );
+		$strings_initialized_property->setAccessible( true );
+		$strings_initialized_property->setValue( $sut, false );
 
 		foreach ( $features as $slug => $definition ) {
 			$sut->add_feature_definition( $slug, $definition['name'], $definition );
@@ -551,38 +555,38 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'mature1'       => array(
-						'name'                         => 'Mature feature 1',
-						'description'                  => 'The mature feature number 1',
+						'name'                         => fn() => 'Mature feature 1',
+						'description'                  => fn() => 'The mature feature number 1',
 						'is_experimental'              => false,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'mature2'       => array(
-						'name'                         => 'Mature feature 2',
-						'description'                  => 'The mature feature number 2',
+						'name'                         => fn() => 'Mature feature 2',
+						'description'                  => fn() => 'The mature feature number 2',
 						'is_experimental'              => false,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'mature3'       => array(
-						'name'                         => 'Mature feature 3',
-						'description'                  => 'The mature feature number 3',
+						'name'                         => fn() => 'Mature feature 3',
+						'description'                  => fn() => 'The mature feature number 3',
 						'is_experimental'              => false,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental1' => array(
-						'name'                         => 'Experimental feature 1',
-						'description'                  => 'The experimental feature number 1',
+						'name'                         => fn() => 'Experimental feature 1',
+						'description'                  => fn() => 'The experimental feature number 1',
 						'is_experimental'              => true,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental2' => array(
-						'name'                         => 'Experimental feature 2',
-						'description'                  => 'The experimental feature number 2',
+						'name'                         => fn() => 'Experimental feature 2',
+						'description'                  => fn() => 'The experimental feature number 2',
 						'is_experimental'              => true,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'experimental3' => array(
-						'name'                         => 'Experimental feature 3',
-						'description'                  => 'The experimental feature number 3',
+						'name'                         => fn() => 'Experimental feature 3',
+						'description'                  => fn() => 'The experimental feature number 3',
 						'is_experimental'              => true,
 						'default_plugin_compatibility' => 'compatible',
 					),
@@ -900,14 +904,14 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'custom_order_tables'  => array(
-						'name'                         => __( 'High-Performance order storage', 'woocommerce' ),
+						'name'                         => fn() => __( 'High-Performance order storage', 'woocommerce' ),
 						'is_experimental'              => true,
 						'enabled_by_default'           => false,
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'cart_checkout_blocks' => array(
-						'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-						'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+						'name'                         => fn() => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+						'description'                  => fn() => __( 'Optimize for faster checkout', 'woocommerce' ),
 						'is_experimental'              => false,
 						'disable_ui'                   => true,
 						'default_plugin_compatibility' => 'compatible',
@@ -1000,15 +1004,15 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'custom_order_tables'  => array(
-						'name'                         => __( 'High-Performance order storage', 'woocommerce' ),
+						'name'                         => fn() => __( 'High-Performance order storage', 'woocommerce' ),
 						'is_experimental'              => false,
 						'enabled_by_default'           => false,
 						'option_key'                   => CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 						'default_plugin_compatibility' => 'incompatible',
 					),
 					'cart_checkout_blocks' => array(
-						'name'                         => __( 'Cart & Checkout Blocks', 'woocommerce' ),
-						'description'                  => __( 'Optimize for faster checkout', 'woocommerce' ),
+						'name'                         => fn() => __( 'Cart & Checkout Blocks', 'woocommerce' ),
+						'description'                  => fn() => __( 'Optimize for faster checkout', 'woocommerce' ),
 						'is_experimental'              => false,
 						'disable_ui'                   => true,
 						'default_plugin_compatibility' => 'compatible',
@@ -1242,5 +1246,98 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$compat_after = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
 		$this->assertNotContains( 'plugin/plugin.php', $compat_after['compatible'] );
 		$this->assertContains( 'plugin/plugin.php', $compat_after['uncertain'] );
+	}
+
+	/**
+	 * @testdox 'add_feature_definition' triggers doing_it_wrong when a string is passed for the feature name.
+	 */
+	public function test_add_feature_definition_with_string_name_triggers_doing_it_wrong() {
+		$function = null;
+		$message  = null;
+		$version  = null;
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+					$function = $f;
+					$message  = $m;
+					$version  = $v;
+				},
+			)
+		);
+
+		$this->sut->add_feature_definition(
+			'test_string_name',
+			'String Name Feature',
+			array( 'default_plugin_compatibility' => 'compatible' )
+		);
+
+		$this->assertEquals( 'add_feature_definition', $function );
+		$this->assertStringContainsString( 'Passing a string for the feature name is deprecated', $message );
+		$this->assertStringContainsString( 'test_string_name', $message );
+		$this->assertEquals( '10.5.0', $version );
+	}
+
+	/**
+	 * @testdox 'add_feature_definition' triggers doing_it_wrong when a string is passed for the feature description.
+	 */
+	public function test_add_feature_definition_with_string_description_triggers_doing_it_wrong() {
+		$function = null;
+		$message  = null;
+		$version  = null;
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+					$function = $f;
+					$message  = $m;
+					$version  = $v;
+				},
+			)
+		);
+
+		$this->sut->add_feature_definition(
+			'test_string_description',
+			fn() => 'Callback Name Feature',
+			array(
+				'description'                  => 'String description',
+				'default_plugin_compatibility' => 'compatible',
+			)
+		);
+
+		$this->assertEquals( 'add_feature_definition', $function );
+		$this->assertStringContainsString( 'Passing a string for the feature description is deprecated', $message );
+		$this->assertStringContainsString( 'test_string_description', $message );
+		$this->assertEquals( '10.5.0', $version );
+	}
+
+	/**
+	 * @testdox 'add_feature_definition' does not trigger doing_it_wrong when callbacks are used for name and description.
+	 */
+	public function test_add_feature_definition_with_callbacks_does_not_trigger_doing_it_wrong() {
+		$doing_it_wrong_called = false;
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$doing_it_wrong_called ) {
+					unset( $f, $v ); // Avoid parameter not used PHPCS errors.
+					// Only track if it's about name/description strings.
+					if ( strpos( $m, 'Passing a string for the feature' ) !== false ) {
+						$doing_it_wrong_called = true;
+					}
+				},
+			)
+		);
+
+		$this->sut->add_feature_definition(
+			'test_callback_feature',
+			fn() => 'Callback Name Feature',
+			array(
+				'description'                  => fn() => 'Callback description',
+				'default_plugin_compatibility' => 'compatible',
+			)
+		);
+
+		$this->assertFalse( $doing_it_wrong_called );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -252,15 +252,15 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 			function ( $features_controller ) {
 				$features = array(
 					'test_feature_1' => array(
-						'name'                         => 'Test feature 1',
+						'name'                         => fn() => 'Test feature 1',
 						'default_plugin_compatibility' => 'incompatible',
 					),
 					'test_feature_2' => array(
-						'name'                         => 'Test feature 2',
+						'name'                         => fn() => 'Test feature 2',
 						'default_plugin_compatibility' => 'compatible',
 					),
 					'test_feature_3' => array(
-						'name'                         => 'Test feature 3',
+						'name'                         => fn() => 'Test feature 3',
 						'default_plugin_compatibility' => 'compatible',
 					),
 				);
@@ -338,7 +338,7 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		);
 
 		$features_controller = wc_get_container()->get( FeaturesController::class );
-		$features_controller->add_feature_definition( 'test_feature', 'Test Feature', array( 'default_plugin_compatibility' => 'compatible' ) );
+		$features_controller->add_feature_definition( 'test_feature', fn() => 'Test Feature', array( 'default_plugin_compatibility' => 'compatible' ) );
 
 		// Simulate declaration (should not call get_plugins yet).
 		$this->simulate_inside_before_woocommerce_init_hook();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Checking if a feature is enabled via `FeaturesController::feature_is_enabled` triggers a full initialization of the existing feature descriptors, this includes translated values for names and descriptions (via `__` function) but if that happens before the `init` hook (typical when checking features from class initializers) errors like _"Function _load_textdomain_just_in_time was called incorrectly" will be triggered.

These translations aren't needed when just checking if a feature is enabled. Thus this pull request modifies the signature of `FeaturesController::add_feature_definition` to accept a callback instead of a direct string for name and description (strings are still accepted for compatibility, but they will trigger `doing_it_wrong` - even thoug `FeaturesController` is an internal class and it should have no usages outside of WooCommerce core) and updates all the usages of the method to effectively pass callbacks. These callbacks will be executed in `FeaturesController::get_feature_definitions` (and the returned strings will replace the callbacks in the feature definitions) as long as `init` has already been fired.

Closes #62540.

(For Bug Fixes) Bug introduced in PR #61613.

### How to test the changes in this Pull Request:

1. Open the WooCommerce features page (WooCommerce - Settings - Advanced - Features) and verify that it renders correctly, including all the feature names and descriptions.
2. Verify that no "Translation loading for the woocommerce domain was triggered too early" errors are being triggered.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
