### PR TITLE
Remove usage of feature_is_enabled in ProductVersionStringInvalidator::init

### DIFF
--- a/plugins/woocommerce/changelog/pr-62665
+++ b/plugins/woocommerce/changelog/pr-62665
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove usage of feature_is_enabled in ProductVersionStringInvalidator::init

--- a/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
+++ b/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
@@ -35,7 +35,7 @@ class ProductVersionStringInvalidator {
 	 */
 	final public function init(): void {
 		// We can't use FeaturesController::feature_is_enabled at this point
-		// (before the 'init' action ins triggered) because that would cause
+		// (before the 'init' action is triggered) because that would cause
 		// "Translation loading for the woocommerce domain was triggered too early" warnings.
 		if ( 'yes' !== get_option( 'woocommerce_feature_rest_api_caching_enabled' ) ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
+++ b/plugins/woocommerce/src/Internal/Caches/ProductVersionStringInvalidator.php
@@ -27,16 +27,17 @@ class ProductVersionStringInvalidator {
 	 * - The REST API caching feature is enabled
 	 * - The backend caching setting is active
 	 *
-	 * @param FeaturesController $features_controller The features controller.
-	 *
 	 * @return void
 	 *
 	 * @since 10.5.0
 	 *
 	 * @internal
 	 */
-	final public function init( FeaturesController $features_controller ): void {
-		if ( ! $features_controller->feature_is_enabled( 'rest_api_caching' ) ) {
+	final public function init(): void {
+		// We can't use FeaturesController::feature_is_enabled at this point
+		// (before the 'init' action ins triggered) because that would cause
+		// "Translation loading for the woocommerce domain was triggered too early" warnings.
+		if ( 'yes' !== get_option( 'woocommerce_feature_rest_api_caching_enabled' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
@@ -44,6 +44,7 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 	 * Tear down test.
 	 */
 	public function tearDown(): void {
+		delete_option( 'woocommerce_feature_rest_api_caching_enabled' );
 		delete_option( 'woocommerce_rest_api_enable_backend_caching' );
 		parent::tearDown();
 	}
@@ -55,10 +56,8 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 	 */
 	private function get_invalidator_with_hooks_enabled(): ProductVersionStringInvalidator {
 		$features_controller = $this->createMock( FeaturesController::class );
-		$features_controller->method( 'feature_is_enabled' )
-			->with( 'rest_api_caching' )
-			->willReturn( true );
 
+		update_option( 'woocommerce_feature_rest_api_caching_enabled', 'yes' );
 		update_option( 'woocommerce_rest_api_enable_backend_caching', 'yes' );
 
 		$invalidator = new ProductVersionStringInvalidator();
@@ -100,10 +99,8 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_hooks_not_registered_when_feature_disabled() {
 		$features_controller = $this->createMock( FeaturesController::class );
-		$features_controller->method( 'feature_is_enabled' )
-			->with( 'rest_api_caching' )
-			->willReturn( false );
 
+		update_option( 'woocommerce_feature_rest_api_caching_enabled', 'no' );
 		update_option( 'woocommerce_rest_api_enable_backend_caching', 'yes' );
 
 		$invalidator = new ProductVersionStringInvalidator();
@@ -119,10 +116,8 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_hooks_not_registered_when_backend_caching_disabled() {
 		$features_controller = $this->createMock( FeaturesController::class );
-		$features_controller->method( 'feature_is_enabled' )
-			->with( 'rest_api_caching' )
-			->willReturn( true );
 
+		update_option( 'woocommerce_feature_rest_api_caching_enabled', 'yes' );
 		update_option( 'woocommerce_rest_api_enable_backend_caching', 'no' );
 
 		$invalidator = new ProductVersionStringInvalidator();
@@ -138,10 +133,8 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_hooks_not_registered_when_backend_caching_not_set() {
 		$features_controller = $this->createMock( FeaturesController::class );
-		$features_controller->method( 'feature_is_enabled' )
-			->with( 'rest_api_caching' )
-			->willReturn( true );
 
+		update_option( 'woocommerce_feature_rest_api_caching_enabled', 'yes' );
 		delete_option( 'woocommerce_rest_api_enable_backend_caching' );
 
 		$invalidator = new ProductVersionStringInvalidator();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `ProductVersionStringInvalidator` class introduced in #61613 calls `FeaturesController::feature_is_enabled` to avoid unnecessarily hooking into product modified actions when the REST API cache feature is disabled. However this happens in the `init` method of the class, which runs as soon as the class is initialized and before the `init` action has run; this causes _"Translation loading for the woocommerce domain was triggered too early"_ warnings.

As a workaround while a proper solution for `FeaturesController::feature_is_enabled` is implemented, this pull reques will modify `ProductVersionStringInvalidator::init` to directly check the relevant option instead of relying on `FeaturesController::feature_is_enabled`.

Closes #62540.

(For Bug Fixes) Bug introduced in PR #61613.

### How to test the changes in this Pull Request:

1. Take note of an existing product id.
2. Enable the REST API caching feature (in WooCommerce - Settings - Advanced - Features).
3. Go to WooCommerce - Settings - Advanced - REST API caching and enable backend caching.
4. Start a wp shell and run the following (adjusting the product id):

```php
$vsg = wc_get_container()->get( Automattic\WooCommerce\Internal\Caches\VersionStringGenerator::class );

$product = wc_get_product(<product id>);
echo $vsg->get_version('product_<product id>');

$product->set_name( 'Test Product - ' . time() );
$product->save();

echo $vsg->get_version('product_<product id>');
```

The two `echo`s should print different values.

5. Disable the REST API caching feature and repeat the previous step (exit the wp shell and open it again). Now the two `echo`s should print the same value.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
