### PR TITLE
Genericize (HPOS) order editor locking to work with order-subtypes

### DIFF
--- a/plugins/woocommerce/changelog/woosubs-1364-hpos-post-locking-for-subtypes
+++ b/plugins/woocommerce/changelog/woosubs-1364-hpos-post-locking-for-subtypes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve order editor locking support for sub-types (like subscriptions) when using HPOS.

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -707,7 +707,7 @@
 		var wc_order_lock = {
 			init: function() {
 				// Order screen.
-				this.$lock_dialog = $( '.woocommerce_page_wc-orders #post-lock-dialog.order-lock-dialog' );
+				this.$lock_dialog = $( '.woocommerce-orders-screen-edit_order #post-lock-dialog.order-lock-dialog' );
 				if ( 0 !== this.$lock_dialog.length && 'undefined' !== typeof woocommerce_admin_meta_boxes ) {
 					// We do not want WP's lock to interfere.
 					$( document ).off( 'heartbeat-send.refresh-lock' );
@@ -718,7 +718,7 @@
 				}
 
 				// Orders list table.
-				this.$list_table = $( '.woocommerce_page_wc-orders table.wc-orders-list-table' );
+				this.$list_table = $( '.woocommerce-orders-screen-list_orders table.wc-orders-list-table' );
 				if ( 0 !== this.$list_table.length ) {
 					$( document ).on( 'heartbeat-send', this.send_orders_in_list );
 					$( document ).on( 'heartbeat-tick', this.check_orders_in_list );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -152,6 +152,7 @@ class PageController {
 
 		add_action( "load-{$page_name}", array( $this, 'handle_load_page_action' ) );
 		add_action( 'admin_title', array( $this, 'set_page_title' ) );
+		add_filter( 'admin_body_class', array( $this, 'update_body_classes' ) );
 	}
 
 	/**
@@ -248,6 +249,28 @@ class PageController {
 				$this->current_action = 'list_orders';
 				break;
 		}
+	}
+
+	/**
+	 * When an order-related admin screen is loaded (and if HPOS is enabled), add an extra body class that is consistent
+	 * regardless of the actual order type.
+	 *
+	 * For example, when an order is being edited, add `woocommerce-orders-screen-edit_order` for regular orders as well
+	 * as sub-types, such as subscription orders.
+	 *
+	 * @param string|mixed $classes The admin body classes. Expected to be a string.
+	 *
+	 * @return mixed The updated body class string, or else the original value (which may be something other than a string in exceptional cases).
+	 */
+	public function update_body_classes( $classes ) {
+		if (
+			! is_string( $classes )
+			|| ! in_array( $this->current_action, array( 'edit_order', 'new_order', 'list_orders' ), true )
+		) {
+			return $classes;
+		}
+
+		return $classes . ' ' . 'woocommerce-orders-screen-' . $this->current_action;
 	}
 
 	/**


### PR DESCRIPTION
Some extensions may define their own order (sub-)types. [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) provides a handy example of this, by way of the subscription order type.

These sub-types may also inherit from the list table and order editing UI supplied by Woo Core. However, when HPOS is enabled and compatibility mode is disabled, order locking does not function as expected for the sub-types.

This is chiefly because, [within `woocommerce-admin.js`](https://github.com/woocommerce/woocommerce/blob/10.4.3/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js#L710), we assume an admin body class of `.woocommerce_page_wc-orders`. However, for sub-types, the equivalent body class will be `.woocommerce_page_wc-orders--<SPECIFIC-TYPE>` (real world example from WooCommerce Subscriptions: `woocommerce_page_wc-orders--shop_subscription`).

The solution this PR presents is to add some new and more generic body classes, which our JS can then reference:

- `.woocommerce-orders-screen-edit_order` (for the order editor screen)
- `.woocommerce-orders-screen-list_orders` (for the order list screen)
- `.woocommerce-orders-screen-new_order` (for the order editor when a *new* order is being crafted ... not currently used, but added for consistency).

### Screenshots or screen recordings

<img width="4120" height="1147" alt="order-locking-order-list" src="https://github.com/user-attachments/assets/cc83d1f7-f4f0-4419-ba38-4faaabd8b98a" />

👆🏼 Order locking in the context of the admin list table (padlock icon).

<img width="4120" height="1147" alt="order-locking-order-editor" src="https://github.com/user-attachments/assets/d25c7e22-4a5d-4b39-8f2e-da1a90644c12" />

👆🏼 Order locking in the context of the order editor (lock dialog).

### How to test the changes in this Pull Request

Looking at this exclusively from a WooCommerce perspective (initially ignoring other extensions like WooCommerce Subscriptions), we basically just expect everything to continue working as it did previously. To confirm this, I suggest using two different user accounts (from two different web browsers, or separate browser contexts):

1. User ♯1 → an admin user (could be a 'full' admin user).
2. User ♯2 → another admin user (could use the shop manager role).

With those things in place (btw, don't forget to rebuild assets, and flush the browser cache if needed):

1. As User ♯1, open an order for editing _(/wp-admin/admin.php?page=wc-orders&action=edit&id=12345)_
2. As User ♯2, open the order list _(/wp-admin/admin.php?page=wc-orders)_ ... you should see the padlock icon for the relevant table row.
3. As User ♯2, go ahead and actually open the order. The order lock dialog should appear, containing messaging like:

```
User ♯1 is currently editing this order. Do you want to take over? 

[Go back]    [Take over]
```

4. If you decide to go back, you are simply returned to the order list screen.
5. If you take over, the dialog disappears. If, as User ♯1, you refresh the same screen, you should (eventually—it may take a moment) see a dialog with messaging as follows:

```
User ♯2 has taken over and is currently editing.

[Go back]
```

With that done, we can install and activate [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) and confirm that those steps also apply when working with subscription types.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**