### PR TITLE
Fix Import Status Bar UI overlap and add loading state

### DIFF
--- a/plugins/woocommerce/changelog/62675-fix-scheduled-import-ui
+++ b/plugins/woocommerce/changelog/62675-fix-scheduled-import-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Import Status Bar UI overlap with filter dropdowns and add loading state feedback

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
@@ -66,6 +66,7 @@
 		font-size: 11px;
 		font-weight: 500;
 		line-height: 20px;
+		// Set a fixed width to prevent layout shift during loading
 		width: 88px;
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
@@ -66,6 +66,7 @@
 		font-size: 11px;
 		font-weight: 500;
 		line-height: 20px;
+		width: 88px;
 	}
 
 	.components-spinner {

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
@@ -44,7 +44,11 @@
 
 
 		@media screen and ( max-width: $break-wide ) {
-			gap: 24px;
+			gap: $gap-large;
+		}
+
+		@media screen and ( max-width: $break-large ) {
+			gap: $gap;
 		}
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.scss
@@ -9,10 +9,20 @@
 	gap: 6px;
 
 	&__label {
+		margin: 7px 0 0; // use same margin as filters to they align vertically
 		font-size: 13px;
 		line-height: 20px;
 		color: $gray-900;
 		font-weight: 400;
+	}
+
+	@media screen and ( max-width: $break-large ) {
+		gap: 5px;
+
+		&__label {
+			line-height: 18px;
+			margin-top: 5px;
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
@@ -109,9 +109,7 @@ export function ImportStatusBar(): JSX.Element | null {
 		}
 	};
 
-	// Disable button when an import is already scheduled/running or currently triggering
-	const isButtonDisabled =
-		status?.import_in_progress_or_due || isTriggeringImport;
+	const isBusy = status?.import_in_progress_or_due || isTriggeringImport;
 
 	return (
 		<div className="woocommerce-analytics-import-status-bar-wrapper">
@@ -157,15 +155,18 @@ export function ImportStatusBar(): JSX.Element | null {
 					<Button
 						variant="tertiary"
 						onClick={ handleTriggerImport }
-						disabled={ isButtonDisabled || isLoading }
-						isBusy={ isTriggeringImport }
+						disabled={ isLoading || isBusy }
 						className="woocommerce-analytics-import-status-bar__trigger"
 						aria-label={ __(
 							'Manually trigger analytics data import',
 							'woocommerce'
 						) }
 					>
-						{ __( 'Update now', 'woocommerce' ) }
+						{ isBusy ? (
+							<Spinner />
+						) : (
+							__( 'Update now', 'woocommerce' )
+						) }
 					</Button>
 				</div>
 			</div>

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/import-status-bar.tsx
@@ -156,11 +156,20 @@ export function ImportStatusBar(): JSX.Element | null {
 						variant="tertiary"
 						onClick={ handleTriggerImport }
 						disabled={ isLoading || isBusy }
+						aria-disabled={ isLoading || isBusy }
+						aria-busy={ isBusy }
 						className="woocommerce-analytics-import-status-bar__trigger"
-						aria-label={ __(
-							'Manually trigger analytics data import',
-							'woocommerce'
-						) }
+						aria-label={
+							isBusy
+								? __(
+										'Analytics data import in progress',
+										'woocommerce'
+								  )
+								: __(
+										'Manually trigger analytics data import',
+										'woocommerce'
+								  )
+						}
 					>
 						{ isBusy ? (
 							<Spinner />

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
@@ -138,10 +138,12 @@ describe( 'ImportStatusBar', () => {
 
 		render( <ImportStatusBar /> );
 
+		// When busy, aria-label changes to "Analytics data import in progress"
 		const button = screen.getByRole( 'button', {
-			name: /Manually trigger analytics data import/i,
+			name: /Analytics data import in progress/i,
 		} );
 		expect( button ).toBeDisabled();
+		expect( button ).toHaveAttribute( 'aria-busy', 'true' );
 	} );
 
 	it( 'should disable button when isTriggeringImport is true', () => {
@@ -153,10 +155,12 @@ describe( 'ImportStatusBar', () => {
 
 		render( <ImportStatusBar /> );
 
+		// When busy, aria-label changes to "Analytics data import in progress"
 		const button = screen.getByRole( 'button', {
-			name: /Manually trigger analytics data import/i,
+			name: /Analytics data import in progress/i,
 		} );
 		expect( button ).toBeDisabled();
+		expect( button ).toHaveAttribute( 'aria-busy', 'true' );
 	} );
 
 	it( 'should trigger import on button click', async () => {

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-header/report-header.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-header/report-header.scss
@@ -21,7 +21,7 @@
 			min-width: fit-content;
 		}
 
-		@media screen and ( max-width: $break-large ) {
+		@media screen and ( max-width: $break-wide ) {
 			.woocommerce-filters-filter {
 				width: 100%;
 			}

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-header/report-header.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-header/report-header.scss
@@ -5,38 +5,53 @@
  */
 
 .woocommerce-analytics-report-header {
-	position: relative;
-	display: flex;
-	align-items: flex-start;
+	// Only apply this layout when the import status bar is present
+	&:has(> .woocommerce-analytics-import-status-bar-wrapper) {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: $gap;
 
-	.woocommerce-filters {
-		flex: 1; // Allow the filters to grow and take up remaining space
-		width: 100%;
-	}
-
-	.woocommerce-analytics-import-status-bar-wrapper {
-		// Absolute positioning ensures the filters’ width is independent from the status bar, which can change its size dynamically as needed
-		position: absolute;
-		right: 0;
-	}
-
-	@media screen and ( max-width: $break-large ) {
-		flex-direction: column;
-
-		.woocommerce-analytics-import-status-bar-wrapper {
-			position: relative;
-			right: auto;
-		}
-	}
-
-	@media screen and ( max-width: $break-medium ) {
-		.woocommerce-analytics-import-status-bar-wrapper,
-		.woocommerce-analytics-import-status-bar__content {
+		.woocommerce-filters {
+			flex: 1; // Allow the filters to grow and take up remaining space
 			width: 100%;
 		}
 
-		.woocommerce-analytics-import-status-bar__content {
-			justify-content: space-between;
+		.woocommerce-filters-filter {
+			min-width: fit-content;
+		}
+
+		@media screen and ( max-width: $break-large ) {
+			.woocommerce-filters-filter {
+				width: 100%;
+			}
+
+			.woocommerce-analytics-import-status-bar-wrapper {
+				flex: 1;
+			}
+		}
+
+		@media screen and ( max-width: $break-medium ) {
+			flex-direction: column;
+			gap: 0;
+
+			.woocommerce-filters__basic-filters {
+				margin-bottom: $gap;
+			}
+
+			.woocommerce-analytics-import-status-bar-wrapper {
+				margin-bottom: $gap-large;
+				width: 100%;
+			}
+
+			.woocommerce-analytics-import-status-bar__content {
+				width: 100%;
+				justify-content: space-between;
+			}
+		}
+
+		@media screen and ( max-width: $break-small ) {
+			align-items: center;
 		}
 	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-overview.spec.js
@@ -357,7 +357,7 @@ test.describe(
 			await expect( page.getByText( 'Data status:' ) ).toBeVisible();
 			// Verify "Update now" button is visible
 			const updateButton = page.getByRole( 'button', {
-				name: 'Manually trigger analytics',
+				name: 'Manually trigger analytics data import',
 			} );
 			await expect( updateButton ).toBeVisible();
 
@@ -373,7 +373,11 @@ test.describe(
 			await updateButton.click();
 
 			// Verify button shows loading state (isBusy)
-			await expect( updateButton ).toBeDisabled();
+			// After clicking, the aria-label changes to "Analytics data import in progress"
+			const busyButton = page.getByRole( 'button', {
+				name: 'Analytics data import in progress',
+			} );
+			await expect( busyButton ).toBeDisabled();
 
 			// Wait for API response
 			await responsePromise;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes UI issues with the Import Status Bar in WooCommerce Analytics:

**1. Layout Overlap Fix**
- Fixed the overlap issue on small desktop viewports (~1024px) where filter dropdowns (e.g., "All variations" in single product reports) would overlap with the Import Status Bar
- Replaced absolute positioning with flexbox layout using `:has()` selector
- Added responsive breakpoints for better layout at different screen sizes

**2. Loading State Enhancement**
- Added visual loading feedback when import is in progress
- Button now shows a spinner instead of "Update now" text during import
- Refactored button logic to use a single `isBusy` state for clarity

**3. Accessibility Improvements**
- Added `aria-busy` attribute to indicate loading state
- Added `aria-disabled` for explicit disabled state indication
- Dynamic `aria-label` that changes based on button state ("Manually trigger analytics data import" → "Analytics data import in progress")


| Before | After |
|--------|-------|
| <img width="1041" height="639" alt="Screenshot 2026-01-06 at 16 48 47" src="https://github.com/user-attachments/assets/0e02e405-e830-4c80-ad4c-f7958a5b2707" /> | <img width="994" height="638" alt="Screenshot 2026-01-06 at 17 03 48" src="https://github.com/user-attachments/assets/01da6b3c-63ff-41ec-bb63-d5db2f6ecbfa" /> |

Loading state:

https://github.com/user-attachments/assets/ae47c9b5-3976-4b60-a117-1af86486345c

Resizing browser window:

https://github.com/user-attachments/assets/e3bad592-2285-492c-8303-6af452760056

Closes https://github.com/woocommerce/woocommerce/issues/62697

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Prerequisites:**

- Enable scheduled import mode in WooCommerce Analytics settings (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fsettings`)
- Generate some variable product data and completed orders for testing

**Test Layout Fix:**
1. Navigate to Analytics > Products
2. Filter by a single product that has variations (e.g., a variable product)
3. Resize browser window
4. Verify the "All variations" dropdown does NOT overlap with the "Data status" bar
5. Test at various viewport sizes (large desktop, small desktop, tablet, mobile)

**Test Loading State:**
1. Navigate to any Analytics page with the Import Status Bar visible
2. Click the "Update now" button
3. Verify the button shows a spinner during import
4. Verify the button returns to "Update now" after import completes

### Testing that has already taken place:

- Manual testing on Chrome at various viewport sizes (1920px, 1024px, 782px, 600px)
- Verified `:has()` CSS selector support (92%+ browser coverage)
- ESLint validation passed

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Import Status Bar UI overlap with filter dropdowns and add loading state feedback

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>