### PR TITLE
Add to Cart + Options: Avoid loading unnecessary scripts when rendering 3rd-party product types

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-3rd-party-product-type-script
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-3rd-party-product-type-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Add to Cart + Options: Avoid loading unnecessary scripts when rendering 3rd-party product types

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -19,7 +19,6 @@
 	},
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"viewScriptModule": "woocommerce/add-to-cart-with-options",
 	"style": "file:../woocommerce/add-to-cart-with-options-style.css",
 	"editorStyle": "file:../woocommerce/add-to-cart-with-options-editor.css"
 }

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -57940,12 +57940,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartForm.php
 
 		-
-			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
-
-		-
 			message: '#^Call to an undefined method WC_Product\:\:get_available_variations\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -57976,18 +57970,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
 
 		-
-			message: '#^One or more @param tags has an invalid name or invalid syntax\.$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(mixed string\|boolean The template part path if it exists\)\: Unexpected token "string", expected variable at offset 121 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
-
-		-
 			message: '#^Parameter \#1 \$amount of function wc_stock_amount expects float\|int, array\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -58009,12 +57991,6 @@ parameters:
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
 			count: 4
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
-
-		-
-			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\AddToCartWithOptions\:\:render\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
 
 		-

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -37,7 +37,6 @@ class AddToCartForm extends AbstractBlock {
 		return wp_parse_args( $attributes, $defaults );
 	}
 
-
 	/**
 	 * Enqueue assets specific to this block.
 	 * We enqueue frontend scripts only if the quantitySelectorStyle is set to 'stepper'.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -68,7 +68,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			if ( $rendered_product instanceof \WC_Product ) {
 				$template_part_path = $this->get_template_part_path( $rendered_product->get_type() );
 
-				if ( is_string( $template_part_path ) && '' !== $template_part_path ) {
+				if ( is_string( $template_part_path ) && '' !== $template_part_path && file_exists( $template_part_path ) ) {
 					wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options' );
 				}
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -29,7 +29,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * Get the template part path for a product type.
 	 *
 	 * @param string $product_type The product type.
-	 * @return string|false The template part path if it exists, false otherwise.
+	 * @return string|bool The template part path if it exists, false otherwise.
 	 */
 	protected function get_template_part_path( $product_type ) {
 		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
@@ -41,7 +41,7 @@ class AddToCartWithOptions extends AbstractBlock {
 		 * for a product type.
 		 *
 		 * @since 9.9.0
-		 * @param mixed string|boolean The template part path if it exists
+		 * @param string|boolean $template_part_path The template part path if it exists
 		 * @param string $product_type The product type
 		 */
 		return apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
@@ -53,9 +53,11 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * part (that's WC core product types and extensions that migrated to block
 	 * templates).
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Block content.
+	 * @param \WP_Block $block Block instance.
+	 *
+	 * @return void
 	 */
 	protected function enqueue_assets( $attributes, $content, $block ) {
 		$product_id = $block->context['postId'];
@@ -172,11 +174,11 @@ class AddToCartWithOptions extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Block content.
+	 * @param \WP_Block $block Block instance.
 	 *
-	 * @return string | void Rendered block output.
+	 * @return string|void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
 		global $product;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -26,6 +26,53 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options';
 
 	/**
+	 * Get the template part path for a product type.
+	 *
+	 * @param string $product_type The product type.
+	 * @return string|false The template part path if it exists, false otherwise.
+	 */
+	protected function get_template_part_path( $product_type ) {
+		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+			return Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $product_type . '-product-add-to-cart-with-options.html';
+		}
+
+		/**
+		 * Filter to declare product type's cart block template is supported.
+		 *
+		 * @since 9.9.0
+		 * @param mixed string|boolean The template part path if it exists
+		 * @param string $product_type The product type
+		 */
+		return apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
+	}
+
+	/**
+	 * Enqueue assets specific to this block.
+	 * We enqueue frontend scripts only if the quantitySelectorStyle is set to 'stepper'.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
+	 * @param WP_Block $block Block instance.
+	 */
+	protected function enqueue_assets( $attributes, $content, $block ) {
+		$product_id = $block->context['postId'];
+
+		if ( isset( $product_id ) ) {
+			$rendered_product = wc_get_product( $product_id );
+
+			if ( $rendered_product instanceof \WC_Product ) {
+				$template_part_path = $this->get_template_part_path( $rendered_product->get_type() );
+
+				if ( is_string( $template_part_path ) && '' !== $template_part_path ) {
+					wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options' );
+				}
+			}
+		}
+
+		parent::enqueue_assets( $attributes, $content, $block );
+	}
+
+	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.
@@ -148,21 +195,6 @@ class AddToCartWithOptions extends AbstractBlock {
 		// For variations, we display the simple product form.
 		$product_type = ProductType::VARIATION === $product->get_type() ? ProductType::SIMPLE : $product->get_type();
 
-		$slug = $product_type . '-product-add-to-cart-with-options';
-
-		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
-			$template_part_path = Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html';
-		} else {
-			/**
-			 * Filter to declare product type's cart block template is supported.
-			 *
-			 * @since 9.9.0
-			 * @param mixed string|boolean The template part path if it exists
-			 * @param string $product_type The product type
-			 */
-			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
-		}
-
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classes            = implode(
 			' ',
@@ -174,7 +206,10 @@ class AddToCartWithOptions extends AbstractBlock {
 			)
 		);
 
-		if ( is_string( $template_part_path ) && file_exists( $template_part_path ) ) {
+		$template_part_path = $this->get_template_part_path( $product_type );
+		$slug               = $product_type . '-product-add-to-cart-with-options';
+
+		if ( is_string( $template_part_path ) && '' !== $template_part_path && file_exists( $template_part_path ) ) {
 
 			$template_part_contents = '';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -60,7 +60,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @return void
 	 */
 	protected function enqueue_assets( $attributes, $content, $block ) {
-		$product_id = isset( $block->context ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ? $block->context['postId'] : null;
+		$product_id = ( is_object( $block ) && property_exists( $block, 'context' ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ) ? $block->context['postId'] : null;
 
 		if ( isset( $product_id ) ) {
 			$rendered_product = wc_get_product( $product_id );
@@ -183,7 +183,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		global $product;
 
-		$product_id = isset( $block->context ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ? $block->context['postId'] : null;
+		$product_id = ( is_object( $block ) && property_exists( $block, 'context' ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ) ? $block->context['postId'] : null;
 
 		if ( ! isset( $product_id ) ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -37,7 +37,8 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		/**
-		 * Filter to declare product type's cart block template is supported.
+		 * Experimental filter for extensions to register a block template part
+		 * for a product type.
 		 *
 		 * @since 9.9.0
 		 * @param mixed string|boolean The template part path if it exists
@@ -48,7 +49,9 @@ class AddToCartWithOptions extends AbstractBlock {
 
 	/**
 	 * Enqueue assets specific to this block.
-	 * We enqueue frontend scripts only if the quantitySelectorStyle is set to 'stepper'.
+	 * We enqueue frontend scripts only if the product type has a block template
+	 * part (that's WC core product types and extensions that migrated to block
+	 * templates).
 	 *
 	 * @param array    $attributes Block attributes.
 	 * @param string   $content Block content.
@@ -207,10 +210,9 @@ class AddToCartWithOptions extends AbstractBlock {
 		);
 
 		$template_part_path = $this->get_template_part_path( $product_type );
-		$slug               = $product_type . '-product-add-to-cart-with-options';
 
 		if ( is_string( $template_part_path ) && '' !== $template_part_path && file_exists( $template_part_path ) ) {
-
+			$slug                   = $product_type . '-product-add-to-cart-with-options';
 			$template_part_contents = '';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( $slug ), 'wp_template_part' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -60,7 +60,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @return void
 	 */
 	protected function enqueue_assets( $attributes, $content, $block ) {
-		$product_id = $block->context['postId'];
+		$product_id = isset( $block->context ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ? $block->context['postId'] : null;
 
 		if ( isset( $product_id ) ) {
 			$rendered_product = wc_get_product( $product_id );
@@ -183,7 +183,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		global $product;
 
-		$product_id = $block->context['postId'];
+		$product_id = isset( $block->context ) && is_array( $block->context ) && array_key_exists( 'postId', $block->context ) ? $block->context['postId'] : null;
 
 		if ( ! isset( $product_id ) ) {
 			return '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/62677.

When rendering a product of a type different than WC core types, we were loading the `add-to-cart-with-options.js` script, even though it was never used because we rendered the PHP form, not the iAPI one.

This PR addresses that by checking early if the product type has a block template part associated with it. If not, we don't load the iAPI script, as we will be loading the PHP form.

### How to test the changes in this Pull Request:

1. Install a plugin that registers a 3rd-party product type, like [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/).
2. Create a product with that type.
3. Go to Appearance > Editor > Templates > Single Product and make sure you are using the blockified _Add to Cart + Options_ block. If not, switch to it.
4. Visit the product you created in the frontend, with the _Network_ tab of your browser devtools open.
5. Verify the script `add-to-cart-with-options.js` is not loaded.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->