### PR TITLE
Prevent showing error messages on empty checkout fields until form submission

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1438-fields-reaction
+++ b/plugins/woocommerce/changelog/wooprd-1438-fields-reaction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Prevent errors showing on empty checkout fields until the form is submitted.

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -303,7 +303,7 @@ describe( 'ValidatedTextInput', () => {
 		// until form submission (showAllValidationErrors is called)
 		expect(
 			screen.queryByText( 'Please enter a valid test input' )
-		).toBeNull();
+		).not.toBeInTheDocument();
 
 		// Add whitespace only to verify this also doesn't trigger validation error on blur.
 		await act( async () => {
@@ -314,7 +314,7 @@ describe( 'ValidatedTextInput', () => {
 		// Empty fields, even whitespace don't show validation errors on blur.
 		expect(
 			screen.queryByText( 'Please enter a valid test input' )
-		).toBeNull();
+		).not.toBeInTheDocument();
 
 		// Simulate form submission which reveals all hidden validation errors
 		await act( () =>

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -305,6 +305,17 @@ describe( 'ValidatedTextInput', () => {
 			screen.queryByText( 'Please enter a valid test input' )
 		).toBeNull();
 
+		// Add whitespace only to verify this also doesn't trigger validation error on blur.
+		await act( async () => {
+			await user.type( textInputElement, ' ' );
+			textInputElement.blur();
+		} );
+
+		// Empty fields, even whitespace don't show validation errors on blur.
+		expect(
+			screen.queryByText( 'Please enter a valid test input' )
+		).toBeNull();
+
 		// Simulate form submission which reveals all hidden validation errors
 		await act( () =>
 			dispatch( validationStore ).showAllValidationErrors()

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -218,7 +218,7 @@ describe( 'ValidatedTextInput', () => {
 			select( validationStore ).getValidationError( 'test-input' )
 		).toBe( undefined );
 	} );
-	it( 'Shows a custom error message for an invalid required input', async () => {
+	it( 'Shows a custom error message for an invalid required input after form submission', async () => {
 		const user = userEvent.setup();
 		const TestComponent = () => {
 			const [ inputValue, setInputValue ] = useState( '' );
@@ -239,13 +239,25 @@ describe( 'ValidatedTextInput', () => {
 		await act( async () => {
 			await user.type( textInputElement, 'test' );
 			await user.clear( textInputElement );
-			await textInputElement.blur();
+			textInputElement.blur();
 		} );
 
-		await expect(
+		// Empty fields don't show validation errors on blur - they stay hidden
+		// until form submission (showAllValidationErrors is called)
+		expect(
+			screen.queryByText( 'Please enter a valid test input' )
+		).toBeNull();
+
+		// Simulate form submission which reveals all hidden validation errors
+		await act( () =>
+			dispatch( validationStore ).showAllValidationErrors()
+		);
+
+		expect(
 			screen.queryByText( 'Please enter a valid test input' )
 		).not.toBeNull();
 	} );
+
 	describe( 'correctly validates on mount', () => {
 		it( 'validates when focusOnMount is true and validateOnMount is not set', async () => {
 			const setValidationErrors = jest.fn();

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -218,6 +218,63 @@ describe( 'ValidatedTextInput', () => {
 			select( validationStore ).getValidationError( 'test-input' )
 		).toBe( undefined );
 	} );
+	it( 'Shows validation error for non-empty invalid input on blur', async () => {
+		const user = userEvent.setup();
+		const TestComponent = () => {
+			const [ inputValue, setInputValue ] = useState( '' );
+			return (
+				<ValidatedTextInput
+					instanceId={ '5' }
+					id={ 'test-input' }
+					onChange={ ( value ) => setInputValue( value ) }
+					value={ inputValue }
+					label={ 'Test Input' }
+					type="email"
+				/>
+			);
+		};
+		render( <TestComponent /> );
+		const textInputElement = await screen.getByLabelText( 'Test Input' );
+
+		await act( async () => {
+			await user.type( textInputElement, 'invalid-email' );
+			textInputElement.blur();
+		} );
+
+		// Non-empty invalid fields SHOULD show validation errors on blur
+		expect(
+			screen.queryByText( 'Please enter a valid test input' )
+		).toBeInTheDocument();
+	} );
+	it( 'Shows validation error for pattern mismatch on blur', async () => {
+		const user = userEvent.setup();
+		const TestComponent = () => {
+			const [ inputValue, setInputValue ] = useState( '' );
+			return (
+				<ValidatedTextInput
+					instanceId={ '6' }
+					id={ 'pattern-input' }
+					onChange={ ( value ) => setInputValue( value ) }
+					value={ inputValue }
+					label={ 'Pattern Input' }
+					pattern="^[A-Za-z]+$"
+				/>
+			);
+		};
+		render( <TestComponent /> );
+		const textInputElement = await screen.getByLabelText( 'Pattern Input' );
+
+		await act( async () => {
+			await user.type( textInputElement, '123456' );
+			textInputElement.blur();
+		} );
+
+		// Non-empty invalid fields (pattern mismatch) SHOULD show validation errors on blur
+		const validationError =
+			select( validationStore ).getValidationError( 'pattern-input' );
+		expect( validationError ).not.toBeUndefined();
+		expect( validationError?.hidden ).toBe( false );
+	} );
 	it( 'Shows a custom error message for an invalid required input after form submission', async () => {
 		const user = userEvent.setup();
 		const TestComponent = () => {

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -255,7 +255,7 @@ describe( 'ValidatedTextInput', () => {
 
 		expect(
 			screen.queryByText( 'Please enter a valid test input' )
-		).not.toBeNull();
+		).toBeInTheDocument();
 	} );
 
 	describe( 'correctly validates on mount', () => {

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -324,6 +324,16 @@ describe( 'ValidatedTextInput', () => {
 		expect(
 			screen.queryByText( 'Please enter a valid test input' )
 		).toBeInTheDocument();
+
+		// After submission, blurring the empty field should NOT hide the error
+		await act( async () => {
+			await user.click( textInputElement );
+			textInputElement.blur();
+		} );
+
+		expect(
+			screen.queryByText( 'Please enter a valid test input' )
+		).toBeInTheDocument();
 	} );
 
 	describe( 'correctly validates on mount', () => {

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/validated-text-input.tsx
@@ -300,7 +300,12 @@ const ValidatedTextInput = forwardRef<
 						onChange( formattedValue );
 					}
 				} }
-				onBlur={ () => validateInput( false ) }
+				onBlur={ () => {
+					// Don't show validation error on blur for empty fields.
+					// Empty field errors should only appear on form submission.
+					const isEmpty = ! inputRef.current?.value.trim();
+					validateInput( isEmpty );
+				} }
 				aria-describedby={ ariaDescribedBy }
 				value={ value }
 				title="" // This prevents the same error being shown on hover.

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/validated-text-input.tsx
@@ -301,10 +301,19 @@ const ValidatedTextInput = forwardRef<
 					}
 				} }
 				onBlur={ () => {
-					// Don't show validation error on blur for empty fields.
-					// Empty field errors should only appear on form submission.
 					const isEmpty = ! inputRef.current?.value.trim();
-					validateInput( isEmpty );
+
+					if ( isEmpty ) {
+						// If the error was already shown (e.g. after form
+						// submission), keep it visible. Otherwise, keep it
+						// hidden until the next form submission.
+						validateInput(
+							! validationError?.message ||
+								validationError?.hidden
+						);
+					} else {
+						validateInput( false );
+					}
 				} }
 				aria-describedby={ ariaDescribedBy }
 				value={ value }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Prevent showing error messages on empty checkout fields until form submission, this is done by setting the `errorsHidden` argument of `validateInput` to false if the input is empty.

Closes WOOPRD-1438

### Screenshots or screen recordings:

https://www.loom.com/share/3ee1a120ec2e471db9ae738070ebd47f

The "Alternative email" field in the above video is a custom field, so has different validation rules.

### How to test the changes in this Pull Request:

1. As a logged-out user, go to the Checkout block and interact with the form.
2. Fields that are empty, or contain only whitespace should not be treated as invalid. Focus and blur them multiple times and verify that no error shows.
3. Fill in an invalid email address and ensure the validation error shows.
4. Submit the form with empty fields, ensure the validation error shows when trying to submit.
5. Fix the validation errors and verify the form submission works.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
