### PR TITLE
Refactor Order Confirmation Block to use ToolsPanel

### DIFF
--- a/plugins/woocommerce/changelog/59464-use-toolspanel-in-order-confirmation-block
+++ b/plugins/woocommerce/changelog/59464-use-toolspanel-in-order-confirmation-block
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Removes PanelBody and uses ToolsPanel for Order COnfirmation Block
+Removes PanelBody and uses ToolsPanel for Order Confirmation Block

--- a/plugins/woocommerce/changelog/59464-use-toolspanel-in-order-confirmation-block
+++ b/plugins/woocommerce/changelog/59464-use-toolspanel-in-order-confirmation-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removes PanelBody and uses ToolsPanel for Order COnfirmation Block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -121,14 +121,21 @@ export const Edit = ( {
 						} }
 					>
 						<ToolsPanelItem
-							hasValue={ () => attributes.hasDarkControls === true }
+							hasValue={ () =>
+								attributes.hasDarkControls === true
+							}
 							label={ __( 'Dark mode inputs', 'woocommerce' ) }
-							onDeselect={ () => setAttributes( { hasDarkControls: false } ) }
+							onDeselect={ () =>
+								setAttributes( { hasDarkControls: false } )
+							}
 							isShownByDefault
 						>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ __( 'Dark mode inputs', 'woocommerce' ) }
+								label={ __(
+									'Dark mode inputs',
+									'woocommerce'
+								) }
 								help={ __(
 									'Inputs styled specifically for use on dark background colors.',
 									'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -9,6 +9,10 @@ import {
 	PanelBody,
 	ToggleControl,
 	ExternalLink,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import {
 	InnerBlocks,
@@ -110,23 +114,35 @@ export const Edit = ( {
 			</Disabled>
 			{ ! generatePassword && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Style', 'woocommerce' ) }>
-						<ToggleControl
-							__nextHasNoMarginBottom
+					<ToolsPanel
+						label={ __( 'Style', 'woocommerce' ) }
+						resetAll={ () => {
+							setAttributes( { hasDarkControls: false } );
+						} }
+					>
+						<ToolsPanelItem
+							hasValue={ () => attributes.hasDarkControls === true }
 							label={ __( 'Dark mode inputs', 'woocommerce' ) }
-							help={ __(
-								'Inputs styled specifically for use on dark background colors.',
-								'woocommerce'
-							) }
-							checked={ attributes.hasDarkControls }
-							onChange={ () =>
-								setAttributes( {
-									hasDarkControls:
-										! attributes.hasDarkControls,
-								} )
-							}
-						/>
-					</PanelBody>
+							onDeselect={ () => setAttributes( { hasDarkControls: false } ) }
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Dark mode inputs', 'woocommerce' ) }
+								help={ __(
+									'Inputs styled specifically for use on dark background colors.',
+									'woocommerce'
+								) }
+								checked={ attributes.hasDarkControls }
+								onChange={ () =>
+									setAttributes( {
+										hasDarkControls:
+											! attributes.hasDarkControls,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
 				</InspectorControls>
 			) }
 			<InspectorControls>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -5,6 +5,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import type { TemplateArray, BlockAttributes } from '@wordpress/blocks';
 import {
+	InnerBlocks,
+	useBlockProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { getSetting, ADMIN_URL } from '@woocommerce/settings';
+import {
 	Disabled,
 	PanelBody,
 	ToggleControl,
@@ -14,12 +20,6 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import {
-	InnerBlocks,
-	useBlockProps,
-	InspectorControls,
-} from '@wordpress/block-editor';
-import { getSetting, ADMIN_URL } from '@woocommerce/settings';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR removes PanelBody and uses ToolsPanel in the Order Confirmation block.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #59464

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="279" height="502" alt="image" src="https://github.com/user-attachments/assets/154d9dca-9e09-43bc-87df-6fb39ce2afc6" /> | <img width="279" height="511" alt="image" src="https://github.com/user-attachments/assets/2fb916f6-ee63-41b7-a994-cab888ba6c87" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Admin Dashboard > WooCommerce > Settings > Accounts & Privacy
2. Turn ON the toggle `Allow customers to create an account` > `During checkout`
3. Turn OFF the toggle ` Send password setup link (recommended)`
4. Go to Admin Dashboard > Appearence > Editor
5. Go to Templates > Order Confirmation
6. Click on the `Account Creation` block and see the inspector control

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
