### PR TITLE
Use items_count from Store API to ensure the total item count in Mini Cart respects filters.

### DIFF
--- a/plugins/woocommerce/changelog/62701-wooplug-6015-mini-cart-does-not-use-the-items_count-property-from
+++ b/plugins/woocommerce/changelog/62701-wooplug-6015-mini-cart-does-not-use-the-items_count-property-from
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Mini-Cart, fix issue where it does not display the items_count property from Store API.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -87,8 +87,8 @@ export type Store = {
 		};
 		restUrl: string;
 		nonce: string;
-		// TODO: We should not use the existing Cart type which was perhaps designed for redux,
-		// the props are camel case, but we're using the Store API cart representation which is snake case.
+		// TODO: We should not use the existing Cart type. The props are camel case,
+		// but we're using the Store API cart representation which is snake case.
 		cart: Omit< Cart, 'items' | 'item_count' > & {
 			items: ( OptimisticCartItem | CartItem )[];
 			totals: CartResponseTotals;

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -87,9 +87,12 @@ export type Store = {
 		};
 		restUrl: string;
 		nonce: string;
-		cart: Omit< Cart, 'items' > & {
+		// TODO: We should not use the existing Cart type which was perhaps designed for redux,
+		// the props are camel case, but we're using the Store API cart representation which is snake case.
+		cart: Omit< Cart, 'items' | 'item_count' > & {
 			items: ( OptimisticCartItem | CartItem )[];
 			totals: CartResponseTotals;
+			item_count: number;
 		};
 	};
 	actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -172,10 +172,7 @@ store< MiniCart >(
 	{
 		state: {
 			get totalItemsInCart() {
-				return woocommerceState.cart.items.reduce< number >(
-					( total, { quantity } ) => total + quantity,
-					0
-				);
+				return woocommerceState.cart.items_count;
 			},
 
 			get formattedSubtotal(): string {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a simple fix, rather than manually calculating the cart total, we rely on `items_count` from the Store API Cart response.

Closes #62479 

### Screenshots or screen recordings:

n/a


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### You can test that normal cart item count tallies as before:

1. Add some items to cart
2. Open the Mini Cart
3. Ensure the tally is correct
4. (Add and remove some items from within Mini Cart and see that the total is maintained correctly)

#### You can test the filter will override everything

1. Add this code snippet to your site: 

`add_filter( 'woocommerce_cart_contents_count', function ( $count ) { return 150; } );`

2. Reload the page, open the Mini Cart, ensure the total item count respects the `150` set in the filter
3. Add and remove items and see that the total is still maintained as the filter value.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Mini-Cart, fix issue where it does not display the items_count property from Store API.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
