### PR TITLE
Refactor Add to Cart + Options grouped product template part to decrease the gap between quantity selector and product name

### DIFF
--- a/plugins/woocommerce/changelog/fix-62464-add-to-cart-with-options-grouped-product-gap
+++ b/plugins/woocommerce/changelog/fix-62464-add-to-cart-with-options-grouped-product-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Refactor Add to Cart + Options grouped product template part to decrease the gap between quantity selector and product name

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
@@ -1,5 +1,11 @@
 @import "../../../../base/components/quantity-selector/style";
 
+// This will make sure buttons and checkboxes take at least the same width as
+// the quantity selector. Buttons might still be wider in certain locales.
+:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
+	min-width: 6.8em;
+	text-align: right;
+}
 :where(.wc-block-add-to-cart-with-options-grouped-product-item-selector .button) {
 	display: inline-flex;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
@@ -4,7 +4,7 @@
 // the quantity selector. Buttons might still be wider in certain locales.
 // We exclude grid layouts to avoid changing the previous default layout.
 // See https://github.com/woocommerce/woocommerce/pull/62702.
-:where(.wp-block-group:not(.is-layout-grid) > .wc-block-add-to-cart-with-options-grouped-product-item-selector) {
+:where(.wp-block-group.is-layout-flex:not(.is-vertical) > .wc-block-add-to-cart-with-options-grouped-product-item-selector) {
 	min-width: 6.8em;
 	text-align: right;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
@@ -2,7 +2,9 @@
 
 // This will make sure buttons and checkboxes take at least the same width as
 // the quantity selector. Buttons might still be wider in certain locales.
-:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
+// We exclude grid layouts to avoid changing the previous default layout.
+// See https://github.com/woocommerce/woocommerce/pull/62702.
+:where(.wp-block-group:not(.is-layout-grid) > .wc-block-add-to-cart-with-options-grouped-product-item-selector) {
 	min-width: 6.8em;
 	text-align: right;
 }

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -8,7 +8,7 @@
 		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-item"
 		role="listitem"
 	>
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
 		<div
 			class="wp-block-group"
 			style="margin-top: 1rem; margin-bottom: 1rem"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPLUG-6009.
Closes #62464.

This PR refactors the grouped product template part used in the _Add to Cart + Options_ block so it uses flexbox instead of grid. While `grid` is usually better to achieve this kind of layouts, the current Gutenberg implementation is quite limited, and I didn't want to add custom CSS to the _Grid_ block. Instead, I refactored it to use the _Row_ block, which I believe is good enough.

### How to test the changes in this Pull Request:

**Making sure the layout doesn't break in stores that edited the existing template part:**

1. Still in `trunk`, make an edit to the Add to Cart + Options grouped product template part. You can do so going to Appearance > Editor > Templates > Single Product, switching to the blockified _Add to Cart + Options_ block, switching to the grouped product and making any edit, like adding a paragraph at the beginning.
2. Visit a grouped product in the frontend, verifying the change you did is visible.
3. Switch to this branch.
4. Verify the layout is still the same.

**Testing the new layout:**

1. Reset the template part by going to Appearance > Editor > Patterns > Add to Cart + Options and resetting the _Grouped Product Add to Cart + Options_.
2. Visit a grouped product in the frontend.
3. Verify the space between the quantity selector and the product name is much smaller than it was. I also took the liberty to align the elements to the right.

Before | After
--- | ---
<img width="2007" height="931" alt="imatge" src="https://github.com/user-attachments/assets/079936d7-b8c8-4d37-895b-a346c3626151" /> | <img width="2007" height="931" alt="imatge" src="https://github.com/user-attachments/assets/d5a79fa5-c1ff-484d-aae7-3dcb5c6c5ac9" />

Note: It's technically possible that in some locales or if the store has replaced the button text with a long string, the button might be wider than the quantity selector. But think it's not that bad and in some way I prefer it rather than pushing all the product names to the right. But let me know if that approach doesn't sound good. :slightly_smiling_face: 

<img width="2007" height="931" alt="imatge" src="https://github.com/user-attachments/assets/d2732182-8b17-4991-b4ba-ccea80bea985" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
