### PR TITLE
Hide price on blocks if regular price AND current price is 0 (e.g. product is not on sale)

### DIFF
--- a/plugins/woocommerce/changelog/fix-zero-price-showing
+++ b/plugins/woocommerce/changelog/fix-zero-price-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent 0 priced (and not on sale) products from showing $0.00 in the cart block

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -283,6 +283,10 @@ const ProductPrice = ( {
 		price !== undefined &&
 		price < regularPrice;
 
+	// Hide price display when both price and regularPrice are explicitly 0 (e.g., quote products).
+	// Don't hide when regularPrice is undefined, as that's used for line totals/subtotals.
+	const shouldHidePrice = price === 0 && regularPrice === 0;
+
 	let priceComponent = (
 		<span
 			className={ clsx(
@@ -314,7 +318,7 @@ const ProductPrice = ( {
 				priceStyle={ priceStyle }
 			/>
 		);
-	} else if ( price || price === 0 ) {
+	} else if ( ! shouldHidePrice && ( price || price === 0 ) ) {
 		priceComponent = (
 			<FormattedMonetaryAmount
 				className={ clsx(

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -285,7 +285,9 @@ const ProductPrice = ( {
 
 	// Hide price display when both price and regularPrice are explicitly 0 (e.g., quote products).
 	// Don't hide when regularPrice is undefined, as that's used for line totals/subtotals.
-	const shouldHidePrice = price === 0 && regularPrice === 0;
+	// Use Number() to handle string values from the API (e.g., "0") consistently with isDiscounted.
+	const shouldHidePrice =
+		Number( price ) === 0 && Number( regularPrice ) === 0;
 
 	let priceComponent = (
 		<span

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -320,6 +320,7 @@ const ProductPrice = ( {
 				priceStyle={ priceStyle }
 			/>
 		);
+		// Explicitly check price === 0 to render when regularPrice is undefined.
 	} else if ( ! shouldHidePrice && ( price || price === 0 ) ) {
 		priceComponent = (
 			<FormattedMonetaryAmount

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/index.js
@@ -60,4 +60,53 @@ describe( 'ProductPrice', () => {
 
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
+
+	test( 'should hide price when both price and regularPrice are 0', () => {
+		const component = TestRenderer.create(
+			<ProductPrice
+				price={ 0 }
+				regularPrice={ 0 }
+				currency={ currency }
+			/>
+		);
+
+		// Should render wrapper with empty price span (no FormattedMonetaryAmount)
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		expect( json.children ).toHaveLength( 1 );
+		expect( json.children[ 0 ].type ).toBe( 'span' );
+		expect( json.children[ 0 ].children ).toBeNull();
+	} );
+
+	test( 'should show $0.00 when price is 0 and regularPrice is undefined', () => {
+		const component = TestRenderer.create(
+			<ProductPrice price={ 0 } currency={ currency } />
+		);
+
+		// Should render $0.00 - regularPrice must be explicitly 0 to hide
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		// Should contain FormattedMonetaryAmount with £0.00
+		const priceSpan = json.children[ 0 ];
+		expect( priceSpan.props.className ).toContain(
+			'wc-block-components-product-price__value'
+		);
+		expect( priceSpan.children[ 0 ] ).toBe( '£0.00' );
+	} );
+
+	test( 'should show strikethrough price when price is 0 but regularPrice is greater', () => {
+		const component = TestRenderer.create(
+			<ProductPrice
+				price={ 0 }
+				regularPrice={ 100 }
+				currency={ currency }
+			/>
+		);
+
+		// Should render as SalePrice (strikethrough)
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		// Should contain screen reader text and price elements
+		expect( json.children.length ).toBeGreaterThan( 1 );
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/test/index.js
@@ -109,4 +109,79 @@ describe( 'ProductPrice', () => {
 		// Should contain screen reader text and price elements
 		expect( json.children.length ).toBeGreaterThan( 1 );
 	} );
+
+	test( 'should hide price when both price and regularPrice are string "0"', () => {
+		const component = TestRenderer.create(
+			<ProductPrice
+				price={ '0' }
+				regularPrice={ '0' }
+				currency={ currency }
+			/>
+		);
+
+		// Should render wrapper with empty price span (no FormattedMonetaryAmount)
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		expect( json.children ).toHaveLength( 1 );
+		expect( json.children[ 0 ].type ).toBe( 'span' );
+		expect( json.children[ 0 ].children ).toBeNull();
+	} );
+
+	test( 'should show price when price is negative', () => {
+		const component = TestRenderer.create(
+			<ProductPrice price={ -10 } currency={ currency } />
+		);
+
+		// Negative prices should still be displayed
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		const priceSpan = json.children[ 0 ];
+		expect( priceSpan.props.className ).toContain(
+			'wc-block-components-product-price__value'
+		);
+	} );
+
+	test( 'should show price when regularPrice is negative and price is 0', () => {
+		const component = TestRenderer.create(
+			<ProductPrice
+				price={ 0 }
+				regularPrice={ -10 }
+				currency={ currency }
+			/>
+		);
+
+		// Should show price since regularPrice is not 0
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		const priceSpan = json.children[ 0 ];
+		expect( priceSpan.props.className ).toContain(
+			'wc-block-components-product-price__value'
+		);
+	} );
+
+	test( 'should render empty span when price is null', () => {
+		const component = TestRenderer.create(
+			<ProductPrice price={ null } currency={ currency } />
+		);
+
+		// Should render wrapper with empty price span
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		expect( json.children ).toHaveLength( 1 );
+		expect( json.children[ 0 ].type ).toBe( 'span' );
+		expect( json.children[ 0 ].children ).toBeNull();
+	} );
+
+	test( 'should render empty span when price is undefined', () => {
+		const component = TestRenderer.create(
+			<ProductPrice currency={ currency } />
+		);
+
+		// Should render wrapper with empty price span
+		const json = component.toJSON();
+		expect( json.type ).toBe( 'span' );
+		expect( json.children ).toHaveLength( 1 );
+		expect( json.children[ 0 ].type ).toBe( 'span' );
+		expect( json.children[ 0 ].children ).toBeNull();
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If the regular price, and current price (e.g. price being used to display) are both 0, then the product is priced at 0, and is not on sale, therefore the price should not show in the Cart block.

If the product is on sale, e.g. its regular price is different to its current price, then the current price should show with the regular price struck through.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|  <img width="567" height="534" alt="image" src="https://github.com/user-attachments/assets/1b0e5277-16e3-404b-aa1b-4dd8e20b24dd" /> |  <img width="561" height="527" alt="image" src="https://github.com/user-attachments/assets/829537d6-2520-4568-9690-2d8195a8ef04" />     |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set a product to have a regular price of 0 in the back end.
2. Add this product to the cart and ensure the price does not show in the Cart block. Ensure it shows $0.00 in the checkout block.
3. Change the product's regular price to a value greater than 0
4. Ensure the price shows in the Cart and Checkout blocks.
5. Change the product's sale price to a number _greater than_ 0.
6. Ensure the sale price shows in the Cart and Checkout blocks with the regular price struck out.
7. Change the product's sale price to 0.
8. Ensure the sale price of 0 shows in the Cart and Checkout blocks with the regular price struck out.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
