### PR TITLE
Email Editor - fix layout controls initialization for buttons block

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-997-buttons-alignment-control-fix
+++ b/packages/js/email-editor/changelog/wooprd-997-buttons-alignment-control-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix buttons block layout controls initialization

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -101,9 +101,9 @@ function onInit() {
 	initDomTracking();
 	createStore();
 	initContentValidationMiddleware();
-	initializeLayout();
 	initBlocks();
 	initTextHooks();
+	initializeLayout();
 }
 
 export function initialize( elementId: string ) {

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -6,7 +6,6 @@ import {
 	StrictMode,
 	createRoot,
 	useEffect,
-	useLayoutEffect,
 	useState,
 	useMemo,
 } from '@wordpress/element';
@@ -157,7 +156,7 @@ export function ExperimentalEmailEditor( {
 } ) {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 
-	useLayoutEffect( () => {
+	useEffect( () => {
 		const backupEditorSettings = select( editorStore ).getEditorSettings();
 		// Set configuration to store from window object for backward compatibility
 		const editorConfig = config || getEditorConfigFromWindow();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue that layout controls (align left, center, right) for buttons block in the email editor are not present and alignment is not working when ExperimentalEditor component is unmonted and rendered again.

Closes WOOPRD-997.

### How to test the changes in this Pull Request:

To be able to replicate the issue you need to ensure that the editor component renders then is unmounted and then renders again.

You can modify `plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts`
and replace `initializeEditor( 'woocommerce-email-editor' )` with

```ts
// Initialize the editor by rendering the EmailEditor component
function renderEmailEditor() {
	const container = document.getElementById( 'woocommerce-email-editor' );
	if ( ! container ) {
		return;
	}

	// Get configuration from the global object
	// eslint-disable-next-line @typescript-eslint/no-explicit-any
	const config = ( window as any ).WooCommerceEmailEditor;
	if ( ! config ) {
		return;
	}

	const root = createRoot( container );

	const renderEditor = () => {
		root.render(
			createElement( EmailEditor, {
				postId: config.current_post_id,
				postType: config.current_post_type,
				config: {
					editorSettings: config.editor_settings,
					theme: config.editor_theme,
					urls: config.urls,
					userEmail: config.current_wp_user_email,
					globalStylesPostId: config.user_theme_post_id,
				},
			} )
		);
	};

	// Render the editor initially
	renderEditor();

	// Test rerendering cycle
	setTimeout( () => {
		// Render null after 1s
		console.log( 'Rendering null...' );
		root.render( null );

		setTimeout( () => {
			// Render the editor again after another 1s with a new key
			console.log( 'Rendering editor again...' );
			renderEditor();
		}, 1000 );
	}, 1000 );
}

if ( document.readyState === 'loading' ) {
	window.addEventListener( 'DOMContentLoaded', renderEmailEditor, {
		once: true,
	} );
} else {
	renderEmailEditor();
}
```
and add proper imports 
```ts
import { ExperimentalEmailEditor as EmailEditor } from '@woocommerce/email-editor';
import { createRoot, createElement } from '@wordpress/element';
```
1. Add button to an email and set it to be aligned horizontaly in the center. This is done via buttons block that wraps button block.

Without this fix the button is aligned left and can't be placed in the center because the controls are missing on the second render.

#### Alternative testing

You can test the change in a SPA app:
1) Link build from this branch and build whole app
2) Create an email and place the button in center
3) Navigate out of the editor and return and buttons block controls should still be present and work properlt

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
