### PR TITLE
Update input borders and colors to use currentColor

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1437-color-system-clean-up
+++ b/plugins/woocommerce/changelog/wooprd-1437-color-system-clean-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update inputs and border colours in Cart/Checkout blocks to match the theme's text colour.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -13,12 +13,12 @@ $input-background-dark: transparent;
 $image-placeholder-border-color: #f2f2f2;
 
 // Universal colors for use on the frontend, currently being applied to checkout blocks.
-// #e7e7e7 on white. Used for low contrast decorative elements such as section borders.
-$universal-border-light: rgba(17, 17, 17, 0.11);
+// Text colour at 20% opacity. Used for low contrast decorative elements such as section borders.
+$universal-border-light: color-mix(in srgb, currentColor 20%, transparent);
 // Used for radio and checkbox resting state.
-$universal-border-medium: rgba(25, 23, 17, 0.48);
+$universal-border-medium: color-mix(in srgb, currentColor 48%, transparent);
 // #1e1e1e on white. Used for low contrast decorative elements such as input borders.
-$universal-border-strong: rgba(17, 17, 17, 0.8);
+$universal-border-strong: color-mix(in srgb, currentColor 80%, transparent);
 // Used for low emphasis text such as input labels.
 $universal-body-low-emphasis: rgba(17, 17, 17, 0.7);
 // Used for low contrast decorative elements background color.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -5,9 +5,9 @@
 $discount-color: $alert-green;
 
 $input-text-light: #2b2d2f;
-$input-text-dark: #fff;
-$input-placeholder-dark: rgba(255, 255, 255, 0.6);
-$input-border-dark: rgba(255, 255, 255, 0.4);
+$input-text-dark: currentColor;
+$input-placeholder-dark: color-mix(in srgb, currentColor 80%, transparent);
+$input-border-dark: currentColor;
 $input-background-light: #fff;
 $input-background-dark: rgba(0, 0, 0, 0.1);
 $image-placeholder-border-color: #f2f2f2;

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -9,7 +9,7 @@ $input-text-dark: currentColor;
 $input-placeholder-dark: color-mix(in srgb, currentColor 80%, transparent);
 $input-border-dark: currentColor;
 $input-background-light: #fff;
-$input-background-dark: rgba(0, 0, 0, 0.1);
+$input-background-dark: transparent;
 $image-placeholder-border-color: #f2f2f2;
 
 // Universal colors for use on the frontend, currently being applied to checkout blocks.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -5,11 +5,11 @@
 $discount-color: $alert-green;
 
 $input-text-light: #2b2d2f;
-$input-text-dark: currentColor;
-$input-placeholder-dark: color-mix(in srgb, currentColor 80%, transparent);
-$input-border-dark: currentColor;
+$input-text-dark: #fff;
+$input-placeholder-dark: rgba(255, 255, 255, 0.6);
+$input-border-dark: rgba(255, 255, 255, 0.4);
 $input-background-light: #fff;
-$input-background-dark: transparent;
+$input-background-dark: rgba(0, 0, 0, 0.1);
 $image-placeholder-border-color: #f2f2f2;
 
 // Universal colors for use on the frontend, currently being applied to checkout blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -79,13 +79,6 @@ $border-width: 1px;
 			pointer-events: none;
 			flex-grow: 1;
 		}
-
-		.has-dark-controls & {
-			&::before,
-			&::after {
-				border-color: $input-border-dark;
-			}
-		}
 	}
 
 	.wc-block-components-express-payment__title {
@@ -105,9 +98,6 @@ $border-width: 1px;
 		border-radius: 0 0 $universal-border-radius $universal-border-radius;
 		margin-top: calc($universal-border-radius + $border-width);
 		min-height: 48px;
-		.has-dark-controls & {
-			border-color: $input-border-dark;
-		}
 
 		> p {
 			margin-bottom: em($gap);
@@ -167,10 +157,6 @@ $border-width: 1px;
 		content: " ";
 		flex: 1;
 		border-bottom: 1px solid $universal-border-light;
-
-		.has-dark-controls & {
-			border-color: $input-border-dark;
-		}
 	}
 }
 @include cart-checkout-below-large-container {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-totals/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-totals/style.scss
@@ -15,8 +15,4 @@
 		padding-bottom: 0;
 		border: 0;
 	}
-
-	.has-dark-controls & {
-		border-color: $input-border-dark;
-	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
@@ -1,10 +1,6 @@
 .wc-block-components-address-card {
 	@include card-styles();
 
-	.has-dark-controls & {
-		border-color: $input-border-dark;
-	}
-
 	address {
 		display: flex;
 		flex-direction: column;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -62,12 +62,6 @@
 	}
 }
 
-.has-dark-controls {
-	.wp-block-woocommerce-checkout-order-summary-block {
-		border: 1px solid $input-border-dark;
-	}
-}
-
 .wc-block-checkout__main {
 	.wc-block-components-order-summary {
 		margin-top: $gap-smaller;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-totals/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-totals/style.scss
@@ -5,8 +5,4 @@
 		padding-bottom: 0;
 		border: 0;
 	}
-
-	.has-dark-controls & {
-		border-color: $input-border-dark;
-	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -73,7 +73,7 @@
 			gap: $gap-smallest;
 
 			.has-dark-controls & {
-				color: $gray-300;
+				color: currentColor;
 			}
 
 			.wc-block-editor-components-block-icon {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -31,7 +31,7 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 	border-radius: $universal-border-radius;
 	border: 2px solid transparent;
 	background-color: transparent;
-	color: $input-text-light;
+	color: currentColor;
 
 	.has-dark-controls & {
 		color: currentColor;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -34,7 +34,7 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 	color: $input-text-light;
 
 	.has-dark-controls & {
-		color: $input-text-dark;
+		color: currentColor;
 	}
 
 	&:hover,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/style.scss
@@ -6,10 +6,6 @@
 		padding-top: $gap-large;
 		border-top: 1px solid $universal-border-light;
 
-		.has-dark-controls & {
-			border-top-color: $input-border-dark;
-		}
-
 		@include cart-checkout-below-large-container {
 			padding-top: 0;
 			border-top: 0;

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -26,12 +26,6 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 			position: absolute;
 		}
 
-		.has-dark-controls & {
-			&::after {
-				background: $input-border-dark;
-			}
-		}
-
 		// The first child doesn't need a fake border-top because it's handled by its parent's border-top. This stops
 		// a double border.
 		&:first-child::after {
@@ -70,12 +64,6 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 		box-sizing: border-box;
 	}
 
-	.has-dark-controls & {
-		&::after {
-			border-color: $input-border-dark;
-		}
-	}
-
 	// Remove the top border when the first element is selected, this is so we don't get a double border with the
 	// box-shadow.
 	&.wc-block-components-radio-control--highlight-checked--first-selected::after {
@@ -109,12 +97,6 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 			left: 1px;
 			top: 0;
 			position: absolute;
-		}
-
-		.has-dark-controls & {
-			&::after {
-				background: $input-border-dark;
-			}
 		}
 
 		// The first child doesn't need a fake border-top because it's handled by its parent's border-top.
@@ -241,7 +223,6 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 		}
 
 		.has-dark-controls & {
-			border-color: $input-border-dark;
 			background-color: $input-background-dark;
 
 			&:checked {

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -223,6 +223,7 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 		}
 
 		.has-dark-controls & {
+			border-color: $input-border-dark;
 			background-color: $input-background-dark;
 
 			&:checked {

--- a/plugins/woocommerce/client/blocks/packages/components/totals-wrapper/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/totals-wrapper/style.scss
@@ -2,10 +2,6 @@
 	border-top: 1px solid $universal-border-light;
 	padding: $gap 0;
 
-	.has-dark-controls & {
-		border-color: $input-border-dark;
-	}
-
 	// TotalWrappers like Discount and Fee are sometimes empty
 	// this prevents displaying the empty areas in Order Summary
 	&:empty,
@@ -35,10 +31,6 @@
 	.wc-block-components-totals-wrapper {
 		&:first-child {
 			border-top: 1px solid $universal-border-light;
-
-			.has-dark-controls & {
-				border-color: $input-border-dark;
-			}
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -942,11 +942,12 @@ p.demo_store,
 	}
 
 	table.shop_table {
-		border: 1px solid rgba(0, 0, 0, 0.1);
+		border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
 		margin: 0 -1px 24px 0;
 		text-align: left;
 		width: 100%;
 		border-collapse: separate;
+		border-spacing: 0;
 		border-radius: 5px;
 
 		th {
@@ -956,7 +957,7 @@ p.demo_store,
 		}
 
 		td {
-			border-top: 1px solid rgba(0, 0, 0, 0.1);
+			border-top: 1px solid color-mix(in srgb, currentColor 20%, transparent);
 			padding: 9px 12px;
 			vertical-align: middle;
 			line-height: 1.5em;
@@ -981,7 +982,7 @@ p.demo_store,
 		tfoot th,
 		tbody th {
 			font-weight: 700;
-			border-top: 1px solid rgba(0, 0, 0, 0.1);
+			border-top: 1px solid color-mix(in srgb, currentColor 20%, transparent);
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Updates CSS so that borders on Cart/Checkout elements, and input elements use the theme's current text colour (at varying opacities depending on application) in dark mode
- Updates inputs to have a `transparent` background when in dark mode, so that they match the page's background.
- Updates inputs to use `currentColor` when in dark mode.
- Update local pickup control to use the theme's current text colour in dark mode rather than the hard coded grey colour previously used.

Closes WOOPRD-1437

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Checkout Before (Dark mode) | Checkout After (Dark mode) |
| ------ | ----- |
| <img width="1622" height="680" alt="image" src="https://github.com/user-attachments/assets/7ec19dd5-2b22-4e3c-80cb-e49ff46c391b" /> | <img width="995" height="597" alt="image" src="https://github.com/user-attachments/assets/c27e347d-2937-4836-9cdc-dbb95167c02e" /> |

| Cart Before (Dark mode) | Cart After (Dark mode) |
| ------ | ----- |
| <img width="1661" height="629" alt="image" src="https://github.com/user-attachments/assets/542450e0-9f7c-475c-aded-76b6ada10b18" />  | <img width="998" height="565" alt="image" src="https://github.com/user-attachments/assets/7129a249-256a-40c5-b1fc-a02931e732f6" /> |

| Checkout Before (Light background, but inputs in dark mode) | Checkout After (Light background, but inputs in dark mode) |
| ------ | ----- |
| <img width="1649" height="673" alt="image" src="https://github.com/user-attachments/assets/f0886b58-d59d-48c0-9619-e8dcecd5acb5" /> | <img width="1644" height="617" alt="image" src="https://github.com/user-attachments/assets/19c14d39-c417-4704-8aee-563224d3f4d2" /> |

| Checkout Before (Light background, inputs in light mode) | Checkout After (Light background, inputs in light mode) |
| ------ | ----- |
| <img width="1632" height="667" alt="image" src="https://github.com/user-attachments/assets/7291dcba-1930-40f3-8ba8-6bdf702e45e6" /> | <img width="1636" height="614" alt="image" src="https://github.com/user-attachments/assets/7fc674c4-a014-4d40-a0f0-469c4373e966" /> |

| Cart Before (Light mode) | Cart After (Light mode) |
| ------ | ----- |
| <img width="1655" height="611" alt="image" src="https://github.com/user-attachments/assets/a2991ff1-e86f-48ef-9517-cc2d5927c01b" /> | <img width="1680" height="610" alt="image" src="https://github.com/user-attachments/assets/66d51d8e-aa39-4044-b1cd-92ea5bcbf4d0" /> |

| Shipping/Payment Before (Light background, inputs in dark mode) | Shipping/Payment After (Light background, inputs in dark mode) |
| ------ | ----- |
| <img width="1019" height="570" alt="image" src="https://github.com/user-attachments/assets/42d9fd15-99b2-4377-b8ce-9a527fd7e78f" /> | <img width="1012" height="561" alt="image" src="https://github.com/user-attachments/assets/5834f69f-88da-49d6-88dc-36dd16e31116" /> |

| Shipping/Payment Before (Light background, inputs in light mode) | Shipping/Payment After (Light background, inputs in light mode) |
| ------ | ----- |
| <img width="1007" height="568" alt="image" src="https://github.com/user-attachments/assets/1c265576-7cbf-40b2-8214-ffecd43aca45" /> | <img width="1023" height="567" alt="image" src="https://github.com/user-attachments/assets/977895ff-deff-480d-aa18-30a48a8b2e0e" /> |

| Shipping/Payment Before (Dark background, inputs in light mode) | Shipping/Payment After (Dark background, inputs in light mode) |
| ------ | ----- |
| <img width="1019" height="564" alt="image" src="https://github.com/user-attachments/assets/1cf53b64-e150-4bf9-8fa7-5143db3aa9d1" /> | <img width="1006" height="563" alt="image" src="https://github.com/user-attachments/assets/3f36fa47-8d8b-4cda-bffb-eeda70bde0c9" /> |

| Shipping/Payment Before (Dark background, inputs in dark mode) | Shipping/Payment After (Dark background, inputs in dark mode) |
| ------ | ----- |
| <img width="1016" height="572" alt="image" src="https://github.com/user-attachments/assets/8ee0cd52-bddf-4bda-99ee-24a97e8b280c" /> | <img width="1018" height="567" alt="image" src="https://github.com/user-attachments/assets/7aa5f2ae-838c-4cea-99f0-15741b5154d5" /> |

| My Account -> Orders before (Dark mode) | My Account -> Orders after (Dark mode) |
| ------ | ----- |
| <img width="1121" height="591" alt="image" src="https://github.com/user-attachments/assets/3f214012-7c94-4b37-b86e-2938e08dd226" /> | <img width="1083" height="596" alt="image" src="https://github.com/user-attachments/assets/edccf531-9165-4894-a93a-70ccb70b3abe" /> |

| My Account -> Downloads before (Dark mode) | My Account -> Downloads after (Dark mode) |
| ------ | ----- |
| <img width="1105" height="469" alt="image" src="https://github.com/user-attachments/assets/e2374a87-f8d6-4aa4-8101-f1e5cd3e495d" /> | <img width="1064" height="769" alt="image" src="https://github.com/user-attachments/assets/33929d4b-e4e1-475b-a73f-671988fbebd7" /> |

| My Account -> Orders before (Light mode) | My Account -> Orders after (Light mode) |
| ------ | ----- |
| <img width="1040" height="522" alt="image" src="https://github.com/user-attachments/assets/fa442085-71a4-4a55-b6bc-d58585f98485" /> | <img width="1049" height="515" alt="image" src="https://github.com/user-attachments/assets/41476aef-05e7-43f2-a0e7-484bebbc511c" /> |

| My Account -> Downloads before (Light mode) | My Account -> Downloads after (Light mode) |
| ------ | ----- |
| <img width="1040" height="247" alt="image" src="https://github.com/user-attachments/assets/9f0994a1-6ff5-4776-802f-c700fdaca417" /> | <img width="1070" height="376" alt="image" src="https://github.com/user-attachments/assets/a2328c6c-cc17-4afa-a350-178a7e8ee232" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Test with both block themes and classic themes. You'll need to edit your themes to create the following styles:

- Dark background with light text
- Light background with dark text

1. Go to the Cart page, ensure the borders surrounding the order summary are using the page's main text colour, at a slightly more transparent rate (20%). Try changing the text colour in the customizer/editor and ensure they change correctly.
3. Go to the Checkout block, ensure the borders around sections and the order summary are using the page's main text colour, at a slightly more transparent rate (20%). Try changing the text colour in the customizer/editor and ensure they change correctly.
4. Ensure the borders on all other blocks and elements are using the page's main text colour, at a slightly more transparent rate (20%). Try changing the text colour in the customizer/editor and ensure they change correctly.
5. Go to the editor and select the Checkout block and enable Dark Mode Inputs
<img width="286" height="179" alt="image" src="https://github.com/user-attachments/assets/3b1c1551-796c-41e4-81ee-ac0aa50770b2" />

6. Go back to the Checkout block and ensure the inputs are rendered in darkmode, they should not have changed in this PR.
7. Order a downloadable product. Go to My Account and check the orders table is using the currentColor for borders.
8. Go to My Account -> Downloads and check the downloads table is using the currentColor for borders.
9. Test on mobile devices, and Safari/Firefox/Chrome

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
