### PR TITLE
Refactor Product Elements Blocks to use ToolsPanel

### DIFF
--- a/plugins/woocommerce/changelog/59464-use-toolspanel-in-product-elements-blocks
+++ b/plugins/woocommerce/changelog/59464-use-toolspanel-in-product-elements-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removes PanelBody and uses ToolsPanel for Button, Image and Title blocks

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -6,7 +6,10 @@ import {
 	Disabled,
 	Button,
 	ButtonGroup,
-	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -26,6 +29,10 @@ import { useProduct } from '@woocommerce/entities';
 import Block from './block';
 import { BlockAttributes } from './types';
 
+const DEFAULT_ATTRIBUTES = {
+	width: undefined,
+};
+
 function WidthPanel( {
 	selectedWidth,
 	setAttributes,
@@ -42,26 +49,40 @@ function WidthPanel( {
 	}
 
 	return (
-		<PanelBody title={ __( 'Width settings', 'woocommerce' ) }>
-			<ButtonGroup aria-label={ __( 'Button width', 'woocommerce' ) }>
-				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-					return (
-						<Button
-							key={ widthValue }
-							isSmall
-							variant={
-								widthValue === selectedWidth
-									? 'primary'
-									: undefined
-							}
-							onClick={ () => handleChange( widthValue ) }
-						>
-							{ widthValue }%
-						</Button>
-					);
-				} ) }
-			</ButtonGroup>
-		</PanelBody>
+		<ToolsPanel
+			label={ __( 'Width settings', 'woocommerce' ) }
+			resetAll={ () =>
+				setAttributes( { width: DEFAULT_ATTRIBUTES.width } )
+			}
+		>
+			<ToolsPanelItem
+				label={ __( 'Button width', 'woocommerce' ) }
+				hasValue={ () => selectedWidth !== DEFAULT_ATTRIBUTES.width }
+				onDeselect={ () =>
+					setAttributes( { width: DEFAULT_ATTRIBUTES.width } )
+				}
+				isShownByDefault
+			>
+				<ButtonGroup aria-label={ __( 'Button width', 'woocommerce' ) }>
+					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+						return (
+							<Button
+								key={ widthValue }
+								isSmall
+								variant={
+									widthValue === selectedWidth
+										? 'primary'
+										: undefined
+								}
+								onClick={ () => handleChange( widthValue ) }
+							>
+								{ widthValue }%
+							</Button>
+						);
+					} ) }
+				</ButtonGroup>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -2,15 +2,6 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import {
-	Disabled,
-	Button,
-	ButtonGroup,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanel as ToolsPanel,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	AlignmentToolbar,
@@ -22,6 +13,15 @@ import type { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
 import { useProduct } from '@woocommerce/entities';
+import {
+	Disabled,
+	Button,
+	ButtonGroup,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
@@ -20,7 +20,6 @@ import { isBoolean } from '@woocommerce/types';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
 import {
-	PanelBody,
 	ToggleControl,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore - Ignoring because `__experimentalToggleGroupControl` is not yet in the type definitions.
@@ -30,6 +29,10 @@ import {
 	// @ts-ignore - Ignoring because `__experimentalToggleGroupControl` is not yet in the type definitions.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 /**
@@ -48,6 +51,11 @@ const TEMPLATE = [
 		},
 	],
 ];
+
+const DEFAULT_ATTRIBUTES = {
+	showProductLink: true,
+	imageSizing: ImageSizing.SINGLE,
+};
 
 const Edit = ( {
 	attributes,
@@ -137,63 +145,103 @@ const Edit = ( {
 						height={ height }
 						setAttributes={ setAttributes }
 					/>
-					<PanelBody title={ __( 'Content', 'woocommerce' ) }>
-						<ToggleControl
+					<ToolsPanel
+						label={ __( 'Content', 'woocommerce' ) }
+						resetAll={ () =>
+							setAttributes( {
+								showProductLink:
+									DEFAULT_ATTRIBUTES.showProductLink,
+								imageSizing: DEFAULT_ATTRIBUTES.imageSizing,
+							} )
+						}
+					>
+						<ToolsPanelItem
 							label={ __(
 								'Link to Product Page',
 								'woocommerce'
 							) }
-							help={ __(
-								'Links the image to the single product listing.',
-								'woocommerce'
-							) }
-							checked={ showProductLink }
-							onChange={ () =>
+							hasValue={ () =>
+								showProductLink !==
+								DEFAULT_ATTRIBUTES.showProductLink
+							}
+							onDeselect={ () =>
 								setAttributes( {
-									showProductLink: ! showProductLink,
+									showProductLink:
+										DEFAULT_ATTRIBUTES.showProductLink,
 								} )
 							}
-						/>
-						<ToggleGroupControl
-							label={ __( 'Resolution', 'woocommerce' ) }
-							isBlock
-							help={
-								! isBlockTheme
-									? createInterpolateElement(
-											__(
-												'Product image cropping can be modified in the <a>Customizer</a>.',
-												'woocommerce'
-											),
-											{
-												a: (
-													// eslint-disable-next-line jsx-a11y/anchor-has-content
-													<a
-														href={ `${ getAdminLink(
-															'customize.php'
-														) }?autofocus[panel]=woocommerce&autofocus[section]=woocommerce_product_images` }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											}
-									  )
-									: null
-							}
-							value={ imageSizing }
-							onChange={ ( value: ImageSizing ) =>
-								setAttributes( { imageSizing: value } )
-							}
+							isShownByDefault
 						>
-							<ToggleGroupControlOption
-								value={ ImageSizing.SINGLE }
-								label={ __( 'Full Size', 'woocommerce' ) }
+							<ToggleControl
+								label={ __(
+									'Link to Product Page',
+									'woocommerce'
+								) }
+								help={ __(
+									'Links the image to the single product listing.',
+									'woocommerce'
+								) }
+								checked={ showProductLink }
+								onChange={ () =>
+									setAttributes( {
+										showProductLink: ! showProductLink,
+									} )
+								}
 							/>
-							<ToggleGroupControlOption
-								value={ ImageSizing.THUMBNAIL }
-								label={ __( 'Thumbnail', 'woocommerce' ) }
-							/>
-						</ToggleGroupControl>
-					</PanelBody>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							label={ __( 'Resolution', 'woocommerce' ) }
+							hasValue={ () =>
+								imageSizing !== DEFAULT_ATTRIBUTES.imageSizing
+							}
+							onDeselect={ () =>
+								setAttributes( {
+									imageSizing: DEFAULT_ATTRIBUTES.imageSizing,
+								} )
+							}
+							isShownByDefault
+						>
+							<ToggleGroupControl
+								label={ __( 'Resolution', 'woocommerce' ) }
+								isBlock
+								help={
+									! isBlockTheme
+										? createInterpolateElement(
+												__(
+													'Product image cropping can be modified in the <a>Customizer</a>.',
+													'woocommerce'
+												),
+												{
+													a: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<a
+															href={ `${ getAdminLink(
+																'customize.php'
+															) }?autofocus[panel]=woocommerce&autofocus[section]=woocommerce_product_images` }
+															target="_blank"
+															rel="noopener noreferrer"
+														/>
+													),
+												}
+										  )
+										: null
+								}
+								value={ imageSizing }
+								onChange={ ( value: ImageSizing ) =>
+									setAttributes( { imageSizing: value } )
+								}
+							>
+								<ToggleGroupControlOption
+									value={ ImageSizing.SINGLE }
+									label={ __( 'Full Size', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value={ ImageSizing.THUMBNAIL }
+									label={ __( 'Thumbnail', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+						</ToolsPanelItem>
+					</ToolsPanel>
 				</InspectorControls>
 			) }
 			<Block

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -2,7 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	Disabled,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import {
 	InspectorControls,
 	BlockControls,
@@ -22,6 +29,11 @@ interface Props {
 	attributes: Attributes;
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
+
+const DEFAULT_ATTRIBUTES = {
+	showProductLink: true,
+	linkTarget: undefined,
+};
 
 const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
@@ -46,18 +58,52 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Link settings', 'woocommerce' ) }>
-					<ToggleControl
+				<ToolsPanel
+					label={ __( 'Link settings', 'woocommerce' ) }
+					resetAll={ () =>
+						setAttributes( {
+							showProductLink: DEFAULT_ATTRIBUTES.showProductLink,
+							linkTarget: DEFAULT_ATTRIBUTES.linkTarget,
+						} )
+					}
+				>
+					<ToolsPanelItem
 						label={ __( 'Make title a link', 'woocommerce' ) }
-						checked={ showProductLink }
-						onChange={ () =>
+						hasValue={ () =>
+							showProductLink !==
+							DEFAULT_ATTRIBUTES.showProductLink
+						}
+						onDeselect={ () =>
 							setAttributes( {
-								showProductLink: ! showProductLink,
+								showProductLink:
+									DEFAULT_ATTRIBUTES.showProductLink,
 							} )
 						}
-					/>
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __( 'Make title a link', 'woocommerce' ) }
+							checked={ showProductLink }
+							onChange={ () =>
+								setAttributes( {
+									showProductLink: ! showProductLink,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
 					{ showProductLink && (
-						<>
+						<ToolsPanelItem
+							label={ __( 'Open in new tab', 'woocommerce' ) }
+							hasValue={ () =>
+								linkTarget !== DEFAULT_ATTRIBUTES.linkTarget
+							}
+							onDeselect={ () =>
+								setAttributes( {
+									linkTarget: DEFAULT_ATTRIBUTES.linkTarget,
+								} )
+							}
+							isShownByDefault
+						>
 							<ToggleControl
 								label={ __( 'Open in new tab', 'woocommerce' ) }
 								onChange={ ( value ) =>
@@ -67,9 +113,9 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 								}
 								checked={ linkTarget === '_blank' }
 							/>
-						</>
+						</ToolsPanelItem>
 					) }
-				</PanelBody>
+				</ToolsPanel>
 			</InspectorControls>
 			<Disabled>
 				<Block { ...attributes } />

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -3,6 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	InspectorControls,
+	BlockControls,
+	AlignmentToolbar,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import HeadingToolbar from '@woocommerce/editor-components/heading-toolbar';
+import {
 	Disabled,
 	ToggleControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -10,13 +17,6 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import {
-	InspectorControls,
-	BlockControls,
-	AlignmentToolbar,
-	useBlockProps,
-} from '@wordpress/block-editor';
-import HeadingToolbar from '@woocommerce/editor-components/heading-toolbar';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 const DEFAULT_ATTRIBUTES = {
 	showProductLink: true,
-	linkTarget: undefined,
+	linkTarget: '_self',
 };
 
 const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR removes PanelBody and uses ToolsPanel in the Button, Image and Title blocks.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #59464

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| | Before | After |
| --- | ------ | ----- |
| Button | <img width="280" height="376" alt="image" src="https://github.com/user-attachments/assets/cb10d850-0ac2-4aa9-87d5-e57103dcbedb" /> | <img width="279" height="374" alt="image" src="https://github.com/user-attachments/assets/fbd421d8-b298-4586-90a5-37d66a7c4b22" /> |
| Image | <img width="280" height="581" alt="image" src="https://github.com/user-attachments/assets/29eefa00-6ae9-431e-97dc-3274fc680498" /> | <img width="280" height="550" alt="image" src="https://github.com/user-attachments/assets/bd08ef8e-91ac-4657-ace0-0be58f365716" /> |
| Title | <img width="279" height="485" alt="image" src="https://github.com/user-attachments/assets/6bc65c13-c23e-4d47-a398-397beec8cf15" /> | <img width="279" height="479" alt="image" src="https://github.com/user-attachments/assets/50a1824a-52b9-4e10-adb4-38e8e56a0993" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a post
2. Add `Product Collection` block and choose `Featured Products` collection
3. Within the product template, click on the:
4. Product Image block to test change in Image block
5. Product Title block to test change in Title block
6. Add to Cart Button block to test change in Button block

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
