### PR TITLE
Style sync controller: If global styles post is empty, loop through them all

### DIFF
--- a/packages/php/email-editor/changelog/62713-fix-custom-colors-palette-missing
+++ b/packages/php/email-editor/changelog/62713-fix-custom-colors-palette-missing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Email Editor: Handle cases where theme paths don't match the post slug.

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -134,15 +134,15 @@ class Site_Style_Sync_Controller {
 			// Get only the theme and user customizations (e.g. from site editor).
 			$this->site_theme = new WP_Theme_JSON();
 			$this->site_theme->merge( WP_Theme_JSON_Resolver::get_theme_data() );
-			
+
 			$user_data = WP_Theme_JSON_Resolver::get_user_data();
-			
+
 			// Fallback: If get_user_data() returns empty data, loop through all global styles posts
 			// to find one with actual data. This handles cases where theme paths don't match
 			// the post slug (e.g., subdirectory themes like 'pub/arbutus').
 			$user_data_raw = $user_data->get_raw_data();
 			$is_empty_data = ! isset( $user_data_raw['settings'] ) && ! isset( $user_data_raw['styles'] );
-			
+
 			if ( $is_empty_data ) {
 				$global_styles_posts = get_posts(
 					array(
@@ -151,13 +151,13 @@ class Site_Style_Sync_Controller {
 						'post_status'    => 'publish',
 					)
 				);
-				
+
 				foreach ( $global_styles_posts as $post ) {
 					$decoded_content = json_decode( $post->post_content, true );
 					if ( ! is_array( $decoded_content ) ) {
 						continue;
 					}
-					
+
 					// Check if this post has actual data (settings or styles).
 					$has_data = isset( $decoded_content['settings'] ) || isset( $decoded_content['styles'] );
 					if ( $has_data ) {
@@ -166,7 +166,7 @@ class Site_Style_Sync_Controller {
 					}
 				}
 			}
-			
+
 			$this->site_theme->merge( $user_data );
 
 			if ( isset( $this->site_theme->get_raw_data()['styles'] ) ) {

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -134,7 +134,40 @@ class Site_Style_Sync_Controller {
 			// Get only the theme and user customizations (e.g. from site editor).
 			$this->site_theme = new WP_Theme_JSON();
 			$this->site_theme->merge( WP_Theme_JSON_Resolver::get_theme_data() );
-			$this->site_theme->merge( WP_Theme_JSON_Resolver::get_user_data() );
+			
+			$user_data = WP_Theme_JSON_Resolver::get_user_data();
+			
+			// Fallback: If get_user_data() returns empty data, loop through all global styles posts
+			// to find one with actual data. This handles cases where theme paths don't match
+			// the post slug (e.g., subdirectory themes like 'pub/arbutus').
+			$user_data_raw = $user_data->get_raw_data();
+			$is_empty_data = ! isset( $user_data_raw['settings'] ) && ! isset( $user_data_raw['styles'] );
+			
+			if ( $is_empty_data ) {
+				$global_styles_posts = get_posts(
+					array(
+						'post_type'      => 'wp_global_styles',
+						'posts_per_page' => -1,
+						'post_status'    => 'publish',
+					)
+				);
+				
+				foreach ( $global_styles_posts as $post ) {
+					$decoded_content = json_decode( $post->post_content, true );
+					if ( ! is_array( $decoded_content ) ) {
+						continue;
+					}
+					
+					// Check if this post has actual data (settings or styles).
+					$has_data = isset( $decoded_content['settings'] ) || isset( $decoded_content['styles'] );
+					if ( $has_data ) {
+						$user_data = new WP_Theme_JSON( $decoded_content, 'custom' );
+						break;
+					}
+				}
+			}
+			
+			$this->site_theme->merge( $user_data );
 
 			if ( isset( $this->site_theme->get_raw_data()['styles'] ) ) {
 				$this->site_theme = WP_Theme_JSON::resolve_variables( $this->site_theme );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/NL-342/fix-missing-custom-color-palette-in-email

If `get_user_data()` returns empty data, loop through all global styles posts to find one with actual data. This handles cases where theme paths don't match the post slug (e.g., subdirectory themes like 'pub/arbutus').

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Without this change | With this change |
| ------ | ----- |
| <img width="597" height="453" alt="Screenshot 2026-01-07 at 2 23 54 PM" src="https://github.com/user-attachments/assets/d061f14c-66e6-4011-9661-02dd5cf7da7b" /> | <img width="605" height="450" alt="Screenshot 2026-01-07 at 2 23 24 PM" src="https://github.com/user-attachments/assets/dfd29243-4a59-49a8-8a89-bfae068b7fe1" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a self-hosted site with a Jetpack connection, add a custom color to your global styles palette (Appearance > Editor > Styles > Colors > Edit palette).
2. Create a post and use the custom color you added to style text or another block.
3. Use the editor Jetpack Newsletter panel to send yourself a test email or preview the email.
4. Verify that the custom color is applied.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Email Editor: Handle cases where theme paths don't match the post slug.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
