### PR TITLE
Add performance guidance to get_available_variations() docblock

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6106-get-available-variations-docs
+++ b/plugins/woocommerce/changelog/wooplug-6106-get-available-variations-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add performance guidance to WC_Product_Variable::get_available_variations() docblock

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -301,9 +301,26 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
-	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
+	 * Important: The default 'array' return type is expensive for products with many variations.
+	 * It calls get_available_variation() for each variation, which processes HTML generation
+	 * (wc_get_stock_html, get_price_html), price calculations (wc_get_price_to_display),
+	 * image attachment lookups, and dimension/weight formatting - all passed through filters.
 	 *
-	 * @return array[]|WC_Product_Variation[]
+	 * Use 'objects' when you only need the WC_Product_Variation objects or a subset of the generated
+	 * output of ::get_available_variation(), avoiding unnecessary processing overhead.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param string $return Optional. The format to return the results in. Default 'array'.
+	 *                       - 'array': Returns fully processed variation data arrays. Each variation
+	 *                         is passed through get_available_variation() which generates HTML,
+	 *                         calculates display prices, and formats dimensions/weights. Use this
+	 *                         when you need the complete variation data for front-end display.
+	 *                       - 'objects': Returns WC_Product_Variation objects directly without
+	 *                         additional processing. Use this when you need to work with variation
+	 *                         objects and will call methods on them selectively.
+	 * @return array[]|WC_Product_Variation[] Array of variation data arrays or variation objects.
+	 *
 	 * @phpstan-param 'array'|'objects' $return
 	 * @phpstan-return ($return is 'array' ? array[] : WC_Product_Variation[])
 	 */


### PR DESCRIPTION
## Summary

- Documents the performance implications of `WC_Product_Variable::get_available_variations()` with 'array' vs 'objects' return types
- The default 'array' return type is expensive for products with many variations as it processes HTML, prices, images, and formatting for each variation
- Guides developers toward using 'objects' when they only need variation objects

## Test plan

N/A

Partially fixes WOOPLUG-6106 / #62686