### PR TITLE
Add job summaries to release workflows

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -45,22 +45,36 @@ jobs:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     steps:
       - name: Workflow checks
+        env:
+          BRANCH: ${{ inputs.branch || github.ref }}
         run: |
           # No special checks when running as a reusable workflow.
           if [ "${{ ! contains( github.workflow_ref, 'release-build-zip-file.yml' ) }}" = "true" ]; then
             exit 0
           fi
 
+          # Build options summary.
+          options=""
+          [ "${{ inputs.skip_verify }}" = "true" ] && options="skipping verification"
+          [ "${{ inputs.create_github_release }}" = "true" ] && options="${options:+$options, }creating release"
+          [ -n "$options" ] && options=" ($options)"
+
+          # Log to console.
+          echo "Building WooCommerce ZIP: branch=${BRANCH}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"
+
+          # Write summary header.
+          echo "🔨 Building WooCommerce ZIP from \`${BRANCH}\`${options}." >> $GITHUB_STEP_SUMMARY
+
           # Must run from trunk.
           if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
-              echo "::error::This workflow must be run from the 'trunk' branch. Enter the release branch as input."
-              exit 1
+            echo "::error::This workflow must be run from the 'trunk' branch. Enter the release branch as input."
+            exit 1
           fi
 
           # Can not skip verification for actual releases.
           if [ "${{ inputs.create_github_release }}" = "true" ] && [ "${{ inputs.skip_verify }}" = "true" ]; then
-              echo "::error::Verification can not be skipped when building for a release."
-              exit 1
+            echo "::error::Verification cannot be skipped when building for a release."
+            exit 1
           fi
 
         # Checkout trunk.
@@ -92,32 +106,36 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+            # Helper to fail with console error and summary message.
+            fail() {
+              echo "::error::$1"
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "❌ Build failed. See annotations or workflow logs for details." >> $GITHUB_STEP_SUMMARY
+              exit 1
+            }
+
             # Branch name must be 'release/*'.
             branch_name="${BRANCH#refs/heads/}"
-            if  [[ $branch_name != release/* ]] ; then
-                echo "::error::Pre-build verification: branch name '$branch_name' is not matching 'release/*' pattern."
-                exit 1
+            if [[ $branch_name != release/* ]]; then
+              fail "Branch name '$branch_name' does not match 'release/*' pattern."
             fi
 
             # Version number in branch name and plugin main version must match.
             branch_plugin_version=$( cat checkout-branch/plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
             version_prefix=${branch_name/"release/"/""}
-            if [[ $branch_plugin_version != "$version_prefix."* ]] ; then
-                echo "::error::Pre-build verification: release version in branch ($branch_plugin_version) is not matching '$version_prefix.*' pattern."
-                exit 1
+            if [[ $branch_plugin_version != "$version_prefix."* ]]; then
+              fail "Release version in branch ($branch_plugin_version) does not match '$version_prefix.*' pattern."
             fi
 
             # GH release should not already exist.
             if gh release view "$branch_plugin_version" &>/dev/null; then
-              echo "::error::Pre-build verification: GitHub release '$branch_plugin_version' already exists."
-              exit 1
+              fail "GitHub release '$branch_plugin_version' already exists."
             fi
 
             # Release should not already exist on wporg.
             tag_exists=$(curl -s 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=woocommerce' | jq "(.versions | has(\"$branch_plugin_version\"))")
             if [ "$tag_exists" == "true" ]; then
-              echo "::error::Tag '$branch_plugin_version' already exists on WordPress.org."
-              exit 1
+              fail "Version '$branch_plugin_version' already exists on WordPress.org."
             fi
 
             # Stable version in release branch should match wporg.
@@ -133,24 +151,21 @@ jobs:
               branch_stable_version=$( cat checkout-branch/plugins/woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1 )            
 
               if [[ $branch_stable_version != $svn_stable_version ]] ; then
-                echo "::error::Pre-build verification: stable version in release branch ($branch_stable_version) is not matching the one in SVN trunk ($svn_stable_version)."
-                exit 1
+                fail "Stable version in release branch ($branch_stable_version) does not match SVN trunk ($svn_stable_version)."
               fi
             fi
 
             # No PRs against release branch should remain open.
             count=$( gh pr list --search "is:open base:$BRANCH" --limit 1 --json number | jq length )
             if (( count > 0 )); then
-                echo "::error::Pre-build verification: there are PRs against the release branch ($BRANCH) still open."
-                exit 1
+              fail "There are open PRs against the release branch ($BRANCH)."
             fi
 
             # No PRs with same milestone as main version should remain open.
             milestone="$version_prefix.0"
             count=$( gh pr list --search "is:open milestone:$milestone" --limit 1 --json number | jq length )
             if (( count > 0 )); then
-                echo "::error::Pre-build verification: there are PRs with milestone '$milestone' still open."
-                exit 1
+              fail "There are open PRs with milestone '$milestone'."
             fi
 
             # Changelog section must have at least one entry.
@@ -184,7 +199,7 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch || github.ref }}
         run: |
-          if ! git ls-remote --exit-code --heads  https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
+          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
             echo "::error::Source branch '$BRANCH' does not exist."
             exit 1
           fi
@@ -224,6 +239,10 @@ jobs:
           # Fetch commit hash for this build.
           commit_hash=$(git rev-parse "${{ inputs.branch || github.ref }}")
           echo "commit-hash=$commit_hash" >> $GITHUB_OUTPUT
+
+          # Write artifact to summary.
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📎 Build artifact: ${ARTIFACT_URL}" >> $GITHUB_STEP_SUMMARY
 
   create-release:
     name: Create GitHub release
@@ -268,3 +287,11 @@ jobs:
             --latest=false \
             --draft \
             $FLAGS
+
+          # Get the release URL directly using gh CLI, since drafts use a different URL.
+          release_url=$(gh release view "${{ steps.get_version.outputs.version }}" --json url --jq ".url")
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📦 Draft release created: ${release_url}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ For next steps, see the [release docs](https://developer.woocommerce.com/docs/contribution/releases/building-and-publishing/)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -53,16 +53,14 @@ jobs:
             exit 0
           fi
 
-          # Build options summary.
+          # Log inputs to console.
+          echo "Building WooCommerce ZIP: branch=${BRANCH}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"
+
+          # Write summary header.
           options=""
           [ "${{ inputs.skip_verify }}" = "true" ] && options="skipping verification"
           [ "${{ inputs.create_github_release }}" = "true" ] && options="${options:+$options, }creating release"
           [ -n "$options" ] && options=" ($options)"
-
-          # Log to console.
-          echo "Building WooCommerce ZIP: branch=${BRANCH}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"
-
-          # Write summary header.
           echo "🔨 Building WooCommerce ZIP from \`${BRANCH}\`${options}." >> $GITHUB_STEP_SUMMARY
 
           # Must run from trunk.

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Get current version
         id: get-current-version
         run: |
+          # Log inputs to console.
+          echo "Bumping version: branch=${{ inputs.branch }}, bump-type=${{ inputs.bump-type }}"
+
           version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
           echo "Current version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -61,8 +61,27 @@ jobs:
             const bumpType = `${{ inputs.bump-type }}`;
             const currentVersion = '${{ steps.get-current-version.outputs.version }}';
 
+            // Helper to write summary.
+            const writeSummary = async (nextVersion = null) => {
+              const versionTransition = nextVersion
+                ? `from \`${currentVersion}\` to \`${nextVersion}\``
+                : `from \`${currentVersion}\``;
+              await core.summary
+                .addRaw(`🚀 Bumping version on \`${branch}\` ${versionTransition} (${bumpType} bump).\n`)
+                .write();
+            };
+
+            // Helper to write error to summary.
+            const writeSummaryError = async (errorMsg) => {
+              await core.summary
+                .addRaw(`\n❌ **Error:** ${errorMsg}\n`)
+                .write();
+            };
+
             const m = currentVersion.match( /(?<base>\d+\.\d+)\.(?<patch>\d+)(-(?<prerelease>rc|beta|dev)(\.(?<prerelease_number>\d+))?)?/ );
             if ( ! m ) {
+              await writeSummary();
+              await writeSummaryError(`Current version (${currentVersion}) does not have the expected format.`);
               core.setFailed( `Current version (${ currentVersion }) does not have the expected format.` );
               return;
             }
@@ -81,11 +100,15 @@ jobs:
                 ( 'rc' === prerelease && ! [ 'rc', 'stable' ].includes( bumpType ) );
 
             if ( invalidBump ) {
+              await writeSummary();
+              await writeSummaryError(`Cannot perform a ${bumpType} bump on version ${currentVersion}.`);
               core.setFailed( `Bump type (${ bumpType }) does not apply to current version (${ currentVersion }).` );
               return;
             }
 
             if ( ( 'trunk' === branch && 'dev' !== bumpType ) || ( 'trunk' !== branch && 'dev' === bumpType ) ) {
+              await writeSummary();
+              await writeSummaryError(`Cannot perform a ${bumpType} bump on branch ${branch}.`);
               core.setFailed( `Bump type (${ bumpType }) does not apply to source branch (${ branch }).` );
               return;
             }
@@ -108,9 +131,14 @@ jobs:
                 break;
 
               default:
+                await writeSummary();
+                await writeSummaryError(`Invalid bump type: ${bumpType}.`);
                 core.setFailed(`Invalid bump type.`);
                 return;
             }
+
+            // Write success summary header.
+            await writeSummary(newVersion);
 
             core.setOutput( 'nextVersion', newVersion );
             core.setOutput( 'nextStable', newVersion.replace( /-(dev|(beta|rc)\.\d+)/, '' ) );
@@ -146,6 +174,8 @@ jobs:
           sed -i -E "s/public \\\$version = '[0-9]+\.[0-9]+\.[0-9]+.*';/public \\\$version = '$NEXT_VERSION'\;/" includes/class-woocommerce.php
 
           if git diff --quiet; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Error:** No file changes were detected. The version may already be set to ${NEXT_VERSION}." >> $GITHUB_STEP_SUMMARY
             echo "::error::No changes to commit."
             exit 1
           fi
@@ -192,14 +222,18 @@ jobs:
             fi
           fi
 
-          # Create PR.
-          gh pr create \
+          # Create PR and capture URL.
+          pr_url=$(gh pr create \
             --title 'Bump WooCommerce version to `${{ steps.compute-new-version.outputs.nextVersion }}` on `${{ inputs.branch }}`' \
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.'$'\n\n''<!-- [x] This Pull Request does not require a changelog -->' \
             --base ${{ inputs.branch }} \
             --head ${branch_name} \
             --label Release \
             ${reviewer_arg} \
-            ${milestone_arg}
+            ${milestone_arg})
+
+          # Write success to summary.
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Next step:** Review and merge [the pull request](${pr_url})." >> $GITHUB_STEP_SUMMARY
 
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -237,6 +237,6 @@ jobs:
 
           # Write success to summary.
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Next step:** Review and merge [the pull request](${pr_url})." >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ **Next step:** Review and merge [the pull request](${pr_url})." >> $GITHUB_STEP_SUMMARY
 
 

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -172,6 +172,8 @@ jobs:
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
           GITHUB_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
+
           # Log inputs to console.
           echo "Compiling changelog: version=$VERSION, branch=$SELECTED_BRANCH, append_changelog=${{ github.event.inputs.append_changelog }}, release_date=${{ github.event.inputs.release_date }}"
 

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -172,11 +172,11 @@ jobs:
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
           GITHUB_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Log inputs to console.
+          echo "Compiling changelog: version=$VERSION, branch=$SELECTED_BRANCH, append_changelog=${{ github.event.inputs.append_changelog }}, release_date=${{ github.event.inputs.release_date }}"
+
           # Write summary header.
           echo "📝 Compiling changelog for \`$VERSION\` on \`$SELECTED_BRANCH\`." >> $GITHUB_STEP_SUMMARY
-
-          echo "Using branch: $SELECTED_BRANCH"
-          echo "Generating changelog for version: $VERSION"
 
           # Determine whether to replace or append.
           APPEND_CHANGELOG=""

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -172,6 +172,9 @@ jobs:
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
           GITHUB_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Write summary header.
+          echo "📝 Compiling changelog for \`$VERSION\` on \`$SELECTED_BRANCH\`." >> $GITHUB_STEP_SUMMARY
+
           echo "Using branch: $SELECTED_BRANCH"
           echo "Generating changelog for version: $VERSION"
 
@@ -196,4 +199,18 @@ jobs:
             OVERRIDE_DATE="--override ${{ github.event.inputs.release_date }}"
           fi
 
-          pnpm utils code-freeze changelog -o ${{ github.repository_owner }} -v $VERSION -b $SELECTED_BRANCH $APPEND_CHANGELOG $OVERRIDE_DATE -ga ${{ github.actor }}
+          # Run changelog tool and capture output.
+          output=$(pnpm utils code-freeze changelog -o ${{ github.repository_owner }} -v $VERSION -b $SELECTED_BRANCH $APPEND_CHANGELOG $OVERRIDE_DATE -ga ${{ github.actor }} 2>&1 | tee /dev/stderr)
+
+          # Parse PR output (tab-separated: URL, branch, type) and write to summary.
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "$output" | grep "^https://github.com/" | while IFS=$'\t' read -r url branch type; do
+            if [[ "$type" == "changelog" ]]; then
+              echo "✅ Changelog PR targeting \`$branch\` [created]($url)." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ Changefile deletion PR targeting \`$branch\` [created]($url)." >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ **Next step:** Review and merge the PRs listed above." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -34,11 +34,15 @@ jobs:
     steps:
       - name: Check confirmation
         run: |
+          # Log inputs to console.
+          echo "Updating stable tag: version=${{ github.event.inputs.version }}, confirm-update=${{ github.event.inputs.confirm-update }}, allow-revert=${{ github.event.inputs.allow-revert }}"
+
+          # Write summary header.
+          echo "🏷️ Updating stable tag to \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
+
           if [ "${{ github.event.inputs.confirm-update }}" != "true" ]; then
-            echo "::error::You must check the confirmation checkbox to proceed with the stable tag update"
+            echo "::error::You must check the confirmation checkbox to proceed with the stable tag update."
             exit 1
-          else
-            echo "✅ Confirmation received - proceeding with stable tag update"
           fi
 
       - name: Validate release version
@@ -138,7 +142,7 @@ jobs:
           if svn list "${{ secrets.WPORG_SVN_URL }}/tags/$TARGET_VERSION" --username "${{ secrets.WPORG_SVN_USERNAME }}" --password "${{ secrets.WPORG_SVN_PASSWORD }}" --non-interactive > /dev/null 2>&1; then
             echo "✅ SVN tag '$TARGET_VERSION' exists"
           else
-            echo "::error::SVN tag '$TARGET_VERSION' does not exist in the repository"
+            echo "::error::SVN tag '$TARGET_VERSION' does not exist in the SVN repository"
             exit 1
           fi
 
@@ -218,6 +222,10 @@ jobs:
             echo "📤 Changes detected. Committing changes to SVN..."
             svn commit -m "Setting stable tag to $TARGET_VERSION" --username "${{ secrets.WPORG_SVN_USERNAME }}" --password "${{ secrets.WPORG_SVN_PASSWORD }}" --non-interactive
             echo "✅ Successfully committed stable tag update to $TARGET_VERSION"
+
+            # Write success to summary.
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ WordPress.org SVN updated: [view readme.txt on WordPress.org](https://plugins.trac.wordpress.org/browser/woocommerce/trunk/readme.txt#L7)" >> $GITHUB_STEP_SUMMARY
           fi
 
   update-gh-stable-tag:
@@ -279,16 +287,19 @@ jobs:
             milestone=$( cat ./plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
             echo "Using milestone: '$milestone'."
 
-            gh pr create \
+            pr_url=$(gh pr create \
               --title "Update stable tag to $TARGET_VERSION ($BRANCH_NAME)" \
               --body "This PR updates the stable tag to $TARGET_VERSION." \
               --base "$BRANCH_NAME" \
               --head "$UPDATE_BRANCH" \
               --reviewer ${{ github.actor }} \
               --label Release \
-              --milestone "$milestone"
+              --milestone "$milestone")
 
             echo "✅ Successfully created PR to update stable tag to $TARGET_VERSION on $BRANCH_NAME with milestone $milestone"
+
+            # Write PR to summary.
+            echo "✅ PR targeting \`$BRANCH_NAME\` [created](${pr_url})." >> $GITHUB_STEP_SUMMARY
           fi
 
   notify-release:
@@ -304,3 +315,10 @@ jobs:
           slack-optional-unfurl_links: false
           slack-text: |
             :woo-bounce: *<https://github.com/woocommerce/woocommerce/releases/tag/${{ github.event.inputs.version }}|WooCommerce ${{ github.event.inputs.version }}>* has been released! :rocket:
+
+      - name: Write next steps to summary
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📢 Release announcement sent." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ **Next step:** Review and merge the PRs listed above." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -284,7 +284,7 @@ jobs:
             git push origin "$UPDATE_BRANCH"
 
             # Determine milestone from woocommerce.php version.
-            milestone=$( cat ./plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed 's/\.[0-9]\+\(-dev\)\?$/.0/' )
+            milestone=$( cat ./plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 | sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+.*$/\1.0/' )
             echo "Using milestone: '$milestone'."
 
             pr_url=$(gh pr create \

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - name: Check confirmation
         run: |
+          # Log inputs to console.
+          echo "Uploading to WordPress.org: release=${{ inputs.release }}, confirm-update=${{ github.event.inputs.confirm-update }}"
+
+          # Write summary header.
+          echo "📤 Uploading release \`${{ inputs.release }}\` to WordPress.org." >> $GITHUB_STEP_SUMMARY
+
           if [ "${{ github.event.inputs.confirm-update }}" != "true" ]; then
             echo "::error::You must check the confirmation checkbox to proceed."
             exit 1
@@ -227,6 +233,14 @@ jobs:
             --non-interactive \
             --config-option=servers:global:http-timeout=1800
 
+          # Write success to summary.
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Release committed to WordPress.org (trunk + tag):" >> $GITHUB_STEP_SUMMARY
+          echo "- [view trunk](https://plugins.trac.wordpress.org/browser/woocommerce/trunk)" >> $GITHUB_STEP_SUMMARY
+          echo "- [view tag](https://plugins.trac.wordpress.org/browser/woocommerce/tags/$RELEASE_TAG)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ **Next step:** Validate the release as described in the [release docs](https://developer.woocommerce.com/docs/contribution/releases/building-and-publishing/)." >> $GITHUB_STEP_SUMMARY
+
       - name: Commit to tag only
         if: ${{ needs.get-and-validate-release-asset.outputs.overwrite_trunk != 1 }}
         working-directory: ./svn
@@ -253,3 +267,9 @@ jobs:
             --no-auth-cache \
             --non-interactive \
             --config-option=servers:global:http-timeout=1800
+
+          # Write success to summary.
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Release committed to WordPress.org (tag only): [view tag](https://plugins.trac.wordpress.org/browser/woocommerce/tags/$RELEASE_TAG)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⏭️ **Next step:** Validate the release as described in the [release docs](https://developer.woocommerce.com/docs/contribution/releases/building-and-publishing/)." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR enhances the output of release workflows by way of [job summaries](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary) which allow for better visibility into the execution of the jobs (as opposed to logs). It also provides some next steps for guidance.

Most workflows now link to the results of the process, be it the release artifact, tag, SVN tag, or the generated PRs, etc.

Closes WOOPLUG-5980, #62360.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

You can replicate everything below in your own fork or confirm with the runs in my own fork (linked at every step).

1. ([example run](https://github.com/jorgeatorres/woocommerce/actions/runs/20830949496)) Go to **Actions > Release: Bump version number** and run the workflow with inputs `release/10.3` (release branch) and `stable` (bump type).
   Once it finalizes, it should've produced a summary like the following one, including a link to the generated PR:
   <img width="446" height="125" alt="Screenshot 2026-01-08 at 12 58 56" src="https://github.com/user-attachments/assets/31545a75-9581-4bed-8390-a5d4feb11c50" />
   Merge this PR.
1. Use the GH UI to make any small change on `trunk` and make sure to include a changelog entry with it (you can use the automated CI tool for this). Set milestone `10.3.0` for that PR and merge.
   After merging, PRs targeting both `release/10.3` and `release/10.4` with a cherry pick of your change should've been created. Merge both.  
1. ([example run](https://github.com/jorgeatorres/woocommerce/actions/runs/20828960015)) Go to **Actions > Release: Compile changelog** and run with input `10.3` (version).
   Once the job finalizes, the summary should list all the PRs that need to be merged, their nature and indicate some next steps.
   <img width="400" height="" alt="Screenshot 2026-01-08 at 19 29 06" src="https://github.com/user-attachments/assets/07a1fe08-43d2-4d65-b10f-d70631199735" />
   Merge all those PRs.
1. ([example run](https://github.com/jorgeatorres/woocommerce/actions/runs/20831328423)) Run **Actions > Release: Build ZIP file** with inputs `release/10.3` (release branch) and check off **Create GitHub release**.
   Once the workflow completes, the summary should include links to the release artifact, the draft release itself and links to the release docs.
   <img width="800" height="542" alt="Screenshot 2026-01-08 at 21 06 47" src="https://github.com/user-attachments/assets/b3e1db79-6e4e-4f90-8535-9ea54f2cf798" />
1. Testing the **Release: Upload release to WordPress.org** and **Release: Update stable tag** is much more risky and complex, but you can see the results in my fork, which show the new summaries:
   - [Release: Upload release to WordPress.org](https://github.com/jorgeatorres/woocommerce/actions/runs/20832149971)
      <img width="400" height="380" alt="Screenshot 2026-01-08 at 21 22 47" src="https://github.com/user-attachments/assets/7ea5c5c6-02cb-4889-ad69-41308fa26d9c" />
   - [Release: Update stable tag](https://github.com/jorgeatorres/woocommerce/actions/runs/20832320161)
      <img width="400" height="664" alt="Screenshot 2026-01-08 at 21 36 42" src="https://github.com/user-attachments/assets/4268fc9a-5c53-42ab-a3ce-1f20e31ec58b" />

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.