### PR TITLE
Refactor Product Gallery Block to use ToolsPanel

### DIFF
--- a/plugins/woocommerce/changelog/59464-use-toolspanel-in-product-gallery-blocks
+++ b/plugins/woocommerce/changelog/59464-use-toolspanel-in-product-gallery-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removes PanelBody and uses ToolsPanel for Product Gallery block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/block-settings/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/block-settings/index.tsx
@@ -2,8 +2,14 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,34 +23,61 @@ export const ProductGalleryBlockSettings = ( {
 	const { hoverZoom, fullScreenOnClick } = attributes;
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Media Settings', 'woocommerce' ) }>
-				<ToggleControl
+			<ToolsPanel
+				label={ __( 'Media Settings', 'woocommerce' ) }
+				resetAll={ () => {
+					setAttributes( {
+						hoverZoom: true,
+						fullScreenOnClick: true,
+					} );
+				} }
+			>
+				<ToolsPanelItem
+					hasValue={ () => hoverZoom !== true }
 					label={ __( 'Zoom while hovering', 'woocommerce' ) }
-					help={ __(
-						'While hovering the image in the viewer will zoom in by 30%.',
-						'woocommerce'
-					) }
-					checked={ hoverZoom }
-					onChange={ () =>
-						setAttributes( {
-							hoverZoom: ! hoverZoom,
-						} )
-					}
-				/>
-				<ToggleControl
+					onDeselect={ () => setAttributes( { hoverZoom: true } ) }
+					isShownByDefault
+				>
+					<ToggleControl
+						label={ __( 'Zoom while hovering', 'woocommerce' ) }
+						help={ __(
+							'While hovering the image in the viewer will zoom in by 30%.',
+							'woocommerce'
+						) }
+						checked={ hoverZoom }
+						onChange={ () =>
+							setAttributes( {
+								hoverZoom: ! hoverZoom,
+							} )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					hasValue={ () => fullScreenOnClick !== true }
 					label={ __( 'Open pop-up when clicked', 'woocommerce' ) }
-					help={ __(
-						'Clicking on the image in the viewer will open a full-screen gallery experience.',
-						'woocommerce'
-					) }
-					checked={ fullScreenOnClick }
-					onChange={ () =>
-						setAttributes( {
-							fullScreenOnClick: ! fullScreenOnClick,
-						} )
+					onDeselect={ () =>
+						setAttributes( { fullScreenOnClick: true } )
 					}
-				/>
-			</PanelBody>
+					isShownByDefault
+				>
+					<ToggleControl
+						label={ __(
+							'Open pop-up when clicked',
+							'woocommerce'
+						) }
+						help={ __(
+							'Clicking on the image in the viewer will open a full-screen gallery experience.',
+							'woocommerce'
+						) }
+						checked={ fullScreenOnClick }
+						onChange={ () =>
+							setAttributes( {
+								fullScreenOnClick: ! fullScreenOnClick,
+							} )
+						}
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
 		</InspectorControls>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/block-settings/index.tsx
@@ -8,7 +8,10 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis, @woocommerce/dependency-group
 	__experimentalUnitControl as UnitControl,
 	SelectControl,
-	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 /**
@@ -81,70 +84,110 @@ export const ProductGalleryThumbnailsBlockSettings = ( {
 	];
 
 	return (
-		<PanelBody>
-			<UnitControl
+		<ToolsPanel
+			label={ __( 'Settings', 'woocommerce' ) }
+			resetAll={ () => {
+				setAttributes( {
+					thumbnailSize: '25%',
+					aspectRatio: '1',
+					activeThumbnailStyle:
+						ProductGalleryActiveThumbnailStyle.OVERLAY,
+				} );
+			} }
+		>
+			<ToolsPanelItem
+				hasValue={ () => thumbnailSize !== '25%' }
 				label={ __( 'Thumbnail Size', 'woocommerce' ) }
-				value={ thumbnailSize }
-				onChange={ ( value: string | undefined ) => {
-					const numberValue = Number(
-						value?.replace( '%', '' ) || defaultValue
-					);
-					const validated = Math.min(
-						Math.max( numberValue, minValue ),
-						maxValue
-					);
-					setAttributes( {
-						thumbnailSize: validated + '%',
-					} );
-				} }
-				units={ [ { value: '%', label: '%' } ] }
-				min={ minValue }
-				max={ maxValue }
-				step={ 1 }
-				size="default"
-				__next40pxDefaultSize
-				help={ __(
-					'Choose the size of each thumbnail in respect to the product image. If thumbnails container size gets bigger than the product image, thumbnails will turn to slider.',
-					'woocommerce'
-				) }
-			/>
-			<SelectControl
-				__next40pxDefaultSize
-				multiple={ false }
-				value={ aspectRatio }
-				options={ aspectRatioOptions }
-				label={ __( 'Aspect Ratio', 'woocommerce' ) }
-				onChange={ ( value ) => {
-					setAttributes( {
-						aspectRatio: value,
-					} );
-				} }
-				help={ __(
-					'Applies the selected aspect ratio to product thumbnails.',
-					'woocommerce'
-				) }
-			/>
-			<SelectControl
-				__next40pxDefaultSize
-				multiple={ false }
-				value={ activeThumbnailStyle }
-				options={ activeThumbnailStyleOptions }
-				label={ __( 'Active Thumbnail Style', 'woocommerce' ) }
-				onChange={ ( value ) => {
-					if (
-						value === ProductGalleryActiveThumbnailStyle.OVERLAY ||
-						value === ProductGalleryActiveThumbnailStyle.OUTLINE
-					) {
+				onDeselect={ () => setAttributes( { thumbnailSize: '25%' } ) }
+				isShownByDefault
+			>
+				<UnitControl
+					label={ __( 'Thumbnail Size', 'woocommerce' ) }
+					value={ thumbnailSize }
+					onChange={ ( value: string | undefined ) => {
+						const numberValue = Number(
+							value?.replace( '%', '' ) || defaultValue
+						);
+						const validated = Math.min(
+							Math.max( numberValue, minValue ),
+							maxValue
+						);
 						setAttributes( {
-							activeThumbnailStyle: value,
+							thumbnailSize: validated + '%',
 						} );
-					}
-				} }
-				help={ __(
-					'Choose how the active thumbnail is highlighted.',
-					'woocommerce'
-				) }
-			/>
-		</PanelBody>
+					} }
+					units={ [ { value: '%', label: '%' } ] }
+					min={ minValue }
+					max={ maxValue }
+					step={ 1 }
+					size="default"
+					__next40pxDefaultSize
+					help={ __(
+						'Choose the size of each thumbnail in respect to the product image. If thumbnails container size gets bigger than the product image, thumbnails will turn to slider.',
+						'woocommerce'
+					) }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () => aspectRatio !== '1' }
+				label={ __( 'Aspect Ratio', 'woocommerce' ) }
+				onDeselect={ () => setAttributes( { aspectRatio: '1' } ) }
+				isShownByDefault
+			>
+				<SelectControl
+					__next40pxDefaultSize
+					multiple={ false }
+					value={ aspectRatio }
+					options={ aspectRatioOptions }
+					label={ __( 'Aspect Ratio', 'woocommerce' ) }
+					onChange={ ( value ) => {
+						setAttributes( {
+							aspectRatio: value,
+						} );
+					} }
+					help={ __(
+						'Applies the selected aspect ratio to product thumbnails.',
+						'woocommerce'
+					) }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () =>
+					activeThumbnailStyle !==
+					ProductGalleryActiveThumbnailStyle.OVERLAY
+				}
+				label={ __( 'Active Thumbnail Style', 'woocommerce' ) }
+				onDeselect={ () =>
+					setAttributes( {
+						activeThumbnailStyle:
+							ProductGalleryActiveThumbnailStyle.OVERLAY,
+					} )
+				}
+				isShownByDefault
+			>
+				<SelectControl
+					__next40pxDefaultSize
+					multiple={ false }
+					value={ activeThumbnailStyle }
+					options={ activeThumbnailStyleOptions }
+					label={ __( 'Active Thumbnail Style', 'woocommerce' ) }
+					onChange={ ( value ) => {
+						if (
+							value ===
+								ProductGalleryActiveThumbnailStyle.OVERLAY ||
+							value === ProductGalleryActiveThumbnailStyle.OUTLINE
+						) {
+							setAttributes( {
+								activeThumbnailStyle: value,
+							} );
+						}
+					} }
+					help={ __(
+						'Choose how the active thumbnail is highlighted.',
+						'woocommerce'
+					) }
+				/>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR removes PanelBody and uses ToolsPanel in the Product Gallery and Product Gallery Thumbnail blocks.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #59464

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| | Before | After |
| --- | ------ | ----- |
| Product Gallery | <img width="279" height="594" alt="image" src="https://github.com/user-attachments/assets/c6506e98-6d8e-4f69-951d-70633a8f6983" /> | <img width="280" height="586" alt="image" src="https://github.com/user-attachments/assets/b6a233be-6a14-40bd-8d1e-5df776793803" /> |
| Thumbanil | <img width="280" height="682" alt="image" src="https://github.com/user-attachments/assets/f9f1277f-2e9d-49c5-ad7e-36180870e992" /> | <img width="280" height="703" alt="image" src="https://github.com/user-attachments/assets/d4992b76-b525-497c-81ef-152e2d0aa0a9" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a post
2. Add `Product` block
3. Select a product (for example: Beanie)
4. Add `Product Gallery` inside it and see the inspector control
5. Now click on the `Thumbnail` block (it should be inside `Product Gallery` block) and see the inspector control

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
