### PR TITLE
Unify loading indicator in the email editor with the site editor

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
+++ b/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Unify loading indicator with the site editor

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useEffect } from '@wordpress/element';
-import { SlotFillProvider, Spinner } from '@wordpress/components';
+import { SlotFillProvider, ProgressBar } from '@wordpress/components';
 import { store as coreStore, Post } from '@wordpress/core-data';
 import { CommandMenu, store as commandsStore } from '@wordpress/commands';
 import { PluginArea } from '@wordpress/plugins';
@@ -128,7 +128,7 @@ export function InnerEditor( {
 	if ( ! canRenderEditor ) {
 		return (
 			<div className="spinner-container">
-				<Spinner style={ { width: '80px', height: '80px' } } />
+				<ProgressBar />
 			</div>
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes loading indicator used when the email editor starts. Let's switch to ProgressBar which is also used in the Site Editor.

I found only one appearance of the Spinner in the codebase and replaced it with the ProgressBar component. 

Closes WOOPRD-1630.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="180" height="138" alt="Screenshot 2026-01-08 at 10 51 11" src="https://github.com/user-attachments/assets/3a82d1d5-1f00-4dc5-bd3d-09c318a95426" />| <img width="264" height="117" alt="Screenshot 2026-01-08 at 10 46 49" src="https://github.com/user-attachments/assets/685dc0eb-4a09-4166-b428-97d8b5c0b0aa" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1) Open the email editor and verify it shows the progress bar during the initial loading.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
