### PR TITLE
Skip changelog auto-add on bot-generated PRs

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     add-changelog:
         name: 'Add changelog to PR'
-        if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' && ( github.event_name != 'pull_request_target' || contains( github.event.pull_request.body, '[x] Automatically create a changelog' ) ) }}
+        if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' && github.event.pull_request.user.login != 'woocommercebot' && ( github.event_name != 'pull_request_target' || contains( github.event.pull_request.body, '[x] Automatically create a changelog' ) ) }}
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -270,6 +270,11 @@ jobs:
 
               prBody += `## Original PR Description\n\n${originalPr.body || '*No description provided*'}`;
 
+              // Replace milestone selection and changelog sections.
+              prBody = prBody.replace(/\[\s*(?:[xX])?\s*\]\s*(Automatically create a changelog.*)/g, '[ ] ~~$1~~');
+              prBody = prBody.replace(/\[\s*(?:[xX])?\s*\]\s*(This Pull Request does not require a changelog.*)/g, '[ ] ~~$1~~');
+              prBody = prBody.replace(/\[\s*(?:[xX])?\s*\]\s*(Automatically assign milestone.*\*\*.*next WooCommerce version.*\*\*.*)/g, '[ ] ~~$1~~');
+
               // Create new PR
               const { data: newPr } = await github.rest.pulls.create({
                 owner: context.repo.owner,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes the "changelog auto add" workflow be skipped on PRs where the `woocommercebot` account is the author as these are always the result of automations.

This also addresses an issue with backported PRs where duplicate changelog files might be generated ([example](https://github.com/woocommerce/woocommerce/pull/62478)). This is because the backport PR includes the description of the original PR, which might have the changelog autogeneration checkboxes checked off.

### How to test the changes in this Pull Request:

Given the involved workflow uses `pull_request_target` (which runs in the context of the default base branch, i.e. `trunk`) we need to test this in a fork.

1. Fork this repository including `trunk` and at least `release/10.4`. Make sure milestone `10.4.0` also exists in your repo.
1. Merge this PR into `trunk` in your repo.
1. Using the GH UI and submit a PR against `trunk` with any change.
1. Use the changelog section in the PR template to auto-generate a changelog file. ([Example in my fork](https://github.com/jorgeatorres/woocommerce/pull/456/changes/e3e0e7f238e2bca560a278323f6b4a16e2f06477)).
1. Merge the PR and set it to milestone `10.4.0` to trigger a backport.
1. Review the backport PR and confirm that the **Changelog Auto Add** job doesn't run in this backport and also that the changelog / milestone checkboxes appear in strikethrough style. ([Example in my fork](https://github.com/jorgeatorres/woocommerce/pull/458))
   <img width="500" height="" alt="Screenshot 2026-01-08 at 17 29 13" src="https://github.com/user-attachments/assets/5f0fad6e-3fbd-448a-bdc0-e4307c1992fc" />
   <img width="500" height="57" alt="Screenshot 2026-01-08 at 17 38 04" src="https://github.com/user-attachments/assets/8cefc037-edc7-488f-95a1-998219297147" />
1. Use the GH UI to temporarily edit `.github/workflows/changelog-auto-add.yml` on your fork's `trunk` changing the instance of `woocommercebot` [on line 25](https://github.com/woocommerce/woocommerce/blob/c1f714adcdf9ea3e73221657dc5e0277a47efe7a/.github/workflows/changelog-auto-add.yml#L25) to your own username.
1. Submit a PR with any change using your account and confirm that **Changelog Auto Add** doesn't run regardless of any changes you make to the changelog section in the PR template. ([Example in my fork](https://github.com/jorgeatorres/woocommerce/actions/runs/20826093430/job/59827683861?pr=459))

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.