### PR TITLE
Fix deprecated preg_match null subject warning

### DIFF
--- a/plugins/woocommerce/includes/libraries/class-wc-eval-math.php
+++ b/plugins/woocommerce/includes/libraries/class-wc-eval-math.php
@@ -159,7 +159,7 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 							$output[] = $o2;
 						}
 					}
-					if ( preg_match( "/^([A-Za-z]\w*)\($/", $stack->last( 2 ), $matches ) ) { // did we just close a function?
+					if ( preg_match( "/^([A-Za-z]\w*)\($/", (String) $stack->last( 2 ), $matches ) ) { // did we just close a function?
 						$fnn = $matches[1]; // get the function name
 						$arg_count = $stack->pop(); // see how many arguments there were (cleverly stored on the stack, thank you)
 						$output[] = $stack->pop(); // pop the function and push onto the output


### PR DESCRIPTION
Fixes #52689

Summary:
- Prevents passing null to preg_match
- Avoids PHP 8.1 deprecated warning
