### PR TITLE
Email editor: Skip adding spacer if the block already has a top-margin

### DIFF
--- a/packages/php/email-editor/changelog/62741-fix-email-editor-to-margin-spacer
+++ b/packages/php/email-editor/changelog/62741-fix-email-editor-to-margin-spacer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Email editor: Skip adding spacer if the block already has a top-margin.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
@@ -97,8 +97,21 @@ abstract class Abstract_Block_Renderer implements Block_Renderer {
 	 * @return string
 	 */
 	public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$rendered_content = $this->render_content( $block_content, $parsed_block, $rendering_context );
+
+		// Skip adding spacer if the block has its own margin-top set.
+		// The spacer adds wrapper divs that get extra margins from CSS inlining.
+		$block_margins = $parsed_block['attrs']['style']['spacing']['margin'] ?? array();
+		if ( ! empty( $block_margins ) ) {
+			$margin_top = $block_margins['top'] ?? '';
+			// Check if margin-top exists and is not explicitly '0' or empty.
+			if ( is_string( $margin_top ) && '' !== $margin_top && '0' !== $margin_top && '0px' !== $margin_top && '0em' !== $margin_top && '0rem' !== $margin_top ) {
+				return $rendered_content;
+			}
+		}
+
 		return $this->add_spacer(
-			$this->render_content( $block_content, $parsed_block, $rendering_context ),
+			$rendered_content,
 			$parsed_block['email_attrs'] ?? array()
 		);
 	}

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Paragraph_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Paragraph_Test.php
@@ -246,4 +246,58 @@ class Paragraph_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringNotContainsString( 'text-align:center;', $rendered );
 		$this->assertStringNotContainsString( 'align="center"', $rendered );
 	}
+
+	/**
+	 * Test it skips spacer when margin-top is set
+	 */
+	public function testItSkipsSpacerWhenMarginTopIsSet(): void {
+		$parsed_paragraph = $this->parsed_paragraph;
+		$parsed_paragraph['attrs']['style']['spacing']['margin']['top']  = '10px';
+		$parsed_paragraph['attrs']['style']['spacing']['margin']['left'] = '20px';
+
+		$rendered = $this->paragraph_renderer->render( '<p>Lorem Ipsum</p>', $parsed_paragraph, $this->rendering_context );
+		// Spacer wrapper should not be added when margin-top is set.
+		// The spacer adds a div with class "email-block-layout" and Outlook conditional comments.
+		$this->assertStringNotContainsString( 'email-block-layout', $rendered );
+		$this->assertStringNotContainsString( '<!--[if mso | IE]>', $rendered );
+		// Content should still be rendered.
+		$this->assertStringContainsString( 'Lorem Ipsum', $rendered );
+		$this->assertStringContainsString( 'font-size:16px;', $rendered );
+		// Margins should be applied to the table cell.
+		$this->assertStringContainsString( 'margin-top:10px', $rendered );
+		$this->assertStringContainsString( 'margin-left:20px', $rendered );
+	}
+
+	/**
+	 * Test it adds spacer when only margin-left is set
+	 */
+	public function testItAddsSpacerWhenOnlyMarginLeftIsSet(): void {
+		$parsed_paragraph = $this->parsed_paragraph;
+		$parsed_paragraph['attrs']['style']['spacing']['margin']['left'] = '20px';
+
+		$rendered = $this->paragraph_renderer->render( '<p>Lorem Ipsum</p>', $parsed_paragraph, $this->rendering_context );
+		// Spacer wrapper should be added when only margin-left is set (not margin-top).
+		$this->assertStringContainsString( 'email-block-layout', $rendered );
+		// Content should still be rendered.
+		$this->assertStringContainsString( 'Lorem Ipsum', $rendered );
+		$this->assertStringContainsString( 'font-size:16px;', $rendered );
+		// Margin-left should be applied to the table cell.
+		$this->assertStringContainsString( 'margin-left:20px', $rendered );
+	}
+
+	/**
+	 * Test it adds spacer when margin-top is zero
+	 */
+	public function testItAddsSpacerWhenMarginTopIsZero(): void {
+		$parsed_paragraph = $this->parsed_paragraph;
+		$parsed_paragraph['attrs']['style']['spacing']['margin']['top']  = '0';
+		$parsed_paragraph['attrs']['style']['spacing']['margin']['left'] = '20px';
+
+		$rendered = $this->paragraph_renderer->render( '<p>Lorem Ipsum</p>', $parsed_paragraph, $this->rendering_context );
+		// Spacer wrapper should be added when margin-top is 0.
+		$this->assertStringContainsString( 'email-block-layout', $rendered );
+		// Content should still be rendered.
+		$this->assertStringContainsString( 'Lorem Ipsum', $rendered );
+		$this->assertStringContainsString( 'font-size:16px;', $rendered );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/NL-335/newsletter-rendering-issues-on-respostanapalavracom

- A user reported oversized spaces between paragraphs, and I traced it to the spacer that the `Abstract_Block_Renderer` adds: a top margin of 16px plus a bottom margin of 24px. This change prevents the spacer from being added when the user has set their own top paragraph margin (or other top block margins). 
- Also, in the editor, either a top/bottom or left/right margin can be added. We don't want to skip the spacer if it's a left/right margin.
- The margin setting isn't available in the WooCommerce Email Editor UI.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="936" height="522" alt="Screenshot 2026-01-08 at 1 42 37 PM" src="https://github.com/user-attachments/assets/c27544ed-b8e9-4a0a-a6c1-8be3d4589ab6" /> | <img width="811" height="488" alt="Screenshot 2026-01-08 at 1 42 25 PM" src="https://github.com/user-attachments/assets/8094d3f5-ac96-4ffb-a032-aaf3609a9f81" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Test on WP.com: PCYsg-19om-p2

1. Add a paragraph block to a post. In block settings > Dimensions, add a top/bottom margin.
2. Check that only the selected margin is added (no extra spacer div). I check by sending a test email and inspecting the html.
3. Test paragraph blocks with no margins and left/right margins. Verify that the spacer div is added.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Email editor: Skip adding spacer if the block already has a top-margin.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>