### PR TITLE
[Fraud Protection] Added tracking to visits to checkout and cart pages

### DIFF
--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
@@ -8,6 +8,9 @@
  * @version 2.3.0
  */
 
+use Automattic\WooCommerce\Internal\FraudProtection\CartEventTracker;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -77,6 +80,12 @@ class WC_Shortcode_Cart {
 
 		// Constants.
 		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
+
+		// Track cart page loaded for fraud protection.
+		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( CartEventTracker::class )
+				->track_cart_page_loaded();
+		}
 
 		$atts        = shortcode_atts( array(), $atts, 'woocommerce_cart' );
 		$nonce_value = wc_get_var( $_REQUEST['woocommerce-shipping-calculator-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -345,6 +345,12 @@ class WC_Shortcode_Checkout {
 			return;
 		}
 
+		// Track checkout page loaded for fraud protection.
+		if ( wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker::class )
+				->track_checkout_page_loaded();
+		}
+
 		// Check cart contents for errors.
 		do_action( 'woocommerce_check_cart_items' );
 

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -11,6 +11,8 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
 use Automattic\WooCommerce\Internal\Utilities\Users;
 
 /**
@@ -346,8 +348,8 @@ class WC_Shortcode_Checkout {
 		}
 
 		// Track checkout page loaded for fraud protection.
-		if ( wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController::class )->feature_is_enabled() ) {
-			wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker::class )
+		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_checkout_page_loaded();
 		}
 

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -8,6 +8,9 @@
  * @version 2.0.0
  */
 
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
+use Automattic\WooCommerce\Internal\FraudProtection\PaymentMethodEventTracker;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -409,6 +412,12 @@ class WC_Shortcode_My_Account {
 			wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
 			exit();
 		} else {
+			// Track add payment method page loaded for fraud protection.
+			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+				wc_get_container()->get( PaymentMethodEventTracker::class )
+					->track_add_payment_method_page_loaded();
+			}
+
 			do_action( 'before_woocommerce_add_payment_method' );
 
 			wc_get_template( 'myaccount/form-add-payment-method.php' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -2,7 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
-use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
+use Automattic\WooCommerce\Internal\FraudProtection\CartEventTracker;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
 
 /**
  * Cart class.
@@ -164,6 +165,12 @@ class Cart extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		// Dequeue the core scripts when rendering this block.
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
+
+		// Track cart page loaded for fraud protection.
+		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( CartEventTracker::class )
+				->track_cart_page_loaded();
+		}
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -230,6 +230,12 @@ class Checkout extends AbstractBlock {
 			return wp_is_block_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
 
+		// Track checkout page loaded for fraud protection.
+		if ( wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker::class )
+				->track_checkout_page_loaded();
+		}
+
 		// Dequeue the core scripts when rendering this block.
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\StoreApi\Utilities\PaymentUtils;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFieldsSchema\Validation;
 use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
+use Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
 
 /**
  * Checkout class.
@@ -231,8 +233,8 @@ class Checkout extends AbstractBlock {
 		}
 
 		// Track checkout page loaded for fraud protection.
-		if ( wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController::class )->feature_is_enabled() ) {
-			wc_get_container()->get( \Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker::class )
+		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_checkout_page_loaded();
 		}
 

--- a/plugins/woocommerce/src/Internal/FraudProtection/CartEventTracker.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/CartEventTracker.php
@@ -40,6 +40,20 @@ class CartEventTracker {
 	}
 
 	/**
+	 * Track cart page loaded event.
+	 *
+	 * Triggers fraud protection event dispatching when the cart page is initially loaded.
+	 * This captures the initial session state before any user interactions.
+	 *
+	 * @internal
+	 * @return void
+	 */
+	public function track_cart_page_loaded(): void {
+		// Track the page load event. Session data will be collected by the dispatcher.
+		$this->dispatcher->dispatch_event( 'cart_page_loaded', array() );
+	}
+
+	/**
 	 * Track cart item added event.
 	 *
 	 * Triggers fraud protection event dispatching when an item is added to the cart.

--- a/plugins/woocommerce/src/Internal/FraudProtection/CheckoutEventTracker.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/CheckoutEventTracker.php
@@ -49,6 +49,20 @@ class CheckoutEventTracker {
 	}
 
 	/**
+	 * Track checkout page loaded event.
+	 *
+	 * Triggers fraud protection event dispatching when the checkout page is initially loaded.
+	 * This captures the initial session state before any user interactions.
+	 *
+	 * @internal
+	 * @return void
+	 */
+	public function track_checkout_page_loaded(): void {
+		// Track the page load event. Session data will be collected by the dispatcher.
+		$this->dispatcher->dispatch_event( 'checkout_page_loaded', array() );
+	}
+
+	/**
 	 * Track Store API customer update event (WooCommerce Blocks checkout).
 	 *
 	 * Triggered when customer information is updated via the Store API endpoint

--- a/plugins/woocommerce/src/Internal/FraudProtection/PaymentMethodEventTracker.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/PaymentMethodEventTracker.php
@@ -40,6 +40,20 @@ class PaymentMethodEventTracker {
 	}
 
 	/**
+	 * Track add payment method page loaded event.
+	 *
+	 * Triggers fraud protection event dispatching when the add payment method page is initially loaded.
+	 * This captures the initial session state before any user interactions.
+	 *
+	 * @internal
+	 * @return void
+	 */
+	public function track_add_payment_method_page_loaded(): void {
+		// Track the page load event. Session data will be collected by the dispatcher.
+		$this->dispatcher->dispatch_event( 'add_payment_method_page_loaded', array() );
+	}
+
+	/**
 	 * Track payment method added event.
 	 *
 	 * Triggers fraud protection event tracking when a payment method is added.

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CartEventTrackerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CartEventTrackerTest.php
@@ -73,6 +73,26 @@ class CartEventTrackerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test track_cart_page_loaded dispatches event.
+	 * The CartEventTracker::track_cart_page_loaded does not add any event data.
+	 * The data collection is handled by the SessionDataCollector.
+	 * So we only need to test if the dispatcher is called with no event data.
+	 */
+	public function test_track_cart_page_loaded_dispatches_event(): void {
+		// Mock dispatcher to verify event is dispatched with empty event data.
+		$this->mock_dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				$this->equalTo( 'cart_page_loaded' ),
+				$this->equalTo( array() )
+			);
+
+		// Call the method.
+		$this->sut->track_cart_page_loaded();
+	}
+
+	/**
 	 * Test track_cart_item_added tracks event.
 	 */
 	public function test_track_cart_item_added_tracks_event(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CheckoutEventTrackerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CheckoutEventTrackerTest.php
@@ -71,6 +71,30 @@ class CheckoutEventTrackerTest extends \WC_Unit_Test_Case {
 	}
 
 	// ========================================
+	// Checkout Page Load Tests
+	// ========================================
+
+	/**
+	 * Test track_checkout_page_loaded dispatches event.
+	 * The CheckoutEventTracker::track_checkout_page_loaded does not add any event data.
+	 * The data collection is handled by the SessionDataCollector.
+	 * So we only need to test if the dispatcher is called with no event data.
+	 */
+	public function test_track_checkout_page_loaded_dispatches_event(): void {
+		// Mock dispatcher to verify event is dispatched with empty event data.
+		$this->mock_dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				$this->equalTo( 'checkout_page_loaded' ),
+				$this->equalTo( array() )
+			);
+
+		// Call the method.
+		$this->sut->track_checkout_page_loaded();
+	}
+
+	// ========================================
 	// Blocks Checkout Tests
 	// ========================================
 

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
@@ -27,6 +27,13 @@ class PaymentMethodEventTrackerTest extends \WC_Unit_Test_Case {
 	private $sut;
 
 	/**
+	 * Mock fraud protection dispatcher.
+	 *
+	 * @var \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionDispatcher|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $mock_dispatcher;
+
+	/**
 	 * Setup test.
 	 */
 	public function setUp(): void {
@@ -39,6 +46,32 @@ class PaymentMethodEventTrackerTest extends \WC_Unit_Test_Case {
 		$container->reset_all_resolved();
 
 		$this->sut = $container->get( PaymentMethodEventTracker::class );
+	}
+
+	/**
+	 * Test add payment method page loaded event tracking.
+	 *
+	 * @testdox Should track add payment method page loaded event.
+	 */
+	public function test_track_add_payment_method_page_loaded_dispatches_event(): void {
+		// Create mock dispatcher.
+		$this->mock_dispatcher = $this->createMock( \Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionDispatcher::class );
+
+		// Create system under test with mock dispatcher.
+		$sut = new PaymentMethodEventTracker();
+		$sut->init( $this->mock_dispatcher );
+
+		// Mock dispatcher to verify event is dispatched with empty event data.
+		$this->mock_dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				$this->equalTo( 'add_payment_method_page_loaded' ),
+				$this->equalTo( array() )
+			);
+
+		// Call the method.
+		$sut->track_add_payment_method_page_loaded();
 	}
 
 	/**


### PR DESCRIPTION
# Track Cart and Checkout Page Loads for Fraud Protection

## Summary
This PR adds tracking for cart and checkout page loads to the WooCommerce fraud protection system. When customers visit these critical pages, session data is captured for fraud analysis before any user interactions occur.

## Changes Made

### New Event Types
- **`cart_page_loaded`** - Triggered when a customer lands on the cart page
- **`checkout_page_loaded`** - Triggered when a customer lands on the checkout page
## Testing
### Manual Testing Instructions

#### Prerequisites
1. Enable the fraud protection feature flag:
   ```php
   add_filter( 'woocommerce_feature_enabled', function( $enabled, $feature ) {
       if ( 'fraud_protection' === $feature ) {
           return true;
       }
       return $enabled;
   }, 10, 2 );
   ```

2. Enable WooCommerce logging:
   - Go to WooCommerce → Status → Logs
   - Select the `woo-fraud-protection` log file

#### Test Case 1: Shortcode Cart Page Load Tracking

**Steps:**
1. Clear your WooCommerce logs
2. Navigate to the Cart page (using shortcode/classic cart)
3. Check the WooCommerce logs for `woo-fraud-protection`

**Expected Result:**
- Log entry showing: `Fraud protection event tracked: cart_page_loaded`
- Event data includes:
  - `event_type`: `cart_page_loaded`
  - `session.session_id`: Unique session identifier
  - `session.ip_address`: Customer IP
  - `session.user_agent`: Browser user agent
  - `order.cart_hash`: Current cart hash
  - `order.items_total`: Cart item count

#### Test Case 2: Block Cart Page Load Tracking

**Steps:**
1. Enable a block theme or add the Cart block to a page
2. Clear your WooCommerce logs
3. Navigate to the Cart block page
4. Check the WooCommerce logs for `woo-fraud-protection`

**Expected Result:**
- Same as Test Case 1
- Tracking occurs for block-based cart

#### Test Case 3: Shortcode Checkout Page Load Tracking

**Steps:**
1. Add items to cart
2. Clear your WooCommerce logs
3. Navigate to the Checkout page (classic checkout)
4. Check the WooCommerce logs for `woo-fraud-protection`

**Expected Result:**
- Log entry showing: `Fraud protection event tracked: checkout_page_loaded`
- Event data includes:
  - `event_type`: `checkout_page_loaded`
  - Full session and cart data
  - Customer data (if logged in)

#### Test Case 4: Block Checkout Page Load Tracking

**Steps:**
1. Enable a block theme or add the Checkout block to a page
2. Add items to cart
3. Clear your WooCommerce logs
4. Navigate to the Checkout block page
5. Check the WooCommerce logs for `woo-fraud-protection`

**Expected Result:**
- Same as Test Case 3
- Tracking occurs for block-based checkout

#### Test Case 5: Feature Flag Disabled

**Steps:**
1. Disable the fraud protection feature flag
2. Navigate to cart and checkout pages
3. Check the WooCommerce logs

**Expected Result:**
- No fraud protection events logged
- No errors in PHP error log
- Pages function normally

#### Test Case 6: Empty Cart Scenario

**Steps:**
1. Ensure cart is empty
2. Navigate to the Cart page
3. Check logs

**Expected Result:**
- Event still tracked (important for fraud detection)
- `order.items_total`: 0
- `order.cart_hash`: Empty cart hash

#### Test Case 7: Multiple Page Loads

**Steps:**
1. Clear logs
2. Visit cart page → check logs
3. Visit checkout page → check logs
4. Go back to cart → check logs
5. Return to checkout → check logs

**Expected Result:**
- Each page load generates a separate event
- Each event has a unique timestamp
- Session ID remains consistent across page loads

#### Test Case 8: Logged In vs Guest Users

**Steps:**
1. As a guest user, visit cart and checkout → check logs
2. Log in as a customer
3. Visit cart and checkout again → check logs

**Expected Result:**
- Guest user events: `customer` data mostly empty or null
- Logged-in user events: `customer` data populated with:
  - `first_name`, `last_name`
  - `billing_email`
  - `lifetime_order_count`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
