### PR TITLE
Set preferred term in core Breadrcumbs block to keep compatibility with Woo's block

### DIFF
--- a/plugins/woocommerce/changelog/add-breadcrumbs-extensibility-points
+++ b/plugins/woocommerce/changelog/add-breadcrumbs-extensibility-points
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Breadcrumbs: Set preferred term in core Breadrcumbs block to keep compatibility with Woo's block

--- a/plugins/woocommerce/changelog/add-breadcrumbs-extensibility-points
+++ b/plugins/woocommerce/changelog/add-breadcrumbs-extensibility-points
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Breadcrumbs: Set preferred term in core Breadrcumbs block to keep compatibility with Woo's block
+Breadcrumbs: Set preferred term in core Breadcrumbs block to keep compatibility with Woo's block

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -718,8 +718,8 @@ final class BlockTypesController {
 				 *
 				 * @since 9.5.0
 				 *
-				 * @param WP_Term   $main_term The main term to be used in breadcrumbs.
-				 * @param WP_Term[] $terms     Array of all product category terms.
+				 * @param \WP_Term   $main_term The main term to be used in breadcrumbs.
+				 * @param \WP_Term[] $terms     Array of all product category terms.
 				 */
 				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,7 +63,7 @@ final class BlockTypesController {
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
 		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
-		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 2 );
+		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 3 );
 	}
 
 	/**
@@ -671,20 +671,50 @@ final class BlockTypesController {
 	}
 
 	/**
-	 * Change the preferred taxonomy for the breadcrumbs block on the product post type.
+	 * Set the preferred taxonomy and term for the breadcrumbs block on the product post type.
+	 *
+	 * This method mimics the behavior of WC_Breadcrumb::add_crumbs_single() to ensure
+	 * consistent breadcrumb term selection between WooCommerce's legacy breadcrumbs
+	 * and the Core breadcrumbs block.
 	 *
 	 * @param array  $settings The settings for the breadcrumbs block.
 	 * @param string $post_type The post type.
+	 * @param int    $post_id The current post ID.
 	 * @return array The settings for the breadcrumbs block.
 	 *
 	 * @internal
 	 */
-	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type ) {
+	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type, $post_id = 0 ) {
 		if ( ! is_array( $settings ) || 'product' !== $post_type ) {
 			return $settings;
 		}
 
 		$settings['taxonomy'] = 'product_cat';
+
+		// If we have a post ID, determine the specific term using WooCommerce's logic.
+		if ( ! empty( $post_id ) ) {
+			$terms = wc_get_product_terms(
+				$post_id,
+				'product_cat',
+				apply_filters(
+					'woocommerce_breadcrumb_product_terms_args',
+					array(
+						'orderby' => 'parent',
+						'order'   => 'DESC',
+					)
+				)
+			);
+
+			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+				// Apply the same filter WooCommerce uses to determine the main term.
+				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );
+
+				if ( $main_term && isset( $main_term->term_id ) ) {
+					$settings['term_id'] = $main_term->term_id;
+				}
+			}
+		}
+
 		return $settings;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -723,7 +723,7 @@ final class BlockTypesController {
 				 */
 				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );
 
-				if ( $main_term && isset( $main_term->slug ) ) {
+				if ( $main_term instanceof \WP_Term ) {
 					$settings['term'] = $main_term->slug;
 				}
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -709,8 +709,8 @@ final class BlockTypesController {
 				// Apply the same filter WooCommerce uses to determine the main term.
 				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );
 
-				if ( $main_term && isset( $main_term->term_id ) ) {
-					$settings['term_id'] = $main_term->term_id;
+				if ( $main_term && isset( $main_term->slug ) ) {
+					$settings['term'] = $main_term->slug;
 				}
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -693,6 +693,13 @@ final class BlockTypesController {
 
 		// If we have a post ID, determine the specific term using WooCommerce's logic.
 		if ( ! empty( $post_id ) ) {
+			/**
+			 * Filters the arguments used to fetch product terms for breadcrumbs.
+			 *
+			 * @since 9.5.0
+			 *
+			 * @param array $args Array of arguments for `wc_get_product_terms()`.
+			 */
 			$terms = wc_get_product_terms(
 				$post_id,
 				'product_cat',
@@ -706,7 +713,14 @@ final class BlockTypesController {
 			);
 
 			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-				// Apply the same filter WooCommerce uses to determine the main term.
+				/**
+				 * Filters the main term used in product breadcrumbs.
+				 *
+				 * @since 9.5.0
+				 *
+				 * @param WP_Term   $main_term The main term to be used in breadcrumbs.
+				 * @param WP_Term[] $terms     Array of all product category terms.
+				 */
 				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );
 
 				if ( $main_term && isset( $main_term->slug ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -693,16 +693,16 @@ final class BlockTypesController {
 
 		// If we have a post ID, determine the specific term using WooCommerce's logic.
 		if ( ! empty( $post_id ) ) {
-			/**
-			 * Filters the arguments used to fetch product terms for breadcrumbs.
-			 *
-			 * @since 9.5.0
-			 *
-			 * @param array $args Array of arguments for `wc_get_product_terms()`.
-			 */
 			$terms = wc_get_product_terms(
 				$post_id,
 				'product_cat',
+				/**
+				 * Filters the arguments used to fetch product terms for breadcrumbs.
+				 *
+				 * @since 9.5.0
+				 *
+				 * @param array $args Array of arguments for `wc_get_product_terms()`.
+				 */
 				apply_filters(
 					'woocommerce_breadcrumb_product_terms_args',
 					array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR enhances the Core breadcrumbs block integration to respect WooCommerce's breadcrumb term selection filters, ensuring consistent behavior between WooCommerce's Breadcrumbs and the Core Breadcrumbs block.

**What changed:**
- Extended `set_product_breadcrumbs_preferred_taxonomy()` to accept and utilize the `$post_id` parameter now provided by WordPress Core's `block_core_breadcrumbs_post_type_settings` filter (WordPress PR #74170 -  not yet merged, needs to be merged in order to work(!))
- Added logic to fetch product terms using `wc_get_product_terms()` with the `woocommerce_breadcrumb_product_terms_args` filter applied
- Applied the `woocommerce_breadcrumb_main_term` filter to determine which term should be used in breadcrumbs

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="507" height="238" alt="image" src="https://github.com/user-attachments/assets/c9b40583-eeb0-494c-b57b-87c090426365" />   |    <img width="414" height="242" alt="image" src="https://github.com/user-attachments/assets/9e838070-d7fc-46ce-9a77-ac7522dde363" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you use Gutenberg built from this branch [PR #74170](https://github.com/WordPress/gutenberg/pull/74170) (or `trunk` if PR is already merged). Also, make sure you have experimental Gutenberg blocks enabled.
2. Create a product with multiple categories assigned 
3. Add this test filter to your theme's `functions.php`. It reverts the default order so you can see the difference easily:

```
add_filter(
	'woocommerce_breadcrumb_product_terms_args',
	function ( $args ) {
		$args['orderby'] = 'name';
		$args['order']   = 'DESC';

		return $args;
	}
);
```

4. Go to Editor > Single Product and insert both blocks:
  - Store Breadrcumbs (Woo)
  - Breadcrumbs (Gutenberg)
5. Go to frontend
6. **Expected:** Both block show the same categories 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
