### PR TITLE
Adds controller boilerplate for the push token registration endpoint

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -13,9 +13,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use InvalidArgumentException;
 use Exception;
-use WP_REST_Server;
 use WP_REST_Request;
-use WP_REST_Response;
 use WP_Error;
 use WP_Http;
 
@@ -132,13 +130,13 @@ class PushTokenRestController extends RestApiControllerBase {
 			default => 'rest_internal_error',
 		};
 
-		$code = match ( get_class( $e ) ) {
+		$status = match ( get_class( $e ) ) {
 			PushTokenNotFoundException::class => WP_Http::NOT_FOUND,
 			InvalidArgumentException::class => WP_Http::BAD_REQUEST,
 			default => WP_Http::INTERNAL_SERVER_ERROR,
 		};
 
-		return new WP_Error( $slug, $e->getMessage(), array( 'status' => $code ) );
+		return new WP_Error( $slug, $e->getMessage(), array( 'status' => $status ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -86,7 +86,8 @@ class PushTokenRestController extends RestApiControllerBase {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @param WP_REST_Request<array<string, mixed>> $request The request object. phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
+	 * @param WP_REST_Request $request The request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 * @return bool|WP_Error
 	 */
 	public function authorize( WP_REST_Request $request ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -218,7 +218,7 @@ class PushTokenRestController extends RestApiControllerBase {
 		if ( $context ) {
 			$args = array_filter(
 				$args,
-				fn ( $arg ) => in_array( $context, $arg['context'] ?? [], true )
+				fn ( $arg ) => in_array( $context, $arg['context'], true )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -20,6 +20,8 @@ use WP_Http;
 /**
  * Controller for the REST endpoints associated with push notification device
  * tokens.
+ *
+ * @since 10.5.0
  */
 class PushTokenRestController extends RestApiControllerBase {
 	/**
@@ -39,6 +41,8 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the WooCommerce REST API namespace for the class.
 	 *
+	 * @since 10.5.0
+	 *
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
@@ -47,14 +51,18 @@ class PushTokenRestController extends RestApiControllerBase {
 
 	/**
 	 * Register the REST API endpoints handled by this controller.
+	 *
+	 * @since 10.5.0
 	 */
 	public function register_routes() {
-		// Routes will registered here, can't omit method due to parent class
+		// Routes will be registered here, can't omit method due to parent class
 		// constraints.
 	}
 
 	/**
 	 * Get the schema for the POST endpoint.
+	 *
+	 * @since 10.5.0
 	 *
 	 * @return array[]
 	 */
@@ -73,6 +81,8 @@ class PushTokenRestController extends RestApiControllerBase {
 
 	/**
 	 * Checks user is authorized to access this endpoint.
+	 *
+	 * @since 10.5.0
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return bool|WP_Error
@@ -120,6 +130,8 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Converts an exception to an instance of WP_Error.
 	 *
+	 * @since 10.5.0
+	 *
 	 * @param Exception $e The exception to convert.
 	 * @return WP_Error
 	 */
@@ -144,6 +156,8 @@ class PushTokenRestController extends RestApiControllerBase {
 
 	/**
 	 * Get the accepted arguments for the POST request.
+	 *
+	 * @since 10.5.0
 	 *
 	 * @param string $context The context to return args for.
 	 * @return array
@@ -170,7 +184,6 @@ class PushTokenRestController extends RestApiControllerBase {
 				'default'           => '',
 				'type'              => 'string',
 				'context'           => array( 'create' ),
-				'validate_callback' => array( $this, 'validate_device_uuid' ),
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'platform'    => array(
@@ -185,8 +198,7 @@ class PushTokenRestController extends RestApiControllerBase {
 				'type'              => 'string',
 				'required'          => true,
 				'context'           => array( 'create' ),
-				'validate_callback' => array( $this, 'validate_token' ),
-				'sanitize_callback' => 'wp_unslash',
+				'sanitize_callback' => 'sanitize_text_field',
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -36,7 +36,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	 *
 	 * @var string
 	 */
-	protected string $rest_base = '/push-tokens';
+	protected string $rest_base = 'push-tokens';
 
 	/**
 	 * Get the WooCommerce REST API namespace for the class.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -211,7 +211,7 @@ class PushTokenRestController extends RestApiControllerBase {
 				'type'              => 'string',
 				'required'          => true,
 				'context'           => array( 'create' ),
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => 'wp_unslash',
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -53,8 +53,10 @@ class PushTokenRestController extends RestApiControllerBase {
 	 * Register the REST API endpoints handled by this controller.
 	 *
 	 * @since 10.5.0
+	 *
+	 * @return void
 	 */
-	public function register_routes() {
+	public function register_routes(): void {
 		// Routes will be registered here, can't omit method due to parent class
 		// constraints.
 	}
@@ -84,7 +86,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @param WP_REST_Request $request The request object.
+	 * @param WP_REST_Request<array<string, mixed>> $request The request object.
 	 * @return bool|WP_Error
 	 */
 	public function authorize( WP_REST_Request $request ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -86,7 +86,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @param WP_REST_Request<array<string, mixed>> $request The request object.
+	 * @param WP_REST_Request<array<string, mixed>> $request The request object. phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
 	 * @return bool|WP_Error
 	 */
 	public function authorize( WP_REST_Request $request ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -21,7 +21,7 @@ use WP_Http;
  * Controller for the REST endpoints associated with push notification device
  * tokens.
  *
- * @since 10.5.0
+ * @since 10.6.0
  */
 class PushTokenRestController extends RestApiControllerBase {
 	/**
@@ -41,7 +41,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the WooCommerce REST API namespace for the class.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @return string
 	 */
@@ -52,7 +52,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Register the REST API endpoints handled by this controller.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @return void
 	 */
@@ -64,7 +64,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the schema for the POST endpoint.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @return array[]
 	 */
@@ -94,7 +94,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Checks user is authorized to access this endpoint.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
@@ -143,7 +143,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Converts an exception to an instance of WP_Error.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @param Exception $e The exception to convert.
 	 * @return WP_Error
@@ -170,7 +170,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the accepted arguments for the POST request.
 	 *
-	 * @since 10.5.0
+	 * @since 10.6.0
 	 *
 	 * @param string $context The context to return args for.
 	 * @return array

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -74,7 +74,17 @@ class PushTokenRestController extends RestApiControllerBase {
 			array(
 				'title'      => PushToken::POST_TYPE,
 				'properties' => array_map(
-					fn ( $item ) => array_diff_key( $item, array( 'validate_callback' => null ) ),
+					fn ( $item ) => array_intersect_key(
+						$item,
+						array(
+							'description' => null,
+							'type'        => null,
+							'enum'        => null,
+							'minimum'     => null,
+							'default'     => null,
+							'required'    => null,
+						)
+					),
 					$this->get_args()
 				),
 			)
@@ -208,7 +218,7 @@ class PushTokenRestController extends RestApiControllerBase {
 		if ( $context ) {
 			$args = array_filter(
 				$args,
-				fn ( $arg ) => in_array( $context, $arg['context'], true )
+				fn ( $arg ) => in_array( $context, $arg['context'] ?? [], true )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -1,0 +1,201 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
+use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use InvalidArgumentException;
+use Exception;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+use WP_Http;
+
+/**
+ * Controller for the REST endpoints associated with push notification device
+ * tokens.
+ */
+class PushTokenRestController extends RestApiControllerBase {
+	/**
+	 * The root namespace for the JSON REST API endpoints.
+	 *
+	 * @var string
+	 */
+	protected string $route_namespace = 'wc-push-notifications';
+
+	/**
+	 * The REST base for the endpoints URL.
+	 *
+	 * @var string
+	 */
+	protected string $rest_base = '/push-tokens';
+
+	/**
+	 * Get the WooCommerce REST API namespace for the class.
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return $this->route_namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints handled by this controller.
+	 */
+	public function register_routes() {
+		// Routes will registered here, can't omit method due to parent class
+		// constraints.
+	}
+
+	/**
+	 * Get the schema for the POST endpoint.
+	 *
+	 * @return array[]
+	 */
+	public function get_schema(): array {
+		return array_merge(
+			$this->get_base_schema(),
+			array(
+				'title'      => PushToken::POST_TYPE,
+				'properties' => array_map(
+					fn ( $item ) => array_diff_key( $item, array( 'validate_callback' => null ) ),
+					$this->get_args()
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks user is authorized to access this endpoint.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error
+	 */
+	public function authorize( WP_REST_Request $request ) {
+		if (
+			! get_current_user_id()
+			|| ! wc_get_container()->get( PushNotifications::class )->should_be_enabled()
+		) {
+			return false;
+		}
+
+		$has_valid_role = array_reduce(
+			PushNotifications::ROLES_WITH_PUSH_NOTIFICATIONS_ENABLED,
+			fn ( $carry, $role ) => $this->check_permission( $request, $role ) === true ? true : $carry,
+			false
+		);
+
+		if ( ! $has_valid_role ) {
+			return false;
+		}
+
+		if ( $request->has_param( 'id' ) ) {
+			$push_token = new PushToken();
+			$push_token->set_id( (int) $request->get_param( 'id' ) );
+
+			try {
+				wc_get_container()->get( PushTokensDataStore::class )->read( $push_token );
+			} catch ( Exception $e ) {
+				return $this->convert_exception_to_wp_error( $e );
+			}
+
+			if ( $push_token->get_user_id() !== get_current_user_id() ) {
+				return new WP_Error(
+					'rest_invalid_push_token',
+					'Push token could not be found.',
+					array( 'status' => WP_Http::NOT_FOUND )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Converts an exception to an instance of WP_Error.
+	 *
+	 * @param Exception $e The exception to convert.
+	 * @return WP_Error
+	 */
+	private function convert_exception_to_wp_error( Exception $e ): WP_Error {
+		$slug = match ( get_class( $e ) ) {
+			PushTokenNotFoundException::class => 'rest_invalid_push_token',
+			InvalidArgumentException::class => 'rest_invalid_argument',
+			default => 'rest_internal_error',
+		};
+
+		$code = match ( get_class( $e ) ) {
+			PushTokenNotFoundException::class => WP_Http::NOT_FOUND,
+			InvalidArgumentException::class => WP_Http::BAD_REQUEST,
+			default => WP_Http::INTERNAL_SERVER_ERROR,
+		};
+
+		return new WP_Error( $slug, $e->getMessage(), array( 'status' => $code ) );
+	}
+
+	/**
+	 * Get the accepted arguments for the POST request.
+	 *
+	 * @param string $context The context to return args for.
+	 * @return array
+	 */
+	private function get_args( ?string $context = null ): array {
+		$args = array(
+			'id'          => array(
+				'description'       => __( 'Push Token ID', 'woocommerce' ),
+				'type'              => 'integer',
+				'required'          => true,
+				'context'           => array( 'delete' ),
+				'minimum'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'origin'      => array(
+				'description' => __( 'Origin', 'woocommerce' ),
+				'type'        => 'string',
+				'required'    => true,
+				'context'     => array( 'create' ),
+				'enum'        => PushToken::ORIGINS,
+			),
+			'device_uuid' => array(
+				'description'       => __( 'Device UUID', 'woocommerce' ),
+				'default'           => '',
+				'type'              => 'string',
+				'context'           => array( 'create' ),
+				'validate_callback' => array( $this, 'validate_device_uuid' ),
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'platform'    => array(
+				'description' => __( 'Platform', 'woocommerce' ),
+				'type'        => 'string',
+				'required'    => true,
+				'context'     => array( 'create' ),
+				'enum'        => PushToken::PLATFORMS,
+			),
+			'token'       => array(
+				'description'       => __( 'Push Token', 'woocommerce' ),
+				'type'              => 'string',
+				'required'          => true,
+				'context'           => array( 'create' ),
+				'validate_callback' => array( $this, 'validate_token' ),
+				'sanitize_callback' => 'wp_unslash',
+			),
+		);
+
+		if ( $context ) {
+			$args = array_filter(
+				$args,
+				fn ( $arg ) => in_array( $context, $arg['context'], true )
+			);
+		}
+
+		return $args;
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -124,17 +124,20 @@ class PushTokenRestController extends RestApiControllerBase {
 	 * @return WP_Error
 	 */
 	private function convert_exception_to_wp_error( Exception $e ): WP_Error {
-		$slug = match ( get_class( $e ) ) {
-			PushTokenNotFoundException::class => 'rest_invalid_push_token',
-			InvalidArgumentException::class => 'rest_invalid_argument',
-			default => 'rest_internal_error',
-		};
+		$exception_class = get_class( $e );
 
-		$status = match ( get_class( $e ) ) {
+		$slugs = array(
+			PushTokenNotFoundException::class => 'rest_invalid_push_token',
+			InvalidArgumentException::class   => 'rest_invalid_argument',
+		);
+
+		$statuses = array(
 			PushTokenNotFoundException::class => WP_Http::NOT_FOUND,
-			InvalidArgumentException::class => WP_Http::BAD_REQUEST,
-			default => WP_Http::INTERNAL_SERVER_ERROR,
-		};
+			InvalidArgumentException::class   => WP_Http::BAD_REQUEST,
+		);
+
+		$slug   = $slugs[ $exception_class ] ?? 'rest_internal_error';
+		$status = $statuses[ $exception_class ] ?? WP_Http::INTERNAL_SERVER_ERROR;
 
 		return new WP_Error( $slug, $e->getMessage(), array( 'status' => $status ) );
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -45,18 +45,29 @@ class PushNotifications {
 	private ?bool $enabled = null;
 
 	/**
-	 * Loads the push notifications class.
+	 * Registers initialisation tasks to the `init` hook.
 	 *
 	 * @return void
 	 *
 	 * @since 10.4.0
 	 */
 	public function register(): void {
+		add_action( 'init', array( $this, 'on_init' ) );
+	}
+
+	/**
+	 * Loads the push notifications class.
+	 *
+	 * @return void
+	 *
+	 * @since 10.6.0
+	 */
+	public function on_init(): void {
 		if ( ! $this->should_be_enabled() ) {
 			return;
 		}
 
-		add_action( 'init', array( $this, 'register_post_types' ) );
+		$this->register_post_types();
 
 		wc_get_container()->get( PushTokenRestController::class )->register();
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -56,6 +57,8 @@ class PushNotifications {
 		}
 
 		add_action( 'init', array( $this, 'register_post_types' ) );
+
+		wc_get_container()->get( PushTokenRestController::class )->register();
 
 		// Library endpoints and scheduled tasks will be registered here.
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Controllers;
+
+use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use ReflectionClass;
+use WC_REST_Unit_Test_Case;
+use WP_Http;
+use WP_REST_Request;
+
+/**
+ * Tests for the PushTokenRestController class.
+ *
+ * @package WooCommerce\Tests\PushNotifications
+ */
+class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * User ID for testing.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * @var JetpackConnectionManager|MockObject
+	 */
+	private $jetpack_connection_manager_mock;
+
+	/**
+	 * @var FeaturesController|MockObject
+	 */
+	private $features_controller_mock;
+
+	/**
+	 * @var PushTokenRestController
+	 */
+	private $controller;
+
+	/**
+	 * Set up test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->set_up_features_controller_mock();
+		$this->reset_push_notifications_cache();
+
+		$this->controller = new PushTokenRestController();
+		$this->user_id    = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		$this->reset_container_replacements();
+		wc_get_container()->reset_all_resolved();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Test authorize returns false when no user is logged in.
+	 */
+	public function test_authorize_returns_false_without_authentication() {
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @testdox Test authorize returns false when push notifications are disabled.
+	 */
+	public function test_authorize_returns_false_when_push_notifications_disabled() {
+		wp_set_current_user( $this->user_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( false );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @testdox Test authorize returns false when user doesn't have required role.
+	 */
+	public function test_authorize_returns_false_without_required_role() {
+		$customer_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @testdox Test authorize returns true for shop_manager role.
+	 */
+	public function test_authorize_returns_true_for_shop_manager() {
+		wp_set_current_user( $this->user_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @testdox Test authorize returns true for administrator role.
+	 */
+	public function test_authorize_returns_true_for_administrator() {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @testdox Test authorize returns error when token ID doesn't exist.
+	 */
+	public function test_authorize_returns_error_when_token_not_found() {
+		wp_set_current_user( $this->user_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc-push-notifications/push-tokens/999999' );
+		$request->set_param( 'id', 999999 );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'rest_invalid_push_token', $result->get_error_code() );
+		$this->assertEquals( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @testdox Test authorize returns error when token belongs to another user.
+	 */
+	public function test_authorize_returns_error_when_token_belongs_to_another_user() {
+		/**
+		 * Create a token for another shop manager.
+		 */
+		$other_user_id = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+
+		$push_token = new PushToken();
+		$push_token->set_user_id( $other_user_id );
+		$push_token->set_token( str_repeat( 'a', 64 ) );
+		$push_token->set_platform( PushToken::PLATFORM_APPLE );
+		$push_token->set_device_uuid( 'device-other-user' );
+		$push_token->set_origin( PushToken::ORIGIN_WOOCOMMERCE_IOS );
+
+		$data_store = wc_get_container()->get( PushTokensDataStore::class );
+		$data_store->create( $push_token );
+		$token_id = $push_token->get_id();
+
+		/**
+		 * Try to authorize as a different user.
+		 */
+		wp_set_current_user( $this->user_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc-push-notifications/push-tokens/' . $token_id );
+		$request->set_param( 'id', $token_id );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'rest_invalid_push_token', $result->get_error_code() );
+		$this->assertEquals( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @testdox Test authorize returns true when token belongs to current user.
+	 */
+	public function test_authorize_returns_true_when_token_belongs_to_current_user() {
+		wp_set_current_user( $this->user_id );
+
+		$this->mock_jetpack_connection_manager_is_connected( true );
+
+		/**
+		 * Create a token for the current user.
+		 */
+		$push_token = new PushToken();
+		$push_token->set_user_id( $this->user_id );
+		$push_token->set_token( str_repeat( 'a', 64 ) );
+		$push_token->set_platform( PushToken::PLATFORM_APPLE );
+		$push_token->set_device_uuid( 'device-current-user' );
+		$push_token->set_origin( PushToken::ORIGIN_WOOCOMMERCE_IOS );
+
+		$data_store = wc_get_container()->get( PushTokensDataStore::class );
+		$data_store->create( $push_token );
+		$token_id = $push_token->get_id();
+
+		$request = new WP_REST_Request( 'DELETE', '/wc-push-notifications/push-tokens/' . $token_id );
+		$request->set_param( 'id', $token_id );
+
+		$result = $this->controller->authorize( $request );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @testdox Test the schema is correctly formatted.
+	 */
+	public function test_get_schema_returns_correct_structure() {
+		$schema = $this->controller->get_schema();
+
+		$this->assertArrayHasKey( 'title', $schema );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertEquals( PushToken::POST_TYPE, $schema['title'] );
+
+		$this->assertArrayHasKey( 'token', $schema['properties'] );
+		$this->assertArrayHasKey( 'platform', $schema['properties'] );
+		$this->assertArrayHasKey( 'device_uuid', $schema['properties'] );
+		$this->assertArrayHasKey( 'origin', $schema['properties'] );
+		$this->assertArrayHasKey( 'enum', $schema['properties']['platform'] );
+		$this->assertArrayHasKey( 'enum', $schema['properties']['origin'] );
+
+		$this->assertArrayNotHasKey( 'validate_callback', $schema['properties']['token'] );
+		$this->assertArrayNotHasKey( 'validate_callback', $schema['properties']['platform'] );
+		$this->assertArrayNotHasKey( 'validate_callback', $schema['properties']['device_uuid'] );
+		$this->assertArrayNotHasKey( 'validate_callback', $schema['properties']['origin'] );
+
+		$this->assertEquals( 'string', $schema['properties']['token']['type'] );
+		$this->assertEquals( 'string', $schema['properties']['platform']['type'] );
+		$this->assertEquals( 'string', $schema['properties']['device_uuid']['type'] );
+		$this->assertEquals( 'string', $schema['properties']['origin']['type'] );
+
+		$this->assertEquals(
+			PushToken::PLATFORMS,
+			$schema['properties']['platform']['enum']
+		);
+
+		$this->assertEquals(
+			PushToken::ORIGINS,
+			$schema['properties']['origin']['enum']
+		);
+	}
+
+	/**
+	 * Sets up the Jetpack connection manager mocking, and ensures the
+	 * PushNotifications class state is reset so `should_be_enabled` calculates
+	 * this from scratch.
+	 *
+	 * @param bool $is_connected Whether the manager should report Jetpack is
+	 * connected or not.
+	 */
+	private function mock_jetpack_connection_manager_is_connected( bool $is_connected = true ) {
+		$this->jetpack_connection_manager_mock = $this
+			->getMockBuilder( JetpackConnectionManager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'is_connected' ) )
+			->getMock();
+
+		wc_get_container()->get( LegacyProxy::class )->register_class_mocks(
+			array( JetpackConnectionManager::class => $this->jetpack_connection_manager_mock )
+		);
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( $is_connected );
+
+		$this->reset_push_notifications_cache();
+	}
+
+	/**
+	 * Sets up the FeaturesController mock to enable push_notifications feature.
+	 */
+	private function set_up_features_controller_mock() {
+		$this->features_controller_mock = $this
+			->getMockBuilder( FeaturesController::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'feature_is_enabled' ) )
+			->getMock();
+
+		$this->features_controller_mock
+			->method( 'feature_is_enabled' )
+			->willReturnCallback(
+				function ( $feature_id ) {
+					return PushNotifications::FEATURE_NAME === $feature_id;
+				}
+			);
+
+		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
+	}
+
+	/**
+	 * Resets the cached enablement state on the container's PushNotifications
+	 * instance.
+	 */
+	private function reset_push_notifications_cache() {
+		$push_notifications = wc_get_container()->get( PushNotifications::class );
+		$reflection         = new ReflectionClass( $push_notifications );
+		$property           = $reflection->getProperty( 'enabled' );
+
+		$property->setAccessible( true );
+		$property->setValue( $push_notifications, null );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use ReflectionClass;
 use WC_REST_Unit_Test_Case;
+use WP_Error;
 use WP_Http;
 use WP_REST_Request;
 
@@ -76,8 +77,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
-
-		$result = $this->controller->authorize( $request );
+		$result  = $this->controller->authorize( $request );
 
 		$this->assertFalse( $result );
 	}
@@ -91,8 +91,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( false );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
-
-		$result = $this->controller->authorize( $request );
+		$result  = $this->controller->authorize( $request );
 
 		$this->assertFalse( $result );
 	}
@@ -107,8 +106,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
-
-		$result = $this->controller->authorize( $request );
+		$result  = $this->controller->authorize( $request );
 
 		$this->assertFalse( $result );
 	}
@@ -122,8 +120,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
-
-		$result = $this->controller->authorize( $request );
+		$result  = $this->controller->authorize( $request );
 
 		$this->assertTrue( $result );
 	}
@@ -138,8 +135,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
 		$request = new WP_REST_Request( 'POST', '/wc-push-notifications/push-tokens' );
-
-		$result = $this->controller->authorize( $request );
+		$result  = $this->controller->authorize( $request );
 
 		$this->assertTrue( $result );
 	}
@@ -154,10 +150,9 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$request = new WP_REST_Request( 'DELETE', '/wc-push-notifications/push-tokens/999999' );
 		$request->set_param( 'id', 999999 );
-
 		$result = $this->controller->authorize( $request );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'rest_invalid_push_token', $result->get_error_code() );
 		$this->assertEquals( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
 	}
@@ -194,7 +189,7 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$result = $this->controller->authorize( $request );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'rest_invalid_push_token', $result->get_error_code() );
 		$this->assertEquals( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
 	}
@@ -207,9 +202,6 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->mock_jetpack_connection_manager_is_connected( true );
 
-		/**
-		 * Create a token for the current user.
-		 */
 		$push_token = new PushToken();
 		$push_token->set_user_id( $this->user_id );
 		$push_token->set_token( str_repeat( 'a', 64 ) );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataS
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use WC_REST_Unit_Test_Case;
 use WP_Error;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Focus: Woo-driven Push Notifications
Team: Apps Infrastructure
Relates to: AINFRA-1322
Closes: AINFRA-1428

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change adds the boilerplate for the endpoint that will save/update and delete push tokens. Note that the main functionality has been omitted in this PR in an effort to keep the PR small, as requested.

**Key Requirements:**
1. Controller should not be accessible to unauthenticated users
2. Controller should not be accessible if push notifications are not enabled (e.g. if Jetpack is not connected, if the feature is disabled etc)
3. Controller should not be accessible if the authenticated user does not have either the administrator or shop manager role
4. If trying to access a specific push token record which is not allowed (e.g. doesn't belong to the authenticated user) then it should return a 404 response

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
There are no functional changes to test in this PR, but to ensure no side effects, you can:
* Check out this branch to your WooCommerce install
* Ensure your WooCommerce install functions as expected, e.g.:
  * Add a product to cart
  * View WooCommerce settings in WP Admin
  * View WooCommerce orders in WP Admin
* Make an authenticated request to the API to ensure this works as expected, e.g.:
  * https://YOUR_URL/wp-json/wc-admin/features
  * https://YOUR_URL/wp-json/wc/v3/settings
  * https://YOUR_URL/wp-json/wc/v3/customers

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Adds internal library foundations which will eventually be used to send push notifications to user devices. This will support WooCommerce in directly triggering push notifications, instead of relying on Jetpack Sync.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an internal, non-user facing change.

</details>
