### PR TITLE
Replace get_available_variations() with get_visible_children() in product-image.php

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6119-replace-get-available-variations-product-image
+++ b/plugins/woocommerce/changelog/fix-wooplug-6119-replace-get-available-variations-product-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Replace get_available_variations() with get_visible_children() and get_price() in product-image.php template for better performance.

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.7.0
+ * @version 10.5.0
  */
 
 use Automattic\WooCommerce\Enums\ProductType;
@@ -44,7 +44,10 @@ $wrapper_classes   = apply_filters(
 		if ( $post_thumbnail_id ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
-			$wrapper_classname = $product->is_type( ProductType::VARIABLE ) && ! empty( $product->get_available_variations( 'image' ) ) ?
+			// Check for visible children with prices to determine if variation image swapping is possible.
+			// Using get_visible_children() + get_price() is more efficient than get_available_variations()
+			// as it uses cached IDs and synced price data rather than loading all variation objects.
+			$wrapper_classname = $product->is_type( ProductType::VARIABLE ) && ! empty( $product->get_visible_children() ) && '' !== $product->get_price() ?
 				'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' :
 				'woocommerce-product-gallery__image--placeholder';
 			$html              = sprintf( '<div class="%s">', esc_attr( $wrapper_classname ) );


### PR DESCRIPTION
## Summary

Fixes WOOPLUG-6119 / #62717

- Replaces inefficient `get_available_variations('image')` call with `get_visible_children()` + `get_price()` check
- Uses cached IDs and synced price data rather than loading all variation objects
- Maintains behavioral parity by checking both visible children existence and price availability

## Test plan

1. Create a variable product with at least one variation that has a price set
2. Remove the product's main image so only the placeholder shows
3. Visit the single product page and verify the placeholder wrapper has class `woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder`
4. Edit all variations to remove their prices
5. Revisit the single product page and verify the placeholder wrapper only has class `woocommerce-product-gallery__image--placeholder`
6. Add prices back to variations and set a variation image
7. Verify image swapping still works when selecting different variations