### PR TITLE
Add EAN search to product admin list

### DIFF
--- a/plugins/woocommerce/changelog/62756-feature-62188-ean-product-search
+++ b/plugins/woocommerce/changelog/62756-feature-62188-ean-product-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add EAN/GTIN/UPC/ISBN search to product admin list

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1957,13 +1957,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- an array of placeholders is a valid arg.
 				$term_query = $wpdb->prepare(
-					'( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s )',
-					array_fill( 0, 4, $like )
+					'( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) OR ( wc_product_meta_lookup.global_unique_id LIKE %s )',
+					array_fill( 0, 5, $like )
 				);
 
-				// Variations should also search the parent's meta table for fallback fields.
+				// For variations, also check parent if variation has empty value.
 				if ( $include_variations ) {
 					$term_query .= $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s )", $like );
+					$term_query .= $wpdb->prepare( " OR ( wc_product_meta_lookup.global_unique_id = '' AND parent_wc_product_meta_lookup.global_unique_id LIKE %s )", $like );
 				}
 
 				$term_group_query[] = "( {$term_query} )";

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/data-store.php
@@ -901,6 +901,91 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test searching products by global_unique_id (EAN/barcode).
+	 *
+	 * @return void
+	 */
+	public function test_search_products_by_global_unique_id() {
+		$product = new WC_Product();
+		$product->set_regular_price( 42 );
+		$product->set_name( 'Product A' );
+		$product->set_sku( 'PROD-A' );
+		$product->set_global_unique_id( '4521121209036' );
+		$product->save();
+
+		$product2 = new WC_Product();
+		$product2->set_regular_price( 42 );
+		$product2->set_name( 'Product B' );
+		$product2->set_sku( 'PROD-B' );
+		$product2->set_global_unique_id( '1234567890123' );
+		$product2->save();
+
+		$product3 = new WC_Product();
+		$product3->set_regular_price( 42 );
+		$product3->set_name( 'Product C' );
+		$product3->set_sku( 'PROD-C' );
+		$product3->set_global_unique_id( '9876543210987' );
+		$product3->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		// Full barcode search.
+		$results = $data_store->search_products( '4521121209036', '', true, true );
+		$this->assertContains( $product->get_id(), $results );
+		$this->assertNotContains( $product2->get_id(), $results );
+		$this->assertNotContains( $product3->get_id(), $results );
+
+		// Partial barcode search.
+		$results = $data_store->search_products( '123456', '', true, true );
+		$this->assertNotContains( $product->get_id(), $results );
+		$this->assertContains( $product2->get_id(), $results );
+		$this->assertNotContains( $product3->get_id(), $results );
+
+		// Another barcode search.
+		$results = $data_store->search_products( '9876543210987', '', true, true );
+		$this->assertNotContains( $product->get_id(), $results );
+		$this->assertNotContains( $product2->get_id(), $results );
+		$this->assertContains( $product3->get_id(), $results );
+	}
+
+	/**
+	 * Test searching variations by global_unique_id.
+	 *
+	 * @return void
+	 */
+	public function test_search_products_by_global_unique_id_with_variations() {
+		$variable_product = new WC_Product_Variable();
+		$variable_product->set_name( 'Variable Product' );
+		$variable_product->set_global_unique_id( '1111111111111' );
+		$variable_product->save();
+
+		// Variation with its own barcode.
+		$variation1 = new WC_Product_Variation();
+		$variation1->set_parent_id( $variable_product->get_id() );
+		$variation1->set_global_unique_id( '2222222222222' );
+		$variation1->save();
+
+		// Variation without barcode - inherits from parent.
+		$variation2 = new WC_Product_Variation();
+		$variation2->set_parent_id( $variable_product->get_id() );
+		$variation2->set_global_unique_id( '' );
+		$variation2->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		// Search parent barcode - finds parent and variation that inherits.
+		$results = $data_store->search_products( '1111111111111', '', true, true );
+		$this->assertContains( $variable_product->get_id(), $results );
+		$this->assertContains( $variation2->get_id(), $results );
+
+		// Search variation barcode - finds variation and parent (WC includes parents when variations match).
+		$results = $data_store->search_products( '2222222222222', '', true, true );
+		$this->assertContains( $variation1->get_id(), $results );
+		$this->assertContains( $variable_product->get_id(), $results );
+		$this->assertNotContains( $variation2->get_id(), $results );
+	}
+
+	/**
 	 * Test WC_Product_Data_Store_CPT::create_all_product_variations
 	 */
 	public function test_variable_create_all_product_variations() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Added `global_unique_id` (EAN/GTIN/UPC/ISBN) to the product search query so you can search products by barcode in the admin product list.

The search now checks the `global_unique_id` field in the product meta lookup table, same as it does for SKU. Also handles variations - if a variation doesn't have its own barcode, it falls back to the parent product's barcode.

Closes #62188.

### Screenshots or screen recordings:

N/A - Backend change only.

### How to test the changes in this Pull Request:

1. Go to Products > All Products in the admin
2. Create a product and set a GTIN/UPC/EAN/ISBN value in the Inventory tab
3. Use the search box at the top and search for the barcode value
4. The product should appear in the search results
5. Test with partial matches (e.g., search "123" if barcode is "1234567890123")
6. Test with variations - create a variable product with a barcode, then create variations with and without their own barcodes to verify the fallback works

### Testing that has already taken place:

- All existing product search tests pass
- Added new tests for `global_unique_id` search (full and partial matching)
- Added tests for variation fallback behavior
- Tested in local environment with various barcode formats
- Verified no regressions in existing search functionality

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Enhancement - Improvement to existing functionality

#### Message

Add EAN/GTIN/UPC/ISBN search to product admin list

</details>