### PR TITLE
Fraud Protection: Display blocked notice on add payment method page 

### DIFF
--- a/plugins/woocommerce/src/Internal/FraudProtection/BlockedSessionNotice.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlockedSessionNotice.php
@@ -52,21 +52,39 @@ class BlockedSessionNotice implements RegisterHooksInterface {
 	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'woocommerce_before_checkout_form', array( $this, 'display_blocked_notice' ), 1, 0 );
-		add_action( 'before_woocommerce_add_payment_method', array( $this, 'display_blocked_notice' ), 1, 0 );
+		add_action( 'woocommerce_before_checkout_form', array( $this, 'display_checkout_blocked_notice' ), 1, 0 );
+		add_action( 'before_woocommerce_add_payment_method', array( $this, 'display_generic_blocked_notice' ), 1, 0 );
 	}
 
 	/**
-	 * Display blocked notice on shortcode checkout and add payment method pages.
+	 * Display blocked notice on shortcode checkout page.
 	 *
-	 * Shows a user-friendly message explaining that the request cannot be
+	 * Shows a checkout-specific message explaining that the purchase cannot be
+	 * completed online and provides contact information for support.
+	 *
+	 * @internal
+	 *
+	 * @return void
+	 */
+	public function display_checkout_blocked_notice(): void {
+		if ( ! $this->session_manager->is_session_blocked() ) {
+			return;
+		}
+
+		wc_print_notice( $this->get_message_html( 'checkout' ), 'error' );
+	}
+
+	/**
+	 * Display blocked notice for non-checkout pages.
+	 *
+	 * Shows a generic message explaining that the request cannot be
 	 * processed online and provides contact information for support.
 	 *
 	 * @internal
 	 *
 	 * @return void
 	 */
-	public function display_blocked_notice(): void {
+	public function display_generic_blocked_notice(): void {
 		if ( ! $this->session_manager->is_session_blocked() ) {
 			return;
 		}
@@ -77,16 +95,26 @@ class BlockedSessionNotice implements RegisterHooksInterface {
 	/**
 	 * Get the blocked session message as HTML.
 	 *
-	 * Includes a mailto link for the support email. Used by shortcode checkout.
+	 * Includes a mailto link for the support email.
 	 *
+	 * @param string $context Message context: 'checkout' for purchase-specific message, 'generic' for general use.
 	 * @return string HTML message with mailto link.
 	 */
-	public function get_message_html(): string {
+	public function get_message_html( string $context = 'generic' ): string {
 		$email = WC()->mailer()->get_from_address();
+
+		if ( 'checkout' === $context ) {
+			return sprintf(
+				/* translators: %1$s: mailto link, %2$s: email address */
+				__( 'We are unable to process this request online. Please <a href="%1$s">contact support (%2$s)</a> to complete your purchase.', 'woocommerce' ),
+				esc_url( 'mailto:' . $email ),
+				esc_html( $email )
+			);
+		}
 
 		return sprintf(
 			/* translators: %1$s: mailto link, %2$s: email address */
-			__( 'We are unable to process this request online. Please <a href="%1$s">contact support (%2$s)</a> to complete your purchase.', 'woocommerce' ),
+			__( 'We are unable to process this request online. Please <a href="%1$s">contact support (%2$s)</a> for assistance.', 'woocommerce' ),
 			esc_url( 'mailto:' . $email ),
 			esc_html( $email )
 		);
@@ -97,14 +125,23 @@ class BlockedSessionNotice implements RegisterHooksInterface {
 	 *
 	 * Used by Store API responses where HTML is not supported.
 	 *
+	 * @param string $context Message context: 'checkout' for purchase-specific message, 'generic' for general use.
 	 * @return string Plaintext message with email address.
 	 */
-	public function get_message_plaintext(): string {
+	public function get_message_plaintext( string $context = 'generic' ): string {
 		$email = WC()->mailer()->get_from_address();
+
+		if ( 'checkout' === $context ) {
+			return sprintf(
+				/* translators: %s: support email address */
+				__( 'We are unable to process this request online. Please contact support (%s) to complete your purchase.', 'woocommerce' ),
+				$email
+			);
+		}
 
 		return sprintf(
 			/* translators: %s: support email address */
-			__( 'We are unable to process this request online. Please contact support (%s) to complete your purchase.', 'woocommerce' ),
+			__( 'We are unable to process this request online. Please contact support (%s) for assistance.', 'woocommerce' ),
 			$email
 		);
 	}

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlockedSessionNotice.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlockedSessionNotice.php
@@ -53,10 +53,11 @@ class BlockedSessionNotice implements RegisterHooksInterface {
 	 */
 	public function register(): void {
 		add_action( 'woocommerce_before_checkout_form', array( $this, 'display_blocked_notice' ), 1, 0 );
+		add_action( 'before_woocommerce_add_payment_method', array( $this, 'display_blocked_notice' ), 1, 0 );
 	}
 
 	/**
-	 * Display blocked notice on shortcode checkout page.
+	 * Display blocked notice on shortcode checkout and add payment method pages.
 	 *
 	 * Shows a user-friendly message explaining that the request cannot be
 	 * processed online and provides contact information for support.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -161,7 +161,7 @@ class Checkout extends AbstractCartRoute {
 			&& wc_get_container()->get( SessionClearanceManager::class )->is_session_blocked() ) {
 			$response = $this->get_route_error_response(
 				'woocommerce_rest_checkout_error',
-				wc_get_container()->get( BlockedSessionNotice::class )->get_message_plaintext(),
+				wc_get_container()->get( BlockedSessionNotice::class )->get_message_plaintext( 'checkout' ),
 				403
 			);
 		}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -1839,5 +1839,6 @@ class Checkout extends MockeryTestCase {
 		$this->assertEquals( 403, $response->get_status(), 'Should return 403 when session is blocked' );
 		$this->assertEquals( 'woocommerce_rest_checkout_error', $response->get_data()['code'] );
 		$this->assertStringContainsString( 'unable to process this request online', $response->get_data()['message'] );
+		$this->assertStringContainsString( 'to complete your purchase', $response->get_data()['message'], 'Should use checkout-specific message' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlockedSessionNoticeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlockedSessionNoticeTest.php
@@ -58,7 +58,7 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should display error notice when woocommerce_before_checkout_form action fires for blocked sessions.
+	 * @testdox Should display checkout-specific error notice when woocommerce_before_checkout_form action fires for blocked sessions.
 	 */
 	public function test_checkout_action_displays_blocked_message(): void {
 		$this->mock_session_manager->method( 'is_session_blocked' )->willReturn( true );
@@ -68,6 +68,7 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'unable to process this request online', $output, 'Should display blocked message on checkout' );
+		$this->assertStringContainsString( 'to complete your purchase', $output, 'Should display checkout-specific message' );
 		$this->assertStringContainsString( 'support@example.com', $output, 'Should include support email in message' );
 		$this->assertStringContainsString( 'mailto:support@example.com', $output, 'Should include mailto link' );
 	}
@@ -86,7 +87,7 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should display error notice when before_woocommerce_add_payment_method action fires for blocked sessions.
+	 * @testdox Should display generic error notice when before_woocommerce_add_payment_method action fires for blocked sessions.
 	 */
 	public function test_add_payment_method_action_displays_blocked_message(): void {
 		$this->mock_session_manager->method( 'is_session_blocked' )->willReturn( true );
@@ -96,6 +97,7 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'unable to process this request online', $output, 'Should display blocked message on add payment method page' );
+		$this->assertStringContainsString( 'for assistance', $output, 'Should display generic message' );
 		$this->assertStringContainsString( 'support@example.com', $output, 'Should include support email in message' );
 		$this->assertStringContainsString( 'mailto:support@example.com', $output, 'Should include mailto link' );
 	}
@@ -114,10 +116,10 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_message_html should return the expected HTML message with mailto link.
+	 * @testdox get_message_html should return checkout-specific message when context is 'checkout'.
 	 */
-	public function test_get_message_html(): void {
-		$message = $this->sut->get_message_html();
+	public function test_get_message_html_checkout_context(): void {
+		$message = $this->sut->get_message_html( 'checkout' );
 
 		$this->assertEquals(
 			'We are unable to process this request online. Please <a href="mailto:support@example.com">contact support (support@example.com)</a> to complete your purchase.',
@@ -126,14 +128,40 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_message_plaintext should return the expected plaintext message.
+	 * @testdox get_message_html should return generic message when context is 'generic' or not specified.
 	 */
-	public function test_get_message_plaintext(): void {
-		$message = $this->sut->get_message_plaintext();
+	public function test_get_message_html_generic_context(): void {
+		$message_default  = $this->sut->get_message_html();
+		$message_explicit = $this->sut->get_message_html( 'generic' );
+
+		$expected = 'We are unable to process this request online. Please <a href="mailto:support@example.com">contact support (support@example.com)</a> for assistance.';
+
+		$this->assertEquals( $expected, $message_default, 'Default context should return generic message' );
+		$this->assertEquals( $expected, $message_explicit, 'Explicit generic context should return generic message' );
+	}
+
+	/**
+	 * @testdox get_message_plaintext should return checkout-specific message when context is 'checkout'.
+	 */
+	public function test_get_message_plaintext_checkout_context(): void {
+		$message = $this->sut->get_message_plaintext( 'checkout' );
 
 		$this->assertEquals(
 			'We are unable to process this request online. Please contact support (support@example.com) to complete your purchase.',
 			$message
 		);
+	}
+
+	/**
+	 * @testdox get_message_plaintext should return generic message when context is 'generic' or not specified.
+	 */
+	public function test_get_message_plaintext_generic_context(): void {
+		$message_default  = $this->sut->get_message_plaintext();
+		$message_explicit = $this->sut->get_message_plaintext( 'generic' );
+
+		$expected = 'We are unable to process this request online. Please contact support (support@example.com) for assistance.';
+
+		$this->assertEquals( $expected, $message_default, 'Default context should return generic message' );
+		$this->assertEquals( $expected, $message_explicit, 'Explicit generic context should return generic message' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlockedSessionNoticeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlockedSessionNoticeTest.php
@@ -53,6 +53,7 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_all_actions( 'woocommerce_before_checkout_form' );
+		remove_all_actions( 'before_woocommerce_add_payment_method' );
 		delete_option( 'woocommerce_email_from_address' );
 	}
 
@@ -79,6 +80,34 @@ class BlockedSessionNoticeTest extends \WC_Unit_Test_Case {
 
 		ob_start();
 		do_action( 'woocommerce_before_checkout_form' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Non-blocked sessions should not display any message' );
+	}
+
+	/**
+	 * @testdox Should display error notice when before_woocommerce_add_payment_method action fires for blocked sessions.
+	 */
+	public function test_add_payment_method_action_displays_blocked_message(): void {
+		$this->mock_session_manager->method( 'is_session_blocked' )->willReturn( true );
+
+		ob_start();
+		do_action( 'before_woocommerce_add_payment_method' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'unable to process this request online', $output, 'Should display blocked message on add payment method page' );
+		$this->assertStringContainsString( 'support@example.com', $output, 'Should include support email in message' );
+		$this->assertStringContainsString( 'mailto:support@example.com', $output, 'Should include mailto link' );
+	}
+
+	/**
+	 * @testdox Should not display message when add payment method action fires for non-blocked sessions.
+	 */
+	public function test_add_payment_method_action_no_message_for_non_blocked_session(): void {
+		$this->mock_session_manager->method( 'is_session_blocked' )->willReturn( false );
+
+		ob_start();
+		do_action( 'before_woocommerce_add_payment_method' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$output = ob_get_clean();
 
 		$this->assertEmpty( $output, 'Non-blocked sessions should not display any message' );


### PR DESCRIPTION
# Payment Method Update Protection - PR Documentation

## Summary
Extends fraud protection blocking to the My Account "Add Payment Method" page. When fraud protection is enabled and a session is blocked, users see a clear error message explaining they cannot add payment methods, with support contact information.

This completes the payment method protection flow by adding user-friendly messaging to complement the gateway filtering already implemented in PR #62691.

<img width="1060" height="363" alt="Payment methods block message" src="https://github.com/user-attachments/assets/f0cc5d59-753c-4d2e-9fe1-5df8de0d1924" />



### What This PR Adds
- Display `BlockedSessionNotice` on the add-payment-method page when session is blocked
- Consistent messaging with checkout blocking

### What Was Already Handled by PR #62691
- `WC_Payment_Gateways::get_available_payment_gateways()` returns empty array for blocked sessions
- Add payment method form doesn't render (template checks for available gateways)
- "Add payment method" button hidden on payment-methods list page

### Design Decision: No Notice on Payment Methods List Page
The `/my-account/payment-methods/` page does NOT display a blocked notice because:
1. Users can view existing saved payment methods normally
2. The "Add payment method" button is already hidden
3. If users navigate directly to `/my-account/add-payment-method/`, they see the explanation there

### Fail-Safe Design
- Only active when fraud protection feature flag is enabled
- Uses existing `BlockedSessionNotice` class for consistent messaging
- No block-based My Account pages exist, so only shortcode path needs handling

## Testing

### Manual Test Scenarios

#### Prerequisites
1. Install and activate WooCommerce
2. Enable the fraud protection feature flag:
   - Go to WooCommerce > Settings > Advanced > Features
   - Enable "Fraud Protection" feature
3. Connect to Jetpack (or feature will fail-open)
4. Create a test user account and log in

---

#### Test Scenario 1: Blocked Session - Add Payment Method Page
**Objective:** Verify blocked session prevents adding new payment methods

**Steps:**
1. Navigate to My Account > Payment methods > Add payment method page (`/my-account/add-payment-method/`)
2. Make [this](https://github.com/woocommerce/woocommerce/blob/dc38a0c930ddfdb0f86d3ce13653fd2a5fbab74e/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php#L106) method return the blocked decision
3. Refresh the page

**Expected Results:**
- ✅ Red error notice displayed: "We are unable to process this request online. Please contact support (email@example.com) to complete your purchase."
- ✅ Payment method form is NOT displayed
- ✅ No payment gateway options shown
- ✅ Submit button is NOT displayed

---

#### Test Scenario 2: Feature Disabled - No Blocking
**Objective:** Verify no blocking occurs when feature is disabled

**Steps:**
1. Disable the fraud protection feature:
   - Go to WooCommerce > Settings > Advanced > Features
   - Disable "Fraud Protection"
3. Refresh the Add payment method page

**Expected Results:**
- ✅ NO error notice displayed
- ✅ All functionality works normally
- ✅ Forms display normally
- ✅ Session blocking has no effect (fail-safe pattern)

**Cleanup:** revert the early session block return

---

#### Test Scenario 3: Allowed Session - Normal Operation
**Objective:** Verify normal functionality when session is allowed

**Steps:**
1. Ensure session is allowed (default state or call `->allow_session()`)
2. Navigate to My Account > Payment methods
3. Click "Add payment method"
4. Verify form displays normally

**Expected Results:**
- ✅ NO error notice displayed
- ✅ "Add payment method" button IS displayed
- ✅ Add payment method form displays normally
- ✅ Payment gateway options are shown
- ✅ User can complete payment method addition

---
## Related

- **Base PR:** #62691 (Checkout-level gateway blocking)
- **Linear:** [WOOSUBS-1325](https://linear.app/a8c/issue/WOOSUBS-1325) (Payment Method Update Protection)
- **Base Branch:** `woosubs-1320-woofraudprotection-checkout-level-gateway-blocking`

## Implementation Notes

### Decision Flow

```
User visits My Account Payment Methods page
             ↓
Is Fraud Protection enabled?
    No → Display normally
    Yes → Is session blocked?
             No → Display normally
             Yes → Show error notice + Hide payment methods
```

Closes WOOSUBS-1325
### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)


<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR adds internal fraud protection infrastructure behind a feature flag.

</details>
