### PR TITLE
Allow releases in prior release branches to bypass stable tag checks

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -135,6 +135,7 @@ jobs:
               if [[ $branch_stable_version != $svn_stable_version ]] ; then
                 echo "::error::Pre-build verification: stable version in release branch ($branch_stable_version) is not matching the one in SVN trunk ($svn_stable_version)."
                 exit 1
+              fi
             fi
 
             # No PRs against release branch should remain open.

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -121,9 +121,18 @@ jobs:
             fi
 
             # Stable version in release branch should match wporg.
+            svn_trunk_version=$( wget --quiet https://plugins.svn.wordpress.org/woocommerce/trunk/woocommerce.php -O /dev/stdout |  grep -oP '(?<=Version: )(.+)' | head -n1 )
             svn_stable_version=$( wget --quiet https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt -O /dev/stdout |  grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
-            branch_stable_version=$( cat checkout-branch/plugins/woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
-            if [[ $branch_stable_version != $svn_stable_version ]] ; then
+            
+            if [[ -z "$svn_trunk_version" || -z "$svn_stable_version" ]]; then
+                echo "::error::Pre-build verification: could not determine current version number or stable tag from SVN."
+                exit 1
+            fi
+
+            if php -r "exit( version_compare('$branch_plugin_version', '$svn_trunk_version', '>') ? 0 : 1 );"; then
+              branch_stable_version=$( cat checkout-branch/plugins/woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1 )            
+
+              if [[ $branch_stable_version != $svn_stable_version ]] ; then
                 echo "::error::Pre-build verification: stable version in release branch ($branch_stable_version) is not matching the one in SVN trunk ($svn_stable_version)."
                 exit 1
             fi

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -132,6 +132,15 @@ jobs:
           fi
 
           if php -r "die( version_compare( '$RELEASE_TAG', '$svn_plugin_version', '>' ) ? 0 : 1 );"; then
+            # Check that the stable tag in the release matches the stable tag in SVN.
+            svn_stable_version=$( svn cat "$SVN_URL/trunk/readme.txt" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" |  grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
+            stable_tag_in_release=$(cat woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1)
+
+            if [[ -z "$svn_stable_version" || $svn_stable_version != $stable_tag_in_release ]]; then
+              echo "::error::Stable tag in SVN ($svn_stable_version) does not match release stable tag ($stable_tag_in_release)."
+              exit 1
+            fi
+
             echo "overwrite_trunk=1" >> "$GITHUB_OUTPUT"
           else
             echo "overwrite_trunk=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -146,10 +146,15 @@ jobs:
             echo "overwrite_trunk=0" >> "$GITHUB_OUTPUT"
           fi
 
+      - if: ${{ github.repository != 'woocommerce/woocommerce' }}
+        run: |
+          echo "::notice::This is not the 'woocommerce/woocommerce' repository. Commit to WordPress.org SVN will be skipped."
+
   commit:
     name: Commit release to WordPress.org
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [get-and-validate-release-asset]
+    if: ${{ github.repository == 'woocommerce/woocommerce' }}
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     env:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When building a version in an old release branch (say, `release/10.2` or `release/10.3`), which can happen as part of security releases, for example, the build process shouldn't fail because the "Stable tag" in that release's `readme.txt` doesn't match the one in SVN's `trunk`.

This check is only relevant for versions that _will_ replace the content in the SVN repo's `trunk` as that's the source of truth for the stable tag. The stable tag in older release tags is simply ignored.

This PR enforces the check only when appropriate and also adds a final check before uploading a version to WordPress.org just to be extra safe. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository including the `release/10.3` and `release/10.4` branches.
1. Go to **Actions > Release: Bump version number** and run it twice:
   1. With inputs `release/10.3`  and `stable` bump type. 
   1. With inputs `release/10.4`  and `stable` bump type. 
1. Merge both of the generated PRs.
1. You'll need at least a changelog entry to build the releases, so use the GH UI to add a changelog entry to the `readme.txt` on **both** the `release/10.3` and `release/10.4` branches. For example:
   > = 10.4.4 2026-XX-XX =
   > 
   > **WooCommerce**
   > 
   > * Fix - A fix.
1. Use the GH UI to change the `Stable tag: 10.4.3` header in the `readme.txt` file on `release/10.4` to `Stable tag: 10.4.2`.
1. Go to **Actions > Release: Build ZIP file** and run the workflow with inputs `release/10.3` (release branch) and `[x] Create GitHub release.`.
   Confirm that the action succeeds and a draft `10.3.8` release is created.
1. Go to **Actions > Release: Upload release to WordPress.org** and run the workflow with input `10.3.8` and check off the confirmation checkbox.
   The workflow should succeed but the SVN commit be skipped (due to repository restrictions).
   <img width="784" height="56" alt="Screenshot 2026-01-12 at 14 44 29" src="https://github.com/user-attachments/assets/49bda81c-edf4-46dc-947a-41d991ba987d" />
1. Now, go to **Actions > Release: Build ZIP file** and run the workflow with inputs `release/10.4` (release branch) and `[x] Create GitHub release.`.
   Confirm that the workflows fails due the stable tag not matching wporg's `trunk`.
1. We'll now simulate that somehow a release that would replace wporg's "Stable tag" was built and about to be released:
   1. Go to **Actions > Release: Build ZIP file** and run the workflow with inputs `release/10.4` (release branch) and `[x] Skip verification steps.`.
      Download the generated asset.
   1. Go to **Code > Releases** and create a release named `10.4.4` and upload the asset from the previous step as `woocommerce.zip`.
   1. Go to **Actions > Release: Upload release to WordPress.org** and run the workflow with input `10.4.4` and check off the confirmation checkbox.
   1. Confirm that the workflow fails due to the stable tag verification.
      <img width="593" height="67" alt="Screenshot 2026-01-12 at 14 46 35" src="https://github.com/user-attachments/assets/7e1d4fcb-f4c1-4ae3-a3e4-11dcac4956c1" />

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.