### PR TITLE
[Fraud Protection] Fix session ID extraction in fraud decision logging

### DIFF
--- a/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
@@ -129,7 +129,8 @@ class ApiClient {
 			return self::DECISION_ALLOW;
 		}
 
-		$session_id = $session_data['session_id'] ?? 'unknown';
+		$session     = is_array( $session_data['session'] ?? null ) ? $session_data['session'] : array();
+		$session_id  = $session['session_id'] ?? 'unknown';
 		FraudProtectionController::log(
 			'info',
 			sprintf(

--- a/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
@@ -74,14 +74,14 @@ class ApiClient {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @param string               $event_type   Type of event being sent (e.g., 'cart_updated', 'checkout_started').
-	 * @param array<string, mixed> $session_data Session data to send to the endpoint.
+	 * @param string               $event_type Type of event being sent (e.g., 'cart_updated', 'checkout_started').
+	 * @param array<string, mixed> $event_data Event data to send to the endpoint.
 	 * @return string Decision: "allow" or "block".
 	 */
-	public function send_event( string $event_type, array $session_data ): string {
+	public function send_event( string $event_type, array $event_data ): string {
 		$payload = array_merge(
 			array( 'event_type' => $event_type ),
-			array_filter( $session_data, fn( $value ) => null !== $value )
+			array_filter( $event_data, fn( $value ) => null !== $value )
 		);
 
 		FraudProtectionController::log(
@@ -129,7 +129,7 @@ class ApiClient {
 			return self::DECISION_ALLOW;
 		}
 
-		$session    = is_array( $session_data['session'] ?? null ) ? $session_data['session'] : array();
+		$session    = is_array( $event_data['session'] ?? null ) ? $event_data['session'] : array();
 		$session_id = $session['session_id'] ?? 'unknown';
 		FraudProtectionController::log(
 			'info',

--- a/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
@@ -129,8 +129,8 @@ class ApiClient {
 			return self::DECISION_ALLOW;
 		}
 
-		$session     = is_array( $session_data['session'] ?? null ) ? $session_data['session'] : array();
-		$session_id  = $session['session_id'] ?? 'unknown';
+		$session    = is_array( $session_data['session'] ?? null ) ? $session_data['session'] : array();
+		$session_id = $session['session_id'] ?? 'unknown';
 		FraudProtectionController::log(
 			'info',
 			sprintf(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The session ID was always logged as "unknown" in the fraud decision logging because it was being accessed at the wrong path in the session data structure.

**Root cause:** The `SessionDataCollector::collect()` returns a nested structure where session data is at `$session_data['session']['session_id']`, but `ApiClient::send_event()` was looking for `$session_data['session_id']` at the top level.

**This fix:**
- Corrects the path to access the nested session ID
- Adds fail-safe checks for missing or invalid session data to prevent potential fatals
- Adds 3 unit tests to verify the correct behavior with the nested structure

### How to test the changes in this Pull Request:

1. Run the fraud protection unit tests:
   ```bash
   cd plugins/woocommerce
   pnpm test:php:env -- --filter=ApiClientTest
   ```
2. Verify all 14 tests pass, including the 3 new tests:
   - `test_send_event_logs_session_id_from_nested_structure`
   - `test_send_event_logs_unknown_when_session_data_missing`
   - `test_send_event_logs_unknown_when_session_is_not_array`

### Testing on a store

1. If even tracking changes are not merged yet, add the following code snippet within else statement of WC_Shortcode_My_Account::add_payment_method (plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php). You'll also need to add use statements at the top of the file for FraudProtectionController and FraudProtectionDispatcher classes.

```php
			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
				wc_get_container()->get( FraudProtectionDispatcher::class )
					->dispatch_event( 'add_payment_method_page_loaded', array() );
			}
```

2. Go to My Account > Payment Method > Add new payment method page
3. After page is loaded new event with proper log statement should appear in woo-fraud-protection logs. Without the changes in this PR it will be `unknown`.

### Testing that has already taken place:

- All 104 fraud protection unit tests pass
- Code review of the data flow from `SessionDataCollector` through `FraudProtectionDispatcher` to `ApiClient`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The fraud protection feature is currently behind a feature flag and not available to users. No changelog entry is needed until the feature is publicly released.

</details>