### PR TITLE
Fraud Protection: Add WooCommerce version to event data

### DIFF
--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
@@ -65,6 +65,7 @@ class SessionDataCollector {
 		return array(
 			'event_type'       => $event_type,
 			'timestamp'        => gmdate( 'Y-m-d H:i:s' ),
+			'wc_version'       => WC()->version,
 			'session'          => $this->get_session_data(),
 			'customer'         => $this->get_customer_data(),
 			'order'            => $this->get_order_data( $order_id_from_event ),

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionDataCollectorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionDataCollectorTest.php
@@ -51,7 +51,7 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that collect() method returns properly structured nested array with 8 top-level keys.
+	 * Test that collect() method returns properly structured nested array with 9 top-level keys.
 	 */
 	public function test_collect_returns_properly_structured_nested_array() {
 		$result = $this->sut->collect();
@@ -59,13 +59,14 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'event_type', $result );
 		$this->assertArrayHasKey( 'timestamp', $result );
+		$this->assertArrayHasKey( 'wc_version', $result );
 		$this->assertArrayHasKey( 'session', $result );
 		$this->assertArrayHasKey( 'customer', $result );
 		$this->assertArrayHasKey( 'order', $result );
 		$this->assertArrayHasKey( 'shipping_address', $result );
 		$this->assertArrayHasKey( 'billing_address', $result );
 		$this->assertArrayHasKey( 'event_data', $result );
-		$this->assertCount( 8, $result );
+		$this->assertCount( 9, $result );
 	}
 
 	/**
@@ -94,11 +95,20 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 		$result = $this->sut->collect();
 
 		$this->assertIsArray( $result );
-		$this->assertCount( 8, $result );
+		$this->assertCount( 9, $result );
 		// All sections should be initialized even if session unavailable.
 		$this->assertIsArray( $result['session'] );
 		$this->assertIsArray( $result['customer'] );
 		$this->assertIsArray( $result['order'] );
+	}
+
+	/**
+	 * Test wc_version field is included in collected data.
+	 */
+	public function test_wc_version_is_included() {
+		$result = $this->sut->collect();
+
+		$this->assertEquals( WC()->version, $result['wc_version'] );
 	}
 
 	/**
@@ -742,7 +752,7 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 
 		// Verify structure is intact even with minimal data.
 		$this->assertIsArray( $result );
-		$this->assertCount( 8, $result );
+		$this->assertCount( 9, $result );
 
 		// All sections should be arrays.
 		$this->assertIsArray( $result['session'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds `wc_version` field to fraud protection event payloads to enable version-based analysis of fraud patterns on the WPCOM side.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter='@woocommerce/plugin-woocommerce' run test:php:env -- --filter SessionDataCollectorTest`
2. All 29 tests should pass
3. Verify `wc_version` field appears in the collected session data

### Testing that has already taken place:

- All `SessionDataCollectorTest` tests pass (29 tests, 183 assertions)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal change to fraud protection system - adds metadata field to event payloads for backend analysis. No user-facing changes.

</details>