### PR TITLE
Block cherry-picking PR from merging when they have conflicts

### DIFF
--- a/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
+++ b/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
@@ -2,8 +2,6 @@ name: 'Block merge if cherry-pick conflicts exist'
 
 on:
   pull_request:
-    branches:
-      - 'cherry-pick-**'
     types:
       - opened
       - reopened
@@ -21,27 +19,14 @@ jobs:
   check-conflicts-label:
     name: Check for conflicts label
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'cherry pick has conflicts')
+    if: |
+      startsWith(github.head_ref, 'cherry-pick-') &&
+      contains(github.event.pull_request.labels.*.name, 'cherry pick has conflicts')
     permissions:
       pull-requests: read
       statuses: write
     steps:
-      - name: Check if PR has conflicts label
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            
-            const hasConflictsLabel = pr.labels.some(
-              label => label.name === 'cherry pick has conflicts'
-            );
-            
-            if (hasConflictsLabel) {
-              core.setFailed('❌ This PR has unresolved cherry-pick conflicts. Please resolve conflicts before merging.');
-            } else {
-              core.info('✅ No conflicts label found. PR can be merged.');
-            }
+      - name: Block merge due to conflicts
+        run: |
+          echo "❌ This PR has unresolved cherry-pick conflicts. Please resolve conflicts before merging."
+          exit 1

--- a/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
+++ b/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
@@ -1,7 +1,9 @@
 name: 'Block merge if cherry-pick conflicts exist'
 
 on:
-  pull_request_target:
+  pull_request:
+    branches:
+      - 'cherry-pick-**'
     types:
       - opened
       - reopened
@@ -19,6 +21,7 @@ jobs:
   check-conflicts-label:
     name: Check for conflicts label
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'cherry pick has conflicts')
     permissions:
       pull-requests: read
       statuses: write
@@ -32,11 +35,11 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-
+            
             const hasConflictsLabel = pr.labels.some(
               label => label.name === 'cherry pick has conflicts'
             );
-
+            
             if (hasConflictsLabel) {
               core.setFailed('❌ This PR has unresolved cherry-pick conflicts. Please resolve conflicts before merging.');
             } else {

--- a/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
+++ b/.github/workflows/release-cherry-pick-pr-check-conflicts.yml
@@ -1,0 +1,44 @@
+name: 'Block merge if cherry-pick conflicts exist'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-conflicts-label:
+    name: Check for conflicts label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check if PR has conflicts label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const hasConflictsLabel = pr.labels.some(
+              label => label.name === 'cherry pick has conflicts'
+            );
+
+            if (hasConflictsLabel) {
+              core.setFailed('❌ This PR has unresolved cherry-pick conflicts. Please resolve conflicts before merging.');
+            } else {
+              core.info('✅ No conflicts label found. PR can be merged.');
+            }

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -204,7 +204,6 @@ jobs:
           else
             # Capture conflicted files with their status codes
             CONFLICTED_STATUS=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" || true)
-            echo "conf_status:$CONFLICTED_STATUS"
             
             if [[ -n "$CONFLICTED_STATUS" ]]; then
               echo "has_conflicts=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -257,7 +257,7 @@ jobs:
             const targetBranch = '${{ inputs.target_branch }}';
             const cherryPickBranch = '${{ needs.verify.outputs.cherry_pick_branch }}';
             const hasConflicts = '${{ steps.cherry-pick.outputs.has_conflicts }}' === 'true';
-            const conflictStatus = `${{ steps.cherry-pick.outputs.conflict_status }}`;
+            const conflictStatus = '${{ steps.cherry-pick.outputs.conflict_status }}';
 
             try {
               // Get original PR details

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -250,6 +250,8 @@ jobs:
       - name: Create cherry-pick pull request
         id: create-pr
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        env:
+          CONFLICT_STATUS: ${{ steps.cherry-pick.outputs.conflict_status }}
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -257,7 +259,6 @@ jobs:
             const targetBranch = '${{ inputs.target_branch }}';
             const cherryPickBranch = '${{ needs.verify.outputs.cherry_pick_branch }}';
             const hasConflicts = '${{ steps.cherry-pick.outputs.has_conflicts }}' === 'true';
-            const conflictStatus = '${{ steps.cherry-pick.outputs.conflict_status }}';
 
             try {
               // Get original PR details
@@ -277,7 +278,7 @@ jobs:
                 prBody += `> 2. Remove the \`cherry pick has conflicts\` label (required to merge)\n`;
 
                 // Parse JSON array of conflicts
-                const conflicts = JSON.parse(conflictStatus || '[]');
+                const conflicts = JSON.parse(process.env.CONFLICT_STATUS || '[]');
                 // Map status codes to human-readable descriptions
                 const conflictTypeMap = {
                   'DD': 'deleted by both',

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -206,19 +206,14 @@ jobs:
           else
             # Capture conflicted files with their status codes
             CONFLICTED_STATUS=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" || true)
+            echo "conf_status:$CONFLICTED_STATUS"
             
             if [[ -n "$CONFLICTED_STATUS" ]]; then
               echo "has_conflicts=true" >> $GITHUB_OUTPUT
               
-              # Extract file paths
-              CONFLICT_FILES=$(echo "$CONFLICTED_STATUS" | awk '{print $2}' | tr '\n' ',' | sed 's/,$//')
-              echo "conflict_files=$CONFLICT_FILES" >> $GITHUB_OUTPUT
+              echo "conflict_status=$(echo "$CONFLICTED_STATUS" | tr '\n' '|' | sed 's/|$//')" >> $GITHUB_OUTPUT
               
-              # Create detailed conflict information (status_code:filename)
-              CONFLICT_DETAILS=$(echo "$CONFLICTED_STATUS" | awk '{print $1":"$2}' | tr '\n' '|' | sed 's/|$//')
-              echo "conflict_details=$CONFLICT_DETAILS" >> $GITHUB_OUTPUT
-              
-              echo "Cherry-pick had conflicts - details: $CONFLICT_DETAILS"
+              echo "Cherry-pick had conflicts - details: $CONFLICTED_STATUS"
 
               # Add all files (both conflicted and resolved)
               git add .
@@ -264,18 +259,7 @@ jobs:
             const targetBranch = '${{ inputs.target_branch }}';
             const cherryPickBranch = '${{ needs.verify.outputs.cherry_pick_branch }}';
             const hasConflicts = '${{ steps.cherry-pick.outputs.has_conflicts }}' === 'true';
-            const conflictDetails = '${{ steps.cherry-pick.outputs.conflict_details }}';
-
-            // Map status codes to human-readable descriptions
-            const conflictTypeMap = {
-              'DD': 'deleted by both',
-              'UA': 'added by cherry-pick, does not exist in target branch',
-              'UD': 'deleted by cherry-pick, modified in target branch',
-              'AU': 'modified by cherry-pick, added in target branch',
-              'DU': 'modified by cherry-pick, deleted in target branch',
-              'AA': 'added by both with different content',
-              'UU': 'modified by both'
-            };
+            const conflictStatus = '${{ steps.cherry-pick.outputs.conflict_status }}';
 
             try {
               // Get original PR details
@@ -289,17 +273,30 @@ jobs:
               let prBody = `This PR is a cherry-pick of #${prNumber} to \`${targetBranch}\`.\n\n`;
 
               if (hasConflicts) {
-                prBody += `⚠️ **WARNING**: This cherry-pick contained conflicts that have not been resolved. Please review the changes carefully before merging!\n\n`;
+                prBody += `⚠️ **WARNING**: This cherry-pick contained conflicts that have not been resolved\n\n`;
+                prBody += `1. Review and resolve all conflicts\n`;
+                prBody += `2. Remove the \`cherry pick has conflicts\` label (required to merge)\n\n`;
                 
-                if (conflictDetails) {
-                  const conflicts = conflictDetails.split('|').filter(c => c.trim());
-                  prBody += `### Files with conflicts:\n\n`;
-                  
-                  conflicts.forEach(conflict => {
-                    const [statusCode, file] = conflict.split(':');
-                    const description = conflictTypeMap[statusCode] || 'unknown conflict type';
-                    prBody += `- \`${file}\` — *${description}*\n`;
-                  });
+                if (conflictStatus) {
+                  // Map status codes to human-readable descriptions
+                  const conflictTypeMap = {
+                    'DD': 'deleted by both',
+                    'UA': 'added by cherry-pick, does not exist in target branch',
+                    'UD': 'deleted by cherry-pick, modified in target branch',
+                    'AU': 'modified by cherry-pick, added in target branch',
+                    'DU': 'modified by cherry-pick, deleted in target branch',
+                    'AA': 'added by both with different content',
+                    'UU': 'modified by both'
+                  };
+                  prBody += `### Conflicted Files:\n`;
+                  const conflictLines = conflictStatus.split('|');
+                  for (const line of conflictLines) {
+                    const statusCode = line.slice(0, 2);
+                    const filePath = line.slice(3).trim();
+                    const conflictType = conflictTypeMap[statusCode] || 'unknown conflict type';
+                    prBody += `- \`${filePath}\` (${conflictType})\n`;
+                  }
+
                   prBody += `\n`;
                 }
               }

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -282,7 +282,8 @@ jobs:
                 head: cherryPickBranch,
                 base: targetBranch,
                 title: `[Backport to ${targetBranch}] ${originalPr.title}`,
-                body: prBody
+                body: prBody,
+                labels: hasConflicts ? ['cherry pick has conflicts'] : []
               });
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -270,11 +270,11 @@ jobs:
             const conflictTypeMap = {
               'DD': 'deleted by both',
               'AU': 'added by cherry-pick, does not exist in target branch',
-              'UD': 'modified by cherry-pick, deleted in target branch',
+              'UD': 'deleted by cherry-pick, modified in target branch',
               'UA': 'modified by cherry-pick, added in target branch',
-              'DU': 'deleted by cherry-pick, modified in target branch',
+              'DU': 'modified by cherry-pick, deleted in target branch',
               'AA': 'added by both with different content',
-              'UU': 'modified by both (standard merge conflict)'
+              'UU': 'modified by both'
             };
 
             try {

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -200,8 +200,6 @@ jobs:
           if git cherry-pick -m1 "$MERGE_COMMIT_SHA"; then
             # Success case
             echo "has_conflicts=false" >> $GITHUB_OUTPUT
-            echo "conflict_files=" >> $GITHUB_OUTPUT
-            echo "conflict_details=" >> $GITHUB_OUTPUT
             echo "Cherry-pick completed successfully"
           else
             # Capture conflicted files with their status codes

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -269,9 +269,9 @@ jobs:
             // Map status codes to human-readable descriptions
             const conflictTypeMap = {
               'DD': 'deleted by both',
-              'AU': 'added by cherry-pick, does not exist in target branch',
+              'UA': 'added by cherry-pick, does not exist in target branch',
               'UD': 'deleted by cherry-pick, modified in target branch',
-              'UA': 'modified by cherry-pick, added in target branch',
+              'AU': 'modified by cherry-pick, added in target branch',
               'DU': 'modified by cherry-pick, deleted in target branch',
               'AA': 'added by both with different content',
               'UU': 'modified by both'

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -270,10 +270,10 @@ jobs:
               let prBody = `This PR is a cherry-pick of #${prNumber} to \`${targetBranch}\`.\n\n`;
 
               if (hasConflicts) {
-                prBody += `⚠️ **WARNING**: This cherry-pick contained conflicts that have not been resolved\n\n`;
-                prBody += `1. Review and resolve all conflicts\n`;
-                prBody += `2. Remove the \`cherry pick has conflicts\` label (required to merge)\n\n`;
-                
+                prBody += `> [!WARNING]\n`;
+                prBody += `> This cherry-pick contained conflicts that have not been resolved\n`;
+                prBody += `> 1. Review and resolve all conflicts\n`;
+                prBody += `> 2. Remove the \`cherry pick has conflicts\` label (required to merge)\n`;
                 if (conflictStatus) {
                   // Map status codes to human-readable descriptions
                   const conflictTypeMap = {
@@ -285,17 +285,17 @@ jobs:
                     'AA': 'added by both with different content',
                     'UU': 'modified by both'
                   };
-                  prBody += `### Conflicted Files:\n`;
+                  prBody += `>\n`; // Empty blockquote line for spacing
+                  prBody += `> **Conflicted Files:**\n`;
                   const conflictLines = conflictStatus.split('|');
                   for (const line of conflictLines) {
                     const statusCode = line.slice(0, 2);
                     const filePath = line.slice(3).trim();
                     const conflictType = conflictTypeMap[statusCode] || 'unknown conflict type';
-                    prBody += `- \`${filePath}\` (${conflictType})\n`;
+                    prBody += `> - \`${filePath}\` (${conflictType})\n`;
                   }
-
-                  prBody += `\n`;
                 }
+                prBody += `\n`;
               }
 
               prBody += `## Original PR Description\n\n${originalPr.body || '*No description provided*'}`;

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -202,15 +202,16 @@ jobs:
             echo "has_conflicts=false" >> $GITHUB_OUTPUT
             echo "Cherry-pick completed successfully"
           else
-            # Capture conflicted files with their status codes
-            CONFLICTED_STATUS=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" || true)
-            
-            if [[ -n "$CONFLICTED_STATUS" ]]; then
+            # Capture conflicted files with their status codes and build JSON array using jq
+            CONFLICT_JSON=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" | jq -R -n -c '
+              [inputs | {status: .[0:2], file: .[3:]}]
+            ')
+
+            if [[ "$CONFLICT_JSON" != "[]" ]]; then
               echo "has_conflicts=true" >> $GITHUB_OUTPUT
-              
-              echo "conflict_status=$(echo "$CONFLICTED_STATUS" | tr '\n' '|' | sed 's/|$//')" >> $GITHUB_OUTPUT
-              
-              echo "Cherry-pick had conflicts - details: $CONFLICTED_STATUS"
+              echo "conflict_status=$CONFLICT_JSON" >> $GITHUB_OUTPUT
+
+              echo "Cherry-pick had conflicts - details: $CONFLICT_JSON"
 
               # Add all files (both conflicted and resolved)
               git add .
@@ -256,7 +257,7 @@ jobs:
             const targetBranch = '${{ inputs.target_branch }}';
             const cherryPickBranch = '${{ needs.verify.outputs.cherry_pick_branch }}';
             const hasConflicts = '${{ steps.cherry-pick.outputs.has_conflicts }}' === 'true';
-            const conflictStatus = '${{ steps.cherry-pick.outputs.conflict_status }}';
+            const conflictStatus = `${{ steps.cherry-pick.outputs.conflict_status }}`;
 
             try {
               // Get original PR details
@@ -274,26 +275,24 @@ jobs:
                 prBody += `> This cherry-pick contained conflicts that have not been resolved\n`;
                 prBody += `> 1. Review and resolve all conflicts\n`;
                 prBody += `> 2. Remove the \`cherry pick has conflicts\` label (required to merge)\n`;
-                if (conflictStatus) {
-                  // Map status codes to human-readable descriptions
-                  const conflictTypeMap = {
-                    'DD': 'deleted by both',
-                    'UA': 'added by cherry-pick, does not exist in target branch',
-                    'UD': 'deleted by cherry-pick, modified in target branch',
-                    'AU': 'modified by cherry-pick, added in target branch',
-                    'DU': 'modified by cherry-pick, deleted in target branch',
-                    'AA': 'added by both with different content',
-                    'UU': 'modified by both'
-                  };
-                  prBody += `>\n`; // Empty blockquote line for spacing
-                  prBody += `> **Conflicted Files:**\n`;
-                  const conflictLines = conflictStatus.split('|');
-                  for (const line of conflictLines) {
-                    const statusCode = line.slice(0, 2);
-                    const filePath = line.slice(3).trim();
-                    const conflictType = conflictTypeMap[statusCode] || 'unknown conflict type';
-                    prBody += `> - \`${filePath}\` (${conflictType})\n`;
-                  }
+
+                // Parse JSON array of conflicts
+                const conflicts = JSON.parse(conflictStatus || '[]');
+                // Map status codes to human-readable descriptions
+                const conflictTypeMap = {
+                  'DD': 'deleted by both',
+                  'UA': 'added by cherry-pick, does not exist in target branch',
+                  'UD': 'deleted by cherry-pick, modified in target branch',
+                  'AU': 'modified by cherry-pick, added in target branch',
+                  'DU': 'modified by cherry-pick, deleted in target branch',
+                  'AA': 'added by both with different content',
+                  'UU': 'modified by both'
+                };
+                prBody += `>\n`; // Empty blockquote line for spacing
+                prBody += `> **Conflicted Files:**\n`;
+                for (const { status, file } of conflicts) {
+                  const conflictType = conflictTypeMap[status] || 'unknown conflict type';
+                  prBody += `> - \`${file}\` (${conflictType})\n`;
                 }
                 prBody += `\n`;
               }

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -200,14 +200,26 @@ jobs:
           if git cherry-pick -m1 "$MERGE_COMMIT_SHA"; then
             # Success case
             echo "has_conflicts=false" >> $GITHUB_OUTPUT
+            echo "conflict_files=" >> $GITHUB_OUTPUT
+            echo "conflict_details=" >> $GITHUB_OUTPUT
             echo "Cherry-pick completed successfully"
           else
-            # Look for conflict markers in git status
-            if git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)"; then
+            # Capture conflicted files with their status codes
+            CONFLICTED_STATUS=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" || true)
+            
+            if [[ -n "$CONFLICTED_STATUS" ]]; then
               echo "has_conflicts=true" >> $GITHUB_OUTPUT
-              echo "Cherry-pick had conflicts - resolving automatically"
+              
+              # Extract file paths
+              CONFLICT_FILES=$(echo "$CONFLICTED_STATUS" | awk '{print $2}' | tr '\n' ',' | sed 's/,$//')
+              echo "conflict_files=$CONFLICT_FILES" >> $GITHUB_OUTPUT
+              
+              # Create detailed conflict information (status_code:filename)
+              CONFLICT_DETAILS=$(echo "$CONFLICTED_STATUS" | awk '{print $1":"$2}' | tr '\n' '|' | sed 's/|$//')
+              echo "conflict_details=$CONFLICT_DETAILS" >> $GITHUB_OUTPUT
+              
+              echo "Cherry-pick had conflicts - details: $CONFLICT_DETAILS"
 
-              # For modify/delete conflicts, we need to handle them specifically
               # Add all files (both conflicted and resolved)
               git add .
 
@@ -252,6 +264,18 @@ jobs:
             const targetBranch = '${{ inputs.target_branch }}';
             const cherryPickBranch = '${{ needs.verify.outputs.cherry_pick_branch }}';
             const hasConflicts = '${{ steps.cherry-pick.outputs.has_conflicts }}' === 'true';
+            const conflictDetails = '${{ steps.cherry-pick.outputs.conflict_details }}';
+
+            // Map status codes to human-readable descriptions
+            const conflictTypeMap = {
+              'DD': 'deleted by both',
+              'AU': 'added by cherry-pick, does not exist in target branch',
+              'UD': 'modified by cherry-pick, deleted in target branch',
+              'UA': 'modified by cherry-pick, added in target branch',
+              'DU': 'deleted by cherry-pick, modified in target branch',
+              'AA': 'added by both with different content',
+              'UU': 'modified by both (standard merge conflict)'
+            };
 
             try {
               // Get original PR details
@@ -266,6 +290,18 @@ jobs:
 
               if (hasConflicts) {
                 prBody += `⚠️ **WARNING**: This cherry-pick contained conflicts that have not been resolved. Please review the changes carefully before merging!\n\n`;
+                
+                if (conflictDetails) {
+                  const conflicts = conflictDetails.split('|').filter(c => c.trim());
+                  prBody += `### Files with conflicts:\n\n`;
+                  
+                  conflicts.forEach(conflict => {
+                    const [statusCode, file] = conflict.split(':');
+                    const description = conflictTypeMap[statusCode] || 'unknown conflict type';
+                    prBody += `- \`${file}\` — *${description}*\n`;
+                  });
+                  prBody += `\n`;
+                }
               }
 
               prBody += `## Original PR Description\n\n${originalPr.body || '*No description provided*'}`;
@@ -282,15 +318,30 @@ jobs:
                 head: cherryPickBranch,
                 base: targetBranch,
                 title: `[Backport to ${targetBranch}] ${originalPr.title}`,
-                body: prBody,
-                labels: hasConflicts ? ['cherry pick has conflicts'] : []
+                body: prBody
               });
+              
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: newPr.number,
                 reviewers: [context.actor, originalPr.user.login]
               });
+
+              // Add label if there are conflicts
+              if (hasConflicts) {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: newPr.number,
+                    labels: ['cherry pick has conflicts']
+                  });
+                  core.info(`Added 'cherry pick has conflicts' label to PR #${newPr.number}`);
+                } catch (error) {
+                  core.warning(`Failed to add conflicts label: ${error.message}`);
+                }
+              }
 
               core.setOutput('pr_number', newPr.number.toString());
               core.setOutput('original_author', originalPr.user?.login || '');


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR introduces 3 changes:
1. Adds the `cherry pick has conflicts` label to cherry-pick PRs when they have conflicts.
2. Adds the new `Block merge if cherry-pick conflicts exist` workflow to avoid merging PRs with conflicts.
3. Improves the warning about conflicts in the cherry-pick PR description to specify the kind of conflicts that happened by file.

Part of https://github.com/woocommerce/woocommerce/issues/62068

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
4. In the forked repo, create a PR with the `fix/62068-check-cp-conflicts` and merge it.
5. Create the `Release` and `cherry pick to trunk` labels in your fork.
6. Go to `Actions` and enable them.
7. Create a PR against a release branch that would create conflicts when cherry-picked to `trunk` by following these instructions, or create one of your choice:
```
git checkout trunk
git pull origin trunk

echo "Original content line 1" > file-uu.txt
echo "Original content line 1" > file-du.txt
git add file-uu.txt file-du.txt
git commit -m "Add base files for testing"
git push origin trunk

git switch -c release/10.7
git push origin release/10.7
git checkout -b test-multi-conflict
echo "Modified in release line 2" >> file-uu.txt
echo "Modified in release line 2" >> file-du.txt
echo “File from release 10.7” > file-aa.txt
git add file-uu.txt file-du.txt file-aa.txt
git commit -m "Multi-conflict test"
git push origin test-multi-conflict

# In the GitHub UI:
# - Create the PR for `test-multi-conflict` into the `release/10.7`
# - Merge the PR

git checkout trunk
echo "Modified in trunk line 2" >> file-uu.txt
git rm file-du.txt
echo "Test from trunk" > file-aa.txt
git add file-uu.txt file-aa.txt
git commit -m "Create conflicts: modify, delete, and add"
git push origin trunk
```
8. In the GitHub UI, add the `cherry pick to trunk` label to the PR to run the cherry-pick workflow.
9. Wait for it to finish, go to the `[Backport...]` PR it created, and check that in the PR description has a message saying it has conflicts and there's also a list of the files with conflicts and a description of the conflict. For this example:
<img width="851" height="206" alt="Screenshot 2026-01-15 at 10 59 03" src="https://github.com/user-attachments/assets/d337d8f0-289d-4dc4-ba37-b7130f12cfcf" />

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
