### PR TITLE
Harden input validation in wc_clean

### DIFF
--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -403,11 +403,15 @@ function wc_sanitize_coupon_code( $value ) {
  * @return string|array
  */
 function wc_clean( $var ) {
-	if ( is_array( $var ) ) {
-		return array_map( 'wc_clean', $var );
-	} else {
-		return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
-	}
+    if ( is_array( $var ) ) {
+        return array_map( 'wc_clean', $var );
+    }
+
+    if ( is_object( $var ) || is_bool( $var ) || is_null( $var ) ) {
+        return '';
+    }
+
+    return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -407,12 +407,13 @@ function wc_clean( $var ) {
         return array_map( 'wc_clean', $var );
     }
 
-    if ( is_object( $var ) || is_bool( $var ) || is_null( $var ) ) {
+    if ( ! is_scalar( $var ) ) {
         return '';
     }
 
-    return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
+    return sanitize_text_field( $var );
 }
+
 
 /**
  * Function wp_check_invalid_utf8 with recursive array support.


### PR DESCRIPTION
This PR improves defensive input handling in wc_clean() by ensuring
objects, booleans, and null values are safely handled before sanitization.

Benefits:
- Prevents unexpected behavior and PHP notices
- Improves data consistency across admin, checkout, and API inputs
- Aligns with secure coding practices in WooCommerce core
