### PR TITLE
Fix the PR autoassign config file

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,116 +1,116 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
 
 "*":
-  - Flux
+  - team: flux
 
 ".github/**/*":
-  - Flux
+  - team: flux
 
 "bin/*":
-  - Flux
+  - team: flux
 
 "docs/**/*":
-  - Developer Advocacy
+  - team: developer-advocacy
 
 "packages/js/api/**/*":
-  - Flux
+  - team: flux
 
 "packages/js/components/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "packages/js/csv-export/**/*":
-  - SomewhereWarm
+  - team: somewherewarm
 
 "packages/js/currency/**/*":
-  - Rubik
+  - team: rubik
 
 "packages/js/customer-effort-score/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "packages/js/data/**/*":
-  - Ventures
+  - team: ventures
 
 "packages/js/date/**/*":
-  - Rubik
+  - team: rubik
 
 "packages/js/dependency-extraction-webpack-plugin/**/*":
-  - Flux
+  - team: flux
 
 "packages/js/eslint-plugin/**/*":
-  - Flux
+  - team: flux
 
 "packages/js/experimental/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "packages/js/explat/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "packages/js/navigation/**/*":
-  - SomewhereWarm
+  - team: somewherewarm
 
 "packages/js/number/**/*":
-  - Rubik
+  - team: rubik
 
 "packages/js/onboarding/**/*":
-  - Rubik
+  - team: rubik
 
 "packages/js/product-editor/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "packages/js/tracks/**/*":
-  - Flux
+  - team: flux
 
 "packages/js/email-editor/**/*":
-  - Ballade
+  - team: ballade
 
 "packages/php/email-editor/**/*":
-  - Ballade
+  - team: ballade
 
 "plugins/woocommerce/**/*":
-  - Flux
+  - team: flux
 
 "plugins/woocommerce/templates/**/*":
-  - Rubik
-  - Kirigami
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce/templates/emails/**/*":
-  - Ballade
+  - team: ballade
 
 "plugins/woocommerce/src/Admin/**/*":
-  - team: Kirigami
+  - team: woo-fse
 
 "plugins/woocommerce/src/Blocks/**/*":
-  - Rubik
-  - Kirigami
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce/src/Internal/Admin/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "plugins/woocommerce/src/StoreApi/**/*":
-  - Rubik
-  - Kirigami
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce/client/admin/**/*":
-  - Kirigami
+  - team: woo-fse
 
 "plugins/woocommerce/client/blocks/**/*":
-  - Rubik
-  - Kirigami
+  - team: rubik
+  - team: woo-fse
 
 "plugins/woocommerce-beta-tester/**/*":
-  - Flux
+  - team: flux
 
 "plugins/woocommerce/src/Internal/EmailEditor/**/*":
-  - Ballade
+  - team: ballade
 
 "plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/**/*":
-  - Ballade
+  - team: ballade
 
 "tools/**/*":
-  - Flux
+  - team: flux
 
 '**/composer.json':
-  - Flux
+  - team: flux
 
 '**/package.json':
-  - Flux
+  - team: flux


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/commit/84d8a9e8d6cb59d5f953f21f50dd843aaf626115 the configuration file for the automatic assignment of reviewers to pull requests action was updated to use the new team labels, however:

- `team: ` markers were removed, but [these are required by the GitHub API](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request) to tell apart teams from individual users.
- Team slugs were replaced by printable names, but slugs are actually required.

Additionally, references to Kirigami are replaceed with references to Woo FSE, as the former has been merged into the later.

### How to test the changes in this Pull Request:

There's no way to test this change beforehand except maybe create a fork of WooCommerce, replicate all the teams from the WooCommerce organization there, create a pull request from a community account (or modify [the workflow](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/automate-team-review-assignment.yml) to disable the "community pr" check) and verity that it gets a reviewer from the appropriate team.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This pull request makes a change in an internal GitHub workflow, not in WooCommerce itself, so no changelog entry is required.

</details>
