### PR TITLE
Migrate WooCommerce Accordion block usages to WordPress core Accordion

### DIFF
--- a/plugins/woocommerce/changelog/feat-62121-migrate-wc-accordion
+++ b/plugins/woocommerce/changelog/feat-62121-migrate-wc-accordion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add migration UI and conversion logic to upgrade WooCommerce Accordion blocks to the WordPress core Accordion block in WP 6.9+.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
@@ -5,16 +5,118 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	InspectorControls,
+	Warning,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl, Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { isWpVersion } from '@woocommerce/settings';
 
 const ACCORDION_BLOCK_NAME = 'woocommerce/accordion-item';
 const ACCORDION_BLOCK = {
 	name: ACCORDION_BLOCK_NAME,
 };
 
-export default function Edit( { attributes: { autoclose }, setAttributes } ) {
+/**
+ * Recursively convert WooCommerce accordion blocks to WordPress core accordion blocks.
+ *
+ * @param {Array<*>} innerBlocks - The inner blocks to convert.
+ *
+ * @return {Array<*>} The converted blocks.
+ */
+function convertInnerBlocks( innerBlocks ) {
+	return innerBlocks.map( ( block ) => {
+		let newBlockName = block.name;
+		const newAttributes = { ...block.attributes };
+
+		// Map WooCommerce block names to WordPress core block names
+		if ( block.name === 'woocommerce/accordion-item' ) {
+			newBlockName = 'core/accordion-item';
+		} else if ( block.name === 'woocommerce/accordion-header' ) {
+			newBlockName = 'core/accordion-heading';
+		} else if ( block.name === 'woocommerce/accordion-panel' ) {
+			newBlockName = 'core/accordion-panel';
+		}
+
+		// Recursively convert inner blocks
+		const convertedInnerBlocks = block.innerBlocks?.length
+			? convertInnerBlocks( block.innerBlocks )
+			: [];
+
+		return createBlock( newBlockName, newAttributes, convertedInnerBlocks );
+	} );
+}
+
+/**
+ * Deprecation notice component for the WooCommerce Accordion block.
+ *
+ * @param {Object} props          - Component props.
+ * @param {string} props.clientId - The block client ID.
+ *
+ * @return {JSX.Element} The deprecation notice component.
+ */
+function DeprecatedBlockEdit( { clientId } ) {
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	const { currentBlockAttributes, innerBlocks } = useSelect(
+		( select ) => {
+			const blockEditor = select( 'core/block-editor' );
+			return {
+				currentBlockAttributes:
+					blockEditor.getBlockAttributes( clientId ),
+				innerBlocks: blockEditor.getBlocks( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const updateBlock = () => {
+		const convertedInnerBlocks = convertInnerBlocks( innerBlocks );
+
+		replaceBlocks(
+			clientId,
+			createBlock(
+				'core/accordion',
+				currentBlockAttributes,
+				convertedInnerBlocks
+			)
+		);
+	};
+
+	const actions = [
+		<Button key="update" onClick={ updateBlock } variant="primary">
+			{ __( 'Upgrade Block', 'woocommerce' ) }
+		</Button>,
+	];
+
+	return (
+		<Warning actions={ actions } className="wc-block-components-actions">
+			{ __(
+				'This version of the Accordion block is outdated. Upgrade to continue using.',
+				'woocommerce'
+			) }
+		</Warning>
+	);
+}
+
+/**
+ * Edit component for the WooCommerce Accordion Group block.
+ *
+ * @param {Object}   props                      - Component props.
+ * @param {Object}   props.attributes           - Block attributes.
+ * @param {boolean}  props.attributes.autoclose - Whether to auto-close other accordions.
+ * @param {Function} props.setAttributes        - Function to set block attributes.
+ * @param {string}   props.clientId             - The block client ID.
+ *
+ * @return {JSX.Element} The edit component.
+ */
+export default function Edit( {
+	attributes: { autoclose },
+	setAttributes,
+	clientId,
+} ) {
 	const blockProps = useBlockProps();
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -23,6 +125,12 @@ export default function Edit( { attributes: { autoclose }, setAttributes } ) {
 		directInsert: true,
 	} );
 
+	// Show deprecation notice for WordPress 6.9+.
+	if ( isWpVersion( '6.9', '>=' ) ) {
+		return <DeprecatedBlockEdit clientId={ clientId } />;
+	}
+
+	// Original edit UI for WordPress 6.8 and below.
 	return (
 		<>
 			<InspectorControls key="setting">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
@@ -96,7 +96,7 @@ function DeprecatedBlockEdit( { clientId } ) {
 
 	const { currentBlockAttributes, innerBlocks } = useSelect(
 		( select ) => {
-			const blockEditor = select( 'core/block-editor' );
+			const blockEditor = select( blockEditorStore );
 			return {
 				currentBlockAttributes:
 					blockEditor.getBlockAttributes( clientId ),
@@ -107,6 +107,10 @@ function DeprecatedBlockEdit( { clientId } ) {
 	);
 
 	const updateBlock = () => {
+		if ( ! currentBlockAttributes ) {
+			return;
+		}
+
 		const convertedInnerBlocks = convertInnerBlocks( innerBlocks );
 
 		// Filter accordion-group attributes - remove 'allowedBlocks'.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
@@ -20,70 +20,6 @@ const ACCORDION_BLOCK = {
 };
 
 /**
- * Recursively convert WooCommerce accordion blocks to WordPress core accordion blocks.
- *
- * @param {Array<*>} innerBlocks - The inner blocks to convert.
- *
- * @return {Array<*>} The converted blocks.
- */
-function convertInnerBlocks( innerBlocks ) {
-	// Define attributes to REMOVE for each block type.
-	const attributesToRemove = {
-		'woocommerce/accordion-header': [
-			'icon',
-			'textAlignment',
-			'levelOptions',
-		],
-		'woocommerce/accordion-panel': [
-			'allowedBlocks',
-			'isSelected',
-			'openByDefault',
-		],
-	};
-
-	return innerBlocks.map( ( block ) => {
-		let newBlockName = block.name;
-		const newAttributes = { ...block.attributes };
-
-		// Map WooCommerce block names to WordPress core block names
-		if ( block.name === 'woocommerce/accordion-item' ) {
-			newBlockName = 'core/accordion-item';
-			// No attribute changes needed.
-		} else if ( block.name === 'woocommerce/accordion-header' ) {
-			newBlockName = 'core/accordion-heading';
-
-			// Convert icon to showIcon
-			if ( block.attributes.icon !== undefined ) {
-				newAttributes.showIcon = block.attributes.icon !== false;
-			}
-
-			// Remove incompatible attributes
-			const headerAttrs =
-				attributesToRemove[ 'woocommerce/accordion-header' ];
-			headerAttrs.forEach( ( attr ) => {
-				delete newAttributes[ attr ];
-			} );
-		} else if ( block.name === 'woocommerce/accordion-panel' ) {
-			newBlockName = 'core/accordion-panel';
-
-			// Remove incompatible attributes
-			const panelAttrs =
-				attributesToRemove[ 'woocommerce/accordion-panel' ];
-			panelAttrs.forEach( ( attr ) => {
-				delete newAttributes[ attr ];
-			} );
-		}
-
-		// Recursively convert inner blocks
-		const convertedInnerBlocks = block.innerBlocks?.length
-			? convertInnerBlocks( block.innerBlocks )
-			: [];
-
-		return createBlock( newBlockName, newAttributes, convertedInnerBlocks );
-	} );
-}
-
-/**
  * Deprecation notice component for the WooCommerce Accordion block.
  *
  * @param {Object} props          - Component props.
@@ -105,6 +41,74 @@ function DeprecatedBlockEdit( { clientId } ) {
 		},
 		[ clientId ]
 	);
+
+	/**
+	 * Recursively convert WooCommerce accordion blocks to WordPress core accordion blocks.
+	 *
+	 * @param {Array<*>} blocks - The inner blocks to convert.
+	 *
+	 * @return {Array<*>} The converted blocks.
+	 */
+	const convertInnerBlocks = ( blocks ) => {
+		// Define attributes to REMOVE for each block type.
+		const attributesToRemove = {
+			'woocommerce/accordion-header': [
+				'icon',
+				'textAlignment',
+				'levelOptions',
+			],
+			'woocommerce/accordion-panel': [
+				'allowedBlocks',
+				'isSelected',
+				'openByDefault',
+			],
+		};
+
+		return blocks.map( ( block ) => {
+			let newBlockName = block.name;
+			const newAttributes = { ...block.attributes };
+
+			// Map WooCommerce block names to WordPress core block names.
+			if ( block.name === 'woocommerce/accordion-item' ) {
+				newBlockName = 'core/accordion-item';
+				// No attribute changes needed.
+			} else if ( block.name === 'woocommerce/accordion-header' ) {
+				newBlockName = 'core/accordion-heading';
+
+				// Convert icon to showIcon.
+				if ( block.attributes.icon !== undefined ) {
+					newAttributes.showIcon = block.attributes.icon !== false;
+				}
+
+				// Remove incompatible attributes.
+				const headerAttrs =
+					attributesToRemove[ 'woocommerce/accordion-header' ];
+				headerAttrs.forEach( ( attr ) => {
+					delete newAttributes[ attr ];
+				} );
+			} else if ( block.name === 'woocommerce/accordion-panel' ) {
+				newBlockName = 'core/accordion-panel';
+
+				// Remove incompatible attributes.
+				const panelAttrs =
+					attributesToRemove[ 'woocommerce/accordion-panel' ];
+				panelAttrs.forEach( ( attr ) => {
+					delete newAttributes[ attr ];
+				} );
+			}
+
+			// Recursively convert inner blocks.
+			const convertedInnerBlocks = block.innerBlocks?.length
+				? convertInnerBlocks( block.innerBlocks )
+				: [];
+
+			return createBlock(
+				newBlockName,
+				newAttributes,
+				convertedInnerBlocks
+			);
+		} );
+	};
 
 	const updateBlock = () => {
 		if ( ! currentBlockAttributes ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/accordion-group/edit.js
@@ -27,6 +27,20 @@ const ACCORDION_BLOCK = {
  * @return {Array<*>} The converted blocks.
  */
 function convertInnerBlocks( innerBlocks ) {
+	// Define attributes to REMOVE for each block type.
+	const attributesToRemove = {
+		'woocommerce/accordion-header': [
+			'icon',
+			'textAlignment',
+			'levelOptions',
+		],
+		'woocommerce/accordion-panel': [
+			'allowedBlocks',
+			'isSelected',
+			'openByDefault',
+		],
+	};
+
 	return innerBlocks.map( ( block ) => {
 		let newBlockName = block.name;
 		const newAttributes = { ...block.attributes };
@@ -34,10 +48,30 @@ function convertInnerBlocks( innerBlocks ) {
 		// Map WooCommerce block names to WordPress core block names
 		if ( block.name === 'woocommerce/accordion-item' ) {
 			newBlockName = 'core/accordion-item';
+			// No attribute changes needed.
 		} else if ( block.name === 'woocommerce/accordion-header' ) {
 			newBlockName = 'core/accordion-heading';
+
+			// Convert icon to showIcon
+			if ( block.attributes.icon !== undefined ) {
+				newAttributes.showIcon = block.attributes.icon !== false;
+			}
+
+			// Remove incompatible attributes
+			const headerAttrs =
+				attributesToRemove[ 'woocommerce/accordion-header' ];
+			headerAttrs.forEach( ( attr ) => {
+				delete newAttributes[ attr ];
+			} );
 		} else if ( block.name === 'woocommerce/accordion-panel' ) {
 			newBlockName = 'core/accordion-panel';
+
+			// Remove incompatible attributes
+			const panelAttrs =
+				attributesToRemove[ 'woocommerce/accordion-panel' ];
+			panelAttrs.forEach( ( attr ) => {
+				delete newAttributes[ attr ];
+			} );
 		}
 
 		// Recursively convert inner blocks
@@ -75,11 +109,15 @@ function DeprecatedBlockEdit( { clientId } ) {
 	const updateBlock = () => {
 		const convertedInnerBlocks = convertInnerBlocks( innerBlocks );
 
+		// Filter accordion-group attributes - remove 'allowedBlocks'.
+		const { allowedBlocks, ...filteredGroupAttributes } =
+			currentBlockAttributes;
+
 		replaceBlocks(
 			clientId,
 			createBlock(
 				'core/accordion',
-				currentBlockAttributes,
+				filteredGroupAttributes,
 				convertedInnerBlocks
 			)
 		);

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
@@ -7,6 +7,53 @@ const blockData = {
 	slug: 'woocommerce/accordion-group',
 };
 
+const accordionInnerBlocks = [
+	{
+		name: 'woocommerce/accordion-item',
+		innerBlocks: [
+			{
+				name: 'woocommerce/accordion-header',
+				attributes: {
+					title: 'First Accordion Header',
+				},
+			},
+			{
+				name: 'woocommerce/accordion-panel',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content: 'First accordion content',
+						},
+					},
+				],
+			},
+		],
+	},
+	{
+		name: 'woocommerce/accordion-item',
+		innerBlocks: [
+			{
+				name: 'woocommerce/accordion-header',
+				attributes: {
+					title: 'Second Accordion Header',
+				},
+			},
+			{
+				name: 'woocommerce/accordion-panel',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content: 'Second accordion content',
+						},
+					},
+				],
+			},
+		],
+	},
+];
+
 test.describe( `${ blockData.slug } Block - Deprecation`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -15,16 +62,48 @@ test.describe( `${ blockData.slug } Block - Deprecation`, () => {
 	test( 'shows deprecation notice and converts all inner blocks to core accordion on upgrade', async ( {
 		editor,
 		frontendUtils,
+		page,
 	} ) => {
-		// Insert WooCommerce accordion block.
-		await editor.insertBlock( { name: blockData.slug } );
+		// Insert WooCommerce accordion block with inner blocks and content.
+		await editor.insertBlock( {
+			name: blockData.slug,
+			innerBlocks: accordionInnerBlocks,
+		} );
 
-		// Verify deprecation message is displayed in the canvas.
+		// Wait for the deprecation notice to appear.
 		await expect(
 			editor.canvas.getByText(
 				'This version of the Accordion block is outdated. Upgrade to continue using.'
 			)
 		).toBeVisible();
+
+		// Verify legacy block still renders as expected before upgrade. Save as draft and preview it.
+		await editor.saveDraft();
+		const postId = await page.evaluate( () => {
+			return window.wp.data.select( 'core/editor' ).getCurrentPostId();
+		} );
+		await page.goto( `/?p=${ postId }&preview=true` );
+		const legacyAccordionFrontend = frontendUtils.page.locator(
+			'.wp-block-woocommerce-accordion-group'
+		);
+		await expect( legacyAccordionFrontend ).toBeVisible();
+
+		// Verify legacy accordion has accordion items with buttons.
+		const legacyAccordionButtons =
+			legacyAccordionFrontend.getByRole( 'button' );
+		const legacyItemCount = await legacyAccordionButtons.count();
+		expect( legacyItemCount ).toBe( 2 );
+
+		// Verify the content is visible.
+		await expect(
+			legacyAccordionFrontend.getByText( 'First Accordion Header' )
+		).toBeVisible();
+		await expect(
+			legacyAccordionFrontend.getByText( 'Second Accordion Header' )
+		).toBeVisible();
+
+		// Go back to editor.
+		await page.goBack();
 
 		// Verify upgrade button is displayed.
 		const upgradeButton = editor.canvas.getByRole( 'button', {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
@@ -59,11 +59,18 @@ test.describe( `${ blockData.slug } Block - Deprecation`, () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'shows deprecation notice and converts all inner blocks to core accordion on upgrade', async ( {
+	test( 'shows deprecation notice and converts all inner blocks to core accordion on upgrade (WP 6.9+)', async ( {
 		editor,
 		frontendUtils,
 		page,
+		wpCoreVersion,
 	} ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			wpCoreVersion < 6.9,
+			'This test requires WordPress 6.9 or later'
+		);
+
 		// Insert WooCommerce accordion block with inner blocks and content.
 		await editor.insertBlock( {
 			name: blockData.slug,
@@ -172,5 +179,28 @@ test.describe( `${ blockData.slug } Block - Deprecation`, () => {
 		// Verify accordion buttons are present.
 		const accordionButtons = accordionFrontend.getByRole( 'button' );
 		await expect( accordionButtons ).toHaveCount( itemCount );
+	} );
+
+	test( 'does not show deprecation notice in WordPress 6.8 or earlier', async ( {
+		editor,
+		wpCoreVersion,
+	} ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			wpCoreVersion >= 6.9,
+			'This test is only for WordPress 6.8 or earlier'
+		);
+
+		// Insert WooCommerce accordion block with inner blocks and content.
+		await editor.insertBlock( {
+			name: blockData.slug,
+			innerBlocks: accordionInnerBlocks,
+		} );
+
+		// Verify deprecation notice is NOT shown.
+		const deprecationNotice = editor.canvas.getByText(
+			'This version of the Accordion block is outdated. Upgrade to continue using.'
+		);
+		await expect( deprecationNotice ).toBeHidden();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/accordion/accordion.block_theme.spec.ts
@@ -1,214 +1,97 @@
 /**
  * External dependencies
  */
-import { expect, test as base } from '@woocommerce/e2e-utils';
-
-/**
- * Internal dependencies
- */
-import { AccordionPage } from './accordion.page';
+import { expect, test } from '@woocommerce/e2e-utils';
 
 const blockData = {
 	slug: 'woocommerce/accordion-group',
 };
 
-const test = base.extend< { pageObject: AccordionPage } >( {
-	pageObject: async (
-		{ page, editor, frontendUtils, requestUtils },
-		use
-	) => {
-		const pageObject = new AccordionPage( {
-			page,
-			editor,
-			frontendUtils,
-			requestUtils,
-		} );
-		await use( pageObject );
-	},
-} );
-
-test.describe( `${ blockData.slug } Block`, () => {
+test.describe( `${ blockData.slug } Block - Deprecation`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'can be inserted in Post Editor and it is visible on the frontend when feature flag is enabled', async ( {
+	test( 'shows deprecation notice and converts all inner blocks to core accordion on upgrade', async ( {
 		editor,
 		frontendUtils,
 	} ) => {
+		// Insert WooCommerce accordion block.
 		await editor.insertBlock( { name: blockData.slug } );
-		const blockLocator = await editor.getBlockByName( blockData.slug );
-		await expect(
-			blockLocator.getByLabel( 'Accordion title' )
-		).toHaveCount( 2 );
-		await editor.publishAndVisitPost();
-		const blockLocatorFrontend = await frontendUtils.getBlockByName(
-			blockData.slug
-		);
-		await expect( blockLocatorFrontend.getByRole( 'button' ) ).toHaveCount(
-			2
-		);
-	} );
 
-	test( 'can add title and panel content', async ( {
-		editor,
-		frontendUtils,
-		pageObject,
-	} ) => {
-		await pageObject.insertAccordionGroup( [
-			{
-				title: 'Accordion title 1',
-				content: 'Test paragraph content for first panel',
-			},
-			{
-				title: 'Accordion title 2',
-				content: 'Test paragraph content for second panel',
-			},
-		] );
-		await editor.publishAndVisitPost();
-		const blockLocatorFrontend = await frontendUtils.getBlockByName(
-			blockData.slug
-		);
+		// Verify deprecation message is displayed in the canvas.
 		await expect(
-			blockLocatorFrontend.getByText( 'Accordion title 1' )
+			editor.canvas.getByText(
+				'This version of the Accordion block is outdated. Upgrade to continue using.'
+			)
 		).toBeVisible();
-		await expect(
-			blockLocatorFrontend.getByText( 'Accordion title 2' )
-		).toBeVisible();
-		await expect(
-			blockLocatorFrontend.getByText(
-				'Test paragraph content for first panel'
-			)
-		).toBeAttached();
-		await expect(
-			blockLocatorFrontend.getByText(
-				'Test paragraph content for second panel'
-			)
-		).toBeAttached();
-	} );
 
-	test( 'can toggle panel visibility', async ( {
-		editor,
-		frontendUtils,
-		pageObject,
-	} ) => {
-		await pageObject.insertAccordionGroup( [
-			{
-				title: 'Accordion title',
-				content: 'Test paragraph content for first panel',
-			},
-			{
-				title: 'Accordion title 2',
-				content: 'Test paragraph content for second panel',
-			},
-		] );
+		// Verify upgrade button is displayed.
+		const upgradeButton = editor.canvas.getByRole( 'button', {
+			name: 'Upgrade Block',
+		} );
+		await expect( upgradeButton ).toBeVisible();
+
+		// Click the upgrade button.
+		await upgradeButton.click();
+
+		// Verify the block was converted to core/accordion.
+		const coreAccordion = await editor.getBlockByName( 'core/accordion' );
+		await expect( coreAccordion ).toBeVisible();
+
+		// Verify the WooCommerce accordion block is no longer present.
+		const wooAccordion = editor.canvas.locator(
+			'[data-type="woocommerce/accordion-group"]'
+		);
+		await expect( wooAccordion ).toHaveCount( 0 );
+
+		// Verify all inner blocks are converted correctly.
+		// Check that accordion items exist (woocommerce/accordion-item → core/accordion-item).
+		const coreAccordionItems = editor.canvas.locator(
+			'[data-type="core/accordion-item"]'
+		);
+		const itemCount = await coreAccordionItems.count();
+		expect( itemCount ).toBeGreaterThan( 0 );
+
+		// Check accordion headings (woocommerce/accordion-header → core/accordion-heading).
+		const coreAccordionHeadings = editor.canvas.locator(
+			'[data-type="core/accordion-heading"]'
+		);
+		await expect( coreAccordionHeadings ).toHaveCount( itemCount );
+
+		// Check accordion panels (woocommerce/accordion-panel → core/accordion-panel).
+		const coreAccordionPanels = editor.canvas.locator(
+			'[data-type="core/accordion-panel"]'
+		);
+		await expect( coreAccordionPanels ).toHaveCount( itemCount );
+
+		// Verify no WooCommerce accordion inner blocks remain.
+		const wooAccordionItems = editor.canvas.locator(
+			'[data-type="woocommerce/accordion-item"]'
+		);
+		await expect( wooAccordionItems ).toHaveCount( 0 );
+
+		const wooAccordionHeaders = editor.canvas.locator(
+			'[data-type="woocommerce/accordion-header"]'
+		);
+		await expect( wooAccordionHeaders ).toHaveCount( 0 );
+
+		const wooAccordionPanels = editor.canvas.locator(
+			'[data-type="woocommerce/accordion-panel"]'
+		);
+		await expect( wooAccordionPanels ).toHaveCount( 0 );
+
+		// Publish the post.
 		await editor.publishAndVisitPost();
-		const blockLocatorFrontend = await frontendUtils.getBlockByName(
-			blockData.slug
+
+		// Verify the core accordion block is visible on the frontend.
+		const accordionFrontend = frontendUtils.page.locator(
+			'.wp-block-accordion'
 		);
-		await expect(
-			blockLocatorFrontend.getByText(
-				'Test paragraph content for first panel'
-			)
-		).not.toBeInViewport();
-		await blockLocatorFrontend.getByRole( 'button' ).first().click();
-		await expect(
-			blockLocatorFrontend.getByText(
-				'Test paragraph content for first panel'
-			)
-		).toBeInViewport();
-	} );
+		await expect( accordionFrontend ).toBeVisible();
 
-	test( 'can set panel to open by default and should close when clicked', async ( {
-		editor,
-		frontendUtils,
-		pageObject,
-	} ) => {
-		await pageObject.insertAccordionGroup( [
-			{
-				title: 'Accordion title',
-				content: 'Test paragraph content 1',
-			},
-			{
-				title: 'Accordion title 2',
-				content: 'Test paragraph content 2',
-			},
-		] );
-		const accordionPanel = await editor.getBlockByName(
-			'woocommerce/accordion-item'
-		);
-		await editor.selectBlocks( accordionPanel.first() );
-
-		// Open block settings sidebar and check "Open by default" option
-		await editor.openDocumentSettingsSidebar();
-		await editor.page
-			.getByLabel( 'Settings' )
-			.getByRole( 'checkbox', { name: 'Open by default' } )
-			.check();
-
-		// Publish and visit post and check that the panel is hidden.
-		await editor.publishAndVisitPost();
-		const blockLocatorFrontend = await frontendUtils.getBlockByName(
-			blockData.slug
-		);
-		await expect(
-			blockLocatorFrontend.getByText( 'Test paragraph content 1' )
-		).toBeInViewport();
-		await blockLocatorFrontend.getByRole( 'button' ).first().click();
-		await expect(
-			blockLocatorFrontend.getByText( 'Test paragraph content 1' )
-		).not.toBeInViewport();
-	} );
-
-	test( 'can set to auto close when another panel is clicked', async ( {
-		editor,
-		frontendUtils,
-		pageObject,
-	} ) => {
-		await pageObject.insertAccordionGroup( [
-			{
-				title: 'Accordion title 1',
-				content: 'Test paragraph content 1',
-			},
-			{
-				title: 'Accordion title 2',
-				content: 'Test paragraph content 2',
-			},
-			{
-				title: 'Accordion title 3',
-				content: 'Test paragraph content 3',
-			},
-		] );
-		const accordionPanel = await editor.getBlockByName(
-			'woocommerce/accordion-group'
-		);
-		await editor.selectBlocks( accordionPanel.first() );
-
-		// Open block settings sidebar and check "Open by default" option
-		await editor.openDocumentSettingsSidebar();
-		await editor.page
-			.getByLabel( 'Settings' )
-			.getByRole( 'checkbox', {
-				name: 'Auto-close',
-			} )
-			.check();
-
-		// Publish and visit post and check that the panel is hidden.
-		await editor.publishAndVisitPost();
-		const blockLocatorFrontend = await frontendUtils.getBlockByName(
-			blockData.slug
-		);
-		await blockLocatorFrontend.getByRole( 'button' ).first().click();
-		await expect(
-			blockLocatorFrontend.getByText( 'Test paragraph content 1' )
-		).toBeInViewport();
-		await blockLocatorFrontend.getByRole( 'button' ).nth( 1 ).click();
-		await expect(
-			blockLocatorFrontend.getByText( 'Test paragraph content 1' )
-		).not.toBeInViewport();
-		await blockLocatorFrontend.getByRole( 'button' ).nth( 2 ).click();
-		await expect(
-			blockLocatorFrontend.getByText( 'Test paragraph content 2' )
-		).not.toBeInViewport();
+		// Verify accordion buttons are present.
+		const accordionButtons = accordionFrontend.getByRole( 'button' );
+		await expect( accordionButtons ).toHaveCount( itemCount );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces a migration path for WooCommerce Accordion blocks in WordPress 6.9 and later.

For WP 6.9+:
- Displays a warning banner prompting users to upgrade to the WordPress core Accordion block.
- Provides an “Upgrade Block” action that converts WooCommerce Accordion blocks to their core equivalents.
- Handles nested accordion structures via a recursive block conversion.
- This follows the same UX pattern used for the `Product Search` block deprecation.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #62121 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/26400e97-9419-4d81-a8b1-22167fc3b1a6

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the WP version is 6.9+
2. Go to Appearance > Template
3. Edit the `Single Product` template
4. Click on the `Product Summary` block
5. Add the `Product Details` block below it
6. See a notice appears `This version of the Accordion block is outdated. Upgrade to continue using.`
7. And a button should be there with name `Upgrade block`
8. Click on that button and the WC Accordion block should be updated to the Core Accordion block
9. Confirm it on the frontend too

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
