### PR TITLE
Prevent inconsistent and flaky quantity updates in Cart block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5076-quantity-qty-selector-in-new-block-cart-inconsistentflaky
+++ b/plugins/woocommerce/changelog/wooplug-5076-quantity-qty-selector-in-new-block-cart-inconsistentflaky
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cart quantity selector briefly reverting to previous value when changing quantity rapidly.

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -95,12 +95,24 @@ export const useStoreCartItemQuantity = (
 		const hasInflightRequest = isPending.quantity;
 		// Only block if debounce JUST caught up and differs from server (about to fire API)
 		// If debounce didn't change, server must have changed cartItemQuantity → allow sync
-		const debouncedJustChanged = debouncedQuantity !== previousDebouncedQuantity;
-		const aboutToFireApiCall = debouncedJustChanged && debouncedQuantity !== cartItemQuantity;
-		if ( ! hasPendingLocalChange && ! hasInflightRequest && ! aboutToFireApiCall ) {
+		const debouncedJustChanged =
+			debouncedQuantity !== previousDebouncedQuantity;
+		const aboutToFireApiCall =
+			debouncedJustChanged && debouncedQuantity !== cartItemQuantity;
+		if (
+			! hasPendingLocalChange &&
+			! hasInflightRequest &&
+			! aboutToFireApiCall
+		) {
 			setQuantity( cartItemQuantity );
 		}
-	}, [ cartItemQuantity, quantity, debouncedQuantity, previousDebouncedQuantity, isPending.quantity ] );
+	}, [
+		cartItemQuantity,
+		quantity,
+		debouncedQuantity,
+		previousDebouncedQuantity,
+		isPending.quantity,
+	] );
 
 	const removeItem = useCallback( () => {
 		if ( cartItemKey ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -87,16 +87,20 @@ export const useStoreCartItemQuantity = (
 	// Update local state when server updates, but only if:
 	// 1. User hasn't made a change waiting to be debounced
 	// 2. No API request is currently in flight
-	// 3. Debounced quantity matches server (no pending API call about to fire)
-	// This prevents stale API responses from overwriting user's pending changes.
+	// 3. No API call about to fire (debounce just caught up but thunk hasn't started)
+	// This prevents stale API responses from overwriting user's pending changes,
+	// while still allowing server-initiated changes (e.g., bundled products) to sync.
 	useEffect( () => {
 		const hasPendingLocalChange = quantity !== debouncedQuantity;
 		const hasInflightRequest = isPending.quantity;
-		const hasPendingApiCall = debouncedQuantity !== cartItemQuantity;
-		if ( ! hasPendingLocalChange && ! hasInflightRequest && ! hasPendingApiCall ) {
+		// Only block if debounce JUST caught up and differs from server (about to fire API)
+		// If debounce didn't change, server must have changed cartItemQuantity → allow sync
+		const debouncedJustChanged = debouncedQuantity !== previousDebouncedQuantity;
+		const aboutToFireApiCall = debouncedJustChanged && debouncedQuantity !== cartItemQuantity;
+		if ( ! hasPendingLocalChange && ! hasInflightRequest && ! aboutToFireApiCall ) {
 			setQuantity( cartItemQuantity );
 		}
-	}, [ cartItemQuantity, quantity, debouncedQuantity, isPending.quantity ] );
+	}, [ cartItemQuantity, quantity, debouncedQuantity, previousDebouncedQuantity, isPending.quantity ] );
 
 	const removeItem = useCallback( () => {
 		if ( cartItemKey ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -66,9 +66,6 @@ export const useStoreCartItemQuantity = (
 	const { removeItemFromCart, changeCartItemQuantity } =
 		useDispatch( cartStore );
 
-	// Update local state when server updates.
-	useEffect( () => setQuantity( cartItemQuantity ), [ cartItemQuantity ] );
-
 	// Track when things are already pending updates.
 	const isPending = useSelect(
 		( select ) => {
@@ -86,6 +83,20 @@ export const useStoreCartItemQuantity = (
 		},
 		[ cartItemKey ]
 	);
+
+	// Update local state when server updates, but only if:
+	// 1. User hasn't made a change waiting to be debounced
+	// 2. No API request is currently in flight
+	// 3. Debounced quantity matches server (no pending API call about to fire)
+	// This prevents stale API responses from overwriting user's pending changes.
+	useEffect( () => {
+		const hasPendingLocalChange = quantity !== debouncedQuantity;
+		const hasInflightRequest = isPending.quantity;
+		const hasPendingApiCall = debouncedQuantity !== cartItemQuantity;
+		if ( ! hasPendingLocalChange && ! hasInflightRequest && ! hasPendingApiCall ) {
+			setQuantity( cartItemQuantity );
+		}
+	}, [ cartItemQuantity, quantity, debouncedQuantity, isPending.quantity ] );
 
 	const removeItem = useCallback( () => {
 		if ( cartItemKey ) {

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -1,0 +1,247 @@
+/**
+ * Internal dependencies
+ */
+import { changeCartItemQuantity } from '../thunks';
+import { apiFetchWithHeaders } from '../../shared-controls';
+
+jest.mock( '../../shared-controls', () => ( {
+	apiFetchWithHeaders: jest.fn(),
+} ) );
+
+const mockApiFetchWithHeaders = apiFetchWithHeaders as jest.MockedFunction<
+	typeof apiFetchWithHeaders
+>;
+
+describe( 'changeCartItemQuantity', () => {
+	const createMockDispatchAndSelect = (
+		cartItems: Record< string, number >
+	) => {
+		const mockDispatch = {
+			receiveCart: jest.fn(),
+			receiveError: jest.fn(),
+			itemIsPendingQuantity: jest.fn(),
+		};
+
+		const mockSelect = {
+			getCartItem: jest.fn( ( key: string ) => {
+				if ( key in cartItems ) {
+					return { quantity: cartItems[ key ] };
+				}
+				return null;
+			} ),
+		};
+
+		return { dispatch: mockDispatch, select: mockSelect };
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should not make API call if quantity is unchanged', async () => {
+		const { dispatch, select } = createMockDispatchAndSelect( {
+			'item-1': 5,
+		} );
+
+		await changeCartItemQuantity(
+			'item-1',
+			5
+		)( { dispatch, select } as never );
+
+		expect( mockApiFetchWithHeaders ).not.toHaveBeenCalled();
+		expect( dispatch.itemIsPendingQuantity ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should make API call when quantity changes', async () => {
+		const { dispatch, select } = createMockDispatchAndSelect( {
+			'item-1': 1,
+		} );
+
+		mockApiFetchWithHeaders.mockResolvedValueOnce( {
+			response: { items: [ { key: 'item-1', quantity: 5 } ] },
+		} );
+
+		await changeCartItemQuantity(
+			'item-1',
+			5
+		)( { dispatch, select } as never );
+
+		expect( mockApiFetchWithHeaders ).toHaveBeenCalledTimes( 1 );
+		expect( mockApiFetchWithHeaders ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/wc/store/v1/cart/update-item',
+				method: 'POST',
+				data: {
+					key: 'item-1',
+					quantity: 5,
+				},
+				signal: expect.any( AbortSignal ),
+			} )
+		);
+		expect( dispatch.itemIsPendingQuantity ).toHaveBeenCalledWith(
+			'item-1'
+		);
+		expect( dispatch.itemIsPendingQuantity ).toHaveBeenCalledWith(
+			'item-1',
+			false
+		);
+	} );
+
+	it( 'should abort previous request when same item quantity changes again', async () => {
+		const cartItems: Record< string, number > = { 'item-1': 1 };
+
+		const mockDispatch = {
+			receiveCart: jest.fn(),
+			receiveError: jest.fn(),
+			itemIsPendingQuantity: jest.fn(),
+		};
+
+		const mockSelect = {
+			getCartItem: jest.fn( ( key: string ) => {
+				if ( key in cartItems ) {
+					return { quantity: cartItems[ key ] };
+				}
+				return null;
+			} ),
+		};
+
+		// Track abort signals
+		const abortSignals: AbortSignal[] = [];
+
+		// First request is slow
+		mockApiFetchWithHeaders.mockImplementation(
+			( options: { signal?: AbortSignal } ) => {
+				if ( options.signal ) {
+					abortSignals.push( options.signal );
+				}
+				return new Promise( ( resolve, reject ) => {
+					// Check if already aborted
+					if ( options.signal?.aborted ) {
+						const error = new DOMException(
+							'Aborted',
+							'AbortError'
+						);
+						reject( error );
+						return;
+					}
+					// Listen for abort
+					options.signal?.addEventListener( 'abort', () => {
+						const error = new DOMException(
+							'Aborted',
+							'AbortError'
+						);
+						reject( error );
+					} );
+					// Resolve after delay if not aborted
+					setTimeout( () => {
+						resolve( {
+							response: { items: [ { key: 'item-1', quantity: 5 } ] },
+						} );
+					}, 100 );
+				} );
+			}
+		);
+
+		// Start first request (1→5)
+		const promise1 = changeCartItemQuantity(
+			'item-1',
+			5
+		)( { dispatch: mockDispatch, select: mockSelect } as never );
+
+		// Start second request before first completes (should abort first)
+		const promise2 = changeCartItemQuantity(
+			'item-1',
+			10
+		)( { dispatch: mockDispatch, select: mockSelect } as never );
+
+		await Promise.all( [ promise1, promise2 ] );
+
+		// First signal should be aborted
+		expect( abortSignals[ 0 ].aborted ).toBe( true );
+		// Second signal should not be aborted
+		expect( abortSignals[ 1 ].aborted ).toBe( false );
+
+		// receiveCart should only be called once (for the second request)
+		expect( mockDispatch.receiveCart ).toHaveBeenCalledTimes( 1 );
+		// receiveError should NOT be called for aborted requests
+		expect( mockDispatch.receiveError ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not abort requests for different items', async () => {
+		const cartItems: Record< string, number > = {
+			'item-a': 1,
+			'item-b': 1,
+		};
+
+		const mockDispatch = {
+			receiveCart: jest.fn(),
+			receiveError: jest.fn(),
+			itemIsPendingQuantity: jest.fn(),
+		};
+
+		const mockSelect = {
+			getCartItem: jest.fn( ( key: string ) => {
+				if ( key in cartItems ) {
+					return { quantity: cartItems[ key ] };
+				}
+				return null;
+			} ),
+		};
+
+		const abortSignals: AbortSignal[] = [];
+
+		mockApiFetchWithHeaders.mockImplementation(
+			( options: { signal?: AbortSignal } ) => {
+				if ( options.signal ) {
+					abortSignals.push( options.signal );
+				}
+				return Promise.resolve( {
+					response: { items: [] },
+				} );
+			}
+		);
+
+		// Change different items
+		const promise1 = changeCartItemQuantity(
+			'item-a',
+			5
+		)( { dispatch: mockDispatch, select: mockSelect } as never );
+		const promise2 = changeCartItemQuantity(
+			'item-b',
+			3
+		)( { dispatch: mockDispatch, select: mockSelect } as never );
+
+		await Promise.all( [ promise1, promise2 ] );
+
+		// Neither should be aborted - they're different items
+		expect( abortSignals[ 0 ].aborted ).toBe( false );
+		expect( abortSignals[ 1 ].aborted ).toBe( false );
+
+		// Both should complete
+		expect( mockApiFetchWithHeaders ).toHaveBeenCalledTimes( 2 );
+		expect( mockDispatch.receiveCart ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should handle API errors', async () => {
+		const { dispatch, select } = createMockDispatchAndSelect( {
+			'item-1': 1,
+		} );
+
+		mockApiFetchWithHeaders.mockRejectedValueOnce(
+			new Error( 'Network error' )
+		);
+
+		await expect(
+			changeCartItemQuantity(
+				'item-1',
+				5
+			)( { dispatch, select } as never )
+		).rejects.toThrow( 'Network error' );
+
+		expect( dispatch.receiveError ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.itemIsPendingQuantity ).toHaveBeenCalledWith(
+			'item-1',
+			false
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -135,7 +135,9 @@ describe( 'changeCartItemQuantity', () => {
 					// Resolve after delay if not aborted
 					setTimeout( () => {
 						resolve( {
-							response: { items: [ { key: 'item-1', quantity: 5 } ] },
+							response: {
+								items: [ { key: 'item-1', quantity: 5 } ],
+							},
 						} );
 					}, 100 );
 				} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -443,10 +443,16 @@ export const removeItemFromCart =
 	};
 
 /**
- * Persists a quantity change the for specified cart item:
+ * Tracks AbortControllers per cart item for cancelling in-flight quantity requests.
+ */
+const quantityAbortControllers = new Map< string, AbortController >();
+
+/**
+ * Persists a quantity change for the specified cart item:
+ * - Aborts any in-flight request for the same item.
  * - Calls API to set quantity.
  * - If successful, yields action to update store.
- * - If error, yields action to store error.
+ * - If error (except AbortError), yields action to store error.
  *
  * @param {string} cartItemKey Cart item being updated.
  * @param {number} quantity    Specified (new) quantity.
@@ -462,6 +468,22 @@ export const changeCartItemQuantity =
 		if ( cartItem?.quantity === quantity ) {
 			return;
 		}
+
+		// Abort any existing in-flight request for this item.
+		const existingController = quantityAbortControllers.get( cartItemKey );
+		if ( existingController ) {
+			existingController.abort();
+		}
+
+		// Create new AbortController for this request.
+		const abortController =
+			typeof AbortController === 'undefined'
+				? null
+				: new AbortController();
+		if ( abortController ) {
+			quantityAbortControllers.set( cartItemKey, abortController );
+		}
+
 		try {
 			dispatch.itemIsPendingQuantity( cartItemKey );
 			const { response } = await apiFetchWithHeaders< {
@@ -474,18 +496,28 @@ export const changeCartItemQuantity =
 					quantity,
 				},
 				cache: 'no-store',
+				signal: abortController?.signal,
 			} );
+
 			dispatch.receiveCart( response );
 			return response;
 		} catch ( error ) {
+			// Don't treat aborted requests as errors - they were intentionally cancelled.
+			if ( error instanceof DOMException && error.name === 'AbortError' ) {
+				return;
+			}
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			return Promise.reject( error );
 		} finally {
+			// Clean up controller if it's still the current one for this item.
+			if ( quantityAbortControllers.get( cartItemKey ) === abortController ) {
+				quantityAbortControllers.delete( cartItemKey );
+			}
 			dispatch.itemIsPendingQuantity( cartItemKey, false );
 		}
 	};
 
-// Facilitates aborting fetch requests.
+// Facilitates aborting fetch requests for shipping rate selection.
 let abortController: AbortController | null = null;
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -496,21 +496,26 @@ export const changeCartItemQuantity =
 					quantity,
 				},
 				cache: 'no-store',
-				signal: abortController?.signal,
+				signal: abortController?.signal ?? null,
 			} );
 
 			dispatch.receiveCart( response );
 			return response;
 		} catch ( error ) {
 			// Don't treat aborted requests as errors - they were intentionally cancelled.
-			if ( error instanceof DOMException && error.name === 'AbortError' ) {
+			if (
+				error instanceof DOMException &&
+				error.name === 'AbortError'
+			) {
 				return;
 			}
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			return Promise.reject( error );
 		} finally {
 			// Clean up controller if it's still the current one for this item.
-			if ( quantityAbortControllers.get( cartItemKey ) === abortController ) {
+			if (
+				quantityAbortControllers.get( cartItemKey ) === abortController
+			) {
 				quantityAbortControllers.delete( cartItemKey );
 			}
 			dispatch.itemIsPendingQuantity( cartItemKey, false );

--- a/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/shared-controls.ts
@@ -129,6 +129,7 @@ export const apiFetchWithHeadersControl = ( options: APIFetchOptions ) =>
 const preventBatching = [
 	'/wc/store/v1/checkout',
 	'/wc/store/v1/checkout?__experimental_calc_totals=true',
+	'/wc/store/v1/cart/update-item',
 ];
 
 /**
@@ -167,7 +168,12 @@ const doApiFetchWithHeaders = ( options: APIFetchOptions ) =>
 					}
 				} )
 				.catch( ( errorResponse ) => {
-					if ( errorResponse.name !== 'AbortError' ) {
+					// Propagate AbortError directly so callers can detect cancelled requests.
+					if ( errorResponse.name === 'AbortError' ) {
+						reject( errorResponse );
+						return;
+					}
+					if ( errorResponse.headers ) {
 						processHeadersOnFetch( errorResponse.headers );
 					}
 					if ( typeof errorResponse.json === 'function' ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Removes quantity update requests from being batched
- Add AbortControllers for quantity update requests and stop any existing ones when a new one is made
- Prevent quantity syncing from Redux -> UI when API call is pending

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5076
Closes #59758

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    https://www.loom.com/share/fc589dd9acfb4574af8e166809cba2d6    |    https://www.loom.com/share/21c7eb093a8d4766bd02e0b8cb8c30d9   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add items to the cart, go to the Cart block.
2. Optionally enable network throttling to slow requests down. Change the quantity of an item, vary your speed of quantity change so it's sometimes fast, sometimes has a short interval between changes (half a second or so), and sometimes has a long break (2+ seconds)
3. Observe the quantity, and snackbar notices, there should not be any weird jumps and the quantity should not revert to an old number. No notices about "The quantity of X was changed to Y" should show.

#### Extension testing

##### Product Bundles

1. Install [Product Bundles](https://woocommerce.com/products/product-bundles/)
2. Set up a bundled product with two sub products of varying quantity limits, for example:

<img width="980" height="716" alt="image" src="https://github.com/user-attachments/assets/7d33a446-7532-43fe-a0dd-4307aa066f7b" />

3. Add this bundled product to your cart and go to the Cart block.
4. Modify the quantity of the sub-products, following the same steps as above (rapidly, slowly etc.) and ensure no weird jumps in quantity
5. Modify the quantity of the parent product, ensure the sub-product quantities update correctly (if you had 1x bundled product, and 2x Sub-product A, 3x Sub-product B, then 2x bundled products would result in 4x Sub-product A, and 6x Sub-product B)
6. Do this with varying speeds and ensure the quantities update correctly, and don't weirdly jump around. 
7. Ensure no snackbar notices show announcing quantity changes (because this is an _expected_ quantity change)

##### Custom code to modify quantities

1. Add two products in your cart, take note of their IDs
2. Add the following snippet to your site
```php
add_action( 'woocommerce_after_cart_item_quantity_update', function( $cart_item_key, $quantity, $old_quantity, $cart ) {
      $item_a_id = XX;
      $item_b_id = XX;

      $cart_item = $cart->get_cart_item( $cart_item_key );

      // Only trigger when item A is updated
      if ( ! $cart_item || $cart_item['product_id'] !== $item_a_id ) {
          return;
      }

      // Find and update item B
      foreach ( $cart->get_cart() as $key => $item ) {
          if ( $item['product_id'] === $item_b_id ) {
              $cart->set_quantity( $key, floor( $quantity / 2 ) + 1 );
              break;
          }
      }
  }, 10, 4 );
```
3. This snippet causes item B to update with half of item A's quantity + 1, so if you have 10 item A, you should have 6 item B.
4. Change item A's quantity and ensure item B's quantity updates correctly. You _should_ see a snackbar notice about the quantity change as this is an _unexpected_ change (from the user's perspective, they don't know what snippets are in place!)
5. Update item B on its own, ensure you don't see a notice.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
