### PR TITLE
VariationSelectorAttribute: Use variation objects instead of arrays for better performance

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-6121-variation-selector-use-objects
+++ b/plugins/woocommerce/changelog/WOOPLUG-6121-variation-selector-use-objects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Use variation objects instead of arrays in VariationSelectorAttribute block to avoid unnecessary data processing

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58090,12 +58090,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
 
 		-
-			message: '#^Anonymous function has an unused use \$attribute_terms\.$#'
-			identifier: closure.unusedUse
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
-
-		-
 			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
 			identifier: class.notFound
 			count: 4

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -57,16 +57,17 @@ class VariationSelectorAttribute extends AbstractBlock {
 		global $product;
 
 		$attribute_terms    = $this->get_terms( $attribute_name, $product_attribute_terms );
-		$product_variations = $product->get_available_variations();
+		$product_variations = $product->get_available_variations( 'objects' );
 
 		// Filter out terms which are not available in any product variation.
 		$attribute_terms = array_filter(
 			$attribute_terms,
-			function ( $term ) use ( $product_variations, $attribute_name, $attribute_terms ) {
-				foreach ( $product_variations as $product_variation ) {
+			function ( $term ) use ( $product_variations, $attribute_name ) {
+				foreach ( $product_variations as $variation ) {
+					$attributes = $variation->get_variation_attributes();
 					if (
-						$term['value'] === $product_variation['attributes'][ wc_variation_attribute_name( $attribute_name ) ] ||
-						'' === $product_variation['attributes'][ wc_variation_attribute_name( $attribute_name ) ]
+						$term['value'] === $attributes[ wc_variation_attribute_name( $attribute_name ) ] ||
+						'' === $attributes[ wc_variation_attribute_name( $attribute_name ) ]
 					) {
 						return true;
 					}


### PR DESCRIPTION
## Summary

Closes [WOOPLUG-6121](https://linear.app/a8c/issue/WOOPLUG-6121/use-objects-instead-of-array-in-variationselectorattributephp-get) / #62719

- Use `get_available_variations('objects')` instead of the default 'array' return type in VariationSelectorAttribute.php
- Only variation attributes are needed to filter available terms, so the expensive processing (HTML generation, price calculations, image lookups) was being wasted
- Uses `$variation->get_variation_attributes()` to access the attribute data directly

## Test plan

- [x] PHP unit tests pass: `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=AddToCartWithOptions`
- [ ] Manual testing:

  **Prerequisites:**
  1. Ensure you have a block-based theme active (e.g., Twenty Twenty-Five)
  2. Create a variable product with variations:
     - Go to **Products > Add New**
     - Set the product type to **Variable product**
     - Add attributes (e.g., Color with values Red, Green, Blue) and check "Used for variations"
     - Go to the **Variations** tab and generate variations
     - Set prices for each variation
     - Publish the product

  **Testing steps:**
  1. In WP Admin, go to **Appearance > Editor** to open the Site Editor
  2. Click **Templates** in the left sidebar, then select **Single Product**
  3. Clear the existing template content and add an **Add to Cart with Options** block
  4. Click **Save** to save the template
  5. Go to the frontend and visit your variable product page
  6. Verify the variation selector displays all attribute options correctly
  7. Select different attribute values and verify the form updates appropriately
