### PR TITLE
fix: address autocomplete sync

### DIFF
--- a/plugins/woocommerce/changelog/62796-fix-address-autocomplete-sync
+++ b/plugins/woocommerce/changelog/62796-fix-address-autocomplete-sync
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-fix: esure address autocomplete is persisted on both billing and shipping forms
+fix: ensure address autocomplete is persisted on both billing and shipping forms

--- a/plugins/woocommerce/changelog/62796-fix-address-autocomplete-sync
+++ b/plugins/woocommerce/changelog/62796-fix-address-autocomplete-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: esure address autocomplete is persisted on both billing and shipping forms

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -13,6 +13,7 @@ import { cartStore, checkoutStore } from '@woocommerce/block-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { AddressFormType, getSettingWithCoercion } from '@woocommerce/settings';
+import { useCheckoutAddress } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { ValidatedTextInputProps } from '../../../../../../packages/components/t
 import './style.scss';
 import { Suggestions } from './suggestions';
 import { useUpdatePreferredAutocompleteProvider } from '../../../hooks/use-update-preferred-autocomplete-provider';
-import { useCheckoutAddress } from '@woocommerce/base-context';
 
 /**
  * Address Autocomplete component.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -21,6 +21,7 @@ import { ValidatedTextInputProps } from '../../../../../../packages/components/t
 import './style.scss';
 import { Suggestions } from './suggestions';
 import { useUpdatePreferredAutocompleteProvider } from '../../../hooks/use-update-preferred-autocomplete-provider';
+import { useCheckoutAddress } from '@woocommerce/base-context';
 
 /**
  * Address Autocomplete component.
@@ -37,6 +38,8 @@ export const AddressAutocomplete = ( {
 }: { addressType: AddressFormType; id: string } & ValidatedTextInputProps ) => {
 	// This hook will monitor for changes in country and update the provider accordingly.
 	useUpdatePreferredAutocompleteProvider( addressType );
+
+	const { useShippingAsBilling, useBillingAsShipping } = useCheckoutAddress();
 	const inputRef = useRef< ValidatedTextInputHandle >( null );
 	const observerRef = useRef< MutationObserver | null >( null );
 	const serverProviders = getSettingWithCoercion<
@@ -279,13 +282,17 @@ export const AddressAutocomplete = ( {
 					provider
 						.select( selected.id, country )
 						.then( ( address ) => {
-							const actionToDispatch =
-								addressType === 'shipping'
-									? setShippingAddress
-									: setBillingAddress;
-							actionToDispatch( {
-								...address,
-							} );
+							if ( addressType === 'shipping' ) {
+								setShippingAddress( address );
+								if ( useShippingAsBilling ) {
+									setBillingAddress( address );
+								}
+							} else {
+								setBillingAddress( address );
+								if ( useBillingAsShipping ) {
+									setShippingAddress( address );
+								}
+							}
 						} )
 						.finally( () => {
 							// Clear suggestions.
@@ -312,13 +319,17 @@ export const AddressAutocomplete = ( {
 			}, 1000 );
 			try {
 				const address = await provider.select( suggestionId, country );
-				const actionToDispatch =
-					addressType === 'shipping'
-						? setShippingAddress
-						: setBillingAddress;
-				actionToDispatch( {
-					...address,
-				} );
+				if ( addressType === 'shipping' ) {
+					setShippingAddress( address );
+					if ( useShippingAsBilling ) {
+						setBillingAddress( address );
+					}
+				} else {
+					setBillingAddress( address );
+					if ( useBillingAsShipping ) {
+						setShippingAddress( address );
+					}
+				}
 			} finally {
 				// Clear suggestions.
 				setIsSettingAddress( false );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/integration.tsx
@@ -1291,7 +1291,10 @@ describe( 'Suggestions - when rendered in AddressAutocomplete component', () => 
 
 				wpData.useDispatch.mockImplementation(
 					( store: StoreDescriptor | string ) => {
-						if ( store === cartStore || store === 'wc/store/cart' ) {
+						if (
+							store === cartStore ||
+							store === 'wc/store/cart'
+						) {
 							return {
 								...jest
 									.requireActual( '@wordpress/data' )
@@ -1386,7 +1389,10 @@ describe( 'Suggestions - when rendered in AddressAutocomplete component', () => 
 
 				wpData.useDispatch.mockImplementation(
 					( store: StoreDescriptor | string ) => {
-						if ( store === cartStore || store === 'wc/store/cart' ) {
+						if (
+							store === cartStore ||
+							store === 'wc/store/cart'
+						) {
 							return {
 								...jest
 									.requireActual( '@wordpress/data' )

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/integration.tsx
@@ -12,6 +12,13 @@ import type { StoreDescriptor } from '@wordpress/data';
  * Internal dependencies
  */
 import { AddressAutocomplete } from '../address-autocomplete';
+
+const mockUseCheckoutAddress = jest.fn();
+jest.mock( '@woocommerce/base-context', () => ( {
+	...jest.requireActual( '@woocommerce/base-context' ),
+	useCheckoutAddress: () => mockUseCheckoutAddress(),
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	__esModule: true,
 	...jest.requireActual( '@wordpress/data' ),
@@ -78,6 +85,11 @@ jest.mock( '@woocommerce/settings', () => ( {
 } ) );
 describe( 'Suggestions - when rendered in AddressAutocomplete component', () => {
 	beforeAll( () => {
+		mockUseCheckoutAddress.mockReturnValue( {
+			useShippingAsBilling: false,
+			useBillingAsShipping: false,
+		} );
+
 		const genericProvider = {
 			id: 'generic-provider',
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -124,6 +136,14 @@ describe( 'Suggestions - when rendered in AddressAutocomplete component', () => 
 			},
 		};
 	} );
+
+	afterEach( () => {
+		mockUseCheckoutAddress.mockReturnValue( {
+			useShippingAsBilling: false,
+			useBillingAsShipping: false,
+		} );
+	} );
+
 	it( 'Shows suggestions when provider returns results', async () => {
 		const Component = () => {
 			const [ value, setValue ] = useState( '' );
@@ -1221,5 +1241,231 @@ describe( 'Suggestions - when rendered in AddressAutocomplete component', () => 
 			// Still no suggestions should appear
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
+	} );
+
+	describe( 'Address sync behavior', () => {
+		beforeEach( () => {
+			const genericProvider = {
+				id: 'generic-provider',
+				canSearch: () => true,
+				search: async () => [
+					{
+						label: '123 Example St, Berlin, Germany',
+						id: '1',
+						matchedSubstrings: [ { length: 3, offset: 0 } ],
+					},
+					{
+						label: '456 Sample Rd, Munich, Germany',
+						id: '2',
+						matchedSubstrings: [ { length: 3, offset: 0 } ],
+					},
+				],
+				select: async () => ( {
+					address_1: '123 Example St',
+					address_2: 'Address 2',
+					city: 'Berlin',
+					state: 'BE',
+					postcode: '10115',
+					country: 'DE',
+				} ),
+			};
+
+			window.wc.addressAutocomplete.providers[ 'generic-provider' ] =
+				genericProvider;
+			window.wc.addressAutocomplete.activeProvider.shipping =
+				genericProvider;
+			window.wc.addressAutocomplete.activeProvider.billing =
+				genericProvider;
+		} );
+
+		it.each( [ 'Enter key', 'click' ] )(
+			'Shipping autocomplete syncs to billing when useShippingAsBilling is true (%s)',
+			async ( interactionMethod ) => {
+				const mockSetBillingAddress = jest.fn();
+				const mockSetShippingAddress = jest.fn();
+
+				mockUseCheckoutAddress.mockReturnValue( {
+					useShippingAsBilling: true,
+					useBillingAsShipping: false,
+				} );
+
+				wpData.useDispatch.mockImplementation(
+					( store: StoreDescriptor | string ) => {
+						if ( store === cartStore || store === 'wc/store/cart' ) {
+							return {
+								...jest
+									.requireActual( '@wordpress/data' )
+									.useDispatch( store ),
+								setShippingAddress: mockSetShippingAddress,
+								setBillingAddress: mockSetBillingAddress,
+							};
+						}
+						return jest
+							.requireActual( '@wordpress/data' )
+							.useDispatch( store );
+					}
+				);
+
+				const Component = () => {
+					const [ value, setValue ] = useState( '' );
+					return (
+						<AddressAutocomplete
+							addressType="shipping"
+							id="shipping-test"
+							label="Address 1"
+							onChange={ setValue }
+							value={ value }
+						/>
+					);
+				};
+				render( <Component /> );
+				const input = screen.getByLabelText( 'Address 1' );
+
+				await act( async () => {
+					await userEvent.type( input, '1234' );
+				} );
+
+				await waitFor(
+					() => {
+						expect(
+							screen.getByRole( 'listbox' )
+						).toBeInTheDocument();
+					},
+					{ timeout: 3000 }
+				);
+
+				if ( interactionMethod === 'Enter key' ) {
+					await act( async () => {
+						await userEvent.type( input, '{arrowdown}' );
+					} );
+					await act( async () => {
+						await userEvent.type( input, '{Enter}' );
+					} );
+				} else {
+					const options = screen.getAllByRole( 'option' );
+					await act( async () => {
+						await userEvent.click( options[ 0 ] );
+					} );
+				}
+
+				await waitFor(
+					() => {
+						expect( mockSetShippingAddress ).toHaveBeenCalled();
+					},
+					{ timeout: 3000 }
+				);
+
+				const expectedAddress = {
+					address_1: '123 Example St',
+					address_2: 'Address 2',
+					city: 'Berlin',
+					state: 'BE',
+					postcode: '10115',
+					country: 'DE',
+				};
+
+				expect( mockSetShippingAddress ).toHaveBeenCalledWith(
+					expectedAddress
+				);
+				expect( mockSetBillingAddress ).toHaveBeenCalledWith(
+					expectedAddress
+				);
+			}
+		);
+
+		it.each( [ 'Enter key', 'click' ] )(
+			'Billing autocomplete syncs to shipping when useBillingAsShipping is true (%s)',
+			async ( interactionMethod ) => {
+				const mockSetBillingAddress = jest.fn();
+				const mockSetShippingAddress = jest.fn();
+
+				mockUseCheckoutAddress.mockReturnValue( {
+					useShippingAsBilling: false,
+					useBillingAsShipping: true,
+				} );
+
+				wpData.useDispatch.mockImplementation(
+					( store: StoreDescriptor | string ) => {
+						if ( store === cartStore || store === 'wc/store/cart' ) {
+							return {
+								...jest
+									.requireActual( '@wordpress/data' )
+									.useDispatch( store ),
+								setShippingAddress: mockSetShippingAddress,
+								setBillingAddress: mockSetBillingAddress,
+							};
+						}
+						return jest
+							.requireActual( '@wordpress/data' )
+							.useDispatch( store );
+					}
+				);
+
+				const Component = () => {
+					const [ value, setValue ] = useState( '' );
+					return (
+						<AddressAutocomplete
+							addressType="billing"
+							id="billing-test"
+							label="Address 1"
+							onChange={ setValue }
+							value={ value }
+						/>
+					);
+				};
+				render( <Component /> );
+				const input = screen.getByLabelText( 'Address 1' );
+
+				await act( async () => {
+					await userEvent.type( input, '1234' );
+				} );
+
+				await waitFor(
+					() => {
+						expect(
+							screen.getByRole( 'listbox' )
+						).toBeInTheDocument();
+					},
+					{ timeout: 3000 }
+				);
+
+				if ( interactionMethod === 'Enter key' ) {
+					await act( async () => {
+						await userEvent.type( input, '{arrowdown}' );
+					} );
+					await act( async () => {
+						await userEvent.type( input, '{Enter}' );
+					} );
+				} else {
+					const options = screen.getAllByRole( 'option' );
+					await act( async () => {
+						await userEvent.click( options[ 0 ] );
+					} );
+				}
+
+				await waitFor(
+					() => {
+						expect( mockSetBillingAddress ).toHaveBeenCalled();
+					},
+					{ timeout: 3000 }
+				);
+
+				const expectedAddress = {
+					address_1: '123 Example St',
+					address_2: 'Address 2',
+					city: 'Berlin',
+					state: 'BE',
+					postcode: '10115',
+					country: 'DE',
+				};
+
+				expect( mockSetBillingAddress ).toHaveBeenCalledWith(
+					expectedAddress
+				);
+				expect( mockSetShippingAddress ).toHaveBeenCalledWith(
+					expectedAddress
+				);
+			}
+		);
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPMNT-5631

Fixing a bug where selecting an address from the address autocomplete would only update the shipping address fields (city, state, postcode) but not sync them to the billing address when "Use same address for billing" is enabled on page refresh.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     https://github.com/user-attachments/assets/7bf41f00-510d-43b9-9d30-db50af4d4b43   |    https://github.com/user-attachments/assets/7a0f1b53-61b2-4475-a915-76d67d03dfd3   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Requisites
1. Set up a WooCommerce store with the block-based checkout enabled
2. Install and activate WooPayments plugin
3. Connect WooPayments to WordPress.com (you can use a Jurassic Ninja site or have your local environment "talk" with WPcom)
4. Navigate to _WooCommerce > Settings > General_ and scroll to the "Store Address" section
5. Ensure the store address is set to a country where predictive address search is supported (e.g., United States)
6. Navigate to _WooCommerce > Settings > General_ and enable the "Enable predictive address search" checkbox
7. As a customer, add a physical product to the cart

#### Instructions

1. Navigate to the block-based Checkout page
2. In the Shipping address section, start typing an address in the "Address" field (e.g., "123 Main")
3. Wait for the autocomplete suggestions to appear
4. Select an address from the autocomplete dropdown (either by clicking on it, or using arrow keys + Enter)
5. Verify the shipping address fields (Address, City, State, Postcode) are populated with the selected address data
6. Refresh the page
7. Uncheck "Use same address for billing" to reveal the billing address form
8. Verify the billing address fields also show the same address data as the shipping address (City, State, Postcode should match the shipping address)

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here --> fix: ensure address autocomplete is persisted on both billing and shipping forms

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
