### PR TITLE
Use variation objects instead of arrays in ProductPrice block

### DIFF
--- a/plugins/woocommerce/changelog/WOOPLUG-6122-product-price-use-variation-objects
+++ b/plugins/woocommerce/changelog/WOOPLUG-6122-product-price-use-variation-objects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Use variation objects instead of arrays in ProductPrice block to avoid unnecessary data processing

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -60958,12 +60958,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductPrice.php
 
 		-
-			message: '#^Call to an undefined method WC_Product\:\:get_available_variations\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/ProductPrice.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductPrice\:\:get_block_type_uses_context\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -79,6 +79,8 @@ class ProductPrice extends AbstractBlock {
 			$context_directive      = '';
 
 			if ( $is_interactive ) {
+				// phpcs:ignore Squiz.Commenting.VariableComment.MissingVar -- Type hint for PHPStan.
+				/** @var \WC_Product_Variable $product */
 				// Check if variation prices differ (replicates logic from WC_Product_Variable::get_available_variation).
 				$prices_vary = $product->get_variation_sale_price( 'min' ) !== $product->get_variation_sale_price( 'max' )
 					|| $product->get_variation_regular_price( 'min' ) !== $product->get_variation_regular_price( 'max' );
@@ -93,9 +95,9 @@ class ProductPrice extends AbstractBlock {
 						 * Filter whether to show variation price.
 						 * Replicates the filter from WC_Product_Variable::get_available_variation().
 						 *
-						 * @param bool                 $show_price Whether to show the price.
-						 * @param WC_Product_Variable  $product    The variable product.
-						 * @param WC_Product_Variation $variation  The variation.
+						 * @param bool                  $show_price Whether to show the price.
+						 * @param \WC_Product_Variable  $product    The variable product.
+						 * @param \WC_Product_Variation $variation  The variation.
 						 */
 						$show_variation_price = apply_filters(
 							'woocommerce_show_variation_price',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -79,7 +79,7 @@ class ProductPrice extends AbstractBlock {
 			$context_directive      = '';
 
 			if ( $is_interactive ) {
-				// phpcs:ignore Squiz.Commenting.VariableComment.MissingVar -- Type hint for PHPStan.
+				// phpcs:ignore Generic.Commenting.DocComment.MissingShort -- Type hint for PHPStan.
 				/** @var \WC_Product_Variable $product */
 				// Check if variation prices differ (replicates logic from WC_Product_Variable::get_available_variation).
 				$prices_vary = $product->get_variation_sale_price( 'min' ) !== $product->get_variation_sale_price( 'max' )
@@ -94,6 +94,8 @@ class ProductPrice extends AbstractBlock {
 						/**
 						 * Filter whether to show variation price.
 						 * Replicates the filter from WC_Product_Variable::get_available_variation().
+						 *
+						 * @since 2.4.0
 						 *
 						 * @param bool                  $show_price Whether to show the price.
 						 * @param \WC_Product_Variable  $product    The variable product.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -79,26 +79,42 @@ class ProductPrice extends AbstractBlock {
 			$context_directive      = '';
 
 			if ( $is_interactive ) {
-				$variations_data           = $product->get_available_variations();
+				// Check if variation prices differ (replicates logic from WC_Product_Variable::get_available_variation).
+				$prices_vary = $product->get_variation_sale_price( 'min' ) !== $product->get_variation_sale_price( 'max' )
+					|| $product->get_variation_regular_price( 'min' ) !== $product->get_variation_regular_price( 'max' );
+
 				$formatted_variations_data = array();
-				$has_variation_price_html  = false;
-				foreach ( $variations_data as $variation ) {
-					if (
-						empty( $variation['variation_id'] )
-						|| ! array_key_exists( 'price_html', $variation )
-						|| '' === $variation['price_html']
-					) {
-						continue;
+
+				if ( $prices_vary ) {
+					$variations_data = $product->get_available_variations( 'objects' );
+
+					foreach ( $variations_data as $variation ) {
+						/**
+						 * Filter whether to show variation price.
+						 * Replicates the filter from WC_Product_Variable::get_available_variation().
+						 *
+						 * @param bool                 $show_price Whether to show the price.
+						 * @param WC_Product_Variable  $product    The variable product.
+						 * @param WC_Product_Variation $variation  The variation.
+						 */
+						$show_variation_price = apply_filters(
+							'woocommerce_show_variation_price',
+							true,
+							$product,
+							$variation
+						);
+
+						if ( ! $show_variation_price ) {
+							continue;
+						}
+
+						$formatted_variations_data[ $variation->get_id() ] = array(
+							'price_html' => '<span class="price">' . $variation->get_price_html() . '</span>',
+						);
 					}
-					// Core behavior: when all variation prices are identical, Core returns '' for variation['price_html'].
-					// Therefore, the presence of any non-empty price_html implies price differences and warrants interactivity.
-					$has_variation_price_html                                = true;
-					$formatted_variations_data[ $variation['variation_id'] ] = array(
-						'price_html' => $variation['price_html'],
-					);
 				}
 
-				if ( ! $has_variation_price_html ) {
+				if ( empty( $formatted_variations_data ) ) {
 					$is_interactive = false;
 				} else {
 					wp_interactivity_config(


### PR DESCRIPTION
Closes WOOPLUG-6122

## Summary

- Optimizes the ProductPrice block by using `get_available_variations('objects')` instead of the default array return type
- Avoids unnecessary data processing since we only need the variation ID and price_html
- Replicates the `woocommerce_show_variation_price` filter logic from `WC_Product_Variable::get_available_variation()` to maintain filter compatibility

## Test coverage

The existing unit test `test_variable_product_price_interactivity` in `tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php` covers this change. It validates that:
1. ProductPrice block is NOT interactive when all variation prices are the same
2. ProductPrice block IS interactive (has `data-wp-watch`) when variation prices differ

Run with:
```
pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=AddToCartWithOptions::test_variable_product_price_interactivity
```

## Manual test plan

1. Install and activate a block-based theme (e.g., Twenty Twenty-Five)
2. Create a variable product with at least two variations that have different prices (e.g., Small at $10, Large at $15)
3. Visit the single product page on the frontend
4. Open browser DevTools and inspect the price element
5. Verify it has the `data-wp-watch` attribute (indicating interactivity is enabled)
6. Select different variations and verify the price updates dynamically
7. Create another variable product where all variations have the same price
8. Visit that product's page and verify the price element does NOT have `data-wp-watch` (no interactivity needed)