### PR TITLE
Add filter for prepare objects query

### DIFF
--- a/plugins/woocommerce/changelog/feat-filter-arguments-products-rest-api
+++ b/plugins/woocommerce/changelog/feat-filter-arguments-products-rest-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added filter woocommerce_rest_products_prepare_objects_query to modify final query arguments in products REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -469,7 +469,17 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$args['post_type'] = array( 'product', 'product_variation' );
 		}
 
-		return $args;
+		/**
+		 * Filters the final query arguments for products REST API.
+		 *
+		 * This filter runs after all internal argument processing, allowing
+		 * modification of final query arguments.
+		 *
+		 * @since 10.6.0
+		 * @param array           $args    Query arguments.
+		 * @param WP_REST_Request $request Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_products_prepare_objects_query', $args, $request );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -2114,4 +2114,30 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertContains( $visible_product->get_id(), $product_ids );
 		$this->assertContains( $hidden_product->get_id(), $product_ids );
 	}
-}
+
+	/**
+	 * Test that woocommerce_rest_products_prepare_objects_query filter can modify query arguments.
+	 */
+	public function test_prepare_objects_query_filter() {
+		$filter_called = false;
+
+		add_filter(
+			'woocommerce_rest_products_prepare_objects_query',
+			function ( $args, $request ) use ( &$filter_called ) {
+				$filter_called = true;
+				$args['posts_per_page'] = 5;
+				return $args;
+			},
+			10,
+			2
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'per_page', 10 );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( $filter_called, 'Filter should be called' );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+ }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #52987  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Tests have been added for the particular filter. These tests are visible by running the following command

```bash
cd plugins/woocommerce
pnpm test:php:env -- --filter WC_REST_Products_Controller_Tests --testdox
```

We can see that the test "Prepare objects query filter" test passes


<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Added changelog file manually

</details>
