### PR TITLE
[Performance] Slow comments queries in admin: actualize indexes and use caches priming for reviews page

### DIFF
--- a/plugins/woocommerce/changelog/performance-62767-slow-comments-queries-in-admin
+++ b/plugins/woocommerce/changelog/performance-62767-slow-comments-queries-in-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Admin: Improved the performance of approved comment counting and reduced the number of SQL queries on the product reviews page.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -497,15 +497,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			/** @var \WP_Comment[] $comments */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$comments = get_comments(
 				array(
-					'type'   => 'review',
-					'status' => 'approve',
-					'number' => 5,
+					'type'                      => 'review',
+					'status'                    => 'approve',
+					'number'                    => 5,
+					'update_comment_post_cache' => true,
 				)
-			);
-			_prime_post_caches(
-				array_map( static fn( \WP_Comment $comment ) => (int) $comment->comment_post_ID, $comments ),
-				false,
-				false
 			);
 			$comments = array_filter(
 				$comments,

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1722,7 +1722,7 @@ class WC_Install {
 
 		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
 		if (  null === $comment_type_index_exists ) {
-			// TBD (updated description).
+			// Improve performance of the admin comments query when counting approved comments while excluding internal notes.
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -320,7 +320,7 @@ class WC_Install {
 			'wc_update_1050_remove_deprecated_marketplace_option',
 		),
 		'10.6.0' => array(
-			'wc_update_1060_update_woo_idx_comment_type_index',
+			'wc_update_1060_add_woo_idx_comment_approved_type_index',
 		),
 	);
 
@@ -1725,14 +1725,21 @@ class WC_Install {
 
 		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
 		if ( null === $comment_type_index_exists ) {
-			// Improve performance of the admin comments query when counting approved comments while excluding internal notes.
-			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
+			// Add an index to the field comment_type to improve the response time of the query
+			// used by WC_Comments::wp_count_comments() to get the number of comments by type.
+			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
 		}
 
 		$date_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_date_type'" );
 		if ( null === $date_type_index_exists ) {
 			// Improve performance of the admin comments query when fetching the latest 25 comments while excluding reviews and internal notes.
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_date_type (comment_date_gmt, comment_type, comment_approved, comment_post_ID)" );
+		}
+
+		$comment_approved_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_approved_type'" );
+		if ( null === $comment_approved_type_index_exists ) {
+			// Improve performance of the admin comments query when counting approved comments while excluding internal notes.
+			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_approved_type (comment_approved, comment_type, comment_post_ID)" );
 		}
 
 		// Clear table caches.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1720,17 +1720,14 @@ class WC_Install {
 
 		$db_delta_result = dbDelta( self::get_schema() );
 
-		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE column_name = 'comment_type' and key_name = 'woo_idx_comment_type'" );
-
-		if ( is_null( $comment_type_index_exists ) ) {
-			// Add an index to the field comment_type to improve the response time of the query
-			// used by WC_Comments::wp_count_comments() to get the number of comments by type.
-			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
+		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
+		if (  null === $comment_type_index_exists ) {
+			// TBD (updated description).
+			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
 		}
 
 		$date_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_date_type'" );
-
-		if ( is_null( $date_type_index_exists ) ) {
+		if ( null === $date_type_index_exists ) {
 			// Improve performance of the admin comments query when fetching the latest 25 comments while excluding reviews and internal notes.
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_date_type (comment_date_gmt, comment_type, comment_approved, comment_post_ID)" );
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -319,6 +319,9 @@ class WC_Install {
 			'wc_update_1050_add_idx_user_email',
 			'wc_update_1050_remove_deprecated_marketplace_option',
 		),
+		'10.6.0' => array(
+			'wc_update_1060_update_woo_idx_comment_type_index',
+		),
 	);
 
 	/**
@@ -1721,7 +1724,7 @@ class WC_Install {
 		$db_delta_result = dbDelta( self::get_schema() );
 
 		$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
-		if (  null === $comment_type_index_exists ) {
+		if ( null === $comment_type_index_exists ) {
 			// Improve performance of the admin comments query when counting approved comments while excluding internal notes.
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
 		}

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3243,7 +3243,6 @@ function wc_update_1060_update_woo_idx_comment_type_index(): void {
 
 	$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
 	if ( null !== $comment_type_index_exists ) {
-		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type" );
-		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type, ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
 	}
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3232,17 +3232,18 @@ function wc_update_1050_remove_deprecated_marketplace_option(): void {
 }
 
 /**
- * Update the `woo_idx_comment_type` index to improve the performance of comment-related queries in the admin area.
+ * Add the `woo_idx_comment_approved_type` index to improve the performance of comment-related queries in the admin area.
  *
  * @since 10.6.0
  *
  * @return void
  */
-function wc_update_1060_update_woo_idx_comment_type_index(): void {
+function wc_update_1060_add_woo_idx_comment_approved_type_index(): void {
 	global $wpdb;
 
-	$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
-	if ( null !== $comment_type_index_exists ) {
-		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type, ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
+	$comment_approved_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_approved_type'" );
+	if ( null === $comment_approved_type_index_exists ) {
+		// Improve performance of the admin comments query when counting approved comments while excluding internal notes.
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_approved_type (comment_approved, comment_type, comment_post_ID)" );
 	}
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3230,3 +3230,20 @@ function wc_update_1050_enable_autoload_options() {
 function wc_update_1050_remove_deprecated_marketplace_option(): void {
 	delete_option( 'woocommerce_feature_marketplace_enabled' );
 }
+
+/**
+ * Update the `woo_idx_comment_type` index to improve the performance of comment-related queries in the admin area.
+ *
+ * @since 10.6.0
+ *
+ * @return void
+ */
+function wc_update_1060_update_woo_idx_comment_type_index(): void {
+	global $wpdb;
+
+	$comment_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_type'" );
+	if ( null !== $comment_type_index_exists ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_type" );
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_approved, comment_type, comment_post_ID)" );
+	}
+}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -40984,12 +40984,6 @@ parameters:
 			path: includes/wc-order-item-functions.php
 
 		-
-			message: '#^Call to an undefined method WC_Logger_Interface\:\:clear\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/wc-order-step-logger-functions.php
-
-		-
 			message: '#^Call to an undefined method WC_Order_Item\:\:get_product_id\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -67744,12 +67744,6 @@ parameters:
 			path: src/Internal/Admin/ProductReviews/ReviewsListTable.php
 
 		-
-			message: '#^Parameter \#1 \$comments of function update_comment_cache expects array\<WP_Comment\>, array\<int\|WP_Comment\>\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/ProductReviews/ReviewsListTable.php
-
-		-
 			message: '#^Parameter \#1 \$number of function number_format_i18n expects float, int\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -67783,12 +67777,6 @@ parameters:
 			message: '#^Parameter \#3 \$number of function _n expects int, int\|string given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Internal/Admin/ProductReviews/ReviewsListTable.php
-
-		-
-			message: '#^Property WP_List_Table\:\:\$items \(array\) does not accept array\<int\|WP_Comment\>\|int\.$#'
-			identifier: assign.propertyType
-			count: 1
 			path: src/Internal/Admin/ProductReviews/ReviewsListTable.php
 
 		-

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -1183,8 +1183,6 @@ class ReviewsListTable extends WP_List_Table {
 
 		if ( $product_post ) :
 
-
-
 			?>
 			<div class="response-links">
 				<?php

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -371,6 +371,20 @@ class ReviewsListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Generates the list table rows.
+	 *
+	 * @return void
+	 */
+	public function display_rows() {
+		if ( ! empty( $this->items ) ) {
+			_prime_comment_caches( array_map( fn( $item ) => (int) $item->comment_post_ID, $this->items ) );
+			_prime_post_caches( array_map( fn( $item ) => (int) $item->comment_post_ID, $this->items ), false, false );
+		}
+
+		parent::display_rows();
+	}
+
+	/**
 	 * Render a single row HTML.
 	 *
 	 * @global WP_Post $post
@@ -1168,6 +1182,8 @@ class ReviewsListTable extends WP_List_Table {
 		ob_start();
 
 		if ( $product_post ) :
+
+
 
 			?>
 			<div class="response-links">

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -76,8 +76,9 @@ class ReviewsListTable extends WP_List_Table {
 		$this->set_review_product();
 
 		$args = [
-			'number'    => $this->get_per_page(),
-			'post_type' => 'product',
+			'number'                    => $this->get_per_page(),
+			'post_type'                 => 'product',
+			'update_comment_post_cache' => true,
 		];
 
 		// Include the order & orderby arguments.
@@ -106,11 +107,7 @@ class ReviewsListTable extends WP_List_Table {
 		$args = (array) apply_filters( 'woocommerce_product_reviews_list_table_prepare_items_args', $args );
 
 		/** @var \WP_Comment[] $comments */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-		$comments = get_comments( $args );
-
-		update_comment_cache( $comments );
-		_prime_post_caches( array_map( fn( $comment ) => (int) $comment->comment_post_ID, $comments ), false, false );
-
+		$comments    = get_comments( $args );
 		$this->items = $comments;
 
 		$this->set_pagination_args(

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -103,7 +103,9 @@ class ReviewsListTable extends WP_List_Table {
 		 *
 		 * @param array $args Comment query args.
 		 */
-		$args     = (array) apply_filters( 'woocommerce_product_reviews_list_table_prepare_items_args', $args );
+		$args = (array) apply_filters( 'woocommerce_product_reviews_list_table_prepare_items_args', $args );
+
+		/** @var \WP_Comment[] $comments */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		$comments = get_comments( $args );
 
 		update_comment_cache( $comments );

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -107,6 +107,7 @@ class ReviewsListTable extends WP_List_Table {
 		$comments = get_comments( $args );
 
 		update_comment_cache( $comments );
+		_prime_post_caches( array_map( fn( $comment ) => (int) $comment->comment_post_ID, $comments ), false, false );
 
 		$this->items = $comments;
 
@@ -368,20 +369,6 @@ class ReviewsListTable extends WP_List_Table {
 		<?php
 
 		$this->display_tablenav( 'bottom' );
-	}
-
-	/**
-	 * Generates the list table rows.
-	 *
-	 * @return void
-	 */
-	public function display_rows() {
-		if ( ! empty( $this->items ) ) {
-			_prime_comment_caches( array_map( fn( $item ) => (int) $item->comment_post_ID, $this->items ) );
-			_prime_post_caches( array_map( fn( $item ) => (int) $item->comment_post_ID, $this->items ), false, false );
-		}
-
-		parent::display_rows();
 	}
 
 	/**

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -59,6 +59,10 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	if ( null !== $date_type_index_exists ) {
 		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_date_type;" );
 	}
+	$comment_approved_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_approved_type';" );
+	if ( null !== $date_type_index_exists ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_approved_type;" );
+	}
 
 	// Roles + caps.
 	WC_Install::remove_roles();

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -60,7 +60,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_date_type;" );
 	}
 	$comment_approved_type_index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE key_name = 'woo_idx_comment_approved_type';" );
-	if ( null !== $date_type_index_exists ) {
+	if ( null !== $comment_approved_type_index_exists ) {
 		$wpdb->query( "ALTER TABLE {$wpdb->comments} DROP INDEX woo_idx_comment_approved_type;" );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #62767, WOOPLUG-6135.
Related stream of work: https://github.com/WordPress/wordpress-develop/pull/10736

- Adds posts cache priming on the reviews page to reduce the number of SQL queries there.
- Improves the below SQL performance (and not impacting other SQLs' performance)

```sql
# SQL_NO_CACHE is added so if re-evaluating query performance during review, caching is not misleading
EXPLAIN SELECT SQL_NO_CACHE COUNT(*)
        FROM wp_comments
                 LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews
                           ON comment_post_ID = wp_posts_to_exclude_reviews.ID
        WHERE ( comment_approved = '1' )
          AND comment_type NOT IN ('note')
          AND comment_type != 'order_note'
          AND comment_type != 'webhook_delivery'
          AND comment_type != 'action_log'
          AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');

# Originally:        1 row retrieved starting from 1 in 416 ms (execution: 54 ms, fetching: 362 ms)
# After changes: 1 row retrieved starting from 1 in 395 ms (execution: 17 ms, fetching: 378 ms)
# Delta: 69% faster, as the new index is utilized
```

Considerations:

The index update is also making sense for the original SQL it was aiming to optimize (not sure how relevant is it, but we are going full backward-compatibility here):
 ```sql
EXPLAIN SELECT SQL_NO_CACHE
            comment_approved,
            COUNT(*) AS num_comments
        FROM
            wp_comments
        WHERE
            comment_type != 'trackback'
          AND comment_type != 'pingback'
        GROUP BY
            comment_approved;
# with woo_idx_test
# 1,SIMPLE,wp_comments,index,woo_idx_comment_type,woo_idx_test,172,,109021,Using where; Using index
# 1 row retrieved starting from 1 in 455 ms (execution: 76 ms, fetching: 379 ms)

# with woo_idx_comment_date_type
# 1,SIMPLE,wp_comments,index,woo_idx_comment_type,woo_idx_comment_date_type,177,,107992,Using where; Using index; Using temporary; Using filesort
# 1 row retrieved starting from 1 in 751 ms (execution: 365 ms, fetching: 386 ms)

# with woo_idx_comment_type
# 1,SIMPLE,wp_comments,ALL,woo_idx_comment_type,,,,95463,Using where; Using temporary; Using filesort
# 1 row retrieved starting from 1 in 641 ms (execution: 271 ms, fetching: 370 ms)
```
`woo_idx_comment_date_type`: I found no better alternatives that would satisfy all queries and not degrade performance for the tracked queries (see the ticket for evaluation details).

### How to test the changes in this Pull Request:

- as a pre-requisite, ensure you have sufficient testing data (1K products, 50K orders, and 10K reviews is what I've tested with)
- also, Query Monitor or a similar plugin to verify SQL queries reduction on the reviews page
- starting with trunk, validate the mentioned query is reported as slow in WordPress dashboard page
- starting with trunk, validate the number of SQL queries on the product review page (`Product -> Reviews`)
- switch to this branch
- modify two records in `wp_options` table: `woocommerce_version`, `woocommerce_db_version` 0 set it to `10.5.0`
- navigate to the admin area and refresh the page
- wait for `woo_idx_comment_approved_type` index on `wp_comments` to appear
- validate IF the mentioned query is reported as slow in the WordPress dashboard page (or query directly to DB if results are inconsistent)
- validate IF the number of SQL queries on the product review page decreased (`Product -> Reviews`) - the delta depends on how many unique products is involved
