### PR TITLE
Stop autoloading `woocommerce_status_log_db_sources` option

### DIFF
--- a/plugins/woocommerce/changelog/62806-fix-do-not-autoload-woocommerce_status_log_db_sources-option
+++ b/plugins/woocommerce/changelog/62806-fix-do-not-autoload-woocommerce_status_log_db_sources-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Stop autoloading `woocommerce_status_log_db_sources` option

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -331,8 +331,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Not necessary.
 		$sources = $wpdb->get_col( $sql );
 
-		// Autoload this option so that the log handler doesn't have to run another query when checking the source list.
-		update_option( self::SOURCE_CACHE_OPTION_KEY, $sources, true );
+		update_option( self::SOURCE_CACHE_OPTION_KEY, $sources );
 
 		return $sources;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This option is not needed for 99% of pages. It's used only on admin page with logs, so we don't need to autoload it.

It can also grow (especially with custom loggers which don't implement clear() method). We noticed that on one site it would autoload almost 4MB option.

<img width="2227" height="300" alt="image" src="https://github.com/user-attachments/assets/e86ad9a9-e070-40e6-91b9-3e88e60c0125" />


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install query monitor on your site
2. Delete `woocommerce_status_log_db_sources` option from your site
3. Go to `/admin.php?page=wc-status&tab=logs`
4. Confirm that Sources dropdown still works 
<img width="710" height="287" alt="image" src="https://github.com/user-attachments/assets/216c8c14-ad88-4cfc-95ec-428396469028" />

5. Then visit any frontend page
6. In Query Monitor check the "Autoloaded Options" tab. confirm that it doesn't include `woocommerce_status_log_db_sources`
7. Please test around this issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Stop autoloading `woocommerce_status_log_db_sources` option

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
