### PR TITLE
[Fraud Protection] Do not track admin users

### DIFF
--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -378,7 +378,7 @@ class WC_AJAX {
 		do_action( 'woocommerce_checkout_update_order_review', isset( $_POST['post_data'] ) ? wp_unslash( $_POST['post_data'] ) : '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Track checkout field update for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_shortcode_checkout_field_update( isset( $_POST['post_data'] ) ? wp_unslash( $_POST['post_data'] ) : '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1347,7 +1347,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			do_action( 'woocommerce_add_to_cart', $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data );
 
 			// Track cart event for fraud protection (only for newly added items).
-			if ( ! $item_was_already_in_cart && wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( ! $item_was_already_in_cart && wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 				wc_get_container()->get( CartEventTracker::class )
 					->track_cart_item_added( $cart_item_key, (int) $product_id, (int) $quantity, $variation_id );
 			}
@@ -1378,7 +1378,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			do_action( 'woocommerce_remove_cart_item', $cart_item_key, $this );
 
 			// Track cart event for fraud protection.
-			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 				wc_get_container()->get( CartEventTracker::class )
 					->track_cart_item_removed( $cart_item_key, $this );
 			}
@@ -1407,7 +1407,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this );
 
 			// Track cart event for fraud protection.
-			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 				wc_get_container()->get( CartEventTracker::class )
 					->track_cart_item_restored( $cart_item_key, $this );
 			}
@@ -1443,7 +1443,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		do_action( 'woocommerce_after_cart_item_quantity_update', $cart_item_key, $quantity, $old_quantity, $this );
 
 		// Track cart event for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CartEventTracker::class )
 				->track_cart_item_updated( $cart_item_key, $quantity, $old_quantity, $this );
 		}

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1103,7 +1103,7 @@ class WC_Checkout {
 			);
 
 			// Track successful order placement.
-			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 				$fp_order = wc_get_order( $order_id );
 				if ( $fp_order instanceof \WC_Order ) {
 					wc_get_container()->get( CheckoutEventTracker::class )
@@ -1143,7 +1143,7 @@ class WC_Checkout {
 		);
 
 		// Track successful order placement.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() && $order instanceof \WC_Order ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() && $order instanceof \WC_Order ) {
 			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_order_placed( $order_id, $order );
 		}

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -395,7 +395,7 @@ All at %6$s
 	 */
 	public function get_available_payment_gateways() {
 		// Early return if fraud protection blocks session.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled()
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track()
 			&& wc_get_container()->get( SessionClearanceManager::class )->is_session_blocked() ) {
 			return array();
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -77,7 +77,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		do_action( 'woocommerce_new_payment_token', $token_id, $token );
 
 		// Track payment method event for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( PaymentMethodEventTracker::class )
 				->track_payment_method_added( $token_id, $token );
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -377,5 +377,4 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 			)
 		);
 	}
-
 }

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-cart.php
@@ -82,7 +82,7 @@ class WC_Shortcode_Cart {
 		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
 
 		// Track cart page loaded for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CartEventTracker::class )
 				->track_cart_page_loaded();
 		}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -348,7 +348,7 @@ class WC_Shortcode_Checkout {
 		}
 
 		// Track checkout page loaded for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_checkout_page_loaded();
 		}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -413,7 +413,7 @@ class WC_Shortcode_My_Account {
 			exit();
 		} else {
 			// Track add payment method page loaded for fraud protection.
-			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 				wc_get_container()->get( PaymentMethodEventTracker::class )
 					->track_add_payment_method_page_loaded();
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -167,7 +167,7 @@ class Cart extends AbstractBlock {
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
 
 		// Track cart page loaded for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CartEventTracker::class )
 				->track_cart_page_loaded();
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -233,7 +233,7 @@ class Checkout extends AbstractBlock {
 		}
 
 		// Track checkout page loaded for fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_checkout_page_loaded();
 		}

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
@@ -162,9 +162,10 @@ class FraudProtectionController implements RegisterHooksInterface {
 
 	/**
 	 * Check if the fraud protection is enabled and should track events for the current user.
+	 *
 	 * @return bool True if fraud protection should track events for the current user, false otherwise.
 	 */
-	public function should_track(){
+	public function should_track() {
 		return $this->feature_is_enabled() && ! current_user_can( 'manage_woocommerce' );
 	}
 

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
@@ -161,6 +161,14 @@ class FraudProtectionController implements RegisterHooksInterface {
 	}
 
 	/**
+	 * Check if the fraud protection is enabled and should track events for the current user.
+	 * @return bool True if fraud protection should track events for the current user, false otherwise.
+	 */
+	public function should_track(){
+		return $this->feature_is_enabled() && ! current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
 	 * Log helper method for consistent logging across all fraud protection components.
 	 *
 	 * This static method ensures all fraud protection logs are written with

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
@@ -92,7 +92,7 @@ class FraudProtectionDispatcher {
 	public function dispatch_event( string $event_type, array $event_data = array() ): void {
 		try {
 			// Check if feature is enabled - fail-open if not.
-			if ( ! $this->fraud_protection_controller->feature_is_enabled() ) {
+			if ( ! $this->fraud_protection_controller->should_track() ) {
 				FraudProtectionController::log(
 					'debug',
 					sprintf(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -216,7 +216,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		$customer->save();
 
 		$container = wc_get_container();
-		if ( $container->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( $container->get( FraudProtectionController::class )->should_track() ) {
 			$container->get( CheckoutEventTracker::class )->track_blocks_checkout_update();
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -158,7 +158,7 @@ class Checkout extends AbstractCartRoute {
 		}
 
 		// Block early if session is blocked by fraud protection.
-		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled()
+		if ( wc_get_container()->get( FraudProtectionController::class )->should_track()
 			&& wc_get_container()->get( SessionClearanceManager::class )->is_session_blocked() ) {
 			$response = $this->get_route_error_response(
 				'woocommerce_rest_checkout_error',
@@ -586,7 +586,7 @@ class Checkout extends AbstractCartRoute {
 		// Track successful order placement (success or pending payment).
 		if ( in_array( $payment_result->get_status(), array( 'success', 'pending' ), true ) ) {
 			$container = wc_get_container();
-			if ( $container->get( FraudProtectionController::class )->feature_is_enabled() ) {
+			if ( $container->get( FraudProtectionController::class )->should_track() ) {
 				$container->get( CheckoutEventTracker::class )
 					->track_order_placed( $this->order->get_id(), $this->order );
 			}

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -226,7 +226,7 @@ class CartController {
 		);
 
 		// Track cart event for fraud protection.
-		if ( $product instanceof \WC_Product && wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
+		if ( $product instanceof \WC_Product && wc_get_container()->get( FraudProtectionController::class )->should_track() ) {
 			wc_get_container()->get( CartEventTracker::class )
 				->track_cart_item_added( $cart_id, $this->get_product_id( $product ), (int) $request_quantity, $this->get_variation_id( $product ) );
 		}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -308,7 +308,7 @@ class CartControllerTests extends TestCase {
 
 		// Create mock for FraudProtectionController that returns enabled.
 		$mock_controller = $this->createMock( FraudProtectionController::class );
-		$mock_controller->method( 'feature_is_enabled' )->willReturn( true );
+		$mock_controller->method( 'should_track' )->willReturn( true );
 
 		// Replace container instances with mocks.
 		$container = wc_get_container();
@@ -353,7 +353,7 @@ class CartControllerTests extends TestCase {
 
 		// Create mock for FraudProtectionController that returns disabled.
 		$mock_controller = $this->createMock( FraudProtectionController::class );
-		$mock_controller->method( 'feature_is_enabled' )->willReturn( false );
+		$mock_controller->method( 'should_track' )->willReturn( false );
 
 		// Replace container instances with mocks.
 		$container = wc_get_container();
@@ -391,7 +391,7 @@ class CartControllerTests extends TestCase {
 
 		// Create mock for FraudProtectionController that returns enabled.
 		$mock_controller = $this->createMock( FraudProtectionController::class );
-		$mock_controller->method( 'feature_is_enabled' )->willReturn( true );
+		$mock_controller->method( 'should_track' )->willReturn( true );
 
 		// Replace container instances with mocks.
 		$container = wc_get_container();

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionControllerTest.php
@@ -168,6 +168,86 @@ class FraudProtectionControllerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that should_track returns false when feature is enabled but user is admin.
+	 */
+	public function test_should_track_returns_false_when_enabled_for_admin(): void {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_fraud_protection_enabled', 'yes' );
+
+		// Create an admin user and set as current user.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// Get a fresh controller instance to pick up the option change.
+		$controller = $this->get_fresh_controller();
+
+		// Check if the method returns false (admins should NOT be tracked).
+		$this->assertFalse( $controller->should_track() );
+
+		// Clean up.
+		wp_delete_user( $admin_id );
+	}
+
+	/**
+	 * Test that should_track returns false when feature is disabled regardless of user role.
+	 */
+	public function test_should_track_returns_false_when_disabled_for_regular_user(): void {
+		// Disable the feature.
+		update_option( 'woocommerce_feature_fraud_protection_enabled', 'no' );
+
+		// Create a subscriber user (regular user, no admin capability).
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		// Get a fresh controller instance to pick up the option change.
+		$controller = $this->get_fresh_controller();
+
+		// Check if the method returns false (feature disabled = no tracking).
+		$this->assertFalse( $controller->should_track() );
+
+		// Clean up.
+		wp_delete_user( $subscriber_id );
+	}
+
+	/**
+	 * Test that should_track returns true when feature is enabled for regular users.
+	 */
+	public function test_should_track_returns_true_when_enabled_for_regular_user(): void {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_fraud_protection_enabled', 'yes' );
+
+		// Create a subscriber user (no manage_woocommerce capability) and set as current user.
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		// Get a fresh controller instance to pick up the option change.
+		$controller = $this->get_fresh_controller();
+
+		// Check if the method returns true (regular users should be tracked).
+		$this->assertTrue( $controller->should_track() );
+
+		// Clean up.
+		wp_delete_user( $subscriber_id );
+	}
+
+	/**
+	 * Test that should_track returns true when no user is logged in (guest).
+	 */
+	public function test_should_track_returns_true_when_no_user(): void {
+		// Enable the feature.
+		update_option( 'woocommerce_feature_fraud_protection_enabled', 'yes' );
+
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Get a fresh controller instance to pick up the option change.
+		$controller = $this->get_fresh_controller();
+
+		// Check if the method returns true (guests should be tracked).
+		$this->assertTrue( $controller->should_track() );
+	}
+
+	/**
 	 * Cleanup after test.
 	 */
 	public function tearDown(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionDispatcherTest.php
@@ -69,8 +69,8 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 		$this->controller_mock       = $this->createMock( FraudProtectionController::class );
 		$this->data_collector_mock   = $this->createMock( SessionDataCollector::class );
 
-		// By default, feature is enabled.
-		$this->controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		// By default, tracking is enabled (simulating a non-admin user with feature enabled).
+		$this->controller_mock->method( 'should_track' )->willReturn( true );
 
 		// Create dispatcher and inject mocks.
 		$this->sut = new FraudProtectionDispatcher();
@@ -245,10 +245,10 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 		$data_collector_mock = $this->createMock( SessionDataCollector::class );
 		$data_collector_mock->expects( $this->never() )->method( 'collect' );
 
-		// Create controller mock with feature disabled.
+		// Create controller mock with tracking disabled (feature disabled or admin user).
 		$controller_mock = $this->createMock( FraudProtectionController::class );
 		$controller_mock->expects( $this->once() )
-			->method( 'feature_is_enabled' )
+			->method( 'should_track' )
 			->willReturn( false );
 
 		// Create new dispatcher with feature disabled.

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
@@ -85,7 +85,9 @@ class PaymentMethodEventTrackerTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_handle_payment_method_added(): void {
 
-		$user_id = $this->factory->user->create();
+		// Create a regular user (not admin) and set as current user for should_track() to pass.
+		$user_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $user_id );
 
 		$token = new \WC_Payment_Token_CC();
 		$token->set_token( 'test_token_123' );


### PR DESCRIPTION
# Fraud Protection: Do Not Track Admin Users

## Summary

Modifies the fraud protection system to exclude admin users from tracking. Previously, all users were tracked when fraud protection was enabled. Now, only non-admin users (those without the `manage_woocommerce` capability) are tracked.

## Why This Change?

Admin users performing testing, debugging, or routine store management should not be tracked as potential fraud risks. This reduces noise in fraud detection data and focuses tracking on actual customer behavior.

## Test Plan

### Manual Testing Instructions

#### Prerequisites
1. Enable fraud protection feature:
   - Navigate to **WooCommerce → Settings → Advanced → Features**
   - Enable **Fraud Protection**
   - Save changes

#### Test Scenario 1: Admin User Not Tracked
1. Log in as an admin user (or shop manager)
2. Add products to cart
3. Update cart quantities
4. Remove items from cart
5. Complete checkout
6. **Expected**: No fraud protection events should be dispatched (check logs or monitoring)

#### Test Scenario 2: Regular User Tracked
1. Create a test customer account with **Customer** or **Subscriber** role
2. Log in as that user
3. Add products to cart
4. Update cart quantities
5. Complete checkout
6. **Expected**: Fraud protection events should be tracked normally

#### Test Scenario 3: Guest User Tracked
1. Log out (browse as guest)
2. Add products to cart
3. Update cart quantities
4. Complete checkout as guest
5. **Expected**: Fraud protection events should be tracked normally

#### Test Scenario 4: Feature Disabled
1. Disable fraud protection feature in settings
2. Perform cart/checkout operations as any user type
3. **Expected**: No fraud protection events tracked for any user

### Verification Points

For scenarios where tracking is expected, verify events are dispatched at these points:
- Cart item added
- Cart item removed
- Cart item quantity updated
- Cart item restored
- Order placed
- Payment method added

For admin users, verify these events are **not** dispatched even when fraud protection is enabled.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
