### PR TITLE
Update stylelint settings to allow units in 0 values when used inside calc()

### DIFF
--- a/plugins/woocommerce/changelog/update-stylelint-allow-0-units-inside-calc
+++ b/plugins/woocommerce/changelog/update-stylelint-allow-0-units-inside-calc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Update stylelint settings to allow units in 0 values when used inside calc()
+
+

--- a/plugins/woocommerce/client/admin/stylelint.config.js
+++ b/plugins/woocommerce/client/admin/stylelint.config.js
@@ -27,5 +27,6 @@ module.exports = {
 		'scss/selector-no-redundant-nesting-selector': null,
 		'selector-id-pattern': null,
 		'no-invalid-position-at-import-rule': null,
+		'length-zero-no-unit': [ true, { ignoreFunctions: [ 'calc', 'var' ] } ],
 	},
 };

--- a/plugins/woocommerce/client/blocks/.stylelintrc.json
+++ b/plugins/woocommerce/client/blocks/.stylelintrc.json
@@ -9,6 +9,10 @@
 		"no-duplicate-selectors": null,
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
-		"value-keyword-case": null
+		"value-keyword-case": null,
+		"length-zero-no-unit": [
+			true,
+			{ "ignoreFunctions": [ "calc", "var" ] }
+		]
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Apparently, our linting rules don't allow using units with `0` values. That's problematic in functions like `calc()`, where values are required to have a unit. You can try setting `position: fixed; top: calc(10px + 0);` into any element to see that it doesn't work.

This PR updates the rules to allow units in `0` inside `calc()` and `var()` functions.

### How to test the changes in this Pull Request:

1. Merge or copy some of the changes from https://github.com/woocommerce/woocommerce/pull/62608.
2. Run `pnpm --filter="@woocommerce/admin-library" lint` and `pnpm --filter="@woocommerce/block-library" lint`.
3. Verify you don't get the `length-zero-no-unit` error.