### PR TITLE
Fix personalization tag attributes not being processed in email links

### DIFF
--- a/packages/php/email-editor/changelog/62822-wooplug-6143-inconsistent-handling-of-personalizer-tag-attributes-in
+++ b/packages/php/email-editor/changelog/62822-wooplug-6143-inconsistent-handling-of-personalizer-tag-attributes-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix personalization tag attributes not being processed in email links

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -179,16 +179,25 @@ class Personalizer {
 			$attributes_string = $matches[2]; // The attributes part (e.g., 'default="subscriber"').
 
 			// Step 2: Extract attributes from the attribute string.
-			// Match both quoted values (url="foo") and unquoted values (url=foo).
+			// Match quoted values (double or single quotes separately to avoid mixing) and unquoted values.
 			// Unquoted values can occur when esc_url() strips quotes from personalization tags.
 			// For unquoted values with spaces, capture until the next key= pattern or closing bracket.
-			if ( preg_match_all( '/(\w+)=(?:["\']([^"\']*)["\']|([^\s\]]+(?:\s+(?!\w+=)[^\s\]]+)*))/', $attributes_string, $attribute_matches, PREG_SET_ORDER ) ) {
+			if ( preg_match_all( '/(\w+)=(?:"([^"]*)"|\'([^\']*)\'|([^\s\]]+(?:\s+(?!\w+=)[^\s\]]+)*))/', $attributes_string, $attribute_matches, PREG_SET_ORDER ) ) {
 				foreach ( $attribute_matches as $attribute ) {
-					// $attribute[2] is quoted value, $attribute[3] is unquoted value (may contain spaces).
+					// $attribute[2] is double-quoted value, $attribute[3] is single-quoted value,
+					// $attribute[4] is unquoted value (may contain spaces).
 					// Use null coalescing as only one of these will be populated depending on which pattern matched.
-					$quoted_value                         = $attribute[2] ?? '';
-					$unquoted_value                       = $attribute[3] ?? '';
-					$result['arguments'][ $attribute[1] ] = '' !== $quoted_value ? $quoted_value : $unquoted_value;
+					$double_quoted_value = $attribute[2] ?? '';
+					$single_quoted_value = $attribute[3] ?? '';
+					$unquoted_value      = $attribute[4] ?? '';
+
+					if ( '' !== $double_quoted_value ) {
+						$result['arguments'][ $attribute[1] ] = $double_quoted_value;
+					} elseif ( '' !== $single_quoted_value ) {
+						$result['arguments'][ $attribute[1] ] = $single_quoted_value;
+					} else {
+						$result['arguments'][ $attribute[1] ] = $unquoted_value;
+					}
 				}
 			}
 		}

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -18,6 +18,12 @@ use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalizatio
 class Personalizer {
 
 	/**
+	 * Regex pattern for matching personalization tag names (e.g., "woocommerce/store-url", "user-firstname").
+	 * Used in both tag detection and parsing.
+	 */
+	private const TAG_NAME_PATTERN = '[a-zA-Z0-9\-\/]+';
+
+	/**
 	 * Personalization tags registry.
 	 *
 	 * @var Personalization_Tags_Registry
@@ -130,7 +136,9 @@ class Personalizer {
 					continue;
 				}
 
-				if ( ! $href || ! preg_match( '/\[[a-z-\/]+\]/', urldecode( $href ), $matches ) ) {
+				// Decode both URL encoding (%XX) and HTML entities (&#039;) to handle various encoding scenarios.
+				$decoded_href = html_entity_decode( urldecode( $href ), ENT_QUOTES, 'UTF-8' );
+				if ( ! preg_match( '/\[' . self::TAG_NAME_PATTERN . '(?:\s+[^\]]+)?\]/', $decoded_href, $matches ) ) {
 					continue;
 				}
 
@@ -166,14 +174,21 @@ class Personalizer {
 		);
 
 		// Step 1: Separate the tag and attributes.
-		if ( preg_match( '/^\[([a-zA-Z0-9\-\/]+)\s*(.*?)\]$/', trim( $token ), $matches ) ) {
+		if ( preg_match( '/^\[(' . self::TAG_NAME_PATTERN . ')\s*(.*?)\]$/', trim( $token ), $matches ) ) {
 			$result['token']   = "[{$matches[1]}]"; // The tag part (e.g., "[mailpoet/subscriber-firstname]").
 			$attributes_string = $matches[2]; // The attributes part (e.g., 'default="subscriber"').
 
 			// Step 2: Extract attributes from the attribute string.
-			if ( preg_match_all( '/(\w+)=["\']([^"\']*)["\']/', $attributes_string, $attribute_matches, PREG_SET_ORDER ) ) {
+			// Match both quoted values (url="foo") and unquoted values (url=foo).
+			// Unquoted values can occur when esc_url() strips quotes from personalization tags.
+			// For unquoted values with spaces, capture until the next key= pattern or closing bracket.
+			if ( preg_match_all( '/(\w+)=(?:["\']([^"\']*)["\']|([^\s\]]+(?:\s+(?!\w+=)[^\s\]]+)*))/', $attributes_string, $attribute_matches, PREG_SET_ORDER ) ) {
 				foreach ( $attribute_matches as $attribute ) {
-					$result['arguments'][ $attribute[1] ] = $attribute[2];
+					// $attribute[2] is quoted value, $attribute[3] is unquoted value (may contain spaces).
+					// Use null coalescing as only one of these will be populated depending on which pattern matched.
+					$quoted_value                         = $attribute[2] ?? '';
+					$unquoted_value                       = $attribute[3] ?? '';
+					$result['arguments'][ $attribute[1] ] = '' !== $quoted_value ? $quoted_value : $unquoted_value;
 				}
 			}
 		}

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -182,6 +182,9 @@ class Personalizer {
 			// Match quoted values (double or single quotes separately to avoid mixing) and unquoted values.
 			// Unquoted values can occur when esc_url() strips quotes from personalization tags.
 			// For unquoted values with spaces, capture until the next key= pattern or closing bracket.
+			// The negative lookahead (?!\w+=) is critical for preventing ReDoS:
+			// it ensures the inner loop terminates as soon as the next key= pattern appears,
+			// preventing excessive backtracking despite the nested quantifiers.
 			if ( preg_match_all( '/(\w+)=(?:"([^"]*)"|\'([^\']*)\'|([^\s\]]+(?:\s+(?!\w+=)[^\s\]]+)*))/', $attributes_string, $attribute_matches, PREG_SET_ORDER ) ) {
 				foreach ( $attribute_matches as $attribute ) {
 					// $attribute[2] is double-quoted value, $attribute[3] is single-quoted value,

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
@@ -88,8 +88,9 @@ class Button extends Abstract_Block_Renderer {
 			return '';
 		}
 
-		$button_text = $dom_helper->get_element_inner_html( $button_link ) ? $dom_helper->get_element_inner_html( $button_link ) : '';
-		$button_url  = $button_link->getAttribute( 'href' ) ? $button_link->getAttribute( 'href' ) : '#';
+		$button_text    = $dom_helper->get_element_inner_html( $button_link ) ? $dom_helper->get_element_inner_html( $button_link ) : '';
+		$button_url     = $button_link->getAttribute( 'href' ) ? $button_link->getAttribute( 'href' ) : '#';
+		$data_link_href = $button_link->getAttribute( 'data-link-href' );
 
 		$block_attributes = wp_parse_args(
 			$parsed_block['attrs'] ?? array(),
@@ -117,11 +118,16 @@ class Button extends Abstract_Block_Renderer {
 			'role'   => 'presentation',
 		);
 
+		$data_link_attr = $data_link_href
+			? sprintf( ' data-link-href="%s"', esc_attr( $data_link_href ) )
+			: '';
+
 		$button_content = sprintf(
-			'<a class="button-link %1$s" style="%2$s" href="%3$s" target="_blank">%4$s</a>',
+			'<a class="button-link %1$s" style="%2$s" href="%3$s"%4$s target="_blank">%5$s</a>',
 			esc_attr( $link_styles['classnames'] ),
 			esc_attr( $link_styles['css'] ),
 			esc_url( $button_url ),
+			$data_link_attr,
 			$button_text
 		);
 

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -230,6 +230,28 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test personalizing content with a tag in href attribute that includes attributes.
+	 */
+	public function testPersonalizeContentWithHrefTagWithAttributes(): void {
+		// Register a tag in the registry.
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Trackable Link',
+				'trackable-link',
+				'Links',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- The $context parameter is not used in this test.
+					return 'https://example.com?url=' . ( $args['url'] ?? '' ) . '&desc=' . ( $args['desc'] ?? '' );
+				}
+			)
+		);
+
+		$html_content = '<a href="[trackable-link url=\'wordpress.com\' desc=\'home-page\']">Click here</a>';
+		// Note: WordPress encodes & as &#038; in URLs.
+		$expected = '<a href="https://example.com?url=wordpress.com&#038;desc=home-page">Click here</a>';
+		$this->assertSame( $expected, $this->personalizer->personalize_content( $html_content ) );
+	}
+
+	/**
 	 * Test parsing tokens with various formats.
 	 */
 	public function testParsingPersonalizationTagAttributes(): void {
@@ -306,7 +328,72 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$result['arguments']
 		);
 
-		// Test case 6 Invalid token format.
+		// Test case 6: Token with unquoted values (as produced by esc_url stripping quotes).
+		$result = $method->invoke( $this->personalizer, '[trackable-link url=wordpress.com desc=home-page]' );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[trackable-link]', $result['token'] );
+		$this->assertSame(
+			array(
+				'url'  => 'wordpress.com',
+				'desc' => 'home-page',
+			),
+			$result['arguments']
+		);
+
+		// Test case 7: Token with unquoted values containing spaces (last argument).
+		$result = $method->invoke( $this->personalizer, '[trackable-link url=uf desc=desc 123 asd]' );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[trackable-link]', $result['token'] );
+		$this->assertSame(
+			array(
+				'url'  => 'uf',
+				'desc' => 'desc 123 asd',
+			),
+			$result['arguments']
+		);
+
+		// Test case 8: Token with unquoted values containing spaces (first argument, followed by another).
+		$result = $method->invoke( $this->personalizer, '[trackable-link desc=desc 123 asd url=example.com]' );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[trackable-link]', $result['token'] );
+		$this->assertSame(
+			array(
+				'desc' => 'desc 123 asd',
+				'url'  => 'example.com',
+			),
+			$result['arguments']
+		);
+
+		// Test case 9: Token with three unquoted arguments, middle one with spaces.
+		$result = $method->invoke( $this->personalizer, '[trackable-link first=one middle=has some spaces last=three]' );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[trackable-link]', $result['token'] );
+		$this->assertSame(
+			array(
+				'first'  => 'one',
+				'middle' => 'has some spaces',
+				'last'   => 'three',
+			),
+			$result['arguments']
+		);
+
+		// Test case 10: Invalid token format.
 		$result = $method->invoke( $this->personalizer, 'invalid-token' );
 		/**
 		 * Typehint needed by PHPStan.

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -393,7 +393,37 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$result['arguments']
 		);
 
-		// Test case 10: Invalid token format.
+		// Test case 10: Token with embedded single quote in double-quoted value.
+		$result = $method->invoke( $this->personalizer, '[user/greeting title="What\'s up"]' );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[user/greeting]', $result['token'] );
+		$this->assertSame(
+			array(
+				'title' => "What's up",
+			),
+			$result['arguments']
+		);
+
+		// Test case 11: Token with embedded double quote in single-quoted value.
+		$result = $method->invoke( $this->personalizer, "[user/greeting title='Say \"hello\"']" );
+		/**
+		 * Typehint needed by PHPStan.
+		 *
+		 * @var array{token: string, arguments: array<string, string>} $result
+		 */
+		$this->assertSame( '[user/greeting]', $result['token'] );
+		$this->assertSame(
+			array(
+				'title' => 'Say "hello"',
+			),
+			$result['arguments']
+		);
+
+		// Test case 12: Invalid token format.
 		$result = $method->invoke( $this->personalizer, 'invalid-token' );
 		/**
 		 * Typehint needed by PHPStan.

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Button_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Button_Test.php
@@ -234,4 +234,21 @@ class Button_Test extends \Email_Editor_Integration_Test_Case {
 		// because of special email HTML markup.
 		$this->assertStringContainsString( 'color:#fff', $output );
 	}
+
+	/**
+	 * Test it preserves data-link-href attribute for personalization tags
+	 */
+	public function testItPreservesDataLinkHref(): void {
+		$parsed_button              = $this->parsed_button;
+		$parsed_button['innerHTML'] = '<div class="wp-block-button"><a href="#" data-link-href="[trackable-link url=\'test\']" class="wp-block-button__link">Button Text</a></div>';
+
+		$output = $this->button_renderer->render(
+			$parsed_button['innerHTML'],
+			$parsed_button,
+			$this->rendering_context
+		);
+
+		// Note: esc_attr() encodes single quotes as &#039;.
+		$this->assertStringContainsString( 'data-link-href="[trackable-link url=&#039;test&#039;]"', $output );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
@@ -372,4 +372,24 @@ class Image_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'width="600"', $rendered );
 		$this->assertStringContainsString( 'width:600px;', $rendered );
 	}
+
+	/**
+	 * Test it preserves data-link-href attribute for personalization tags
+	 */
+	public function testItPreservesDataLinkHref(): void {
+		$image_content_with_data_link = '
+			<figure class="wp-block-image alignleft size-full is-style-default">
+				<a href="#" data-link-href="[trackable-link url=\'test\']">
+					<img src="https://test.com/wp-content/uploads/2023/05/image.jpg" alt="" style=""/>
+				</a>
+			</figure>
+		';
+		$parsed_image                 = $this->parsed_image;
+		$parsed_image['innerHTML']    = $image_content_with_data_link;
+
+		$rendered = $this->image_renderer->render( $image_content_with_data_link, $parsed_image, $this->rendering_context );
+
+		// Note: esc_attr() encodes single quotes as &#039;.
+		$this->assertStringContainsString( 'data-link-href="[trackable-link url=&#039;test&#039;]"', $rendered );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

  Fixes two issues with personalization tags in email links:

  1. **Personalization tag attributes in `href` not passed to callback**: Tags like `[trackable-link url='foo' desc='bar']` in href attributes were only matching the tag name, not capturing the attributes. The callback received empty arguments.

  2. **`data-link-href` attribute stripped by block renderers**: The Button and Image block renderers rebuild anchor HTML, losing the `data-link-href` attribute used for personalization tags.

  **Changes:**
  - Add `TAG_NAME_PATTERN` constant for consistent regex matching
  - Update href regex to capture full tag with attributes
  - Handle HTML entity decoding for encoded attributes
  - Support unquoted attribute values (when `esc_url()` strips quotes)
  - Support attribute values containing spaces
  - Preserve `data-link-href` in Button and Image block renderers

  Closes WOOPLUG-6143

  ### How to test the changes in this Pull Request:

  1. Create a new email in the Email Editor
  2. Add a Button block with a personalization tag in the link, e.g., `[trackable-link url="example.com" desc="test link"]`
  3. Add an Image block with a link containing a personalization tag
  4. Preview/send the email
  5. Verify the personalization tag callback receives the correct `url` and `desc` arguments
  6. Verify both Button and Image links are correctly personalized

  ### Testing that has already taken place:

  - Unit tests added for all new functionality
  - All existing tests pass
  - Manual testing with personalization tags containing:
    - Single attributes
    - Multiple attributes
    - Attributes with spaces in values
    - Quoted and unquoted attribute values

  ### Changelog entry

  -   [x] Automatically create a changelog entry from the details below.

  <details>
  <summary>Changelog Entry Details</summary>

  #### Significance
  -   [x] Patch

  #### Type
  -   [x] Fix - Fixes an existing bug

  #### Message
  Fix personalization tag attributes not being processed in email links

  </details>