### PR TITLE
Update variation date_modified when toggling POS visibility

### DIFF
--- a/plugins/woocommerce/changelog/62824-wooplug-6145-addingremoving-pos-hidden-taxonomy-on-variations-doesnt
+++ b/plugins/woocommerce/changelog/62824-wooplug-6145-addingremoving-pos-hidden-taxonomy-on-variations-doesnt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variation date_modified not updating when toggling POS visibility on variable products.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySync.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySync.php
@@ -49,6 +49,12 @@ class POSProductVisibilitySync {
 	 * @return void
 	 */
 	public function set_product_pos_visibility( int $product_id, bool $visible_in_pos ): void {
+		$is_currently_visible = ! has_term( 'pos-hidden', 'pos_product_visibility', $product_id );
+
+		if ( $is_currently_visible === $visible_in_pos ) {
+			return; // No change detected.
+		}
+
 		if ( $visible_in_pos ) {
 			wp_remove_object_terms( $product_id, 'pos-hidden', 'pos_product_visibility' );
 		} else {
@@ -77,6 +83,12 @@ class POSProductVisibilitySync {
 				wp_remove_object_terms( $variation_id, 'pos-hidden', 'pos_product_visibility' );
 			} else {
 				wp_set_object_terms( $variation_id, 'pos-hidden', 'pos_product_visibility' );
+			}
+
+			// Save variation to update date_modified.
+			$variation = wc_get_product( $variation_id );
+			if ( $variation ) {
+				$variation->save();
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
@@ -193,18 +193,13 @@ class POSProductVisibilitySyncTest extends \WC_Unit_Test_Case {
 		$this->sut->set_product_pos_visibility( $product->get_id(), false );
 
 		// Track if any variations have save() called.
-		$save_called = false;
-		$callback    = function () use ( &$save_called ) {
-			$save_called = true;
-		};
-		add_action( 'woocommerce_update_product_variation', $callback );
+		// Make sure that `save` is never called.
+		$mock_callback = $this->createMock( WC_Product::class );
+		$mock_callback->expects( $this->never() )->method( 'save' );
 
 		// Try to set hidden again (no change).
+		add_action( 'woocommerce_update_product_variation', array( $mock_callback, 'save' ) );
 		$this->sut->set_product_pos_visibility( $product->get_id(), false );
-
-		remove_action( 'woocommerce_update_product_variation', $callback );
-
-		// Verify save() was NOT called (because state was already hidden).
-		$this->assertFalse( $save_called, 'save() should not be called when visibility is unchanged' );
+		remove_action( 'woocommerce_update_product_variation', array( $mock_callback, 'save' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
@@ -176,18 +176,11 @@ class POSProductVisibilitySyncTest extends \WC_Unit_Test_Case {
 		remove_action( 'woocommerce_update_product_variation', $callback );
 
 		// Verify save() was called for all variations.
-		$this->assertCount(
-			count( $variation_ids ),
+		$this->assertEquals(
+			$variation_ids,
 			$saved_variation_ids,
 			'save() should be called for each variation'
 		);
-		foreach ( $variation_ids as $variation_id ) {
-			$this->assertContains(
-				$variation_id,
-				$saved_variation_ids,
-				"Variation $variation_id should have been saved"
-			);
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
@@ -155,4 +155,63 @@ class POSProductVisibilitySyncTest extends \WC_Unit_Test_Case {
 		// No exception should be thrown - test passes if we reach this point.
 		$this->assertTrue( true );
 	}
+
+	/**
+	 * Test that variations are saved when POS visibility changes.
+	 */
+	public function test_variations_saved_when_visibility_changes(): void {
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
+
+		// Track which variations have save() called.
+		$saved_variation_ids = array();
+		$callback            = function ( $variation_id ) use ( &$saved_variation_ids ) {
+			$saved_variation_ids[] = $variation_id;
+		};
+		add_action( 'woocommerce_update_product_variation', $callback );
+
+		// Change visibility to hidden.
+		$this->sut->set_product_pos_visibility( $product->get_id(), false );
+
+		remove_action( 'woocommerce_update_product_variation', $callback );
+
+		// Verify save() was called for all variations.
+		$this->assertCount(
+			count( $variation_ids ),
+			$saved_variation_ids,
+			'save() should be called for each variation'
+		);
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertContains(
+				$variation_id,
+				$saved_variation_ids,
+				"Variation $variation_id should have been saved"
+			);
+		}
+	}
+
+	/**
+	 * Test that no updates occur when visibility state hasn't changed.
+	 */
+	public function test_no_updates_when_visibility_unchanged(): void {
+		$product = WC_Helper_Product::create_variation_product();
+
+		// Set product as hidden first.
+		$this->sut->set_product_pos_visibility( $product->get_id(), false );
+
+		// Track if any variations have save() called.
+		$save_called = false;
+		$callback    = function () use ( &$save_called ) {
+			$save_called = true;
+		};
+		add_action( 'woocommerce_update_product_variation', $callback );
+
+		// Try to set hidden again (no change).
+		$this->sut->set_product_pos_visibility( $product->get_id(), false );
+
+		remove_action( 'woocommerce_update_product_variation', $callback );
+
+		// Verify save() was NOT called (because state was already hidden).
+		$this->assertFalse( $save_called, 'save() should not be called when visibility is unchanged' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/POSProductVisibilitySyncTest.php
@@ -194,7 +194,7 @@ class POSProductVisibilitySyncTest extends \WC_Unit_Test_Case {
 
 		// Track if any variations have save() called.
 		// Make sure that `save` is never called.
-		$mock_callback = $this->createMock( WC_Product::class );
+		$mock_callback = $this->createMock( \WC_Product::class );
 		$mock_callback->expects( $this->never() )->method( 'save' );
 
 		// Try to set hidden again (no change).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When toggling POS visibility on a variable product, the parent product's `date_modified` was updated but variations' `date_modified` remained unchanged. This happened because variations only had `wp_set_object_terms()` called directly, which updates the taxonomy relationship but doesn't touch the variation's modification timestamp.

Key changes:

1. **Early return optimization** - `set_product_pos_visibility()` now checks if the visibility state is actually changing before doing any work. If the state hasn't changed, the method returns early, avoiding unnecessary database writes.

2. **Variation saving** - When visibility changes, each variation is now loaded and `save()` is called to update its `date_modified` timestamp.

Closes WOOPLUG-6145

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test 1: Smoke test - POS visibility toggle works correctly

1. Go to Products > All Products
2. Create a new variable product with at least 2 variations
3. Navigate to the Product data > Advanced tab
4. Verify the "Show in Point of Sale" checkbox is checked by default
5. Uncheck the "Show in Point of Sale" checkbox
6. Click Update to save the product
7. Refresh the page
8. Expected: The checkbox should remain unchecked
9. Check the checkbox again and save
10. Expected: The checkbox should remain checked after refresh

#### Test 2: Variations date_modified is updated when toggling visibility

1. Create a variable product with at least 2 variations (or use an existing one)
2. Note the current time (e.g., `2026-01-15T12:00:00`)
3. Toggle the "Show in Point of Sale" checkbox and save
4. Make a REST API request to get variations modified after your noted time:
```bash
curl -X GET "https://yoursite.com/wp-json/wc/v3/variations?modified_after=2026-01-15T12:00:00" \
  -u consumer_key:consumer_secret
```
5. Expected: All variations of the product should be returned, confirming their `date_modified` was updated

#### Test 3: No updates when visibility state unchanged

1. Set a variable product's POS visibility to hidden (unchecked)
2. Note the `date_modified` of a variation via REST API:
```bash
curl -X GET "https://yoursite.com/wp-json/wc/v3/variations/{variation_id}" \
  -u consumer_key:consumer_secret
```
3. Save the product again without changing the POS visibility checkbox
4. Check the variation's `date_modified` again
5. Expected: The `date_modified` should remain unchanged (optimization working)

### Testing that has already taken place:

- Unit tests added and passing for both the date_modified update behavior and the early return optimization
- Existing POSProductVisibilitySyncTest tests continue to pass
- I've tested the API behavior by testing POS mode on an Android tablet.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Fix variation date_modified not updating when toggling POS visibility on variable products.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>