### PR TITLE
[Fraud Protection] fix outdated data for logged out users

### DIFF
--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
@@ -395,7 +395,6 @@ class SessionDataCollector {
 		$billing_data = array(
 			'first_name' => null,
 			'last_name'  => null,
-			'address'    => null,
 			'address_1'  => null,
 			'address_2'  => null,
 			'city'       => null,
@@ -404,47 +403,66 @@ class SessionDataCollector {
 			'phone'      => null,
 			'postcode'   => null,
 		);
-
 		try {
-			// Try WC_Customer object first.
-			if ( WC()->customer instanceof \WC_Customer ) {
+
+			// Session data is more up to date for guest users.
+			$customer_data = null;
+			if ( WC()->session instanceof \WC_Session ) {
+				$customer_data = WC()->session->get( 'customer' );
+			}
+
+			if ( is_array( $customer_data ) && ! empty( $customer_data ) ) {
 				$billing_data = array_merge(
 					$billing_data,
 					array(
-						'first_name' => \sanitize_text_field( WC()->customer->get_billing_first_name() ),
-						'last_name'  => \sanitize_text_field( WC()->customer->get_billing_last_name() ),
-						'address_1'  => \sanitize_text_field( WC()->customer->get_billing_address_1() ),
-						'address_2'  => \sanitize_text_field( WC()->customer->get_billing_address_2() ),
-						'city'       => \sanitize_text_field( WC()->customer->get_billing_city() ),
-						'state'      => \sanitize_text_field( WC()->customer->get_billing_state() ),
-						'country'    => \sanitize_text_field( WC()->customer->get_billing_country() ),
-						'phone'      => \sanitize_text_field( WC()->customer->get_billing_phone() ),
-						'postcode'   => \sanitize_text_field( WC()->customer->get_billing_postcode() ),
+						'first_name' => $customer_data['first_name'] ?? null,
+						'last_name'  => $customer_data['last_name'] ?? null,
+						'address_1'  => $customer_data['address_1'] ?? null,
+						'address_2'  => $customer_data['address_2'] ?? null,
+						'city'       => $customer_data['city'] ?? null,
+						'state'      => $customer_data['state'] ?? null,
+						'country'    => $customer_data['country'] ?? null,
+						'phone'      => $customer_data['phone'] ?? null,
+						'postcode'   => $customer_data['postcode'] ?? null,
 					)
 				);
-			} elseif ( WC()->session instanceof \WC_Session ) {
-				// Fallback to session customer data if WC_Customer not available.
-				$customer_data = WC()->session->get( 'customer' );
-				if ( is_array( $customer_data ) ) {
-					$billing_data = array_merge(
-						$billing_data,
-						array(
-							'first_name' => \sanitize_text_field( $customer_data['first_name'] ?? null ),
-							'last_name'  => \sanitize_text_field( $customer_data['last_name'] ?? null ),
-							'address'    => \sanitize_text_field( $customer_data['address'] ?? null ),
-							'address_1'  => \sanitize_text_field( $customer_data['address_1'] ?? null ),
-							'address_2'  => \sanitize_text_field( $customer_data['address_2'] ?? null ),
-							'city'       => \sanitize_text_field( $customer_data['city'] ?? null ),
-							'state'      => \sanitize_text_field( $customer_data['state'] ?? null ),
-							'country'    => \sanitize_text_field( $customer_data['country'] ?? null ),
-							'phone'      => \sanitize_text_field( $customer_data['phone'] ?? null ),
-							'postcode'   => \sanitize_text_field( $customer_data['postcode'] ?? null ),
-						)
-					);
+			} elseif ( WC()->customer instanceof \WC_Customer ) {
+				$billing_data = array_merge(
+					$billing_data,
+					array(
+						'first_name' => WC()->customer->get_billing_first_name(),
+						'last_name'  => WC()->customer->get_billing_last_name(),
+						'address_1'  => WC()->customer->get_billing_address_1(),
+						'address_2'  => WC()->customer->get_billing_address_2(),
+						'city'       => WC()->customer->get_billing_city(),
+						'state'      => WC()->customer->get_billing_state(),
+						'country'    => WC()->customer->get_billing_country(),
+						'phone'      => WC()->customer->get_billing_phone(),
+						'postcode'   => WC()->customer->get_billing_postcode(),
+					)
+				);
+
+				// Look into WC()->customer->get_changes()['billing'] for any updated data.
+				$customer_changes = WC()->customer->get_changes();
+				if ( is_array( $customer_changes ) && isset( $customer_changes['billing'] ) && is_array( $customer_changes['billing'] ) ) {
+					$billing_changes = $customer_changes['billing'];
+
+					// Only merge the fields that actually changed.
+					foreach ( $billing_changes as $key => $value ) {
+						if ( array_key_exists( $key, $billing_data ) ) {
+							$billing_data[ $key ] = $value;
+						}
+					}
 				}
 			}
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Graceful degradation - prevents any errors from being thrown.
+			// Graceful degradation - returns as much data as possible.
+		}
+
+		foreach ( $billing_data as $key => $value ) {
+			if ( is_string( $value ) ) {
+				$billing_data[ $key ] = sanitize_text_field( $value );
+			}
 		}
 
 		return $billing_data;
@@ -464,7 +482,6 @@ class SessionDataCollector {
 		$shipping_data = array(
 			'first_name' => null,
 			'last_name'  => null,
-			'address'    => null,
 			'address_1'  => null,
 			'address_2'  => null,
 			'city'       => null,
@@ -473,41 +490,61 @@ class SessionDataCollector {
 			'country'    => null,
 		);
 		try {
-			if ( WC()->customer instanceof \WC_Customer ) {
+			$customer_data = null;
+			if ( WC()->session instanceof \WC_Session ) {
+				$customer_data = WC()->session->get( 'customer' );
+			}
+
+			if ( is_array( $customer_data ) && ! empty( $customer_data ) ) {
 				$shipping_data = array_merge(
 					$shipping_data,
 					array(
-						'first_name' => \sanitize_text_field( WC()->customer->get_shipping_first_name() ),
-						'last_name'  => \sanitize_text_field( WC()->customer->get_shipping_last_name() ),
-						'address_1'  => \sanitize_text_field( WC()->customer->get_shipping_address_1() ),
-						'address_2'  => \sanitize_text_field( WC()->customer->get_shipping_address_2() ),
-						'city'       => \sanitize_text_field( WC()->customer->get_shipping_city() ),
-						'state'      => \sanitize_text_field( WC()->customer->get_shipping_state() ),
-						'postcode'   => \sanitize_text_field( WC()->customer->get_shipping_postcode() ),
-						'country'    => \sanitize_text_field( WC()->customer->get_shipping_country() ),
+						'first_name' => $customer_data['shipping_first_name'] ?? null,
+						'last_name'  => $customer_data['shipping_last_name'] ?? null,
+						'address_1'  => $customer_data['shipping_address_1'] ?? null,
+						'address_2'  => $customer_data['shipping_address_2'] ?? null,
+						'city'       => $customer_data['shipping_city'] ?? null,
+						'state'      => $customer_data['shipping_state'] ?? null,
+						'postcode'   => $customer_data['shipping_postcode'] ?? null,
+						'country'    => $customer_data['shipping_country'] ?? null,
 					)
 				);
-			} elseif ( WC()->session instanceof \WC_Session ) {
-				// Fallback to session customer data if WC_Customer not available.
-				$customer_data = WC()->session->get( 'customer' );
-				if ( is_array( $customer_data ) ) {
-					$shipping_data = array_merge(
-						$shipping_data,
-						array(
-							'first_name' => \sanitize_text_field( $customer_data['shipping_first_name'] ?? null ),
-							'last_name'  => \sanitize_text_field( $customer_data['shipping_last_name'] ?? null ),
-							'address_1'  => \sanitize_text_field( $customer_data['shipping_address_1'] ?? null ),
-							'address_2'  => \sanitize_text_field( $customer_data['shipping_address_2'] ?? null ),
-							'city'       => \sanitize_text_field( $customer_data['shipping_city'] ?? null ),
-							'state'      => \sanitize_text_field( $customer_data['shipping_state'] ?? null ),
-							'postcode'   => \sanitize_text_field( $customer_data['shipping_postcode'] ?? null ),
-							'country'    => \sanitize_text_field( $customer_data['shipping_country'] ?? null ),
-						)
-					);
+			} elseif ( WC()->customer instanceof \WC_Customer ) {
+				$shipping_data = array_merge(
+					$shipping_data,
+					array(
+						'first_name' => WC()->customer->get_shipping_first_name(),
+						'last_name'  => WC()->customer->get_shipping_last_name(),
+						'address_1'  => WC()->customer->get_shipping_address_1(),
+						'address_2'  => WC()->customer->get_shipping_address_2(),
+						'city'       => WC()->customer->get_shipping_city(),
+						'state'      => WC()->customer->get_shipping_state(),
+						'postcode'   => WC()->customer->get_shipping_postcode(),
+						'country'    => WC()->customer->get_shipping_country(),
+					)
+				);
+
+				// Look into WC()->customer->get_changes()['shipping'] for any updated data.
+				$customer_changes = WC()->customer->get_changes();
+				if ( is_array( $customer_changes ) && isset( $customer_changes['shipping'] ) && is_array( $customer_changes['shipping'] ) ) {
+					$shipping_changes = $customer_changes['shipping'];
+
+					// Only merge the fields that actually changed.
+					foreach ( $shipping_changes as $key => $value ) {
+						if ( array_key_exists( $key, $shipping_data ) ) {
+							$shipping_data[ $key ] = $value;
+						}
+					}
 				}
 			}
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Graceful degradation - returns as much data as possible.
+		}
+
+		foreach ( $shipping_data as $key => $value ) {
+			if ( is_string( $value ) ) {
+				$shipping_data[ $key ] = sanitize_text_field( $value );
+			}
 		}
 
 		return $shipping_data;

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionDataCollectorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionDataCollectorTest.php
@@ -42,12 +42,25 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 			wc_load_cart();
 		}
 
+		// Clear session data to ensure clean state for each test.
+		WC()->session->set( 'customer', array() );
+
 		$this->session_clearance_manager = new SessionClearanceManager();
 		$this->sut                       = new SessionDataCollector();
 		$this->sut->init( $this->session_clearance_manager );
 
 		// Disable taxes before adding products to cart.
 		update_option( 'woocommerce_calc_taxes', 'no' );
+	}
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		// Clear session data to ensure test isolation.
+		WC()->session->set( 'customer', array() );
+
+		parent::tearDown();
 	}
 
 	/**
@@ -176,10 +189,8 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 
 		$this->assertArrayHasKey( 'session_id', $result['session'] );
 		// Session ID should be a string when session is available.
-		if ( isset( WC()->session ) ) {
-			$this->assertIsString( $result['session']['session_id'] );
-			$this->assertNotEmpty( $result['session']['session_id'] );
-		}
+		$this->assertIsString( $result['session']['session_id'] );
+		$this->assertNotEmpty( $result['session']['session_id'] );
 	}
 
 	/**
@@ -262,16 +273,14 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		// Set customer data in session.
-		if ( isset( WC()->session ) ) {
-			WC()->session->set(
-				'customer',
-				array(
-					'first_name' => 'Jane',
-					'last_name'  => 'Smith',
-					'email'      => 'jane.smith@example.com',
-				)
-			);
-		}
+		WC()->session->set(
+			'customer',
+			array(
+				'first_name' => 'Jane',
+				'last_name'  => 'Smith',
+				'email'      => 'jane.smith@example.com',
+			)
+		);
 
 		// Nullify WC_Customer to force fallback to session.
 		$original_customer = WC()->customer;
@@ -283,11 +292,9 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 		WC()->customer = $original_customer;
 
 		// Verify session data was used.
-		if ( isset( WC()->session ) ) {
-			$this->assertEquals( 'Jane', $result['customer']['first_name'] );
-			$this->assertEquals( 'Smith', $result['customer']['last_name'] );
-			$this->assertEquals( 'jane.smith@example.com', $result['customer']['billing_email'] );
-		}
+		$this->assertEquals( 'Jane', $result['customer']['first_name'] );
+		$this->assertEquals( 'Smith', $result['customer']['last_name'] );
+		$this->assertEquals( 'jane.smith@example.com', $result['customer']['billing_email'] );
 	}
 
 	/**
@@ -787,5 +794,155 @@ class SessionDataCollectorTest extends \WC_Unit_Test_Case {
 
 		// No automatic data collection should have occurred.
 		// This is a design verification test - the class should not register hooks.
+	}
+
+	/**
+	 * Test billing address uses changes array for unsaved data.
+	 */
+	public function test_billing_address_uses_changes_array() {
+		// Setting these values automatically populates the changes array.
+		// This mimics what happens when a customer updates their address during checkout.
+		WC()->customer->set_billing_address_1( '456 New Street' );
+		WC()->customer->set_billing_city( 'New City' );
+		WC()->customer->set_billing_state( 'CA' );
+		WC()->customer->set_billing_country( 'US' );
+		WC()->customer->set_billing_postcode( '67890' );
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['billing_address'] );
+		// Verify the values are collected correctly.
+		$this->assertArrayHasKey( 'address_1', $result['billing_address'] );
+		$this->assertSame( '456 New Street', $result['billing_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['billing_address'] );
+		$this->assertSame( 'New City', $result['billing_address']['city'] );
+		$this->assertArrayHasKey( 'postcode', $result['billing_address'] );
+		$this->assertSame( '67890', $result['billing_address']['postcode'] );
+		$this->assertArrayHasKey( 'state', $result['billing_address'] );
+		$this->assertSame( 'CA', $result['billing_address']['state'] );
+		$this->assertArrayHasKey( 'country', $result['billing_address'] );
+		$this->assertSame( 'US', $result['billing_address']['country'] );
+	}
+
+	/**
+	 * Test shipping address uses changes array for unsaved data.
+	 */
+	public function test_shipping_address_uses_changes_array() {
+		// Setting these values automatically populates the changes array.
+		// This mimics what happens when a customer updates their address during checkout.
+		WC()->customer->set_shipping_address_1( '101 Updated Blvd' );
+		WC()->customer->set_shipping_city( 'Updated City' );
+		WC()->customer->set_shipping_state( 'NY' );
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_postcode( '22222' );
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['shipping_address'] );
+		// Verify the values are collected correctly.
+		$this->assertArrayHasKey( 'address_1', $result['shipping_address'] );
+		$this->assertSame( '101 Updated Blvd', $result['shipping_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['shipping_address'] );
+		$this->assertSame( 'Updated City', $result['shipping_address']['city'] );
+		$this->assertArrayHasKey( 'postcode', $result['shipping_address'] );
+		$this->assertSame( '22222', $result['shipping_address']['postcode'] );
+		$this->assertArrayHasKey( 'state', $result['shipping_address'] );
+		$this->assertSame( 'NY', $result['shipping_address']['state'] );
+		$this->assertArrayHasKey( 'country', $result['shipping_address'] );
+		$this->assertSame( 'US', $result['shipping_address']['country'] );
+	}
+
+	/**
+	 * Test billing address collects data correctly.
+	 */
+	public function test_billing_address_collects_data_correctly() {
+		// Set billing address data.
+		WC()->customer->set_billing_address_1( '123 Test St' );
+		WC()->customer->set_billing_city( 'Test City' );
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['billing_address'] );
+		$this->assertArrayHasKey( 'address_1', $result['billing_address'] );
+		$this->assertSame( '123 Test St', $result['billing_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['billing_address'] );
+		$this->assertSame( 'Test City', $result['billing_address']['city'] );
+	}
+
+	/**
+	 * Test shipping address collects data correctly.
+	 */
+	public function test_shipping_address_collects_data_correctly() {
+		// Set shipping address data.
+		WC()->customer->set_shipping_address_1( '456 Ship St' );
+		WC()->customer->set_shipping_city( 'Ship City' );
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['shipping_address'] );
+		$this->assertArrayHasKey( 'address_1', $result['shipping_address'] );
+		$this->assertSame( '456 Ship St', $result['shipping_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['shipping_address'] );
+		$this->assertSame( 'Ship City', $result['shipping_address']['city'] );
+	}
+
+	/**
+	 * Test session data takes precedence for guest users.
+	 */
+	public function test_session_data_takes_precedence_for_billing() {
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Set customer billing data.
+		WC()->customer->set_billing_address_1( 'Customer Address' );
+		WC()->customer->set_billing_city( 'Customer City' );
+
+		// Set session data (should take precedence for guest users).
+		WC()->session->set(
+			'customer',
+			array(
+				'address_1' => 'Session Address',
+				'city'      => 'Session City',
+			)
+		);
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['billing_address'] );
+		// Session data should be used.
+		$this->assertArrayHasKey( 'address_1', $result['billing_address'] );
+		$this->assertSame( 'Session Address', $result['billing_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['billing_address'] );
+		$this->assertSame( 'Session City', $result['billing_address']['city'] );
+	}
+
+	/**
+	 * Test session data takes precedence for shipping address.
+	 */
+	public function test_session_data_takes_precedence_for_shipping() {
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Set customer shipping data.
+		WC()->customer->set_shipping_address_1( 'Customer Shipping' );
+		WC()->customer->set_shipping_city( 'Customer Ship City' );
+
+		// Set session data (should take precedence).
+		WC()->session->set(
+			'customer',
+			array(
+				'shipping_address_1' => 'Session Shipping',
+				'shipping_city'      => 'Session Ship City',
+			)
+		);
+
+		$result = $this->sut->collect();
+
+		$this->assertIsArray( $result['shipping_address'] );
+		// Session data should be used.
+		$this->assertArrayHasKey( 'address_1', $result['shipping_address'] );
+		$this->assertSame( 'Session Shipping', $result['shipping_address']['address_1'] );
+		$this->assertArrayHasKey( 'city', $result['shipping_address'] );
+		$this->assertSame( 'Session Ship City', $result['shipping_address']['city'] );
 	}
 }


### PR DESCRIPTION
This PR changes the precedence of checks to use the session data before falling back to use the customer object data. This is due to the fact that session data is the most up to date for guest users.

### Testing instructions
- Make sure the feature is enabled
- As a guest user add a product to your cart
- Go to the shortcode checkout page
- Fill in the form
- Change the country
- Check your logs to make sure they match the data you typed
- Update something in the form and change the country again
- Check your logs to make sure they match the data you updated
- Log in and repeat the test
- Repeat the tests with the blocks checkout. You won't need to change the country to trigger the tracking.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
