### PR TITLE
Add caching for the countries REST API endpoints

### DIFF
--- a/plugins/woocommerce/changelog/pr-62834
+++ b/plugins/woocommerce/changelog/pr-62834
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add caching for the countries REST API endpoints

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
@@ -8,6 +8,8 @@
  * @since   3.5.0
  */
 
+use Automattic\WooCommerce\Internal\Traits\RestApiCache;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -17,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  * @extends WC_REST_Controller
  */
 class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
+
+	use RestApiCache;
 
 	/**
 	 * Endpoint namespace.
@@ -33,6 +37,13 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	protected $rest_base = 'data/countries';
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->initialize_rest_api_cache();
+	}
+
+	/**
 	 * Register routes.
 	 *
 	 * @since 3.5.0
@@ -44,7 +55,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
+					'callback'            => $this->with_cache( array( $this, 'get_items' ) ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
@@ -56,7 +67,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
+					'callback'            => $this->with_cache( array( $this, 'get_item' ) ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => array(
 						'location' => array(
@@ -159,6 +170,8 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 		 *
 		 * Allows modification of the location data right before it is returned.
 		 *
+		 * @since 3.5.0
+		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param array            $data     The original country's states list.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
@@ -240,5 +253,66 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 		);
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the default entity type for response caching.
+	 *
+	 * @return string|null The entity type.
+	 */
+	protected function get_default_response_entity_type(): ?string {
+		return 'country';
+	}
+
+	/**
+	 * Get the files relevant to response caching.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request     The request object.
+	 * @param string|null                           $endpoint_id Optional endpoint identifier.
+	 * @return array Array of file paths to track for cache invalidation.
+	 */
+	protected function get_files_relevant_to_response_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
+		return array( 'i18n/countries.php', 'i18n/states.php' );
+	}
+
+	/**
+	 * Get the hooks relevant to response caching.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request     The request object.
+	 * @param string|null                           $endpoint_id Optional endpoint identifier.
+	 * @return array Array of hook names to track for cache invalidation.
+	 */
+	protected function get_hooks_relevant_to_caching( WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
+		return array(
+			'woocommerce_countries',
+			'woocommerce_states',
+			'woocommerce_sort_countries',
+			'woocommerce_rest_prepare_data_country',
+		);
+	}
+
+	/**
+	 * Whether the response cache should vary by user.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request     The request object.
+	 * @param string|null                           $endpoint_id Optional endpoint identifier.
+	 * @return bool False since country data doesn't vary by user.
+	 */
+	protected function response_cache_vary_by_user( WP_REST_Request $request, ?string $endpoint_id = null ): bool { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
+		return false;
+	}
+
+	/**
+	 * Extract entity IDs from response data.
+	 *
+	 * Countries don't have entity IDs, cache invalidation is file-based.
+	 *
+	 * @param array                                 $response_data Response data.
+	 * @param WP_REST_Request<array<string, mixed>> $request       The request object.
+	 * @param string|null                           $endpoint_id   Optional endpoint identifier.
+	 * @return array Empty array since countries don't have entity IDs.
+	 */
+	protected function extract_entity_ids_from_response( array $response_data, WP_REST_Request $request, ?string $endpoint_id = null ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint
+		return array();
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Similarly to how https://github.com/woocommerce/woocommerce/pull/62816 did for currencies, this pull request adds REST API caching capabilities to the v3 REST API endpoints `/data/countries` and `/data/countries/<code>`.

### How to test the changes in this Pull Request:

1. Setup an object cache, enable the REST API caching feature, and configure it for both backend caching and cache control headers; details in https://github.com/woocommerce/woocommerce/pull/61986

2. Create a REST API key (WooCommerce - Settings - Advanced - REST API keys).

3. Temporarily add the following to the `includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php` file (so that you don't have to wait 10 minutes to see cache misses):

```php
protected function get_file_check_interval_for_response_caching(): int {
   return 0;
}
```
4. Run `curl -IXGET http://localhost/wp-json/wc/v3/data/countries -u <key>:<secret>` a few times, you should get a cache miss followed by cache hits (if you only want to see the response headers, replace `-IXGET` with `-i`).

6. Make any change to the `i18n/countries.php` file, e.g. adding a space or a new line.

7. Repeat step 4, again you should get a cache miss followed by cache hits.

8. Repeat 6 and 7 but changing the `i18n/states.php` file.

9. Repeat from step 4 adding `/ES` to the request URL, you should get the same behavior.

10. Add the following snippet to your server: `add_filter('woocommerce_countries', fn($c) => $c);`

11. Repeat 4, again you should get a cache miss followed by cache hits. You can try too with the other filters returned by `get_hooks_relevant_to_caching` in the controller. 


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
