### PR TITLE
Email editor: Add support for horizontal blockGap settings on columns

### DIFF
--- a/packages/php/email-editor/changelog/62838-add-column-blockgap-support
+++ b/packages/php/email-editor/changelog/62838-add-column-blockgap-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Email editor: Add support for horizontal blockGap settings on columns.

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -49,10 +49,70 @@ class Spacing_Preprocessor implements Preprocessor {
 				$block['email_attrs']['margin-top'] = $gap;
 			}
 
+			// Handle horizontal gap for columns: apply padding-left to column children (except the first).
+			if ( 'core/columns' === $parent_block_name && 0 !== $key && null !== $parent_block ) {
+				$columns_gap = $this->get_columns_block_gap( $parent_block );
+				if ( $columns_gap ) {
+					$block['email_attrs']['padding-left'] = $columns_gap;
+				}
+			}
+
 			$block['innerBlocks']  = $this->add_block_gaps( $block['innerBlocks'] ?? array(), $gap, $block );
 			$parsed_blocks[ $key ] = $block;
 		}
 
 		return $parsed_blocks;
+	}
+
+	/**
+	 * Extracts the horizontal blockGap from a columns block.
+	 *
+	 * @param array $columns_block The columns block.
+	 * @return string|null The horizontal gap value (e.g., "30px") or null if not set.
+	 */
+	private function get_columns_block_gap( array $columns_block ): ?string {
+		$block_gap = $columns_block['attrs']['style']['spacing']['blockGap'] ?? null;
+
+		// Columns block uses object format: { "top": "...", "left": "..." }.
+		// Only apply horizontal gap when explicitly set via "left".
+		if ( ! is_array( $block_gap ) || ! isset( $block_gap['left'] ) || ! is_string( $block_gap['left'] ) ) {
+			return null;
+		}
+
+		$gap_value = $block_gap['left'];
+
+		// Validate against potentially malicious values.
+		if ( preg_match( '/[<>"\']/', $gap_value ) ) {
+			return null;
+		}
+
+		// Resolve preset variables (e.g., "var:preset|spacing|30" → "30px").
+		return $this->resolve_preset_variable( $gap_value );
+	}
+
+	/**
+	 * Extracts numeric value from CSS preset variables (e.g., "var:preset|spacing|30" → "30px").
+	 *
+	 * @param string $value The value which may contain a preset variable.
+	 * @return string The numeric value with "px" unit, or original value if not a preset variable.
+	 */
+	private function resolve_preset_variable( string $value ): string {
+		// Check if this is a preset variable format: "var:preset|spacing|30".
+		if ( ! str_starts_with( $value, 'var:preset|' ) ) {
+			return $value;
+		}
+
+		// Extract the numeric value from the format "var:preset|spacing|30".
+		// Split by "|" and get the last part which should be the number.
+		$parts         = explode( '|', $value );
+		$numeric_value = end( $parts );
+
+		// If we got a valid numeric value, return it with "px" unit.
+		if ( is_numeric( $numeric_value ) ) {
+			return $numeric_value . 'px';
+		}
+
+		// If extraction failed, return original value.
+		return $value;
 	}
 }

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -68,7 +68,7 @@ class Spacing_Preprocessor implements Preprocessor {
 	 * Extracts the horizontal blockGap from a columns block.
 	 *
 	 * @param array $columns_block The columns block.
-	 * @return string|null The horizontal gap value (e.g., "30px") or null if not set.
+	 * @return string|null The horizontal gap value (e.g., "30px" or "var:preset|spacing|30") or null if not set.
 	 */
 	private function get_columns_block_gap( array $columns_block ): ?string {
 		$block_gap = $columns_block['attrs']['style']['spacing']['blockGap'] ?? null;
@@ -86,33 +86,7 @@ class Spacing_Preprocessor implements Preprocessor {
 			return null;
 		}
 
-		// Resolve preset variables (e.g., "var:preset|spacing|30" → "30px").
-		return $this->resolve_preset_variable( $gap_value );
-	}
-
-	/**
-	 * Extracts numeric value from CSS preset variables (e.g., "var:preset|spacing|30" → "30px").
-	 *
-	 * @param string $value The value which may contain a preset variable.
-	 * @return string The numeric value with "px" unit, or original value if not a preset variable.
-	 */
-	private function resolve_preset_variable( string $value ): string {
-		// Check if this is a preset variable format: "var:preset|spacing|30".
-		if ( ! str_starts_with( $value, 'var:preset|' ) ) {
-			return $value;
-		}
-
-		// Extract the numeric value from the format "var:preset|spacing|30".
-		// Split by "|" and get the last part which should be the number.
-		$parts         = explode( '|', $value );
-		$numeric_value = end( $parts );
-
-		// If we got a valid numeric value, return it with "px" unit.
-		if ( is_numeric( $numeric_value ) ) {
-			return $numeric_value . 'px';
-		}
-
-		// If extraction failed, return original value.
-		return $value;
+		// Return the value as-is. WP's styles engine will handle transformation of preset variables.
+		return $gap_value;
 	}
 }

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -51,7 +51,7 @@ class Spacing_Preprocessor implements Preprocessor {
 
 			// Handle horizontal gap for columns: apply padding-left to column children (except the first).
 			if ( 'core/columns' === $parent_block_name && 0 !== $key && null !== $parent_block ) {
-				$columns_gap = $this->get_columns_block_gap( $parent_block );
+				$columns_gap = $this->get_columns_block_gap( $parent_block, $gap );
 				if ( $columns_gap ) {
 					$block['email_attrs']['padding-left'] = $columns_gap;
 				}
@@ -67,26 +67,32 @@ class Spacing_Preprocessor implements Preprocessor {
 	/**
 	 * Extracts the horizontal blockGap from a columns block.
 	 *
-	 * @param array $columns_block The columns block.
+	 * @param array  $columns_block The columns block.
+	 * @param string $default_gap Default gap value to use if blockGap is not set on the columns block.
 	 * @return string|null The horizontal gap value (e.g., "30px" or "var:preset|spacing|30") or null if not set.
 	 */
-	private function get_columns_block_gap( array $columns_block ): ?string {
+	private function get_columns_block_gap( array $columns_block, string $default_gap = '' ): ?string {
 		$block_gap = $columns_block['attrs']['style']['spacing']['blockGap'] ?? null;
 
 		// Columns block uses object format: { "top": "...", "left": "..." }.
-		// Only apply horizontal gap when explicitly set via "left".
-		if ( ! is_array( $block_gap ) || ! isset( $block_gap['left'] ) || ! is_string( $block_gap['left'] ) ) {
-			return null;
+		// If blockGap.left is explicitly set, use it.
+		if ( is_array( $block_gap ) && isset( $block_gap['left'] ) && is_string( $block_gap['left'] ) ) {
+			$gap_value = $block_gap['left'];
+
+			// Validate against potentially malicious values.
+			if ( preg_match( '/[<>"\']/', $gap_value ) ) {
+				return null;
+			}
+
+			// Return the value as-is. WP's styles engine will handle transformation of preset variables.
+			return $gap_value;
 		}
 
-		$gap_value = $block_gap['left'];
-
-		// Validate against potentially malicious values.
-		if ( preg_match( '/[<>"\']/', $gap_value ) ) {
-			return null;
+		// If blockGap.left is not set, use the default gap value if provided.
+		if ( $default_gap ) {
+			return $default_gap;
 		}
 
-		// Return the value as-is. WP's styles engine will handle transformation of preset variables.
-		return $gap_value;
+		return null;
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
@@ -109,6 +109,12 @@ class Column extends Abstract_Block_Renderer {
 
 		$inner_table = Table_Wrapper_Helper::render_table_wrapper( '{column_content}', $inner_table_attrs, $inner_cell_attrs );
 
+		// Apply padding-left from email_attrs (set by Spacing_Preprocessor for columns blockGap).
+		$padding_left = $parsed_block['email_attrs']['padding-left'] ?? null;
+		if ( $padding_left ) {
+			$wrapper_styles = Styles_Helper::extend_block_styles( $wrapper_styles, array( 'padding-left' => $padding_left ) );
+		}
+
 		// Create the outer td element (since this is meant to be used within a columns structure).
 		$wrapper_cell_attrs = array(
 			'class' => $wrapper_classname,

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
@@ -112,7 +112,8 @@ class Column extends Abstract_Block_Renderer {
 		// Apply padding-left from email_attrs (set by Spacing_Preprocessor for columns blockGap).
 		$padding_left = $parsed_block['email_attrs']['padding-left'] ?? null;
 		if ( $padding_left ) {
-			$wrapper_styles = Styles_Helper::extend_block_styles( $wrapper_styles, array( 'padding-left' => $padding_left ) );
+			$gap_padding_styles = wp_style_engine_get_styles( array( 'spacing' => array( 'padding' => array( 'left' => $padding_left ) ) ) );
+			$wrapper_styles     = Styles_Helper::extend_block_styles( $wrapper_styles, $gap_padding_styles['declarations'] ?? array() );
 		}
 
 		// Create the outer td element (since this is meant to be used within a columns structure).

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
@@ -18,8 +18,8 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
  */
 class Columns extends Abstract_Block_Renderer {
 	/**
-	 * Override this method to disable spacing (block gap) for columns.
-	 * Spacing is applied on wrapping columns block. Columns are rendered side by side so no spacer is needed.
+	 * Renders the block content.
+	 * BlockGap spacing is handled by Spacing_Preprocessor which sets padding-left on column children.
 	 *
 	 * @param string            $block_content Block content.
 	 * @param array             $parsed_block Parsed block.

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
@@ -181,4 +181,15 @@ class Column_Test extends \Email_Editor_Integration_Test_Case {
 		$this->checkValidHTML( $rendered );
 		$this->assertStringContainsString( 'wp-block-column editor-class-1 another-class', $rendered );
 	}
+
+	/**
+	 * Test it applies padding-left from email_attrs (set by Spacing_Preprocessor for columns blockGap)
+	 */
+	public function testItAppliesPaddingLeftFromEmailAttrs(): void {
+		$parsed_column                                = $this->parsed_column;
+		$parsed_column['email_attrs']['padding-left'] = '30px';
+		$rendered                                     = $this->column_renderer->render( '<p>Column content</p>', $parsed_column, $this->rendering_context );
+		$this->checkValidHTML( $rendered );
+		$this->assertStringContainsString( 'padding-left:30px', $rendered );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
@@ -192,4 +192,17 @@ class Column_Test extends \Email_Editor_Integration_Test_Case {
 		$this->checkValidHTML( $rendered );
 		$this->assertStringContainsString( 'padding-left:30px', $rendered );
 	}
+
+	/**
+	 * Test it applies padding-left with preset variable from email_attrs (set by Spacing_Preprocessor for columns blockGap)
+	 * Verifies that wp_style_engine_get_styles transforms var:preset|spacing|30 to CSS variable format
+	 */
+	public function testItAppliesPaddingLeftWithPresetVariableFromEmailAttrs(): void {
+		$parsed_column                                = $this->parsed_column;
+		$parsed_column['email_attrs']['padding-left'] = 'var:preset|spacing|30';
+		$rendered                                     = $this->column_renderer->render( '<p>Column content</p>', $parsed_column, $this->rendering_context );
+		$this->checkValidHTML( $rendered );
+		// wp_style_engine_get_styles transforms var:preset|spacing|30 to var(--wp--preset--spacing--30).
+		$this->assertStringContainsString( 'var(--wp--preset--spacing--30)', $rendered );
+	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
@@ -167,9 +167,9 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 	}
 
 	/**
-	 * Test it resolves preset variables for columns blockGap
+	 * Test it passes preset variables through for columns blockGap (WP styles engine will handle transformation)
 	 */
-	public function testItResolvesPresetVariablesForColumnsBlockGap(): void {
+	public function testItPassesPresetVariablesThroughForColumnsBlockGap(): void {
 		$blocks = array(
 			array(
 				'blockName'   => 'core/columns',
@@ -200,8 +200,8 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
 		$second_column = $result[0]['innerBlocks'][1];
 
-		// Should resolve "var:preset|spacing|40" to "40px".
-		$this->assertEquals( '40px', $second_column['email_attrs']['padding-left'] );
+		// Should pass through "var:preset|spacing|40" as-is. WP's styles engine will handle transformation.
+		$this->assertEquals( 'var:preset|spacing|40', $second_column['email_attrs']['padding-left'] );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
@@ -112,4 +112,172 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$this->assertArrayHasKey( 'margin-top', $nested_column_second_item['email_attrs'] );
 		$this->assertEquals( '10px', $nested_column_second_item['email_attrs']['margin-top'] );
 	}
+
+	/**
+	 * Test it adds padding-left to column blocks when parent columns has blockGap.left
+	 */
+	public function testItAddsPaddingLeftToColumnsWithBlockGap(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/columns',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'blockGap' => array(
+								'top'  => '20px',
+								'left' => '30px',
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+				),
+			),
+		);
+
+		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$columns_block = $result[0];
+		$first_column  = $columns_block['innerBlocks'][0];
+		$second_column = $columns_block['innerBlocks'][1];
+		$third_column  = $columns_block['innerBlocks'][2];
+
+		// First column should not have padding-left.
+		$this->assertArrayNotHasKey( 'padding-left', $first_column['email_attrs'] );
+
+		// Second and third columns should have padding-left.
+		$this->assertArrayHasKey( 'padding-left', $second_column['email_attrs'] );
+		$this->assertEquals( '30px', $second_column['email_attrs']['padding-left'] );
+		$this->assertArrayHasKey( 'padding-left', $third_column['email_attrs'] );
+		$this->assertEquals( '30px', $third_column['email_attrs']['padding-left'] );
+	}
+
+	/**
+	 * Test it resolves preset variables for columns blockGap
+	 */
+	public function testItResolvesPresetVariablesForColumnsBlockGap(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/columns',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'blockGap' => array(
+								'left' => 'var:preset|spacing|40',
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+				),
+			),
+		);
+
+		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$second_column = $result[0]['innerBlocks'][1];
+
+		// Should resolve "var:preset|spacing|40" to "40px".
+		$this->assertEquals( '40px', $second_column['email_attrs']['padding-left'] );
+	}
+
+	/**
+	 * Test it does not add padding-left when columns has no blockGap.left
+	 */
+	public function testItDoesNotAddPaddingLeftWithoutBlockGapLeft(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/columns',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'blockGap' => array(
+								'top' => '20px',
+								// No 'left' key.
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+				),
+			),
+		);
+
+		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$second_column = $result[0]['innerBlocks'][1];
+
+		// Should not have padding-left since blockGap.left is not set.
+		$this->assertArrayNotHasKey( 'padding-left', $second_column['email_attrs'] );
+	}
+
+	/**
+	 * Test it rejects malicious values in blockGap
+	 */
+	public function testItRejectsMaliciousBlockGapValues(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/columns',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'blockGap' => array(
+								'left' => '30px"><script>alert("xss")</script>',
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'attrs'       => array(),
+						'innerBlocks' => array(),
+					),
+				),
+			),
+		);
+
+		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$second_column = $result[0]['innerBlocks'][1];
+
+		// Should not have padding-left due to malicious value.
+		$this->assertArrayNotHasKey( 'padding-left', $second_column['email_attrs'] );
+	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
@@ -205,9 +205,9 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 	}
 
 	/**
-	 * Test it does not add padding-left when columns has no blockGap.left
+	 * Test it adds default padding-left when columns has no blockGap.left
 	 */
-	public function testItDoesNotAddPaddingLeftWithoutBlockGapLeft(): void {
+	public function testItAddsDefaultPaddingLeftWithoutBlockGapLeft(): void {
 		$blocks = array(
 			array(
 				'blockName'   => 'core/columns',
@@ -239,8 +239,9 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$result        = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
 		$second_column = $result[0]['innerBlocks'][1];
 
-		// Should not have padding-left since blockGap.left is not set.
-		$this->assertArrayNotHasKey( 'padding-left', $second_column['email_attrs'] );
+		// Should have padding-left with default gap value since blockGap.left is not set.
+		$this->assertArrayHasKey( 'padding-left', $second_column['email_attrs'] );
+		$this->assertEquals( '10px', $second_column['email_attrs']['padding-left'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/NL-157/add-padding-to-group-blocks-in-jetpack-newsletter-email-rendering

I'm adding left padding to column blocks: the `blockGap` set on the columns block, or a fallback to the default gap if not set. This is a simple fix but does have the downside of column backgrounds expanding to fill the padding:

Post | Email
--- | ---
<img width="655" height="614" alt="Screenshot 2026-01-16 at 1 01 10 PM" src="https://github.com/user-attachments/assets/25179871-b3dc-4e45-9eb0-9480021e71e8" /> | <img width="582" height="392" alt="Screenshot 2026-01-16 at 12 11 08 PM" src="https://github.com/user-attachments/assets/7ed788f6-f51d-4792-92f8-fc3e6f0470f8" />

Another simple option is using `border-spacing`, but that property isn't supported in Outlook.

A more complicated solution, but with wider support and no background issue, would be to add empty cells between columns.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="677" height="617" alt="Screenshot 2026-01-16 at 11 25 26 AM" src="https://github.com/user-attachments/assets/d452cc26-095e-4fd4-99e8-77641a15daa4" /> | <img width="679" height="619" alt="Screenshot 2026-01-16 at 11 22 06 AM" src="https://github.com/user-attachments/assets/a7f63292-d7cf-4686-a5f6-989699ce4488" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a columns block to a post.
2. Add content to the columns.
3. In the block style settings, add horizontal block spacing.
6. Preview or send a test email and check that left padding has been added to the child columns, to create a gap.
7. Test different block spacing values and numbers of columns.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Email editor: Add support for horizontal blockGap settings on columns.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
