### PR TITLE
Add caching for the continents REST API endpoints

### DIFF
--- a/plugins/woocommerce/changelog/pr-62856
+++ b/plugins/woocommerce/changelog/pr-62856
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add caching for the continents REST API endpoints


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Similarly to how https://github.com/woocommerce/woocommerce/pull/62834 did for countries, this pull request adds REST API caching capabilities to the v3 REST API endpoints `/data/continents` and `/data/continents/<code>`.

### How to test the changes in this Pull Request:

1. Setup an object cache, enable the REST API caching feature, and configure it for both backend caching and cache control headers; details in https://github.com/woocommerce/woocommerce/pull/61986

2. Create a REST API key (WooCommerce - Settings - Advanced - REST API keys).

3. Temporarily add the following to the `includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php` file (so that you don't have to wait 10 minutes to see cache misses):

```php
protected function get_file_check_interval_for_response_caching(): int {
   return 0;
}
```
4. Run `curl -IXGET http://localhost/wp-json/wc/v3/data/continents -u <key>:<secret>` a few times, you should get a cache miss followed by cache hits (if you only want to see the response headers, replace `-IXGET` with `-i`).

6. Make any change to the `i18n/continents.php` file, e.g. adding a space or a new line.

7. Repeat step 4, again you should get a cache miss followed by cache hits.

8. Repeat 6 and 7 but changing the `i18n/countries.php` file, the `i18n/states.php` file or the `i18n/locale-info.php` file.

9. Repeat from step 4 adding `/AF` to the request URL, you should get the same behavior.

10. Add the following snippet to your server: `add_filter('woocommerce_continents', fn($c) => $c);`

11. Repeat 4, again you should get a cache miss followed by cache hits. You can try too with the other filters returned by `get_hooks_relevant_to_caching` in the controller. 

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
