### PR TITLE
PHPStan - add Action Scheduler to scanned directories

### DIFF
--- a/plugins/woocommerce/changelog/62858-phpstan-add-action-scheduler
+++ b/plugins/woocommerce/changelog/62858-phpstan-add-action-scheduler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Added Action Scheduler's code to the scanned directories in PHPStan
+

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1547,6 +1547,9 @@ final class WooCommerce {
 
 		// Schedule daily sales event at midnight tomorrow.
 		$scheduled_sales_time = strtotime( '00:00 tomorrow ' . $offset_hours );
+		if ( false === $scheduled_sales_time ) {
+			$scheduled_sales_time = strtotime( '00:00 tomorrow' );
+		}
 
 		as_schedule_recurring_action( $scheduled_sales_time, DAY_IN_SECONDS, 'woocommerce_scheduled_sales', array(), 'woocommerce', true );
 
@@ -1565,7 +1568,13 @@ final class WooCommerce {
 		}
 
 		$tomorrow_3am = strtotime( 'tomorrow 03:00 am ' . $offset_hours );
+		if ( false === $tomorrow_3am ) {
+			$tomorrow_3am = strtotime( 'tomorrow 03:00 am' );
+		}
 		$tomorrow_6am = strtotime( 'tomorrow 06:00 am ' . $offset_hours );
+		if ( false === $tomorrow_6am ) {
+			$tomorrow_6am = strtotime( 'tomorrow 06:00 am' );
+		}
 
 		// Delay the first run of `woocommerce_cleanup_personal_data` by 10 seconds
 		// so it doesn't occur in the same request. WooCommerce Admin also schedules

--- a/plugins/woocommerce/includes/interfaces/class-wc-queue-interface.php
+++ b/plugins/woocommerce/includes/interfaces/class-wc-queue-interface.php
@@ -21,7 +21,7 @@ interface WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID
+	 * @return int The action ID
 	 */
 	public function add( $hook, $args = array(), $group = '' );
 
@@ -32,7 +32,7 @@ interface WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID
+	 * @return int The action ID
 	 */
 	public function schedule_single( $timestamp, $hook, $args = array(), $group = '' );
 
@@ -44,7 +44,7 @@ interface WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID
+	 * @return int The action ID
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' );
 
@@ -66,7 +66,7 @@ interface WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID
+	 * @return int The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' );
 

--- a/plugins/woocommerce/includes/queue/class-wc-action-queue.php
+++ b/plugins/woocommerce/includes/queue/class-wc-action-queue.php
@@ -25,7 +25,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID.
+	 * @return int The action ID.
 	 */
 	public function add( $hook, $args = array(), $group = '' ) {
 		return $this->schedule_single( time(), $hook, $args, $group );
@@ -38,7 +38,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID.
+	 * @return int The action ID.
 	 */
 	public function schedule_single( $timestamp, $hook, $args = array(), $group = '' ) {
 		return as_schedule_single_action( $timestamp, $hook, $args, $group );
@@ -52,7 +52,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID.
+	 * @return int The action ID.
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 		return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
@@ -76,7 +76,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @param string $hook The hook to trigger.
 	 * @param array  $args Arguments to pass when the hook triggers.
 	 * @param string $group The group to assign this job to.
-	 * @return string The action ID
+	 * @return int The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' ) {
 		return as_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $group );

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -55,8 +55,8 @@ function wc_admin_update_0230_rename_gross_total() {
  * Remove the note unsnoozing scheduled action.
  */
 function wc_admin_update_0251_remove_unsnooze_action() {
-	as_unschedule_action( Notes::UNSNOOZE_HOOK, array(), 'wc-admin-data' );
-	as_unschedule_action( Notes::UNSNOOZE_HOOK, array(), 'wc-admin-notes' );
+	as_unschedule_action( Notes::UNSNOOZE_HOOK, null, 'wc-admin-data' ); // @phpstan-ignore-line argument.type We want to use null. With null we clean any action with the given hook. Passing array would only clean actions with the given args.
+	as_unschedule_action( Notes::UNSNOOZE_HOOK, null, 'wc-admin-notes' ); // @phpstan-ignore-line argument.type
 }
 
 /**

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -55,8 +55,8 @@ function wc_admin_update_0230_rename_gross_total() {
  * Remove the note unsnoozing scheduled action.
  */
 function wc_admin_update_0251_remove_unsnooze_action() {
-	as_unschedule_action( Notes::UNSNOOZE_HOOK, null, 'wc-admin-data' );
-	as_unschedule_action( Notes::UNSNOOZE_HOOK, null, 'wc-admin-notes' );
+	as_unschedule_action( Notes::UNSNOOZE_HOOK, array(), 'wc-admin-data' );
+	as_unschedule_action( Notes::UNSNOOZE_HOOK, array(), 'wc-admin-notes' );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -566,7 +566,7 @@ function wc_schedule_product_sale_events( WC_Product $product ): void {
 	if ( $date_from ) {
 		$start_ts = $date_from->getTimestamp();
 		if ( $start_ts > time() ) {
-			as_schedule_single_action( // @phpstan-ignore function.notFound
+			as_schedule_single_action(
 				$start_ts,
 				'wc_product_start_scheduled_sale',
 				array( 'product_id' => $product_id ),
@@ -578,7 +578,7 @@ function wc_schedule_product_sale_events( WC_Product $product ): void {
 	if ( $date_to ) {
 		$end_ts = $date_to->getTimestamp();
 		if ( $end_ts > time() ) {
-			as_schedule_single_action( // @phpstan-ignore function.notFound
+			as_schedule_single_action(
 				$end_ts,
 				'wc_product_end_scheduled_sale',
 				array( 'product_id' => $product_id ),
@@ -734,8 +734,8 @@ function wc_maybe_schedule_product_sale_events( $product_id, $product = null ): 
 	$product_id = $product->get_id();
 
 	// Always clear existing events first.
-	as_unschedule_all_actions( 'wc_product_start_scheduled_sale', array( 'product_id' => $product_id ), 'woocommerce-sales' ); // @phpstan-ignore function.notFound
-	as_unschedule_all_actions( 'wc_product_end_scheduled_sale', array( 'product_id' => $product_id ), 'woocommerce-sales' ); // @phpstan-ignore function.notFound
+	as_unschedule_all_actions( 'wc_product_start_scheduled_sale', array( 'product_id' => $product_id ), 'woocommerce-sales' );
+	as_unschedule_all_actions( 'wc_product_end_scheduled_sale', array( 'product_id' => $product_id ), 'woocommerce-sales' );
 
 	$date_from = $product->get_date_on_sale_from( 'edit' );
 	$date_to   = $product->get_date_on_sale_to( 'edit' );

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2120,7 +2120,7 @@ function wc_update_400_increase_size_of_column() {
 function wc_update_400_reset_action_scheduler_migration_status() {
 	if (
 		class_exists( 'ActionScheduler_DataController' ) &&
-		method_exists( 'ActionScheduler_DataController', 'mark_migration_incomplete' )
+		method_exists( 'ActionScheduler_DataController', 'mark_migration_incomplete' ) // @phpstan-ignore function.alreadyNarrowedType
 	) {
 		\ActionScheduler_DataController::mark_migration_incomplete();
 	}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -14281,20 +14281,8 @@ parameters:
 			path: includes/class-wc-download-handler.php
 
 		-
-			message: '#^Call to static method instance\(\) on an unknown class ActionScheduler_Versions\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/class-wc-download-handler.php
-
-		-
 			message: '#^Cannot call method get_file_download_path\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-download-handler.php
-
-		-
-			message: '#^Function as_schedule_single_action not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: includes/class-wc-download-handler.php
 
@@ -15261,12 +15249,6 @@ parameters:
 		-
 			message: '#^Class WC_Post_Types referenced with incorrect case\: WC_Post_types\.$#'
 			identifier: class.nameCase
-			count: 2
-			path: includes/class-wc-install.php
-
-		-
-			message: '#^Function as_schedule_single_action not found\.$#'
-			identifier: function.notFound
 			count: 2
 			path: includes/class-wc-install.php
 
@@ -16995,12 +16977,6 @@ parameters:
 		-
 			message: '#^Expected 4 @param tags, found 3\.$#'
 			identifier: paramTag.count
-			count: 1
-			path: includes/class-wc-post-data.php
-
-		-
-			message: '#^Function as_next_scheduled_action not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: includes/class-wc-post-data.php
 
@@ -20200,24 +20176,6 @@ parameters:
 			message: '#^Cannot access an offset on list\<string\>\|false\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: includes/class-woocommerce.php
-
-		-
-			message: '#^Function as_next_scheduled_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/class-woocommerce.php
-
-		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/class-woocommerce.php
-
-		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
-			count: 6
 			path: includes/class-woocommerce.php
 
 		-
@@ -27151,48 +27109,6 @@ parameters:
 			path: includes/product-usage/class-wc-product-usage.php
 
 		-
-			message: '#^Function as_get_scheduled_actions not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_next_scheduled_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_schedule_cron_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_schedule_single_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_unschedule_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/queue/class-wc-action-queue.php
-
-		-
 			message: '#^Method WC_Action_Queue\:\:cancel\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -27303,12 +27219,6 @@ parameters:
 		-
 			message: '#^Call to static method update_db_version\(\) on an unknown class Installer\.$#'
 			identifier: class.notFound
-			count: 2
-			path: includes/react-admin/wc-admin-update-functions.php
-
-		-
-			message: '#^Function as_unschedule_action not found\.$#'
-			identifier: function.notFound
 			count: 2
 			path: includes/react-admin/wc-admin-update-functions.php
 
@@ -42286,12 +42196,6 @@ parameters:
 			path: includes/wc-update-functions.php
 
 		-
-			message: '#^Call to function method_exists\(\) with ''ActionScheduler…'' and ''mark_migration…'' will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
 			message: '#^Cannot access offset 0 on non\-empty\-array\|true\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -42330,12 +42234,6 @@ parameters:
 		-
 			message: '#^Cannot call method remove_cap\(\) on WP_Role\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: includes/wc-update-functions.php
 
@@ -54988,12 +54886,6 @@ parameters:
 			path: src/Admin/PluginsHelper.php
 
 		-
-			message: '#^Call to method get_status\(\) on an unknown class ActionScheduler_DBStore\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/PluginsHelper.php
-
-		-
 			message: '#^Cannot access property \$download_link on array\|object\.$#'
 			identifier: property.nonObject
 			count: 2
@@ -55008,12 +54900,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$version on array\|object\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: src/Admin/PluginsHelper.php
-
-		-
-			message: '#^Instantiated class ActionScheduler_DBStore not found\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Admin/PluginsHelper.php
 
@@ -55894,12 +55780,6 @@ parameters:
 			path: src/Admin/RemoteSpecs/RuleProcessors/StoredStateSetupForProducts.php
 
 		-
-			message: '#^Function as_enqueue_async_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Admin/RemoteSpecs/RuleProcessors/StoredStateSetupForProducts.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\RemoteSpecs\\RuleProcessors\\StoredStateSetupForProducts\:\:admin_init\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -56218,12 +56098,6 @@ parameters:
 			path: src/Admin/ReportExporter.php
 
 		-
-			message: '#^Call to method get_schedule\(\) on an unknown class ActionScheduler_Action\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/ReportExporter.php
-
-		-
 			message: '#^Call to method schedule_single\(\) on an unknown class Automattic\\WooCommerce\\Admin\\Schedulers\\WC_Queue_Interface\.$#'
 			identifier: class.notFound
 			count: 2
@@ -56233,18 +56107,6 @@ parameters:
 			message: '#^Call to method search\(\) on an unknown class Automattic\\WooCommerce\\Admin\\Schedulers\\WC_Queue_Interface\.$#'
 			identifier: class.notFound
 			count: 2
-			path: src/Admin/ReportExporter.php
-
-		-
-			message: '#^Call to static method instance\(\) on an unknown class ActionScheduler_Versions\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/ReportExporter.php
-
-		-
-			message: '#^Call to static method store\(\) on an unknown class ActionScheduler\.$#'
-			identifier: class.notFound
-			count: 1
 			path: src/Admin/ReportExporter.php
 
 		-
@@ -56364,12 +56226,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$object_or_string of function is_a expects object, Automattic\\WooCommerce\\Admin\\Schedulers\\DateTime\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Admin/ReportExporter.php
-
-		-
-			message: '#^Parameter \$action of method Automattic\\WooCommerce\\Admin\\ReportExporter\:\:get_next_action_time\(\) has invalid type ActionScheduler_Action\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Admin/ReportExporter.php
 
@@ -56718,12 +56574,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockPatterns\:\:set_pattern_cache\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Blocks/BlockPatterns.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, ''as_has_scheduled…''\|''as_next_scheduled…'' given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Blocks/BlockPatterns.php
 
@@ -61660,12 +61510,6 @@ parameters:
 			path: src/Blocks/Domain/Services/DraftOrders.php
 
 		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Blocks/Domain/Services/DraftOrders.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\DraftOrders\:\:assert_order_results\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -61704,12 +61548,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\DraftOrders\:\:unschedule_cronjobs\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Blocks/Domain/Services/DraftOrders.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, ''as_has_scheduled…''\|''as_next_scheduled…'' given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Blocks/Domain/Services/DraftOrders.php
 
@@ -61951,18 +61789,6 @@ parameters:
 			message: '#^Callback expects 0 parameters, \$accepted_args is set to 2\.$#'
 			identifier: arguments.count
 			count: 3
-			path: src/Blocks/Patterns/PTKPatternsStore.php
-
-		-
-			message: '#^Function as_has_scheduled_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Blocks/Patterns/PTKPatternsStore.php
-
-		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
 			path: src/Blocks/Patterns/PTKPatternsStore.php
 
 		-
@@ -62888,12 +62714,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: src/Caches/OrderCountCache.php
-
-		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Caches/OrderCountCacheService.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Caches\\OrderCountCacheService\:\:init\(\) has no return type specified\.$#'
@@ -67366,12 +67186,6 @@ parameters:
 			path: src/Internal/Admin/Schedulers/ImportScheduler.php
 
 		-
-			message: '#^Call to method get_schedule\(\) on an unknown class ActionScheduler_Action\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Internal/Admin/Schedulers/ImportScheduler.php
-
-		-
 			message: '#^Call to method schedule_single\(\) on an unknown class Automattic\\WooCommerce\\Admin\\Schedulers\\WC_Queue_Interface\.$#'
 			identifier: class.notFound
 			count: 2
@@ -67381,18 +67195,6 @@ parameters:
 			message: '#^Call to method search\(\) on an unknown class Automattic\\WooCommerce\\Admin\\Schedulers\\WC_Queue_Interface\.$#'
 			identifier: class.notFound
 			count: 4
-			path: src/Internal/Admin/Schedulers/ImportScheduler.php
-
-		-
-			message: '#^Call to static method instance\(\) on an unknown class ActionScheduler_Versions\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/Admin/Schedulers/ImportScheduler.php
-
-		-
-			message: '#^Call to static method store\(\) on an unknown class ActionScheduler\.$#'
-			identifier: class.notFound
-			count: 1
 			path: src/Internal/Admin/Schedulers/ImportScheduler.php
 
 		-
@@ -67522,12 +67324,6 @@ parameters:
 			path: src/Internal/Admin/Schedulers/ImportScheduler.php
 
 		-
-			message: '#^Parameter \$action of method Automattic\\WooCommerce\\Internal\\Admin\\Schedulers\\ImportScheduler\:\:get_next_action_time\(\) has invalid type ActionScheduler_Action\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/Admin/Schedulers/ImportScheduler.php
-
-		-
 			message: '#^Parameter \$queue of method Automattic\\WooCommerce\\Internal\\Admin\\Schedulers\\ImportScheduler\:\:set_queue\(\) has invalid type Automattic\\WooCommerce\\Admin\\Schedulers\\WC_Queue_Interface\.$#'
 			identifier: class.notFound
 			count: 1
@@ -67576,18 +67372,6 @@ parameters:
 			path: src/Internal/Admin/Schedulers/OrdersScheduler.php
 
 		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Internal/Admin/Schedulers/OrdersScheduler.php
-
-		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Internal/Admin/Schedulers/OrdersScheduler.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Schedulers\\OrdersScheduler\:\:get_items\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -67608,12 +67392,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Admin\\Schedulers\\OrdersScheduler\:\:schedule_recurring_batch_processor\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Internal/Admin/Schedulers/OrdersScheduler.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, ''as_has_scheduled…''\|''as_next_scheduled…'' given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Internal/Admin/Schedulers/OrdersScheduler.php
 
@@ -68752,30 +68530,6 @@ parameters:
 			path: src/Internal/BatchProcessing/BatchProcessingController.php
 
 		-
-			message: '#^Function as_has_scheduled_action not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: src/Internal/BatchProcessing/BatchProcessingController.php
-
-		-
-			message: '#^Function as_schedule_single_action not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: src/Internal/BatchProcessing/BatchProcessingController.php
-
-		-
-			message: '#^Function as_unschedule_all_actions not found\.$#'
-			identifier: function.notFound
-			count: 3
-			path: src/Internal/BatchProcessing/BatchProcessingController.php
-
-		-
-			message: '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, ''as_has_scheduled…''\|''as_next_scheduled…'' given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/BatchProcessing/BatchProcessingController.php
-
-		-
 			message: '#^Parameter \#1 \$id of method Automattic\\WooCommerce\\Container\:\:get\(\) expects class\-string\<object\>, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -69871,12 +69625,6 @@ parameters:
 			message: '#^Filter callback return statement is missing\.$#'
 			identifier: return.missing
 			count: 3
-			path: src/Internal/DataStores/Orders/DataSynchronizer.php
-
-		-
-			message: '#^Function as_schedule_recurring_action not found\.$#'
-			identifier: function.notFound
-			count: 1
 			path: src/Internal/DataStores/Orders/DataSynchronizer.php
 
 		-
@@ -71045,12 +70793,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Internal/DependencyManagement/RuntimeContainer.php
-
-		-
-			message: '#^Access to constant STATUS_PENDING on an unknown class ActionScheduler_Store\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/DownloadPermissionsAdjuster.php
 
 		-
 			message: '#^Call to method create_from_data\(\) on an unknown class Automattic\\WooCommerce\\Internal\\WC_Data_Store\.$#'
@@ -72967,12 +72709,6 @@ parameters:
 			path: src/Internal/ProductAttributesLookup/CLIRunner.php
 
 		-
-			message: '#^Access to constant STATUS_PENDING on an unknown class ActionScheduler_Store\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/ProductAttributesLookup/DataRegenerator.php
-
-		-
 			message: '#^Call to an undefined method object\:\:cancel_all\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -73139,12 +72875,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Internal/ProductAttributesLookup/Filterer.php
-
-		-
-			message: '#^Access to constant STATUS_PENDING on an unknown class ActionScheduler_Store\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Internal/ProductAttributesLookup/LookupDataStore.php
 
 		-
 			message: '#^Call to an undefined method object\:\:schedule_single\(\)\.$#'
@@ -78093,24 +77823,6 @@ parameters:
 		-
 			message: '#^Expected 1 @param tags, found 2\.$#'
 			identifier: paramTag.count
-			count: 1
-			path: src/Internal/TransientFiles/TransientFilesEngine.php
-
-		-
-			message: '#^Function as_has_scheduled_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Internal/TransientFiles/TransientFilesEngine.php
-
-		-
-			message: '#^Function as_schedule_single_action not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: src/Internal/TransientFiles/TransientFilesEngine.php
-
-		-
-			message: '#^Function as_unschedule_action not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: src/Internal/TransientFiles/TransientFilesEngine.php
 

--- a/plugins/woocommerce/phpstan.neon
+++ b/plugins/woocommerce/phpstan.neon
@@ -18,6 +18,7 @@ parameters:
 		- vendor/autoload.php
 	scanDirectories:
 		- vendor/wordpress/abilities-api
+		- packages/action-scheduler
 	scanFiles:
 		- php-stubs/wc-admin-feature-config.php
 		- php-stubs/wc-constants.php

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -79,7 +79,10 @@ class DraftOrders {
 	protected function maybe_create_cronjobs() {
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
 		if ( false === call_user_func( $has_scheduled_action, self::DRAFT_CLEANUP_EVENT_HOOK ) ) {
-			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, self::DRAFT_CLEANUP_EVENT_HOOK );
+			$midnight_tonight = strtotime( 'midnight tonight' );
+			if ( false !== $midnight_tonight ) {
+				as_schedule_recurring_action( $midnight_tonight, DAY_IN_SECONDS, self::DRAFT_CLEANUP_EVENT_HOOK );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -381,6 +381,9 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 */
 	public static function schedule_recurring_batch_processor() {
 		$action_hook = self::get_action( self::PROCESS_PENDING_ORDERS_BATCH_ACTION );
+		if ( null === $action_hook ) {
+			return;
+		}
 		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
 		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
@@ -390,7 +393,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 
 		$interval = self::get_import_interval();
 
-		as_schedule_recurring_action( time(), $interval, $action_hook, array(), static::$group, true );
+		as_schedule_recurring_action( time(), $interval, $action_hook, array(), static::$group ?? '', true );
 	}
 
 	/**
@@ -412,7 +415,9 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 		if ( 'yes' === $old_value && 'no' === $new_value ) {
 			// Unschedule the recurring batch processor.
 			$action_hook = self::get_action( self::PROCESS_PENDING_ORDERS_BATCH_ACTION );
-			as_unschedule_all_actions( $action_hook, array(), static::$group );
+			if ( null !== $action_hook ) {
+				as_unschedule_all_actions( $action_hook, array(), static::$group ?? '' );
+			}
 
 			// Schedule an immediate catchup batch to process all orders up to now.
 			// This ensures no orders are missed during the transition.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -108,7 +108,7 @@ class AsyncGenerator {
 		}
 
 		// Clear all previous actions to avoid race conditions.
-		as_unschedule_all_actions( self::FEED_GENERATION_ACTION, array( $option_key ), 'woo-product-feed' ); // @phpstan-ignore function.notFound
+		as_unschedule_all_actions( self::FEED_GENERATION_ACTION, array( $option_key ), 'woo-product-feed' );
 
 		$status = array(
 			'scheduled_at' => time(),
@@ -126,7 +126,6 @@ class AsyncGenerator {
 		);
 
 		// Start an immediate async action to generate the feed.
-		// @phpstan-ignore-next-line function.notFound -- Action Scheduler.
 		as_enqueue_async_action(
 			self::FEED_GENERATION_ACTION,
 			array( $option_key ),
@@ -200,7 +199,6 @@ class AsyncGenerator {
 			update_option( $option_key, $status );
 
 			// Schedule another action to delete the file after the expiry time.
-			// @phpstan-ignore-next-line function.notFound -- Action Scheduler.
 			as_schedule_single_action(
 				time() + self::FEED_EXPIRY,
 				self::FEED_DELETION_ACTION,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently the PHPStan report issues that Action Scheduler's functios don't exists. This forces devs to add ignore comments or additional checks that are not necessary.

This PR adds Action Scheduler's files in packages directory to scanned directories. This change causes that PHPStan knows the action scheduler functions and their types and uses them in the analysis.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce phpstan` and verify it is passing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Added Action Scheduler's code to the scanned directories in PHPStan
</details>
