### PR TITLE
Remove a no longer needed phpstan baseline item

### DIFF
--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -40564,12 +40564,6 @@ parameters:
 			path: includes/wc-order-item-functions.php
 
 		-
-			message: '#^Call to an undefined method WC_Logger_Interface\:\:clear\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/wc-order-step-logger-functions.php
-
-		-
 			message: '#^Call to an undefined method WC_Order_Item\:\:get_product_id\(\)\.$#'
 			identifier: method.notFound
 			count: 1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/62637 introduced the following change:

<img width="1476" height="414" alt="image" src="https://github.com/user-attachments/assets/a6024677-efae-4f4a-bb70-6c91591436d1" />

This causes the following phpstan failure:

```
---------------------------------------------------------------------------------------------------------------
Line   includes/wc-order-step-logger-functions.php
---------------------------------------------------------------------------------------------------------------
Ignored error pattern #^Call to an undefined method WC_Logger_Interface\:\:clear\(\)\.$# (method.notFound) in
path /home/konamiman/woocommerce/plugins/woocommerce/includes/wc-order-step-logger-functions.php was not
matched in reported errors.
---------------------------------------------------------------------------------------------------------------
```

This pull request fixes this error by removing the now obsolete corresponding baseline item from the `plugins/woocommerce/phpstan-baseline.neon` file.

### How to test the changes in this Pull Request:

Run `pnpm run phpstan` and verify that there are no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Change to the phpstan baseline file, doesn't affect how WooCommerce is built or used.

</details>
