### PR TITLE
Add defensive coding for WooCommerce Helper API transients

### DIFF
--- a/plugins/woocommerce/changelog/62865-update-more-defensive-coding-around-wccom-helper-api
+++ b/plugins/woocommerce/changelog/62865-update-more-defensive-coding-around-wccom-helper-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when WooCommerce.com Helper API transients contain corrupted data.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1700,7 +1700,11 @@ class WC_Helper {
 		$cache_key = '_woocommerce_helper_product_usage_notice_rules';
 		$data      = get_transient( $cache_key );
 		if ( false !== $data ) {
-			return $data;
+			if ( is_array( $data ) ) {
+				return $data;
+			}
+			// Cached data is corrupted, delete and fetch fresh.
+			delete_transient( $cache_key );
 		}
 
 		try {
@@ -1780,7 +1784,13 @@ class WC_Helper {
 	 * @return array|bool cached connection data or false connection data is not cached.
 	 */
 	public static function get_cached_connection_data() {
-		return get_transient( self::CACHE_KEY_CONNECTION_DATA );
+		$data = get_transient( self::CACHE_KEY_CONNECTION_DATA );
+		if ( false !== $data && ! is_array( $data ) ) {
+			// Cached data is corrupted, delete and return false to trigger fresh fetch.
+			delete_transient( self::CACHE_KEY_CONNECTION_DATA );
+			return false;
+		}
+		return $data;
 	}
 
 	/**
@@ -1836,7 +1846,11 @@ class WC_Helper {
 		$cache_key = '_woocommerce_helper_subscriptions';
 		$data      = get_transient( $cache_key );
 		if ( false !== $data ) {
-			return $data;
+			if ( is_array( $data ) ) {
+				return $data;
+			}
+			// Cached data is corrupted, delete and fetch fresh.
+			delete_transient( $cache_key );
 		}
 
 		try {
@@ -2740,7 +2754,11 @@ class WC_Helper {
 		$cached_data = get_transient( $cache_key );
 
 		if ( false !== $cached_data ) {
-			return $cached_data;
+			if ( is_array( $cached_data ) ) {
+				return $cached_data;
+			}
+			// Cached data is corrupted, delete and fetch fresh.
+			delete_transient( $cache_key );
 		}
 
 		// Fetch notice data for connected store.

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
@@ -6,6 +6,280 @@
 class WC_Helper_Test extends \WC_Unit_Test_Case {
 
 	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->cleanup_helper_transients();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		$this->cleanup_helper_transients();
+		parent::tearDown();
+	}
+
+	/**
+	 * Clean up transients used by WC_Helper.
+	 */
+	private function cleanup_helper_transients(): void {
+		delete_transient( '_woocommerce_helper_subscriptions' );
+		delete_transient( '_woocommerce_helper_product_usage_notice_rules' );
+		delete_transient( '_woocommerce_helper_notices' );
+		delete_transient( '_woocommerce_helper_connection_data' );
+	}
+
+	/**
+	 * @testdox get_subscriptions should delete corrupted string transient and return empty array.
+	 */
+	public function test_get_subscriptions_handles_corrupted_string_transient(): void {
+		set_transient( '_woocommerce_helper_subscriptions', 'corrupted_string_data', HOUR_IN_SECONDS );
+
+		// Mock API to prevent actual network call - return WP_Error to trigger empty array return.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		$result = WC_Helper::get_subscriptions();
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertIsArray( $result, 'Result should be an array even when transient was corrupted' );
+		$this->assertEmpty( $result, 'Result should be empty array on API error' );
+
+		// Verify corrupted string is no longer in transient (replaced with empty array).
+		$transient_value = get_transient( '_woocommerce_helper_subscriptions' );
+		$this->assertNotEquals( 'corrupted_string_data', $transient_value, 'Corrupted string transient should have been replaced' );
+		$this->assertIsArray( $transient_value, 'Transient should now be an array' );
+	}
+
+	/**
+	 * @testdox get_subscriptions should return valid cached array without modification.
+	 */
+	public function test_get_subscriptions_returns_valid_cached_array(): void {
+		$valid_data = array(
+			array(
+				'product_id'  => 123,
+				'product_key' => 'test_key',
+			),
+		);
+		set_transient( '_woocommerce_helper_subscriptions', $valid_data, HOUR_IN_SECONDS );
+
+		$result = WC_Helper::get_subscriptions();
+
+		$this->assertEquals( $valid_data, $result, 'Valid cached data should be returned as-is' );
+	}
+
+	/**
+	 * @testdox get_cached_connection_data should return false for corrupted string transient.
+	 */
+	public function test_get_cached_connection_data_handles_corrupted_string_transient(): void {
+		set_transient( '_woocommerce_helper_connection_data', 'corrupted_string', HOUR_IN_SECONDS );
+
+		$result = WC_Helper::get_cached_connection_data();
+
+		$this->assertFalse( $result, 'Corrupted transient should return false' );
+		$this->assertFalse( get_transient( '_woocommerce_helper_connection_data' ), 'Corrupted transient should be deleted' );
+	}
+
+	/**
+	 * @testdox get_cached_connection_data should return valid cached array.
+	 */
+	public function test_get_cached_connection_data_returns_valid_array(): void {
+		$valid_data = array( 'url' => 'https://example.com' );
+		set_transient( '_woocommerce_helper_connection_data', $valid_data, HOUR_IN_SECONDS );
+
+		$result = WC_Helper::get_cached_connection_data();
+
+		$this->assertEquals( $valid_data, $result, 'Valid cached array should be returned' );
+	}
+
+	/**
+	 * @testdox get_cached_connection_data should return false when transient does not exist.
+	 */
+	public function test_get_cached_connection_data_returns_false_for_missing_transient(): void {
+		delete_transient( '_woocommerce_helper_connection_data' );
+
+		$result = WC_Helper::get_cached_connection_data();
+
+		$this->assertFalse( $result, 'Missing transient should return false' );
+	}
+
+	/**
+	 * @testdox get_product_usage_notice_rules should delete corrupted transient and fetch fresh data.
+	 */
+	public function test_get_product_usage_notice_rules_handles_corrupted_transient(): void {
+		set_transient( '_woocommerce_helper_product_usage_notice_rules', 'corrupted_data', HOUR_IN_SECONDS );
+
+		// Mock API to return empty array.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		$result = WC_Helper::get_product_usage_notice_rules();
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+	}
+
+	/**
+	 * @testdox get_notices should delete corrupted transient and return empty array.
+	 */
+	public function test_get_notices_handles_corrupted_transient(): void {
+		set_transient( '_woocommerce_helper_notices', 'corrupted_data', HOUR_IN_SECONDS );
+
+		// Mock API to return non-200 response.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 500 ),
+					'body'     => '',
+				);
+			}
+		);
+
+		$result = WC_Helper::get_notices();
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Result should be empty on API failure' );
+	}
+
+	/**
+	 * @testdox get_subscription_list_data should handle non-array subscriptions gracefully.
+	 */
+	public function test_get_subscription_list_data_handles_non_array_subscriptions(): void {
+		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
+
+		// Mock API to prevent network call.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		$result = WC_Helper::get_subscription_list_data();
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertIsArray( $result, 'Result should be an array even with corrupted subscriptions transient' );
+	}
+
+	/**
+	 * @testdox get_installed_subscriptions should return empty array when subscriptions are corrupted.
+	 */
+	public function test_get_installed_subscriptions_handles_corrupted_subscriptions(): void {
+		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
+
+		// Mock API to prevent network call.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		// Set up auth to avoid early return.
+		WC_Helper_Options::update( 'auth', array( 'site_id' => 12345 ) );
+
+		$result = WC_Helper::get_installed_subscriptions();
+
+		remove_all_filters( 'pre_http_request' );
+		WC_Helper_Options::update( 'auth', array() );
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertEmpty( $result, 'Result should be empty when subscriptions are corrupted' );
+	}
+
+	/**
+	 * @testdox get_subscription should return false when subscriptions are corrupted.
+	 */
+	public function test_get_subscription_handles_corrupted_subscriptions(): void {
+		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
+
+		// Mock API to prevent network call.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		$result = WC_Helper::get_subscription( 'some_product_key' );
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result, 'Result should be false when subscriptions are corrupted' );
+	}
+
+	/**
+	 * @testdox has_host_plan_orders should return false when subscriptions are corrupted.
+	 */
+	public function test_has_host_plan_orders_handles_corrupted_subscriptions(): void {
+		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
+
+		// Mock API to prevent network call.
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'test', 'Mocked error' );
+			}
+		);
+
+		$result = WC_Woo_Helper_Connection::has_host_plan_orders();
+
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result, 'Should return false when subscriptions are corrupted' );
+	}
+
+	/**
+	 * @testdox has_host_plan_orders should return true when subscription has host plan.
+	 */
+	public function test_has_host_plan_orders_returns_true_for_host_plan(): void {
+		$subscriptions = array(
+			array(
+				'product_id'            => 123,
+				'included_in_host_plan' => true,
+			),
+		);
+		set_transient( '_woocommerce_helper_subscriptions', $subscriptions, HOUR_IN_SECONDS );
+
+		$result = WC_Woo_Helper_Connection::has_host_plan_orders();
+
+		$this->assertTrue( $result, 'Should return true when subscription has host plan' );
+	}
+
+	/**
+	 * @testdox has_host_plan_orders should return false when no subscription has host plan.
+	 */
+	public function test_has_host_plan_orders_returns_false_without_host_plan(): void {
+		$subscriptions = array(
+			array(
+				'product_id'            => 123,
+				'included_in_host_plan' => false,
+			),
+		);
+		set_transient( '_woocommerce_helper_subscriptions', $subscriptions, HOUR_IN_SECONDS );
+
+		$result = WC_Woo_Helper_Connection::has_host_plan_orders();
+
+		$this->assertFalse( $result, 'Should return false when no subscription has host plan' );
+	}
+
+	/**
 	 * Test that woo plugins are loaded correctly even if incorrect cache is initially set.
 	 */
 	public function test_get_local_woo_plugins_without_woo_header_cache() {

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
@@ -39,16 +39,14 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_subscriptions', 'corrupted_string_data', HOUR_IN_SECONDS );
 
 		// Mock API to prevent actual network call - return WP_Error to trigger empty array return.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Helper::get_subscriptions();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertIsArray( $result, 'Result should be an array even when transient was corrupted' );
 		$this->assertEmpty( $result, 'Result should be empty array on API error' );
@@ -118,16 +116,14 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_product_usage_notice_rules', 'corrupted_data', HOUR_IN_SECONDS );
 
 		// Mock API to return empty array.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Helper::get_product_usage_notice_rules();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertIsArray( $result, 'Result should be an array' );
 	}
@@ -139,19 +135,17 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_notices', 'corrupted_data', HOUR_IN_SECONDS );
 
 		// Mock API to return non-200 response.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'response' => array( 'code' => 500 ),
-					'body'     => '',
-				);
-			}
-		);
+		$http_mock = function () {
+			return array(
+				'response' => array( 'code' => 500 ),
+				'body'     => '',
+			);
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Helper::get_notices();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertIsArray( $result, 'Result should be an array' );
 		$this->assertEmpty( $result, 'Result should be empty on API failure' );
@@ -164,16 +158,14 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
 
 		// Mock API to prevent network call.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Helper::get_subscription_list_data();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertIsArray( $result, 'Result should be an array even with corrupted subscriptions transient' );
 	}
@@ -185,19 +177,17 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
 
 		// Mock API to prevent network call.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		// Set up auth to avoid early return.
 		WC_Helper_Options::update( 'auth', array( 'site_id' => 12345 ) );
 
 		$result = WC_Helper::get_installed_subscriptions();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 		WC_Helper_Options::update( 'auth', array() );
 
 		$this->assertIsArray( $result, 'Result should be an array' );
@@ -211,16 +201,14 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
 
 		// Mock API to prevent network call.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Helper::get_subscription( 'some_product_key' );
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertFalse( $result, 'Result should be false when subscriptions are corrupted' );
 	}
@@ -232,16 +220,14 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		set_transient( '_woocommerce_helper_subscriptions', 'corrupted', HOUR_IN_SECONDS );
 
 		// Mock API to prevent network call.
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'test', 'Mocked error' );
-			}
-		);
+		$http_mock = function () {
+			return new WP_Error( 'test', 'Mocked error' );
+		};
+		add_filter( 'pre_http_request', $http_mock );
 
 		$result = WC_Woo_Helper_Connection::has_host_plan_orders();
 
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $http_mock );
 
 		$this->assertFalse( $result, 'Should return false when subscriptions are corrupted' );
 	}

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 /**
  * Class WC_Tests_WC_Helper.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is adding some defensive coding around the data we store in transients in Helper API - especially when reading from those. 

Code changes prevent fatal errors when transient data becomes corrupted (e.g., string instead of expected array). It also validates cached data at the producer level in `get_subscriptions()`, `get_product_usage_notice_rules()`, `get_notices()`, and `get_cached_connection_data()`.

Closes WCCOM-2132.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch on your local env
2. Do a regular dependency install and build the project
3. Confirm that you can still connect to WCCOM in the In-App and you get get subscriptions available for your WCCOM user
4. Corrupt the data `pnpm wp-env run cli wp transient set _woocommerce_helper_subscriptions 'corrupted_string' 3600`
5. Refresh In-App's My Subscription page and confirm it loads as expected
6. Corrupt  two more transients
```bash
 pnpm wp-env run cli wp transient set _woocommerce_helper_connection_data 'bad_data' 3600       
 pnpm wp-env run cli wp transient set _woocommerce_helper_notices 'invalid' 3600
 ```
6. Confirm that you can use In-App without any issues.
7. Confirm that new tests pass `pnpm test:php:env -- --filter WC_Helper_Test`
8. Please test around this issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent fatal errors when WooCommerce.com Helper API transients contain corrupted data.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
