### PR TITLE
Add new x-small font size to blocks CSS and apply to Cart/Checkout

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1455-font-size-system-missing-one-value
+++ b/plugins/woocommerce/changelog/wooprd-1455-font-size-system-missing-one-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Bind some Cart/Checkout UI elements to block themes' "extra-small" font size for consistency.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -399,7 +399,7 @@ $fontSizes: (
 }
 
 @mixin card-styles() {
-	@include font-regular-locked;
+	@include font-small-locked;
 	border: 1px solid $universal-border-light;
 	padding: $gap;
 	margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -19,19 +19,25 @@ $fontSizes: (
 }
 
 @mixin font-large-locked {
-	font-size: var(--wp--preset--font-size--medium, 22px);
-	line-height: 27px;
+	font-size: var(--wp--preset--font-size--large, 28px);
+	line-height: 1.4;
 }
 
-@mixin font-regular-locked {
-	font-size: var(--wp--preset--font-size--small, 14px);
-	line-height: 20px;
+@mixin font-medium-locked {
+	font-size: var(--wp--preset--font-size--medium, 22px);
+	line-height: 1.4;
 }
 
 @mixin font-small-locked {
-	font-size: 13px;
-	line-height: 16px;
+	font-size: var(--wp--preset--font-size--small, 14px);
+	line-height: 1.4;
 }
+
+@mixin font-x-small-locked {
+	font-size: var(--wp--preset--font-size--x-small, calc( var(--wp--preset--font-size--small, 14px) * 0.875 ) );
+	line-height: 1.4;
+}
+
 
 @mixin font-for-inputs-locked {
 	font-size: 16px;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -13,7 +13,7 @@ table.wc-block-cart-items {
 	width: 100%;
 
 	.wc-block-cart-items__header {
-		@include font-regular-locked;
+		@include font-small-locked;
 		text-transform: uppercase;
 
 		.wc-block-cart-items__header-image {
@@ -45,7 +45,7 @@ table.wc-block-cart-items {
 			margin: 0;
 		}
 		.wc-block-cart-item__prices {
-			@include font-regular-locked;
+			@include font-small-locked;
 		}
 
 		.wc-block-cart-item__quantity {
@@ -66,7 +66,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-components-product-name {
-			@include font-regular-locked;
+			@include font-small-locked;
 			display: block;
 			max-width: max-content;
 			line-height: 1.4;
@@ -75,7 +75,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-cart-item__total {
-			@include font-regular-locked;
+			@include font-small-locked;
 			text-align: right;
 			line-height: 1.8;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -56,7 +56,7 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__remove-link {
 				@include link-button();
 				@include hover-effect();
-				@include font-size(smaller);
+				@include font-x-small-locked;
 
 				text-transform: none;
 				white-space: nowrap;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
@@ -1,5 +1,6 @@
 // Extra class added for specificity so styles are applied in the editor.
 .wc-block-components-product-details.wc-block-components-product-details {
+	@include font-x-small-locked;
 	list-style: none;
 	margin: 0.5em 0;
 	padding: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,5 +1,5 @@
 .wc-block-components-product-metadata {
-	@include font-regular-locked;
+	@include font-small-locked;
 
 	.wc-block-components-product-metadata__description > p,
 	.wc-block-components-product-metadata__variation-data {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -4,5 +4,6 @@
 	.wc-block-components-product-metadata__description > p,
 	.wc-block-components-product-metadata__variation-data {
 		margin: 0;
+		@include font-x-small-locked;
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -112,7 +112,7 @@
 }
 
 .wc-block-components-shipping-rates-control__package-title {
-	@include font-regular-locked;
+	@include font-small-locked;
 }
 
 .wc-block-components-shipping-rates-control__package-items {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -116,7 +116,7 @@
 }
 
 .wc-block-components-shipping-rates-control__package-items {
-	@include font-small-locked;
+	@include font-x-small-locked;
 	display: inline-block;
 	list-style: none;
 	margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -33,6 +33,6 @@
 
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
-		@include font-large-locked;
+		@include font-medium-locked;
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -22,7 +22,7 @@
 
 	// Extra label for specificity needed in the editor.
 	input.wc-block-components-quantity-selector__input {
-		@include font-regular-locked;
+		@include font-small-locked;
 		appearance: textfield;
 		background: transparent;
 		border: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -63,7 +63,8 @@
 
 	.wc-blocks-components-select__label {
 		@include reset-typography();
-		@include font-small-locked;
+		font-size: 13px;
+		line-height: 1.4;
 		position: absolute;
 		top: $gap-smallest * 1.5;
 		left: $gap-smaller * 1.25;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -82,7 +82,7 @@ $border-width: 1px;
 	}
 
 	.wc-block-components-express-payment__title {
-		@include font-regular-locked;
+		@include font-small-locked;
 		@include reset-box;
 		word-break: break-word;
 		font-weight: 400;
@@ -136,7 +136,7 @@ $border-width: 1px;
 }
 
 .wc-block-components-express-payment-continue-rule {
-	@include font-regular-locked;
+	@include font-small-locked;
 
 	display: flex;
 	align-items: center;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -57,14 +57,14 @@
 	}
 
 	.wc-block-components-checkout-step__description-payments-aligned {
-		@include font-regular-locked;
+		@include font-small-locked;
 		margin: 0;
 		padding-top: $gap-small;
 		padding-bottom: $gap-smaller;
 	}
 }
 .wc-block-components-radio-control-accordion-content {
-	@include font-regular-locked;
+	@include font-small-locked;
 	padding: 0 $gap $gap;
 
 	&:empty,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -25,7 +25,7 @@
 	.wp-block-woocommerce-cart-order-summary-block {
 		border-bottom: 1px solid $universal-border-light;
 		margin-bottom: $gap;
-		@include font-regular-locked;
+		@include font-small-locked;
 
 		.wc-block-components-totals-item,
 		.wc-block-components-panel,
@@ -131,7 +131,7 @@
 
 		.wc-block-cart__totals-title {
 			@include text-heading();
-			@include font-regular-locked;
+			@include font-small-locked;
 			display: block;
 			font-weight: 500;
 			padding: $gap-smaller $gap $gap-smaller * 1.25 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
@@ -24,7 +24,7 @@
 	}
 }
 .wc-block-components-address-card__edit {
-	@include font-regular-locked;
+	@include font-small-locked;
 	background-color: transparent;
 	border: 0;
 	color: inherit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -2,7 +2,7 @@
 	margin-bottom: $gap-larger;
 
 	.wc-block-checkout__actions_row {
-		@include font-regular-locked;
+		@include font-small-locked;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -84,7 +84,7 @@
 }
 
 .wc-block-components-address-form__address_2-toggle {
-	@include font-regular-locked;
+	@include font-small-locked;
 	display: inline-block;
 	background: none;
 	border: none;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -2,7 +2,7 @@
 	border: 1px solid $universal-border-light;
 	border-radius: 5px;
 	box-sizing: border-box;
-	@include font-regular-locked;
+	@include font-small-locked;
 
 	&.checkout-order-summary-block-fill-wrapper {
 		.wc-block-components-order-summary {
@@ -29,7 +29,7 @@
 			margin: 0 0 $gap-smaller $gap;
 			flex-grow: 1;
 			font-weight: 500;
-			@include font-large-locked;
+			@include font-medium-locked;
 		}
 
 		.wc-block-components-checkout-order-summary__title-open-close {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -42,7 +42,7 @@
 		}
 
 		.wc-block-components-radio-control__description-group {
-			@include font-regular-locked;
+			@include font-small-locked;
 
 			display: flex;
 			flex-direction: column;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -69,7 +69,7 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 
 .wc-block-checkout__shipping-method-option-title {
 	@include reset-typography();
-	@include font-regular-locked;
+	@include font-small-locked;
 	line-height: 28px; // Match the icon size
 	text-wrap: balance;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.wc-block-components-shipping-rates-control__no-shipping-address-message {
-		@include font-regular-locked;
+		@include font-small-locked;
 		padding: $gap-large;
 		background-color: color-mix(in srgb, currentColor 6%, transparent);
 		color: color-mix(in srgb, currentColor 66%, transparent);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/style.scss
@@ -1,5 +1,5 @@
 .wc-block-checkout__terms {
-	@include font-regular-locked;
+	@include font-small-locked;
 	margin: 0 0 $gap-large;
 
 	&.wc-block-checkout__terms--with-separator {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
@@ -32,7 +32,7 @@
 		margin-top: -$gap-large;
 		font-weight: 400;
 		line-height: $gap * 1.25;
-		@include font-regular-locked;
+		@include font-small-locked;
 	}
 	.wc-block-checkout__create-account {
 		margin-top: $gap !important;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/style.scss
@@ -174,8 +174,8 @@ h2.wc-block-mini-cart__title {
 		margin-bottom: $gap;
 
 		.wc-block-components-totals-item__description {
+			@include font-x-small-locked;
 			display: none;
-			font-size: 0.75em;
 			font-weight: 400;
 
 			@media only screen and (min-width: 480px) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	h2.wp-block-heading {
-		@include font-regular-locked;
+		@include font-small-locked;
 	}
 
 	// Gutenberg adds margin between elements but notices are often empty

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
@@ -83,7 +83,7 @@
 }
 
 .wc-block-components-checkout-step__description {
-	@include font-regular-locked;
+	@include font-small-locked;
 	margin: 0;
 }
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -175,12 +175,12 @@ $content-padding-left: calc($gap + 24px + $gap-smaller);
 
 .wc-block-components-radio-control__label,
 .wc-block-components-radio-control__secondary-label {
-	@include font-regular-locked;
+	@include font-small-locked;
 }
 
 .wc-block-components-radio-control__description,
 .wc-block-components-radio-control__secondary-description {
-	@include font-regular-locked;
+	@include font-small-locked;
 }
 
 // Extra class for specificity.

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-textarea {
 	@include reset-typography();
-	@include font-regular-locked;
+	@include font-small-locked;
 	background-color: $input-background-light;
 	border: 1px solid $universal-border-strong;
 	border-radius: $universal-border-radius;

--- a/plugins/woocommerce/client/blocks/packages/components/title/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/title/style.scss
@@ -1,6 +1,6 @@
 @mixin title {
 	@include reset-box();
-	@include font-large-locked;
+	@include font-medium-locked;
 	word-break: break-word;
 	font-weight: 500;
 }

--- a/plugins/woocommerce/client/blocks/packages/components/totals/item/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/item/style.scss
@@ -11,6 +11,6 @@
 }
 
 .wc-block-components-totals-item__description {
-	@include font-size(small);
+	@include font-x-small-locked;
 	width: 100%;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a new mixin: `font-x-small-locked` which is based on the theme's `--wp--preset--font-size--x-small` variable, if set, otherwise it falls back to the theme's `--wp--preset--font-size--small` (which falls back to 14px if not set) at 0.875.

I also noticed the mixins for font sizes did not match the actual font sizes in use, for example: `font-large-locked` actually used `--wp--preset--font-size--medium`, so I updated this to match. This resulted in the following mixins being present:

- `font-large-locked`
- `font-medium-locked`
- `font-small-locked`
- `font-x-small-locked`

Next, I updated all occurrences of the updated mixins to reflect the new names.

Finally, I updated the following parts of the Cart/Checkout blocks to use the new `font-x-small` mixin:

- Remove item link
- Product metadata/variation data
- The list of items in a shipping package when more than one package is shown (e.g. during subscriptions)
- Total item descriptions, e.g. "Ships via"

I also opened https://github.com/woocommerce/woocommerce-subscriptions/pull/5272 to update the "Details" button for recurring carts.

Closes WOOPRD-1455

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Cart before | Cart after |
| ------ | ----- |
| <img width="1052" height="842" alt="image" src="https://github.com/user-attachments/assets/2a6cd52a-fab0-492c-84b1-8f0ac045cad7" /> | <img width="1076" height="826" alt="image" src="https://github.com/user-attachments/assets/7849b8c9-44b6-4b86-b70b-05b6b0431ba9" /> |

| Mini-cart before | Mini-cart after |
| ------ | ----- |
| <img width="472" height="820" alt="image" src="https://github.com/user-attachments/assets/7d7a2d50-9e77-400b-a680-ac84a6f2926c" /> | <img width="463" height="781" alt="image" src="https://github.com/user-attachments/assets/8665981f-e084-4c2e-8041-5889c5a13e1c" /> |

| Checkout before | Checkout after |
| ------ | ----- |
| <img width="1067" height="813" alt="image" src="https://github.com/user-attachments/assets/48bb0879-edbe-4e49-8037-23bfa51729f3" /> | <img width="1078" height="820" alt="image" src="https://github.com/user-attachments/assets/7b1067a8-57c5-45a0-a40a-03458c43a094" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out https://github.com/woocommerce/woocommerce-subscriptions/pull/5272 in WC Subscriptions.
2. Have a theme that defines the `--wp--preset--font-size--x-small` variable, e.g.  Twenty Twenty-Three.
3. Add a short description to a product.
4. Add a subscription item a normal item (use the one you added a short description to), and a variable item to your cart and open the Mini-Cart.
5. Notice the "Remove item" link is now smaller, the short description, and the variation information is now smaller.
6. In the editor, go to Styles -> Typography -> Font Size Presets, change the "X-small" font size to a different value (if the names don't show, it's the top one)
7. Repeat the test and ensure the "extra-small" items listed above have changed size to match what you chose.
9. Test in a theme that does _not_ define the `--wp--preset--font-size--x-small` variable, e.g.  Tove.
10. Verify these elements are still smaller than other parts of the mini-cart.
11. Repeat this test with the Cart block.
12. Go to the Checkout block, ensure the controls for choosing Shipping for the initial package and recurring package list the products in a smaller font.
13. Repeat this test in a classic theme, for example Storefront.
14. Ensure the elements listed and tested above appear smaller than the surrounding elements.
15. Repeat these tests in Safari/Firefox/Chrome browsers and ensure no errors or styling issues occur.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
