### PR TITLE
Fraud Protection: Block cart modifications for fraud-blocked sessions

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -4,6 +4,9 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Internal\FraudProtection\BlockedSessionNotice;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
+use Automattic\WooCommerce\Internal\FraudProtection\SessionClearanceManager;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
@@ -118,6 +121,18 @@ abstract class AbstractCartRoute extends AbstractRoute {
 
 		if ( is_wp_error( $nonce_check ) ) {
 			$response = $nonce_check;
+		}
+
+		// Block cart modifications if session is blocked by fraud protection.
+		if ( ! $response && $this->is_update_request( $request ) ) {
+			if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled()
+				&& wc_get_container()->get( SessionClearanceManager::class )->is_session_blocked() ) {
+				$response = $this->get_route_error_response(
+					'woocommerce_rest_cart_error',
+					wc_get_container()->get( BlockedSessionNotice::class )->get_message_plaintext( 'purchase' ),
+					403
+				);
+			}
 		}
 
 		if ( ! $response ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartFraudProtection.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CartFraudProtection.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Cart Fraud Protection Tests.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Internal\FraudProtection\BlockedSessionNotice;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
+use Automattic\WooCommerce\Internal\FraudProtection\SessionClearanceManager;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+
+/**
+ * Cart Fraud Protection Tests.
+ *
+ * Tests that cart modification routes are blocked when a session is blocked by fraud protection.
+ * All cart routes extend AbstractCartRoute which checks session status before processing mutations.
+ */
+class CartFraudProtection extends ControllerTestCase {
+
+	/**
+	 * Test product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Mock FraudProtectionController.
+	 *
+	 * @var FraudProtectionController|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $fraud_controller_mock;
+
+	/**
+	 * Mock SessionClearanceManager.
+	 *
+	 * @var SessionClearanceManager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $session_manager_mock;
+
+	/**
+	 * Mock BlockedSessionNotice.
+	 *
+	 * @var BlockedSessionNotice|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $blocked_notice_mock;
+
+	/**
+	 * Setup test product data.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$fixtures      = new FixtureData();
+		$this->product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+				'regular_price' => 10,
+			)
+		);
+
+		wc_empty_cart();
+
+		$this->fraud_controller_mock = $this->createMock( FraudProtectionController::class );
+		$this->session_manager_mock  = $this->createMock( SessionClearanceManager::class );
+		$this->blocked_notice_mock   = $this->createMock( BlockedSessionNotice::class );
+
+		wc_get_container()->replace( FraudProtectionController::class, $this->fraud_controller_mock );
+		wc_get_container()->replace( SessionClearanceManager::class, $this->session_manager_mock );
+		wc_get_container()->replace( BlockedSessionNotice::class, $this->blocked_notice_mock );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	protected function tearDown(): void {
+		wc_get_container()->reset_replacement( FraudProtectionController::class );
+		wc_get_container()->reset_replacement( SessionClearanceManager::class );
+		wc_get_container()->reset_replacement( BlockedSessionNotice::class );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Cart mutations return 403 with blocked message when session is blocked.
+	 */
+	public function test_cart_mutations_blocked_when_session_blocked(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( true );
+		$this->blocked_notice_mock->method( 'get_message_plaintext' )->willReturn( 'Session blocked message' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->product->get_id(),
+				'quantity' => 1,
+			)
+		);
+
+		$this->assertApiResponse(
+			$request,
+			403,
+			array(
+				'code'    => 'woocommerce_rest_cart_error',
+				'message' => 'Session blocked message',
+			)
+		);
+	}
+
+	/**
+	 * @testdox Cart mutations succeed when session is allowed.
+	 */
+	public function test_cart_mutations_allowed_when_session_allowed(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( false );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->product->get_id(),
+				'quantity' => 1,
+			)
+		);
+
+		$this->assertApiResponse( $request, 201 );
+	}
+
+	/**
+	 * @testdox Cart mutations succeed when fraud protection is disabled.
+	 */
+	public function test_cart_mutations_allowed_when_feature_disabled(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( false );
+		$this->session_manager_mock->expects( $this->never() )->method( 'is_session_blocked' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->product->get_id(),
+				'quantity' => 1,
+			)
+		);
+
+		$this->assertApiResponse( $request, 201 );
+	}
+
+	/**
+	 * @testdox GET requests are not blocked (read-only).
+	 */
+	public function test_get_requests_allowed_when_session_blocked(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( true );
+
+		$this->assertApiResponse( '/wc/store/v1/cart', 200 );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CartBlockingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/CartBlockingTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * CartBlockingTest class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\FraudProtection;
+
+use Automattic\WooCommerce\Internal\FraudProtection\BlockedSessionNotice;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
+use Automattic\WooCommerce\Internal\FraudProtection\SessionClearanceManager;
+
+/**
+ * Tests for cart blocking when session is blocked by fraud protection.
+ *
+ * Tests WC_Cart method integration (add_to_cart, remove_cart_item, set_quantity).
+ *
+ * @covers \WC_Cart
+ */
+class CartBlockingTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Mock FraudProtectionController.
+	 *
+	 * @var FraudProtectionController|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $fraud_controller_mock;
+
+	/**
+	 * Mock SessionClearanceManager.
+	 *
+	 * @var SessionClearanceManager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $session_manager_mock;
+
+	/**
+	 * Mock BlockedSessionNotice.
+	 *
+	 * @var BlockedSessionNotice|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $blocked_notice_mock;
+
+	/**
+	 * Test product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product = \WC_Helper_Product::create_simple_product();
+
+		$this->fraud_controller_mock = $this->createMock( FraudProtectionController::class );
+		$this->session_manager_mock  = $this->createMock( SessionClearanceManager::class );
+		$this->blocked_notice_mock   = $this->createMock( BlockedSessionNotice::class );
+
+		wc_get_container()->replace( FraudProtectionController::class, $this->fraud_controller_mock );
+		wc_get_container()->replace( SessionClearanceManager::class, $this->session_manager_mock );
+		wc_get_container()->replace( BlockedSessionNotice::class, $this->blocked_notice_mock );
+
+		wc_empty_cart();
+		wc_clear_notices();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		wc_get_container()->reset_replacement( FraudProtectionController::class );
+		wc_get_container()->reset_replacement( SessionClearanceManager::class );
+		wc_get_container()->reset_replacement( BlockedSessionNotice::class );
+
+		$this->product->delete( true );
+		wc_empty_cart();
+		wc_clear_notices();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox add_to_cart returns false and adds notice when session is blocked.
+	 */
+	public function test_add_to_cart_blocked_when_session_blocked(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( true );
+		$this->blocked_notice_mock->method( 'get_message_html' )->willReturn( 'Blocked message' );
+
+		$result = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+		$this->assertTrue( wc_has_notice( 'Blocked message', 'error' ) );
+	}
+
+	/**
+	 * @testdox add_to_cart succeeds when session is allowed.
+	 */
+	public function test_add_to_cart_allowed_when_session_allowed(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( false );
+
+		$result = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+
+		$this->assertNotFalse( $result );
+		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox add_to_cart succeeds when fraud protection is disabled.
+	 */
+	public function test_add_to_cart_allowed_when_feature_disabled(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( false );
+		$this->session_manager_mock->expects( $this->never() )->method( 'is_session_blocked' );
+
+		$result = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+
+		$this->assertNotFalse( $result );
+		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox remove_cart_item returns false when session is blocked.
+	 */
+	public function test_remove_cart_item_blocked_when_session_blocked(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock
+			->method( 'is_session_blocked' )
+			->willReturnOnConsecutiveCalls( false, true ); // Allow add, block remove.
+		$this->blocked_notice_mock->method( 'get_message_html' )->willReturn( 'Blocked message' );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox remove_cart_item succeeds when session is allowed.
+	 */
+	public function test_remove_cart_item_allowed_when_session_allowed(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( false );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox remove_cart_item succeeds when fraud protection is disabled.
+	 */
+	public function test_remove_cart_item_allowed_when_feature_disabled(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( false );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->remove_cart_item( $cart_item_key );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox set_quantity returns false when session is blocked.
+	 */
+	public function test_set_quantity_blocked_when_session_blocked(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock
+			->method( 'is_session_blocked' )
+			->willReturnOnConsecutiveCalls( false, true ); // Allow add, block update.
+		$this->blocked_notice_mock->method( 'get_message_html' )->willReturn( 'Blocked message' );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->set_quantity( $cart_item_key, 5 );
+
+		$this->assertFalse( $result );
+		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox set_quantity succeeds when session is allowed.
+	 */
+	public function test_set_quantity_allowed_when_session_allowed(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock->method( 'is_session_blocked' )->willReturn( false );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->set_quantity( $cart_item_key, 5 );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 5, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * @testdox set_quantity succeeds when fraud protection is disabled.
+	 */
+	public function test_set_quantity_allowed_when_feature_disabled(): void {
+		$this->fraud_controller_mock->method( 'feature_is_enabled' )->willReturn( false );
+
+		$cart_item_key = WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		$result        = WC()->cart->set_quantity( $cart_item_key, 5 );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( 5, WC()->cart->get_cart_contents_count() );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR implements cart modification blocking for sessions flagged by fraud protection. When a session is blocked, users cannot add items, remove items, or change quantities in their cart.

**Blocking implemented at two levels:**
- **Store API**: `AbstractCartRoute` returns 403 for mutation requests. This covers add to cart from product blocks (which bypasses `WC_Cart`) and all other cart operations via the Store API.
- **WC_Cart**: `add_to_cart`, `remove_cart_item`, and `set_quantity` block directly (catches traditional form submissions and AJAX)

| Shop page | Cart page |
| ----------- | ---------- |
| <img width="1361" height="737" alt="shop-page-cart-block" src="https://github.com/user-attachments/assets/d1c21530-3fe6-45b0-8a20-704cb8cc1753" /> | <img width="1373" height="314" alt="product-page-cart-block" src="https://github.com/user-attachments/assets/a6404dde-9f5b-4215-9d27-c2dab70a462f" /> |

**Design decisions:**
- Coupon operations are not blocked (cart is already emptied when session is blocked)
- `add_to_cart` throws an exception (uses existing try-catch), other methods return false with notice
- GET requests (read-only) are not blocked - users can still view their cart
- Store API tests cover the mechanism once (all routes share `AbstractCartRoute` check)
- WC_Cart tests cover each method separately (independent implementations)

Closes WOOSUBS-1380.

> [!IMPORTANT]
> The PHPStan failure is coming from trunk, not related to the changes from this PR.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the fraud protection feature flag
2. Add more than $100 worth of products to the cart to trigger a blocked session
3. From the **shop page**, try adding another product to cart → should show error notice and not add the item
4. From the **product page**, try adding a product to cart → should show error notice and not add the item
5. _The edit and remove checks are defensive checks as there's no way to edit or remove items due to the empty cart_

### Testing that has already taken place:

- Unit tests for Store API cart routes and WC_Cart methods
- Manual testing on local environment with fraud protection enabled

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is an internal feature behind a feature flag (fraud_protection) that is not yet publicly available.

</details>