### PR TITLE
Email Editor: Add support for VideoPress embeds

### DIFF
--- a/packages/php/email-editor/changelog/62870-add-email-rendering-for-videopress-embeds
+++ b/packages/php/email-editor/changelog/62870-add-email-rendering-for-videopress-embeds
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for VideoPress embeds in the Email Editor package.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-cover.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-cover.php
@@ -83,10 +83,12 @@ class Cover extends Abstract_Block_Renderer {
 
 		// Add background image to table styles if present.
 		if ( ! empty( $background_image ) ) {
+			// Use esc_url_raw() for CSS context - esc_url() encodes & as &#038; which
+			// causes WP_Style_Engine::compile_css() to strip the background-image property.
 			$block_styles = Styles_Helper::extend_block_styles(
 				$block_styles,
 				array(
-					'background-image'    => 'url("' . esc_url( $background_image ) . '")',
+					'background-image'    => 'url("' . esc_url_raw( $background_image ) . '")',
 					'background-size'     => 'cover',
 					'background-position' => 'center',
 					'background-repeat'   => 'no-repeat',
@@ -127,6 +129,7 @@ class Cover extends Abstract_Block_Renderer {
 
 	/**
 	 * Extract background image from block attributes or HTML content.
+	 * Returns raw URL - escaping happens at final CSS output context.
 	 *
 	 * @param array  $block_attrs Block attributes.
 	 * @param string $block_content Original block content.
@@ -134,8 +137,9 @@ class Cover extends Abstract_Block_Renderer {
 	 */
 	private function extract_background_image( array $block_attrs, string $block_content ): string {
 		// First check block attributes for URL.
+		// Use esc_url_raw() to sanitize without HTML entity encoding.
 		if ( ! empty( $block_attrs['url'] ) ) {
-			return esc_url( $block_attrs['url'] );
+			return esc_url_raw( $block_attrs['url'] );
 		}
 
 		// Fallback: use HTML API to find background image src.
@@ -147,7 +151,7 @@ class Cover extends Abstract_Block_Renderer {
 			if ( is_string( $class_attr ) && false !== strpos( $class_attr, 'wp-block-cover__image-background' ) ) {
 				$src = $html->get_attribute( 'src' );
 				if ( is_string( $src ) ) {
-					return esc_url( $src );
+					return esc_url_raw( $src );
 				}
 			}
 		}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -436,6 +436,40 @@ class Embed extends Abstract_Block_Renderer {
 	}
 
 	/**
+	 * Validate that a URL's host matches the expected provider's domains.
+	 * This prevents SSRF when provider is set via user-controlled attributes.
+	 *
+	 * @param string $url      URL to validate.
+	 * @param string $provider Provider name.
+	 * @return bool True if URL host matches provider domains.
+	 */
+	private function url_matches_provider( string $url, string $provider ): bool {
+		if ( ! $this->is_valid_url( $url ) ) {
+			return false;
+		}
+
+		$parsed_url = wp_parse_url( $url );
+		if ( ! isset( $parsed_url['host'] ) ) {
+			return false;
+		}
+
+		$url_host = strtolower( $parsed_url['host'] );
+
+		// Get allowed domains for this provider.
+		$all_providers   = $this->get_all_provider_configs();
+		$allowed_domains = $all_providers[ $provider ]['domains'] ?? array();
+
+		foreach ( $allowed_domains as $allowed_domain ) {
+			$allowed_domain = strtolower( $allowed_domain );
+			if ( $url_host === $allowed_domain || str_ends_with( $url_host, '.' . $allowed_domain ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Render a video embed using the Video renderer.
 	 *
 	 * @param string            $url URL of the video.
@@ -446,6 +480,14 @@ class Embed extends Abstract_Block_Renderer {
 	 * @return string Rendered video embed or fallback.
 	 */
 	private function render_video_embed( string $url, string $provider, array $parsed_block, Rendering_Context $rendering_context, string $block_content ): string {
+		// Validate URL matches the detected provider to prevent SSRF.
+		// Provider can come from user-controlled providerNameSlug attribute,
+		// so we must verify the URL actually belongs to that provider's domains.
+		if ( ! $this->url_matches_provider( $url, $provider ) ) {
+			$fallback_attr = $this->create_fallback_attributes( $url, $url );
+			return $this->render_link_fallback( $fallback_attr, $block_content, $parsed_block, $rendering_context );
+		}
+
 		// Try to get video thumbnail URL.
 		$poster_url = $this->get_video_thumbnail_url( $url, $provider );
 
@@ -531,9 +573,12 @@ class Embed extends Abstract_Block_Renderer {
 	 * Uses WordPress oEmbed API to get thumbnail_url from the provider response.
 	 * Results are cached using transients to avoid repeated HTTP requests.
 	 *
+	 * Note: URL validation against VideoPress domains is done in render_video_embed()
+	 * via url_matches_provider() before this method is called.
+	 *
 	 * @since 10.6.0
 	 *
-	 * @param string $url VideoPress video URL.
+	 * @param string $url VideoPress video URL (pre-validated by caller).
 	 * @return string Thumbnail URL or empty string.
 	 */
 	private function get_videopress_thumbnail( string $url ): string {
@@ -547,7 +592,9 @@ class Embed extends Abstract_Block_Renderer {
 			return is_string( $cached_thumbnail ) ? $cached_thumbnail : '';
 		}
 
-		// Use WP_oEmbed::get_data() to get raw oEmbed data (not HTML).
+		// Use WP_oEmbed::get_data() to fetch thumbnail from oEmbed endpoint.
+		// URL is pre-validated by render_video_embed() via url_matches_provider(),
+		// ensuring only VideoPress domains reach this point (SSRF mitigation).
 		$oembed      = new \WP_oEmbed();
 		$oembed_data = $oembed->get_data( $url );
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -576,8 +576,6 @@ class Embed extends Abstract_Block_Renderer {
 	 * Note: URL validation against VideoPress domains is done in render_video_embed()
 	 * via url_matches_provider() before this method is called.
 	 *
-	 * @since 10.6.0
-	 *
 	 * @param string $url VideoPress video URL (pre-validated by caller).
 	 * @return string Thumbnail URL or empty string.
 	 */
@@ -611,8 +609,6 @@ class Embed extends Abstract_Block_Renderer {
 		 * @param string $url     The embedded URL.
 		 * @param array  $attr    Attributes array.
 		 * @param string $post_id Post ID (empty string in email context).
-		 *
-		 * @since 10.6.0
 		 */
 		// Default TTL matches WordPress oEmbed cache (1 day).
 		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -531,6 +531,8 @@ class Embed extends Abstract_Block_Renderer {
 	 * Uses WordPress oEmbed API to get thumbnail_url from the provider response.
 	 * Results are cached using transients to avoid repeated HTTP requests.
 	 *
+	 * @since 10.6.0
+	 *
 	 * @param string $url VideoPress video URL.
 	 * @return string Thumbnail URL or empty string.
 	 */
@@ -562,6 +564,8 @@ class Embed extends Abstract_Block_Renderer {
 		 * @param string $url     The embedded URL.
 		 * @param array  $attr    Attributes array.
 		 * @param string $post_id Post ID (empty string in email context).
+		 *
+		 * @since 10.6.0
 		 */
 		// Default TTL matches WordPress oEmbed cache (1 day).
 		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -447,7 +447,7 @@ class Embed extends Abstract_Block_Renderer {
 	 */
 	private function render_video_embed( string $url, string $provider, array $parsed_block, Rendering_Context $rendering_context, string $block_content ): string {
 		// Try to get video thumbnail URL.
-		$poster_url = $this->get_video_thumbnail_url( $url, $provider, $parsed_block );
+		$poster_url = $this->get_video_thumbnail_url( $url, $provider );
 
 		// If no poster available, fall back to a simple link.
 		if ( empty( $poster_url ) ) {
@@ -489,13 +489,13 @@ class Embed extends Abstract_Block_Renderer {
 	 * @param string $provider Provider name.
 	 * @return string Thumbnail URL or empty string.
 	 */
-	private function get_video_thumbnail_url( string $url, string $provider, array $parsed_block = array() ): string {
+	private function get_video_thumbnail_url( string $url, string $provider ): string {
 		if ( 'youtube' === $provider ) {
 			return $this->get_youtube_thumbnail( $url );
 		}
 
 		if ( 'videopress' === $provider ) {
-			return $this->get_videopress_thumbnail( $url, $parsed_block );
+			return $this->get_videopress_thumbnail( $url );
 		}
 
 		// For other providers, we don't have thumbnail extraction implemented.
@@ -532,27 +532,24 @@ class Embed extends Abstract_Block_Renderer {
 	 * Note: wp_oembed_get() returns HTML, so we use WP_oEmbed::get_data() to get the raw data object.
 	 *
 	 * @param string $url VideoPress video URL.
-	 * @param array  $parsed_block Parsed block (optional, for checking guid attribute).
 	 * @return string Thumbnail URL or empty string.
 	 */
-	private function get_videopress_thumbnail( string $url, array $parsed_block = array() ): string {
+	private function get_videopress_thumbnail( string $url ): string {
 		// Use WP_oEmbed::get_data() to get raw oEmbed data (not HTML).
-		// wp_oembed_get() returns HTML, but we need the data object with thumbnail_url.
-		$oembed = new \WP_oEmbed();
+		$oembed      = new \WP_oEmbed();
 		$oembed_data = $oembed->get_data( $url );
 
-		if ( ! is_object( $oembed_data ) && ! is_array( $oembed_data ) ) {
+		// get_data() returns object|false, so check for false or non-object.
+		if ( false === $oembed_data || ! is_object( $oembed_data ) ) {
 			return '';
 		}
 
 		// Extract thumbnail_url from oEmbed response.
-		// Handle both object and array formats.
-		$thumbnail_url = '';
-		if ( is_object( $oembed_data ) && isset( $oembed_data->thumbnail_url ) ) {
-			$thumbnail_url = $oembed_data->thumbnail_url;
-		} elseif ( is_array( $oembed_data ) && isset( $oembed_data['thumbnail_url'] ) ) {
-			$thumbnail_url = $oembed_data['thumbnail_url'];
+		if ( ! isset( $oembed_data->thumbnail_url ) ) {
+			return '';
 		}
+
+		$thumbnail_url = $oembed_data->thumbnail_url;
 
 		// Validate the thumbnail URL.
 		if ( ! empty( $thumbnail_url ) && $this->is_valid_url( $thumbnail_url ) ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -549,6 +549,20 @@ class Embed extends Abstract_Block_Renderer {
 		$oembed      = new \WP_oEmbed();
 		$oembed_data = $oembed->get_data( $url );
 
+		/**
+		 * Filter the oEmbed cache time-to-live (TTL).
+		 *
+		 * This filter matches WordPress core's oembed_ttl filter signature:
+		 * - $ttl: Time to live in seconds (default: DAY_IN_SECONDS)
+		 * - $url: The URL being embedded
+		 * - $attr: Attributes array (empty in this context)
+		 * - $post_id: Post ID where embed is used (empty string here since email rendering is not post-specific)
+		 *
+		 * @param int    $ttl     Cache TTL in seconds.
+		 * @param string $url     The embedded URL.
+		 * @param array  $attr    Attributes array.
+		 * @param string $post_id Post ID (empty string in email context).
+		 */
 		// Default TTL matches WordPress oEmbed cache (1 day).
 		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -529,23 +529,40 @@ class Embed extends Abstract_Block_Renderer {
 	/**
 	 * Extract VideoPress video thumbnail URL.
 	 * Uses WordPress oEmbed API to get thumbnail_url from the provider response.
-	 * Note: wp_oembed_get() returns HTML, so we use WP_oEmbed::get_data() to get the raw data object.
+	 * Results are cached using transients to avoid repeated HTTP requests.
 	 *
 	 * @param string $url VideoPress video URL.
 	 * @return string Thumbnail URL or empty string.
 	 */
 	private function get_videopress_thumbnail( string $url ): string {
+		// Generate a cache key based on the URL.
+		$cache_key = 'wc_email_vp_thumb_' . md5( $url );
+
+		// Check for cached thumbnail URL.
+		$cached_thumbnail = get_transient( $cache_key );
+		if ( false !== $cached_thumbnail ) {
+			// Return cached value (empty string means previous lookup failed).
+			return is_string( $cached_thumbnail ) ? $cached_thumbnail : '';
+		}
+
 		// Use WP_oEmbed::get_data() to get raw oEmbed data (not HTML).
 		$oembed      = new \WP_oEmbed();
 		$oembed_data = $oembed->get_data( $url );
 
+		// Default TTL matches WordPress oEmbed cache (1 day).
+		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );
+
 		// get_data() returns object|false, so check for false or non-object.
 		if ( false === $oembed_data || ! is_object( $oembed_data ) ) {
+			// Cache empty result to avoid repeated failed lookups.
+			set_transient( $cache_key, '', $cache_ttl );
 			return '';
 		}
 
 		// Extract thumbnail_url from oEmbed response.
 		if ( ! isset( $oembed_data->thumbnail_url ) ) {
+			// Cache empty result.
+			set_transient( $cache_key, '', $cache_ttl );
 			return '';
 		}
 
@@ -553,9 +570,13 @@ class Embed extends Abstract_Block_Renderer {
 
 		// Validate the thumbnail URL.
 		if ( ! empty( $thumbnail_url ) && $this->is_valid_url( $thumbnail_url ) ) {
+			// Cache the valid thumbnail URL.
+			set_transient( $cache_key, $thumbnail_url, $cache_ttl );
 			return $thumbnail_url;
 		}
 
+		// Cache empty result for invalid URLs.
+		set_transient( $cache_key, '', $cache_ttl );
 		return '';
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -56,9 +56,13 @@ class Embed extends Abstract_Block_Renderer {
 	 * @var array
 	 */
 	private const VIDEO_PROVIDERS = array(
-		'youtube' => array(
+		'youtube'    => array(
 			'domains'  => array( 'youtube.com', 'youtu.be' ),
 			'base_url' => 'https://www.youtube.com/',
+		),
+		'videopress' => array(
+			'domains'  => array( 'videopress.com', 'video.wordpress.com' ),
+			'base_url' => 'https://videopress.com/',
 		),
 	);
 
@@ -322,6 +326,8 @@ class Embed extends Abstract_Block_Renderer {
 				return __( 'Listen on ReverbNation', 'woocommerce' );
 			case 'youtube':
 				return __( 'Watch on YouTube', 'woocommerce' );
+			case 'videopress':
+				return __( 'Watch on VideoPress', 'woocommerce' );
 			default:
 				return __( 'Listen to the audio', 'woocommerce' );
 		}
@@ -441,7 +447,7 @@ class Embed extends Abstract_Block_Renderer {
 	 */
 	private function render_video_embed( string $url, string $provider, array $parsed_block, Rendering_Context $rendering_context, string $block_content ): string {
 		// Try to get video thumbnail URL.
-		$poster_url = $this->get_video_thumbnail_url( $url, $provider );
+		$poster_url = $this->get_video_thumbnail_url( $url, $provider, $parsed_block );
 
 		// If no poster available, fall back to a simple link.
 		if ( empty( $poster_url ) ) {
@@ -483,10 +489,13 @@ class Embed extends Abstract_Block_Renderer {
 	 * @param string $provider Provider name.
 	 * @return string Thumbnail URL or empty string.
 	 */
-	private function get_video_thumbnail_url( string $url, string $provider ): string {
-		// Currently only YouTube supports thumbnail extraction.
+	private function get_video_thumbnail_url( string $url, string $provider, array $parsed_block = array() ): string {
 		if ( 'youtube' === $provider ) {
 			return $this->get_youtube_thumbnail( $url );
+		}
+
+		if ( 'videopress' === $provider ) {
+			return $this->get_videopress_thumbnail( $url, $parsed_block );
 		}
 
 		// For other providers, we don't have thumbnail extraction implemented.
@@ -515,5 +524,41 @@ class Embed extends Abstract_Block_Renderer {
 		// Return YouTube thumbnail URL.
 		// Using 0.jpg format as shown in the example.
 		return 'https://img.youtube.com/vi/' . $video_id . '/0.jpg';
+	}
+
+	/**
+	 * Extract VideoPress video thumbnail URL.
+	 * Uses WordPress oEmbed API to get thumbnail_url from the provider response.
+	 * Note: wp_oembed_get() returns HTML, so we use WP_oEmbed::get_data() to get the raw data object.
+	 *
+	 * @param string $url VideoPress video URL.
+	 * @param array  $parsed_block Parsed block (optional, for checking guid attribute).
+	 * @return string Thumbnail URL or empty string.
+	 */
+	private function get_videopress_thumbnail( string $url, array $parsed_block = array() ): string {
+		// Use WP_oEmbed::get_data() to get raw oEmbed data (not HTML).
+		// wp_oembed_get() returns HTML, but we need the data object with thumbnail_url.
+		$oembed = new \WP_oEmbed();
+		$oembed_data = $oembed->get_data( $url );
+
+		if ( ! is_object( $oembed_data ) && ! is_array( $oembed_data ) ) {
+			return '';
+		}
+
+		// Extract thumbnail_url from oEmbed response.
+		// Handle both object and array formats.
+		$thumbnail_url = '';
+		if ( is_object( $oembed_data ) && isset( $oembed_data->thumbnail_url ) ) {
+			$thumbnail_url = $oembed_data->thumbnail_url;
+		} elseif ( is_array( $oembed_data ) && isset( $oembed_data['thumbnail_url'] ) ) {
+			$thumbnail_url = $oembed_data['thumbnail_url'];
+		}
+
+		// Validate the thumbnail URL.
+		if ( ! empty( $thumbnail_url ) && $this->is_valid_url( $thumbnail_url ) ) {
+			return $thumbnail_url;
+		}
+
+		return '';
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-video.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-video.php
@@ -44,6 +44,7 @@ class Video extends Cover {
 
 	/**
 	 * Extract poster URL from block attributes.
+	 * Returns raw URL - escaping should happen at the final output context.
 	 *
 	 * @param array  $block_attrs Block attributes.
 	 * @param string $block_content Original block content (unused, kept for consistency).
@@ -51,8 +52,10 @@ class Video extends Cover {
 	 */
 	private function extract_poster_url( array $block_attrs, string $block_content ): string {
 		// Check for poster attribute.
+		// Use esc_url_raw() to sanitize without HTML entity encoding.
+		// Final escaping happens in Cover block based on output context.
 		if ( ! empty( $block_attrs['poster'] ) ) {
-			return esc_url( $block_attrs['poster'] );
+			return esc_url_raw( $block_attrs['poster'] );
 		}
 
 		return '';

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Cover_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Cover_Test.php
@@ -213,4 +213,21 @@ class Cover_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringNotContainsString( 'wp-block-cover__background', $rendered );
 		$this->assertStringNotContainsString( 'background-color:#4b74b2', $rendered );
 	}
+
+	/**
+	 * Test that background image URLs with query parameters work correctly
+	 */
+	public function test_background_image_urls_with_query_parameters_work_correctly(): void {
+		$parsed_cover                 = $this->parsed_cover;
+		$parsed_cover['attrs']['url'] = 'https://example.com/background.jpg?w=500&h=281';
+
+		$rendered = $this->cover_renderer->render( '', $parsed_cover, $this->rendering_context );
+
+		// Should contain background-image with query parameters.
+		// The key test is that background-image is present (not stripped by WP_Style_Engine).
+		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
+		// Verify query parameters are present.
+		$this->assertStringContainsString( 'w=500', $rendered, 'Query parameters should be present' );
+		$this->assertStringContainsString( 'h=281', $rendered, 'Query parameters should be present' );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -579,4 +579,136 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'https://img.youtube.com/vi/invalid/0.jpg', $rendered );
 		$this->assertStringContainsString( 'play2x.png', $rendered );
 	}
+
+	/**
+	 * Test that VideoPress embed is detected and renders (may fall back to link if oEmbed unavailable)
+	 */
+	public function test_renders_videopress_embed(): void {
+		$parsed_videopress_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => 'https://videopress.com/v/BZHMfMfN',
+				'type'             => 'video',
+				'providerNameSlug' => 'videopress',
+				'responsive'       => true,
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
+
+		// Should detect VideoPress and render (either as video with thumbnail or fallback link).
+		$this->assertNotEmpty( $rendered );
+		// Should contain either video thumbnail or fallback link.
+		$this->assertTrue(
+			strpos( $rendered, 'Watch on VideoPress' ) !== false || strpos( $rendered, 'play2x.png' ) !== false,
+			'VideoPress embed should render as video or fallback link'
+		);
+	}
+
+	/**
+	 * Test that VideoPress embed handles URLs with query parameters correctly
+	 */
+	public function test_videopress_embed_handles_urls_with_query_parameters(): void {
+		$parsed_videopress_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => 'https://videopress.com/v/BZHMfMfN?w=500&h=281',
+				'type'             => 'video',
+				'providerNameSlug' => 'videopress',
+				'responsive'       => true,
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN?w=500&h=281</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
+
+		// Should handle URLs with query parameters correctly.
+		// The key test is that background-image is present (not stripped by WP_Style_Engine).
+		// In final HTML output, & becomes &amp; which is correct HTML encoding.
+		$this->assertNotEmpty( $rendered );
+		// Verify background-image is present (our fix ensures it's not stripped).
+		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
+		// Verify query parameters are present (as &amp; in HTML, which is correct).
+		$this->assertStringContainsString( 'w=500', $rendered, 'Query parameters should be present' );
+		$this->assertStringContainsString( 'h=281', $rendered, 'Query parameters should be present' );
+	}
+
+	/**
+	 * Test that VideoPress embed detects VideoPress by providerNameSlug
+	 */
+	public function test_videopress_embed_detects_videopress_by_provider_name_slug(): void {
+		$parsed_videopress_by_slug = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'providerNameSlug' => 'videopress',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">Some content</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_videopress_by_slug['innerHTML'], $parsed_videopress_by_slug, $this->rendering_context );
+
+		// Should return graceful fallback link since provider is detected but no URL is available for thumbnail extraction.
+		$this->assertStringContainsString( '<a href="https://videopress.com/"', $rendered );
+		$this->assertStringContainsString( 'Watch on VideoPress', $rendered );
+		$this->assertStringContainsString( 'target="_blank"', $rendered );
+		$this->assertStringContainsString( 'rel="noopener nofollow"', $rendered );
+	}
+
+	/**
+	 * Test that VideoPress embed detects VideoPress by URL in attributes
+	 */
+	public function test_videopress_embed_detects_videopress_by_url_in_attributes(): void {
+		$parsed_videopress_by_url = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url' => 'https://videopress.com/v/BZHMfMfN',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_videopress_by_url['innerHTML'], $parsed_videopress_by_url, $this->rendering_context );
+
+		// Should detect VideoPress by URL domain.
+		$this->assertNotEmpty( $rendered );
+	}
+
+	/**
+	 * Test that VideoPress embed detects video.wordpress.com domain
+	 */
+	public function test_videopress_embed_detects_video_wordpress_com_domain(): void {
+		$parsed_videopress_wordpress_com = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url' => 'https://video.wordpress.com/v/BZHMfMfN',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video"><div class="wp-block-embed__wrapper">https://video.wordpress.com/v/BZHMfMfN</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_videopress_wordpress_com['innerHTML'], $parsed_videopress_wordpress_com, $this->rendering_context );
+
+		// Should detect VideoPress by video.wordpress.com domain.
+		$this->assertNotEmpty( $rendered );
+	}
+
+	/**
+	 * Test that background images with query parameters work correctly
+	 */
+	public function test_background_images_with_query_parameters_work_correctly(): void {
+		$parsed_youtube_with_query = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+				'type'             => 'video',
+				'providerNameSlug' => 'youtube',
+				'responsive'       => true,
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">https://www.youtube.com/watch?v=dQw4w9WgXcQ</div></figure>',
+		);
+
+		$rendered = $this->embed_renderer->render( $parsed_youtube_with_query['innerHTML'], $parsed_youtube_with_query, $this->rendering_context );
+
+		// Verify background-image is present (our fix ensures URLs with query parameters work).
+		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -581,9 +581,33 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that VideoPress embed is detected and renders (may fall back to link if oEmbed unavailable)
+	 * Test that VideoPress embed is detected and renders as video player
 	 */
 	public function test_renders_videopress_embed(): void {
+		// Mock the oEmbed HTTP response to avoid external calls in CI.
+		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg';
+		$mock_oembed_response = wp_json_encode(
+			array(
+				'type'          => 'video',
+				'thumbnail_url' => $mock_thumbnail_url,
+				'title'         => 'Test Video',
+			)
+		);
+
+		// Use pre_http_request filter to intercept oEmbed HTTP calls.
+		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_oembed_response ) {
+			// Intercept VideoPress oEmbed requests.
+			if ( strpos( $url, 'public-api.wordpress.com/oembed' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $mock_oembed_response,
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+
 		$parsed_videopress_embed = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
@@ -597,19 +621,43 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
 
-		// Should detect VideoPress and render (either as video with thumbnail or fallback link).
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
+
+		// Should detect VideoPress and render as video with thumbnail.
 		$this->assertNotEmpty( $rendered );
-		// Should contain either video thumbnail or fallback link.
-		$this->assertTrue(
-			strpos( $rendered, 'Watch on VideoPress' ) !== false || strpos( $rendered, 'play2x.png' ) !== false,
-			'VideoPress embed should render as video or fallback link'
-		);
+		$this->assertStringContainsString( 'play2x.png', $rendered, 'VideoPress embed should render with play button' );
+		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
 
 	/**
 	 * Test that VideoPress embed handles URLs with query parameters correctly
 	 */
 	public function test_videopress_embed_handles_urls_with_query_parameters(): void {
+		// Mock the oEmbed HTTP response to avoid external calls in CI.
+		// Return a thumbnail URL with query parameters to test the URL encoding fix.
+		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg?w=500&h=281';
+		$mock_oembed_response = wp_json_encode(
+			array(
+				'type'          => 'video',
+				'thumbnail_url' => $mock_thumbnail_url,
+				'title'         => 'Test Video',
+			)
+		);
+
+		// Use pre_http_request filter to intercept oEmbed HTTP calls.
+		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_oembed_response ) {
+			// Intercept VideoPress oEmbed requests.
+			if ( strpos( $url, 'public-api.wordpress.com/oembed' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $mock_oembed_response,
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+
 		$parsed_videopress_embed = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
@@ -622,6 +670,8 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		);
 
 		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
+
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
 
 		// Should handle URLs with query parameters correctly.
 		// The key test is that background-image is present (not stripped by WP_Style_Engine).
@@ -659,6 +709,29 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	 * Test that VideoPress embed detects VideoPress by URL in attributes
 	 */
 	public function test_videopress_embed_detects_videopress_by_url_in_attributes(): void {
+		// Mock the oEmbed HTTP response to avoid external calls in CI.
+		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg';
+		$mock_oembed_response = wp_json_encode(
+			array(
+				'type'          => 'video',
+				'thumbnail_url' => $mock_thumbnail_url,
+				'title'         => 'Test Video',
+			)
+		);
+
+		// Use pre_http_request filter to intercept oEmbed HTTP calls.
+		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_oembed_response ) {
+			if ( strpos( $url, 'public-api.wordpress.com/oembed' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $mock_oembed_response,
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+
 		$parsed_videopress_by_url = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
@@ -669,14 +742,40 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->embed_renderer->render( $parsed_videopress_by_url['innerHTML'], $parsed_videopress_by_url, $this->rendering_context );
 
-		// Should detect VideoPress by URL domain.
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
+
+		// Should detect VideoPress by URL domain and render with thumbnail.
 		$this->assertNotEmpty( $rendered );
+		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
 
 	/**
 	 * Test that VideoPress embed detects video.wordpress.com domain
 	 */
 	public function test_videopress_embed_detects_video_wordpress_com_domain(): void {
+		// Mock the oEmbed HTTP response to avoid external calls in CI.
+		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg';
+		$mock_oembed_response = wp_json_encode(
+			array(
+				'type'          => 'video',
+				'thumbnail_url' => $mock_thumbnail_url,
+				'title'         => 'Test Video',
+			)
+		);
+
+		// Use pre_http_request filter to intercept oEmbed HTTP calls.
+		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_oembed_response ) {
+			if ( strpos( $url, 'public-api.wordpress.com/oembed' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $mock_oembed_response,
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+
 		$parsed_videopress_wordpress_com = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
@@ -687,8 +786,11 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->embed_renderer->render( $parsed_videopress_wordpress_com['innerHTML'], $parsed_videopress_wordpress_com, $this->rendering_context );
 
-		// Should detect VideoPress by video.wordpress.com domain.
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
+
+		// Should detect VideoPress by video.wordpress.com domain and render with thumbnail.
 		$this->assertNotEmpty( $rendered );
+		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -138,15 +138,6 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that embed block uses default label when no custom label provided
-	 */
-	public function test_uses_default_label_when_no_custom_label(): void {
-		$rendered = $this->embed_renderer->render( $this->parsed_spotify_embed['innerHTML'], $this->parsed_spotify_embed, $this->rendering_context );
-
-		$this->assertStringContainsString( 'Listen on Spotify', $rendered );
-	}
-
-	/**
 	 * Test that embed block handles email attributes for spacing
 	 */
 	public function test_handles_email_attributes_for_spacing(): void {
@@ -457,43 +448,6 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that YouTube embed handles email attributes for spacing
-	 */
-	public function test_youtube_embed_handles_email_attributes_for_spacing(): void {
-		$parsed_youtube_with_spacing                = $this->parsed_youtube_embed;
-		$parsed_youtube_with_spacing['email_attrs'] = array(
-			'margin' => '20px 0',
-		);
-
-		$rendered = $this->embed_renderer->render( $this->parsed_youtube_embed['innerHTML'], $parsed_youtube_with_spacing, $this->rendering_context );
-
-		// Email attributes are handled by the cover block renderer.
-		$this->assertStringContainsString( 'https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg', $rendered );
-		$this->assertStringContainsString( 'play2x.png', $rendered );
-	}
-
-	/**
-	 * Test that YouTube embed includes proper security attributes
-	 */
-	public function test_youtube_embed_includes_proper_security_attributes(): void {
-		$rendered = $this->embed_renderer->render( $this->parsed_youtube_embed['innerHTML'], $this->parsed_youtube_embed, $this->rendering_context );
-
-		// The play button may or may not be wrapped in a link depending on post context.
-		// In test environment, there may not be a valid post URL, so the play button is just an image.
-		$this->assertStringContainsString( 'alt="Play"', $rendered );
-		$this->assertStringContainsString( 'play2x.png', $rendered );
-	}
-
-	/**
-	 * Test that YouTube embed includes proper accessibility attributes
-	 */
-	public function test_youtube_embed_includes_proper_accessibility_attributes(): void {
-		$rendered = $this->embed_renderer->render( $this->parsed_youtube_embed['innerHTML'], $this->parsed_youtube_embed, $this->rendering_context );
-
-		$this->assertStringContainsString( 'alt="Play"', $rendered );
-	}
-
-	/**
 	 * Test that YouTube embed detects YouTube by providerNameSlug
 	 */
 	public function test_youtube_embed_detects_youtube_by_provider_name_slug(): void {
@@ -581,58 +535,9 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that VideoPress embed is detected and renders as video player
+	 * Test that VideoPress embed is detected and renders as video player, including handling URLs with query parameters.
 	 */
 	public function test_renders_videopress_embed(): void {
-		// Mock the oEmbed HTTP response to avoid external calls in CI.
-		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg';
-		$mock_oembed_response = wp_json_encode(
-			array(
-				'type'          => 'video',
-				'thumbnail_url' => $mock_thumbnail_url,
-				'title'         => 'Test Video',
-			)
-		);
-
-		// Use pre_http_request filter to intercept oEmbed HTTP calls.
-		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_oembed_response ) {
-			// Intercept VideoPress oEmbed requests.
-			if ( strpos( $url, 'public-api.wordpress.com/oembed' ) !== false ) {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => $mock_oembed_response,
-				);
-			}
-			return $preempt;
-		};
-
-		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
-
-		$parsed_videopress_embed = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => 'https://videopress.com/v/BZHMfMfN',
-				'type'             => 'video',
-				'providerNameSlug' => 'videopress',
-				'responsive'       => true,
-			),
-			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN</div></figure>',
-		);
-
-		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
-
-		remove_filter( 'pre_http_request', $filter_callback, 10 );
-
-		// Should detect VideoPress and render as video with thumbnail.
-		$this->assertNotEmpty( $rendered );
-		$this->assertStringContainsString( 'play2x.png', $rendered, 'VideoPress embed should render with play button' );
-		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
-	}
-
-	/**
-	 * Test that VideoPress embed handles URLs with query parameters correctly
-	 */
-	public function test_videopress_embed_handles_urls_with_query_parameters(): void {
 		// Mock the oEmbed HTTP response to avoid external calls in CI.
 		// Return a thumbnail URL with query parameters to test the URL encoding fix.
 		$mock_thumbnail_url   = 'https://videos.files.wordpress.com/BZHMfMfN/thumbnail.jpg?w=500&h=281';
@@ -673,10 +578,9 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 		remove_filter( 'pre_http_request', $filter_callback, 10 );
 
-		// Should handle URLs with query parameters correctly.
-		// The key test is that background-image is present (not stripped by WP_Style_Engine).
-		// In final HTML output, & becomes &amp; which is correct HTML encoding.
+		// Should detect VideoPress and render as video with thumbnail.
 		$this->assertNotEmpty( $rendered );
+		$this->assertStringContainsString( 'play2x.png', $rendered, 'VideoPress embed should render with play button' );
 		// Verify background-image is present (our fix ensures it's not stripped).
 		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
 		// Verify query parameters are present (as &amp; in HTML, which is correct).
@@ -793,24 +697,4 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
 
-	/**
-	 * Test that background images with query parameters work correctly
-	 */
-	public function test_background_images_with_query_parameters_work_correctly(): void {
-		$parsed_youtube_with_query = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-				'type'             => 'video',
-				'providerNameSlug' => 'youtube',
-				'responsive'       => true,
-			),
-			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">https://www.youtube.com/watch?v=dQw4w9WgXcQ</div></figure>',
-		);
-
-		$rendered = $this->embed_renderer->render( $parsed_youtube_with_query['innerHTML'], $parsed_youtube_with_query, $this->rendering_context );
-
-		// Verify background-image is present (our fix ensures URLs with query parameters work).
-		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
-	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -574,9 +574,11 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN?w=500&h=281</div></figure>',
 		);
 
-		$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
-
-		remove_filter( 'pre_http_request', $filter_callback, 10 );
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_videopress_embed['innerHTML'], $parsed_videopress_embed, $this->rendering_context );
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+		}
 
 		// Should detect VideoPress and render as video with thumbnail.
 		$this->assertNotEmpty( $rendered );
@@ -644,9 +646,11 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 			'innerHTML' => '<figure class="wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/BZHMfMfN</div></figure>',
 		);
 
-		$rendered = $this->embed_renderer->render( $parsed_videopress_by_url['innerHTML'], $parsed_videopress_by_url, $this->rendering_context );
-
-		remove_filter( 'pre_http_request', $filter_callback, 10 );
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_videopress_by_url['innerHTML'], $parsed_videopress_by_url, $this->rendering_context );
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+		}
 
 		// Should detect VideoPress by URL domain and render with thumbnail.
 		$this->assertNotEmpty( $rendered );
@@ -688,13 +692,14 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 			'innerHTML' => '<figure class="wp-block-embed is-type-video"><div class="wp-block-embed__wrapper">https://video.wordpress.com/v/BZHMfMfN</div></figure>',
 		);
 
-		$rendered = $this->embed_renderer->render( $parsed_videopress_wordpress_com['innerHTML'], $parsed_videopress_wordpress_com, $this->rendering_context );
-
-		remove_filter( 'pre_http_request', $filter_callback, 10 );
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_videopress_wordpress_com['innerHTML'], $parsed_videopress_wordpress_com, $this->rendering_context );
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+		}
 
 		// Should detect VideoPress by video.wordpress.com domain and render with thumbnail.
 		$this->assertNotEmpty( $rendered );
 		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
-
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Video_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Video_Test.php
@@ -233,4 +233,27 @@ class Video_Test extends \Email_Editor_Integration_Test_Case {
 		// Should apply minimum height for consistent video block appearance.
 		$this->assertStringContainsString( 'min-height:390px', $rendered );
 	}
+
+	/**
+	 * Test that poster URLs with query parameters work correctly
+	 */
+	public function test_poster_urls_with_query_parameters_work_correctly(): void {
+		$parsed_video_with_query = array(
+			'blockName' => 'core/video',
+			'attrs'     => array(
+				'poster' => 'https://example.com/poster.jpg?w=500&h=281',
+				'title'  => 'Sample Video',
+			),
+			'innerHTML' => '<figure class="wp-block-video"><video controls poster="https://example.com/poster.jpg?w=500&h=281"><source src="https://example.com/video.mp4" type="video/mp4" /></video></figure>',
+		);
+
+		$rendered = $this->video_renderer->render( '', $parsed_video_with_query, $this->rendering_context );
+
+		// Should contain background-image with query parameters.
+		// The key test is that background-image is present (not stripped by WP_Style_Engine).
+		$this->assertStringContainsString( 'background-image', $rendered, 'Background image should be present in CSS' );
+		// Verify query parameters are present.
+		$this->assertStringContainsString( 'w=500', $rendered, 'Query parameters should be present' );
+		$this->assertStringContainsString( 'h=281', $rendered, 'Query parameters should be present' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/NL-156/add-email-rendering-for-videopress-blocks-and-videopress-embeds

I'm adding support for VideoPress embeds, which are supported in core:
- I'm using the `WP_oEmbed` class to fetch the video thumbnail, and caching the result. The alternative is to use the rest API endpoint directly: `https://public-api.wordpress.com/rest/v1.1/videos/{$video_guid}`. That would provide more metadata if we need it, and provide the thumbnail via Photon CDN. I haven't found a way to do this without an external HTTP request. The other alternative would be to not support embeds like this in the package, just on WPCOM. But that doesn't reflect core support.
- I'm changing `esc_url` to `esc_url_raw` to avoid encoding until the URL goes through the WP Style Engine.
- I'm adding some tests.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Post | Email |
| ------ | ----- |
|    <img width="652" height="374" alt="Screenshot 2026-01-20 at 4 38 39 PM" src="https://github.com/user-attachments/assets/68edfe8d-4ab4-434d-ae1b-dc36829c42c9" />    |   <img width="686" height="424" alt="Screenshot 2026-01-20 at 4 38 51 PM" src="https://github.com/user-attachments/assets/b6278d2d-8128-4778-955f-a74e2f12080d" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an embed block and paste in a VideoPress URL like: https://videopress.com/v/BZHMfMfN
2. Preview or send the email. 
3. Check that the thumbnail renders with a play button, and that clicking it opens the video.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I've tested on WPCOM.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add support for VideoPress embeds in the Email Editor package.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
