### PR TITLE
Fix dashboard showing $0 revenue when browser timezone differs from store timezone

### DIFF
--- a/packages/js/date/changelog/fix-timezone-fallback
+++ b/packages/js/date/changelog/fix-timezone-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix getStoreTimeZoneMoment() to check wcSettings.admin.timeZone when wcSettings.timeZone is not set

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -173,15 +173,18 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
  * @return {string} - Datetime string.
  */
 export function getStoreTimeZoneMoment() {
-	if ( ! window.wcSettings || ! window.wcSettings.timeZone ) {
+	const timeZone =
+		window.wcSettings?.timeZone || window.wcSettings?.admin?.timeZone;
+
+	if ( ! timeZone ) {
 		return moment();
 	}
 
-	if ( [ '+', '-' ].includes( window.wcSettings.timeZone.charAt( 0 ) ) ) {
-		return moment().utcOffset( window.wcSettings.timeZone );
+	if ( [ '+', '-' ].includes( timeZone.charAt( 0 ) ) ) {
+		return moment().utcOffset( timeZone );
 	}
 
-	return ( moment() as momentTz.Moment ).tz( window.wcSettings.timeZone );
+	return ( moment() as momentTz.Moment ).tz( timeZone );
 }
 
 /**

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -176,7 +176,7 @@ export function getStoreTimeZoneMoment() {
 	const timeZone =
 		window.wcSettings?.timeZone || window.wcSettings?.admin?.timeZone;
 
-	if ( ! timeZone ) {
+	if ( typeof timeZone !== 'string' || timeZone.length === 0 ) {
 		return moment();
 	}
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -33,6 +33,9 @@ declare global {
 	interface Window {
 		wcSettings: {
 			timeZone?: string;
+			admin?: {
+				timeZone?: string;
+			};
 		};
 	}
 }
@@ -1073,6 +1076,55 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
+	} );
+
+	it( 'should fall back to wcSettings.admin.timeZone when wcSettings.timeZone is not set', () => {
+		global.window.wcSettings = {
+			admin: {
+				timeZone: 'America/New_York',
+			},
+		};
+
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).toHaveBeenCalledWith( 'America/New_York' );
+		expect( utcOffset ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should use wcSettings.admin.timeZone utc offset when wcSettings.timeZone is not set', () => {
+		global.window.wcSettings = {
+			admin: {
+				timeZone: '+05:00',
+			},
+		};
+
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).not.toHaveBeenCalled();
+		expect( utcOffset ).toHaveBeenCalledWith( '+05:00' );
+	} );
+
+	it( 'should prefer wcSettings.timeZone over wcSettings.admin.timeZone', () => {
+		global.window.wcSettings = {
+			timeZone: 'Europe/London',
+			admin: {
+				timeZone: 'America/New_York',
+			},
+		};
+
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).toHaveBeenCalledWith( 'Europe/London' );
+		expect( utcOffset ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/packages/js/date/typings/global.d.ts
+++ b/packages/js/date/typings/global.d.ts
@@ -2,6 +2,9 @@ declare global {
 	interface Window {
 		wcSettings: {
 			timeZone?: string;
+			admin?: {
+				timeZone?: string;
+			};
 		};
 	}
 }

--- a/plugins/woocommerce/changelog/fix-dashboard-timezone
+++ b/plugins/woocommerce/changelog/fix-dashboard-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dashboard showing $0 revenue when browser timezone differs from store timezone

--- a/plugins/woocommerce/client/admin/client/dashboard/store-performance/utils.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/store-performance/utils.js
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-import moment from 'moment';
 import { find } from 'lodash';
-import { getCurrentDates, appendTimestamp } from '@woocommerce/date';
+import {
+	getCurrentDates,
+	appendTimestamp,
+	getStoreTimeZoneMoment,
+} from '@woocommerce/date';
 import { getFilterQuery, settingsStore, reportsStore } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { calculateDelta, formatValue } from '@woocommerce/number';
@@ -87,7 +90,7 @@ export const getIndicatorData = ( select, indicators, query, filters ) => {
 		after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 		before: appendTimestamp(
 			endPrimary,
-			endPrimary.isSame( moment(), 'day' ) ? 'now' : 'end'
+			endPrimary.isSame( getStoreTimeZoneMoment(), 'day' ) ? 'now' : 'end'
 		),
 		stats: statKeys,
 	};
@@ -97,7 +100,9 @@ export const getIndicatorData = ( select, indicators, query, filters ) => {
 		after: appendTimestamp( datesFromQuery.secondary.after, 'start' ),
 		before: appendTimestamp(
 			endSecondary,
-			endSecondary.isSame( moment(), 'day' ) ? 'now' : 'end'
+			endSecondary.isSame( getStoreTimeZoneMoment(), 'day' )
+				? 'now'
+				: 'end'
 		),
 		stats: statKeys,
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6068

The WooCommerce Admin Dashboard shows $0 revenue when the user's browser timezone differs from the store's configured timezone. Revenue appears temporarily after visiting Analytics reports but disappears on page refresh.

**Root Cause:** The `getStoreTimeZoneMoment()` function in `@woocommerce/date` was checking `window.wcSettings.timeZone`, but on WooCommerce Admin pages, the timezone is actually stored at `window.wcSettings.admin.timeZone`. When `wcSettings.timeZone` was undefined, the function fell back to the browser's local timezone, causing incorrect date queries to be sent to the API.

**Solution:**
1. Updated `getStoreTimeZoneMoment()` to check `wcSettings.admin.timeZone` as a fallback when `wcSettings.timeZone` is not set
2. Updated dashboard `utils.js` to use `getStoreTimeZoneMoment()` instead of `moment()` for "today" detection in date queries
3. Added TypeScript type definition for `wcSettings.admin.timeZone`
4. Added unit tests for the new fallback behavior

### How to test the changes in this Pull Request:

1. Set your WordPress site timezone to something different from your browser's timezone (e.g., if your browser is in UTC-5, set WordPress to UTC+5)
   - Go to **Settings > General** in WordPress admin
   - Change the timezone setting
2. Create a completed order in WooCommerce with a sale amount
3. Wait for order import sync to complete (if you use scheduled imports, manually trigger sync)
4. Navigate to the WooCommerce Admin Dashboard at **WooCommerce > Home**
5. Verify that the revenue displays correctly (not $0)
6. Open browser DevTools, go to the Network tab
7. Look for the `/wc-analytics/reports/performance-indicators` request
8. Verify the `before` parameter uses the store timezone (not browser timezone)
9. Refresh the page and verify revenue still displays correctly

<img width="1147" height="196" alt="Screenshot 2026-01-20 at 14 51 41" src="https://github.com/user-attachments/assets/7071dd8a-0c9d-4d7e-ae10-13b2aca6b9ae" />


<img width="1681" height="636" alt="Screenshot 2026-01-20 at 14 51 48" src="https://github.com/user-attachments/assets/cf80c11a-4359-4ab2-9f62-06154105405d" />


### Testing that has already taken place:

- All 94 unit tests in `@woocommerce/date` pass, including 3 new tests for the admin.timeZone fallback
- ESLint passes on all changed files
- Verified the fix logic by tracing through the code

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entries have been manually created in the PR:
- `packages/js/date/changelog/fix-timezone-fallback`
- `plugins/woocommerce/changelog/fix-dashboard-timezone`

</details>