### PR TITLE
Fix: Add null check in BlocksUtil::get_block_from_template_part

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocksutil-null-template-check
+++ b/plugins/woocommerce/changelog/fix-blocksutil-null-template-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP warning in BlocksUtil::get_block_from_template_part when using classic themes like Storefront.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -77929,12 +77929,6 @@ parameters:
 			path: src/Internal/Utilities/ArrayUtil.php
 
 		-
-			message: '#^Cannot access property \$content on WP_Block_Template\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Internal/Utilities/BlocksUtil.php
-
-		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_order_type\(\)\.$#'
 			identifier: method.notFound
 			count: 2

--- a/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
@@ -65,7 +65,12 @@ class BlocksUtil {
 	 */
 	public static function get_block_from_template_part( $block_name, $template_part_slug ) {
 		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
-		$blocks   = parse_blocks( $template->content );
+
+		if ( ! $template || empty( $template->content ) ) {
+			return array();
+		}
+
+		$blocks = parse_blocks( $template->content );
 
 		$flatten_blocks = self::flatten_blocks( $blocks );
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a null check in `BlocksUtil::get_block_from_template_part()` to handle cases where `get_block_template()` returns null.

When using a classic theme like Storefront, `get_block_template()` returns null because classic themes don't have block template parts. The `DependencyDetection` class added in #62229 calls this method to check for mini-cart blocks in the header, which triggers PHP warnings on classic themes.

**Errors fixed:**
```
Warning: Attempt to read property "content" on null in .../BlocksUtil.php on line 68
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```

(For Bug Fixes) Bug introduced in PR #62229.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate a classic theme (e.g., Storefront)
2. Enable `WP_DEBUG` and `WP_DEBUG_DISPLAY` in wp-config.php
3. Load any wp-admin page
4. Verify no PHP warnings appear related to BlocksUtil or template content

### Testing that has already taken place:

Verified that the warnings no longer appear when loading wp-admin with Storefront theme active.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry was created manually and included in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)