### PR TITLE
Update performance results API endpoint to codevitals.run

### DIFF
--- a/tools/compare-perf/log-to-codevitals.js
+++ b/tools/compare-perf/log-to-codevitals.js
@@ -64,7 +64,7 @@ const data = JSON.stringify( {
 } );
 
 const options = {
-	hostname: 'codehealth.vercel.app',
+	hostname: 'codevitals.run',
 	port: 443,
 	path: '/api/log?token=' + token,
 	method: 'POST',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Switch the API endpoint for publishing performance metrics from `codehealth.vercel.app` to the canonical `codevitals.run` endpoint in the performance testing script.

### Testing that has already taken place:

Code review of endpoint configuration change.

- [x] This Pull Request does not require a changelog entry. (Performance infrastructure update only)