### PR TITLE
Ensure that checking compatibility with deprecated features does not trigger deprecation notices

### DIFF
--- a/plugins/woocommerce/changelog/62884-fix-features-deprecation-notice
+++ b/plugins/woocommerce/changelog/62884-fix-features-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure there's no deprecation warning about deprecated feature flags when plugins are activated.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -877,6 +877,30 @@ class FeaturesController {
 	}
 
 	/**
+	 * Check if a given feature is enabled, without triggering deprecation notices.
+	 *
+	 * This is used internally for compatibility checks to avoid flooding logs with deprecation notices
+	 * when iterating over all features. For deprecated features, it returns the deprecated_value directly.
+	 *
+	 * @param string $feature_id Unique feature id.
+	 * @return bool True if the feature is enabled, false otherwise.
+	 */
+	private function feature_is_enabled_without_deprecation_notice( string $feature_id ): bool {
+		$feature = $this->get_feature_definition( $feature_id );
+
+		if ( null === $feature ) {
+			return false;
+		}
+
+		// For deprecated features, return the deprecated_value without triggering notice.
+		if ( ! empty( $feature['deprecated_since'] ) ) {
+			return (bool) ( $feature['deprecated_value'] ?? false );
+		}
+
+		return $this->feature_is_enabled( $feature_id );
+	}
+
+	/**
 	 * Change the enabled/disabled status of a feature.
 	 *
 	 * @param string $feature_id Unique feature id.
@@ -1042,10 +1066,11 @@ class FeaturesController {
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
 		$features = $this->get_feature_definitions();
+
 		if ( $enabled_features_only ) {
 			$features = array_filter(
 				$features,
-				array( $this, 'feature_is_enabled' ),
+				fn( $feature_id ) => $this->feature_is_enabled_without_deprecation_notice( $feature_id ),
 				ARRAY_FILTER_USE_KEY
 			);
 		}
@@ -1583,7 +1608,7 @@ class FeaturesController {
 				$features_considered_incompatible = array_filter(
 					$this->plugin_util->get_items_considered_incompatible( $feature_id, $compatibility_info ),
 					$only_enabled_features ?
-						fn( $id ) => $this->feature_is_enabled( $id ) && ! $this->should_skip_compatibility_checks( $id ) :
+						fn( $id ) => $this->feature_is_enabled_without_deprecation_notice( $id ) && ! $this->should_skip_compatibility_checks( $id ) :
 						fn( $id ) => ! $this->should_skip_compatibility_checks( $id )
 				);
 				if ( in_array( $feature_id, $features_considered_incompatible, true ) ) {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -884,6 +884,8 @@ class FeaturesController {
 	 *
 	 * @param string $feature_id Unique feature id.
 	 * @return bool True if the feature is enabled, false otherwise.
+	 *
+	 * @since 10.5.0
 	 */
 	private function feature_is_enabled_without_deprecation_notice( string $feature_id ): bool {
 		$feature = $this->get_feature_definition( $feature_id );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -808,36 +808,15 @@ class FeaturesController {
 	 *
 	 * @since 10.5.0
 	 */
-	private function get_feature_definition( string $feature_id ): ?array {
+	public function get_feature_definition( string $feature_id ): ?array {
 		return $this->get_feature_definitions()[ $feature_id ] ?? null;
 	}
 
 	/**
-	 * Log usage of a deprecated feature.
-	 *
-	 * This method ensures logging only happens once per request to avoid spam.
-	 *
-	 * @param string $feature_id       The feature id being checked.
-	 * @param string $deprecated_since The version since which the feature is deprecated.
-	 *
-	 * @since 10.5.0
-	 */
-	private function log_deprecated_feature_usage( string $feature_id, string $deprecated_since ): void {
-		static $logged = array();
-
-		if ( isset( $logged[ $feature_id ] ) ) {
-			return;
-		}
-		$logged[ $feature_id ] = true;
-
-		wc_deprecated_function(
-			"FeaturesUtil::feature_is_enabled('{$feature_id}')",
-			$deprecated_since
-		);
-	}
-
-	/**
 	 * Check if a given feature is currently enabled.
+	 *
+	 * Note: This method does not log deprecation notices for deprecated features.
+	 * Deprecation logging is handled by FeaturesUtil::feature_is_enabled() which is the public API.
 	 *
 	 * @param  string $feature_id Unique feature id.
 	 * @return bool True if the feature is enabled, false if not or if the feature doesn't exist.
@@ -851,7 +830,6 @@ class FeaturesController {
 
 		// Handle deprecated features - return the backwards-compatible value.
 		if ( ! empty( $feature['deprecated_since'] ) ) {
-			$this->log_deprecated_feature_usage( $feature_id, $feature['deprecated_since'] );
 			return (bool) ( $feature['deprecated_value'] ?? false );
 		}
 
@@ -874,32 +852,6 @@ class FeaturesController {
 		$features = $this->get_feature_definitions();
 
 		return ! empty( $features[ $feature_id ]['enabled_by_default'] );
-	}
-
-	/**
-	 * Check if a given feature is enabled, without triggering deprecation notices.
-	 *
-	 * This is used internally for compatibility checks to avoid flooding logs with deprecation notices
-	 * when iterating over all features. For deprecated features, it returns the deprecated_value directly.
-	 *
-	 * @param string $feature_id Unique feature id.
-	 * @return bool True if the feature is enabled, false otherwise.
-	 *
-	 * @since 10.5.0
-	 */
-	private function feature_is_enabled_without_deprecation_notice( string $feature_id ): bool {
-		$feature = $this->get_feature_definition( $feature_id );
-
-		if ( null === $feature ) {
-			return false;
-		}
-
-		// For deprecated features, return the deprecated_value without triggering notice.
-		if ( ! empty( $feature['deprecated_since'] ) ) {
-			return (bool) ( $feature['deprecated_value'] ?? false );
-		}
-
-		return $this->feature_is_enabled( $feature_id );
 	}
 
 	/**
@@ -1072,7 +1024,7 @@ class FeaturesController {
 		if ( $enabled_features_only ) {
 			$features = array_filter(
 				$features,
-				fn( $feature_id ) => $this->feature_is_enabled_without_deprecation_notice( $feature_id ),
+				array( $this, 'feature_is_enabled' ),
 				ARRAY_FILTER_USE_KEY
 			);
 		}
@@ -1610,7 +1562,7 @@ class FeaturesController {
 				$features_considered_incompatible = array_filter(
 					$this->plugin_util->get_items_considered_incompatible( $feature_id, $compatibility_info ),
 					$only_enabled_features ?
-						fn( $id ) => $this->feature_is_enabled_without_deprecation_notice( $id ) && ! $this->should_skip_compatibility_checks( $id ) :
+						fn( $id ) => $this->feature_is_enabled( $id ) && ! $this->should_skip_compatibility_checks( $id ) :
 						fn( $id ) => ! $this->should_skip_compatibility_checks( $id )
 				);
 				if ( in_array( $feature_id, $features_considered_incompatible, true ) ) {

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -39,7 +39,37 @@ class FeaturesUtil {
 	 * @return bool True if the feature is enabled, false if not or if the feature doesn't exist.
 	 */
 	public static function feature_is_enabled( string $feature_id ): bool {
-		return wc_get_container()->get( FeaturesController::class )->feature_is_enabled( $feature_id );
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$feature             = $features_controller->get_feature_definition( $feature_id );
+
+		// Log deprecation notice for deprecated features (only from the public API).
+		if ( null !== $feature && ! empty( $feature['deprecated_since'] ) ) {
+			self::log_deprecated_feature_usage( $feature_id, $feature['deprecated_since'] );
+		}
+
+		return $features_controller->feature_is_enabled( $feature_id );
+	}
+
+	/**
+	 * Log usage of a deprecated feature.
+	 *
+	 * This method ensures logging only happens once per request to avoid spam.
+	 *
+	 * @param string $feature_id       The feature id being checked.
+	 * @param string $deprecated_since The version since which the feature is deprecated.
+	 */
+	private static function log_deprecated_feature_usage( string $feature_id, string $deprecated_since ): void {
+		static $logged = array();
+
+		if ( isset( $logged[ $feature_id ] ) ) {
+			return;
+		}
+		$logged[ $feature_id ] = true;
+
+		wc_deprecated_function(
+			"FeaturesUtil::feature_is_enabled('{$feature_id}')",
+			$deprecated_since
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -43,7 +43,7 @@ class FeaturesUtil {
 		$feature             = $features_controller->get_feature_definition( $feature_id );
 
 		// Log deprecation notice for deprecated features (only from the public API).
-		if ( null !== $feature && ! empty( $feature['deprecated_since'] ) ) {
+		if ( ! empty( $feature['deprecated_since'] ) ) {
 			self::log_deprecated_feature_usage( $feature_id, $feature['deprecated_since'] );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

It turns out that changes introduced in https://github.com/woocommerce/woocommerce/pull/62264/ can trigger deprecation warnings on plugin activation. While this is not breaking anything on the site, those notices can show in admin UI. Additionally, some plugins have build systems that fail when any deprecation notice is triggered. This PR adds additional backwards-compatibility protection to changes introduced in  #62264.

(For Bug Fixes) Bug introduced in PR #62264.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1502" height="562" alt="Screenshot 2026-01-21 at 11 31 28" src="https://github.com/user-attachments/assets/5e318bf5-9d26-44b6-b6ab-983bb9323fc4" />    |    <img width="1345" height="230" alt="Screenshot 2026-01-21 at 11 31 46" src="https://github.com/user-attachments/assets/86a8a421-083f-4856-92c4-e80dc8163a34" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Do not checkout this branch yet 
2. Ensure your wp-env has debug logs enabled and debug display is enabled too
3. Reproduce the problem:
   - Install and activate on your site some WooCommerce plugin, for example "WooCommerce PayPal Payments" (available on WP.org). It can be also MailPoet.
   - Notice that after activation, the warning is there. Refresh the page - warning should still be there. <img width="1502" height="562" alt="Screenshot 2026-01-21 at 11 31 28" src="https://github.com/user-attachments/assets/5e318bf5-9d26-44b6-b6ab-983bb9323fc4" />
   - Deactivate the plugin
4. Checkout branch form this PR
5. Activate the plugin and confirm that the notice is not visible
6. Refresh the plugins page and confirm that the notice is still not there
7. Run `pnpm test:php:env -- --filter FeaturesControllerTest` and confirm that all tests pass
8. Activate another Woo plugin - confirm no depreciation notices are shown
9. Please test around this issue.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure there's no deprecation warning about deprecated feature flags when plugins are activated.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
