### PR TITLE
Prevent warnings when accessing templates without content

### DIFF
--- a/plugins/woocommerce/changelog/fix-template-access-warning
+++ b/plugins/woocommerce/changelog/fix-template-access-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent PHP warnings when accessing templates without content

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -77803,12 +77803,6 @@ parameters:
 			path: src/Internal/Utilities/ArrayUtil.php
 
 		-
-			message: '#^Cannot access property \$content on WP_Block_Template\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Internal/Utilities/BlocksUtil.php
-
-		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_order_type\(\)\.$#'
 			identifier: method.notFound
 			count: 2

--- a/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
@@ -65,7 +65,12 @@ class BlocksUtil {
 	 */
 	public static function get_block_from_template_part( $block_name, $template_part_slug ) {
 		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
-		$blocks   = parse_blocks( $template->content );
+
+		if ( ! $template || null === $template->content ) {
+			return array();
+		}
+
+		$blocks = parse_blocks( $template->content );
 
 		$flatten_blocks = self::flatten_blocks( $blocks );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

 Added a null check to the `get_block_from_template_part()` util to handle cases where `get_block_template()` returns null or a template object with null content. This _could_ occur when certain plugins modify template parts in ways that leave content uninitialized. If this happens, PHP errors ("Attempt to read property 'content' on null") and deprecation warnings in WordPress's block parsershow. The method now returns an empty array if this happens, preventing downstream warnings.

This warning would have happened in any case where the template or its content was null, but the PR mentioned below is what actually revealed the warning in tests because it actively checks templates for their content.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/62229

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following to mu-plugins:

```php
<?php
/**
 * MU-Plugin to reproduce null content issue in BlocksUtil::get_block_from_template_part()
 *
 * Delete this file after testing.
 */

add_filter( 'get_block_template', function( $block_template, $id, $template_type ) {
	if ( $template_type !== 'wp_template_part' ) {
		return $block_template;
	}

	if ( str_ends_with( $id, '//header' ) ) {
		return null;
	}

	return $block_template;
}, 10, 3 );
```

3. Ensure `WP_DEBUG` is set to true in `wp-config.php`
4. Go to WP Admin and ensure you don't see any warnings like `Attempt to read property "content" on null`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
