### PR TITLE
Make variation and itemData show inline with separators on Cart/Checkout block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,18 @@ For detailed test commands, see `woocommerce-dev-cycle` skill.
 - Never create standalone functions (always use class methods)
 - Tests require Docker environment
 
+## Interactivity API Stores
+
+All WooCommerce Interactivity API stores are **private by design**:
+
+- Stores use `lock: true` indicating they are not intended for extension
+- Removing or changing store state/selectors is **not a breaking change**
+- No backwards compatibility is required for store internals
+- If a store needs to be extensible in the future, it will be split into private (internal) and public (API) stores
+- General stores (namespace `woocommerce`) may become public eventually, but currently all are locked
+
+Reference: [WordPress Interactivity API - Private Stores](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference#private-stores)
+
 ## Quick Reference
 
 ### Most Common Commands

--- a/plugins/woocommerce/changelog/wooprd-1446-consolidate-variable-product-attributes
+++ b/plugins/woocommerce/changelog/wooprd-1446-consolidate-variable-product-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Item data and variation data now show inline on the Cart and Checkout blocks

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -35,23 +35,15 @@ const ProductDetails = ( {
 		return null;
 	}
 
-	details = details.filter( ( detail ) => ! detail.hidden );
+	const filteredDetails = details.filter( ( detail ) => ! detail.hidden );
 
-	if ( details.length === 0 ) {
+	if ( filteredDetails.length === 0 ) {
 		return null;
 	}
 
-	let ParentTag = 'ul' as keyof JSX.IntrinsicElements;
-	let ChildTag = 'li' as keyof JSX.IntrinsicElements;
-
-	if ( details.length === 1 ) {
-		ParentTag = 'div';
-		ChildTag = 'div';
-	}
-
 	return (
-		<ParentTag className="wc-block-components-product-details">
-			{ details.map( ( detail ) => {
+		<div className="wc-block-components-product-details">
+			{ filteredDetails.map( ( detail, index ) => {
 				// Support both `key` and `name` props
 				const name = detail?.key || detail.name || '';
 				// Strip HTML tags from name for CSS class generation
@@ -67,8 +59,10 @@ const ProductDetails = ( {
 						  ) }`
 						: '' );
 
+				const isLast = index === filteredDetails.length - 1;
+
 				return (
-					<ChildTag
+					<span
 						key={ name + ( detail.display || detail.value ) }
 						className={ className }
 					>
@@ -98,10 +92,11 @@ const ProductDetails = ( {
 								),
 							} }
 						/>
-					</ChildTag>
+						{ ! isLast && ' / ' }
+					</span>
 				);
 			} ) }
-		</ParentTag>
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -92,9 +92,7 @@ const ProductDetails = ( {
 								),
 							} }
 						/>
-						{ ! isLast && (
-							<span aria-hidden="true"> / </span>
-						) }
+						{ ! isLast && <span aria-hidden="true"> / </span> }
 					</span>
 				);
 			} ) }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -92,7 +92,9 @@ const ProductDetails = ( {
 								),
 							} }
 						/>
-						{ ! isLast && ' / ' }
+						{ ! isLast && (
+							<span aria-hidden="true"> / </span>
+						) }
 					</span>
 				);
 			} ) }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
@@ -1,22 +1,16 @@
 // Extra class added for specificity so styles are applied in the editor.
 .wc-block-components-product-details.wc-block-components-product-details {
 	@include font-x-small-locked;
-	list-style: none;
 	margin: 0.5em 0;
-	padding: 0;
 
 	&:last-of-type {
 		margin-bottom: 0;
-	}
-
-	li {
-		margin-left: 0;
 	}
 }
 
 .wc-block-components-product-details__name,
 .wc-block-components-product-details__value {
-	display: inline-block;
+	display: inline;
 }
 
 @include cart-checkout-large-container {
@@ -25,4 +19,4 @@
 			font-weight: bold;
 		}
 	}
-}
+		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/style.scss
@@ -13,10 +13,3 @@
 	display: inline;
 }
 
-@include cart-checkout-large-container {
-	.wc-block-cart__main {
-		.wc-block-components-product-details__name {
-			font-weight: bold;
-		}
-	}
-		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/test/index.js
@@ -18,15 +18,17 @@ describe( 'ProductDetails', () => {
 
 		const { container } = render( <ProductDetails details={ details } /> );
 
-		// Should render as ul since there are multiple details
-		const list = container.querySelector(
-			'ul.wc-block-components-product-details'
+		// Should render as div
+		const wrapper = container.querySelector(
+			'div.wc-block-components-product-details'
 		);
-		expect( list ).toBeInTheDocument();
+		expect( wrapper ).toBeInTheDocument();
 
-		// Should have 3 list items
-		const listItems = container.querySelectorAll( 'li' );
-		expect( listItems ).toHaveLength( 3 );
+		// Should have 3 span items
+		const items = container.querySelectorAll(
+			'.wc-block-components-product-details > span'
+		);
+		expect( items ).toHaveLength( 3 );
 
 		// First item should have name and value
 		expect( screen.getByText( 'Lorem:' ) ).toBeInTheDocument();
@@ -37,7 +39,7 @@ describe( 'ProductDetails', () => {
 		expect( screen.getByText( 'IPSUM' ) ).toBeInTheDocument();
 
 		// Third item should only have value (no name)
-		const thirdItem = listItems[ 2 ];
+		const thirdItem = items[ 2 ];
 		expect(
 			thirdItem.querySelector(
 				'.wc-block-components-product-details__name'
@@ -59,18 +61,20 @@ describe( 'ProductDetails', () => {
 
 		const { container } = render( <ProductDetails details={ details } /> );
 
-		// Should render as ul since there are multiple visible details
-		const list = container.querySelector(
-			'ul.wc-block-components-product-details'
+		// Should render as div
+		const wrapper = container.querySelector(
+			'div.wc-block-components-product-details'
 		);
-		expect( list ).toBeInTheDocument();
+		expect( wrapper ).toBeInTheDocument();
 
 		// Should only have 2 items (hidden one filtered out)
-		const listItems = container.querySelectorAll( 'li' );
-		expect( listItems ).toHaveLength( 2 );
+		const items = container.querySelectorAll(
+			'.wc-block-components-product-details > span'
+		);
+		expect( items ).toHaveLength( 2 );
 
 		// Hidden item should not be rendered
-		expect( screen.queryByText( 'Lorem' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Lorem:' ) ).not.toBeInTheDocument();
 
 		// Visible items should be rendered
 		expect( screen.getByText( 'LOREM:' ) ).toBeInTheDocument();
@@ -106,32 +110,52 @@ describe( 'ProductDetails', () => {
 		expect( container.firstChild ).toBeNull();
 	} );
 
-	test( 'should not render list if there is only one detail', () => {
+	test( 'should render separators between multiple details', () => {
+		const details = [
+			{ name: 'Color', value: 'Red' },
+			{ name: 'Size', value: 'Large' },
+			{ name: 'Material', value: 'Cotton' },
+		];
+
+		const { container } = render( <ProductDetails details={ details } /> );
+
+		const wrapper = container.querySelector(
+			'div.wc-block-components-product-details'
+		);
+
+		// Should have separators between items but not after last
+		expect( wrapper.textContent ).toBe(
+			'Color: Red / Size: Large / Material: Cotton'
+		);
+
+		// Separators should be hidden from screen readers
+		const separators = container.querySelectorAll( '[aria-hidden="true"]' );
+		expect( separators ).toHaveLength( 2 );
+	} );
+
+	test( 'should render single detail without separator', () => {
 		const details = [ { name: 'LOREM', value: 'Ipsum', display: 'IPSUM' } ];
 
 		const { container } = render( <ProductDetails details={ details } /> );
 
-		// Should render as div (not ul) since there's only one detail
-		const div = container.querySelector(
+		// Should render as div
+		const wrapper = container.querySelector(
 			'div.wc-block-components-product-details'
 		);
-		expect( div ).toBeInTheDocument();
+		expect( wrapper ).toBeInTheDocument();
 
-		// Should not render as ul
-		const list = container.querySelector(
-			'ul.wc-block-components-product-details'
+		// Should have one span item
+		const items = container.querySelectorAll(
+			'.wc-block-components-product-details > span'
 		);
-		expect( list ).not.toBeInTheDocument();
-
-		// Should have one child div
-		const childDivs = container.querySelectorAll(
-			'div.wc-block-components-product-details > div'
-		);
-		expect( childDivs ).toHaveLength( 1 );
+		expect( items ).toHaveLength( 1 );
 
 		// Should contain name and value
 		expect( screen.getByText( 'LOREM:' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'IPSUM' ) ).toBeInTheDocument();
+
+		// Should not have separator (single item)
+		expect( items[ 0 ].textContent ).toBe( 'LOREM: IPSUM' );
 
 		// Should have proper CSS classes
 		expect(
@@ -154,9 +178,12 @@ describe( 'ProductDetails', () => {
 
 		const { container } = render( <ProductDetails details={ details } /> );
 
-		const listItems = container.querySelectorAll( 'li' );
-		expect( listItems[ 0 ].textContent ).toBe( 'Color: Red' );
-		expect( listItems[ 1 ].textContent ).toBe( 'Size: L' );
+		const items = container.querySelectorAll(
+			'.wc-block-components-product-details > span'
+		);
+		// First item has separator, last item does not
+		expect( items[ 0 ].textContent ).toBe( 'Color: Red / ' );
+		expect( items[ 1 ].textContent ).toBe( 'Size: L' );
 	} );
 
 	test( 'should apply correct CSS classes', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -853,13 +853,6 @@ const { state: cartItemState } = store(
 				return `${ name }:${ value }`;
 			},
 
-			get itemDataHasMultipleAttributes(): boolean {
-				const { dataProperty } = getContext< {
-					dataProperty: DataProperty;
-				} >();
-				return cartItemState.cartItem[ dataProperty ]?.length > 1;
-			},
-
 			get shouldHideProductDetails(): boolean {
 				const { dataProperty } = getContext< {
 					dataProperty: DataProperty;
@@ -867,18 +860,35 @@ const { state: cartItemState } = store(
 				return cartItemState.cartItem[ dataProperty ].length === 0;
 			},
 
-			get shouldHideSingleProductDetails(): boolean {
-				return (
-					cartItemState.shouldHideProductDetails ||
-					cartItemState.itemDataHasMultipleAttributes
-				);
-			},
+			get isLastCartItemDataAttr(): boolean {
+				const { itemData, dataProperty } = getContext< {
+					itemData: ItemData;
+					dataProperty: DataProperty;
+				} >();
 
-			get shouldHideMultipleProductDetails(): boolean {
-				return (
-					cartItemState.shouldHideProductDetails ||
-					! cartItemState.itemDataHasMultipleAttributes
+				const items = cartItemState.cartItem[ dataProperty ];
+				if ( ! items || items.length === 0 ) {
+					return true;
+				}
+
+				// Filter out hidden items
+				const visibleItems = items.filter(
+					( item: ItemData ) =>
+						! (
+							item.hidden === true ||
+							item.hidden === 'true' ||
+							item.hidden === '1' ||
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							( item.hidden as any ) === 1
+						)
 				);
+
+				if ( visibleItems.length === 0 ) {
+					return true;
+				}
+
+				const lastItem = visibleItems[ visibleItems.length - 1 ];
+				return itemData === lastItem;
 			},
 		},
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -275,22 +275,15 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 		<div
 			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			class="wc-block-components-product-details"
-			data-wp-bind--hidden="state.shouldHideSingleProductDetails"
-		>
-			<?php echo $this->render_product_details_item_markup( 'div', $is_item_data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</div>
-		<ul
-			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-			class="wc-block-components-product-details"
-			data-wp-bind--hidden="state.shouldHideMultipleProductDetails"
+			data-wp-bind--hidden="state.shouldHideProductDetails"
 		>
 			<template
 				data-wp-each--item-data="state.cartItem.<?php echo esc_attr( $property ); ?>"
 				data-wp-each-key="state.cartItemDataKey"
 			>
-				<?php echo $this->render_product_details_item_markup( 'li', $is_item_data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo $this->render_product_details_item_markup( $is_item_data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</template>
-		</ul>
+		</div>
 		<?php
 		return ob_get_clean();
 	}
@@ -298,25 +291,25 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 	/**
 	 * Render markup for a single product detail item.
 	 *
-	 * @param string $tag_name   The HTML tag to use for the item.
-	 * @param bool   $is_item_data Whether the item is of item_data type.
+	 * @param bool $is_item_data Whether the item is of item_data type.
 	 * @return string Rendered product detail item output based on item type.
 	 */
-	private function render_product_details_item_markup( $tag_name, $is_item_data = false ) {
+	private function render_product_details_item_markup( $is_item_data = false ) {
 		ob_start();
 		?>
-	<<?php echo tag_escape( $tag_name ); ?>
-		data-wp-bind--hidden="state.cartItemDataAttrHidden"
-		data-wp-bind--class="state.cartItemDataAttr.className"
-	>
+		<span
+			data-wp-bind--hidden="state.cartItemDataAttrHidden"
+			data-wp-bind--class="state.cartItemDataAttr.className"
+		>
 		<?php if ( $is_item_data ) : ?>
 			<span class="wc-block-components-product-details__name" data-wp-watch="callbacks.itemDataNameInnerHTML"></span>
 			<span class="wc-block-components-product-details__value" data-wp-watch="callbacks.itemDataValueInnerHTML"></span>
 		<?php else : ?>
-			<span class="wc-block-components-product-details__name"  data-wp-text="state.cartItemDataAttr.name"></span>
+			<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
 			<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
 		<?php endif; ?>
-		</<?php echo tag_escape( $tag_name ); ?>>
+			<span aria-hidden="true" data-wp-bind--hidden="state.isLastCartItemDataAttr"> / </span>
+		</span>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Makes the item data and variation data display inline on the Cart and Checkout blocks.

If there is only one item, it would display as a div rather than a list.

The item data and variation data are intentionally being kept separate.

Closes WOOPRD-1446

### Screenshots or screen recordings:

| Cart Before | Cart After |
| ------ | ----- |
| <img width="1068" height="884" alt="image" src="https://github.com/user-attachments/assets/06977bf0-1089-4d6c-85db-371995750bda" /> | <img width="1054" height="898" alt="image" src="https://github.com/user-attachments/assets/dc71c44a-e46f-4db1-a98d-cff6620b405f" /> |

| Checkout Before | Checkout After |
| ------ | ----- |
| <img width="1068" height="823" alt="image" src="https://github.com/user-attachments/assets/db7467f6-9110-4139-be59-9fe1ee1602f9" /> | <img width="1059" height="819" alt="image" src="https://github.com/user-attachments/assets/5c75d531-a473-43e7-86f2-258cb3004bde" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a variation item to your cart with only one attribute, and one with multiple attributes. Also add a normal product to your cart.
2. Add this snippet to an `mu-plugin` on your site:

```php
<?php
/**
 * Plugin Name: Test Cart Item Data
 * Description: Adds test item data to cart items for development purposes.
 */

add_filter( 'woocommerce_get_item_data', function( $item_data, $cart_item ) {
    $item_data[] = [
        'key'   => 'Test Field',
        'value' => 'Test Value',
    ];
    $item_data[] = [
        'key'   => 'Another Field',
        'value' => 'Another Value',
    ];
    return $item_data;
}, 10, 2 );

```

4. Go to the Cart block and ensure the variations and item data show correctly as per the screenshots below (from Figma)
5. Remove the snippet and ensure products with no data (the regular product added in step 1) displays normally.

<img width="763" height="270" alt="image" src="https://github.com/user-attachments/assets/21e9133f-e076-473b-a9af-72fc82063267" />


<img width="2970" height="992" alt="image" src="https://github.com/user-attachments/assets/f346f1ca-745e-403b-bf43-8b5ff3d7fd67" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
