### PR TITLE
Email Editor image renderer: Add alignment to inner cell and border wrapper

### DIFF
--- a/packages/php/email-editor/changelog/62899-fix-email-editor-image-center-alignment
+++ b/packages/php/email-editor/changelog/62899-fix-email-editor-image-center-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix image alignment by adding alignment to the inner cell when rendered.  Fix image border alignment by adding a border wrapper.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -63,12 +63,12 @@ class Image extends Abstract_Block_Renderer {
 		// Because the isn't an attribute for definition of rounded style, we have to check the class name.
 		if ( isset( $parsed_block['attrs']['className'] ) && strpos( $parsed_block['attrs']['className'], 'is-style-rounded' ) !== false ) {
 			// If the image should be in a circle, we need to set the border-radius to 9999px to make it the same as is in the editor
-			// This style is applied to both wrapper and the image.
+			// This style is applied to both the border cell wrapper and the image.
 			$block_content = $this->remove_style_attribute_from_element(
 				$block_content,
 				array(
 					'tag_name'   => 'td',
-					'class_name' => 'email-image-cell',
+					'class_name' => 'email-image-border-cell',
 				),
 				'border-radius'
 			);
@@ -76,7 +76,7 @@ class Image extends Abstract_Block_Renderer {
 				$block_content,
 				array(
 					'tag_name'   => 'td',
-					'class_name' => 'email-image-cell',
+					'class_name' => 'email-image-border-cell',
 				),
 				'border-radius: 9999px;'
 			);
@@ -174,9 +174,11 @@ class Image extends Abstract_Block_Renderer {
 			$border_styles['border-style'] = 'solid';
 			$border_styles['box-sizing']   = 'border-box';
 		}
+		// Apply border to the dedicated border cell wrapper, not the outer image cell.
+		// This ensures borders stay tight around the image on mobile when the outer wrapper becomes 100% width.
 		$border_element_tag         = array(
 			'tag_name'   => 'td',
-			'class_name' => 'email-image-cell',
+			'class_name' => 'email-image-border-cell',
 		);
 		$content_with_border_styles = $this->add_style_to_element( $block_content, $border_element_tag, \WP_Style_Engine::compile_css( $border_styles, '' ) );
 		// Remove border styles from the image HTML tag.
@@ -330,6 +332,22 @@ class Image extends Abstract_Block_Renderer {
 				'{image_content}'
 			);
 		}
+
+		// Wrap image in a border wrapper table that won't expand to 100% on mobile.
+		// This ensures borders stay tight around the image regardless of screen size.
+		$border_wrapper_styles = array(
+			'border-collapse' => 'separate',
+			'border-spacing'  => '0px',
+		);
+		$border_wrapper_attrs  = array(
+			'class' => 'email-image-border-wrapper',
+			'style' => \WP_Style_Engine::compile_css( $border_wrapper_styles, '' ),
+		);
+		$border_cell_attrs     = array(
+			'class' => 'email-image-border-cell',
+		);
+		$image_content         = Table_Wrapper_Helper::render_table_wrapper( $image_content, $border_wrapper_attrs, $border_cell_attrs );
+
 		$image_html    = Table_Wrapper_Helper::render_table_wrapper( $image_content, $image_table_attrs, $image_cell_attrs );
 		$inner_content = $image_html . $caption_html;
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -315,6 +315,7 @@ class Image extends Abstract_Block_Renderer {
 		$image_cell_attrs = array(
 			'class' => 'email-image-cell',
 			'style' => 'overflow: hidden;',
+			'align' => $align,
 		);
 
 		$image_content = '{image_content}';

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
@@ -138,6 +138,16 @@ class Image_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'height="300"', $rendered );
 		$this->assertStringContainsString( 'height:300px;', $rendered );
 		$this->assertStringContainsString( 'width:400px;', $rendered );
+
+		// Verify alignment is also applied to the inner image cell for mobile responsiveness.
+		$html = new \WP_HTML_Tag_Processor( $rendered );
+		$html->next_tag(
+			array(
+				'tag_name'   => 'td',
+				'class_name' => 'email-image-cell',
+			)
+		);
+		$this->assertEquals( 'center', $html->get_attribute( 'align' ) );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Image_Test.php
@@ -168,11 +168,12 @@ class Image_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->image_renderer->render( $image_content, $parsed_image, $this->rendering_context );
 		$html     = new \WP_HTML_Tag_Processor( $rendered );
-		// Border is rendered on the wrapping table cell.
+		// Border is rendered on the dedicated border cell wrapper (not the outer image cell).
+		// This ensures borders stay tight around the image on mobile.
 		$html->next_tag(
 			array(
 				'tag_name'   => 'td',
-				'class_name' => 'email-image-cell',
+				'class_name' => 'email-image-border-cell',
 			)
 		);
 		$table_cell_style = $html->get_attribute( 'style' );
@@ -200,11 +201,11 @@ class Image_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->image_renderer->render( $image_content, $parsed_image, $this->rendering_context );
 		$html     = new \WP_HTML_Tag_Processor( $rendered );
-		// Border is rendered on the wrapping table cell and the border classes are moved to the wrapping table cell.
+		// Border is rendered on the dedicated border cell wrapper and the border classes are moved there.
 		$html->next_tag(
 			array(
 				'tag_name'   => 'td',
-				'class_name' => 'email-image-cell',
+				'class_name' => 'email-image-border-cell',
 			)
 		);
 		$table_cell_class = $html->get_attribute( 'class' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/NL-365/jetpack-newsletter-center-aligned-images-display-as-left-aligned-on

I'm adding alignment to the inner image cell for mobile responsiveness. A user reported that images did not stay center-aligned on mobile.

I also noticed that the border didn't stay wrapped around the image. I added a border wrapper to fix it.

Known existing issue: There are small gaps between the image and the border when a border-radius is applied.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="367" height="597" alt="Screenshot 2026-01-21 at 3 57 40 PM" src="https://github.com/user-attachments/assets/a4653b1a-5942-49f0-8cb6-0cce661fac84" />    |    <img width="367" alt="IMG_0520" src="https://github.com/user-attachments/assets/5d71e107-51a3-4530-8fe1-c7e7addf2f98" /> | 
<img width="822" height="760" alt="Screenshot 2026-01-21 at 4 32 27 PM" src="https://github.com/user-attachments/assets/3532e8c3-62b7-4c3c-9980-bb1159947526" /> | <img width="949" height="716" alt="Screenshot 2026-01-21 at 4 31 24 PM" src="https://github.com/user-attachments/assets/7066274d-b567-4f3a-ba08-7e0429c7d459" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an image.
2. Center-align the image.
3. Test the email on mobile, tablet, and desktop sizes.
4. Verify that the image stays centered.
5. Add a border to the image.
6. Test the email on mobile, tablet, and desktop sizes.
7. Verify that the border stays close to the image, vs. expanding to fill the width.

<!-- End testing instructions -->

### Testing that has already taken place:

I tested on WPCOM.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix image alignment by adding alignment to the inner cell when rendered. 
Fix image border alignment by adding a border wrapper.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
