### PR TITLE
[dev] CI: set authoring of prepare package release PRs to WooCommerce bot

### DIFF
--- a/.github/workflows/prepare-package-release.yml
+++ b/.github/workflows/prepare-package-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: '0'
 
@@ -49,11 +49,13 @@ jobs:
         run: echo "str=${{ github.event.inputs.packages }}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 #v8.1.0
         env:
           HUSKY: '0' # pre-push hook incorrectly considers the working branch as the push-to branch and the push will fail if the working branch is trunk
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
+          author: 'woocommercebot <woocommercebot@users.noreply.github.com>'
+          committer: 'woocommercebot <woocommercebot@users.noreply.github.com>'
           commit-message: 'Automated change: Prep ${{ steps.all_description.outputs.str || steps.specific_description.outputs.str }} for release.'
           branch: prepare-releases/packages-${{ steps.date.outputs.date }}
           delete-branch: true

--- a/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
+++ b/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Unify loading indicator with the site editor

--- a/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
+++ b/packages/js/email-editor/changelog/wooprd-1630-unify-loading-indicato
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Unify loading indicator with the site editor


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #59728, WOOPLUG-5052.

Pins actions versions in alignment with other workflows, adds new attributes related to authoring to the PR creation action.

### How to test the changes in this Pull Request:

- see https://github.com/woocommerce/woocommerce/pull/62908 for reference