### PR TITLE
[`@woocommerce/extend-cart-checkout-block`] Ensure all relevant files are included in built zip

### DIFF
--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -100,14 +100,14 @@ function {{slugPascalCase}}_register_custom_checkout_fields() {
 	 */
 	add_action(
 		'woocommerce_sanitize_additional_field',
-		function ( $value, $key, $group ) {
+		function ( $value, $key ) {
 			if ( '{{slug}}/custom-text-input' === $key ) {
 				return strtoupper( $value );
 			}
 			return $value;
 		},
 		10,
-		3
+		2
 	);
 
 	/**
@@ -115,13 +115,13 @@ function {{slugPascalCase}}_register_custom_checkout_fields() {
 	 */
 	add_action(
 		'woocommerce_blocks_validate_location_address_fields',
-		function ( \WP_Error $errors, $fields, $group ) {
+		function ( \WP_Error $errors, $fields ) {
 			if ( 'INVALID' === $fields['{{slug}}/custom-text-input'] ) {
 				$errors->add( 'invalid_text_detected', 'Please ensure your custom text input is not "INVALID".' );
 			}
 		},
 		10,
-		3
+		2
 	);
 
 	woocommerce_register_additional_checkout_field(

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -116,7 +116,7 @@ function {{slugPascalCase}}_register_custom_checkout_fields() {
 	add_action(
 		'woocommerce_blocks_validate_location_address_fields',
 		function ( \WP_Error $errors, $fields ) {
-			if ( 'INVALID' === $fields['{{slug}}/custom-text-input'] ) {
+			if ( isset( $fields['{{slug}}/custom-text-input'] ) && 'INVALID' === $fields['{{slug}}/custom-text-input'] ) {
 				$errors->add( 'invalid_text_detected', 'Please ensure your custom text input is not "INVALID".' );
 			}
 		},

--- a/packages/js/extend-cart-checkout-block/changelog/wooplug-6127-woocommerceextend-cart-checkout-block-template-produces
+++ b/packages/js/extend-cart-checkout-block/changelog/wooplug-6127-woocommerceextend-cart-checkout-block-template-produces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure correct files are included when building a zip using build-zip

--- a/packages/js/extend-cart-checkout-block/index.js
+++ b/packages/js/extend-cart-checkout-block/index.js
@@ -11,5 +11,8 @@ module.exports = {
 			'@wordpress/prettier-config@2.18.2',
 			'@wordpress/scripts',
 		],
+		customPackageJSON: {
+			files: [ '*.php', 'build', 'block.json' ],
+		},
 	},
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Change the index.js file in `@woocommerce/extend-cart-checkout-block` template to explicitly includes all php files, `build/`, and `block.json` in the archive when building with `npm run plugin-zip`

Closes #62742
Closes WOOPLUG-6127

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Be using node 20
2. From your `plugins` folder Run `npx @wordpress/create-block -t <path-to-woocommerce-monorepo>/packages/js/extend-cart-checkout-block test-62742`
3. Once this is done, go to `test-62742` and run `npm run plugin-zip` this will create a zip file in the same directory. Copy this zip file somewhere else, so you can upload it to your site later.
4. Delete the `test-62742` directory and install the zip via the WordPress plugin installer, ensure there are no fatal errors after installing.
5. Go to the Checkout block and verify you can see the plugin working (Cart items should have `+ extra data` and there should be a "Data passed to this component: This is some example data from the server" slot on the bottom of the order summary on Checkout.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
