### PR TITLE
Fix block spacing issues in emails on Assembler theme 

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-1714-assempler-theme-no-block-spacing
+++ b/packages/php/email-editor/changelog/wooprd-1714-assempler-theme-no-block-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improved extraction of style values from site theme

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -28,6 +28,13 @@ class Site_Style_Sync_Controller {
 	private ?WP_Theme_JSON $site_theme = null;
 
 	/**
+	 * Base theme data for fallback lookups
+	 *
+	 * @var array|null
+	 */
+	private ?array $base_theme_data = null;
+
+	/**
 	 * Email-safe fonts
 	 *
 	 * @var array
@@ -56,9 +63,13 @@ class Site_Style_Sync_Controller {
 	/**
 	 * Sync site styles to email theme format
 	 *
+	 * @param WP_Theme_JSON|null $base_theme Base theme for fallback values. If null, no fallbacks are used.
 	 * @return array Email-compatible theme data.
 	 */
-	public function sync_site_styles(): array {
+	public function sync_site_styles( ?WP_Theme_JSON $base_theme = null ): array {
+		// Store base theme data for fallback lookups.
+		$this->base_theme_data = $base_theme ? $base_theme->get_data() : null;
+
 		$site_theme = $this->get_site_theme();
 		$site_data  = $site_theme->get_data();
 
@@ -82,14 +93,15 @@ class Site_Style_Sync_Controller {
 	/**
 	 * Getter for site theme.
 	 *
+	 * @param WP_Theme_JSON|null $base_theme Base theme for fallback values. If null, no fallbacks are used.
 	 * @return ?WP_Theme_JSON Synced site theme.
 	 */
-	public function get_theme(): ?WP_Theme_JSON {
+	public function get_theme( ?WP_Theme_JSON $base_theme = null ): ?WP_Theme_JSON {
 		if ( ! $this->is_sync_enabled() ) {
 			return null;
 		}
 
-		$synced_data = $this->sync_site_styles();
+		$synced_data = $this->sync_site_styles( $base_theme );
 
 		if ( empty( $synced_data ) || ! isset( $synced_data['version'] ) ) {
 			return null;
@@ -247,15 +259,31 @@ class Site_Style_Sync_Controller {
 	/**
 	 * Convert site typography styles to email format
 	 *
-	 * @param array $typography_styles Site typography styles.
+	 * @param array  $typography_styles Site typography styles.
+	 * @param string $element Optional element name for context-aware fallbacks.
 	 * @return array Email-compatible typography styles.
 	 */
-	private function convert_typography_styles( array $typography_styles ): array {
+	private function convert_typography_styles( array $typography_styles, string $element = '' ): array {
 		$email_typography = array();
 
 		// Handle special cases with processors.
 		$this->resolve_and_assign( $typography_styles, 'fontFamily', $email_typography, array( $this, 'convert_to_email_safe_font' ) );
-		$this->resolve_and_assign( $typography_styles, 'fontSize', $email_typography, array( $this, 'convert_to_px_size' ) );
+		$this->resolve_and_assign(
+			$typography_styles,
+			'fontSize',
+			$email_typography,
+			function ( $value ) use ( $element ) {
+				// Try element-specific fallback first, then global fallback.
+				$fallback = null;
+				if ( $element ) {
+					$fallback = $this->get_base_theme_value( array( 'styles', 'elements', $element, 'typography', 'fontSize' ) );
+				}
+				if ( ! $fallback ) {
+					$fallback = $this->get_base_theme_value( array( 'styles', 'typography', 'fontSize' ) );
+				}
+				return $this->convert_to_px_size( $value, $fallback );
+			}
+		);
 
 		// Handle compatible properties without processing.
 		$compatible_props = array( 'fontWeight', 'fontStyle', 'lineHeight', 'letterSpacing', 'textTransform', 'textDecoration' );
@@ -275,8 +303,23 @@ class Site_Style_Sync_Controller {
 	private function convert_spacing_styles( array $spacing_styles ): array {
 		$email_spacing = array();
 
-		$this->resolve_and_assign( $spacing_styles, 'padding', $email_spacing, array( $this, 'convert_spacing_values' ) );
-		$this->resolve_and_assign( $spacing_styles, 'blockGap', $email_spacing, array( $this, 'convert_to_px_size' ) );
+		$this->resolve_and_assign(
+			$spacing_styles,
+			'padding',
+			$email_spacing,
+			function ( $value ) {
+				return $this->convert_spacing_values( $value, array( 'styles', 'spacing', 'padding' ) );
+			}
+		);
+		$this->resolve_and_assign(
+			$spacing_styles,
+			'blockGap',
+			$email_spacing,
+			function ( $value ) {
+				$fallback = $this->get_base_theme_value( array( 'styles', 'spacing', 'blockGap' ) );
+				return $this->convert_to_px_size( $value, $fallback );
+			}
+		);
 
 		// Note: We intentionally skip margin as it's not supported in email renderer.
 
@@ -297,7 +340,7 @@ class Site_Style_Sync_Controller {
 
 		foreach ( $supported_elements as $element ) {
 			if ( isset( $element_styles[ $element ] ) ) {
-				$email_elements[ $element ] = $this->convert_element_style( $element_styles[ $element ] );
+				$email_elements[ $element ] = $this->convert_element_style( $element_styles[ $element ], $element );
 			}
 		}
 
@@ -307,15 +350,16 @@ class Site_Style_Sync_Controller {
 	/**
 	 * Convert individual element style to email format
 	 *
-	 * @param array $element_style Site element style.
+	 * @param array  $element_style Site element style.
+	 * @param string $element_name Element name (e.g., 'h1', 'h2', 'button').
 	 * @return array Email-compatible element style.
 	 */
-	private function convert_element_style( array $element_style ): array {
+	private function convert_element_style( array $element_style, string $element_name = '' ): array {
 		$email_element = array();
 
 		// Convert typography if present.
 		if ( isset( $element_style['typography'] ) ) {
-			$email_element['typography'] = $this->convert_typography_styles( $element_style['typography'] );
+			$email_element['typography'] = $this->convert_typography_styles( $element_style['typography'], $element_name );
 		}
 
 		// Convert color if present.
@@ -427,44 +471,82 @@ class Site_Style_Sync_Controller {
 	}
 
 	/**
-	 * Convert size value to px format.
+	 * Convert size value to px format with optional fallback
 	 *
-	 * @param string $size Original size value.
+	 * @param string      $size Original size value.
+	 * @param string|null $fallback Fallback value to use if conversion fails.
 	 * @return string Size in px format.
 	 */
-	private function convert_to_px_size( string $size ): string {
+	private function convert_to_px_size( string $size, ?string $fallback = null ): string {
+		$converted = null;
 		// Replace clamp() with its average value.
 		if ( stripos( $size, 'clamp(' ) !== false ) {
-			return Styles_Helper::clamp_to_static_px( $size, 'avg' ) ?? $size;
+			$converted = Styles_Helper::clamp_to_static_px( $size, 'avg' );
+			// If clamp_to_static_px returns the original value, it failed to convert.
+			if ( $converted === $size ) {
+				$converted = null;
+			}
 		}
-		return Styles_Helper::convert_to_px( $size, false ) ?? $size; // Fallback to original value if conversion fails.
+
+		// Try standard conversion.
+		if ( is_null( $converted ) ) {
+			$converted = Styles_Helper::convert_to_px( $size, false );
+		}
+
+		// If all conversions failed, use fallback if provided.
+		if ( is_null( $converted ) && $fallback ) {
+			return $fallback;
+		}
+
+		// Return converted value or original if conversion failed.
+		return $converted ?? $size;
 	}
 
 	/**
 	 * Convert spacing values to px format.
 	 *
 	 * @param string|array $spacing_values Original spacing values.
+	 * @param array        $base_path Base path for fallback lookup (e.g., ['styles', 'spacing', 'padding']).
 	 * @return string|array Spacing values in px format.
 	 */
-	private function convert_spacing_values( $spacing_values ) {
+	private function convert_spacing_values( $spacing_values, array $base_path ) {
 		if ( ! is_string( $spacing_values ) && ! is_array( $spacing_values ) ) {
 			return $spacing_values;
 		}
 
 		if ( is_string( $spacing_values ) ) {
-			return $this->convert_to_px_size( $spacing_values );
+			$fallback = $this->get_base_theme_value( $base_path );
+			return $this->convert_to_px_size( $spacing_values, $fallback );
 		}
 
 		$px_values = array();
 
 		foreach ( $spacing_values as $side => $value ) {
 			if ( is_string( $value ) ) {
-				$px_values[ $side ] = $this->convert_to_px_size( $value );
+				// Build path for side-specific fallback (e.g., ['styles', 'spacing', 'padding', 'top']).
+				$side_path          = array_merge( $base_path, array( $side ) );
+				$fallback           = $this->get_base_theme_value( $side_path );
+				$px_values[ $side ] = $this->convert_to_px_size( $value, $fallback );
 			} else {
 				$px_values[ $side ] = $value;
 			}
 		}
 
 		return $px_values;
+	}
+
+	/**
+	 * Get value from base theme by path
+	 *
+	 * @param array $path Path array for _wp_array_get (e.g., ['styles', 'typography', 'fontSize']).
+	 * @return string|null Value from base theme or null if not found.
+	 */
+	private function get_base_theme_value( array $path ): ?string {
+		if ( ! $this->base_theme_data ) {
+			return null;
+		}
+
+		$value = _wp_array_get( $this->base_theme_data, $path );
+		return is_string( $value ) ? $value : null;
 	}
 }

--- a/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
+++ b/packages/php/email-editor/src/Engine/class-site-style-sync-controller.php
@@ -479,9 +479,9 @@ class Site_Style_Sync_Controller {
 	 */
 	private function convert_to_px_size( string $size, ?string $fallback = null ): string {
 		$converted = null;
-		// Replace clamp() with its average value.
+		// Replace clamp() with its minimum value. We use min because it's emails are most likely to be viewed on smaller screens.
 		if ( stripos( $size, 'clamp(' ) !== false ) {
-			$converted = Styles_Helper::clamp_to_static_px( $size, 'avg' );
+			$converted = Styles_Helper::clamp_to_static_px( $size, 'min' );
 			// If clamp_to_static_px returns the original value, it failed to convert.
 			if ( $converted === $size ) {
 				$converted = null;

--- a/packages/php/email-editor/src/Engine/class-theme-controller.php
+++ b/packages/php/email-editor/src/Engine/class-theme-controller.php
@@ -81,7 +81,7 @@ class Theme_Controller {
 		// Merge synced styles from current active theme.
 		if ( $this->site_style_sync_controller->is_sync_enabled() ) {
 			/** @var WP_Theme_JSON $site_theme */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$site_theme = $this->site_style_sync_controller->get_theme();
+			$site_theme = $this->site_style_sync_controller->get_theme( $theme );
 			$theme->merge( $site_theme );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR improves the handling of unresolvable CSS values when syncing site theme styles to the email editor. When the site theme contains complex CSS functions (like `calc()`, `min()`, `max()`) with CSS variables that cannot be converted to pixel values, the email editor now falls back to base email theme defaults rather than passing through potentially incompatible values.



#### Problem

Email clients have limited CSS support and cannot process complex CSS functions or CSS variables. When syncing site theme styles, values like:

```css
min(calc(var(--wp--custom--spacing-unit) * 2), 2vw)
```

Previously remained unresolved in the email output, causing unpredictable rendering across email clients.

#### Solution

Fallback Mechanism: When CSS value conversion fails, the system now uses email-safe defaults from the base theme (theme.json). This ensures emails always render with predictable, email-client-compatible values rather than potentially broken CSS.

#### Switch to min size strategy for conversion from clamp()

It also chages strategy in the function we use for reading font size from `clamp()`. We newly use `min` strategy (was `avg`). This works better with the Assembler theme, and the change could be supported by the fact that emails are nowadays mostly read on small-screen devices.

Closes WOOPRD-1714.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="760" height="1209" alt="Screenshot 2026-01-22 at 14 44 25" src="https://github.com/user-attachments/assets/abb33803-1c44-47cd-937f-6085a9392c7c" /> | <img width="694" height="1206" alt="Screenshot 2026-01-22 at 14 43 27" src="https://github.com/user-attachments/assets/3ad6790d-4ec3-44b0-939e-1f6069a792cb" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate [Assembler theme](https://wordpress.com/theme/assembler)
2. Go to WooCommerce > Settings > Emails and open an email in the block email editor
3. Observe that heading size is appropriate and there is a default horizontal gap

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I tested the rendering on WPCOM

<img width="666" height="1107" alt="Screenshot 2026-01-22 at 15 31 34" src="https://github.com/user-attachments/assets/e772d2c1-cfe5-4a57-9637-1bf31aba18a0" />


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
