### PR TITLE
Refine Store API product visibility filtering based on query type

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -70,17 +70,34 @@ class ProductsById extends AbstractRoute {
 	}
 
 	/**
-	 * Get a single item.
+	 * Get a single product by ID.
+	 *
+	 * Single product lookups bypass catalog visibility and stock filtering,
+	 * allowing product pages to display any published product regardless of
+	 * visibility settings. Only post status and password protection are enforced.
 	 *
 	 * @throws RouteException On error.
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$object = wc_get_product( (int) $request['id'] );
+		$product_id = (int) $request['id'];
+		$post       = get_post( $product_id );
+
+		// Check post exists and is published.
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			throw new RouteException( 'woocommerce_rest_product_invalid_id', esc_html__( 'Invalid product ID.', 'woocommerce' ), 404 );
+		}
+
+		// Exclude password-protected products.
+		if ( ! empty( $post->post_password ) ) {
+			throw new RouteException( 'woocommerce_rest_product_invalid_id', esc_html__( 'Invalid product ID.', 'woocommerce' ), 404 );
+		}
+
+		$object = wc_get_product( $product_id );
 
 		if ( ! $object || 0 === $object->get_id() ) {
-			throw new RouteException( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), 404 );
+			throw new RouteException( 'woocommerce_rest_product_invalid_id', esc_html__( 'Invalid product ID.', 'woocommerce' ), 404 );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $object ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 
 /**
  * ProductsBySlug class.
@@ -70,7 +71,10 @@ class ProductsBySlug extends AbstractRoute {
 	}
 
 	/**
-	 * Get a single item.
+	 * Get a single item using the same query logic as the collection endpoint.
+	 *
+	 * This ensures that single product requests respect the same visibility
+	 * and stock status filtering as the collection endpoint.
 	 *
 	 * @throws RouteException On error.
 	 * @param \WP_REST_Request $request Request object.
@@ -79,49 +83,19 @@ class ProductsBySlug extends AbstractRoute {
 	protected function get_route_response( \WP_REST_Request $request ) {
 		$slug = sanitize_title( $request['slug'] );
 
-		$object = $this->get_product_by_slug( $slug );
-		if ( ! $object ) {
-			$object = $this->get_product_variation_by_slug( $slug );
+		$collection_request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$collection_request->set_param( 'slug', $slug );
+		$collection_request->set_param( 'per_page', 1 );
+
+		$product_query = new ProductQuery();
+		$query_results = $product_query->get_objects( $collection_request );
+
+		if ( empty( $query_results['objects'] ) || ! $query_results['objects'][0] ) {
+			throw new RouteException( 'woocommerce_rest_product_invalid_slug', esc_html__( 'Invalid product slug.', 'woocommerce' ), 404 );
 		}
 
-		if ( ! $object || 0 === $object->get_id() ) {
-			throw new RouteException( 'woocommerce_rest_product_invalid_slug', __( 'Invalid product slug.', 'woocommerce' ), 404 );
-		}
+		$object = $query_results['objects'][0];
 
 		return rest_ensure_response( $this->schema->get_item_response( $object ) );
-	}
-
-	/**
-	 * Get a product  by slug.
-	 *
-	 * @param string $slug The slug of the product.
-	 */
-	public function get_product_by_slug( $slug ) {
-		return wc_get_product( get_page_by_path( $slug, OBJECT, 'product' ) );
-	}
-
-	/**
-	 * Get a product variation by slug.
-	 *
-	 * @param string $slug The slug of the product variation.
-	 */
-	private function get_product_variation_by_slug( $slug ) {
-		global $wpdb;
-
-		$result = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT ID, post_name, post_parent, post_type
-				FROM $wpdb->posts
-				WHERE post_name = %s
-				AND post_type = 'product_variation'",
-				$slug
-			)
-		);
-
-		if ( ! $result ) {
-			return null;
-		}
-
-		return wc_get_product( $result[0]->ID );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -39,6 +39,7 @@ class ProductQuery implements QueryClausesGenerator {
 			'post_status'         => ProductStatus::PUBLISH,
 			'date_query'          => array(),
 			'post_type'           => 'product',
+			'has_password'        => false, // Exclude password-protected products from Store API responses.
 		);
 
 		// If searching for a specific SKU or slug, allow any post type.
@@ -207,7 +208,12 @@ class ProductQuery implements QueryClausesGenerator {
 		$rating             = $request->get_param( 'rating' );
 		$visibility_options = wc_get_product_visibility_options();
 
-		if ( in_array( $catalog_visibility, array_keys( $visibility_options ), true ) ) {
+		// Determine query type for visibility filtering.
+		$is_direct_lookup = ! empty( $request['include'] ) || ! empty( $request['slug'] ) || ! empty( $request['sku'] );
+		$is_search_query  = ! empty( $request['search'] ) && '' !== $request->get_param( 'search' );
+
+		if ( $catalog_visibility && in_array( $catalog_visibility, array_keys( $visibility_options ), true ) ) {
+			// Explicit catalog_visibility param - use existing logic.
 			$exclude_from_catalog = CatalogVisibility::SEARCH === $catalog_visibility ? '' : 'exclude-from-catalog';
 			$exclude_from_search  = CatalogVisibility::CATALOG === $catalog_visibility ? '' : 'exclude-from-search';
 
@@ -217,6 +223,28 @@ class ProductQuery implements QueryClausesGenerator {
 				'terms'         => array( $exclude_from_catalog, $exclude_from_search ),
 				'operator'      => CatalogVisibility::HIDDEN === $catalog_visibility ? 'AND' : 'NOT IN',
 				'rating_filter' => true,
+			);
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif -- Intentionally empty for direct lookups.
+		} elseif ( $is_direct_lookup ) {
+			// Direct lookups (include, slug, sku) - no catalog visibility filtering.
+			// These queries are for specific product access, not catalog browsing.
+		} elseif ( $is_search_query ) {
+			// Search queries - exclude products hidden from search.
+			$args['tax_query'][] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'name',
+				'terms'    => array( 'exclude-from-search' ),
+				'operator' => 'NOT IN',
+			);
+		} else {
+			// Default catalog view - exclude products hidden from catalog.
+			// This excludes products with 'exclude-from-catalog' visibility term,
+			// which includes both "Search results only" and "Hidden" products.
+			$args['tax_query'][] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'name',
+				'terms'    => array( 'exclude-from-catalog' ),
+				'operator' => 'NOT IN',
 			);
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductVisibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductVisibilityTest.php
@@ -1,0 +1,513 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Enums\CatalogVisibility;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Tests for product visibility filtering in Store API routes.
+ *
+ * The Store API has nuanced visibility filtering based on query type:
+ * - products/$id: Bypasses visibility and stock filtering (for product pages)
+ * - products?include=$ids: Bypasses catalog visibility, applies stock filtering
+ * - products?slug=$slug: Bypasses catalog visibility, applies stock filtering
+ * - products?sku=$sku: Bypasses catalog visibility, applies stock filtering
+ * - products?search=$term: Applies search visibility filtering, applies stock filtering
+ * - products (no params): Applies catalog visibility filtering, applies stock filtering
+ *
+ * Password-protected products are always filtered from all Store API responses.
+ */
+class ProductVisibilityTest extends ControllerTestCase {
+
+	/**
+	 * Visible product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $visible_product;
+
+	/**
+	 * Hidden product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $hidden_product;
+
+	/**
+	 * Catalog-only product (Shop only - visible in catalog, hidden from search).
+	 *
+	 * @var \WC_Product
+	 */
+	private $catalog_only_product;
+
+	/**
+	 * Search-only product (Search results only - visible in search, hidden from catalog).
+	 *
+	 * @var \WC_Product
+	 */
+	private $search_only_product;
+
+	/**
+	 * Out of stock product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $out_of_stock_product;
+
+	/**
+	 * Password-protected product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $password_protected_product;
+
+	/**
+	 * Draft product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $draft_product;
+
+	/**
+	 * Store original option value.
+	 *
+	 * @var string
+	 */
+	private $original_hide_out_of_stock;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_hide_out_of_stock = get_option( 'woocommerce_hide_out_of_stock_items', 'no' );
+
+		$fixtures = new FixtureData();
+
+		$this->visible_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Visible Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$this->visible_product->set_catalog_visibility( CatalogVisibility::VISIBLE );
+		$this->visible_product->save();
+
+		$this->hidden_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Hidden Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$this->hidden_product->set_catalog_visibility( CatalogVisibility::HIDDEN );
+		$this->hidden_product->save();
+
+		$this->catalog_only_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Catalog Only Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$this->catalog_only_product->set_catalog_visibility( CatalogVisibility::CATALOG );
+		$this->catalog_only_product->save();
+
+		$this->search_only_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Search Only Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$this->search_only_product->set_catalog_visibility( CatalogVisibility::SEARCH );
+		$this->search_only_product->save();
+
+		$this->out_of_stock_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Out of Stock Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::OUT_OF_STOCK,
+			)
+		);
+		$this->out_of_stock_product->set_catalog_visibility( CatalogVisibility::VISIBLE );
+		$this->out_of_stock_product->save();
+
+		$this->password_protected_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Password Protected Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+		$this->password_protected_product->set_catalog_visibility( CatalogVisibility::VISIBLE );
+		$this->password_protected_product->save();
+
+		wp_update_post(
+			array(
+				'ID'            => $this->password_protected_product->get_id(),
+				'post_password' => 'secret',
+			)
+		);
+
+		$this->draft_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Draft Product',
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+				'status'        => 'draft',
+			)
+		);
+		$this->draft_product->set_catalog_visibility( CatalogVisibility::VISIBLE );
+		$this->draft_product->save();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', $this->original_hide_out_of_stock );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Single product endpoint returns hidden product (bypasses visibility).
+	 */
+	public function test_single_product_returns_hidden_product(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->hidden_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Hidden product should be accessible by ID' );
+		$this->assertEquals( $this->hidden_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns search-only product (bypasses visibility).
+	 */
+	public function test_single_product_returns_search_only_product(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->search_only_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Search-only product should be accessible by ID' );
+		$this->assertEquals( $this->search_only_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns out of stock product (bypasses stock filtering).
+	 */
+	public function test_single_product_returns_out_of_stock_product(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->out_of_stock_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Out of stock product should be accessible by ID even when hide option is enabled' );
+		$this->assertEquals( $this->out_of_stock_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns 404 for password-protected product.
+	 */
+	public function test_single_product_returns_404_for_password_protected(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->password_protected_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status(), 'Password-protected product should return 404' );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns 404 for draft product.
+	 */
+	public function test_single_product_returns_404_for_draft(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->draft_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status(), 'Draft product should return 404' );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns visible product.
+	 */
+	public function test_single_product_returns_visible_product(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->visible_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $this->visible_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Single product endpoint returns catalog-only product.
+	 */
+	public function test_single_product_returns_catalog_only_product(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->catalog_only_product->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $this->catalog_only_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Collection with include param returns hidden product (bypasses visibility).
+	 */
+	public function test_collection_with_include_returns_hidden_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'include', array( $this->hidden_product->get_id() ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->hidden_product->get_id(), $product_ids, 'Hidden product should be returned with include parameter' );
+	}
+
+	/**
+	 * @testdox Collection with include param respects stock status filtering.
+	 */
+	public function test_collection_with_include_respects_stock_status(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'include', array( $this->out_of_stock_product->get_id() ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $data, 'Out of stock product should not be returned with include parameter when hide option is enabled' );
+	}
+
+	/**
+	 * @testdox Collection with include param excludes password-protected product.
+	 */
+	public function test_collection_with_include_excludes_password_protected(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'include', array( $this->password_protected_product->get_id() ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $data, 'Password-protected product should not be returned with include parameter' );
+	}
+
+	/**
+	 * @testdox Collection with slug param returns hidden product (bypasses visibility).
+	 */
+	public function test_collection_with_slug_returns_hidden_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'slug', $this->hidden_product->get_slug() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->hidden_product->get_id(), $product_ids, 'Hidden product should be returned with slug parameter' );
+	}
+
+	/**
+	 * @testdox Collection with slug param excludes password-protected product.
+	 */
+	public function test_collection_with_slug_excludes_password_protected(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'slug', $this->password_protected_product->get_slug() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $data, 'Password-protected product should not be returned with slug parameter' );
+	}
+
+	/**
+	 * @testdox Products by slug endpoint returns hidden product (bypasses visibility).
+	 */
+	public function test_products_by_slug_endpoint_returns_hidden_product(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->hidden_product->get_slug() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Hidden product should be accessible by slug' );
+		$this->assertEquals( $this->hidden_product->get_id(), $data['id'] );
+	}
+
+	/**
+	 * @testdox Products by slug endpoint returns 404 for password-protected product.
+	 */
+	public function test_products_by_slug_endpoint_returns_404_for_password_protected(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->password_protected_product->get_slug() );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status(), 'Password-protected product should return 404 by slug' );
+	}
+
+	/**
+	 * @testdox Search query returns search-only product.
+	 */
+	public function test_search_returns_search_only_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'search', 'Search Only' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->search_only_product->get_id(), $product_ids, 'Search-only product should be returned in search results' );
+	}
+
+	/**
+	 * @testdox Search query excludes catalog-only product.
+	 */
+	public function test_search_excludes_catalog_only_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'search', 'Catalog Only' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertNotContains( $this->catalog_only_product->get_id(), $product_ids, 'Catalog-only product should be excluded from search results' );
+	}
+
+	/**
+	 * @testdox Search query excludes hidden product.
+	 */
+	public function test_search_excludes_hidden_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'search', 'Hidden' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertNotContains( $this->hidden_product->get_id(), $product_ids, 'Hidden product should be excluded from search results' );
+	}
+
+	/**
+	 * @testdox Search query excludes password-protected product.
+	 */
+	public function test_search_excludes_password_protected_product(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'search', 'Password Protected' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertNotContains( $this->password_protected_product->get_id(), $product_ids, 'Password-protected product should be excluded from search results' );
+	}
+
+	/**
+	 * @testdox Collection endpoint excludes hidden products by default.
+	 */
+	public function test_collection_excludes_hidden_products(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->visible_product->get_id(), $product_ids, 'Visible product should be included' );
+		$this->assertContains( $this->catalog_only_product->get_id(), $product_ids, 'Catalog-only product should be included' );
+		$this->assertNotContains( $this->hidden_product->get_id(), $product_ids, 'Hidden product should be excluded' );
+		$this->assertNotContains( $this->search_only_product->get_id(), $product_ids, 'Search-only product should be excluded from catalog view' );
+	}
+
+	/**
+	 * @testdox Collection endpoint excludes password-protected products.
+	 */
+	public function test_collection_excludes_password_protected_products(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertNotContains( $this->password_protected_product->get_id(), $product_ids, 'Password-protected product should be excluded' );
+	}
+
+	/**
+	 * @testdox Collection endpoint can explicitly request hidden products.
+	 */
+	public function test_collection_can_request_hidden_visibility(): void {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'catalog_visibility', CatalogVisibility::HIDDEN );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->hidden_product->get_id(), $product_ids, 'Hidden product should be returned when explicitly requested' );
+		$this->assertNotContains( $this->visible_product->get_id(), $product_ids, 'Visible product should be excluded when requesting hidden visibility' );
+	}
+
+	/**
+	 * @testdox Collection endpoint excludes out of stock products when option is enabled.
+	 */
+	public function test_collection_excludes_out_of_stock_when_option_enabled(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->visible_product->get_id(), $product_ids, 'In-stock product should be included' );
+		$this->assertNotContains( $this->out_of_stock_product->get_id(), $product_ids, 'Out of stock product should be excluded' );
+	}
+
+	/**
+	 * @testdox Collection endpoint includes out of stock products when option is disabled.
+	 */
+	public function test_collection_includes_out_of_stock_when_option_disabled(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertContains( $this->visible_product->get_id(), $product_ids, 'In-stock product should be included' );
+		$this->assertContains( $this->out_of_stock_product->get_id(), $product_ids, 'Out of stock product should be included when option is disabled' );
+	}
+
+	/**
+	 * @testdox Collection endpoint excludes draft products.
+	 */
+	public function test_collection_excludes_draft_products(): void {
+		$request  = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product_ids = array_column( $data, 'id' );
+
+		$this->assertNotContains( $this->draft_product->get_id(), $product_ids, 'Draft product should be excluded' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR refines the Store API product visibility filtering to provide nuanced behavior based on query type:

| Query Type | Catalog Visibility | Stock Visibility | Password | Post Status |
|------------|-------------------|------------------|----------|-------------|
| `products/$id` | ❌ Ignore | ❌ Ignore | ✅ Filter | ✅ Apply |
| `products?include=$ids` | ❌ Ignore | ✅ Apply | ✅ Filter | ✅ Apply |
| `products?slug=$slug` | ❌ Ignore | ✅ Apply | ✅ Filter | ✅ Apply |
| `products?sku=$sku` | ❌ Ignore | ✅ Apply | ✅ Filter | ✅ Apply |
| `products?search=$term` | ✅ Apply (search) | ✅ Apply | ✅ Filter | ✅ Apply |
| `products` (no params) | ✅ Apply (catalog) | ✅ Apply | ✅ Filter | ✅ Apply |

**Key changes:**
- **Single product lookups** (`products/$id`) now bypass ALL visibility and stock filtering, allowing product pages to display any published product regardless of catalog visibility settings
- **Direct lookups** via `include`, `slug`, or `sku` params bypass catalog visibility but still apply stock filtering
- **Search queries** apply search-specific visibility filtering (excludes products marked "hidden from search")
- **Password-protected products** are filtered from ALL Store API responses (new `has_password => false` query arg)
- **ProductsById** rewritten to use direct `wc_get_product()` with explicit post status and password checks
- **ProductsBySlug** now uses `ProductQuery` for consistent filtering behavior

### Screenshots or screen recordings:

N/A - This is a backend API change with no UI changes.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create test products with various visibility settings:
   - A visible product (catalog visibility: "Shop and search results")
   - A hidden product (catalog visibility: "Hidden")
   - A catalog-only product (catalog visibility: "Shop only")
   - A search-only product (catalog visibility: "Search results only")
   - An out-of-stock product
   - A password-protected product
   - A draft product

2. Test single product by ID endpoint (`/wc/store/v1/products/{id}`):
   - ✅ Hidden product should return 200 (bypasses visibility)
   - ✅ Out-of-stock product should return 200 (bypasses stock filtering)
   - ❌ Password-protected product should return 404
   - ❌ Draft product should return 404

3. Test collection with include param (`/wc/store/v1/products?include={id}`):
   - ✅ Hidden product should be returned (bypasses catalog visibility)
   - ❌ Out-of-stock product should NOT be returned when `woocommerce_hide_out_of_stock_items=yes`
   - ❌ Password-protected product should NOT be returned

4. Test search queries (`/wc/store/v1/products?search=term`):
   - ✅ Search-only products should be returned
   - ❌ Catalog-only products should NOT be returned
   - ❌ Hidden products should NOT be returned

5. Test default collection (`/wc/store/v1/products`):
   - ✅ Visible and catalog-only products should be returned
   - ❌ Hidden, search-only, password-protected, and draft products should NOT be returned

### Testing that has already taken place:

- Unit tests added covering all visibility scenarios (24 tests, 51 assertions)
- All existing Store API tests pass
- PHP linting passes with no errors

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Store API: Refine product visibility filtering - single product lookups now bypass catalog visibility for product pages, password-protected products filtered from all responses.

</details>