### PR TITLE
[Performance] Comments: use `akismet_excluded_comment_types`hook to filter out product notes

### DIFF
--- a/plugins/woocommerce/changelog/perfromance-61916-akismet-comments-count-integration
+++ b/plugins/woocommerce/changelog/perfromance-61916-akismet-comments-count-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Integrate the `akismet_excluded_comment_types` hook from `Akismet::get_user_comments_approved()` to ensure order notes are excluded from the count.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -125,6 +125,8 @@ class WC_Comments {
 	/**
 	 * Exclude order comments from Akismet comments counting SQL queries for better performance.
 	 *
+	 * @since 10.6.0
+	 *
 	 * @param string[] $comment_types Excluded comments types.
 	 * @return string[]
 	 */

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -45,8 +45,9 @@ class WC_Comments {
 		add_action( 'wp_update_comment_count', array( __CLASS__, 'clear_transients' ) );
 
 		// Secure order notes.
-		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_order_comments' ), 10, 1 );
+		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_order_comments' ) );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_order_comments_from_feed_where' ) );
+		add_filter( 'akismet_excluded_comment_types', array( __CLASS__, 'akismet_excluded_comment_types' ) );
 
 		// Secure webhook comments.
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
@@ -119,6 +120,17 @@ class WC_Comments {
 	public static function exclude_order_comments( $clauses ) {
 		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 		return $clauses;
+	}
+
+	/**
+	 * Exclude order comments from Akismet comments counting SQL queries for better performance.
+	 *
+	 * @param string[] $comment_types Excluded comments types.
+	 * @return string[]
+	 */
+	public static function akismet_excluded_comment_types( $comment_types ): array {
+		$comment_types[] = 'order_note';
+		return $comment_types;
 	}
 
 	/**
@@ -317,6 +329,7 @@ class WC_Comments {
 	private static function is_comment_excluded_from_wp_comment_counts( $comment ) {
 		return in_array( $comment->comment_type, array( 'action_log', 'order_note', 'webhook_delivery' ), true )
 			|| get_post_type( $comment->comment_post_ID ) === 'product';
+		// Marker
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -329,7 +329,6 @@ class WC_Comments {
 	private static function is_comment_excluded_from_wp_comment_counts( $comment ) {
 		return in_array( $comment->comment_type, array( 'action_log', 'order_note', 'webhook_delivery' ), true )
 			|| get_post_type( $comment->comment_post_ID ) === 'product';
-		// Marker
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -142,4 +142,12 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		// Clean up.
 		wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Test hook akismet_excluded_comment_types integration.
+	 */
+	public function test_integrates_akismet_excluded_comment_types(): void {
+		$this->assertTrue( has_filter( 'akismet_excluded_comment_types' ) );
+		$this->assertSame( array( 'order_note' ), apply_filters( 'akismet_excluded_comment_types', array() ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -148,6 +148,7 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 	 */
 	public function test_integrates_akismet_excluded_comment_types(): void {
 		$this->assertTrue( has_filter( 'akismet_excluded_comment_types' ) );
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertSame( array( 'order_note' ), apply_filters( 'akismet_excluded_comment_types', array() ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #61916, WOOPLUG-5843.

Integrate `akismet_excluded_comment_types` hook from `Akismet::get_user_comments_approved()` to remove order notes from counting.

### How to test the changes in this Pull Request:

- covered by UTs
