### PR TITLE
Fix PHPStan errors in wc_get_product_attachment_props()

### DIFF
--- a/plugins/woocommerce/changelog/62919-fix-phpstan-wc-get-product-attachment-props
+++ b/plugins/woocommerce/changelog/62919-fix-phpstan-wc-get-product-attachment-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHPStan errors in wc_get_product_attachment_props() by adding is_array() checks before accessing array offsets.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1209,15 +1209,9 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		 */
 		$full_size = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 		$src       = wp_get_attachment_image_src( $attachment_id, $full_size );
-		if ( is_array( $src ) ) {
-			$props['full_src']   = $src[0];
-			$props['full_src_w'] = $src[1];
-			$props['full_src_h'] = $src[2];
-		} else {
-			$props['full_src']   = null;
-			$props['full_src_w'] = null;
-			$props['full_src_h'] = null;
-		}
+		$props['full_src']   = $src[0] ?? null;
+		$props['full_src_w'] = $src[1] ?? null;
+		$props['full_src_h'] = $src[2] ?? null;
 
 		$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 		/**
@@ -1228,15 +1222,9 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		 */
 		$gallery_thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
 		$src                    = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
-		if ( is_array( $src ) ) {
-			$props['gallery_thumbnail_src']   = $src[0];
-			$props['gallery_thumbnail_src_w'] = $src[1];
-			$props['gallery_thumbnail_src_h'] = $src[2];
-		} else {
-			$props['gallery_thumbnail_src']   = null;
-			$props['gallery_thumbnail_src_w'] = null;
-			$props['gallery_thumbnail_src_h'] = null;
-		}
+		$props['gallery_thumbnail_src']   = $src[0] ?? null;
+		$props['gallery_thumbnail_src_w'] = $src[1] ?? null;
+		$props['gallery_thumbnail_src_h'] = $src[2] ?? null;
 
 		/**
 		 * Filters the thumbnail size.
@@ -1246,15 +1234,9 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		 */
 		$thumbnail_size = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
 		$src            = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
-		if ( is_array( $src ) ) {
-			$props['thumb_src']   = $src[0];
-			$props['thumb_src_w'] = $src[1];
-			$props['thumb_src_h'] = $src[2];
-		} else {
-			$props['thumb_src']   = null;
-			$props['thumb_src_w'] = null;
-			$props['thumb_src_h'] = null;
-		}
+		$props['thumb_src']   = $src[0] ?? null;
+		$props['thumb_src_w'] = $src[1] ?? null;
+		$props['thumb_src_h'] = $src[2] ?? null;
 
 		// Image source.
 		/**
@@ -1265,15 +1247,9 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		 */
 		$image_size = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
 		$src        = wp_get_attachment_image_src( $attachment_id, $image_size );
-		if ( is_array( $src ) ) {
-			$props['src']   = $src[0];
-			$props['src_w'] = $src[1];
-			$props['src_h'] = $src[2];
-		} else {
-			$props['src']   = null;
-			$props['src_w'] = null;
-			$props['src_h'] = null;
-		}
+		$props['src']   = $src[0] ?? null;
+		$props['src_w'] = $src[1] ?? null;
+		$props['src_h'] = $src[2] ?? null;
 		$props['srcset'] = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $attachment_id, $image_size ) : false;
 		$props['sizes']  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $attachment_id, $image_size ) : false;
 	}

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1202,6 +1202,16 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$props['alt'] = $alt_text ? reset( $alt_text ) : '';
 
 		// Large version.
+		/**
+		 * Filters the size for the product thumbnails large size.
+		 *
+		 * @param string $size Image size name.
+		 */
+		/**
+		 * Filters the size for the full gallery image.
+		 *
+		 * @param string $size Image size name.
+		 */
 		$full_size = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 		$src       = wp_get_attachment_image_src( $attachment_id, $full_size );
 		if ( is_array( $src ) ) {
@@ -1211,7 +1221,12 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		}
 
 		// Gallery thumbnail.
-		$gallery_thumbnail      = wc_get_image_size( 'gallery_thumbnail' );
+		$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
+		/**
+		 * Filters the size for the gallery thumbnail.
+		 *
+		 * @param array $size Array containing width and height dimensions.
+		 */
 		$gallery_thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
 		$src                    = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
 		if ( is_array( $src ) ) {
@@ -1221,6 +1236,11 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		}
 
 		// Thumbnail version.
+		/**
+		 * Filters the thumbnail size.
+		 *
+		 * @param string $size Image size name.
+		 */
 		$thumbnail_size = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
 		$src            = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 		if ( is_array( $src ) ) {
@@ -1230,6 +1250,11 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		}
 
 		// Image source.
+		/**
+		 * Filters the size for the gallery image.
+		 *
+		 * @param string $size Image size name.
+		 */
 		$image_size = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
 		$src        = wp_get_attachment_image_src( $attachment_id, $image_size );
 		if ( is_array( $src ) ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1202,12 +1202,6 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$props['alt'] = $alt_text ? reset( $alt_text ) : '';
 
 		/**
-		 * Filters the size for the product thumbnails large size.
-		 *
-		 * @since 2.6.0
-		 * @param string $size Image size name.
-		 */
-		/**
 		 * Filters the size for the full gallery image.
 		 *
 		 * @since 2.6.0

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1202,33 +1202,41 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$props['alt'] = $alt_text ? reset( $alt_text ) : '';
 
 		// Large version.
-		$full_size           = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
-		$src                 = wp_get_attachment_image_src( $attachment_id, $full_size );
-		$props['full_src']   = $src[0];
-		$props['full_src_w'] = $src[1];
-		$props['full_src_h'] = $src[2];
+		$full_size = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
+		$src       = wp_get_attachment_image_src( $attachment_id, $full_size );
+		if ( is_array( $src ) ) {
+			$props['full_src']   = $src[0];
+			$props['full_src_w'] = $src[1];
+			$props['full_src_h'] = $src[2];
+		}
 
 		// Gallery thumbnail.
-		$gallery_thumbnail                = wc_get_image_size( 'gallery_thumbnail' );
-		$gallery_thumbnail_size           = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-		$src                              = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
-		$props['gallery_thumbnail_src']   = $src[0];
-		$props['gallery_thumbnail_src_w'] = $src[1];
-		$props['gallery_thumbnail_src_h'] = $src[2];
+		$gallery_thumbnail      = wc_get_image_size( 'gallery_thumbnail' );
+		$gallery_thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+		$src                    = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
+		if ( is_array( $src ) ) {
+			$props['gallery_thumbnail_src']   = $src[0];
+			$props['gallery_thumbnail_src_w'] = $src[1];
+			$props['gallery_thumbnail_src_h'] = $src[2];
+		}
 
 		// Thumbnail version.
-		$thumbnail_size       = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
-		$src                  = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
-		$props['thumb_src']   = $src[0];
-		$props['thumb_src_w'] = $src[1];
-		$props['thumb_src_h'] = $src[2];
+		$thumbnail_size = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
+		$src            = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+		if ( is_array( $src ) ) {
+			$props['thumb_src']   = $src[0];
+			$props['thumb_src_w'] = $src[1];
+			$props['thumb_src_h'] = $src[2];
+		}
 
 		// Image source.
-		$image_size      = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
-		$src             = wp_get_attachment_image_src( $attachment_id, $image_size );
-		$props['src']    = $src[0];
-		$props['src_w']  = $src[1];
-		$props['src_h']  = $src[2];
+		$image_size = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
+		$src        = wp_get_attachment_image_src( $attachment_id, $image_size );
+		if ( is_array( $src ) ) {
+			$props['src']   = $src[0];
+			$props['src_w'] = $src[1];
+			$props['src_h'] = $src[2];
+		}
 		$props['srcset'] = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $attachment_id, $image_size ) : false;
 		$props['sizes']  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $attachment_id, $image_size ) : false;
 	}

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1201,15 +1201,16 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$alt_text     = array_filter( $alt_text );
 		$props['alt'] = $alt_text ? reset( $alt_text ) : '';
 
-		// Large version.
 		/**
 		 * Filters the size for the product thumbnails large size.
 		 *
+		 * @since 2.6.0
 		 * @param string $size Image size name.
 		 */
 		/**
 		 * Filters the size for the full gallery image.
 		 *
+		 * @since 2.6.0
 		 * @param string $size Image size name.
 		 */
 		$full_size = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
@@ -1218,13 +1219,17 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 			$props['full_src']   = $src[0];
 			$props['full_src_w'] = $src[1];
 			$props['full_src_h'] = $src[2];
+		} else {
+			$props['full_src']   = null;
+			$props['full_src_w'] = null;
+			$props['full_src_h'] = null;
 		}
 
-		// Gallery thumbnail.
 		$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 		/**
 		 * Filters the size for the gallery thumbnail.
 		 *
+		 * @since 2.6.0
 		 * @param array $size Array containing width and height dimensions.
 		 */
 		$gallery_thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
@@ -1233,12 +1238,16 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 			$props['gallery_thumbnail_src']   = $src[0];
 			$props['gallery_thumbnail_src_w'] = $src[1];
 			$props['gallery_thumbnail_src_h'] = $src[2];
+		} else {
+			$props['gallery_thumbnail_src']   = null;
+			$props['gallery_thumbnail_src_w'] = null;
+			$props['gallery_thumbnail_src_h'] = null;
 		}
 
-		// Thumbnail version.
 		/**
 		 * Filters the thumbnail size.
 		 *
+		 * @since 2.6.0
 		 * @param string $size Image size name.
 		 */
 		$thumbnail_size = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
@@ -1247,12 +1256,17 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 			$props['thumb_src']   = $src[0];
 			$props['thumb_src_w'] = $src[1];
 			$props['thumb_src_h'] = $src[2];
+		} else {
+			$props['thumb_src']   = null;
+			$props['thumb_src_w'] = null;
+			$props['thumb_src_h'] = null;
 		}
 
 		// Image source.
 		/**
 		 * Filters the size for the gallery image.
 		 *
+		 * @since 2.6.0
 		 * @param string $size Image size name.
 		 */
 		$image_size = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
@@ -1261,6 +1275,10 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 			$props['src']   = $src[0];
 			$props['src_w'] = $src[1];
 			$props['src_h'] = $src[2];
+		} else {
+			$props['src']   = null;
+			$props['src_w'] = null;
+			$props['src_h'] = null;
 		}
 		$props['srcset'] = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $attachment_id, $image_size ) : false;
 		$props['sizes']  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $attachment_id, $image_size ) : false;

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1204,11 +1204,12 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		/**
 		 * Filters the size for the full gallery image.
 		 *
-		 * @since 2.6.0
 		 * @param string $size Image size name.
+		 *
+		 * @since 2.6.0
 		 */
-		$full_size = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
-		$src       = wp_get_attachment_image_src( $attachment_id, $full_size );
+		$full_size           = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
+		$src                 = wp_get_attachment_image_src( $attachment_id, $full_size );
 		$props['full_src']   = $src[0] ?? null;
 		$props['full_src_w'] = $src[1] ?? null;
 		$props['full_src_h'] = $src[2] ?? null;
@@ -1217,11 +1218,12 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		/**
 		 * Filters the size for the gallery thumbnail.
 		 *
-		 * @since 2.6.0
 		 * @param array $size Array containing width and height dimensions.
+		 *
+		 * @since 2.6.0
 		 */
-		$gallery_thumbnail_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-		$src                    = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
+		$gallery_thumbnail_size           = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+		$src                              = wp_get_attachment_image_src( $attachment_id, $gallery_thumbnail_size );
 		$props['gallery_thumbnail_src']   = $src[0] ?? null;
 		$props['gallery_thumbnail_src_w'] = $src[1] ?? null;
 		$props['gallery_thumbnail_src_h'] = $src[2] ?? null;
@@ -1229,27 +1231,28 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		/**
 		 * Filters the thumbnail size.
 		 *
-		 * @since 2.6.0
 		 * @param string $size Image size name.
+		 *
+		 * @since 2.6.0
 		 */
-		$thumbnail_size = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
-		$src            = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+		$thumbnail_size       = apply_filters( 'woocommerce_thumbnail_size', 'woocommerce_thumbnail' );
+		$src                  = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 		$props['thumb_src']   = $src[0] ?? null;
 		$props['thumb_src_w'] = $src[1] ?? null;
 		$props['thumb_src_h'] = $src[2] ?? null;
 
-		// Image source.
 		/**
 		 * Filters the size for the gallery image.
 		 *
-		 * @since 2.6.0
 		 * @param string $size Image size name.
+		 *
+		 * @since 2.6.0
 		 */
-		$image_size = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
-		$src        = wp_get_attachment_image_src( $attachment_id, $image_size );
-		$props['src']   = $src[0] ?? null;
-		$props['src_w'] = $src[1] ?? null;
-		$props['src_h'] = $src[2] ?? null;
+		$image_size      = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
+		$src             = wp_get_attachment_image_src( $attachment_id, $image_size );
+		$props['src']    = $src[0] ?? null;
+		$props['src_w']  = $src[1] ?? null;
+		$props['src_h']  = $src[2] ?? null;
 		$props['srcset'] = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $attachment_id, $image_size ) : false;
 		$props['sizes']  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $attachment_id, $image_size ) : false;
 	}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -40552,24 +40552,6 @@ parameters:
 			path: includes/wc-product-functions.php
 
 		-
-			message: '#^Cannot access offset 0 on array\{string, int, int, bool\}\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: includes/wc-product-functions.php
-
-		-
-			message: '#^Cannot access offset 1 on array\{string, int, int, bool\}\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: includes/wc-product-functions.php
-
-		-
-			message: '#^Cannot access offset 2 on array\{string, int, int, bool\}\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: includes/wc-product-functions.php
-
-		-
 			message: '#^Cannot access property \$slug on WP_Error\|WP_Term\|null\.$#'
 			identifier: property.nonObject
 			count: 2


### PR DESCRIPTION
## Summary

Fixes PHPStan errors in `wc_get_product_attachment_props()` by adding `is_array()` checks before accessing array offsets from `wp_get_attachment_image_src()`.

## Changes

- Add `is_array()` checks before accessing array offsets in four locations where `wp_get_attachment_image_src()` is called
- This prevents PHPStan errors about accessing offsets on potentially false values

## Technical Details

`wp_get_attachment_image_src()` returns `array<int, int|string>|false`, but the code was accessing array indices directly without checking the return type. This change adds defensive checks to ensure the value is an array before accessing its indices.

The fix is applied in four places:
- Lines 1207-1210: Full size image
- Lines 1217-1220: Gallery thumbnail
- Lines 1226-1229: Thumbnail version  
- Lines 1235-1237: Image source

## Testing

- Verified PHPStan errors are resolved
- No functional changes - when `wp_get_attachment_image_src()` returns false, the props simply won't be set (which is the desired behavior)

Fixes WOOPLUG-6174