### PR TITLE
Fix: render order checkboxes correctly for HPOS-only orders

### DIFF
--- a/plugins/woocommerce/changelog/62924-fix-62159-cap-check
+++ b/plugins/woocommerce/changelog/62924-fix-62159-cap-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bulk action checkboxes on the Orders page for some users when HPOS is enabled.

--- a/plugins/woocommerce/changelog/62924-fix-62159-cap-check
+++ b/plugins/woocommerce/changelog/62924-fix-62159-cap-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix bulk action checkboxes on the Orders page for some users when HPOS is enabled.
+Fix bulk action checkboxes not displaying on the Orders page for some users when HPOS is enabled.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1084,7 +1084,7 @@ class ListTable extends WP_List_Table {
 		}
 
 		$capability = OrderUtil::custom_orders_table_usage_is_enabled()
-			? 'edit_shop_orders'
+			? $this->wp_post_type->cap->edit_posts
 			: $this->wp_post_type->cap->edit_post;
 
 		if (! current_user_can($capability, $item->get_id())) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1079,7 +1079,15 @@ class ListTable extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $item ) {
-		if ( ! $this->wp_post_type || ! current_user_can( $this->wp_post_type->cap->edit_post, $item->get_id() ) ) {
+		if (! $this->wp_post_type) {
+			return;
+		}
+
+		$capability = OrderUtil::custom_orders_table_usage_is_enabled()
+			? 'edit_shop_orders'
+			: $this->wp_post_type->cap->edit_post;
+
+		if (! current_user_can($capability, $item->get_id())) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Summary**
Fixes order bulk-action checkboxes not rendering when HPOS is enabled by using the correct capability check, while preserving legacy (CPT-backed) behavior.

**What was happening**
The checkbox renderer gated access using a post-based meta capability:

`current_user_can( $post_type->cap->edit_post, $order_id )`

- For meta caps like edit_post, WordPress resolves permissions by loading the post via get_post( $order_id ) to determine post type, author, and status.
- When HPOS is enabled, orders may not have a corresponding row in wp_posts, causing get_post( $order_id ) to return false.

In this scenario, WordPress cannot resolve the order’s post-type-specific capabilities and the meta-cap mapping may fall back to generic post caps (e.g. edit_others_posts) instead of order caps (e.g. edit_others_shop_orders). This results in inconsistent behavior where bulk action checkboxes would not render as expected.

**Why this went unnoticed**
- The check continued to pass for users who also had generic post editing capabilities (such as admins or editor-like roles), making the issue appear benign.
- It failed for roles correctly scoped to orders only (e.g. users with edit_others_shop_orders but not edit_others_posts), causing bulk-action checkboxes to disappear unexpectedly.

**What this change does**
- Uses the appropriate primitive order capability (edit_shop_orders) when HPOS is enabled, avoiding reliance on get_post().
- Preserves the existing per-order meta-cap check (edit_post) for legacy, CPT-backed order storage.
- Limits changes strictly to the capability gate; no UI or behavioral changes otherwise.

**Result**
- Bulk-action checkboxes render correctly for HPOS-only orders, and permission checks are consistently enforced based on order capabilities rather than generic post fallbacks.

Closes https://github.com/woocommerce/woocommerce/issues/62159

(For Bug Fixes) Bug introduced in PR # unknown.

### Screenshots or screen recordings:

**Before**
<img width="388" height="268" alt="image" src="https://github.com/user-attachments/assets/73e0244d-d4e7-4513-b07b-9f672b030053" />

**After**
<img width="389" height="267" alt="image" src="https://github.com/user-attachments/assets/b4982553-dd3b-47ed-b956-0f64fadbdf2b" />

### How to test the changes in this Pull Request:

1. Create or use a non-admin backend user.
2. Grant the user both capabilities:
   - `edit_others_posts`
   - `edit_others_shop_orders`
3. Log in as this user and go to **WooCommerce → Orders**.
4. Verify that bulk-action checkboxes are visible for each order row.
5. Remove the `edit_others_posts` capability from the user, leaving only:
   - `edit_others_shop_orders`
6. Refresh **WooCommerce → Orders**.
7. Verify that bulk-action checkboxes are still visible.

Before this fix: checkboxes disappear.  
After this fix: checkboxes remain visible.


### Testing that has already taken place:

Tested on a live store with HPOS enabled, confirming bulk action checkboxes render correctly before and after removing generic post capabilities from a non-admin user.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix bulk action checkboxes not displaying on the Orders page for some users when HPOS is enabled.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
