### PR TITLE
Drop A-S dependency for refunds note creation

### DIFF
--- a/plugins/woocommerce/changelog/fix-possible-notice-after-62033
+++ b/plugins/woocommerce/changelog/fix-possible-notice-after-62033
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Minor update in unreleased change
+
+

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -24,8 +24,20 @@ class WC_Notes_Refund_Returns {
 	 * Attach hooks.
 	 */
 	public static function init() {
-		add_action( 'wc_notes_refund_returns_page_created', array( __CLASS__, 'possibly_add_note' ) );
+		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'on_newly_installed' ) );
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
+	}
+
+	/**
+	 * Add the note when WooCommerce is newly installed.
+	 * 
+	 * @since 10.5.0
+	 */
+	public static function on_newly_installed() {
+		$page_id = get_option( 'woocommerce_refund_returns_page_id' );
+		if ( $page_id ) {
+			self::possibly_add_note( $page_id );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -30,8 +30,9 @@ class WC_Notes_Refund_Returns {
 
 	/**
 	 * Add the note when WooCommerce is newly installed.
-	 * 
+	 *
 	 * @since 10.5.0
+	 * @return void
 	 */
 	public static function on_newly_installed() {
 		$page_id = get_option( 'woocommerce_refund_returns_page_id' );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2990,11 +2990,17 @@ EOT;
 	 * @return void
 	 */
 	public static function page_created( $page_id, $page_data ) {
-		if ( 'refund_returns' === $page_data['post_name'] ) {
-			if ( Constants::is_true( 'WC_INSTALLING' ) ) {
-				as_schedule_single_action( time() + MINUTE_IN_SECONDS, 'wc_notes_refund_returns_page_created', array( $page_id ), 'woocommerce', true );
+		if ( Constants::is_true( 'WC_INSTALLING' ) ) {
+			return;
+		}
+
+		if ( 'refund_returns' === $page_data['post_name'] && class_exists( 'WC_Notes_Refund_Returns', false ) ) {
+			$callback = fn() => WC_Notes_Refund_Returns::possibly_add_note( $page_id );
+
+			if ( did_action( 'init' ) ) {
+				$callback();
 			} else {
-				WC_Notes_Refund_Returns::possibly_add_note( $page_id );
+				add_action( 'init', $callback );
 			}
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Prior to #62033, during the install process an option was added as as flag so we could later on (during a future request) create a wc-admin note for the "Refund and Returns" page.

In #62033 and in order to reduce our options surface, this was changed to a background job using Action Scheduler, but under certain circumstances, particularly during initial activation of the plugin (via its activation hook) or in unit tests that run `WC_Install::install()` before `init`, this results in a PHP notice because Action Scheduler might not have been fully initialized.

In this PR, we drop the A-S dependency. Given the note was only meant to be done when the page is created for the first time, we now create it on `woocommerce_newly_installed`, which happens after the initial install. In older setups where `woocommerce_newly_installed` wouldn't be triggered but the page doesn't exist, we still catch the creation and add the note.

Related to STRPROD-796.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Deactivate the WooCommerce plugin on your test environment and run the following commands to simulate a "new install":
   ```
   wp db query "DELETE FROM wp_wc_admin_notes WHERE name = 'wc-refund-returns-page'"
   wp post delete $(wp option get woocommerce_refund_returns_page_id) --force
   wp option delete woocommerce_refund_returns_page_id
   wp option delete woocommerce_newly_installed
   wp option delete woocommerce_version
   wp option delete woocommerce_db_version
   ```

  Alternatively, run `pnpm run build:zip` and upload the ZIP file to a JN ninja or a clean WP site.
1. Activate the WooCommerce plugin.
1. Go to **WooCommerce > Home** if you're not there already and confirm that the following note is in your **Inbox**:
   <img width="738" height="199" alt="Screenshot 2026-01-23 at 12 36 38" src="https://github.com/user-attachments/assets/43e2b445-3953-40e6-af98-0706f064a41c" />
1. Now, let's delete the refunds page and related note to simulate an old site (for which the install ran already) that is just about to create the page:
   ```
   wp db query "DELETE FROM wp_wc_admin_notes WHERE name = 'wc-refund-returns-page'"
   wp post delete $(wp option get woocommerce_refund_returns_page_id) --force
   wp option delete woocommerce_refund_returns_page_id
   ```
1. Confirm that the refunds note is no longer in your **Inbox** in **WooCommerce > Home**.
1. Go to **WooCommerce > Status > Tools** and run the **Create default WooCommerce pages** tool.
1. Go back to **WooCommerce > Home > Inbox** and confirm that the refunds note is back.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.