### PR TITLE
Avoid Coupon Code block trying to fetch an nonexistent stylesheet

### DIFF
--- a/plugins/woocommerce/changelog/fix-404-error-site-editor-coupon-code-css
+++ b/plugins/woocommerce/changelog/fix-404-error-site-editor-coupon-code-css
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
+Comment: Avoid Coupon Code trying to fetch an nonexistent stylesheet
 
-Avoid Coupon Code trying to fetch an unexisting stylesheet
+

--- a/plugins/woocommerce/changelog/fix-404-error-site-editor-coupon-code-css
+++ b/plugins/woocommerce/changelog/fix-404-error-site-editor-coupon-code-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid Coupon Code trying to fetch an unexisting stylesheet

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CouponCode.php
@@ -57,6 +57,15 @@ class CouponCode extends AbstractBlock {
 	}
 
 	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
 	 * Render the coupon code block.
 	 *
 	 * @param array         $attributes Block attributes.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

By default, blocks using the `AbstractBlock` class will try to fetch a CSS file with their own slug. When a block doesn't have a stylesheet, we need to be explicit about that. This PR fixes that for the _Coupon Code_ block, which apparently doesn't have a stylesheet.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ and open any template, like _Single Product_.
2. Verify in the devtools of your browser there isn't a 404 request trying to fetch `/wp-content/plugins/woocommerce/assets/client/blocks/coupon-code.css`.