### PR TITLE
Taxonomy Filters: add option to order terms by `menu_order`

### DIFF
--- a/plugins/woocommerce/changelog/add-product-filter-menu-order
+++ b/plugins/woocommerce/changelog/add-product-filter-menu-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Taxonomy Filters: Add option to sort terms by menu_order

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -183,6 +183,7 @@ const Edit = ( props: EditProps ) => {
 					count,
 					id: term.id,
 					parent: term.parent || 0,
+					menuOrder: term.menu_order ?? 0,
 				} );
 
 				return acc;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -112,7 +112,7 @@ const Edit = ( props: EditProps ) => {
 			const selectArgs = {
 				per_page: 15,
 				hide_empty: hideEmpty,
-				orderby: sortOrder === 'menu_order-asc' ? 'menu_order' : 'name',
+				orderby: 'name',
 				order: 'asc',
 			};
 			return {
@@ -125,7 +125,7 @@ const Edit = ( props: EditProps ) => {
 				] ),
 			};
 		},
-		[ taxonomy, hideEmpty, isPreview, sortOrder ]
+		[ taxonomy, hideEmpty, isPreview ]
 	);
 
 	// Fetch taxonomy counts using the updated useCollectionData hook

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -112,7 +112,7 @@ const Edit = ( props: EditProps ) => {
 			const selectArgs = {
 				per_page: 15,
 				hide_empty: hideEmpty,
-				orderby: 'name',
+				orderby: sortOrder === 'menu_order-asc' ? 'menu_order' : 'name',
 				order: 'asc',
 			};
 			return {
@@ -125,7 +125,7 @@ const Edit = ( props: EditProps ) => {
 				] ),
 			};
 		},
-		[ taxonomy, hideEmpty, isPreview ]
+		[ taxonomy, hideEmpty, isPreview, sortOrder ]
 	);
 
 	// Fetch taxonomy counts using the updated useCollectionData hook

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -11,6 +11,8 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { getSetting } from '@woocommerce/settings';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,12 +24,53 @@ import {
 } from '../../components/display-style-switcher';
 import metadata from './block.json';
 
+// Get the list of taxonomies that support custom ordering (drag & drop in admin).
+const sortableTaxonomies = getSetting< string[] >( 'sortableTaxonomies', [
+	'product_cat',
+] );
+
 export const TaxonomyFilterInspectorControls = ( {
 	attributes,
 	setAttributes,
 	clientId,
 }: EditProps ) => {
-	const { showCounts, sortOrder, hideEmpty, displayStyle } = attributes;
+	const { showCounts, sortOrder, hideEmpty, displayStyle, taxonomy } =
+		attributes;
+
+	// Only show "Menu order" option for taxonomies that support custom ordering.
+	const sortOrderOptions = useMemo( () => {
+		const baseOptions = [
+			{
+				label: __( 'Count (High to Low)', 'woocommerce' ),
+				value: 'count-desc',
+			},
+			{
+				label: __( 'Count (Low to High)', 'woocommerce' ),
+				value: 'count-asc',
+			},
+			{
+				label: __( 'Name (A to Z)', 'woocommerce' ),
+				value: 'name-asc',
+			},
+			{
+				label: __( 'Name (Z to A)', 'woocommerce' ),
+				value: 'name-desc',
+			},
+		];
+
+		// Add "Menu order" option only for sortable taxonomies.
+		if ( sortableTaxonomies.includes( taxonomy ) ) {
+			return [
+				{
+					label: __( 'Menu order', 'woocommerce' ),
+					value: 'menu_order-asc',
+				},
+				...baseOptions,
+			];
+		}
+
+		return baseOptions;
+	}, [ taxonomy ] );
 
 	return (
 		<InspectorControls>
@@ -58,34 +101,7 @@ export const TaxonomyFilterInspectorControls = ( {
 					<SelectControl
 						label={ __( 'Sort Order', 'woocommerce' ) }
 						value={ sortOrder }
-						options={ [
-							{
-								label: __( 'Menu order', 'woocommerce' ),
-								value: 'menu_order-asc',
-							},
-							{
-								label: __(
-									'Count (High to Low)',
-									'woocommerce'
-								),
-								value: 'count-desc',
-							},
-							{
-								label: __(
-									'Count (Low to High)',
-									'woocommerce'
-								),
-								value: 'count-asc',
-							},
-							{
-								label: __( 'Name (A to Z)', 'woocommerce' ),
-								value: 'name-asc',
-							},
-							{
-								label: __( 'Name (Z to A)', 'woocommerce' ),
-								value: 'name-desc',
-							},
-						] }
+						options={ sortOrderOptions }
 						onChange={ ( value: string ) =>
 							setAttributes( { sortOrder: value } )
 						}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	SelectControl,
@@ -12,7 +13,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { getSetting } from '@woocommerce/settings';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -60,6 +60,10 @@ export const TaxonomyFilterInspectorControls = ( {
 						value={ sortOrder }
 						options={ [
 							{
+								label: __( 'Menu order', 'woocommerce' ),
+								value: 'menu_order-asc',
+							},
+							{
 								label: __(
 									'Count (High to Low)',
 									'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -4,6 +4,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 import {
 	SelectControl,
 	ToggleControl,
@@ -12,7 +13,6 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -27,6 +27,7 @@ export type FilterOptionItem = (
 	id?: number;
 	parent?: number;
 	depth?: number;
+	menuOrder?: number;
 };
 
 export type FilterBlockContext = {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
@@ -23,20 +23,26 @@ function getSortableText( item: FilterOptionItem ): string {
  * Sorts filter options based on the specified sort order
  *
  * @param options   - Array of filter option items to sort
- * @param sortOrder - Sort order (name-asc, name-desc, count-asc, count-desc)
+ * @param sortOrder - Sort order (name-asc, name-desc, count-asc, count-desc, menu_order-asc)
  * @return Sorted array of filter option items
  */
 export function sortFilterOptions(
 	options: FilterOptionItem[],
 	sortOrder: string
 ): FilterOptionItem[] {
-	// For menu_order, preserve the original order from the API
-	if ( sortOrder === 'menu_order-asc' ) {
-		return options;
-	}
-
 	return options.sort( ( a, b ) => {
 		switch ( sortOrder ) {
+			case 'menu_order-asc': {
+				// Sort by menu order, with secondary sort by name when equal.
+				const orderA = a.menuOrder ?? 0;
+				const orderB = b.menuOrder ?? 0;
+				if ( orderA !== orderB ) {
+					return orderA - orderB;
+				}
+				return getSortableText( a ).localeCompare(
+					getSortableText( b )
+				);
+			}
 			case 'name-asc':
 				return getSortableText( a ).localeCompare(
 					getSortableText( b )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
@@ -30,6 +30,11 @@ export function sortFilterOptions(
 	options: FilterOptionItem[],
 	sortOrder: string
 ): FilterOptionItem[] {
+	// For menu_order, preserve the original order from the API
+	if ( sortOrder === 'menu_order-asc' ) {
+		return options;
+	}
+
 	return options.sort( ( a, b ) => {
 		switch ( sortOrder ) {
 			case 'name-asc':

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -88,6 +88,37 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		parent::initialize();
 
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+
+		// Register REST field for menu_order on sortable taxonomies.
+		$this->register_taxonomy_menu_order_rest_field();
+	}
+
+	/**
+	 * Register a REST field to expose the menu_order meta for sortable taxonomies.
+	 * This allows the editor to display terms in menu order.
+	 */
+	private function register_taxonomy_menu_order_rest_field(): void {
+		/** This filter is documented in includes/admin/class-wc-admin-assets.php */
+		$sortable_taxonomies = apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) );
+
+		foreach ( $sortable_taxonomies as $taxonomy ) {
+			register_rest_field(
+				$taxonomy,
+				'menu_order',
+				array(
+					'get_callback' => function ( $term ) {
+						$menu_order = get_term_meta( $term['id'], 'order', true );
+						return is_numeric( $menu_order ) ? (int) $menu_order : 0;
+					},
+					'schema'       => array(
+						'description' => __( 'Menu order, used to custom sort the term.', 'woocommerce' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -98,7 +98,17 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * This allows the editor to display terms in menu order.
 	 */
 	private function register_taxonomy_menu_order_rest_field(): void {
-		/** This filter is documented in includes/admin/class-wc-admin-assets.php */
+		/**
+		 * Filters the list of taxonomies that support custom ordering. Filter was introduced long
+		 * ago is only documented in 10.6.0.
+		 *
+		 * First instance in plugins/woocommerce/includes/admin/class-wc-admin-assets.php.
+		 *
+		 * @since 1.0
+		 *
+		 * @param array $sortable_taxonomies List of taxonomy slugs that support custom ordering.
+		 * @return array List of taxonomy slugs that support custom ordering.
+		 */
 		$sortable_taxonomies = apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) );
 
 		foreach ( $sortable_taxonomies as $taxonomy ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -105,7 +105,6 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			// Expose sortable taxonomies so the editor can show/hide "Menu order" option.
 			$this->asset_data_registry->add(
 				'sortableTaxonomies',
-				/** This filter is documented in includes/admin/class-wc-admin-assets.php */
 				apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) )
 			);
 		}
@@ -279,8 +278,8 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			if ( 'menu_order' === $orderby ) {
 				$terms = array_map(
 					function ( $term ) {
-						$term              = (array) $term;
-						$menu_order        = get_term_meta( $term['term_id'], 'order', true );
+						$term               = (array) $term;
+						$menu_order         = get_term_meta( $term['term_id'], 'order', true );
 						$term['menu_order'] = is_numeric( $menu_order ) ? (int) $menu_order : 0;
 						return (object) $term;
 					},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -105,6 +105,17 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			// Expose sortable taxonomies so the editor can show/hide "Menu order" option.
 			$this->asset_data_registry->add(
 				'sortableTaxonomies',
+				/**
+				 * Filters the list of taxonomies that support custom ordering. Filter was introduced long
+				 * ago is only documented in 10.6.0.
+				 *
+				 * First instance in plugins/woocommerce/includes/admin/class-wc-admin-assets.php.
+				 *
+				 * @since 1.0
+				 *
+				 * @param array $sortable_taxonomies List of taxonomy slugs that support custom ordering.
+				 * @return array List of taxonomy slugs that support custom ordering.
+				 */
 				apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) )
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -269,6 +269,19 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 				return array();
 			}
 
+			// Add menu_order to flat terms for sorting.
+			if ( 'menu_order' === $orderby ) {
+				$terms = array_map(
+					function ( $term ) {
+						$term              = (array) $term;
+						$menu_order        = get_term_meta( $term['term_id'], 'order', true );
+						$term['menu_order'] = is_numeric( $menu_order ) ? (int) $menu_order : 0;
+						return (object) $term;
+					},
+					$terms
+				);
+			}
+
 			return $this->sort_terms_by_criteria( $terms, $orderby, $order, $taxonomy_counts );
 		}
 
@@ -449,7 +462,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	}
 
 	/**
-	 * Sort terms by the specified criteria (name or count).
+	 * Sort terms by the specified criteria (name, count, or menu_order).
 	 *
 	 * @param array  $terms           Array of term objects to sort.
 	 * @param string $orderby         Sort field (name, count, menu_order).
@@ -470,6 +483,16 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 						$count_a    = $taxonomy_counts[ $a->term_id ] ?? 0;
 						$count_b    = $taxonomy_counts[ $b->term_id ] ?? 0;
 						$comparison = $count_a <=> $count_b;
+						break;
+
+					case 'menu_order':
+						$order_a    = $a->menu_order ?? 0;
+						$order_b    = $b->menu_order ?? 0;
+						$comparison = $order_a <=> $order_b;
+						// Secondary sort by name when menu_order is equal.
+						if ( 0 === $comparison ) {
+							$comparison = strcasecmp( $a->name, $b->name );
+						}
 						break;
 
 					case 'name':

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -102,6 +102,12 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 
 		if ( is_admin() ) {
 			$this->asset_data_registry->add( 'filterableProductTaxonomies', $this->get_taxonomies() );
+			// Expose sortable taxonomies so the editor can show/hide "Menu order" option.
+			$this->asset_data_registry->add(
+				'sortableTaxonomies',
+				/** This filter is documented in includes/admin/class-wc-admin-assets.php */
+				apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) )
+			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -328,6 +328,8 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 
 			// Add menu_order to flat terms for sorting.
 			if ( 'menu_order' === $orderby ) {
+				// Prime term meta cache in single query to avoid N+1.
+				update_termmeta_cache( wp_list_pluck( $terms, 'term_id' ) );
 				$terms = array_map(
 					function ( $term ) {
 						$term               = (array) $term;

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -86,7 +86,7 @@ class CacheController implements RegisterHooksInterface {
 	 * @param string $meta_key   Meta key.
 	 * @param mixed  $meta_value Meta value.
 	 */
-	public function clear_taxonomy_hierarchy_cache_on_meta_update( $meta_id, $term_id, $meta_key, $meta_value ) {
+	public function clear_taxonomy_hierarchy_cache_on_meta_update( $meta_id, $term_id, $meta_key, $meta_value ): void {
 		// Only clear cache when the 'order' meta key is updated (used for menu ordering).
 		if ( 'order' !== $meta_key ) {
 			return;

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -54,6 +54,7 @@ class CacheController implements RegisterHooksInterface {
 		// Clear taxonomy hierarchy cache when term meta (like 'order') is added or updated.
 		add_action( 'added_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
 		add_action( 'updated_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
+		add_action( 'deleted_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -50,6 +50,9 @@ class CacheController implements RegisterHooksInterface {
 		add_action( 'created_term', array( $this, 'clear_taxonomy_hierarchy_cache' ), 10, 3 );
 		add_action( 'edited_term', array( $this, 'clear_taxonomy_hierarchy_cache' ), 10, 3 );
 		add_action( 'delete_term', array( $this, 'clear_taxonomy_hierarchy_cache' ), 10, 3 );
+
+		// Clear taxonomy hierarchy cache when term meta (like 'order') is updated.
+		add_action( 'updated_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
 	}
 
 	/**
@@ -72,6 +75,29 @@ class CacheController implements RegisterHooksInterface {
 		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
 			$this->taxonomy_hierarchy_data->clear_cache( $taxonomy );
 		}
+	}
+
+	/**
+	 * Clear taxonomy hierarchy cache when term meta is updated.
+	 * This handles the case when categories are reordered (updates 'order' meta).
+	 *
+	 * @param int    $meta_id    Meta ID.
+	 * @param int    $term_id    Term ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 */
+	public function clear_taxonomy_hierarchy_cache_on_meta_update( $meta_id, $term_id, $meta_key, $meta_value ) {
+		// Only clear cache when the 'order' meta key is updated (used for menu ordering).
+		if ( 'order' !== $meta_key ) {
+			return;
+		}
+
+		$term = get_term( $term_id );
+		if ( ! $term instanceof \WP_Term ) {
+			return;
+		}
+
+		$this->taxonomy_hierarchy_data->clear_cache( $term->taxonomy );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -51,7 +51,8 @@ class CacheController implements RegisterHooksInterface {
 		add_action( 'edited_term', array( $this, 'clear_taxonomy_hierarchy_cache' ), 10, 3 );
 		add_action( 'delete_term', array( $this, 'clear_taxonomy_hierarchy_cache' ), 10, 3 );
 
-		// Clear taxonomy hierarchy cache when term meta (like 'order') is updated.
+		// Clear taxonomy hierarchy cache when term meta (like 'order') is added or updated.
+		add_action( 'added_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
 		add_action( 'updated_term_meta', array( $this, 'clear_taxonomy_hierarchy_cache_on_meta_update' ), 10, 4 );
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -153,6 +153,9 @@ class TaxonomyHierarchyData {
 		$temp_parents  = array();
 		$temp_terms    = array();
 
+		// Prime term meta cache in single query to avoid N+1.
+		update_termmeta_cache( wp_list_pluck( $terms, 'term_id' ) );
+
 		foreach ( $terms as $term ) {
 			$term_id   = $term->term_id;
 			$parent_id = $term->parent;

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -165,11 +165,15 @@ class TaxonomyHierarchyData {
 
 			$temp_children[ $parent_id ][] = $term_id;
 
+			// Get the menu_order from term meta (WooCommerce stores category order in 'order' meta).
+			$menu_order = get_term_meta( $term_id, 'order', true );
+
 			$temp_terms[ $term_id ] = array(
-				'slug'    => $term->slug,
-				'name'    => $term->name,
-				'parent'  => $parent_id,
-				'term_id' => $term->term_id,
+				'slug'       => $term->slug,
+				'name'       => $term->name,
+				'parent'     => $parent_id,
+				'term_id'    => $term->term_id,
+				'menu_order' => is_numeric( $menu_order ) ? (int) $menu_order : 0,
 			);
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
@@ -243,7 +243,7 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should include menu_order field in tree structure with default value of 0.
+	 * Should include menu_order field in tree structure with default value of 0.
 	 */
 	public function test_tree_structure_includes_menu_order_default(): void {
 		$electronics_id = $this->create_test_term( 'Electronics' );
@@ -255,7 +255,7 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should include menu_order field from term meta when set.
+	 * Should include menu_order field from term meta when set.
 	 */
 	public function test_tree_structure_includes_menu_order_from_meta(): void {
 		$electronics_id = $this->create_test_term( 'Electronics' );
@@ -272,7 +272,7 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should handle non-numeric menu_order meta gracefully.
+	 * Should handle non-numeric menu_order meta gracefully.
 	 */
 	public function test_tree_structure_handles_invalid_menu_order_meta(): void {
 		$electronics_id = $this->create_test_term( 'Electronics' );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
@@ -241,4 +241,47 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 		$this->assertEquals( 2, $gaming_tree['depth'] );
 		$this->assertEquals( $laptops_id, $gaming_tree['parent'] );
 	}
+
+	/**
+	 * @testdox Should include menu_order field in tree structure with default value of 0.
+	 */
+	public function test_tree_structure_includes_menu_order_default(): void {
+		$electronics_id = $this->create_test_term( 'Electronics' );
+
+		$map = $this->sut->get_hierarchy_map( $this->taxonomy );
+
+		$this->assertArrayHasKey( 'menu_order', $map['tree'][ $electronics_id ] );
+		$this->assertEquals( 0, $map['tree'][ $electronics_id ]['menu_order'] );
+	}
+
+	/**
+	 * @testdox Should include menu_order field from term meta when set.
+	 */
+	public function test_tree_structure_includes_menu_order_from_meta(): void {
+		$electronics_id = $this->create_test_term( 'Electronics' );
+		$laptops_id     = $this->create_test_term( 'Laptops', $electronics_id );
+
+		update_term_meta( $electronics_id, 'order', 5 );
+		update_term_meta( $laptops_id, 'order', 10 );
+
+		$this->sut->clear_cache( $this->taxonomy );
+		$map = $this->sut->get_hierarchy_map( $this->taxonomy );
+
+		$this->assertEquals( 5, $map['tree'][ $electronics_id ]['menu_order'] );
+		$this->assertEquals( 10, $map['tree'][ $electronics_id ]['children'][ $laptops_id ]['menu_order'] );
+	}
+
+	/**
+	 * @testdox Should handle non-numeric menu_order meta gracefully.
+	 */
+	public function test_tree_structure_handles_invalid_menu_order_meta(): void {
+		$electronics_id = $this->create_test_term( 'Electronics' );
+
+		update_term_meta( $electronics_id, 'order', 'invalid' );
+
+		$this->sut->clear_cache( $this->taxonomy );
+		$map = $this->sut->get_hierarchy_map( $this->taxonomy );
+
+		$this->assertEquals( 0, $map['tree'][ $electronics_id ]['menu_order'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds a "Menu order" sorting option to the Taxonomy Filter block within Product Filters. This allows merchants to display taxonomy terms (like product categories or brands) in the custom order they've set via drag-and-drop in the WordPress admin.

Changes:
- Added "Menu order" option to the Sort Order dropdown in the Taxonomy Filter block inspector
- The option only appears for taxonomies that support custom ordering (those registered via the `woocommerce_sortable_taxonomies` filter)

The main downside is that there's no (clean) way to display menu order in the Editor and we default to alphabetical order. I'm considering adding a note or at least some info in the menu option, something like `Menu order (only applied in frontend)`? Happy to hear your feedback dear reviewer!

Closes #62922.
(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Taxonomies supporting and not supporting ordering:

Product Categories filter - supports ordering | Product Tags filter - doesn't support ordering
-- | --
<img width="281" height="377" alt="image" src="https://github.com/user-attachments/assets/d7b5e111-e34d-47b2-8ae9-a6dc522a59b3" /> | <img width="281" height="289" alt="image" src="https://github.com/user-attachments/assets/836fff3d-59ac-4d32-8bf3-f5fdf2298f89" />

Example on Product Categories:

Admin | Editor | Frontend
-- | -- | --
<img width="1013" height="743" alt="image" src="https://github.com/user-attachments/assets/08d62487-3301-410f-89c5-b370c761dd3a" /> | <img width="1535" height="631" alt="image" src="https://github.com/user-attachments/assets/c2c9d6ef-3898-429c-a182-fc0a6408bbcf" /> | <img width="416" height="560" alt="image" src="https://github.com/user-attachments/assets/b7c75856-926b-496e-a152-78e4a00da1b0" />




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor > Product Catalog
2. Insert Product Filters
3. Make sure to insert Categories Filter, Brand Filter and Tag Filter
4. In Display Settings try changing the Sort Order to "Menu order"
5. **Expected:**
    - it's unavailable for Product Tags since this taxonomy is not sortable
    - it's available for Product Categories and Brands. However terms are displayed in alphabetical order in editor
6. Save and go to frontend
7. Compare the order of terms with order in admin
8. Now change the order of Product Categories and Brands (drag and drop in admin side)
9. Refresh the frontend
10. **Expected:** Order was updated

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
