### PR TITLE
Add correct scoping of replacements to "Update version requirements" workflow

### DIFF
--- a/.github/workflows/maintenance-update-version-requirements.yml
+++ b/.github/workflows/maintenance-update-version-requirements.yml
@@ -149,8 +149,8 @@ jobs:
 
           # Update PHP version requirements.
           sed -i "s/\* Requires PHP: [0-9.]*/\* Requires PHP: $required_php_version/" "woocommerce.php"
-          sed -i "s/Requires PHP: [0-9.]*/Requires PHP: $required_php_version/" "readme.txt"
-          sed -i "s/PHP [0-9.]\+ or greater is required/PHP $required_php_version or greater is required/" "readme.txt"
+          sed -i '1,/^== /{ s/Requires PHP: [0-9.]*/Requires PHP: '"$required_php_version"'/ }' "readme.txt"
+          sed -i '/^= Minimum Requirements =/,/^= /{ s/\* PHP [0-9.]\+ or greater is required/\* PHP '"$required_php_version"' or greater is required/ }' "readme.txt"
 
           # If this resulted in changes, create a commit and changelog entry for the PHP version update.
           if ! git diff --quiet; then
@@ -168,9 +168,9 @@ jobs:
 
           # Update WordPress version requirements.
           sed -i "s/\* Requires at least: [0-9.]*/\* Requires at least: $WP_REQUIRED_VERSION/" "woocommerce.php"
-          sed -i "s/Requires at least: [0-9.]*/Requires at least: $WP_REQUIRED_VERSION/" "readme.txt"
-          sed -i "s/Tested up to: [0-9.]*/Tested up to: $WP_VERSION/" "readme.txt"
-          sed -i "s/WordPress [0-9.]\+/WordPress $WP_REQUIRED_VERSION/" "readme.txt"
+          sed -i '1,/^== /{ s/Requires at least: [0-9.]*/Requires at least: '"$WP_REQUIRED_VERSION"'/ }' "readme.txt"
+          sed -i '1,/^== /{ s/Tested up to: [0-9.]*/Tested up to: '"$WP_VERSION"'/ }' "readme.txt"
+          sed -i '/^= Minimum Requirements =/,/^= /{ s/\* WordPress [0-9.]\+ or greater/\* WordPress '"$WP_REQUIRED_VERSION"' or greater/ }' "readme.txt"
 
           # Check for changes and exit early if none.
           if git diff --quiet; then


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The **Maintenance: Update version requirements** workflow updates PHP and WordPress version numbers in the `readme.txt` and headers in `woocommerce.php`. Previously, these replacements applied globally across the entire file, which could accidentally modify version numbers in unintended locations like changelog entries or documentation text.

This PR scopes the replacements so that header metadata is only updated in the file header, and minimum requirements are only updated within the relevant sections.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a fork of this repository, with at least the `trunk` and `release/10.5` branches.
1. Merge this branch into `trunk`.
1. On `trunk`, use the GitHub UI to edit `plugins/woocommerce/readme.txt` and/or `woocommerce.php` with older PHP/WP version values in the header and **Minimum Requirements** sections. Also add version strings to the changelog or other sections where they should not be replaced (e.g., `* PHP 5.0 is no longer supported.`). ([See example readme.txt](https://github.com/jorgeatorres/woocommerce/blob/trunk/plugins/woocommerce/readme.txt)).
1. Go to **Actions > Update version requirements workflow** and trigger a manual run.
1. Verify that:
   - A PR is created with correct updates to the header metadata and **Minimum Requirements section.
   - Version strings in the changelog or other sections remain unchanged.
1. Merge the PR above.
1. Use the GH UI to make modifications to `plugins/woocomerce/readme.txt` again but this time only modify version strings in sections that shouldn't be updated (that is, not in the header or the **Minimum Requirements** section).
1. Run the workflow and confirm that no PR is created.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.