### PR TITLE
Fix access to the response body properties in the `Release: Assignment` webhook response

### DIFF
--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -188,11 +188,12 @@ jobs:
               console.log('Successfully triggered upcoming release notification webhook');
 
               const responseBody = await response.json();
-              core.setOutput('release-team', responseBody.release_team);
-              core.setOutput('release-lead', responseBody.release_lead);
-              core.setOutput('release-lead-google-login', responseBody.release_lead_google_login);
-              core.setOutput('release-lead-slack-member-id', responseBody.release_lead_slack_member_id);
-              core.setOutput('post', responseBody.post);
+
+              core.setOutput('release-team', responseBody.data.release_team);
+              core.setOutput('release-lead', responseBody.data.release_lead);
+              core.setOutput('release-lead-google-login', responseBody.data.release_lead_google_login);
+              core.setOutput('release-lead-slack-member-id', responseBody.data.release_lead_slack_member_id);
+              core.setOutput('post', responseBody.data.post.view_url);
             }
         env:
           ENVIRONMENT: ${{ secrets.ENVIRONMENT }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes an issue with the `Release: Assignment` workflow, where access to the release assignment webhook was done incorrectly, which caused the Slack notification to fail and Linear issues to miss the TL for the new release.
The previous code assumed the response from the webhook would be:
```json
{
  "release_team": "a team",
  "release_lead": "a_team_lead",
  "post": {
    "ID": 12950,
    "view_url": "https://example.com",
    "edit_url": "https://example.com",
    "message": "Created post 12950 of status"
  },
  "release_lead_google_login": "email@example.com",
  "release_lead_slack_member_id": "foobar"
}
```
When in reality it was:
```json
{
  "success": true,
  "data": {
    "post": {
      "ID": 13265,
      "view_url": "https://example.com",
      "edit_url": "https://example.com",
      "message": "Created post 12950 of status"
    },
    "release_team": "a_team",
    "release_lead": "a_team_lead",
    "release_lead_google_login": "email@example.com",
    "release_lead_slack_member_id": "foobar"
  }
}
```

Closes https://github.com/woocommerce/woocommerce/issues/62958

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In the forked repo, create a PR with the `fix/62958-release-assignment-workflow` and merge it.
3. Add the following secrets to your fork:

| Secret | Value |
|--------|--------|
| CODE_FREEZE_BOT_TOKEN | Get it from `Flux - Test 60232` secret store |
| WOO_RELEASE_SLACK_CHANNEL | Get it from `Flux - Test 60232` secret store |
| RELEASE_CALENDAR_ID | 46e4204b5406a5c6df48addc0dfd3a29e5e69ad7e991b165fa4e331f03ede0e0@group.calendar.google.com |
| WPCOM_RELEASE_WEBHOOK_URL | https://api.mockfly.dev/mocks/76ec7a23-e31a-4fef-aa62-8a43fd1cddff/mock |
| WPCOM_WEBHOOK_SECRET | foo | 
| LINEAR_OAUTH_TOKEN | a token from your test Linear workspace |
| LINEAR_TEAM_ID | the team id of your Linear workspace |

5. Go to `Actions`, enable them, and run `Release: Assignment`.
6. Make sure all steps run successfully, the Slack notification was sent, and the Linear issue was created with the TL assigned.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>