### PR TITLE
Introduce filters for address and name formatting tokens in checkout block utilities.

### DIFF
--- a/plugins/woocommerce/changelog/62962-fix-52148
+++ b/plugins/woocommerce/changelog/62962-fix-52148
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `woocommerce_blocks_checkout_address_tokens` and `woocommerce_blocks_checkout_name_tokens` filters to allow customizing address card formatting in Block Checkout.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/utils.ts
@@ -9,6 +9,7 @@ import {
 } from '@woocommerce/type-defs/cart';
 import { isObject, isString } from '@woocommerce/types';
 import { decodeEntities } from '@wordpress/html-entities';
+import { applyFilters } from '@wordpress/hooks';
 
 export const LOGIN_TO_CHECKOUT_URL = `${ LOGIN_URL }?redirect_to=${ encodeURIComponent(
 	window.location.href
@@ -66,7 +67,7 @@ export const formatAddress = (
 
 	const addressFormatWithoutName = format.replace( `${ nameFormat }\n`, '' );
 
-	const addressTokens = [
+	const defaultAddressTokens = [
 		[ '{company}', address?.company || '' ],
 		[ '{address_1}', address?.address_1 || '' ],
 		[ '{address_2}', address?.address_2 || '' ],
@@ -83,7 +84,13 @@ export const formatAddress = (
 		[ '{postcode_upper}', ( address?.postcode || '' ).toUpperCase() ],
 		[ '{country_upper}', getFormattedCountry( address ).toUpperCase() ],
 	];
-	const nameTokens = [
+	const addressTokens = applyFilters(
+		'woocommerce_blocks_checkout_address_tokens',
+		defaultAddressTokens,
+		address
+	) as [ string, string ][];
+
+	const defaultNameTokens = [
 		[
 			'{name}',
 			address?.first_name +
@@ -105,6 +112,11 @@ export const formatAddress = (
 		[ '{first_name_upper}', ( address?.first_name || '' ).toUpperCase() ],
 		[ '{last_name_upper}', ( address?.last_name || '' ).toUpperCase() ],
 	];
+	const nameTokens = applyFilters(
+		'woocommerce_blocks_checkout_name_tokens',
+		defaultNameTokens,
+		address
+	) as [ string, string ][];
 	let parsedName = nameFormat;
 
 	nameTokens.forEach( ( [ token, value ] ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The block checkout page currently does not apply replacements for custom placeholders added via the `woocommerce_formatted_address_replacements` filter, as the address formatting happens on the client side using localized strings. This prevents third-party plugins (like WooCommerce EU VAT Number) from injecting custom data like VAT IDs into address cards.

This PR introduces two new JavaScript hooks in the [formatAddress](cci:1://file:///Users/muhammad/Local%20Sites/woo/app/public/wp-content/plugins/woocommerce-monorepo/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/utils.ts:58:0-136:2) utility to bridge this gap:
*   `woocommerce_blocks_checkout_address_tokens`: Filters replacing tokens for address fields.
*   `woocommerce_blocks_checkout_name_tokens`: Filters replacing tokens for name fields.

This allows developers to dynamically inject custom token replacements (e.g., replacing `{custom_field}` with a specific value) directly within the Block Checkout address card rendering logic.

Closes #52148.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="769" height="315" alt="image" src="https://github.com/user-attachments/assets/38fb4d5a-68e4-4980-892c-ec1a3999b6c1" /> | <img width="780" height="309" alt="image" src="https://github.com/user-attachments/assets/c1d58587-a6ef-4b5d-81df-80c754faa58b" /> |

### How to test the changes in this Pull Request:

1.  Create a simple testing plugin or add the following code snippet to your site's JavaScript that runs on the checkout page:
    ```javascript
    import { addFilter } from '@wordpress/hooks';

    addFilter(
        'woocommerce_blocks_checkout_address_tokens',
        'test-plugin/address-tokens',
        ( tokens, address ) => {
            return [ ...tokens, [ '{test_token}', 'TEST REPLACEMENT WORKED' ] ];
        }
    );
    ```
2.  Add a custom placeholder `{test_token}` to a country's address format. You can temporarily modify `WC_Countries::get_address_formats()` in core for testing purposes, or use the "Localization Placeholder Demo" plugin code provided in issue #52148.
3.  Go to the Storefront > Checkout page (Block Checkout).
4.  If you are logged in with a saved address, look at the **Address Card** (Shipping or Billing).
5.  Verify that `{test_token}` is replaced with "TEST REPLACEMENT WORKED".
6.  Without this PR, the card would display the literal string `{test_token}`.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message
Add `woocommerce_blocks_checkout_address_tokens` and `woocommerce_blocks_checkout_name_tokens` filters to allow customizing address card formatting in Block Checkout.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>