### PR TITLE
Fix attribute matching for non-ASCII characters in product CSV importer

### DIFF
--- a/plugins/woocommerce/changelog/62963-fix-issue-62709
+++ b/plugins/woocommerce/changelog/62963-fix-issue-62709
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix attribute matching for non-ASCII characters in product CSV importer

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -485,7 +485,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				}
 
 				if ( $attribute_id ) {
-					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
+					$attribute_name = sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
 				} else {
 					$attribute_name = sanitize_title( $attribute['name'] );
 				}
@@ -499,7 +499,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 				if ( $parent_attributes[ $attribute_name ]->is_taxonomy() ) {
 					// If dealing with a taxonomy, we need to get the slug from the name posted to the API.
-					$term = get_term_by( 'name', $attribute_value, $attribute_name );
+					$taxonomy_name = $parent_attributes[ $attribute_name ]->get_name();
+					$term          = get_term_by( 'name', $attribute_value, $taxonomy_name );
 
 					if ( $term && ! is_wp_error( $term ) ) {
 						$attribute_value = $term->slug;
@@ -535,7 +536,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			}
 
 			if ( $attribute_id ) {
-				$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
+				$attribute_name = sanitize_title( wc_attribute_taxonomy_name_by_id( $attribute_id ) );
 			} else {
 				$attribute_name = sanitize_title( $attribute['name'] );
 			}

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -128,9 +128,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		// Set admin user to allow term creation.
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
-		require_once $bootstrap->plugin_dir . '/includes/import/abstract-wc-product-importer.php';
-
 		// Create a CSV importer instance to access protected methods.
 		$csv_file = __DIR__ . '/sample.csv';
 		$importer = new WC_Product_CSV_Importer( $csv_file );

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -132,7 +132,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		require_once $bootstrap->plugin_dir . '/includes/import/abstract-wc-product-importer.php';
 
 		// Create a CSV importer instance to access protected methods.
-		$csv_file = dirname( __FILE__ ) . '/sample.csv';
+		$csv_file = __DIR__ . '/sample.csv';
 		$importer = new WC_Product_CSV_Importer( $csv_file );
 
 		// Create a variable product with non-ASCII attributes (Chinese characters).
@@ -151,7 +151,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 				'has_archives' => false,
 			)
 		);
-		$size_attr_id = wc_create_attribute(
+		$size_attr_id  = wc_create_attribute(
 			array(
 				'name'         => '尺寸',
 				'slug'         => 'chi-cun',
@@ -217,7 +217,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$method->invoke( $importer, $variation_attributes, $product );
 
 		// Reload product to get updated attributes.
-		$product = wc_get_product( $product->get_id() );
+		$product          = wc_get_product( $product->get_id() );
 		$attributes_after = $product->get_attributes();
 
 		// Verify attributes are now set to "Used for Variations".

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -145,7 +145,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$color_attr_id = wc_create_attribute(
 			array(
 				'name'         => '颜色',
-				'slug'         => 'yan-se',
 				'type'         => 'select',
 				'order_by'     => 'menu_order',
 				'has_archives' => false,
@@ -154,7 +153,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$size_attr_id  = wc_create_attribute(
 			array(
 				'name'         => '尺寸',
-				'slug'         => 'chi-cun',
 				'type'         => 'select',
 				'order_by'     => 'menu_order',
 				'has_archives' => false,
@@ -162,8 +160,8 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		);
 
 		// Register taxonomies.
-		$color_taxonomy = wc_attribute_taxonomy_name( 'yan-se' );
-		$size_taxonomy  = wc_attribute_taxonomy_name( 'chi-cun' );
+		$color_taxonomy = wc_attribute_taxonomy_name_by_id( $color_attr_id );
+		$size_taxonomy  = wc_attribute_taxonomy_name_by_id( $size_attr_id );
 		register_taxonomy( $color_taxonomy, 'product' );
 		register_taxonomy( $size_taxonomy, 'product' );
 

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -120,4 +120,113 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $error );
 		$this->assertEquals( 'A product with this SKU already exists.', $error->get_error_message() );
 	}
+
+	/**
+	 * @testdox Test that attributes with non-ASCII characters are correctly set to "Used for Variations" during import.
+	 */
+	public function test_variable_product_attributes_with_non_ascii_characters_set_to_used_for_variations() {
+		// Set admin user to allow term creation.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/import/abstract-wc-product-importer.php';
+
+		// Create a CSV importer instance to access protected methods.
+		$csv_file = dirname( __FILE__ ) . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		// Create a variable product with non-ASCII attributes (Chinese characters).
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Product with Chinese Attributes' );
+		$product->set_sku( 'test-non-ascii-attr' );
+		$product->save();
+
+		// Create global attributes with Chinese names.
+		$color_attr_id = wc_create_attribute(
+			array(
+				'name'         => '颜色',
+				'slug'         => 'yan-se',
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+		$size_attr_id = wc_create_attribute(
+			array(
+				'name'         => '尺寸',
+				'slug'         => 'chi-cun',
+				'type'         => 'select',
+				'order_by'     => 'menu_order',
+				'has_archives' => false,
+			)
+		);
+
+		// Register taxonomies.
+		$color_taxonomy = wc_attribute_taxonomy_name( 'yan-se' );
+		$size_taxonomy  = wc_attribute_taxonomy_name( 'chi-cun' );
+		register_taxonomy( $color_taxonomy, 'product' );
+		register_taxonomy( $size_taxonomy, 'product' );
+
+		// Create terms for the attributes.
+		wp_insert_term( '红色', $color_taxonomy );
+		wp_insert_term( '绿色', $color_taxonomy );
+		wp_insert_term( '大码', $size_taxonomy );
+		wp_insert_term( '小码', $size_taxonomy );
+
+		// Set attributes on the product (initially NOT set to "Used for Variations").
+		$color_attribute = new WC_Product_Attribute();
+		$color_attribute->set_id( $color_attr_id );
+		$color_attribute->set_name( $color_taxonomy );
+		$color_attribute->set_options( array( '红色', '绿色' ) );
+		$color_attribute->set_visible( true );
+		$color_attribute->set_variation( false ); // Initially false.
+
+		$size_attribute = new WC_Product_Attribute();
+		$size_attribute->set_id( $size_attr_id );
+		$size_attribute->set_name( $size_taxonomy );
+		$size_attribute->set_options( array( '大码', '小码' ) );
+		$size_attribute->set_visible( true );
+		$size_attribute->set_variation( false ); // Initially false.
+
+		$product->set_attributes( array( $color_attribute, $size_attribute ) );
+		$product->save();
+
+		// Verify attributes are initially NOT set to "Used for Variations".
+		$attributes_before = $product->get_attributes();
+		$this->assertFalse( $attributes_before[ sanitize_title( $color_taxonomy ) ]->get_variation(), 'Color attribute should initially NOT be set to "Used for Variations"' );
+		$this->assertFalse( $attributes_before[ sanitize_title( $size_taxonomy ) ]->get_variation(), 'Size attribute should initially NOT be set to "Used for Variations"' );
+
+		// Simulate variation import data (as would come from CSV).
+		$variation_attributes = array(
+			array(
+				'name'     => '颜色',
+				'taxonomy' => true,
+			),
+			array(
+				'name'     => '尺寸',
+				'taxonomy' => true,
+			),
+		);
+
+		// Use reflection to call the protected method.
+		$reflection = new ReflectionClass( $importer );
+		$method     = $reflection->getMethod( 'get_variation_parent_attributes' );
+		$method->setAccessible( true );
+
+		// Call the method (this should set "Used for Variations" to true).
+		$method->invoke( $importer, $variation_attributes, $product );
+
+		// Reload product to get updated attributes.
+		$product = wc_get_product( $product->get_id() );
+		$attributes_after = $product->get_attributes();
+
+		// Verify attributes are now set to "Used for Variations".
+		$this->assertTrue( $attributes_after[ sanitize_title( $color_taxonomy ) ]->get_variation(), 'Color attribute should be set to "Used for Variations" after processing variations' );
+		$this->assertTrue( $attributes_after[ sanitize_title( $size_taxonomy ) ]->get_variation(), 'Size attribute should be set to "Used for Variations" after processing variations' );
+
+		// Clean up.
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wc_delete_attribute( $color_attr_id );
+		wc_delete_attribute( $size_attr_id );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When importing variable products via CSV, attributes containing non-ASCII characters (e.g., Chinese characters like 颜色, 尺寸) were not automatically set to "Used for Variations" even when variations were present. This only affected attributes with non-ASCII characters; ASCII attributes (e.g., "Color", "Size") worked correctly.

The issue was caused by a key mismatch when looking up parent attributes:

1. **When storing attributes**: `set_attributes()` uses `sanitize_title($attribute->get_name())` to create array keys, which URL-encodes non-ASCII characters (e.g., `"pa_颜色"` → `"pa_%e9%a2%9c%e8%89%b2"`)

2. **When looking up attributes**: The code used `wc_attribute_taxonomy_name_by_id()` which returns the Unicode name (e.g., `"pa_颜色"`), not the sanitized version

3. **Result**: The lookup key didn't match the stored key, so attributes weren't found and "Used for Variations" wasn't set.

To fix this, this PR applies `sanitize_title()` to the taxonomy name when looking up attributes in `get_variation_parent_attributes()` and `set_variation_data()`, ensuring the lookup key matches how attributes are stored.

Closes #62709 

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a brand new WooCommerce site, click to import the following products using the Products > Import feature: [sample_products.csv](https://github.com/user-attachments/files/24858003/sample_products.csv)
2. View the Variable Product with the Chinese characters in its name.
3. Go to Attributes and notice that Used for Variation is not enabled for this product. 
4. Apply the patch. 
5. On a brand new WooCommerce site, click to import the same CSV file. 
6. Now, the Used for Variation option should be enabled for all the attributes in the Variable Product with the Chinese characters and also variations are generated correctly.  

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix attribute matching for non-ASCII characters in product CSV importer
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
