### PR TITLE
Fix template override detection in System Status to show actual runtime behavior

### DIFF
--- a/plugins/woocommerce/changelog/62964-fix-template-override-detection
+++ b/plugins/woocommerce/changelog/62964-fix-template-override-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix System Status template override detection to show actual runtime behavior, including plugin filter overrides.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1355,24 +1355,31 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$scan_files[] = 'taxonomy-product_cat.php';
 			$scan_files[] = 'taxonomy-product_tag.php';
 
-			foreach ( $scan_files as $file ) {
-				$located = apply_filters( 'wc_get_template', $file, $file, array(), WC()->template_path(), WC()->plugin_path() . '/templates/' );
+			$wc_templates_dir = WC()->plugin_path() . '/templates/';
 
-				if ( file_exists( $located ) ) {
-					$theme_file = $located;
-				} elseif ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
-					$theme_file = get_stylesheet_directory() . '/' . $file;
-				} elseif ( file_exists( get_stylesheet_directory() . '/' . WC()->template_path() . $file ) ) {
-					$theme_file = get_stylesheet_directory() . '/' . WC()->template_path() . $file;
-				} elseif ( file_exists( get_template_directory() . '/' . $file ) ) {
-					$theme_file = get_template_directory() . '/' . $file;
-				} elseif ( file_exists( get_template_directory() . '/' . WC()->template_path() . $file ) ) {
-					$theme_file = get_template_directory() . '/' . WC()->template_path() . $file;
-				} else {
-					$theme_file = false;
+			foreach ( $scan_files as $file ) {
+				$located = wc_locate_template( $file, WC()->template_path(), $wc_templates_dir );
+
+				/**
+				 * Allow 3rd party plugins to filter the template file location.
+				 *
+				 * @param string $located       The located template path.
+				 * @param string $file          The template file name.
+				 * @param array  $args          Template arguments.
+				 * @param string $template_path The template path.
+				 * @param string $default_path  The default path.
+				 *
+				 * @since 2.1.0
+				 */
+				$located = apply_filters( 'wc_get_template', $located, $file, array(), WC()->template_path(), $wc_templates_dir );
+
+				// Check if the template is overridden (located outside WC core templates dir).
+				$override_file = false;
+				if ( 0 !== strpos( $located, $wc_templates_dir ) && file_exists( $located ) ) {
+					$override_file = $located;
 				}
 
-				if ( ! empty( $theme_file ) ) {
+				if ( ! empty( $override_file ) ) {
 					$core_file = $file;
 
 					// Update *-product_<cat|tag> template name before searching in core.
@@ -1380,16 +1387,16 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 						$core_file = str_replace( '_', '-', $core_file );
 					}
 
-					$core_version  = WC_Admin_Status::get_file_version( WC()->plugin_path() . '/templates/' . $core_file );
-					$theme_version = WC_Admin_Status::get_file_version( $theme_file );
-					if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {
+					$core_version     = WC_Admin_Status::get_file_version( WC()->plugin_path() . '/templates/' . $core_file );
+					$override_version = WC_Admin_Status::get_file_version( $override_file );
+					if ( $core_version && ( empty( $override_version ) || version_compare( $override_version, $core_version, '<' ) ) ) {
 						if ( ! $outdated_templates ) {
 							$outdated_templates = true;
 						}
 					}
 					$override_files[] = array(
-						'file'         => str_replace( WP_CONTENT_DIR . '/themes/', '', $theme_file ),
-						'version'      => $theme_version,
+						'file'         => str_replace( WP_CONTENT_DIR . '/themes/', '', $override_file ),
+						'version'      => $override_version,
 						'core_version' => $core_version,
 					);
 				}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1395,7 +1395,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 						}
 					}
 					$override_files[] = array(
-						'file'         => str_replace( WP_CONTENT_DIR . '/themes/', '', $override_file ),
+						'file'         => str_replace( ABSPATH, '', $override_file ),
 						'version'      => $override_version,
 						'core_version' => $core_version,
 					);

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
@@ -1,0 +1,64 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_REST_System_Status_V2_Controller.
+ *
+ * @since 10.6.0
+ */
+class WC_REST_System_Status_V2_Controller_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_REST_System_Status_V2_Controller
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new WC_REST_System_Status_V2_Controller();
+		delete_transient( 'wc_system_status_theme_info' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'wc_get_template' );
+		delete_transient( 'wc_system_status_theme_info' );
+	}
+
+	/**
+	 * @testdox Should detect template override via wc_get_template filter.
+	 */
+	public function test_get_theme_info_detects_wc_get_template_filter_override(): void {
+		$template_to_override = 'cart/cart.php';
+		$override_path        = WC()->plugin_path() . '/includes/class-woocommerce.php';
+
+		add_filter(
+			'wc_get_template',
+			function ( $template, $template_name ) use ( $template_to_override, $override_path ) {
+				if ( $template_to_override === $template_name ) {
+					return $override_path;
+				}
+				return $template;
+			},
+			10,
+			2
+		);
+
+		$theme_info = $this->sut->get_theme_info();
+
+		$override_files = array_column( $theme_info['overrides'], 'file' );
+		$this->assertContains(
+			str_replace( WP_CONTENT_DIR . '/themes/', '', $override_path ),
+			$override_files,
+			'Template overridden via wc_get_template filter should appear in overrides'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller-test.php
@@ -56,7 +56,7 @@ class WC_REST_System_Status_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 
 		$override_files = array_column( $theme_info['overrides'], 'file' );
 		$this->assertContains(
-			str_replace( WP_CONTENT_DIR . '/themes/', '', $override_path ),
+			str_replace( ABSPATH, '', $override_path ),
 			$override_files,
 			'Template overridden via wc_get_template filter should appear in overrides'
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

Closes #62883 

### Changes proposed in this Pull Request:

The System Status template override detection had several issues:

1. **Incorrect filter parameters**: Called `wc_get_template` filter with `$file` (just the filename) instead of the located path, causing plugin filter overrides to not be detected
2. **Misleading results**: Showed theme overrides that would actually be replaced by plugin filters at runtime
3. **False positives**: Incorrectly showed WC core templates as overrides (e.g., `block-notices/*.php`)

This PR fixes the detection by:
- Using `wc_locate_template()` to properly locate templates including plugin filter overrides via `woocommerce_locate_template`
- Applying `wc_get_template` filter with correct parameters matching runtime behavior
- Removing redundant elseif chain (now handled by `wc_locate_template`)
- Showing the template that will **actually be used at runtime**

### Screenshots or screen recordings:

Before (trunk)
<img width="1898" height="558" alt="CleanShot 2026-01-26 at 06 13 47@2x" src="https://github.com/user-attachments/assets/7d772fc1-4792-486c-9da8-baac22767539" />

After (this PR)
<img width="1896" height="430" alt="CleanShot 2026-01-26 at 06 15 06@2x" src="https://github.com/user-attachments/assets/153e852d-b100-4a08-9a6e-30ce99bab84b" />

### How to test the changes in this Pull Request:

1. Create a theme template override (e.g., `wp-content/themes/YOUR-THEME/woocommerce/cart/cart.php`)
2. Go to **WooCommerce → Status → System Status → Templates**
3. Verify the theme override appears in the list

**To test plugin filter detection:**

4. Create a simple plugin that hooks `woocommerce_locate_template` to override a template:
```php
add_filter( 'woocommerce_locate_template', function( $template, $template_name ) {
    if ( 'cart/cart.php' === $template_name ) {
        return plugin_dir_path( __FILE__ ) . 'templates/cart/cart.php';
    }
    return $template;
}, 20, 2 );
```
5. Verify the plugin override appears in System Status (not the theme override)
6. Disable the plugin and verify the theme override now appears

### Testing that has already taken place:

- Unit test added for filter override detection
- Manual testing with theme overrides in twentytwentythree
- Manual testing with plugin filter overrides via `woocommerce_locate_template`
- PHP linting passes

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix System Status template override detection to show actual runtime behavior, including plugin filter overrides.

</details>