### PR TITLE
Position the remove button to the right of the quantity picker and use trash icon instead of text

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1449-position-the-remove-buttonlink-to-the-right-of-the-quantity
+++ b/plugins/woocommerce/changelog/wooprd-1449-position-the-remove-buttonlink-to-the-right-of-the-quantity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Position the remove button to the right of the quantity picker and use trash icon instead of text in Cart block

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -22,6 +22,7 @@ import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/types';
 import { objectHasProp, Currency } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
+import { Icon, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -341,7 +342,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 									} }
 									disabled={ isPendingDelete }
 								>
-									{ __( 'Remove item', 'woocommerce' ) }
+									<Icon icon={ trash } size={ 24 } />
 								</button>
 							) }
 						</div>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -31,8 +31,7 @@ table.wc-block-cart-items {
 		}
 	}
 	.wc-block-cart-items__row {
-		.wc-block-cart-item__wrap > *,
-		.wc-block-components-quantity-selector {
+		.wc-block-cart-item__wrap > * {
 			margin-bottom: $gap-smaller * 1.25;
 		}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -49,14 +49,16 @@ table.wc-block-cart-items {
 
 		.wc-block-cart-item__quantity {
 			display: flex;
-			flex-direction: column;
-			align-items: start;
+			flex-direction: row;
+			gap: $gap-small;
+			align-items: center;
 
 			.wc-block-cart-item__remove-link {
 				@include link-button();
 				@include hover-effect();
-				@include font-x-small-locked;
 
+				height: 24px;
+				width: 24px;
 				text-transform: none;
 				white-space: nowrap;
 				&[hidden] {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/style.scss
@@ -16,7 +16,6 @@
 	border-radius: $universal-border-radius;
 	box-sizing: border-box;
 	display: flex;
-	margin: 0 0 0.25em 0;
 	position: relative;
 	width: 107px;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
@@ -275,7 +275,11 @@ describe( 'Testing cart', () => {
 		render( <CartBlock /> );
 
 		await waitFor( () => {
-			expect( screen.queryAllByText( /Remove item/i ).length ).toBe( 1 );
+			expect(
+				screen.queryAllByRole( 'button', {
+					name: /Remove .* from cart/i,
+				} ).length
+			).toBe( 1 );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-translations.shopper.block_theme.spec.ts
@@ -42,7 +42,7 @@ test.describe( 'Shopper → Translations', () => {
 		await expect( totalsHeader ).toBeVisible();
 
 		await expect(
-			page.getByText( getTestTranslation( 'Remove item' ) )
+			page.getByRole( 'button', { name: /Remove .* from cart/i } )
 		).toBeVisible();
 
 		await expect(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -224,7 +224,9 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											data-wp-bind--aria-label="state.removeFromCartLabel"
 											class="wc-block-cart-item__remove-link"
 										>
-											<?php echo esc_html( $remove_item_label ); ?>
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+												<path fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"/>
+											</svg>
 										</button>
 									</div>
 								</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Changes the "Remove item" link to a trash icon
- Moves the icon to the right of the quantity picker instead of below
- Applies the same changes to the Mini-cart block.

Closes WOOPRD-1448
Closes WOOPRD-1442

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Cart Before | Cart After |
| ------ | ----- |
| <img width="1060" height="628" alt="image" src="https://github.com/user-attachments/assets/9394a1db-c677-4a30-884c-4528f0290b5a" /> |    <img width="1080" height="629" alt="image" src="https://github.com/user-attachments/assets/ed5f9274-2275-4786-8e0c-0d892a22c7b1" />   |

| Mini-Cart Before | Mini-Cart After |
| ------ | ----- |
| <img width="482" height="570" alt="image" src="https://github.com/user-attachments/assets/e47c3781-9294-4f3c-a659-1fc8d494f6f1" /> | <img width="483" height="564" alt="image" src="https://github.com/user-attachments/assets/77c09142-2315-4d40-a675-5e6b60932dc9" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a product that can only be bought individually.
2. Add this item and another regular item to your cart.
3. View the Mini-cart, ensure the remove item icon appears to the right of the quantity input, and is a trash icon rather than a text link.
4. The "sold individually" item should show a trash icon, but no quantity input.
5. Repeat the test on the Cart block.
6. Ensure you can remove items from the Cart using the remove item icon.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
