### PR TITLE
Fix changelog type capitalization

### DIFF
--- a/plugins/woocommerce/changelog/follow-up-60901
+++ b/plugins/woocommerce/changelog/follow-up-60901
@@ -1,4 +1,4 @@
 Significance: patch
-Type: Tweak
+Type: tweak
 
 Use wp_is_serving_rest_request() in MCPAdapterProvider instead of contants.


### PR DESCRIPTION
Fixes changelog validation error by changing `Type: Tweak` to `Type: tweak` (lowercase) in the follow-up-60901 changelog file.

The changelog validator requires lowercase type values, but PR #61167 was merged with capitalized 'Tweak' which is now breaking CI for all PRs.

**Fix:** Change `Type: Tweak` to `Type: tweak`

This is a trivial fix to unblock CI.