### PR TITLE
Increase PR unit:php CI timeout from 10 to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && 20 ) || ( matrix.testType == 'unit:php' && 10 ) ) ) || 360 }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && 20 ) || ( matrix.testType == 'unit:php' && 15 ) ) ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}


### PR DESCRIPTION
## Summary

- Increases the `timeout-minutes` for the `unit:php` test step from 10 to 15 minutes when running on pull requests.

The PHP unit test suite (`wc-phpunit-main`, shard 2/2 on PHP 7.4) routinely takes 9–10 minutes of PHPUnit execution time alone. With setup overhead, the total step time regularly exceeds 10 minutes. Recent trunk runs show consistent PHPUnit times of 544s–608s, leaving almost no headroom under the current 10-minute step timeout.

This has been causing spurious failures on PRs — all tests pass, but the step times out. For example, [this run on PR #60052](https://github.com/woocommerce/woocommerce/actions/runs/21406786247/job/61633100324) completed all 7058 tests with 0 failures in 604s, but the step was killed at the 10-minute mark. Trunk runs for the same shard succeed only because non-PR events use a 360-minute timeout.

Bumping to 15 minutes provides reasonable headroom without being overly generous.

## Test plan

- [ ] Verify CI passes on this PR itself
- [ ] Confirm PHP 7.4 shard 2/2 completes without timeout