### PR TITLE
Add PR template instruction to CLAUDE.md

### DIFF
--- a/.ai/skills/woocommerce-git/SKILL.md
+++ b/.ai/skills/woocommerce-git/SKILL.md
@@ -16,4 +16,4 @@ When creating PRs, use the template at `.github/PULL_REQUEST_TEMPLATE.md`. The P
 - **Milestone** — check the box to auto-assign the next WooCommerce version milestone
 - **Changelog entry** — check "This Pull Request does not require a changelog entry" and add a comment explaining why, OR check "Automatically create a changelog entry" and fill in the significance, type, and message (only if a changelog file was not already committed to the branch)
 
-Omit sections that don't apply (e.g. screenshots for non-UI changes, bug fix links for features). Pass the body via a HEREDOC to `gh pr create --body`.
+Preserve the PR template structure (do not remove required sections used by automation); if a section does not apply, write "N/A" under that heading. Keep changelog/automation fields (e.g., changelog entry details and comments) intact so downstream tools continue to work. Pass the body via a HEREDOC to `gh pr create --body`.

--- a/.ai/skills/woocommerce-git/SKILL.md
+++ b/.ai/skills/woocommerce-git/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: woocommerce-git
+description: Guidelines for git and GitHub operations in the WooCommerce repository.
+---
+
+# WooCommerce Git Guidelines
+
+This skill provides guidance for git and GitHub operations in the WooCommerce repository, including creating pull requests and managing changelogs.
+
+## Pull Request Template
+
+When creating PRs, use the template at `.github/PULL_REQUEST_TEMPLATE.md`. The PR body must include these sections:
+
+- **Changes proposed in this Pull Request** — describe what changed and why
+- **How to test the changes in this Pull Request** — step-by-step testing instructions
+- **Milestone** — check the box to auto-assign the next WooCommerce version milestone
+- **Changelog entry** — check "This Pull Request does not require a changelog entry" and add a comment explaining why, OR check "Automatically create a changelog entry" and fill in the significance, type, and message (only if a changelog file was not already committed to the branch)
+
+Omit sections that don't apply (e.g. screenshots for non-UI changes, bug fix links for features). Pass the body via a HEREDOC to `gh pr create --body`.

--- a/.ai/skills/woocommerce-git/SKILL.md
+++ b/.ai/skills/woocommerce-git/SKILL.md
@@ -5,15 +5,6 @@ description: Guidelines for git and GitHub operations in the WooCommerce reposit
 
 # WooCommerce Git Guidelines
 
-This skill provides guidance for git and GitHub operations in the WooCommerce repository, including creating pull requests and managing changelogs.
+## Pull Requests
 
-## Pull Request Template
-
-When creating PRs, use the template at `.github/PULL_REQUEST_TEMPLATE.md`. The PR body must include these sections:
-
-- **Changes proposed in this Pull Request** — describe what changed and why
-- **How to test the changes in this Pull Request** — step-by-step testing instructions
-- **Milestone** — check the box to auto-assign the next WooCommerce version milestone
-- **Changelog entry** — check "This Pull Request does not require a changelog entry" and add a comment explaining why, OR check "Automatically create a changelog entry" and fill in the significance, type, and message (only if a changelog file was not already committed to the branch)
-
-Preserve the PR template structure (do not remove required sections used by automation); if a section does not apply, write "N/A" under that heading. Keep changelog/automation fields (e.g., changelog entry details and comments) intact so downstream tools continue to work. Pass the body via a HEREDOC to `gh pr create --body`.
+When creating PRs, follow the template at `.github/PULL_REQUEST_TEMPLATE.md`. Include all sections from the template; if a section does not apply, write "N/A" under that heading. Pass the body via a HEREDOC to `gh pr create --body`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ The `.ai/skills/` directory contains procedural HOW-TO instructions:
 - **`woocommerce-copy-guidelines`** - UI text standards (sentence case rules)
 - **`woocommerce-code-review`** - Code review standards and critical violations to flag
 - **`woocommerce-markdown`** - Markdown writing and editing guidelines
+- **`woocommerce-git`** - Guidelines for git and GitHub operations
 
 **CRITICAL:** After reading a skill, check if a personal skill override file exists at
 `~/.ai/skills/{skill-name}-personal/SKILL.md` and apply it too. For example, for the


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a new skill for AI agents for git and GitHub operations, and include instructions to use the project's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) when creating pull requests. Lists the required sections and explains how to handle the changelog entry checkbox.

This addresses PRs being created without the expected template sections (milestone checkbox, changelog entry, testing instructions, etc.).

### How to test the changes in this Pull Request:

1. Review the diff — the file is `.ai/skills/woocommerce-git/SKILL.md` and is mentioned in `CLAUDE.md`. Note that per https://github.com/woocommerce/woocommerce/pull/61811 there's a `.claude` directory that's just a symlink to `.ai`.
2. Verify the listed required sections match what's in `.github/PULL_REQUEST_TEMPLATE.md`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation-only change to CLAUDE.md, no user-facing impact.

</details>