### PR TITLE
[Performance] Products: prime caches before constructing product object

### DIFF
--- a/plugins/woocommerce/changelog/performance-62986-cache-priming-in-product-factory
+++ b/plugins/woocommerce/changelog/performance-62986-cache-priming-in-product-factory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Products: reduce the number of SQL queries needed to construct product objects.

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -41,7 +41,7 @@ class WC_Product_Factory {
 				return $product;
 			}
 		}
-		_prime_post_caches( [ $product_id ] );
+		_prime_post_caches( array( $product_id ) );
 
 		$product_type = self::get_product_type( $product_id );
 

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -21,12 +21,12 @@ class WC_Product_Factory {
 	/**
 	 * Get a product.
 	 *
-	 * @param mixed $product_id WC_Product|WP_Post|int|bool $product Product instance, post instance, numeric or false to use global $post.
+	 * @param mixed $product_id Product instance, post instance, numeric or false to use global $post.
 	 * @param array $deprecated Previously used to pass arguments to the factory, e.g. to force a type.
-	 * @return WC_Product|bool Product object or false if the product cannot be loaded.
+	 * @return WC_Product|bool  Product object or false if the product cannot be loaded.
 	 */
 	public function get_product( $product_id = false, $deprecated = array() ) {
-		$product_id = $this->get_product_id( $product_id );
+		$product_id = (int) $this->get_product_id( $product_id );
 
 		if ( ! $product_id ) {
 			return false;
@@ -36,11 +36,12 @@ class WC_Product_Factory {
 		if ( $use_product_cache && empty( $deprecated ) ) {
 			// Nothing should be using the $deprecated argument still, but avoid using cache if they are.
 			$product_cache = wc_get_container()->get( ProductCache::class );
-			$product       = $product_cache->get( (int) $product_id );
+			$product       = $product_cache->get( $product_id );
 			if ( $product ) {
 				return $product;
 			}
 		}
+		_prime_post_caches( [ $product_id ] );
 
 		$product_type = self::get_product_type( $product_id );
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -17581,18 +17581,6 @@ parameters:
 			path: includes/class-wc-product-factory.php
 
 		-
-			message: '#^Parameter \#1 \$product_id of static method WC_Product_Factory\:\:get_product_classname\(\) expects int, int\<min, \-1\>\|int\<1, max\>\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-product-factory.php
-
-		-
-			message: '#^Parameter \#1 \$product_id of static method WC_Product_Factory\:\:get_product_type\(\) expects int, int\<min, \-1\>\|int\<1, max\>\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-product-factory.php
-
-		-
 			message: '#^Parameter \#2 \$product_type of static method WC_Product_Factory\:\:get_product_classname\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #62986, WOOPLUG-6194.

Reduces the number of SQL queries required in product object construction by adding cache priming.

- Store: product page, variable product with no related products; 123 SQLs -> 104 SQLs
- Store: product page, regular product with 6 related products; 150 SQLs -> 112 SQLs

### How to test the changes in this Pull Request:

When testing, note the reduction in SQL queries and RAM usage on the product page (should decrease by ~1MB).

- Ensure the testing site has Query Monitor plugin installed (or similar) to monitor SQLs and other stats
- Starting with the trunk, navigate to a product page (variable product, simple product with related products)
- Note the number of SQLs executed (swings, you might need to refresh the page multiple times before it stabilizes)
- Switch to this branch and repeat
- Compare the collected numbers

Exploratory part:
- verify the number of SQLs is unchanged on store category pages
- verify the number of SQLs is decreased on the product edit page