### PR TITLE
Email Editor: Fix email template selection modal becomes unresponsive with Gutenberg v22

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-1780-email-template-selection-modal-becomes-unresponsive
+++ b/packages/js/email-editor/changelog/wooprd-1780-email-template-selection-modal-becomes-unresponsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix infinite loop when selecting a template in the email design selector modal

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -60,19 +60,31 @@ export function InnerEditor( {
 
 	const { post, template } = useSelect(
 		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			const { getEditedPostTemplate } = select( storeName );
-			const postObject = getEntityRecord(
+			const { getEditedEntityRecord } = select( coreStore );
+			const editedPost = getEditedEntityRecord(
 				'postType',
 				currentPost.postType,
 				currentPost.postId
-			) as Post | null;
+			);
+
+			// getEditedEntityRecord can return false/undefined if not found
+			if ( ! editedPost || typeof editedPost === 'boolean' ) {
+				return { post: null, template: null };
+			}
+
+			const postData = editedPost as unknown as Post;
+
+			// Get template for non-template post types
+			if ( currentPost.postType === 'wp_template' ) {
+				return { post: postData, template: null };
+			}
+
+			const { getEditedPostTemplate } = select( storeName );
+			const templateData = getEditedPostTemplate( postData.template );
+
 			return {
-				template:
-					postObject && currentPost.postType !== 'wp_template'
-						? getEditedPostTemplate( postObject.template )
-						: null,
-				post: postObject,
+				post: postData,
+				template: templateData,
 			};
 		},
 		[ currentPost.postType, currentPost.postId ]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After updating Gutenberg, the email template selection modal became unresponsive, and the entire browser tab would freeze when selecting a template. The application would hang indefinitely, making it impossible to change email templates.

#### Root Cause

The `InnerEditor` component was using `getEntityRecord()` to read post data, which returns the **saved entity state** from the database. However, when a template is selected, `editEntityRecord()` updates the **edited entity state** in memory (unsaved changes).

This created a state synchronization mismatch:
1. User selects template → `editEntityRecord()` sets `template: "wooemailtemplate"` in edited state
2. Selector reads from edited state → sees `template: "wooemailtemplate"`
3. Component reads from saved state via `getEntityRecord()` → sees `template: undefined`
4. Component re-renders with `undefined` → triggers selector again → infinite loop → browser freeze

#### Solution

Changed `InnerEditor` component in [editor.tsx:64](packages/js/email-editor/src/components/block-editor/editor.tsx#L64) to use `getEditedEntityRecord()` instead of `getEntityRecord()`, ensuring both the component and selector read from the same edited state source.

This fixes the infinite loop while maintaining compatibility with the new Gutenberg architecture.

Closes WOOPRD-1780.

### Testing instructions

<!-- Begin testing instructions -->

This needs to be tested with an integration that supports email creation flow. WooCommerce integration currently supports only editing transactional emails. MailPoet plugin is a good candidate.

To replicate the issue, just install the newest Gutenberg and try to create a new email.

1. Setup MailPoet to consume the build package locally  someting like `"@woocommerce/email-editor": "file:../../../woocommerce/packages/js/email-editor",` with the correct path to build package from this branc 
2. Verify it is possible to select an email from the template selector

<!-- End testing instructions -->

### Testing that has already taken place:

I tested with the MailPoet plugin.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
