### PR TITLE
Fix: Update email settings actions menu divider and terminology

### DIFF
--- a/plugins/woocommerce/changelog/fix-stomail-7742-admin-notification-actions-menu
+++ b/plugins/woocommerce/changelog/fix-stomail-7742-admin-notification-actions-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update email settings actions menu: remove divider between Edit and Send test email, change terminology from Enable/Disable to Activate/Deactivate email.

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -110,17 +110,6 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 	const actions = useMemo(
 		() => [
 			{
-				id: 'preview',
-				label: __( 'Preview', 'woocommerce' ),
-				icon: <Icon icon={ external } />,
-				supportsBulk: false,
-				callback: ( items: EmailType[] ) => {
-					window.open( items[ 0 ].link );
-				},
-				isEligible: ( item: EmailType ) => !! item.post_id,
-				isPrimary: true,
-			},
-			{
 				id: 'edit',
 				label: __( 'Edit', 'woocommerce' ),
 				icon: <Icon icon={ edit } />,
@@ -141,6 +130,17 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 						);
 					}
 				},
+			},
+			{
+				id: 'preview',
+				label: __( 'Preview', 'woocommerce' ),
+				icon: <Icon icon={ external } />,
+				supportsBulk: false,
+				callback: ( items: EmailType[] ) => {
+					window.open( items[ 0 ].link );
+				},
+				isEligible: ( item: EmailType ) => !! item.post_id,
+				isPrimary: true,
 			},
 			{
 				id: 'test',

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -141,7 +141,6 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 						);
 					}
 				},
-				isPrimary: true,
 			},
 			{
 				id: 'test',
@@ -156,8 +155,8 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				id: 'change-status',
 				label: ( items: EmailType[] ) =>
 					items[ 0 ].status === 'enabled'
-						? __( 'Disable email', 'woocommerce' )
-						: __( 'Enable email', 'woocommerce' ),
+						? __( 'Deactivate email', 'woocommerce' )
+						: __( 'Activate email', 'woocommerce' ),
 				supportsBulk: false,
 				isEligible: ( item: EmailType ) =>
 					item.status === 'enabled' || item.status === 'disabled',

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-status.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-status.tsx
@@ -13,7 +13,7 @@ import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 export const EMAIL_STATUSES = [
 	{
 		value: 'enabled',
-		label: __( 'Enabled', 'woocommerce' ),
+		label: __( 'Active', 'woocommerce' ),
 		icon: published,
 		description: __(
 			'Email would be sent if trigger is met',

--- a/plugins/woocommerce/tests/e2e-pw/tests/email-editor/email-editor-settings-sidebar.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email-editor/email-editor-settings-sidebar.spec.js
@@ -33,9 +33,9 @@ test.describe( 'WooCommerce Email Editor Settings Sidebar Integration', () => {
 		await ensureEmailEditorSettingsPanelIsOpened( page );
 		await expect(
 			page.locator( '.editor-post-status__toggle' )
-		).toContainText( 'Enabled' );
+		).toContainText( 'Active' );
 		await page.locator( '.editor-post-status__toggle' ).click();
-		await page.getByLabel( 'Inactive' ).click();
+		await page.getByRole( 'radio', { name: 'Inactive' } ).click();
 		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
 		await expect(
 			page.locator( '.editor-post-status__toggle' )
@@ -48,11 +48,13 @@ test.describe( 'WooCommerce Email Editor Settings Sidebar Integration', () => {
 		).toContainText( 'Inactive' );
 		// reset the email status.
 		await page.locator( '.editor-post-status__toggle' ).click();
-		await page.getByLabel( 'Enabled' ).click();
+		await page
+			.getByRole( 'radio', { name: 'Active', exact: true } )
+			.click();
 		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
 		await expect(
 			page.locator( '.editor-post-status__toggle' )
-		).toContainText( 'Enabled' );
+		).toContainText( 'Active' );
 	} );
 
 	test( 'Can update email subject and preview text', async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
@@ -73,11 +73,13 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		// Open the first row more actions menu
 		await firstRow.locator( '.dataviews-all-actions-button' ).click();
 
-		// Check that the "Disable email" option is present and clickable
+		// Check that the "Deactivate email" option is present and clickable
 		await expect(
-			page.getByRole( 'menuitem', { name: 'Disable email' } )
+			page.getByRole( 'menuitem', { name: 'Deactivate email' } )
 		).toBeVisible();
-		await page.getByRole( 'menuitem', { name: 'Disable email' } ).click();
+		await page
+			.getByRole( 'menuitem', { name: 'Deactivate email' } )
+			.click();
 
 		// Check that the email status is now Draft
 		await expect( firstRow.locator( 'td' ).nth( 2 ) ).toHaveText(
@@ -87,11 +89,11 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		// Open the first row more actions menu again
 		await firstRow.locator( '.dataviews-all-actions-button' ).click();
 
-		// Check that the "Enable email" option is present and clickable
+		// Check that the "Activate email" option is present and clickable
 		await expect(
-			page.getByRole( 'menuitem', { name: 'Enable email' } )
+			page.getByRole( 'menuitem', { name: 'Activate email' } )
 		).toBeVisible();
-		await page.getByRole( 'menuitem', { name: 'Enable email' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Activate email' } ).click();
 
 		// Check that the email status is now Active again
 		await expect( firstRow.locator( 'td' ).nth( 2 ) ).toHaveText(

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
@@ -67,7 +67,7 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		// Check that first row shows Active status
 		const firstRow = listViewLocator.locator( 'tr' ).nth( 1 ); // nth(1) because nth(0) is header row
 		await expect( firstRow.locator( 'td' ).nth( 2 ) ).toHaveText(
-			'Enabled'
+			'Active'
 		);
 
 		// Open the first row more actions menu
@@ -97,7 +97,7 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 
 		// Check that the email status is now Active again
 		await expect( firstRow.locator( 'td' ).nth( 2 ) ).toHaveText(
-			'Enabled'
+			'Active'
 		);
 
 		// I want to check that search works

--- a/plugins/woocommerce/tests/e2e-pw/utils/email.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/email.js
@@ -96,10 +96,13 @@ export async function getWooEmails( params ) {
  */
 export async function accessTheEmailEditor( page, emailTitle = 'New order' ) {
 	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=email' );
-	await page
-		.getByRole( 'row', { name: new RegExp( emailTitle ) } )
-		.getByLabel( 'Edit' )
+	const theRow = page.getByRole( 'row', {
+		name: new RegExp( emailTitle ),
+	} );
+	await theRow
+		.getByRole( 'button', { name: 'Actions', exact: true } )
 		.click();
+	await page.getByRole( 'menuitem', { name: 'Edit', exact: true } ).click();
 	await expect( page.locator( '#woocommerce-email-editor' ) ).toBeVisible();
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes two UI issues in the email settings actions menu as identified in [STOMAIL-7742](https://linear.app/a8c/issue/STOMAIL-7742/admin-notification-actions-menu-has-incorrect-divider-and-copy-need):

**Why these changes are needed:**
- The current actions menu has inconsistent terminology that doesn't align with the latest design specifications
- A visual divider between "Edit" and "Send test email" was creating unnecessary visual separation for items that should be grouped together
- The terminology "Enable/Disable" was changed to "Activate/Deactivate" for inclusive language considerations

**Changes made:**
1. **Remove menu divider**: Removed `isPrimary: true` from the "Edit" action so it groups visually with "Send test email" and "Deactivate email" actions
2. **Update terminology**: Changed "Disable email" → "Deactivate email" and "Enable email" → "Activate email" for more inclusive language
3. **Update status label**: Changed "Enabled" → "Active" in the status column for consistency
4. **Update e2e tests**: Updated test expectations to match the new terminology

Closes https://linear.app/a8c/issue/STOMAIL-7742/admin-notification-actions-menu-has-incorrect-divider-and-copy-need

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1547" height="727" alt="Screenshot 2026-01-28 at 10 47 46 AM" src="https://github.com/user-attachments/assets/6116826d-8f71-4c44-9ac9-0e4022739c65" />  |    <img width="1544" height="773" alt="Screenshot 2026-01-28 at 8 37 39 AM" src="https://github.com/user-attachments/assets/af3af218-81fb-4986-b65a-a09dd47ce495" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to **WooCommerce → Settings → Emails**
2. In the email notifications list, click on the three-dot menu (Actions) for any email row
3. Verify that:
   - There is **no visual divider** between "Edit" and "Send test email" menu items
   - For enabled emails, the action shows **"Deactivate email"** (not "Disable email")
4. Click "Deactivate email" to disable an email
5. Verify the status column shows **"Inactive"**
6. Open the actions menu again and verify it now shows **"Activate email"** (not "Enable email")
7. Click "Activate email" and verify the email is re-enabled

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
