### PR TITLE
Fix V4 Refunds API extracting tax from refund_total on zero-tax shipping items

### DIFF
--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -51,7 +51,14 @@ class DataUtils {
 				$original_item = $order->get_item( $line_item['line_item_id'] );
 				if ( $original_item ) {
 					$original_taxes = $original_item->get_taxes();
-					$tax_ids        = array_keys( $original_taxes['total'] ?? array() );
+					// Filter to only include tax IDs that have non-zero amounts.
+					$tax_totals     = array_filter(
+						$original_taxes['total'] ?? array(),
+						function ( $amount ) {
+							return is_numeric( $amount ) && $amount > 0;
+						}
+					);
+					$tax_ids        = array_keys( $tax_totals );
 
 					if ( ! empty( $tax_ids ) ) {
 						$tax_rates = $this->build_tax_rates_array( $order, $tax_ids );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -52,13 +52,13 @@ class DataUtils {
 				if ( $original_item ) {
 					$original_taxes = $original_item->get_taxes();
 					// Filter to only include tax IDs that have non-zero amounts.
-					$tax_totals     = array_filter(
+					$tax_totals = array_filter(
 						$original_taxes['total'] ?? array(),
 						function ( $amount ) {
 							return is_numeric( $amount ) && $amount > 0;
 						}
 					);
-					$tax_ids        = array_keys( $tax_totals );
+					$tax_ids    = array_keys( $tax_totals );
 
 					if ( ! empty( $tax_ids ) ) {
 						$tax_rates = $this->build_tax_rates_array( $order, $tax_ids );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a shipping item has tax rate IDs with zero or empty amounts in its taxes metadata (e.g. from an external tax service), the API incorrectly enters the tax extraction branch and deducts tax from `refund_total` even though no actual tax was applied. This filters tax IDs to only those with non-zero numeric amounts before deciding whether to extract taxes.

This issue is difficult to reproduce locally because it requires shipping items to have tax rate IDs registered in their metadata with zero or empty amounts, and although I've experienced it, I didn't pinpoint the exact steps when this can happen.

### How to test the changes in this Pull Request:

1. Verify refunds work correctly for shipping items with no tax rates applied (tax rate with shipping checkbox unchecked). By working correctly, I mean that when refunding a shipping item, no tax is deducted from the total sum. So this doesn't happen:

<img width="2766" height="188" alt="CleanShot 2026-01-27 at 15 51 35@2x" src="https://github.com/user-attachments/assets/a94b5c70-4ff9-491b-8577-9277a22b9770" />

2. Verify refunds work correctly for shipping items with a zero-tax rate applied (tax rate set to 0% with the shipping checkbox checked).
3. Verify refunds still extract tax correctly for shipping items with actual tax applied
4. Verify existing refund behavior for line items and fees is unchanged

### Testing that has already taken place:

The above and I am still trying to figure out how to consistently reproduce it. Will update once I learn more.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

The V4 refunds API is not public and a work-in-progress, we don't need a changelog for it yet.

</details>
