### PR TITLE
Fraud Protection: Add Blackbox SDK integration (PoC)

### DIFF
--- a/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/blackbox-mock.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/blackbox-mock.js
@@ -1,0 +1,36 @@
+/**
+ * Mock Blackbox SDK
+ * Provides window.Blackbox.init() that returns Promise<session_id>
+ *
+ * This is a PoC mock that simulates the Blackbox SDK behavior.
+ * In production, this would be replaced by the actual Blackbox SDK.
+ */
+( function () {
+	'use strict';
+
+	const INIT_DELAY_MS = 1000;
+
+	const generateSessionId = () => {
+		return `bb_${ Date.now().toString( 36 ) }_${ Math.random()
+			.toString( 36 )
+			.substring( 2, 15 ) }`;
+	};
+
+	window.Blackbox = {
+		init: () => {
+			return new Promise( ( resolve ) => {
+				// eslint-disable-next-line no-console
+				console.log( '[Blackbox Mock] Initializing...' );
+				setTimeout( () => {
+					const sessionId = generateSessionId();
+					// eslint-disable-next-line no-console
+					console.log( '[Blackbox Mock] Session ID:', sessionId );
+					resolve( sessionId );
+				}, INIT_DELAY_MS );
+			} );
+		},
+	};
+
+	// eslint-disable-next-line no-console
+	console.log( '[Blackbox Mock] SDK loaded' );
+} )();

--- a/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
@@ -1,0 +1,192 @@
+/**
+ * WooCommerce Fraud Protection Checkout Script
+ *
+ * Handles three checkout types:
+ * - blocks: Uses applyExtensionCartUpdate
+ * - shortcode: Uses update_checkout event
+ * - add-payment-method: Uses AJAX verify + page reload
+ */
+( function () {
+	'use strict';
+
+	const config = window.wcFraudProtection;
+	if ( ! config ) {
+		// eslint-disable-next-line no-console
+		console.error( '[FraudProtection] Config not found' );
+		return;
+	}
+
+	const TIMEOUT_MS = config.timeoutMs || 5000;
+
+	/**
+	 * Shortcode checkout: Add hidden input and trigger update_checkout.
+	 *
+	 * @param {string} sessionId The Blackbox session ID.
+	 */
+	const triggerShortcodeUpdate = ( sessionId ) => {
+		const $ = window.jQuery;
+		if ( ! $ ) {
+			return;
+		}
+
+		const form = $( 'form.checkout' );
+		if ( form.length ) {
+			form.find( 'input[name="blackbox_session_id"]' ).remove();
+			form.append(
+				`<input type="hidden" name="blackbox_session_id" value="${ sessionId }" />`
+			);
+		}
+
+		$( document.body ).trigger( 'update_checkout' );
+		// eslint-disable-next-line no-console
+		console.log(
+			'[FraudProtection] Triggered update_checkout with session:',
+			sessionId
+		);
+	};
+
+	/**
+	 * Blocks checkout: Call applyExtensionCartUpdate via wp.data.
+	 *
+	 * @param {string} sessionId The Blackbox session ID.
+	 */
+	const triggerBlocksUpdate = async ( sessionId ) => {
+		const wpData = window.wp && window.wp.data;
+		const dispatch = wpData && wpData.dispatch;
+		if ( ! dispatch ) {
+			// eslint-disable-next-line no-console
+			console.error( '[FraudProtection] wp.data not available' );
+			return;
+		}
+
+		try {
+			await dispatch( 'wc/store/cart' ).applyExtensionCartUpdate( {
+				namespace: config.namespace,
+				data: { blackbox_session_id: sessionId },
+			} );
+			// eslint-disable-next-line no-console
+			console.log(
+				'[FraudProtection] Cart updated with session:',
+				sessionId
+			);
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( '[FraudProtection] Cart update failed:', error );
+		}
+	};
+
+	/**
+	 * Add payment method: AJAX verify, then page reload.
+	 * Payment methods are hidden until session is ALLOWED.
+	 *
+	 * @param {string} sessionId The Blackbox session ID.
+	 */
+	const verifyAndReload = async ( sessionId ) => {
+		const $ = window.jQuery;
+		if ( ! $ ) {
+			return;
+		}
+
+		try {
+			const response = await $.ajax( {
+				url: config.ajaxUrl,
+				method: 'POST',
+				data: {
+					security: config.nonce,
+					blackbox_session_id: sessionId,
+				},
+			} );
+
+			if ( response.success ) {
+				// Session verified - reload to show payment methods
+				// eslint-disable-next-line no-console
+				console.log(
+					'[FraudProtection] Verification successful, reloading page'
+				);
+				window.location.reload();
+			} else {
+				// Blocked - show error (payment methods stay hidden)
+				var errorMessage =
+					( response.data && response.data.message ) ||
+					'Unable to proceed.';
+				// eslint-disable-next-line no-console
+				console.error(
+					'[FraudProtection] Verification failed:',
+					errorMessage
+				);
+				$( '.woocommerce-add-payment-method' ).prepend(
+					'<div class="woocommerce-error">' + errorMessage + '</div>'
+				);
+			}
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( '[FraudProtection] AJAX verify failed:', error );
+			// Fail-open: reload and let server decide
+			window.location.reload();
+		}
+	};
+
+	const initialize = async () => {
+		let sessionId = '';
+
+		// Try to get session_id from Blackbox
+		if ( window.Blackbox && window.Blackbox.init ) {
+			try {
+				sessionId = await Promise.race( [
+					window.Blackbox.init(),
+					new Promise( ( _, reject ) =>
+						setTimeout(
+							() => reject( new Error( 'Blackbox timeout' ) ),
+							TIMEOUT_MS
+						)
+					),
+				] );
+				// eslint-disable-next-line no-console
+				console.log(
+					'[FraudProtection] Got Blackbox session:',
+					sessionId
+				);
+			} catch ( error ) {
+				// Fail-open: continue with empty session_id
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[FraudProtection] Blackbox init failed, continuing with empty session:',
+					error
+				);
+			}
+		} else {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[FraudProtection] Blackbox SDK not loaded, continuing with empty session'
+			);
+		}
+
+		// Trigger appropriate action based on checkout type
+		switch ( config.checkoutType ) {
+			case 'blocks':
+				await triggerBlocksUpdate( sessionId );
+				break;
+			case 'shortcode':
+				triggerShortcodeUpdate( sessionId );
+				break;
+			case 'add-payment-method':
+				// Skip if already verified (prevents infinite reload loop).
+				if ( ! config.sessionVerified ) {
+					await verifyAndReload( sessionId );
+				} else {
+					// eslint-disable-next-line no-console
+					console.log(
+						'[FraudProtection] Session already verified, skipping verification'
+					);
+				}
+				break;
+		}
+	};
+
+	// Start initialization when DOM is ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initialize );
+	} else {
+		initialize();
+	}
+} )();

--- a/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
@@ -127,15 +127,12 @@
 	};
 
 	const initialize = async () => {
-		// For add-payment-method: skip entirely if verified recently.
-		// No need to call Blackbox.init() if we're not going to verify.
-		if (
-			config.checkoutType === 'add-payment-method' &&
-			config.recentlyVerified
-		) {
+		// Skip if session is already verified (ALLOWED or BLOCKED).
+		// Only PENDING sessions need verification.
+		if ( config.isSessionVerified ) {
 			// eslint-disable-next-line no-console
 			console.log(
-				'[FraudProtection] Recently verified, skipping initialization'
+				'[FraudProtection] Session already verified, skipping initialization'
 			);
 			return;
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
@@ -170,14 +170,15 @@
 				triggerShortcodeUpdate( sessionId );
 				break;
 			case 'add-payment-method':
-				// Skip if already verified (prevents infinite reload loop).
-				if ( ! config.sessionVerified ) {
-					await verifyAndReload( sessionId );
-				} else {
+				// Skip if verified recently (prevents infinite reload loop after verification).
+				// Uses timestamp-based check: if verification happened within 10 seconds, skip.
+				if ( config.recentlyVerified ) {
 					// eslint-disable-next-line no-console
 					console.log(
-						'[FraudProtection] Session already verified, skipping verification'
+						'[FraudProtection] Recently verified, skipping verification'
 					);
+				} else {
+					await verifyAndReload( sessionId );
 				}
 				break;
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/fraud-protection/checkout.js
@@ -127,6 +127,19 @@
 	};
 
 	const initialize = async () => {
+		// For add-payment-method: skip entirely if verified recently.
+		// No need to call Blackbox.init() if we're not going to verify.
+		if (
+			config.checkoutType === 'add-payment-method' &&
+			config.recentlyVerified
+		) {
+			// eslint-disable-next-line no-console
+			console.log(
+				'[FraudProtection] Recently verified, skipping initialization'
+			);
+			return;
+		}
+
 		let sessionId = '';
 
 		// Try to get session_id from Blackbox
@@ -170,16 +183,7 @@
 				triggerShortcodeUpdate( sessionId );
 				break;
 			case 'add-payment-method':
-				// Skip if verified recently (prevents infinite reload loop after verification).
-				// Uses timestamp-based check: if verification happened within 10 seconds, skip.
-				if ( config.recentlyVerified ) {
-					// eslint-disable-next-line no-console
-					console.log(
-						'[FraudProtection] Recently verified, skipping verification'
-					);
-				} else {
-					await verifyAndReload( sessionId );
-				}
+				await verifyAndReload( sessionId );
 				break;
 		}
 	};

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Internal\Orders\CouponsController;
 use Automattic\WooCommerce\Internal\Orders\TaxesController;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
+use Automattic\WooCommerce\Internal\FraudProtection\BlackboxIntegration;
 use Automattic\WooCommerce\Internal\FraudProtection\CheckoutEventTracker;
 use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
 use Automattic\WooCommerce\Internal\Utilities\Users;
@@ -381,6 +382,25 @@ class WC_AJAX {
 		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled() ) {
 			wc_get_container()->get( CheckoutEventTracker::class )
 				->track_shortcode_checkout_field_update( isset( $_POST['post_data'] ) ? wp_unslash( $_POST['post_data'] ) : '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+			// Process Blackbox session ID for fraud protection.
+			// Only call handler if blackbox_session_id was explicitly provided in the request.
+			// Even empty string triggers verify (fail-open), but we don't verify on regular
+			// update_checkout calls that don't include the blackbox_session_id field.
+			$blackbox_session_id = null;
+			if ( isset( $_POST['blackbox_session_id'] ) ) {
+				$blackbox_session_id = sanitize_text_field( wp_unslash( $_POST['blackbox_session_id'] ) );
+			} elseif ( isset( $_POST['post_data'] ) ) {
+				parse_str( wp_unslash( $_POST['post_data'] ), $post_data ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				if ( array_key_exists( 'blackbox_session_id', $post_data ) ) {
+					$blackbox_session_id = sanitize_text_field( $post_data['blackbox_session_id'] );
+				}
+			}
+
+			if ( null !== $blackbox_session_id ) {
+				wc_get_container()->get( BlackboxIntegration::class )
+					->handle_shortcode_session_id( $blackbox_session_id );
+			}
 		}
 
 		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -394,9 +394,10 @@ All at %6$s
 	 * @return array The available payment gateways.
 	 */
 	public function get_available_payment_gateways() {
-		// Early return if fraud protection blocks session.
+		// Early return if fraud protection should not render payment methods.
+		// This includes both BLOCKED and PENDING sessions - only ALLOWED sessions see payment methods.
 		if ( wc_get_container()->get( FraudProtectionController::class )->feature_is_enabled()
-			&& wc_get_container()->get( SessionClearanceManager::class )->is_session_blocked() ) {
+			&& ! wc_get_container()->get( SessionClearanceManager::class )->should_render_payment_methods() ) {
 			return array();
 		}
 

--- a/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/ApiClient.php
@@ -74,15 +74,21 @@ class ApiClient {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @param string               $event_type Type of event being sent (e.g., 'cart_updated', 'checkout_started').
-	 * @param array<string, mixed> $event_data Event data to send to the endpoint.
+	 * @param string               $event_type   Type of event being sent (e.g., 'cart_updated', 'checkout_started').
+	 * @param array<string, mixed> $event_data   Event data to send to the endpoint.
+	 * @param array                $prior_events Optional array of prior events queued in session.
 	 * @return string Decision: "allow" or "block".
 	 */
-	public function send_event( string $event_type, array $event_data ): string {
+	public function send_event( string $event_type, array $event_data, array $prior_events = array() ): string {
 		$payload = array_merge(
 			array( 'event_type' => $event_type ),
 			array_filter( $event_data, fn( $value ) => null !== $value )
 		);
+
+		// Include prior events if provided (typically with checkout events).
+		if ( ! empty( $prior_events ) ) {
+			$payload['prior_events'] = $prior_events;
+		}
 
 		FraudProtectionController::log(
 			'info',

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
@@ -156,19 +156,15 @@ class BlackboxIntegration {
 			)
 		);
 
-		// Store the blackbox session ID (even if empty).
+		// Store the blackbox session ID in the WC session.
+		// SessionDataCollector will include it in the 'session' data when collecting event data.
 		if ( ! empty( $session_id ) ) {
 			$this->session_manager->set_blackbox_session_id( $session_id );
 		}
 
-		// Always dispatch checkout event to WPCOM - let server-side decide.
-		// Even without session_id, Blackbox may have other signals.
-		$this->dispatcher->dispatch_event(
-			'checkout',
-			array(
-				'blackbox_session_id' => $session_id,
-			)
-		);
+		// Dispatch checkout event to WPCOM - let server-side decide.
+		// The blackbox_session_id is included in session data via SessionDataCollector.
+		$this->dispatcher->dispatch_event( 'checkout' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * BlackboxIntegration class file.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\FraudProtection;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles Blackbox integration for fraud protection.
+ *
+ * This class manages the client-side Blackbox SDK integration and processes
+ * session IDs from various checkout flows (Blocks, Shortcode, Add Payment Method).
+ *
+ * @since 10.6.0
+ * @internal This class is part of the internal API and is subject to change without notice.
+ */
+class BlackboxIntegration {
+
+	/**
+	 * Session clearance manager instance.
+	 *
+	 * @var SessionClearanceManager
+	 */
+	private SessionClearanceManager $session_manager;
+
+	/**
+	 * Fraud protection dispatcher instance.
+	 *
+	 * @var FraudProtectionDispatcher
+	 */
+	private FraudProtectionDispatcher $dispatcher;
+
+	/**
+	 * Initialize with dependencies.
+	 *
+	 * Note: FraudProtectionController is not injected to avoid circular dependency.
+	 * It's retrieved from the container when needed via feature_is_enabled().
+	 *
+	 * @internal
+	 *
+	 * @param SessionClearanceManager   $session_manager The session clearance manager instance.
+	 * @param FraudProtectionDispatcher $dispatcher      The fraud protection dispatcher instance.
+	 */
+	final public function init(
+		SessionClearanceManager $session_manager,
+		FraudProtectionDispatcher $dispatcher
+	): void {
+		$this->session_manager = $session_manager;
+		$this->dispatcher      = $dispatcher;
+	}
+
+	/**
+	 * Register hooks for Blackbox integration.
+	 *
+	 * Called from FraudProtectionController::on_init() which already checks
+	 * if the feature is enabled.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		// Register Blocks callback for cart/extensions endpoint.
+		woocommerce_store_api_register_update_callback(
+			array(
+				'namespace' => 'woocommerce/fraud-protection',
+				'callback'  => array( $this, 'handle_blocks_session_id' ),
+			)
+		);
+
+		// AJAX endpoint for add-payment-method verification.
+		add_action( 'wc_ajax_fraud_protection_verify', array( $this, 'ajax_verify_session' ) );
+
+		// Enqueue scripts on checkout and add-payment-method pages.
+		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
+		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'enqueue_blocks_data' ) );
+	}
+
+	/**
+	 * Handle session_id from Blocks checkout via cart/extensions.
+	 *
+	 * @param array $data Data from applyExtensionCartUpdate.
+	 * @return void
+	 */
+	public function handle_blocks_session_id( array $data ): void {
+		$session_id = sanitize_text_field( $data['blackbox_session_id'] ?? '' );
+		$this->process_blackbox_session( $session_id );
+	}
+
+	/**
+	 * Handle session_id from shortcode checkout.
+	 * Called from WC_AJAX::update_order_review().
+	 *
+	 * @param string $session_id The Blackbox session ID from POST.
+	 * @return void
+	 */
+	public function handle_shortcode_session_id( string $session_id ): void {
+		$this->process_blackbox_session( sanitize_text_field( $session_id ) );
+	}
+
+	/**
+	 * AJAX endpoint for add-payment-method verification.
+	 * Called via wc_ajax_fraud_protection_verify.
+	 *
+	 * @return void
+	 */
+	public function ajax_verify_session(): void {
+		check_ajax_referer( 'fraud-protection-verify', 'security' );
+
+		$session_id = isset( $_POST['blackbox_session_id'] )
+			? sanitize_text_field( wp_unslash( $_POST['blackbox_session_id'] ) )
+			: '';
+
+		// Process and verify.
+		$this->process_blackbox_session( $session_id );
+
+		// Return result.
+		if ( $this->session_manager->is_session_blocked() ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Unable to proceed at this time. Please try again later.', 'woocommerce' ),
+				)
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'message' => __( 'Verification complete.', 'woocommerce' ),
+			)
+		);
+	}
+
+	/**
+	 * Process Blackbox session - called from all handlers.
+	 * Always calls verify, even with empty session_id (fail-open, let server decide).
+	 *
+	 * @param string $session_id The Blackbox session ID (may be empty).
+	 * @return void
+	 */
+	public function process_blackbox_session( string $session_id ): void {
+		// Skip if already processed this exact session.
+		if ( ! empty( $session_id ) && $this->session_manager->get_blackbox_session_id() === $session_id ) {
+			return;
+		}
+
+		FraudProtectionController::log(
+			'info',
+			sprintf(
+				'Processing Blackbox session: %s | WC Session: %s',
+				$session_id ? $session_id : '(empty - fail-open)',
+				$this->session_manager->get_session_id()
+			)
+		);
+
+		// Store the blackbox session ID (even if empty).
+		if ( ! empty( $session_id ) ) {
+			$this->session_manager->set_blackbox_session_id( $session_id );
+		}
+
+		// Always dispatch checkout event to WPCOM - let server-side decide.
+		// Even without session_id, Blackbox may have other signals.
+		$this->dispatcher->dispatch_event(
+			'checkout',
+			array(
+				'blackbox_session_id' => $session_id,
+			)
+		);
+	}
+
+	/**
+	 * Enqueue scripts on shortcode checkout and add-payment-method pages.
+	 *
+	 * Skips checkout pages that use the Blocks checkout - those are handled
+	 * by enqueue_blocks_data() via the woocommerce_blocks_checkout_enqueue_data hook.
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue_scripts(): void {
+		// Skip if this is a Blocks checkout page - handled by enqueue_blocks_data().
+		if ( is_checkout() && has_block( 'woocommerce/checkout' ) ) {
+			return;
+		}
+
+		if ( is_checkout() || is_wc_endpoint_url( 'order-pay' ) || is_add_payment_method_page() ) {
+			$checkout_type = is_add_payment_method_page() ? 'add-payment-method' : 'shortcode';
+			$this->enqueue_blackbox_scripts( $checkout_type );
+		}
+	}
+
+	/**
+	 * Enqueue scripts and data for Blocks checkout.
+	 *
+	 * @return void
+	 */
+	public function enqueue_blocks_data(): void {
+		$this->enqueue_blackbox_scripts( 'blocks' );
+	}
+
+	/**
+	 * Enqueue Blackbox-related scripts.
+	 *
+	 * @param string $checkout_type The checkout type: 'blocks', 'shortcode', or 'add-payment-method'.
+	 * @return void
+	 */
+	private function enqueue_blackbox_scripts( string $checkout_type ): void {
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		// Enqueue mock Blackbox SDK.
+		wp_enqueue_script(
+			'wc-fraud-protection-blackbox-mock',
+			plugins_url( 'assets/js/frontend/fraud-protection/blackbox-mock' . $suffix . '.js', WC_PLUGIN_FILE ),
+			array(),
+			WC_VERSION,
+			array( 'in_footer' => true )
+		);
+
+		// Enqueue WooCommerce fraud checkout script.
+		$deps = 'blocks' === $checkout_type
+			? array( 'wc-fraud-protection-blackbox-mock', 'wp-data', 'wp-api-fetch' )
+			: array( 'wc-fraud-protection-blackbox-mock', 'jquery' );
+
+		wp_enqueue_script(
+			'wc-fraud-protection-checkout',
+			plugins_url( 'assets/js/frontend/fraud-protection/checkout' . $suffix . '.js', WC_PLUGIN_FILE ),
+			$deps,
+			WC_VERSION,
+			array( 'in_footer' => true )
+		);
+
+		// Check if session is already verified (to prevent infinite reload on add-payment-method).
+		// Use !is_session_pending() since both ALLOWED and BLOCKED are "verified" states.
+		$session_verified = ! $this->session_manager->is_session_pending();
+
+		wp_localize_script(
+			'wc-fraud-protection-checkout',
+			'wcFraudProtection',
+			array(
+				'checkoutType'    => $checkout_type,
+				'namespace'       => 'woocommerce/fraud-protection',
+				'timeoutMs'       => 5000,
+				'ajaxUrl'         => \WC_AJAX::get_endpoint( 'fraud_protection_verify' ),
+				'nonce'           => wp_create_nonce( 'fraud-protection-verify' ),
+				'sessionVerified' => $session_verified,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
@@ -181,8 +181,8 @@ class BlackboxIntegration {
 			return;
 		}
 
-		if ( is_checkout() || is_wc_endpoint_url( 'order-pay' ) || is_add_payment_method_page() ) {
-			$checkout_type = is_add_payment_method_page() ? 'add-payment-method' : 'shortcode';
+		if ( is_checkout() || is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'add-payment-method' ) ) {
+			$checkout_type = is_wc_endpoint_url( 'add-payment-method' ) ? 'add-payment-method' : 'shortcode';
 			$this->enqueue_blackbox_scripts( $checkout_type );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
@@ -227,20 +227,21 @@ class BlackboxIntegration {
 			array( 'in_footer' => true )
 		);
 
-		// Check if session is already verified (to prevent infinite reload on add-payment-method).
-		// Use !is_session_pending() since both ALLOWED and BLOCKED are "verified" states.
-		$session_verified = ! $this->session_manager->is_session_pending();
+		// Check if session was verified recently (to prevent infinite reload on add-payment-method).
+		// This uses a timestamp-based check: if verification happened within 10 seconds,
+		// we know this is a post-reload page load and should skip re-verification.
+		$recently_verified = $this->session_manager->was_verified_recently( 10 );
 
 		wp_localize_script(
 			'wc-fraud-protection-checkout',
 			'wcFraudProtection',
 			array(
-				'checkoutType'    => $checkout_type,
-				'namespace'       => 'woocommerce/fraud-protection',
-				'timeoutMs'       => 5000,
-				'ajaxUrl'         => \WC_AJAX::get_endpoint( 'fraud_protection_verify' ),
-				'nonce'           => wp_create_nonce( 'fraud-protection-verify' ),
-				'sessionVerified' => $session_verified,
+				'checkoutType'      => $checkout_type,
+				'namespace'         => 'woocommerce/fraud-protection',
+				'timeoutMs'         => 5000,
+				'ajaxUrl'           => \WC_AJAX::get_endpoint( 'fraud_protection_verify' ),
+				'nonce'             => wp_create_nonce( 'fraud-protection-verify' ),
+				'recentlyVerified'  => $recently_verified,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/BlackboxIntegration.php
@@ -78,6 +78,10 @@ class BlackboxIntegration {
 		// Enqueue scripts on checkout and add-payment-method pages.
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
 		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'enqueue_blocks_data' ) );
+
+		// Reset session clearance for blocks checkout BEFORE cart data is hydrated.
+		// This ensures payment methods are hidden until verification completes.
+		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before', array( $this->session_manager, 'reset_expired_session_clearance' ) );
 	}
 
 	/**
@@ -176,12 +180,16 @@ class BlackboxIntegration {
 	 * @return void
 	 */
 	public function maybe_enqueue_scripts(): void {
-		// Skip if this is a Blocks checkout page - handled by enqueue_blocks_data().
+		// Skip if this is a Blocks checkout page - handled via woocommerce_blocks_enqueue_checkout_block_scripts_before.
 		if ( is_checkout() && has_block( 'woocommerce/checkout' ) ) {
 			return;
 		}
 
 		if ( is_checkout() || is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'add-payment-method' ) ) {
+			// Reset clearance to hide payment methods until verification completes.
+			// Skips reset if recently verified (prevents infinite loop on add-payment-method reload).
+			$this->session_manager->reset_expired_session_clearance();
+
 			$checkout_type = is_wc_endpoint_url( 'add-payment-method' ) ? 'add-payment-method' : 'shortcode';
 			$this->enqueue_blackbox_scripts( $checkout_type );
 		}
@@ -227,11 +235,6 @@ class BlackboxIntegration {
 			array( 'in_footer' => true )
 		);
 
-		// Check if session was verified recently (to prevent infinite reload on add-payment-method).
-		// This uses a timestamp-based check: if verification happened within 10 seconds,
-		// we know this is a post-reload page load and should skip re-verification.
-		$recently_verified = $this->session_manager->was_verified_recently( 10 );
-
 		wp_localize_script(
 			'wc-fraud-protection-checkout',
 			'wcFraudProtection',
@@ -241,7 +244,7 @@ class BlackboxIntegration {
 				'timeoutMs'         => 5000,
 				'ajaxUrl'           => \WC_AJAX::get_endpoint( 'fraud_protection_verify' ),
 				'nonce'             => wp_create_nonce( 'fraud-protection-verify' ),
-				'recentlyVerified'  => $recently_verified,
+				'isSessionVerified' => ! $this->session_manager->is_session_pending(), // true = ALLOWED or BLOCKED.
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionController.php
@@ -75,6 +75,9 @@ class FraudProtectionController implements RegisterHooksInterface {
 		}
 
 		$this->blocked_session_notice->register();
+
+		// Register Blackbox integration - fetched from container to avoid circular dependency.
+		wc_get_container()->get( BlackboxIntegration::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
@@ -91,6 +91,20 @@ class FraudProtectionDispatcher {
 	 */
 	public function dispatch_event( string $event_type, array $event_data = array() ): void {
 		try {
+			// PoC: Only process 'checkout' events from Blackbox integration.
+			// Skip other events to avoid interference with session status.
+			if ( 'checkout' !== $event_type ) {
+				FraudProtectionController::log(
+					'debug',
+					sprintf(
+						'Fraud protection event skipped (PoC - only checkout events processed): %s',
+						$event_type
+					),
+					array( 'event_type' => $event_type )
+				);
+				return;
+			}
+
 			// Check if feature is enabled - fail-open if not.
 			if ( ! $this->fraud_protection_controller->feature_is_enabled() ) {
 				FraudProtectionController::log(

--- a/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/FraudProtectionDispatcher.php
@@ -36,13 +36,6 @@ class FraudProtectionDispatcher {
 	private DecisionHandler $decision_handler;
 
 	/**
-	 * Fraud protection controller instance.
-	 *
-	 * @var FraudProtectionController
-	 */
-	private FraudProtectionController $fraud_protection_controller;
-
-	/**
 	 * Session data collector instance.
 	 *
 	 * @var SessionDataCollector
@@ -50,74 +43,60 @@ class FraudProtectionDispatcher {
 	private SessionDataCollector $data_collector;
 
 	/**
+	 * Session clearance manager instance.
+	 *
+	 * @var SessionClearanceManager
+	 */
+	private SessionClearanceManager $session_manager;
+
+	/**
 	 * Initialize with dependencies.
+	 *
+	 * Note: FraudProtectionController is NOT injected here to avoid circular dependency.
+	 * It is fetched lazily in dispatch_event() via get_fraud_protection_controller().
 	 *
 	 * @internal
 	 *
-	 * @param ApiClient                 $api_client                  The API client instance.
-	 * @param DecisionHandler           $decision_handler            The decision handler instance.
-	 * @param FraudProtectionController $fraud_protection_controller The fraud protection controller instance.
-	 * @param SessionDataCollector      $data_collector              The session data collector instance.
+	 * @param ApiClient               $api_client       The API client instance.
+	 * @param DecisionHandler         $decision_handler The decision handler instance.
+	 * @param SessionDataCollector    $data_collector   The session data collector instance.
+	 * @param SessionClearanceManager $session_manager  The session clearance manager instance.
 	 */
 	final public function init(
 		ApiClient $api_client,
 		DecisionHandler $decision_handler,
-		FraudProtectionController $fraud_protection_controller,
-		SessionDataCollector $data_collector
+		SessionDataCollector $data_collector,
+		SessionClearanceManager $session_manager
 	): void {
-		$this->api_client                  = $api_client;
-		$this->decision_handler            = $decision_handler;
-		$this->fraud_protection_controller = $fraud_protection_controller;
-		$this->data_collector              = $data_collector;
+		$this->api_client       = $api_client;
+		$this->decision_handler = $decision_handler;
+		$this->data_collector   = $data_collector;
+		$this->session_manager  = $session_manager;
 	}
 
 	/**
 	 * Dispatch fraud protection event.
 	 *
-	 * This method collects session data and dispatches it to the fraud protection service.
-	 * It orchestrates the following flow:
-	 * 1. Check if feature is enabled (fail-open if not)
-	 * 2. Collect comprehensive session data via SessionDataCollector
-	 * 3. Apply extension data filter to allow custom data
-	 * 4. Send event to API and get decision
-	 * 5. Apply decision via DecisionHandler
+	 * This method collects session data and either queues it for later or sends it
+	 * to the fraud protection service immediately, depending on the event type.
+	 *
+	 * Event flow:
+	 * - Non-checkout events: Collected and queued in session (no API call)
+	 * - Checkout events: Collected, combined with queued events, sent to API
 	 *
 	 * The method implements graceful degradation - any errors during tracking
 	 * will be logged but will not break the functionality.
 	 *
-	 * @param string $event_type Event type identifier (e.g., 'cart_item_added').
+	 * Note: This method assumes the fraud protection feature is already enabled.
+	 * The feature check is done by FraudProtectionController before registering
+	 * event trackers that call this dispatcher.
+	 *
+	 * @param string $event_type Event type identifier (e.g., 'cart_item_added', 'checkout').
 	 * @param array  $event_data Optional event-specific data to include with session data.
 	 * @return void
 	 */
 	public function dispatch_event( string $event_type, array $event_data = array() ): void {
 		try {
-			// PoC: Only process 'checkout' events from Blackbox integration.
-			// Skip other events to avoid interference with session status.
-			if ( 'checkout' !== $event_type ) {
-				FraudProtectionController::log(
-					'debug',
-					sprintf(
-						'Fraud protection event skipped (PoC - only checkout events processed): %s',
-						$event_type
-					),
-					array( 'event_type' => $event_type )
-				);
-				return;
-			}
-
-			// Check if feature is enabled - fail-open if not.
-			if ( ! $this->fraud_protection_controller->feature_is_enabled() ) {
-				FraudProtectionController::log(
-					'debug',
-					sprintf(
-						'Fraud protection event not dispatched (feature disabled): %s',
-						$event_type
-					),
-					array( 'event_type' => $event_type )
-				);
-				return;
-			}
-
 			// Collect comprehensive session data.
 			$collected_data = $this->data_collector->collect( $event_type, $event_data );
 
@@ -137,11 +116,20 @@ class FraudProtectionDispatcher {
 			 */
 			$collected_data = apply_filters( 'woocommerce_fraud_protection_event_data', $collected_data, $event_type );
 
-			// Send event to API and get decision.
-			$decision = $this->api_client->send_event( $event_type, $collected_data );
+			// For checkout events: send all queued events + this one to the API.
+			if ( 'checkout' === $event_type ) {
+				$this->send_checkout_with_events( $collected_data );
+				return;
+			}
 
-			// Apply decision via DecisionHandler.
-			$this->decision_handler->apply_decision( $decision, $collected_data );
+			// For other events: queue in session for later sending with checkout.
+			$this->session_manager->queue_event( $event_type, $collected_data );
+
+			FraudProtectionController::log(
+				'debug',
+				sprintf( 'Event queued in session: %s', $event_type ),
+				array( 'event_type' => $event_type )
+			);
 		} catch ( \Exception $e ) {
 			// Gracefully handle errors - fraud protection should never break functionality.
 			FraudProtectionController::log(
@@ -157,5 +145,34 @@ class FraudProtectionDispatcher {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Send checkout event with all previously queued events.
+	 *
+	 * This method retrieves all queued events from the session, sends them
+	 * along with the checkout event to the API, and clears the queue.
+	 *
+	 * @param array $checkout_data The collected checkout event data.
+	 * @return void
+	 */
+	private function send_checkout_with_events( array $checkout_data ): void {
+		// Get all queued events from the session.
+		$prior_events = $this->session_manager->get_event_queue();
+
+		FraudProtectionController::log(
+			'debug',
+			sprintf( 'Sending checkout event with %d prior events', count( $prior_events ) ),
+			array( 'prior_events_count' => count( $prior_events ) )
+		);
+
+		// Send event to API with prior events and get decision.
+		$decision = $this->api_client->send_event( 'checkout', $checkout_data, $prior_events );
+
+		// Clear the event queue after successful send.
+		$this->session_manager->clear_event_queue();
+
+		// Apply decision via DecisionHandler.
+		$this->decision_handler->apply_decision( $decision, $checkout_data );
 	}
 }

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -54,6 +54,16 @@ class SessionClearanceManager {
 	private const BLACKBOX_SESSION_KEY = '_fraud_protection_blackbox_session_id';
 
 	/**
+	 * Session key for storing the event queue.
+	 */
+	private const EVENT_QUEUE_KEY = '_fraud_protection_event_queue';
+
+	/**
+	 * Maximum number of events to store in the queue to prevent session bloat.
+	 */
+	private const MAX_EVENT_QUEUE_SIZE = 50;
+
+	/**
 	 * Check if the current session is allowed.
 	 *
 	 * @return bool True if session is allowed, false otherwise.
@@ -205,6 +215,62 @@ class SessionClearanceManager {
 			return null;
 		}
 		return WC()->session->get( self::BLACKBOX_SESSION_KEY );
+	}
+
+	/**
+	 * Add an event to the queue.
+	 *
+	 * Events are stored in the session until checkout, when they are all sent
+	 * together with the checkout event. Each event is timestamped when queued.
+	 *
+	 * @param string $event_type The type of event being queued.
+	 * @param array  $event_data The collected event data.
+	 * @return void
+	 */
+	public function queue_event( string $event_type, array $event_data ): void {
+		if ( ! $this->is_session_available() ) {
+			return;
+		}
+
+		$queue   = $this->get_event_queue();
+		$queue[] = array(
+			'event_type' => $event_type,
+			'timestamp'  => gmdate( 'c' ),
+			'event_data' => $event_data,
+		);
+
+		// Limit queue size to prevent session bloat - keep most recent events.
+		if ( count( $queue ) > self::MAX_EVENT_QUEUE_SIZE ) {
+			$queue = array_slice( $queue, -self::MAX_EVENT_QUEUE_SIZE );
+		}
+
+		WC()->session->set( self::EVENT_QUEUE_KEY, $queue );
+	}
+
+	/**
+	 * Get all queued events.
+	 *
+	 * @return array Array of queued events, each with event_type, timestamp, and event_data.
+	 */
+	public function get_event_queue(): array {
+		if ( ! $this->is_session_available() ) {
+			return array();
+		}
+		return WC()->session->get( self::EVENT_QUEUE_KEY, array() );
+	}
+
+	/**
+	 * Clear the event queue.
+	 *
+	 * Should be called after successfully sending events to the API.
+	 *
+	 * @return void
+	 */
+	public function clear_event_queue(): void {
+		if ( ! $this->is_session_available() ) {
+			return;
+		}
+		WC()->session->set( self::EVENT_QUEUE_KEY, array() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -101,14 +101,37 @@ class SessionClearanceManager {
 	/**
 	 * Check if payment methods should be rendered.
 	 *
-	 * Payment methods should only be shown when the session is explicitly
-	 * ALLOWED. PENDING and BLOCKED sessions should not see payment methods.
+	 * Payment methods are shown when:
+	 * - Session is ALLOWED (verified safe)
+	 * - Session is PENDING on my-account pages (except add-payment-method)
+	 *
+	 * The second case ensures account navigation shows "Payment methods" link
+	 * and the payment-methods listing page shows saved cards, while the
+	 * add-payment-method page still requires verification before showing
+	 * the payment form.
 	 *
 	 * @return bool True if payment methods should be rendered, false otherwise.
 	 */
 	public function should_render_payment_methods(): bool {
 		$status = $this->get_session_status();
-		return self::STATUS_ALLOWED === $status;
+
+		// ALLOWED sessions can always see payment methods.
+		if ( self::STATUS_ALLOWED === $status ) {
+			return true;
+		}
+
+		// PENDING sessions can see payment methods on my-account pages,
+		// EXCEPT for add-payment-method which requires verification first.
+		// This ensures the "Payment methods" link shows in the account navigation,
+		// and saved payment methods are visible on the payment-methods listing page.
+		if ( self::STATUS_PENDING === $status
+			&& is_account_page()
+			&& ! is_wc_endpoint_url( 'add-payment-method' ) ) {
+			return true;
+		}
+
+		// BLOCKED, or PENDING on checkout/order-pay/add-payment-method: hide payment methods.
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -54,6 +54,11 @@ class SessionClearanceManager {
 	private const BLACKBOX_SESSION_KEY = '_fraud_protection_blackbox_session_id';
 
 	/**
+	 * Session key for storing verification timestamp.
+	 */
+	private const VERIFICATION_TIMESTAMP_KEY = '_fraud_protection_verification_timestamp';
+
+	/**
 	 * Session key for storing the event queue.
 	 */
 	private const EVENT_QUEUE_KEY = '_fraud_protection_event_queue';
@@ -203,6 +208,27 @@ class SessionClearanceManager {
 			return;
 		}
 		WC()->session->set( self::BLACKBOX_SESSION_KEY, $session_id );
+		WC()->session->set( self::VERIFICATION_TIMESTAMP_KEY, time() );
+	}
+
+	/**
+	 * Check if session was verified recently.
+	 *
+	 * Used to prevent infinite reload loops on add-payment-method page.
+	 * If verification happened within the given threshold, we skip re-verification.
+	 *
+	 * @param int $seconds The time threshold in seconds.
+	 * @return bool True if verified within the threshold, false otherwise.
+	 */
+	public function was_verified_recently( int $seconds = 10 ): bool {
+		if ( ! $this->is_session_available() ) {
+			return false;
+		}
+		$timestamp = WC()->session->get( self::VERIFICATION_TIMESTAMP_KEY );
+		if ( ! $timestamp ) {
+			return false;
+		}
+		return ( time() - (int) $timestamp ) < $seconds;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -44,8 +44,14 @@ class SessionClearanceManager {
 
 	/**
 	 * Default session status.
+	 * PENDING means payment methods are hidden until verified.
 	 */
-	public const DEFAULT_STATUS = self::STATUS_ALLOWED;
+	public const DEFAULT_STATUS = self::STATUS_PENDING;
+
+	/**
+	 * Session key for storing Blackbox session ID.
+	 */
+	private const BLACKBOX_SESSION_KEY = '_fraud_protection_blackbox_session_id';
 
 	/**
 	 * Check if the current session is allowed.
@@ -65,6 +71,29 @@ class SessionClearanceManager {
 	public function is_session_blocked(): bool {
 		$status = $this->get_session_status();
 		return self::STATUS_BLOCKED === $status;
+	}
+
+	/**
+	 * Check if the current session is pending verification.
+	 *
+	 * @return bool True if session is pending, false otherwise.
+	 */
+	public function is_session_pending(): bool {
+		$status = $this->get_session_status();
+		return self::STATUS_PENDING === $status;
+	}
+
+	/**
+	 * Check if payment methods should be rendered.
+	 *
+	 * Payment methods should only be shown when the session is explicitly
+	 * ALLOWED. PENDING and BLOCKED sessions should not see payment methods.
+	 *
+	 * @return bool True if payment methods should be rendered, false otherwise.
+	 */
+	public function should_render_payment_methods(): bool {
+		$status = $this->get_session_status();
+		return self::STATUS_ALLOWED === $status;
 	}
 
 	/**
@@ -151,6 +180,31 @@ class SessionClearanceManager {
 	 */
 	public function reset_session(): void {
 		$this->set_session_status( self::DEFAULT_STATUS );
+	}
+
+	/**
+	 * Store the Blackbox session ID.
+	 *
+	 * @param string $session_id The Blackbox session ID.
+	 * @return void
+	 */
+	public function set_blackbox_session_id( string $session_id ): void {
+		if ( ! $this->is_session_available() ) {
+			return;
+		}
+		WC()->session->set( self::BLACKBOX_SESSION_KEY, $session_id );
+	}
+
+	/**
+	 * Get the stored Blackbox session ID.
+	 *
+	 * @return string|null The Blackbox session ID, or null if not set.
+	 */
+	public function get_blackbox_session_id(): ?string {
+		if ( ! $this->is_session_available() ) {
+			return null;
+		}
+		return WC()->session->get( self::BLACKBOX_SESSION_KEY );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -235,6 +235,27 @@ class SessionClearanceManager {
 	}
 
 	/**
+	 * Reset session clearance to pending if currently allowed and not recently verified.
+	 *
+	 * Used when entering checkout/add-payment-method to ensure payment methods are
+	 * hidden until the current visit's verification completes. This prevents a flash
+	 * of payment methods if the session was previously ALLOWED but gets BLOCKED on
+	 * re-verification.
+	 *
+	 * Skips reset if:
+	 * - Session is PENDING (already awaiting verification)
+	 * - Session is BLOCKED (should not be unblocked without explicit allow)
+	 * - Session was verified recently (prevents unnecessary re-verification)
+	 *
+	 * @return void
+	 */
+	public function reset_expired_session_clearance(): void {
+		if ( self::STATUS_ALLOWED === $this->get_session_status() && ! $this->was_verified_recently() ) {
+			$this->set_session_status( self::STATUS_PENDING );
+		}
+	}
+
+	/**
 	 * Check if session was verified recently.
 	 *
 	 * Used to prevent infinite reload loops on add-payment-method page.

--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionDataCollector.php
@@ -138,14 +138,15 @@ class SessionDataCollector {
 	 *
 	 * @since 10.5.0
 	 *
-	 * @return array Session data array with 6 keys.
+	 * @return array Session data array with 7 keys.
 	 */
 	private function get_session_data(): array {
 		try {
-			$session_id = $this->session_clearance_manager->get_session_id();
-			$ip_address = $this->get_ip_address();
-			$email      = $this->get_email();
-			$user_agent = $this->get_user_agent();
+			$session_id          = $this->session_clearance_manager->get_session_id();
+			$blackbox_session_id = $this->session_clearance_manager->get_blackbox_session_id();
+			$ip_address          = $this->get_ip_address();
+			$email               = $this->get_email();
+			$user_agent          = $this->get_user_agent();
 
 			/**
 			 * $is_user_session is flag that we have a real browser session vs API-based interaction.
@@ -154,22 +155,24 @@ class SessionDataCollector {
 			$is_user_session = 'no-session' !== $session_id;
 
 			return array(
-				'session_id'      => $session_id,
-				'ip_address'      => $ip_address,
-				'email'           => $email,
-				'ja3_hash'        => null,
-				'user_agent'      => $user_agent,
-				'is_user_session' => $is_user_session,
+				'session_id'          => $session_id,
+				'blackbox_session_id' => $blackbox_session_id,
+				'ip_address'          => $ip_address,
+				'email'               => $email,
+				'ja3_hash'            => null,
+				'user_agent'          => $user_agent,
+				'is_user_session'     => $is_user_session,
 			);
 		} catch ( \Exception $e ) {
 			// Graceful degradation - return structure with null values.
 			return array(
-				'session_id'      => null,
-				'ip_address'      => null,
-				'email'           => null,
-				'ja3_hash'        => null,
-				'user_agent'      => null,
-				'is_user_session' => false,
+				'session_id'          => null,
+				'blackbox_session_id' => null,
+				'ip_address'          => null,
+				'email'               => null,
+				'ja3_hash'            => null,
+				'user_agent'          => null,
+				'is_user_session'     => false,
 			);
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/ApiClientTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/ApiClientTest.php
@@ -480,4 +480,86 @@ class ApiClientTest extends WC_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'email', $decoded_body, 'Should filter out null email' );
 		$this->assertArrayNotHasKey( 'billing_name', $decoded_body, 'Should filter out null billing_name' );
 	}
+
+	/**
+	 * @testdox Send Event should include prior_events in payload when provided.
+	 */
+	public function test_send_event_includes_prior_events_in_payload(): void {
+		$captured_request_body = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args ) use ( &$captured_request_body ) {
+				$captured_request_body = $args['body'];
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( array( 'decision' => 'allow' ) ),
+				);
+			},
+			10,
+			2
+		);
+
+		$event_data = array(
+			'session' => array( 'session_id' => 'test-session' ),
+		);
+
+		$prior_events = array(
+			array(
+				'event_type' => 'cart_item_added',
+				'timestamp'  => '2024-01-27T10:00:00+00:00',
+				'event_data' => array( 'product_id' => 123 ),
+			),
+			array(
+				'event_type' => 'checkout_update',
+				'timestamp'  => '2024-01-27T10:01:00+00:00',
+				'event_data' => array( 'email' => 'test@example.com' ),
+			),
+		);
+
+		$this->sut->send_event( 'checkout', $event_data, $prior_events );
+
+		$this->assertNotNull( $captured_request_body, 'Request body should be captured' );
+
+		$decoded_body = json_decode( $captured_request_body, true );
+		$this->assertArrayHasKey( 'event_type', $decoded_body );
+		$this->assertEquals( 'checkout', $decoded_body['event_type'] );
+		$this->assertArrayHasKey( 'prior_events', $decoded_body );
+		$this->assertCount( 2, $decoded_body['prior_events'] );
+		$this->assertEquals( 'cart_item_added', $decoded_body['prior_events'][0]['event_type'] );
+		$this->assertEquals( 'checkout_update', $decoded_body['prior_events'][1]['event_type'] );
+	}
+
+	/**
+	 * @testdox Send Event should not include prior_events key when array is empty.
+	 */
+	public function test_send_event_excludes_prior_events_when_empty(): void {
+		$captured_request_body = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args ) use ( &$captured_request_body ) {
+				$captured_request_body = $args['body'];
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( array( 'decision' => 'allow' ) ),
+				);
+			},
+			10,
+			2
+		);
+
+		$event_data = array(
+			'session' => array( 'session_id' => 'test-session' ),
+		);
+
+		// Pass empty prior_events array.
+		$this->sut->send_event( 'checkout', $event_data, array() );
+
+		$this->assertNotNull( $captured_request_body, 'Request body should be captured' );
+
+		$decoded_body = json_decode( $captured_request_body, true );
+		$this->assertArrayHasKey( 'event_type', $decoded_body );
+		$this->assertArrayNotHasKey( 'prior_events', $decoded_body, 'Should not include prior_events when empty' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlackboxIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlackboxIntegrationTest.php
@@ -73,13 +73,12 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 			->method( 'set_blackbox_session_id' )
 			->with( $session_id );
 
+		// blackbox_session_id is now included in session data via SessionDataCollector,
+		// so dispatch_event is called with an empty array.
 		$this->dispatcher
 			->expects( $this->once() )
 			->method( 'dispatch_event' )
-			->with(
-				'checkout',
-				array( 'blackbox_session_id' => $session_id )
-			);
+			->with( 'checkout' );
 
 		$this->sut->process_blackbox_session( $session_id );
 
@@ -122,10 +121,7 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 		$this->dispatcher
 			->expects( $this->once() )
 			->method( 'dispatch_event' )
-			->with(
-				'checkout',
-				array( 'blackbox_session_id' => '' )
-			);
+			->with( 'checkout' );
 
 		$this->sut->process_blackbox_session( '' );
 
@@ -149,10 +145,7 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 		$this->dispatcher
 			->expects( $this->once() )
 			->method( 'dispatch_event' )
-			->with(
-				'checkout',
-				array( 'blackbox_session_id' => $session_id )
-			);
+			->with( 'checkout' );
 
 		$this->sut->handle_blocks_session_id(
 			array( 'blackbox_session_id' => $session_id )
@@ -174,10 +167,7 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 		$this->dispatcher
 			->expects( $this->once() )
 			->method( 'dispatch_event' )
-			->with(
-				'checkout',
-				array( 'blackbox_session_id' => '' )
-			);
+			->with( 'checkout' );
 
 		$this->sut->handle_blocks_session_id( array() );
 	}
@@ -199,10 +189,7 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 		$this->dispatcher
 			->expects( $this->once() )
 			->method( 'dispatch_event' )
-			->with(
-				'checkout',
-				array( 'blackbox_session_id' => $session_id )
-			);
+			->with( 'checkout' );
 
 		$this->sut->handle_shortcode_session_id( $session_id );
 	}
@@ -221,18 +208,22 @@ class BlackboxIntegrationTest extends WC_Unit_Test_Case {
 			->method( 'get_session_id' )
 			->willReturn( 'wc_session_456' );
 
-		$this->dispatcher
+		// Verify that the session_id is sanitized when stored (no HTML tags).
+		$this->session_manager
 			->expects( $this->once() )
-			->method( 'dispatch_event' )
+			->method( 'set_blackbox_session_id' )
 			->with(
-				'checkout',
 				$this->callback(
-					function ( $data ) {
-						// Session ID should be sanitized (no HTML tags).
-						return ! str_contains( $data['blackbox_session_id'], '<script>' );
+					function ( $session_id ) {
+						return ! str_contains( $session_id, '<script>' );
 					}
 				)
 			);
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with( 'checkout' );
 
 		$this->sut->handle_shortcode_session_id( $malicious_input );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlackboxIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/BlackboxIntegrationTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * BlackboxIntegrationTest class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\FraudProtection;
+
+use Automattic\WooCommerce\Internal\FraudProtection\BlackboxIntegration;
+use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionDispatcher;
+use Automattic\WooCommerce\Internal\FraudProtection\SessionClearanceManager;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the BlackboxIntegration class.
+ */
+class BlackboxIntegrationTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var BlackboxIntegration
+	 */
+	private $sut;
+
+	/**
+	 * Mock session clearance manager.
+	 *
+	 * @var SessionClearanceManager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $session_manager;
+
+	/**
+	 * Mock fraud protection dispatcher.
+	 *
+	 * @var FraudProtectionDispatcher|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $dispatcher;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->session_manager = $this->createMock( SessionClearanceManager::class );
+		$this->dispatcher      = $this->createMock( FraudProtectionDispatcher::class );
+
+		$this->sut = new BlackboxIntegration();
+		$this->sut->init( $this->session_manager, $this->dispatcher );
+	}
+
+	/**
+	 * @testdox process_blackbox_session dispatches checkout event with session_id.
+	 */
+	public function test_process_blackbox_session_dispatches_event(): void {
+		$session_id = 'bb_test_session_123';
+
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->session_manager
+			->expects( $this->once() )
+			->method( 'set_blackbox_session_id' )
+			->with( $session_id );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				array( 'blackbox_session_id' => $session_id )
+			);
+
+		$this->sut->process_blackbox_session( $session_id );
+
+		$this->assertLogged( 'info', 'Processing Blackbox session: bb_test_session_123' );
+	}
+
+	/**
+	 * @testdox process_blackbox_session skips if same session_id already processed.
+	 */
+	public function test_process_blackbox_session_skips_duplicate(): void {
+		$session_id = 'bb_test_session_123';
+
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( $session_id );
+
+		$this->dispatcher
+			->expects( $this->never() )
+			->method( 'dispatch_event' );
+
+		$this->sut->process_blackbox_session( $session_id );
+	}
+
+	/**
+	 * @testdox process_blackbox_session dispatches event with empty session_id (fail-open).
+	 */
+	public function test_process_blackbox_session_dispatches_with_empty_session(): void {
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->session_manager
+			->expects( $this->never() )
+			->method( 'set_blackbox_session_id' );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				array( 'blackbox_session_id' => '' )
+			);
+
+		$this->sut->process_blackbox_session( '' );
+
+		$this->assertLogged( 'info', '(empty - fail-open)' );
+	}
+
+	/**
+	 * @testdox handle_blocks_session_id extracts and processes session_id from data array.
+	 */
+	public function test_handle_blocks_session_id(): void {
+		$session_id = 'bb_blocks_session';
+
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				array( 'blackbox_session_id' => $session_id )
+			);
+
+		$this->sut->handle_blocks_session_id(
+			array( 'blackbox_session_id' => $session_id )
+		);
+	}
+
+	/**
+	 * @testdox handle_blocks_session_id handles missing session_id in data.
+	 */
+	public function test_handle_blocks_session_id_missing_data(): void {
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				array( 'blackbox_session_id' => '' )
+			);
+
+		$this->sut->handle_blocks_session_id( array() );
+	}
+
+	/**
+	 * @testdox handle_shortcode_session_id sanitizes and processes session_id.
+	 */
+	public function test_handle_shortcode_session_id(): void {
+		$session_id = 'bb_shortcode_session';
+
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				array( 'blackbox_session_id' => $session_id )
+			);
+
+		$this->sut->handle_shortcode_session_id( $session_id );
+	}
+
+	/**
+	 * @testdox handle_shortcode_session_id sanitizes potentially malicious input.
+	 */
+	public function test_handle_shortcode_session_id_sanitizes_input(): void {
+		$malicious_input = '<script>alert("xss")</script>bb_session';
+
+		$this->session_manager
+			->method( 'get_blackbox_session_id' )
+			->willReturn( null );
+
+		$this->session_manager
+			->method( 'get_session_id' )
+			->willReturn( 'wc_session_456' );
+
+		$this->dispatcher
+			->expects( $this->once() )
+			->method( 'dispatch_event' )
+			->with(
+				'checkout',
+				$this->callback(
+					function ( $data ) {
+						// Session ID should be sanitized (no HTML tags).
+						return ! str_contains( $data['blackbox_session_id'], '<script>' );
+					}
+				)
+			);
+
+		$this->sut->handle_shortcode_session_id( $malicious_input );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/FraudProtectionDispatcherTest.php
@@ -11,8 +11,8 @@ namespace Automattic\WooCommerce\Tests\Internal\FraudProtection;
 
 use Automattic\WooCommerce\Internal\FraudProtection\ApiClient;
 use Automattic\WooCommerce\Internal\FraudProtection\DecisionHandler;
-use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionController;
 use Automattic\WooCommerce\Internal\FraudProtection\FraudProtectionDispatcher;
+use Automattic\WooCommerce\Internal\FraudProtection\SessionClearanceManager;
 use Automattic\WooCommerce\Internal\FraudProtection\SessionDataCollector;
 
 /**
@@ -44,18 +44,18 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 	private $decision_handler_mock;
 
 	/**
-	 * Mock fraud protection controller.
-	 *
-	 * @var FraudProtectionController|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $controller_mock;
-
-	/**
 	 * Mock session data collector.
 	 *
 	 * @var SessionDataCollector|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $data_collector_mock;
+
+	/**
+	 * Mock session clearance manager.
+	 *
+	 * @var SessionClearanceManager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $session_manager_mock;
 
 	/**
 	 * Runs before each test.
@@ -66,82 +66,35 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 		// Create mocks.
 		$this->api_client_mock       = $this->createMock( ApiClient::class );
 		$this->decision_handler_mock = $this->createMock( DecisionHandler::class );
-		$this->controller_mock       = $this->createMock( FraudProtectionController::class );
 		$this->data_collector_mock   = $this->createMock( SessionDataCollector::class );
-
-		// By default, feature is enabled.
-		$this->controller_mock->method( 'feature_is_enabled' )->willReturn( true );
+		$this->session_manager_mock  = $this->createMock( SessionClearanceManager::class );
 
 		// Create dispatcher and inject mocks.
 		$this->sut = new FraudProtectionDispatcher();
 		$this->sut->init(
 			$this->api_client_mock,
 			$this->decision_handler_mock,
-			$this->controller_mock,
-			$this->data_collector_mock
+			$this->data_collector_mock,
+			$this->session_manager_mock
 		);
 	}
 
 	/**
-	 * Test that dispatch_event collects session data and sends event to API and applies decision.
+	 * Test that non-checkout events are queued in session, not sent to API.
 	 */
-	public function test_dispatch_event_sends_to_api_and_applies_decision(): void {
-		$event_type = 'test_event';
+	public function test_non_checkout_events_are_queued_in_session(): void {
+		$event_type = 'cart_item_added';
 		$event_data = array(
-			'action'     => 'test_action',
+			'action'     => 'item_added',
 			'product_id' => 123,
 		);
 
 		$collected_data = array(
 			'session'    => array( 'session_id' => 'test-session-123' ),
-			'action'     => 'test_action',
+			'action'     => 'item_added',
 			'product_id' => 123,
 		);
 
-		// Expect data collector to be called with event type and event data.
-		$this->data_collector_mock
-			->expects( $this->once() )
-			->method( 'collect' )
-			->with( $event_type, $event_data )
-			->willReturn( $collected_data );
-
-		// Expect API client to be called with the collected data.
-		$this->api_client_mock
-			->expects( $this->once() )
-			->method( 'send_event' )
-			->with(
-				$this->equalTo( $event_type ),
-				$this->callback(
-					function ( $data ) use ( $collected_data ) {
-						// Verify the payload structure.
-						$this->assertArrayHasKey( 'session', $data );
-						$this->assertEquals( 'test-session-123', $data['session']['session_id'] );
-						$this->assertEquals( 'test_action', $data['action'] );
-						$this->assertEquals( 123, $data['product_id'] );
-						return true;
-					}
-				)
-			)
-			->willReturn( ApiClient::DECISION_ALLOW );
-
-		// Expect decision handler to be called with the decision and collected data.
-		$this->decision_handler_mock
-			->expects( $this->once() )
-			->method( 'apply_decision' )
-			->with( ApiClient::DECISION_ALLOW, $collected_data );
-
-		// Call dispatch_event with event data.
-		$this->sut->dispatch_event( $event_type, $event_data );
-	}
-
-	/**
-	 * Test that dispatch_event handles data without session gracefully.
-	 */
-	public function test_dispatch_event_handles_missing_session_data(): void {
-		$event_type     = 'test_event';
-		$event_data     = array( 'invalid' => 'data_without_session' );
-		$collected_data = array( 'invalid' => 'data_without_session' );
-
 		// Expect data collector to be called.
 		$this->data_collector_mock
 			->expects( $this->once() )
@@ -149,138 +102,128 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 			->with( $event_type, $event_data )
 			->willReturn( $collected_data );
 
-		// Expect API client to be called with the collected data.
+		// Expect event to be queued in session.
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'queue_event' )
+			->with( $event_type, $collected_data );
+
+		// API should NOT be called for non-checkout events.
 		$this->api_client_mock
-			->expects( $this->once() )
-			->method( 'send_event' )
-			->with(
-				$this->equalTo( $event_type ),
-				$this->callback(
-					function ( $data ) {
-						// Verify the payload has the invalid key.
-						$this->assertArrayHasKey( 'invalid', $data );
-						$this->assertEquals( 'data_without_session', $data['invalid'] );
-						// Session key should not exist or be empty.
-						$this->assertFalse( isset( $data['session']['session_id'] ) || ! empty( $data['session']['session_id'] ) );
-						return true;
-					}
-				)
-			)
-			->willReturn( ApiClient::DECISION_ALLOW );
+			->expects( $this->never() )
+			->method( 'send_event' );
 
-		// Expect decision handler to be called with collected data.
+		// Decision handler should NOT be called for non-checkout events.
 		$this->decision_handler_mock
-			->expects( $this->once() )
-			->method( 'apply_decision' )
-			->with( ApiClient::DECISION_ALLOW, $collected_data );
+			->expects( $this->never() )
+			->method( 'apply_decision' );
 
-		// Call dispatch_event - should handle gracefully.
 		$this->sut->dispatch_event( $event_type, $event_data );
 	}
 
 	/**
-	 * Test that dispatch_event respects block decisions.
+	 * Test that checkout event sends to API with prior events and applies decision.
 	 */
-	public function test_dispatch_event_applies_block_decision(): void {
-		$event_type = 'cart_item_added';
+	public function test_checkout_event_sends_to_api_with_prior_events(): void {
 		$event_data = array(
-			'action'     => 'item_added',
-			'product_id' => 456,
+			'order_id' => 456,
 		);
 
 		$collected_data = array(
-			'session'    => array( 'session_id' => 'test' ),
-			'action'     => 'item_added',
-			'product_id' => 456,
+			'session'  => array( 'session_id' => 'test-session-123' ),
+			'order_id' => 456,
+		);
+
+		$prior_events = array(
+			array(
+				'event_type' => 'cart_item_added',
+				'timestamp'  => '2024-01-27T10:00:00+00:00',
+				'event_data' => array( 'product_id' => 123 ),
+			),
 		);
 
 		// Expect data collector to be called.
 		$this->data_collector_mock
 			->expects( $this->once() )
 			->method( 'collect' )
-			->with( $event_type, $event_data )
+			->with( 'checkout', $event_data )
 			->willReturn( $collected_data );
 
-		// API returns block decision.
+		// Expect prior events to be retrieved from session.
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'get_event_queue' )
+			->willReturn( $prior_events );
+
+		// Expect API client to be called with checkout event and prior events.
 		$this->api_client_mock
 			->expects( $this->once() )
 			->method( 'send_event' )
-			->with(
-				$this->equalTo( $event_type ),
-				$this->callback(
-					function ( $data ) {
-						// Verify the payload structure for cart event.
-						$this->assertArrayHasKey( 'session', $data );
-						$this->assertEquals( 'test', $data['session']['session_id'] );
-						$this->assertEquals( 'item_added', $data['action'] );
-						$this->assertEquals( 456, $data['product_id'] );
-						return true;
-					}
-				)
-			)
+			->with( 'checkout', $collected_data, $prior_events )
+			->willReturn( ApiClient::DECISION_ALLOW );
+
+		// Expect queue to be cleared after successful send.
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'clear_event_queue' );
+
+		// Expect decision handler to be called with the decision.
+		$this->decision_handler_mock
+			->expects( $this->once() )
+			->method( 'apply_decision' )
+			->with( ApiClient::DECISION_ALLOW, $collected_data );
+
+		$this->sut->dispatch_event( 'checkout', $event_data );
+	}
+
+	/**
+	 * Test that checkout event applies block decision.
+	 */
+	public function test_checkout_event_applies_block_decision(): void {
+		$collected_data = array(
+			'session' => array( 'session_id' => 'test' ),
+		);
+
+		$this->data_collector_mock
+			->expects( $this->once() )
+			->method( 'collect' )
+			->willReturn( $collected_data );
+
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'get_event_queue' )
+			->willReturn( array() );
+
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'send_event' )
 			->willReturn( ApiClient::DECISION_BLOCK );
 
-		// Expect decision handler to be called with block decision and collected data.
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'clear_event_queue' );
+
 		$this->decision_handler_mock
 			->expects( $this->once() )
 			->method( 'apply_decision' )
 			->with( ApiClient::DECISION_BLOCK, $collected_data );
 
-		// Call dispatch_event.
-		$this->sut->dispatch_event( $event_type, $event_data );
+		$this->sut->dispatch_event( 'checkout', array() );
 	}
 
 	/**
-	 * Test that dispatch_event doesn't send events when feature is disabled.
+	 * Test that filter is applied to event data before queueing.
 	 */
-	public function test_dispatch_event_skips_when_feature_disabled(): void {
-		// Create fresh API and decision handler mocks that should never be called.
-		$api_client_mock = $this->createMock( ApiClient::class );
-		$api_client_mock->expects( $this->never() )->method( 'send_event' );
-
-		$decision_handler_mock = $this->createMock( DecisionHandler::class );
-		$decision_handler_mock->expects( $this->never() )->method( 'apply_decision' );
-
-		// Create data collector mock that should never be called.
-		$data_collector_mock = $this->createMock( SessionDataCollector::class );
-		$data_collector_mock->expects( $this->never() )->method( 'collect' );
-
-		// Create controller mock with feature disabled.
-		$controller_mock = $this->createMock( FraudProtectionController::class );
-		$controller_mock->expects( $this->once() )
-			->method( 'feature_is_enabled' )
-			->willReturn( false );
-
-		// Create new dispatcher with feature disabled.
-		$sut = new FraudProtectionDispatcher();
-		$sut->init( $api_client_mock, $decision_handler_mock, $controller_mock, $data_collector_mock );
-
-		$event_type = 'test_event';
-		$event_data = array( 'product_id' => 123 );
-
-		// Call dispatch_event - should bail early without calling data collector, API or decision handler.
-		$sut->dispatch_event( $event_type, $event_data );
-	}
-
-	/**
-	 * Test that dispatch_event applies filter to collected data.
-	 */
-	public function test_dispatch_event_applies_filter_to_data(): void {
-		$event_type = 'test_event';
-		$event_data = array(
-			'foo' => 'bar',
-		);
-
+	public function test_filter_is_applied_before_queueing(): void {
+		$event_type     = 'cart_item_added';
 		$collected_data = array(
 			'session' => array( 'session_id' => 'test' ),
 			'foo'     => 'bar',
 		);
 
-		// Expect data collector to be called.
 		$this->data_collector_mock
 			->expects( $this->once() )
 			->method( 'collect' )
-			->with( $event_type, $event_data )
 			->willReturn( $collected_data );
 
 		// Add a filter that modifies the data.
@@ -295,35 +238,122 @@ class FraudProtectionDispatcherTest extends \WC_Unit_Test_Case {
 			2
 		);
 
-		// Expect API client to receive the filtered data.
-		$this->api_client_mock
+		// Expect session manager to receive the filtered data.
+		$this->session_manager_mock
 			->expects( $this->once() )
-			->method( 'send_event' )
+			->method( 'queue_event' )
 			->with(
-				$this->equalTo( $event_type ),
+				$event_type,
 				$this->callback(
 					function ( $data ) {
-						// Verify the original data is preserved.
-						$this->assertArrayHasKey( 'session', $data );
-						$this->assertEquals( 'test', $data['session']['session_id'] );
-						$this->assertEquals( 'bar', $data['foo'] );
-						// Verify the filter added the 'filtered' key.
 						$this->assertArrayHasKey( 'filtered', $data );
 						$this->assertTrue( $data['filtered'] );
 						return true;
 					}
 				)
+			);
+
+		$this->sut->dispatch_event( $event_type, array( 'foo' => 'bar' ) );
+
+		// Clean up filter.
+		remove_all_filters( 'woocommerce_fraud_protection_event_data' );
+	}
+
+	/**
+	 * Test that filter is applied to checkout event data before sending.
+	 */
+	public function test_filter_is_applied_to_checkout_before_sending(): void {
+		$collected_data = array(
+			'session' => array( 'session_id' => 'test' ),
+			'foo'     => 'bar',
+		);
+
+		$this->data_collector_mock
+			->expects( $this->once() )
+			->method( 'collect' )
+			->willReturn( $collected_data );
+
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'get_event_queue' )
+			->willReturn( array() );
+
+		// Add a filter that modifies the data.
+		add_filter(
+			'woocommerce_fraud_protection_event_data',
+			function ( $data, $type ) {
+				$this->assertEquals( 'checkout', $type );
+				$data['filtered'] = true;
+				return $data;
+			},
+			10,
+			2
+		);
+
+		// Expect API client to receive the filtered data.
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'send_event' )
+			->with(
+				'checkout',
+				$this->callback(
+					function ( $data ) {
+						$this->assertArrayHasKey( 'filtered', $data );
+						$this->assertTrue( $data['filtered'] );
+						return true;
+					}
+				),
+				$this->anything()
 			)
 			->willReturn( ApiClient::DECISION_ALLOW );
+
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'clear_event_queue' );
 
 		$this->decision_handler_mock
 			->expects( $this->once() )
 			->method( 'apply_decision' );
 
-		// Call dispatch_event.
-		$this->sut->dispatch_event( $event_type, $event_data );
+		$this->sut->dispatch_event( 'checkout', array( 'foo' => 'bar' ) );
 
 		// Clean up filter.
 		remove_all_filters( 'woocommerce_fraud_protection_event_data' );
+	}
+
+	/**
+	 * Test that checkout event sends empty prior_events array when no events queued.
+	 */
+	public function test_checkout_sends_empty_prior_events_when_none_queued(): void {
+		$collected_data = array(
+			'session' => array( 'session_id' => 'test' ),
+		);
+
+		$this->data_collector_mock
+			->expects( $this->once() )
+			->method( 'collect' )
+			->willReturn( $collected_data );
+
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'get_event_queue' )
+			->willReturn( array() );
+
+		// Expect API client to be called with empty prior_events array.
+		$this->api_client_mock
+			->expects( $this->once() )
+			->method( 'send_event' )
+			->with( 'checkout', $collected_data, array() )
+			->willReturn( ApiClient::DECISION_ALLOW );
+
+		$this->session_manager_mock
+			->expects( $this->once() )
+			->method( 'clear_event_queue' );
+
+		$this->decision_handler_mock
+			->expects( $this->once() )
+			->method( 'apply_decision' );
+
+		$this->sut->dispatch_event( 'checkout', array() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/PaymentMethodEventTrackerTest.php
@@ -81,7 +81,7 @@ class PaymentMethodEventTrackerTest extends \WC_Unit_Test_Case {
 	/**
 	 * Test payment method added event tracking.
 	 *
-	 * @testdox Should track payment method added event.
+	 * @testdox Should track payment method added event (queued for checkout).
 	 */
 	public function test_handle_payment_method_added(): void {
 
@@ -97,22 +97,14 @@ class PaymentMethodEventTrackerTest extends \WC_Unit_Test_Case {
 		$token->set_user_id( $user_id );
 		$token->save();
 
-		// Verify that the event was sent to the API with correct payload.
+		// Verify that the event was queued in session (not sent immediately).
+		// Events are aggregated and only sent with checkout event.
 		$this->assertLogged(
-			'info',
-			'Sending fraud protection event: payment_method_added',
+			'debug',
+			'Event queued in session: payment_method_added',
 			array(
-				'source'  => 'woo-fraud-protection',
-				'payload' => array(
-					'event_type' => 'payment_method_added',
-					'event_data' => array(
-						'action'     => 'added',
-						'token_id'   => $token->get_id(),
-						'gateway_id' => 'stripe',
-						'card_type'  => 'visa',
-						'card_last4' => '4242',
-					),
-				),
+				'source'     => 'woo-fraud-protection',
+				'event_type' => 'payment_method_added',
 			)
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionClearanceManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionClearanceManagerTest.php
@@ -42,7 +42,8 @@ class SessionClearanceManagerTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'pending', SessionClearanceManager::STATUS_PENDING );
 		$this->assertEquals( 'allowed', SessionClearanceManager::STATUS_ALLOWED );
 		$this->assertEquals( 'blocked', SessionClearanceManager::STATUS_BLOCKED );
-		$this->assertEquals( SessionClearanceManager::STATUS_ALLOWED, SessionClearanceManager::DEFAULT_STATUS );
+		// Default status is PENDING for Blackbox integration (payment methods hidden until verified).
+		$this->assertEquals( SessionClearanceManager::STATUS_PENDING, SessionClearanceManager::DEFAULT_STATUS );
 	}
 
 	/**
@@ -141,5 +142,58 @@ class SessionClearanceManagerTest extends \WC_Unit_Test_Case {
 
 		// Should return default status for invalid values.
 		$this->assertEquals( SessionClearanceManager::DEFAULT_STATUS, $this->sut->get_session_status() );
+	}
+
+	/**
+	 * Test should_render_payment_methods returns true only for allowed status.
+	 */
+	public function test_should_render_payment_methods_returns_true_only_for_allowed() {
+		// Default (pending) - should NOT render.
+		$this->assertFalse( $this->sut->should_render_payment_methods() );
+
+		// Allowed - should render.
+		$this->sut->allow_session();
+		$this->assertTrue( $this->sut->should_render_payment_methods() );
+
+		// Pending - should NOT render.
+		$this->sut->challenge_session();
+		$this->assertFalse( $this->sut->should_render_payment_methods() );
+
+		// Blocked - should NOT render.
+		$this->sut->block_session();
+		$this->assertFalse( $this->sut->should_render_payment_methods() );
+	}
+
+	/**
+	 * Test set_blackbox_session_id and get_blackbox_session_id.
+	 */
+	public function test_blackbox_session_id_storage() {
+		// Initially null.
+		$this->assertNull( $this->sut->get_blackbox_session_id() );
+
+		// Set and retrieve.
+		$session_id = 'bb_test_session_123';
+		$this->sut->set_blackbox_session_id( $session_id );
+		$this->assertEquals( $session_id, $this->sut->get_blackbox_session_id() );
+
+		// Can update to new value.
+		$new_session_id = 'bb_test_session_456';
+		$this->sut->set_blackbox_session_id( $new_session_id );
+		$this->assertEquals( $new_session_id, $this->sut->get_blackbox_session_id() );
+	}
+
+	/**
+	 * Test that default status (PENDING) means payment methods are not rendered.
+	 */
+	public function test_default_pending_status_hides_payment_methods() {
+		// Fresh session should default to PENDING.
+		$this->assertEquals( SessionClearanceManager::STATUS_PENDING, $this->sut->get_session_status() );
+
+		// Payment methods should not render for PENDING status.
+		$this->assertFalse( $this->sut->should_render_payment_methods() );
+
+		// After verification (allow), payment methods should render.
+		$this->sut->allow_session();
+		$this->assertTrue( $this->sut->should_render_payment_methods() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionClearanceManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/FraudProtection/SessionClearanceManagerTest.php
@@ -196,4 +196,114 @@ class SessionClearanceManagerTest extends \WC_Unit_Test_Case {
 		$this->sut->allow_session();
 		$this->assertTrue( $this->sut->should_render_payment_methods() );
 	}
+
+	/**
+	 * Test queue_event adds event to session.
+	 */
+	public function test_queue_event_adds_event_to_session() {
+		$event_type = 'cart_item_added';
+		$event_data = array(
+			'session'    => array( 'session_id' => 'test-123' ),
+			'product_id' => 456,
+		);
+
+		$this->sut->queue_event( $event_type, $event_data );
+
+		$queue = $this->sut->get_event_queue();
+		$this->assertCount( 1, $queue );
+		$this->assertEquals( $event_type, $queue[0]['event_type'] );
+		$this->assertEquals( $event_data, $queue[0]['event_data'] );
+		$this->assertArrayHasKey( 'timestamp', $queue[0] );
+	}
+
+	/**
+	 * Test queue_event includes ISO 8601 timestamp.
+	 */
+	public function test_queue_event_includes_timestamp() {
+		$this->sut->queue_event( 'cart_item_added', array( 'product_id' => 123 ) );
+
+		$queue     = $this->sut->get_event_queue();
+		$timestamp = $queue[0]['timestamp'];
+
+		// Verify timestamp is in ISO 8601 format (e.g., 2024-01-27T10:00:00+00:00).
+		$parsed = \DateTime::createFromFormat( \DateTime::ATOM, $timestamp );
+		$this->assertNotFalse( $parsed, 'Timestamp should be in ISO 8601 format' );
+	}
+
+	/**
+	 * Test get_event_queue returns empty array when no events queued.
+	 */
+	public function test_get_event_queue_returns_empty_array_when_no_events() {
+		$queue = $this->sut->get_event_queue();
+		$this->assertIsArray( $queue );
+		$this->assertEmpty( $queue );
+	}
+
+	/**
+	 * Test get_event_queue returns all queued events in order.
+	 */
+	public function test_get_event_queue_returns_all_events_in_order() {
+		$this->sut->queue_event( 'cart_item_added', array( 'product_id' => 1 ) );
+		$this->sut->queue_event( 'cart_item_updated', array( 'product_id' => 2 ) );
+		$this->sut->queue_event( 'checkout_page_loaded', array() );
+
+		$queue = $this->sut->get_event_queue();
+		$this->assertCount( 3, $queue );
+		$this->assertEquals( 'cart_item_added', $queue[0]['event_type'] );
+		$this->assertEquals( 'cart_item_updated', $queue[1]['event_type'] );
+		$this->assertEquals( 'checkout_page_loaded', $queue[2]['event_type'] );
+	}
+
+	/**
+	 * Test clear_event_queue empties the queue.
+	 */
+	public function test_clear_event_queue_empties_queue() {
+		// Add some events.
+		$this->sut->queue_event( 'cart_item_added', array( 'product_id' => 1 ) );
+		$this->sut->queue_event( 'cart_item_updated', array( 'product_id' => 2 ) );
+
+		$this->assertCount( 2, $this->sut->get_event_queue() );
+
+		// Clear the queue.
+		$this->sut->clear_event_queue();
+
+		$this->assertEmpty( $this->sut->get_event_queue() );
+	}
+
+	/**
+	 * Test event queue limits to max size to prevent session bloat.
+	 */
+	public function test_event_queue_limits_to_max_size() {
+		// Queue more than the limit (50 events).
+		for ( $i = 1; $i <= 60; $i++ ) {
+			$this->sut->queue_event( 'cart_item_added', array( 'product_id' => $i ) );
+		}
+
+		$queue = $this->sut->get_event_queue();
+
+		// Should be limited to 50 events.
+		$this->assertCount( 50, $queue );
+
+		// Should keep the most recent events (11-60).
+		$first_event = $queue[0];
+		$this->assertEquals( 11, $first_event['event_data']['product_id'] );
+
+		$last_event = $queue[49];
+		$this->assertEquals( 60, $last_event['event_data']['product_id'] );
+	}
+
+	/**
+	 * Test event queue persists across multiple SessionClearanceManager instances.
+	 */
+	public function test_event_queue_persists_across_instances() {
+		// Queue event with first instance.
+		$this->sut->queue_event( 'cart_item_added', array( 'product_id' => 123 ) );
+
+		// Create new instance and verify event is still there.
+		$new_instance = new SessionClearanceManager();
+		$queue        = $new_instance->get_event_queue();
+
+		$this->assertCount( 1, $queue );
+		$this->assertEquals( 'cart_item_added', $queue[0]['event_type'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR implements a proof-of-concept for integrating the Blackbox SDK with WooCommerce's Fraud Protection system. The Blackbox SDK provides client-side fingerprinting that generates a session ID, which is then sent to the fraud protection API for verification.

**This is a PoC/internal feature** - it uses a mock Blackbox SDK and is behind a feature flag.

https://github.com/user-attachments/assets/fc21b396-446a-461e-b71f-e2a6a2478ef2

Closes WOOSUBS-1422

#### Key Features

1. **Unified checkout flow support** - Handles three checkout types:
   - **Blocks checkout**: Uses `applyExtensionCartUpdate` via Store API
   - **Shortcode checkout**: Injects hidden input + triggers `update_checkout` AJAX
   - **Add-payment-method**: Dedicated AJAX endpoint with page reload

2. **Session-based event aggregation** - Non-checkout events (cart, page views) are queued in session and sent together with the checkout event as `prior_events`

3. **Payment methods flash prevention** - Resets session status to PENDING before checkout page renders, ensuring payment methods stay hidden until verification completes

4. **Infinite loop prevention** - Uses timestamp-based `was_verified_recently()` check (10s window) to prevent add-payment-method from infinitely reloading

#### Architecture Decisions

| Decision | Rationale |
|----------|-----------|
| **Fail-open pattern** | Empty/failed Blackbox sessions proceed with server-side verification. The API decides whether to allow/block. |
| **Session reset on checkout entry** | Prevents flash of payment methods when a previously-ALLOWED session gets BLOCKED on re-verification |
| **Blackbox session stored in WC session** | Enables `SessionDataCollector` to include it automatically in all event payloads |
| **Separate hook for blocks checkout** | Uses `woocommerce_blocks_enqueue_checkout_block_scripts_before` to reset session BEFORE cart data hydration |

#### Files Changed

| File | Purpose |
|------|---------|
| `BlackboxIntegration.php` | New class - orchestrates Blackbox SDK loading, session ID processing, and verification flow |
| `SessionClearanceManager.php` | Added: event queue, verification timestamp, `reset_expired_session_clearance()`, `should_render_payment_methods()` |
| `FraudProtectionDispatcher.php` | Modified to queue non-checkout events and send `prior_events` with checkout |
| `class-wc-ajax.php` | Added Blackbox session handling in `update_order_review()` |
| `class-wc-payment-gateways.php` | Changed from `is_session_blocked()` to `should_render_payment_methods()` |
| `checkout.js` | New - handles Blackbox.init() and triggers appropriate update flow |
| `blackbox-mock.js` | New - mock SDK that generates fake session IDs (PoC only) |

#### Known Limitations (PoC)

- **Mock Blackbox SDK**: Uses a mock that generates random session IDs. Would be replaced by actual SDK in production.
- **Not using Blackbox verification endpoints**: Currently sends the Blackbox session ID to the existing fraud protection endpoint. Should use dedicated Blackbox verification endpoints instead.
- **Verbose console logging**: Helpful for debugging during PoC, should be reduced/removed for production.
- **No loading indicator for session validation**: The checkout and add payment method messages that appear during verification are misleading and should be updated.
- **Limited error handling and blocked messaging**: This PoC did not focus on error handling or displaying blocked session messages to users. It relies on the existing blocked session notice system, which does not integrate well with the new verification flow (e.g., no inline error messages on blocks checkout when verification fails).
- **10-second verification window**: Hardcoded threshold for `was_verified_recently()`. May need tuning based on real-world performance.
- **Event queue cleared after checkout**: Prior events are cleared from the session after being sent with the checkout event. Consider whether we should retain the full event history and send it with every verification call instead.

### How to test the changes in this Pull Request:

Prerequisites: Enable the fraud protection feature flag.

**Test 1: Blocks checkout verification**
1. Add product to cart, go to blocks checkout
2. Open browser console - observe Blackbox mock initialization
3. Payment methods should appear after ~1 second (verification completes)
4. Console shows: `[FraudProtection] Cart updated with session: bb_xxx`
5. Check `wp-content/uploads/wc-logs/woo-fraud-protection-*.log` to verify the checkout event was logged

**Test 2: No payment methods flash on refresh**
1. Complete Test 1 (session is now ALLOWED)
2. Wait >10 seconds, then refresh the checkout page
3. Payment methods should NOT flash - they stay hidden until verification completes
4. After verification, payment methods appear
5. Check logs to verify a new checkout event was processed

**Test 3: Skip verification if recently verified**
1. Complete Test 1 (session is now ALLOWED)
2. Immediately refresh (within 10 seconds)
3. Payment methods appear instantly (no verification needed)
4. Console shows: `[FraudProtection] Session already verified, skipping initialization`
5. Check logs - no new checkout event should be logged

**Test 4: Add-payment-method flow**
1. Go to `/my-account/add-payment-method/`
2. Payment form is hidden initially
3. After verification completes (~1s), page reloads with payment methods visible
4. Refreshing immediately does NOT cause infinite loop
5. Check logs to verify the checkout event was processed

**Test 5: Shortcode checkout**
1. Go to a shortcode-based checkout page
2. Open browser console - observe Blackbox mock initialization
3. Payment methods should appear after ~1 second (verification completes)
4. Console shows: `[FraudProtection] Triggered update_checkout with session: bb_xxx`
5. Check logs to verify the checkout event was handled

**Test 6: Blocked session**
1. Add products totaling more than 100 (in your store's currency) to the cart
2. Go to checkout
3. Payment methods should NOT appear (session is blocked)
4. Check logs to verify the session was blocked

### Testing that has already taken place:

- All unit tests pass (19 SessionClearanceManager tests, 7 BlackboxIntegration tests)
- Manual testing on local wp-env environment
- Tested blocks checkout, shortcode checkout, and add-payment-method flows
- Verified no infinite loops on add-payment-method
- Verified no payment methods flash on page refresh

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal PoC feature behind feature flag - not user-facing functionality.

</details>