### PR TITLE
Make checkout item quantity inherit theme colours and round if single-digit

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1447-update-item-count-in-checkout
+++ b/plugins/woocommerce/changelog/wooprd-1447-update-item-count-in-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make checkout item quantity round and inherit theme colours

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -63,25 +63,27 @@
 	}
 
 	.wc-block-components-order-summary-item__quantity {
+		@include font-x-small-locked;
 		align-items: center;
-		background: #fff;
-		border: 2px solid;
-		border-radius: 1em;
-		box-shadow: 0 0 0 2px #fff;
-		border-color: $universal-border-light;
-		color: #000;
+		background: currentColor;
 		display: flex;
 		line-height: 1;
 		min-height: 20px;
-		padding: 0 0.4em;
 		position: absolute;
 		justify-content: center;
 		min-width: 20px;
+		border-radius: 20px;
 		right: 0;
 		top: 0;
 		transform: translate(50%, -50%);
 		white-space: nowrap;
 		z-index: 1;
+
+		// The span containing the text should be padded, not the quantity container itself.
+		span {
+			padding: 0 0.4em;
+			color: var(--wp--preset--color--background, #fff);
+		}
 	}
 
 	.wc-block-components-order-summary-item__description {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the item quantity in the Checkout order summary to inherit theme colours and be rounded if single-digit, and stretch into a pill-shape if more than one digit.

Closes WOOPRD-1447

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Dark block theme before | Dark block theme after |
| ------ | ----- |
| <img width="379" height="616" alt="image" src="https://github.com/user-attachments/assets/7e9fc298-06a8-48b5-a7bb-7e0a4c6eb4a6" /> | <img width="395" height="613" alt="image" src="https://github.com/user-attachments/assets/197c4479-6731-4b90-9092-a2e6b9470cda" /> |

| Light block theme before | Light block theme after |
| ------ | ----- |
| <img width="362" height="530" alt="image" src="https://github.com/user-attachments/assets/4bf6356b-5407-4f16-aac8-fc9e47ae2ed3" /> | <img width="360" height="533" alt="image" src="https://github.com/user-attachments/assets/0a6f0d5a-ac47-4abf-a4af-3f53b4779d94" /> |

| Classic theme before | Classic theme after |
| ------ | ----- |
| <img width="309" height="582" alt="image" src="https://github.com/user-attachments/assets/54363085-b1fd-464d-a546-b4b24c90918f" /> | <img width="294" height="584" alt="image" src="https://github.com/user-attachments/assets/73d073e3-c49f-4ef1-9f33-66fc5ec59ec3" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add several items to your cart, one with a single-digit quantity, one with a double-digit quantity, and one with 3+ digit quantity (1, 10, 100, for example)
2. View the Mini-cart and Cart blocks, make sure the line items and order summary look normal (no changes here)
3. Go to the Checkout block, ensure the quantity of each item in the order summary shows in a small black circle or pill, and  changes with the theme colours and background. 
4. Edit your theme to modify background, text colour, to a few different settings and make sure it displays well.
5. Try using a classic theme and ensure that it displays sensibly when using a light and dark theme.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
