### PR TITLE
Fix empty cherry-pick handling to skip instead of fail

### DIFF
--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -252,6 +252,18 @@ jobs:
             echo "has_conflicts=false" >> $GITHUB_OUTPUT
             echo "Cherry-pick completed successfully"
           else
+            # Cherry-pick failed - determine the reason
+
+            # Case 1: Empty cherry-pick - changes already exist in target branch.
+            # Git leaves the repo mid cherry-pick (CHERRY_PICK_HEAD exists) with nothing staged.
+            if [[ -f .git/CHERRY_PICK_HEAD ]] && [[ -z "$(git diff --cached --name-only)" ]]; then
+              echo "status=skipped" >> $GITHUB_OUTPUT
+              echo "error_message=Cherry-pick skipped: changes from PR #$PR_NUMBER already exist in '$TARGET_BRANCH'." >> $GITHUB_OUTPUT
+              git cherry-pick --abort 2>/dev/null || true
+              exit 0
+            fi
+
+            # Case 2: Real conflicts
             # Capture conflicted files with their status codes and build JSON array using jq
             CONFLICT_JSON=$(git status --porcelain | grep -E "^(DD|AU|UD|UA|DU|AA|UU)" | jq -R -n -c '
               [inputs | {status: .[0:2], file: .[3:]}]
@@ -299,6 +311,7 @@ jobs:
 
       - name: Create cherry-pick pull request
         id: create-pr
+        if: steps.cherry-pick.outputs.status != 'skipped'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           CONFLICT_STATUS: ${{ steps.cherry-pick.outputs.conflict_status }}
@@ -432,7 +445,11 @@ jobs:
         id: aggregate-status
         if: always()
         run: |
-          if [[ "${{ steps.cherry-pick.outcome }}" == "failure" ]]; then
+          if [[ "${{ steps.cherry-pick.outputs.status }}" == "skipped" ]]; then
+            echo "status=skipped" >> $GITHUB_OUTPUT
+            echo "error_message=${{ steps.cherry-pick.outputs.error_message }}" >> $GITHUB_OUTPUT
+            echo "cherry_pick_pr_number=" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.cherry-pick.outcome }}" == "failure" ]]; then
             # Use the detailed error message from cherry-pick step
             error_msg="${{ steps.cherry-pick.outputs.error_message }}"
             if [[ -z "$error_msg" ]]; then
@@ -474,6 +491,10 @@ jobs:
           elif [[ "$verify_status" != "success" ]]; then
             echo "status=failed" >> $GITHUB_OUTPUT
             echo "error_message=${{ needs.verify.outputs.error_message }}" >> $GITHUB_OUTPUT
+            echo "cherry_pick_pr_number=" >> $GITHUB_OUTPUT
+          elif [[ "$cherry_status" == "skipped" ]]; then
+            echo "status=skipped" >> $GITHUB_OUTPUT
+            echo "error_message=${{ needs.cherry-pick.outputs.error_message }}" >> $GITHUB_OUTPUT
             echo "cherry_pick_pr_number=" >> $GITHUB_OUTPUT
           elif [[ "$cherry_status" != "success" ]]; then
             echo "status=failed" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR updates the `shared-cherry-pick.yml` workflow to skip the cherry-pick when it results in no changes (because the commit already exists in the target branch), instead of failing.
Detection uses git's internal state: CHERRY_PICK_HEAD exists (mid cherry-pick) with nothing staged (empty diff).
Example of this issue:  p1763989718779089-slack-C05EK70EWDN.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of https://github.com/woocommerce/woocommerce/issues/62068

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the `woocommerce/woocommerce` repo.
2. In the forked repo, create a PR with the `fix/62068-avoid-cp-failure-when-empty` and merge it.
3. Go to `Actions` and enable them.
4. Create the branch `release/10.6` from `trunk`.
5. Create a PR from `trunk` with any small change and merge it.
6. Create the branch `release/10.7` from `trunk`.
7. Add milestone `10.6.0` to the merged PR.
8. Make sure the `Cherry-pick Milestoned PRs to Release Branches` workflow runs and finishes.
9. Make sure it has only created a `[Backport to release/10.6]...` PR.
10. Make sure the `Create cherry-pick pull request` step inside `cherry-pick-next`>`Cherry pick` was skipped.
11. Go to the original PR you created in step 5 and make sure a comment was added saying the cherry-pick to `release/10.6` was skipped, like this:
<img width="947" height="211" alt="Screenshot 2026-01-28 at 16 44 19" src="https://github.com/user-attachments/assets/e8538487-78b5-4dc7-8e0d-c6fe2328ba75" />

- Fails because there are no changes to merge
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>