### PR TITLE
Update default email template styling and center-align footer text in block emails

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7737-update-default-email-template
+++ b/plugins/woocommerce/changelog/stomail-7737-update-default-email-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update default email template footer styling and center-align footer text across all block email templates.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -57,7 +57,7 @@ class WooEmailTemplate {
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0","top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:0;padding-bottom:var(--wp--preset--spacing--10);padding-left:0"><!-- wp:paragraph {"align":"center","style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px","style":"solid"},"right":[],"bottom":[],"left":[]},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"color":{"text":"#787c82"},"elements":{"link":{"color":{"text":"#787c82"}}}},"fontSize":"small"} -->
-<p class="has-text-align-center has-text-color has-link-color has-small-font-size" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-style:solid;border-top-width:1px;color:#787c82;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">© <!--[woocommerce/store-name]-->. All Rights Reserved.<br><!--[woocommerce/store-address]--> </p>
+<p class="has-text-align-center has-text-color has-link-color has-small-font-size" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-style:solid;border-top-width:1px;color:#787c82;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">© <!--[woocommerce/store-name]-->. ' . esc_html__( 'All Rights Reserved.', 'woocommerce' ) . '<br><!--[woocommerce/store-address]--> </p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 </div>

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -55,9 +55,9 @@ class WooEmailTemplate {
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:paragraph {"align":"center","fontSize":"small","style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px","style":"solid"},"right":[],"bottom":[],"left":[]},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"color":{"text":"#787c82"},"elements":{"link":{"color":{"text":"#787c82"}}}}} -->
-<p class="has-text-align-center has-text-color has-link-color has-small-font-size" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-style:solid;border-top-width:1px;color:#787c82;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">You received this email because you shopped at <!--[woocommerce/site-title]--></p>
+<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0","top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:0;padding-bottom:var(--wp--preset--spacing--10);padding-left:0"><!-- wp:paragraph {"align":"center","style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px","style":"solid"},"right":[],"bottom":[],"left":[]},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"color":{"text":"#787c82"},"elements":{"link":{"color":{"text":"#787c82"}}}},"fontSize":"small"} -->
+<p class="has-text-align-center has-text-color has-link-color has-small-font-size" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-style:solid;border-top-width:1px;color:#787c82;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">© <!--[woocommerce/store-name]-->. All Rights Reserved.<br><!--[woocommerce/store-address]--> </p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 </div>

--- a/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.4.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -42,6 +42,6 @@ printf( esc_html__( 'Canceled order: #%s,', 'woocommerce' ), '<!--[woocommerce/o
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'Thanks for reading.', 'woocommerce' ); ?> </p>
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"> <?php echo esc_html__( 'Thanks for reading.', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -42,8 +42,8 @@ printf( esc_html__( 'Order failed: #%s,', 'woocommerce' ), '<!--[woocommerce/ord
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 echo wp_kses_post( __( 'We hope they’ll be back soon! Read more about <a href="https://woocommerce.com/document/managing-orders/">troubleshooting failed payments</a>.', 'woocommerce' ) );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -6,7 +6,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -42,8 +42,8 @@ printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'We hope to see you again soon.', 'woocommerce' ) );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -46,8 +46,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -53,8 +53,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -37,8 +37,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 echo esc_html__( 'Please note that couriers may need some time to provide the latest shipping information.', 'woocommerce' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -37,8 +37,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 echo esc_html__( 'If you have any questions or notice anything unexpected, feel free to reach out to our support team through your account or reply to this email.', 'woocommerce' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -43,8 +43,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 echo esc_html__( 'If anything looks off or you have questions, feel free to contact our support team.', 'woocommerce' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/block/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -41,8 +41,8 @@ printf( esc_html__( 'Details for order #%s,', 'woocommerce' ), '<!--[woocommerce
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/block/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -75,7 +75,7 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 	?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'We look forward to seeing you soon.', 'woocommerce' ); ?> </p>
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"> <?php echo esc_html__( 'We look forward to seeing you soon.', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/customer-note.php
+++ b/plugins/woocommerce/templates/emails/block/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -54,8 +54,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -46,8 +46,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
@@ -52,8 +52,8 @@ printf( esc_html__( 'Your order from %s has been partially refunded.', 'woocomme
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'If you need any help with your order, please contact us at %s', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -46,8 +46,8 @@ defined( 'ABSPATH' ) || exit;
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -52,8 +52,8 @@ printf( esc_html__( 'Your order from %s has been refunded.', 'woocommerce' ), '<
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'If you need any help with your order, please contact us at %s', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/block/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/block/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.5.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -58,7 +58,7 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'Thanks for reading.', 'woocommerce' ); ?> </p>
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"> <?php echo esc_html__( 'Thanks for reading.', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/default-block-content.php
+++ b/plugins/woocommerce/templates/emails/block/default-block-content.php
@@ -8,7 +8,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.2.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -36,8 +36,8 @@ esc_html_e( 'Default block content', 'woocommerce' );
 <div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
 <!-- /wp:woocommerce/email-content -->
 
-<!-- wp:paragraph -->
-<p><?php
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -36,7 +36,7 @@ $display_section_divider = (bool) apply_filters( 'woocommerce_email_body_display
 
 ?>
 <?php if ( $display_section_divider ) : ?>
-	<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+	<hr style="border: 0; border-top: 1px solid #1E1E1E; border-top-color: rgba(30, 30, 30, 0.2); margin: 20px 0;">
 <?php endif; ?>
 <table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0" role="presentation">
 	<tr>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -26,7 +26,19 @@ $shipping = $order->get_formatted_shipping_address();
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0" role="presentation">
+/**
+ * Filter whether to display the section divider in the email body.
+ *
+ * @since 10.6.0
+ * @param bool $display_section_divider Whether to display the section divider. Default true.
+ */
+$display_section_divider = apply_filters( 'woocommerce_email_body_display_section_divider', true );
+
+?>
+<?php if ( $display_section_divider ) : ?>
+	<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+<?php endif; ?>
+<table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0" role="presentation">
 	<tr>
 		<td class="font-family text-align-left" style="border:0; padding:0;" valign="top" width="50%">
 			<?php if ( $email_improvements_enabled ) { ?>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -32,7 +32,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
  * @since 10.6.0
  * @param bool $display_section_divider Whether to display the section divider. Default true.
  */
-$display_section_divider = apply_filters( 'woocommerce_email_body_display_section_divider', true );
+$display_section_divider = (bool) apply_filters( 'woocommerce_email_body_display_section_divider', true );
 
 ?>
 <?php if ( $display_section_divider ) : ?>

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -22,10 +22,18 @@ defined( 'ABSPATH' ) || exit;
 $text_align = is_rtl() ? 'right' : 'left';
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
-$heading_class              = $email_improvements_enabled ? 'email-order-detail-heading' : '';
-$order_table_class          = $email_improvements_enabled ? 'email-order-details' : '';
-$order_total_text_align     = $email_improvements_enabled ? 'right' : 'left';
-$order_quantity_text_align  = $email_improvements_enabled ? 'right' : 'left';
+
+/**
+ * Filter whether to display the section divider in the email body.
+ *
+ * @since 10.6.0
+ * @param bool $display_section_divider Whether to display the section divider. Default true.
+ */
+$display_section_divider   = apply_filters( 'woocommerce_email_body_display_section_divider', true );
+$heading_class             = $email_improvements_enabled ? 'email-order-detail-heading' : '';
+$order_table_class         = $email_improvements_enabled ? 'email-order-details' : '';
+$order_total_text_align    = $email_improvements_enabled ? 'right' : 'left';
+$order_quantity_text_align = $email_improvements_enabled ? 'right' : 'left';
 
 if ( $email_improvements_enabled ) {
 	add_filter( 'woocommerce_order_shipping_to_display_shipped_via', '__return_false' );
@@ -95,6 +103,9 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			?>
 		</tbody>
 	</table>
+	<?php if ( $display_section_divider ) : ?>
+		<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+	<?php endif; ?>
 	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">
 		<?php
 		$item_totals       = $order->get_order_item_totals();
@@ -131,6 +142,9 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		?>
 	</table>
 	<?php if ( $order->get_customer_note() && $email_improvements_enabled ) { ?>
+		<?php if ( $display_section_divider ) : ?>
+			<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+		<?php endif; ?>
 		<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1" role="presentation">
 			<tr class="order-customer-note">
 				<td class="td text-align-left">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 10.6.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -29,7 +29,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
  * @since 10.6.0
  * @param bool $display_section_divider Whether to display the section divider. Default true.
  */
-$display_section_divider   = apply_filters( 'woocommerce_email_body_display_section_divider', true );
+$display_section_divider   = (bool) apply_filters( 'woocommerce_email_body_display_section_divider', true );
 $heading_class             = $email_improvements_enabled ? 'email-order-detail-heading' : '';
 $order_table_class         = $email_improvements_enabled ? 'email-order-details' : '';
 $order_total_text_align    = $email_improvements_enabled ? 'right' : 'left';

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -104,7 +104,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		</tbody>
 	</table>
 	<?php if ( $display_section_divider ) : ?>
-		<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+		<hr style="border: 0; border-top: 1px solid #1E1E1E; border-top-color: rgba(30, 30, 30, 0.2); margin: 20px 0;">
 	<?php endif; ?>
 	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">
 		<?php
@@ -143,7 +143,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 	</table>
 	<?php if ( $order->get_customer_note() && $email_improvements_enabled ) { ?>
 		<?php if ( $display_section_divider ) : ?>
-			<hr style="border: 0; border-top: 1px solid #1E1E1E33; margin: 20px 0;">
+			<hr style="border: 0; border-top: 1px solid #1E1E1E; border-top-color: rgba(30, 30, 30, 0.2); margin: 20px 0;">
 		<?php endif; ?>
 		<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1" role="presentation">
 			<tr class="order-customer-note">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR addresses improvements to the default WooCommerce block email template design. The changes align the email templates closer to the design reference in Figma.

**Why:** The current email template implementation needed refinement to match the expected design specifications. The footer text was not center-aligned consistently across all block email templates, and the footer content needed updating to include copyright notice and store address information.

Closes https://linear.app/a8c/issue/STOMAIL-7737/default-email-template

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="2508" height="2368" alt="localhost_8888_woo_email_failed_order__preview_id=1192 preview=true doing_wp_cron=1769616782 8458099365234375000000 (3)" src="https://github.com/user-attachments/assets/47454f59-a7c1-4e23-bf50-fe64a513bb2d" />  |   <img width="2508" height="2584" alt="localhost_8888_woo_email_failed_order__preview_id=1192 preview=true doing_wp_cron=1769616782 8458099365234375000000 (2)" src="https://github.com/user-attachments/assets/e8eeb903-5054-4b6e-a141-633c182f4d9a" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the Email Improvements and Block email editor feature flag in WooCommerce settings
2. Navigate to WooCommerce → Settings → Emails
3. Open the email editor for any email template (e.g., "New Order", "Processing Order", "Completed Order")
4. Verify that:
   - The footer text is center-aligned
   - The footer shows copyright notice with store name and "All Rights Reserved"
   - The footer shows the store address
   - The footer has no side padding (content extends to edges)
5. Send a test email and verify the footer appears correctly in the email client
6. Test with multiple email templates to confirm consistency across all block email types

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
