### PR TITLE
Move product sale badge alongside individual prices in cart and update design

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1450-saved-amount-badges
+++ b/plugins/woocommerce/changelog/wooprd-1450-saved-amount-badges
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Move the "Save $X" badges in Cart/Mini-cart alongside the individual item prices to save vertical space.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -23,6 +23,7 @@ import type { CartItem } from '@woocommerce/types';
 import { objectHasProp, Currency } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
 import { Icon, trash } from '@wordpress/icons';
+import { calculateSaleAmount } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -146,9 +147,10 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 			amount: parseInt( prices.raw_prices.price, 10 ),
 			precision: prices.raw_prices.precision,
 		} );
-		const saleAmountSingle =
-			regularAmountSingle.subtract( purchaseAmountSingle );
-		const saleAmount = saleAmountSingle.multiply( quantity );
+		const saleAmountSingle = calculateSaleAmount(
+			prices,
+			priceCurrency.minorUnit
+		);
 		const totalsCurrency = getCurrencyFromPriceResponse( totals );
 		let lineSubtotal = parseInt( totals.line_subtotal, 10 );
 		if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
@@ -271,10 +273,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							{ quantity === 1 && (
 								<ProductSaleBadge
 									currency={ priceCurrency }
-									saleAmount={ getAmountFromRawPrice(
-										saleAmountSingle,
-										priceCurrency
-									) }
+									saleAmount={ saleAmountSingle }
 									format={ saleBadgePriceFormat }
 								/>
 							) }
@@ -360,10 +359,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						{ quantity > 1 && (
 							<ProductSaleBadge
 								currency={ priceCurrency }
-								saleAmount={ getAmountFromRawPrice(
-									saleAmount,
-									priceCurrency
-								) }
+								saleAmount={ saleAmountSingle * quantity }
 								format={ saleBadgePriceFormat }
 							/>
 						) }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -270,14 +270,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								) }
 								format={ subtotalPriceFormat }
 							/>
-							{ quantity === 1 && (
-								<ProductSaleBadge
-									currency={ priceCurrency }
-									saleAmount={ saleAmountSingle }
-									format={ saleBadgePriceFormat }
-								/>
-							) }
-						</div>
+							</div>
 
 						<ProductMetadata
 							shortDescription={ shortDescription }
@@ -356,13 +349,11 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							price={ subtotalPrice.getAmount() }
 						/>
 
-						{ quantity > 1 && (
-							<ProductSaleBadge
-								currency={ priceCurrency }
-								saleAmount={ saleAmountSingle * quantity }
-								format={ saleBadgePriceFormat }
-							/>
-						) }
+						<ProductSaleBadge
+							currency={ priceCurrency }
+							saleAmount={ saleAmountSingle * quantity }
+							format={ saleBadgePriceFormat }
+						/>
 					</div>
 				</td>
 			</tr>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -30,7 +30,6 @@ import { calculateSaleAmount } from '@woocommerce/base-utils';
  */
 import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
-import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
 import ProductSaleBadge from '../product-sale-badge';
 
@@ -69,7 +68,6 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 			catalog_visibility: catalogVisibility = 'visible',
 			short_description: shortDescription = '',
 			description: fullDescription = '',
-			low_stock_remaining: lowStockRemaining = null,
 			show_backorder_badge: showBackorderBadge = false,
 			quantity_limits: quantityLimits = {
 				minimum: 1,
@@ -247,15 +245,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							name={ name }
 							permalink={ permalink }
 						/>
-						{ showBackorderBadge ? (
-							<ProductBackorderBadge />
-						) : (
-							!! lowStockRemaining && (
-								<ProductLowStockBadge
-									lowStockRemaining={ lowStockRemaining }
-								/>
-							)
-						) }
+						{ showBackorderBadge && <ProductBackorderBadge /> }
 
 						<div className="wc-block-cart-item__prices">
 							<ProductPrice
@@ -270,7 +260,7 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								) }
 								format={ subtotalPriceFormat }
 							/>
-							</div>
+						</div>
 
 						<ProductMetadata
 							shortDescription={ shortDescription }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -268,6 +268,16 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 								) }
 								format={ subtotalPriceFormat }
 							/>
+							{ quantity === 1 && (
+								<ProductSaleBadge
+									currency={ priceCurrency }
+									saleAmount={ getAmountFromRawPrice(
+										saleAmountSingle,
+										priceCurrency
+									) }
+									format={ saleBadgePriceFormat }
+								/>
+							) }
 						</div>
 
 						<ProductSaleBadge

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -280,15 +280,6 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							) }
 						</div>
 
-						<ProductSaleBadge
-							currency={ priceCurrency }
-							saleAmount={ getAmountFromRawPrice(
-								saleAmountSingle,
-								priceCurrency
-							) }
-							format={ saleBadgePriceFormat }
-						/>
-
 						<ProductMetadata
 							shortDescription={ shortDescription }
 							fullDescription={ fullDescription }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -49,6 +49,7 @@ table.wc-block-cart-items {
 			flex-direction: row;
 			flex-wrap: nowrap;
 			gap: $gap-smaller;
+			align-items: center;
 
 			@include cart-checkout-mobile-container {
 				flex-wrap: wrap;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -45,6 +45,19 @@ table.wc-block-cart-items {
 		}
 		.wc-block-cart-item__prices {
 			@include font-small-locked;
+			display: flex;
+			flex-direction: row;
+			flex-wrap: nowrap;
+			gap: $gap-smaller;
+
+			.price {
+				display: flex;
+				align-items: center;
+
+				&[hidden] {
+					display: none;
+				}
+			}
 		}
 
 		.wc-block-cart-item__quantity {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -50,6 +50,10 @@ table.wc-block-cart-items {
 			flex-wrap: nowrap;
 			gap: $gap-smaller;
 
+			@include cart-checkout-mobile-container {
+				flex-wrap: wrap;
+			}
+
 			.price {
 				display: flex;
 				align-items: center;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -81,6 +81,10 @@ table.wc-block-cart-items {
 				&[hidden] {
 					display: none;
 				}
+
+				svg {
+					fill: currentColor;
+				}
 			}
 		}
 		.wc-block-components-product-name {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -93,6 +93,8 @@ table.wc-block-cart-items {
 			display: block;
 			max-width: max-content;
 			line-height: 1.4;
+			margin-bottom: 5px;
+
 			&[hidden] {
 				display: none;
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -19,6 +19,7 @@ import { getSetting } from '@woocommerce/settings';
 import { useMemo } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { CartItem, isString } from '@woocommerce/types';
+import { calculateSaleAmount } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -104,35 +105,10 @@ const OrderSummaryItem = ( {
 		precision: totalsCurrency.minorUnit,
 	} ).getAmount();
 
-	// Sale badge discount calculation — duplicated from cart-line-item-row.tsx.
-	// Both components already depend on Dinero for other price math, and the
-	// logic is small enough that a shared hook would add indirection without
-	// meaningful deduplication.
-
-	const regularAmountSingle = Dinero( {
-		amount: parseInt( prices.raw_prices.regular_price, 10 ),
-		precision: isString( prices.raw_prices.precision )
-			? parseInt( prices.raw_prices.precision, 10 )
-			: prices.raw_prices.precision,
-	} );
-
-	const purchaseAmountSingle = Dinero( {
-		amount: parseInt( prices.raw_prices.price, 10 ),
-		precision: isString( prices.raw_prices.precision )
-			? parseInt( prices.raw_prices.precision, 10 )
-			: prices.raw_prices.precision,
-	} );
-
-	const saleAmountSingle = regularAmountSingle
-		.subtract( purchaseAmountSingle )
-		.convertPrecision( priceCurrency.minorUnit )
-		.getAmount();
-
-	const saleAmount = regularAmountSingle
-		.subtract( purchaseAmountSingle )
-		.multiply( quantity )
-		.convertPrecision( priceCurrency.minorUnit )
-		.getAmount();
+	const saleAmountSingle = calculateSaleAmount(
+		prices,
+		priceCurrency.minorUnit
+	);
 
 	const subtotalPriceFormat = applyCheckoutFilter( {
 		filterName: 'subtotalPriceFormat',
@@ -271,7 +247,7 @@ const OrderSummaryItem = ( {
 					{ quantity > 1 && (
 						<ProductSaleBadge
 							currency={ priceCurrency }
-							saleAmount={ saleAmount }
+							saleAmount={ saleAmountSingle * quantity }
 							format={ saleBadgePriceFormat }
 						/>
 					) }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -201,22 +201,9 @@ const OrderSummaryItem = ( {
 						regularPriceClassName="wc-block-components-order-summary-item__regular-individual-price"
 						format={ subtotalPriceFormat }
 					/>
-					{ quantity === 1 && (
-						<ProductSaleBadge
-							currency={ priceCurrency }
-							saleAmount={ saleAmountSingle }
-							format={ saleBadgePriceFormat }
-						/>
-					) }
-				</div>
-				{ showBackorderBadge ? (
+					</div>
+				{ showBackorderBadge && (
 					<ProductBackorderBadge />
-				) : (
-					!! lowStockRemaining && (
-						<ProductLowStockBadge
-							lowStockRemaining={ lowStockRemaining }
-						/>
-					)
 				) }
 				<ProductMetadata { ...productMetaProps } />
 			</div>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -199,10 +199,8 @@ const OrderSummaryItem = ( {
 						regularPriceClassName="wc-block-components-order-summary-item__regular-individual-price"
 						format={ subtotalPriceFormat }
 					/>
-					</div>
-				{ showBackorderBadge && (
-					<ProductBackorderBadge />
-				) }
+				</div>
+				{ showBackorderBadge && <ProductBackorderBadge /> }
 				<ProductMetadata { ...productMetaProps } />
 			</div>
 			<span className="screen-reader-text">

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -26,7 +26,6 @@ import { calculateSaleAmount } from '@woocommerce/base-utils';
  */
 import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
-import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
 import ProductSaleBadge from '../product-sale-badge';
 
@@ -41,7 +40,6 @@ const OrderSummaryItem = ( {
 }: OrderSummaryProps ): JSX.Element => {
 	const {
 		images,
-		low_stock_remaining: lowStockRemaining,
 		show_backorder_badge: showBackorderBadge,
 		name: initialName,
 		permalink,
@@ -231,13 +229,11 @@ const OrderSummaryItem = ( {
 						format={ productPriceFormat }
 						price={ subtotalPrice }
 					/>
-					{ quantity > 1 && (
-						<ProductSaleBadge
-							currency={ priceCurrency }
-							saleAmount={ saleAmountSingle * quantity }
-							format={ saleBadgePriceFormat }
-						/>
-					) }
+					<ProductSaleBadge
+						currency={ priceCurrency }
+						saleAmount={ saleAmountSingle * quantity }
+						format={ saleBadgePriceFormat }
+					/>
 				</div>
 			</div>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -27,6 +27,7 @@ import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
 import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
+import ProductSaleBadge from '../product-sale-badge';
 
 interface OrderSummaryProps {
 	cartItem: CartItem;
@@ -102,8 +103,47 @@ const OrderSummaryItem = ( {
 		amount: lineSubtotal,
 		precision: totalsCurrency.minorUnit,
 	} ).getAmount();
+
+	// Sale badge discount calculation — duplicated from cart-line-item-row.tsx.
+	// Both components already depend on Dinero for other price math, and the
+	// logic is small enough that a shared hook would add indirection without
+	// meaningful deduplication.
+
+	const regularAmountSingle = Dinero( {
+		amount: parseInt( prices.raw_prices.regular_price, 10 ),
+		precision: isString( prices.raw_prices.precision )
+			? parseInt( prices.raw_prices.precision, 10 )
+			: prices.raw_prices.precision,
+	} );
+
+	const purchaseAmountSingle = Dinero( {
+		amount: parseInt( prices.raw_prices.price, 10 ),
+		precision: isString( prices.raw_prices.precision )
+			? parseInt( prices.raw_prices.precision, 10 )
+			: prices.raw_prices.precision,
+	} );
+
+	const saleAmountSingle = regularAmountSingle
+		.subtract( purchaseAmountSingle )
+		.convertPrecision( priceCurrency.minorUnit )
+		.getAmount();
+
+	const saleAmount = regularAmountSingle
+		.subtract( purchaseAmountSingle )
+		.multiply( quantity )
+		.convertPrecision( priceCurrency.minorUnit )
+		.getAmount();
+
 	const subtotalPriceFormat = applyCheckoutFilter( {
 		filterName: 'subtotalPriceFormat',
+		defaultValue: '<price/>',
+		extensions,
+		arg,
+		validation: productPriceValidation,
+	} );
+
+	const saleBadgePriceFormat = applyCheckoutFilter( {
+		filterName: 'saleBadgePriceFormat',
 		defaultValue: '<price/>',
 		extensions,
 		arg,
@@ -175,15 +215,24 @@ const OrderSummaryItem = ( {
 					permalink={ permalink }
 					disabledTagName="h3"
 				/>
-				<ProductPrice
-					currency={ priceCurrency }
-					price={ priceSingle }
-					regularPrice={ regularPriceSingle }
-					className="wc-block-components-order-summary-item__individual-prices"
-					priceClassName="wc-block-components-order-summary-item__individual-price"
-					regularPriceClassName="wc-block-components-order-summary-item__regular-individual-price"
-					format={ subtotalPriceFormat }
-				/>
+				<div className="wc-block-cart-item__prices">
+					<ProductPrice
+						currency={ priceCurrency }
+						price={ priceSingle }
+						regularPrice={ regularPriceSingle }
+						className="wc-block-components-order-summary-item__individual-prices"
+						priceClassName="wc-block-components-order-summary-item__individual-price"
+						regularPriceClassName="wc-block-components-order-summary-item__regular-individual-price"
+						format={ subtotalPriceFormat }
+					/>
+					{ quantity === 1 && (
+						<ProductSaleBadge
+							currency={ priceCurrency }
+							saleAmount={ saleAmountSingle }
+							format={ saleBadgePriceFormat }
+						/>
+					) }
+				</div>
 				{ showBackorderBadge ? (
 					<ProductBackorderBadge />
 				) : (
@@ -213,11 +262,20 @@ const OrderSummaryItem = ( {
 				className="wc-block-components-order-summary-item__total-price"
 				aria-hidden="true"
 			>
-				<ProductPrice
-					currency={ totalsCurrency }
-					format={ productPriceFormat }
-					price={ subtotalPrice }
-				/>
+				<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
+					<ProductPrice
+						currency={ totalsCurrency }
+						format={ productPriceFormat }
+						price={ subtotalPrice }
+					/>
+					{ quantity > 1 && (
+						<ProductSaleBadge
+							currency={ priceCurrency }
+							saleAmount={ saleAmount }
+							format={ saleBadgePriceFormat }
+						/>
+					) }
+				</div>
 			</div>
 		</div>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -103,6 +103,7 @@
 		flex-direction: row;
 		flex-wrap: wrap;
 		gap: $gap-smaller;
+		align-items: center;
 	}
 
 	.wc-block-components-order-summary-item__individual-prices {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -98,6 +98,34 @@
 		}
 	}
 
+	.wc-block-cart-item__prices {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		gap: $gap-smaller;
+	}
+
+	.wc-block-components-order-summary-item__individual-prices {
+		del {
+			margin-right: 0.5em;
+		}
+
+		ins {
+			display: inline-block;
+			margin-left: 0;
+		}
+	}
+
+	.wc-block-cart-item__total-price-and-sale-badge-wrapper {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+
+		.wc-block-components-sale-badge {
+			margin-top: $gap-smallest;
+		}
+	}
+
 	.wc-block-components-order-summary-item__total-price {
 		margin-left: auto;
 		text-align: right;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-badge/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-badge/style.scss
@@ -1,11 +1,8 @@
 .wc-block-components-product-badge {
-	@include font-size(smaller);
-	border-radius: $universal-border-radius;
-	border: 1px solid;
+	@include font-x-small-locked;
 	display: inline-block;
-	font-weight: 600;
-	padding: 0 0.66em;
-	text-transform: uppercase;
+	background: color-mix(in srgb, currentColor 10%, transparent);
+	padding: 2px 4px;
 	white-space: nowrap;
 
 	&[hidden] {

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/calculate-sale-amount.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/calculate-sale-amount.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import Dinero from 'dinero.js';
+import type { CartItem } from '@woocommerce/types';
+
+/**
+ * Calculate the per-unit sale amount from raw prices.
+ *
+ * @param prices          Cart item prices containing raw_prices.
+ * @param targetPrecision The target currency minor unit precision.
+ * @return Per-unit sale amount as a number, or 0 if no discount.
+ */
+export function calculateSaleAmount(
+	prices: CartItem[ 'prices' ],
+	targetPrecision: number
+): number {
+	const rawPrecision =
+		typeof prices.raw_prices.precision === 'string'
+			? parseInt( prices.raw_prices.precision, 10 )
+			: prices.raw_prices.precision;
+
+	const regular = Dinero( {
+		amount: parseInt( prices.raw_prices.regular_price, 10 ),
+		precision: rawPrecision,
+	} );
+
+	const purchase = Dinero( {
+		amount: parseInt( prices.raw_prices.price, 10 ),
+		precision: rawPrecision,
+	} );
+
+	return regular
+		.subtract( purchase )
+		.convertPrecision( targetPrecision )
+		.getAmount();
+}

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/index.js
@@ -1,5 +1,6 @@
 export * from './errors';
 export * from './address';
+export * from './calculate-sale-amount';
 export * from './shipping-rates';
 export * from './legacy-events';
 export * from './render-frontend';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -105,12 +105,6 @@
 }
 
 @include cart-checkout-below-large-container {
-	.wc-block-cart-item__total {
-		.wc-block-components-sale-badge {
-			display: none;
-		}
-	}
-
 	.wc-block-cart {
 		.wc-block-components-sidebar {
 			.wc-block-cart__totals-title {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -717,6 +717,13 @@ const { state: cartItemState } = store(
 				return price;
 			},
 
+			get isLineItemSingleDiscountVisible(): boolean {
+				return (
+					cartItemState.cartItemHasDiscount &&
+					cartItemState.cartItem.quantity === 1
+				);
+			},
+
 			get isLineItemTotalDiscountVisible(): boolean {
 				return (
 					cartItemState.cartItemHasDiscount &&

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -45,7 +45,6 @@ const {
 	increaseQuantityLabel,
 	quantityDescriptionLabel,
 	removeFromCartLabel,
-	lowInStockLabel,
 } = getConfig( 'woocommerce/mini-cart-products-table-block' );
 const { itemsInCartTextTemplate } = getConfig(
 	'woocommerce/mini-cart-title-items-counter-block'
@@ -410,45 +409,6 @@ const { state: cartItemState } = store(
 				);
 			},
 
-			get cartItemDiscount(): string {
-				const { extensions } = cartItemState.cartItem;
-
-				const discountPrice =
-					cartItemState.regularAmountSingle -
-					cartItemState.purchaseAmountSingle;
-
-				const price = formatPriceWithCurrency(
-					discountPrice,
-					cartItemState.currency
-				);
-
-				// TODO: Add deprecation notice urging to replace with a
-				// `data-wp-text` directive or an alternative solution.
-				if (
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
-				) {
-					const priceText =
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
-							{
-								filterName: 'saleBadgePriceFormat',
-								defaultValue: '<price/>',
-								extensions,
-								arg: {
-									context: 'cart',
-									cartItem: cartItemState.cartItem,
-									cart: woocommerceState.cart,
-								},
-							}
-						);
-
-					return priceText.replace( '<price/>', price );
-				}
-
-				return price;
-			},
-
 			get lineItemDiscount(): string {
 				const { quantity, extensions } = cartItemState.cartItem;
 
@@ -717,20 +677,6 @@ const { state: cartItemState } = store(
 				return price;
 			},
 
-			get isLineItemSingleDiscountVisible(): boolean {
-				return (
-					cartItemState.cartItemHasDiscount &&
-					cartItemState.cartItem.quantity === 1
-				);
-			},
-
-			get isLineItemTotalDiscountVisible(): boolean {
-				return (
-					cartItemState.cartItemHasDiscount &&
-					cartItemState.cartItem.quantity > 1
-				);
-			},
-
 			get isProductHiddenFromCatalog(): boolean {
 				const context = getContext< { isImageHidden: boolean } >();
 				const { catalog_visibility: catalogVisibility } =
@@ -739,20 +685,6 @@ const { state: cartItemState } = store(
 					( catalogVisibility === 'hidden' ||
 						catalogVisibility === 'search' ) &&
 					! context.isImageHidden
-				);
-			},
-
-			get isLowInStockVisible(): boolean {
-				return (
-					! cartItemState.cartItem.show_backorder_badge &&
-					!! cartItemState.cartItem.low_stock_remaining
-				);
-			},
-
-			get lowInStockLabel(): string {
-				return lowInStockLabel.replace(
-					'%d',
-					cartItemState.cartItem.low_stock_remaining
 				);
 			},
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -170,22 +170,22 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											</span>
 											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
-									</div>
-									<div 
-										data-wp-bind--hidden="!state.isLineItemSingleDiscountVisible"
-										class="wc-block-components-product-badge wc-block-components-sale-badge"
-									>
-									<?php
-										echo wp_kses(
-											$cart_item_save_badge,
-											array(
-												'span' => array(
-													'data-wp-text' => true,
-													'class'        => true,
-												),
-											)
-										);
-									?>
+										<div
+											data-wp-bind--hidden="!state.isLineItemSingleDiscountVisible"
+											class="wc-block-components-product-badge wc-block-components-sale-badge"
+										>
+										<?php
+											echo wp_kses(
+												$cart_item_save_badge,
+												array(
+													'span' => array(
+														'data-wp-text' => true,
+														'class'        => true,
+													),
+												)
+											);
+										?>
+										</div>
 									</div>
 									<div class="wc-block-components-product-metadata">
 										<div data-wp-watch="callbacks.itemShortDescription" >

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -61,15 +61,10 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 
 		/* translators: %s is the discount amount. */
 		$save_format             = __( 'Save %s', 'woocommerce' );
-		$cart_item_discount_span = '<span data-wp-text="state.cartItemDiscount" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"></span>';
-		$cart_item_save_badge    = sprintf( $save_format, $cart_item_discount_span );
 		$line_item_discount_span = '<span data-wp-text="state.lineItemDiscount" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"></span>';
 		$line_item_save_badge    = sprintf( $save_format, $line_item_discount_span );
 
 		$available_on_backorder_label = __( 'Available on backorder', 'woocommerce' );
-
-		/* translators: %d stock amount (number of items in stock for product) */
-		$low_in_stock_label = __( '%d left in stock', 'woocommerce' );
 
 		wp_interactivity_config(
 			$this->get_full_block_name(),
@@ -78,7 +73,6 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 				'increaseQuantityLabel'    => $increase_quantity_label,
 				'quantityDescriptionLabel' => $quantity_description_label,
 				'removeFromCartLabel'      => $remove_from_cart_label,
-				'lowInStockLabel'          => $low_in_stock_label,
 			)
 		);
 
@@ -145,12 +139,6 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									<div data-wp-bind--hidden="!state.cartItem.show_backorder_badge" class="wc-block-components-product-badge wc-block-components-product-backorder-badge">
 										<?php echo esc_html( $available_on_backorder_label ); ?>
 									</div>
-									<div 
-										class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
-										data-wp-bind--hidden="!state.isLowInStockVisible"
-										data-wp-text="state.lowInStockLabel"
-									>
-									</div>
 									<div class="wc-block-cart-item__prices">
 										<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price">
 											<span data-wp-text="state.beforeItemPrice"></span>
@@ -170,22 +158,6 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											</span>
 											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
-										<div
-											data-wp-bind--hidden="!state.isLineItemSingleDiscountVisible"
-											class="wc-block-components-product-badge wc-block-components-sale-badge"
-										>
-										<?php
-											echo wp_kses(
-												$cart_item_save_badge,
-												array(
-													'span' => array(
-														'data-wp-text' => true,
-														'class'        => true,
-													),
-												)
-											);
-										?>
-										</div>
 									</div>
 									<div class="wc-block-components-product-metadata">
 										<div data-wp-watch="callbacks.itemShortDescription" >
@@ -247,7 +219,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										</span>											
 									</span>
 									<div 
-										data-wp-bind--hidden="!state.isLineItemTotalDiscountVisible" 
+										data-wp-bind--hidden="!state.cartItemHasDiscount" 
 										class="wc-block-components-product-badge wc-block-components-sale-badge"
 									>
 									<?php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -172,7 +172,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										</span>
 									</div>
 									<div 
-										data-wp-bind--hidden="!state.cartItemHasDiscount" 
+										data-wp-bind--hidden="!state.isLineItemSingleDiscountVisible"
 										class="wc-block-components-product-badge wc-block-components-sale-badge"
 									>
 									<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The sale badges were previously below the individual price on cart line items, and in a box with rounded borders, this PR changes them to be underneath the total price and in a box without borders, but a background appropriate for the theme.

This PR also removes the "Only X remaining" low-stock badge.

Closes WOOPRD-1450

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Mini-cart before | Mini-cart after |
| ------ | ----- |
| <img width="456" height="728" alt="image" src="https://github.com/user-attachments/assets/8b5e8a42-2d39-4e45-a286-862c4bdc53b3" /> | <img width="460" height="708" alt="image" src="https://github.com/user-attachments/assets/38c84023-95d0-4f7f-944c-b70de3f18f24" /> |

| Cart before | Cart after |
| ------ | ----- |
| <img width="689" height="803" alt="image" src="https://github.com/user-attachments/assets/3612622a-a68b-4597-9ba7-7148f3e3f8e4" /> | <img width="584" height="717" alt="image" src="https://github.com/user-attachments/assets/8696a414-00e5-47ff-a25b-b9564f2c41e1" />|

| Light-theme Mini-cart before | Light theme Mini-cart after |
| ------ | ----- |
| <img width="456" height="708" alt="image" src="https://github.com/user-attachments/assets/7a4c22c2-8520-44df-8642-3d56d8efebe3" /> | <img width="476" height="631" alt="image" src="https://github.com/user-attachments/assets/7dff7b1a-ff80-4b53-b4a9-758502ae99ca" /> |

| Light-theme Cart before | Light theme Cart after |
| ------ | ----- |
| <img width="1032" height="834" alt="image" src="https://github.com/user-attachments/assets/59e3ff9c-b251-4a43-97fc-e7d4d715e678" /> | <img width="567" height="720" alt="image" src="https://github.com/user-attachments/assets/54df938f-7437-4464-a53f-62b19dcf70c1" /> |

| Classic theme Mini-cart before | Classic theme Mini-cart after |
| ------ | ----- |
| <img width="468" height="622" alt="image" src="https://github.com/user-attachments/assets/de85bbdd-6b08-4462-9ca3-2a0ac4e5ad62" /> | <img width="466" height="634" alt="image" src="https://github.com/user-attachments/assets/1d3c334c-0dc6-4f43-8d57-572a4b267ad6" /> |

| Checkout before | Checkout after |
| ------ | ----- |
| <img width="405" height="705" alt="image" src="https://github.com/user-attachments/assets/222fac0d-67cf-417f-a0f4-4bffe43a4107" /> | <img width="352" height="678" alt="image" src="https://github.com/user-attachments/assets/57900d12-5dcc-49c8-99c4-51531b2e9328" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
 
1. Put two items on sale
2. Put an item on low stock
3. Add these two sale items, the low-stock item, and one more (not on sale, not low stock) item to your cart
4. Go to the Mini-cart and change the quantity of _one_ of the sale items to >1
5. Verify the sale badge shows under the item's "total price" on the right regardless of quantity.
6. Verify no sale badges show for products not on sale.
7. Verify no "Only X remaining" badge shows on the sale item, or the other items. (This has been removed)
8. Visit the Cart block and verify the same.
9. Visit the Product Collection block and ensure the prices, and sale prices there display normally without any changes to styling.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>