### PR TITLE
Add 'Added to cart' announcement when Mini-Cart is opened after adding to cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-5940-add-to-cart-announcement
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-5940-add-to-cart-announcement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add 'Added to cart' announcement when Mini-Cart is opened after adding to cart

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -89,6 +89,7 @@ type MiniCart = {
 		miniCartButtonRef: HTMLElement | null;
 	};
 	actions: {
+		addedToCart: () => void;
 		openDrawer: () => void;
 		closeDrawer: () => void;
 		overlayCloseDrawer: ( e: MouseEvent ) => void;
@@ -249,11 +250,26 @@ store< MiniCart >(
 		},
 
 		actions: {
+			*addedToCart() {
+				if ( onCartClickBehaviour !== 'navigate_to_checkout' ) {
+					const a11yModulePromise = import( '@wordpress/a11y' );
+
+					const { messages } = getConfig(
+						'woocommerce'
+					) as WooCommerceConfig;
+					if ( messages?.addedToCartText ) {
+						const { speak } = yield a11yModulePromise;
+						speak( messages.addedToCartText, 'assertive' );
+					}
+				}
+				miniCartActions.openDrawer();
+			},
 			openDrawer() {
 				if ( onCartClickBehaviour === 'navigate_to_checkout' ) {
 					window.location.href = checkoutUrl;
 					return;
 				}
+
 				const { ref } = getElement();
 				state.miniCartButtonRef = ref;
 				state.isOpen = true;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -575,6 +575,15 @@ class MiniCart extends AbstractBlock {
 			);
 
 			wp_interactivity_config(
+				'woocommerce',
+				array(
+					'messages' => array(
+						'addedToCartText' => __( 'Added to cart', 'woocommerce' ),
+					),
+				)
+			);
+
+			wp_interactivity_config(
 				$this->get_full_block_name(),
 				array(
 					'displayCartPriceIncludingTax' => $display_cart_price_including_tax,
@@ -605,7 +614,7 @@ class MiniCart extends AbstractBlock {
 				data-wp-on-document--wc-blocks_added_to_cart="woocommerce::actions.refreshCartItems"
 				data-wp-on-document--wc-blocks_removed_from_cart="woocommerce::actions.refreshCartItems"
 				<?php if ( 'open_drawer' === $attributes['addToCartBehaviour'] ) : ?>
-				data-wp-on-document--wc-blocks_added_to_cart---open-drawer="actions.openDrawer"
+				data-wp-on-document--wc-blocks_added_to_cart---open-drawer="actions.addedToCart"
 				<?php endif; ?>
 				data-wp-watch="callbacks.disableScrollingOnBody"
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #62228 (see discussion there for more context).

### How to test the changes in this Pull Request:

1. Go to **Appearance** > **Editor** > **Templates** > edit any template and select the Mini-Cart block.
2. Enable the **Behavior: Open drawer when adding** attribute.
3. On the frontend, go to the *Shop* page, add a product to the cart while using a screen reader.
4. Observe that the mini cart opens and immediately takes focus.
5. Verify it mentions _Added to cart_ (but after reading all the contents already in the cart :sweat_smile: ).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->