### PR TITLE
Products by Brand: journey starts with brand picker

### DIFF
--- a/plugins/woocommerce/changelog/add-58403-brands
+++ b/plugins/woocommerce/changelog/add-58403-brands
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Products by Brand: journey starts with choosing initial Brands

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -50,7 +50,8 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 
 	const isTaxonomyCollection =
 		attributes.collection === CoreCollectionNames.BY_CATEGORY ||
-		attributes.collection === CoreCollectionNames.BY_TAG;
+		attributes.collection === CoreCollectionNames.BY_TAG ||
+		attributes.collection === CoreCollectionNames.BY_BRAND;
 
 	const taxonomySlug = getTaxonomySlugForCollection( attributes.collection );
 	const hasSelectedTerms = taxonomySlug

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/taxonomy-picker.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/taxonomy-picker.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, category, tag } from '@wordpress/icons';
+import { Icon, category, tag, store } from '@wordpress/icons';
 import { Placeholder, Button } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
 import ProductTagControl from '@woocommerce/editor-components/product-tag-control';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
+import ProductBrandControl from '@woocommerce/editor-components/product-brand-control';
 
 /**
  * Internal dependencies
@@ -31,6 +32,8 @@ export const getTaxonomySlugForCollection = (
 			return 'product_cat';
 		case CoreCollectionNames.BY_TAG:
 			return 'product_tag';
+		case CoreCollectionNames.BY_BRAND:
+			return 'product_brand';
 		default:
 			return null;
 	}
@@ -53,6 +56,11 @@ const getDescriptionForCollection = (
 				'Display a grid of products from your selected tags.',
 				'woocommerce'
 			);
+		case CoreCollectionNames.BY_BRAND:
+			return __(
+				'Display a grid of products from your selected brands.',
+				'woocommerce'
+			);
 		default:
 			return __(
 				'Select taxonomy terms to display products from.',
@@ -70,8 +78,9 @@ const getIconForCollection = ( collection: string | undefined ) => {
 			return category;
 		case CoreCollectionNames.BY_TAG:
 			return tag;
+		case CoreCollectionNames.BY_BRAND:
+			return store;
 		default:
-			// For brands and others, use category icon as fallback
 			return category;
 	}
 };
@@ -125,6 +134,18 @@ const TaxonomyPicker = ( props: TaxonomyPickerProps ) => {
 							const ids = value.map(
 								( { id }: { id: number | string } ) =>
 									Number( id )
+							);
+							handleTermChange( ids );
+						} }
+					/>
+				);
+			case CoreCollectionNames.BY_BRAND:
+				return (
+					<ProductBrandControl
+						selected={ selectedTermIds }
+						onChange={ ( value = [] ) => {
+							const ids = value.map(
+								( { id }: { id: number } ) => id
 							);
 							handleTermChange( ids );
 						} }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -285,18 +285,29 @@ export const useProductCollectionUIState = ( {
 		}
 
 		/**
-		 * Case 4: Taxonomy picker for BY_CATEGORY, BY_TAG collections
+		 * Case 4: Taxonomy picker for BY_CATEGORY, BY_TAG, BY_BRAND collections
 		 * Show the picker when no taxonomy terms are selected.
 		 */
 		const isTaxonomyCollection =
 			attributes.collection === CoreCollectionNames.BY_CATEGORY ||
-			attributes.collection === CoreCollectionNames.BY_TAG;
+			attributes.collection === CoreCollectionNames.BY_TAG ||
+			attributes.collection === CoreCollectionNames.BY_BRAND;
 
 		if ( isCollectionSelected && isTaxonomyCollection ) {
-			const taxonomySlug =
-				attributes.collection === CoreCollectionNames.BY_CATEGORY
-					? 'product_cat'
-					: 'product_tag';
+			let taxonomySlug: string;
+			switch ( attributes.collection ) {
+				case CoreCollectionNames.BY_CATEGORY:
+					taxonomySlug = 'product_cat';
+					break;
+				case CoreCollectionNames.BY_TAG:
+					taxonomySlug = 'product_tag';
+					break;
+				case CoreCollectionNames.BY_BRAND:
+					taxonomySlug = 'product_brand';
+					break;
+				default:
+					taxonomySlug = '';
+			}
 
 			const selectedTermIds =
 				attributes.query?.taxQuery?.[ taxonomySlug ] || [];

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/index.tsx
@@ -1,0 +1,217 @@
+/**
+ * External dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	SearchListControl,
+	SearchListItem,
+} from '@woocommerce/editor-components/search-list-control';
+import { SelectControl } from '@wordpress/components';
+import { withSearchedBrands } from '@woocommerce/block-hocs';
+import ErrorMessage from '@woocommerce/editor-components/error-placeholder/error-message';
+import clsx from 'clsx';
+import type { RenderItemArgs } from '@woocommerce/editor-components/search-list-control/types';
+import type {
+	ProductBrandResponseItem,
+	WithInjectedSearchedBrands,
+} from '@woocommerce/types';
+import { convertProductBrandResponseItemToSearchItem } from '@woocommerce/utils';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+interface ProductBrandControlProps {
+	/**
+	 * Callback to update the selected product brands.
+	 */
+	onChange: () => void;
+	/**
+	 * Whether or not the search control should be displayed in a compact way, so it occupies less space.
+	 */
+	isCompact?: boolean;
+	/**
+	 * Allow only a single selection. Defaults to false.
+	 */
+	isSingle?: boolean;
+	/**
+	 * Callback to update the brand operator. If not passed in, setting is not used.
+	 */
+	onOperatorChange?: () => void;
+	/**
+	 * Setting for whether products should match all or any selected brands.
+	 */
+	operator?: 'all' | 'any';
+	/**
+	 * Whether or not to display the number of reviews for a brand in the list.
+	 */
+	showReviewCount?: boolean;
+}
+
+const ProductBrandControl = ( {
+	brands = [],
+	error = null,
+	isLoading = false,
+	onChange,
+	onOperatorChange,
+	operator = 'any',
+	selected,
+	isCompact = false,
+	isSingle = false,
+	showReviewCount,
+}: ProductBrandControlProps & WithInjectedSearchedBrands ) => {
+	const renderItem = ( args: RenderItemArgs< ProductBrandResponseItem > ) => {
+		const { item, search, depth = 0 } = args;
+
+		const accessibleName = ! item.breadcrumbs.length
+			? item.name
+			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
+
+		const listItemAriaLabel = showReviewCount
+			? sprintf(
+					/* translators: %1$s is the item name, %2$d is the count of reviews for the item. */
+					_n(
+						'%1$s, has %2$d review',
+						'%1$s, has %2$d reviews',
+						item.details?.review_count || 0,
+						'woocommerce'
+					),
+					accessibleName,
+					item.details?.review_count || 0
+			  )
+			: sprintf(
+					/* translators: %1$s is the item name, %2$d is the count of products for the item. */
+					_n(
+						'%1$s, has %2$d product',
+						'%1$s, has %2$d products',
+						item.details?.count || 0,
+						'woocommerce'
+					),
+					accessibleName,
+					item.details?.count || 0
+			  );
+
+		const listItemCountLabel = showReviewCount
+			? sprintf(
+					/* translators: %d is the count of reviews. */
+					_n(
+						'%d review',
+						'%d reviews',
+						item.details?.review_count || 0,
+						'woocommerce'
+					),
+					item.details?.review_count || 0
+			  )
+			: sprintf(
+					/* translators: %d is the count of products. */
+					_n(
+						'%d product',
+						'%d products',
+						item.details?.count || 0,
+						'woocommerce'
+					),
+					item.details?.count || 0
+			  );
+
+		return (
+			<SearchListItem
+				className={ clsx(
+					'woocommerce-product-brands__item',
+					'has-count',
+					{
+						'is-searching': search.length > 0,
+						'is-skip-level': depth === 0 && item.parent !== 0,
+					}
+				) }
+				{ ...args }
+				countLabel={ listItemCountLabel }
+				aria-label={ listItemAriaLabel }
+			/>
+		);
+	};
+
+	const messages = {
+		clear: __( 'Clear all product brands', 'woocommerce' ),
+		list: __( 'Product Brands', 'woocommerce' ),
+		noItems: __(
+			"Your store doesn't have any product brands.",
+			'woocommerce'
+		),
+		search: __( 'Search for product brands', 'woocommerce' ),
+		selected: ( n: number ) =>
+			sprintf(
+				/* translators: %d is the count of selected brands. */
+				_n(
+					'%d brand selected',
+					'%d brands selected',
+					n,
+					'woocommerce'
+				),
+				n
+			),
+		updated: __( 'Brand search results updated.', 'woocommerce' ),
+	};
+
+	if ( error ) {
+		return <ErrorMessage error={ error } />;
+	}
+
+	const currentList = brands.map(
+		convertProductBrandResponseItemToSearchItem
+	);
+
+	return (
+		<>
+			<SearchListControl
+				className="woocommerce-product-brands"
+				list={ currentList }
+				isLoading={ isLoading }
+				selected={ currentList.filter( ( { id } ) =>
+					selected.includes( Number( id ) )
+				) }
+				onChange={ onChange }
+				renderItem={ renderItem }
+				messages={ messages }
+				isCompact={ isCompact }
+				isHierarchical
+				isSingle={ isSingle }
+			/>
+			{ !! onOperatorChange && (
+				<div hidden={ selected.length < 2 }>
+					<SelectControl
+						className="woocommerce-product-brands__operator"
+						label={ __(
+							'Display products matching',
+							'woocommerce'
+						) }
+						help={ __(
+							'Pick at least two brands to use this setting.',
+							'woocommerce'
+						) }
+						value={ operator }
+						onChange={ onOperatorChange }
+						options={ [
+							{
+								label: __(
+									'Any selected brands',
+									'woocommerce'
+								),
+								value: 'any',
+							},
+							{
+								label: __(
+									'All selected brands',
+									'woocommerce'
+								),
+								value: 'all',
+							},
+						] }
+					/>
+				</div>
+			) }
+		</>
+	);
+};
+
+export default withSearchedBrands( ProductBrandControl );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/index.tsx
@@ -21,12 +21,13 @@ import { convertProductBrandResponseItemToSearchItem } from '@woocommerce/utils'
  * Internal dependencies
  */
 import './style.scss';
+import type { SearchListItem as SearchListItemProps } from '../search-list-control/types';
 
 interface ProductBrandControlProps {
 	/**
 	 * Callback to update the selected product brands.
 	 */
-	onChange: () => void;
+	onChange: ( selected: SearchListItemProps[] ) => void;
 	/**
 	 * Whether or not the search control should be displayed in a compact way, so it occupies less space.
 	 */
@@ -38,7 +39,7 @@ interface ProductBrandControlProps {
 	/**
 	 * Callback to update the brand operator. If not passed in, setting is not used.
 	 */
-	onOperatorChange?: () => void;
+	onOperatorChange?: ( operator: string ) => void;
 	/**
 	 * Setting for whether products should match all or any selected brands.
 	 */
@@ -56,7 +57,7 @@ const ProductBrandControl = ( {
 	onChange,
 	onOperatorChange,
 	operator = 'any',
-	selected,
+	selected = [],
 	isCompact = false,
 	isSingle = false,
 	showReviewCount,

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-brand-control/style.scss
@@ -1,0 +1,10 @@
+.woocommerce-product-brands__operator {
+	.components-base-control__help {
+		@include visually-hidden;
+	}
+
+	.components-base-control__label {
+		margin-bottom: 0;
+		margin-right: 0.5em;
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/utils/index.js
@@ -192,6 +192,31 @@ export const getCategory = ( categoryId ) => {
 };
 
 /**
+ * Get a promise that resolves to a list of brand objects from the Store API.
+ *
+ * @param {Object} queryArgs Query args to pass in.
+ */
+export const getBrands = ( queryArgs ) => {
+	return apiFetch( {
+		path: addQueryArgs( `wc/store/v1/products/brands`, {
+			per_page: 0,
+			...queryArgs,
+		} ),
+	} );
+};
+
+/**
+ * Get a promise that resolves to a brand object from the API.
+ *
+ * @param {number} brandId Id of the brand to retrieve.
+ */
+export const getBrand = ( brandId ) => {
+	return apiFetch( {
+		path: `wc/store/v1/products/brands/${ brandId }`,
+	} );
+};
+
+/**
  * Get a promise that resolves to a list of variation objects from the Store API
  * and the total number of variations.
  *

--- a/plugins/woocommerce/client/blocks/assets/js/hocs/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/hocs/index.js
@@ -1,5 +1,6 @@
 export { default as withAttributes } from './with-attributes';
 export { default as withSearchedCategories } from './with-searched-categories';
+export { default as withSearchedBrands } from './with-searched-brands';
 export { default as withCategory } from './with-category';
 export { default as withProduct } from './with-product';
 export { default as withProductVariations } from './with-product-variations';

--- a/plugins/woocommerce/client/blocks/assets/js/hocs/with-searched-brands.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/hocs/with-searched-brands.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { getBrands } from '@woocommerce/editor-components/utils';
 import type {
 	ProductBrandResponseItem,
@@ -47,16 +47,14 @@ const withSearchedBrands = <
 			setIsLoading( false );
 		};
 
-		const selectedRef = useRef( selected );
-
 		useEffect( () => {
-			getBrands( { selected: selectedRef.current } )
+			getBrands( {} )
 				.then( ( results ) => {
 					setBrandsList( results as ProductBrandResponseItem[] );
 					setIsLoading( false );
 				} )
 				.catch( setErrorState );
-		}, [ selectedRef ] );
+		}, [] );
 
 		return (
 			<OriginalComponent

--- a/plugins/woocommerce/client/blocks/assets/js/hocs/with-searched-brands.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/hocs/with-searched-brands.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState, useRef } from '@wordpress/element';
+import { getBrands } from '@woocommerce/editor-components/utils';
+import type {
+	ProductBrandResponseItem,
+	WithInjectedSearchedBrands,
+} from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { formatError } from '../base/utils/errors';
+
+export interface WithSearchedBrandsProps {
+	selected: number[];
+}
+
+/**
+ * A higher order component that enhances the provided component with brands from a search query.
+ */
+const withSearchedBrands = <
+	T extends Record< string, unknown > & WithSearchedBrandsProps
+>(
+	OriginalComponent: React.ComponentType< T & WithInjectedSearchedBrands >
+) => {
+	return ( { selected, ...props }: T ): JSX.Element => {
+		const [ isLoading, setIsLoading ] = useState( true );
+		const [ error, setError ] = useState< {
+			message: string;
+			type: string;
+		} | null >( null );
+		const [ brandsList, setBrandsList ] = useState<
+			ProductBrandResponseItem[]
+		>( [] );
+
+		const setErrorState = async ( e: {
+			message: string;
+			type: string;
+		} ) => {
+			const formattedError = ( await formatError( e ) ) as {
+				message: string;
+				type: string;
+			};
+			setError( formattedError );
+			setIsLoading( false );
+		};
+
+		const selectedRef = useRef( selected );
+
+		useEffect( () => {
+			getBrands( { selected: selectedRef.current } )
+				.then( ( results ) => {
+					setBrandsList( results as ProductBrandResponseItem[] );
+					setIsLoading( false );
+				} )
+				.catch( setErrorState );
+		}, [ selectedRef ] );
+
+		return (
+			<OriginalComponent
+				{ ...( props as T ) }
+				selected={ selected }
+				error={ error }
+				brands={ brandsList }
+				isLoading={ isLoading }
+			/>
+		);
+	};
+};
+
+export default withSearchedBrands;

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/hocs.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/hocs.ts
@@ -5,6 +5,7 @@ import { ErrorObject } from '@woocommerce/editor-components/error-placeholder';
 import type {
 	ProductResponseItem,
 	ProductCategoryResponseItem,
+	ProductBrandResponseItem,
 } from '@woocommerce/types';
 
 export interface WithInjectedProductVariations {
@@ -31,6 +32,13 @@ export interface WithInjectedSearchedCategories {
 	error: ErrorObject | null;
 	isLoading: boolean;
 	categories: ProductCategoryResponseItem[];
+	selected: number[];
+}
+
+export interface WithInjectedSearchedBrands {
+	error: ErrorObject | null;
+	isLoading: boolean;
+	brands: ProductBrandResponseItem[];
 	selected: number[];
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-category-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-category-response.ts
@@ -19,3 +19,25 @@ export interface ProductCategoryResponseItem {
 	review_count: number;
 	permalink: string;
 }
+
+export interface ProductBrandResponseImageItem {
+	id: number;
+	src: string;
+	thumbnail: string;
+	srcset: string;
+	sizes: string;
+	name: string;
+	alt: string;
+}
+
+export interface ProductBrandResponseItem {
+	id: number;
+	name: string;
+	slug: string;
+	description: string;
+	parent: number;
+	count: number;
+	image: ProductBrandResponseImageItem | null;
+	review_count: number;
+	permalink: string;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-category-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-category-response.ts
@@ -1,4 +1,8 @@
-export interface ProductCategoryResponseImageItem {
+/**
+ * Generic taxonomy term image response from the Store API.
+ * Used for categories, brands, and other hierarchical taxonomies.
+ */
+export interface TaxonomyResponseImageItem {
 	id: number;
 	src: string;
 	thumbnail: string;
@@ -8,36 +12,24 @@ export interface ProductCategoryResponseImageItem {
 	alt: string;
 }
 
-export interface ProductCategoryResponseItem {
+/**
+ * Generic taxonomy term response from the Store API.
+ * Used for categories, brands, and other hierarchical taxonomies.
+ */
+export interface TaxonomyResponseItem {
 	id: number;
 	name: string;
 	slug: string;
 	description: string;
 	parent: number;
 	count: number;
-	image: ProductCategoryResponseImageItem | null;
+	image: TaxonomyResponseImageItem | null;
 	review_count: number;
 	permalink: string;
 }
 
-export interface ProductBrandResponseImageItem {
-	id: number;
-	src: string;
-	thumbnail: string;
-	srcset: string;
-	sizes: string;
-	name: string;
-	alt: string;
-}
-
-export interface ProductBrandResponseItem {
-	id: number;
-	name: string;
-	slug: string;
-	description: string;
-	parent: number;
-	count: number;
-	image: ProductBrandResponseImageItem | null;
-	review_count: number;
-	permalink: string;
-}
+// Aliases for backward compatibility and semantic clarity
+export type ProductCategoryResponseImageItem = TaxonomyResponseImageItem;
+export type ProductCategoryResponseItem = TaxonomyResponseItem;
+export type ProductBrandResponseImageItem = TaxonomyResponseImageItem;
+export type ProductBrandResponseItem = TaxonomyResponseItem;

--- a/plugins/woocommerce/client/blocks/assets/js/utils/products.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/products.ts
@@ -5,6 +5,7 @@ import type { SearchListItem } from '@woocommerce/editor-components/search-list-
 import type {
 	ProductResponseItem,
 	ProductCategoryResponseItem,
+	ProductBrandResponseItem,
 } from '@woocommerce/types';
 
 /**
@@ -43,6 +44,26 @@ export const convertProductCategoryResponseItemToSearchItem = (
 		children: [],
 		details: category,
 		value: category.slug,
+	};
+};
+
+/**
+ * Converts a Product Brand object into a shape compatible with the `SearchListControl`
+ */
+export const convertProductBrandResponseItemToSearchItem = (
+	brand: ProductBrandResponseItem
+): SearchListItem< ProductBrandResponseItem > => {
+	const { id, name, parent, count } = brand;
+
+	return {
+		id,
+		name,
+		parent,
+		count,
+		breadcrumbs: [],
+		children: [],
+		details: brand,
+		value: brand.slug,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
@@ -27,6 +27,13 @@ tag_id=$(wp wc product_tag create --name="Recommended" --slug="recommended" --de
 wp wc product update $hoodie_product_id --tags="[ { \"id\": $tag_id } ]" --user=1
 wp wc product update $beanie_product_id --tags="[ { \"id\": $tag_id } ]" --user=1
 
+# Create a brand, so we can add tests for brand-related blocks and templates.
+album_product_id=$(wp post list --post_type=product --field=ID --name="Album" --format=ids)
+brand_id=$(wp term create product_brand "WooCommerce" --slug="woocommerce" --description="Official WooCommerce products" --porcelain)
+wp post term set $hoodie_product_id product_brand $brand_id --by=id
+wp post term set $beanie_product_id product_brand $brand_id --by=id
+wp post term set $album_product_id product_brand $brand_id --by=id
+
 # This is a non-hacky work around to set up the cross sells product.
 cap_product_id=$(wp post list --post_type=product --field=ID --name="Cap" --format=ids)
 wp post meta update $beanie_product_id _crosssell_ids "$cap_product_id"

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collection-pickers.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collection-pickers.block_theme.spec.ts
@@ -46,6 +46,13 @@ const taxonomyCollections: {
 		termLabel: 'Recommended',
 		expectedProductCount: 2,
 	},
+	{
+		slug: 'productsByBrand',
+		name: 'Products by Brand',
+		termName: 'brands',
+		termLabel: 'WooCommerce',
+		expectedProductCount: 3,
+	},
 ];
 
 test.describe( 'Product Collection: Collection Pickers', () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -77,6 +77,7 @@ export type Collections =
 	| 'handPicked'
 	| 'productsByCategory'
 	| 'productsByTag'
+	| 'productsByBrand'
 	| 'productCatalog'
 	| 'myCustomCollection'
 	| 'myCustomCollectionWithPreview'
@@ -99,6 +100,7 @@ const collectionToButtonNameMap = {
 	handPicked: 'Hand-Picked Products',
 	productsByCategory: 'Products by Category',
 	productsByTag: 'Products by Tag',
+	productsByBrand: 'Products by Brand',
 	productCatalog: 'create your own',
 	myCustomCollection: 'My Custom Collection',
 	myCustomCollectionWithPreview: 'My Custom Collection with Preview',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR completes the improved Product Collection block experience by adding "Products by Brand" support with an immediate brand picker upon block insertion.

Unlike "Products by Category" and "Products by Tag" which already had existing editor components (`ProductCategoryControl` and `ProductTagControl`), there was no `ProductBrandControl` component available. This PR adds the missing infrastructure:
- New `ProductBrandControl` editor component - A hierarchical brand selector similar to `ProductCategoryControl`, using `SearchListControl `with multi-select and operator toggle (any/all)
- New `withSearchedBrands` HOC - For fetching and searching product brands from the Store API
API utilities and types - `getBrands()` and `getBrand()` functions, TypeScript interfaces for brand response items
- Brand picker integration - Updated `taxonomy-picker.tsx `and UI state logic to support `BY_BRAND` collection
- E2E tests - Added brand fixture data and corresponding E2E tests

Closes #58403. Continues work from #62989 and #62993.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   https://github.com/user-attachments/assets/8978d7d3-b3df-4f68-a2e2-3b27ad2c1308     |   https://github.com/user-attachments/assets/e72794f9-7346-4e3c-8d86-f498f918c151    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new post or page in the editor.
2. Add a Product Collection block.
3. Select "Products by Brand" from the collection chooser.
4. **Expected:** A brand picker should appear immediately (not "No products to display").
5. Search for brands and select multiple brands by clicking checkboxes.
6. **Expected:** Brands remain selected as you add more (multi-select works).
7. Click the "Done" button.
8. **Expected:** The block now shows a preview of products from the selected brands.
9. Check the inspector panel on the right.
10. **Expected:** A brand control appears at the top allowing you to edit the brand selection.
11. Save the post, refresh the page.
12. **Expected:** The block shows the products preview (not the picker).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
