### PR TITLE
Add woocommerce_store_api_product_query_args filter. Closes #63029

### DIFF
--- a/plugins/woocommerce/changelog/issues-63029-filter-product-query-args
+++ b/plugins/woocommerce/changelog/issues-63029-filter-product-query-args
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add woocommerce_store_api_product_query_args filter

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -251,7 +251,13 @@ class ProductQuery implements QueryClausesGenerator {
 			$args['meta_key'] = $ordering_args['meta_key']; // phpcs:ignore
 		}
 
-		return $args;
+		/**
+		 * Filters query args from Store API before passing to WP_Query.
+		 *
+		 * @param \WP_REST_Request $request Request data.
+		 * @return array
+		 */
+		return (array) apply_filters( 'woocommerce_store_api_product_query_args', $args, $request );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add `woocommerce_store_api_product_query_args` filter to modify the store api query args
Closes #63029.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a snippet such as the following:
```
add_filter( 'woocommerce_store_api_product_query_args', function( $args, $request ) {
	if ( boolval( $request['nyp'] ??  false ) ) {
		if ( ! isset( $args['meta_query'] ) ) {
			$args['meta_query'] = array();
		}
		$args['meta_query']['relation'] = 'OR';
		$args['meta_query'][] = array(
			'key' => '_nyp',
			'value' => 'yes',
		);
		$args['meta_query'][] = array(
			'key' => '_has_nyp',
			'value' => 'yes',
		);
	}
	return $args;
}, 10, 2 );
```

2. Hit store api endpoint `wp-json/wc/store/v1/products/?nyp=true`
3. See a list of Name Your Price enabled products

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
