### PR TITLE
Refactor `getQuantityConstraints` and `normalizeProductFromStore` in iAPI cart store

### DIFF
--- a/plugins/woocommerce/changelog/63033-wooplug-6209-refactor-getquantityconstraints-and
+++ b/plugins/woocommerce/changelog/63033-wooplug-6209-refactor-getquantityconstraints-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Refactor `getQuantityConstraints` and `normalizeProductFromStore` in iAPI cart store

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
@@ -9,8 +9,14 @@ import type { ProductsStoreState } from '@woocommerce/stores/woocommerce/product
 import type { NormalizedProductData } from '../types';
 
 let mockProductsState: {
-	products: Record< number, Partial< ProductsStoreState[ 'products' ][ number ] > >;
-	productVariations: Record< number, Partial< ProductsStoreState[ 'productVariations' ][ number ] > >;
+	products: Record<
+		number,
+		Partial< ProductsStoreState[ 'products' ][ number ] >
+	>;
+	productVariations: Record<
+		number,
+		Partial< ProductsStoreState[ 'productVariations' ][ number ] >
+	>;
 };
 
 jest.mock(
@@ -48,6 +54,7 @@ describe( 'getProductData', () => {
 		};
 
 		jest.isolateModules( () => {
+			//eslint-disable-next-line @typescript-eslint/no-var-requires
 			const frontend = require( '../frontend' );
 			getProductData = frontend.getProductData;
 		} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
@@ -1,0 +1,269 @@
+/**
+ * External dependencies
+ */
+import type { ProductsStoreState } from '@woocommerce/stores/woocommerce/products';
+
+/**
+ * Internal dependencies
+ */
+import type { NormalizedProductData } from '../types';
+
+let mockProductsState: {
+	products: Record< number, Partial< ProductsStoreState[ 'products' ][ number ] > >;
+	productVariations: Record< number, Partial< ProductsStoreState[ 'productVariations' ][ number ] > >;
+};
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: jest.fn( ( name ) => {
+			if ( name === 'woocommerce/products' ) {
+				return { state: mockProductsState };
+			}
+			return { state: {} };
+		} ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@woocommerce/stores/woocommerce/product-data', () => ( {} ), {
+	virtual: true,
+} );
+
+jest.mock( '@woocommerce/stores/woocommerce/products', () => ( {} ), {
+	virtual: true,
+} );
+
+describe( 'getProductData', () => {
+	let getProductData: (
+		id: number,
+		selectedAttributes: Array< { attribute: string; value: string } >
+	) => NormalizedProductData | null;
+
+	beforeEach( () => {
+		jest.resetModules();
+		mockProductsState = {
+			products: {},
+			productVariations: {},
+		};
+
+		jest.isolateModules( () => {
+			const frontend = require( '../frontend' );
+			getProductData = frontend.getProductData;
+		} );
+	} );
+
+	it( 'returns null when product is not in store', () => {
+		mockProductsState.products = {};
+
+		const result = getProductData( 999, [] );
+		expect( result ).toBeNull();
+	} );
+
+	it( 'returns product data with default quantity constraints', () => {
+		mockProductsState.products = {
+			1: {
+				id: 1,
+				type: 'simple',
+				is_purchasable: true,
+				is_in_stock: true,
+				sold_individually: false,
+			},
+		};
+
+		const result = getProductData( 1, [] );
+
+		expect( result ).toEqual( {
+			id: 1,
+			type: 'simple',
+			is_in_stock: true,
+			sold_individually: false,
+			min: 1,
+			max: Number.MAX_SAFE_INTEGER,
+			step: 1,
+		} );
+	} );
+
+	it( 'returns product data with custom quantity constraints', () => {
+		mockProductsState.products = {
+			1: {
+				id: 1,
+				type: 'simple',
+				is_purchasable: true,
+				is_in_stock: true,
+				sold_individually: false,
+				add_to_cart: {
+					text: 'Add to cart',
+					description: 'Add to cart',
+					url: '',
+					minimum: 2,
+					maximum: 10,
+					multiple_of: 2,
+					single_text: 'Add to cart',
+				},
+			},
+		};
+
+		const result = getProductData( 1, [] );
+
+		expect( result ).toEqual( {
+			id: 1,
+			type: 'simple',
+			is_in_stock: true,
+			sold_individually: false,
+			min: 2,
+			max: 10,
+			step: 2,
+		} );
+	} );
+
+	it( 'returns max as MAX_SAFE_INTEGER when maximum is 0', () => {
+		mockProductsState.products = {
+			1: {
+				id: 1,
+				type: 'simple',
+				is_purchasable: true,
+				is_in_stock: true,
+				sold_individually: false,
+				add_to_cart: {
+					text: 'Add to cart',
+					description: 'Add to cart',
+					url: '',
+					minimum: 1,
+					maximum: 0,
+					multiple_of: 1,
+					single_text: 'Add to cart',
+				},
+			},
+		};
+
+		const result = getProductData( 1, [] );
+
+		expect( result?.max ).toBe( Number.MAX_SAFE_INTEGER );
+	} );
+
+	describe( 'variable products', () => {
+		it( 'returns variation data when attributes match a variation', () => {
+			mockProductsState.products = {
+				1: {
+					id: 1,
+					type: 'variable',
+					is_purchasable: true,
+					is_in_stock: true,
+					sold_individually: false,
+					add_to_cart: {
+						text: 'Add to cart',
+						description: 'Add to cart',
+						url: '',
+						minimum: 1,
+						maximum: 100,
+						multiple_of: 1,
+						single_text: 'Add to cart',
+					},
+					variations: [
+						{
+							id: 10,
+							attributes: [ { name: 'Color', value: 'red' } ],
+						},
+					],
+				},
+			};
+			mockProductsState.productVariations = {
+				10: {
+					id: 10,
+					type: 'variation',
+					is_purchasable: true,
+					is_in_stock: true,
+					sold_individually: false,
+					add_to_cart: {
+						text: 'Add to cart',
+						description: 'Add to cart',
+						url: '',
+						minimum: 5,
+						maximum: 50,
+						multiple_of: 5,
+						single_text: 'Add to cart',
+					},
+				},
+			};
+
+			const result = getProductData( 1, [
+				{ attribute: 'Color', value: 'red' },
+			] );
+
+			expect( result ).toEqual( {
+				id: 10,
+				type: 'variation',
+				is_in_stock: true,
+				sold_individually: false,
+				min: 5,
+				max: 50,
+				step: 5,
+			} );
+		} );
+
+		it( 'returns null when variation is matched but not in store', () => {
+			mockProductsState.products = {
+				1: {
+					id: 1,
+					type: 'variable',
+					is_purchasable: true,
+					is_in_stock: true,
+					sold_individually: false,
+					variations: [
+						{
+							id: 10,
+							attributes: [ { name: 'Color', value: 'red' } ],
+						},
+					],
+				},
+			};
+			mockProductsState.productVariations = {};
+
+			const result = getProductData( 1, [
+				{ attribute: 'Color', value: 'red' },
+			] );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'returns parent product data when no attributes are selected', () => {
+			mockProductsState.products = {
+				1: {
+					id: 1,
+					type: 'variable',
+					is_purchasable: true,
+					is_in_stock: true,
+					sold_individually: false,
+					add_to_cart: {
+						text: 'Add to cart',
+						description: 'Add to cart',
+						url: '',
+						minimum: 1,
+						maximum: 100,
+						multiple_of: 1,
+						single_text: 'Add to cart',
+					},
+					variations: [
+						{
+							id: 10,
+							attributes: [ { name: 'Color', value: 'red' } ],
+						},
+					],
+				},
+			};
+
+			const result = getProductData( 1, [] );
+
+			expect( result ).toEqual( {
+				id: 1,
+				type: 'variable',
+				is_in_stock: true,
+				sold_individually: false,
+				min: 1,
+				max: 100,
+				step: 1,
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -85,6 +85,9 @@ export const getProductData = (
 		return null;
 	}
 
+	// Determine which product to use for the response.
+	let product = productFromStore;
+
 	// For variable products with selected attributes, find the matching variation.
 	if (
 		productFromStore.type === 'variable' &&
@@ -98,39 +101,30 @@ export const getProductData = (
 		if ( matchedVariation ) {
 			const variation =
 				productsState.productVariations[ matchedVariation.id ];
-			if ( variation ) {
-				const variationAddToCart = variation.add_to_cart;
-				const variationMaximum = variationAddToCart?.maximum ?? 0;
-
-				return {
-					id: variation.id,
-					type: variation.type,
-					is_in_stock:
-						variation.is_purchasable && variation.is_in_stock,
-					sold_individually: variation.sold_individually,
-					min: variationAddToCart?.minimum ?? 1,
-					max:
-						variationMaximum > 0
-							? variationMaximum
-							: Number.MAX_SAFE_INTEGER,
-					step: variationAddToCart?.multiple_of ?? 1,
-				};
+			if ( ! variation ) {
+				// Variation was matched but its data isn't in the store.
+				// Return null to prevent using stale parent product data.
+				return null;
 			}
-			// Variation was matched but its data isn't in the store.
-			// Return null to prevent using stale parent product data.
-			return null;
+			product = variation;
 		}
 	}
 
-	const addToCart = productFromStore.add_to_cart;
+	const {
+		id: productId,
+		type,
+		is_purchasable: isPurchasable,
+		is_in_stock: isInStock,
+		sold_individually: soldIndividually,
+		add_to_cart: addToCart,
+	} = product;
 	const maximum = addToCart?.maximum ?? 0;
 
 	return {
-		id: productFromStore.id,
-		type: productFromStore.type,
-		is_in_stock:
-			productFromStore.is_purchasable && productFromStore.is_in_stock,
-		sold_individually: productFromStore.sold_individually,
+		id: productId,
+		type,
+		is_in_stock: isPurchasable && isInStock,
+		sold_individually: soldIndividually,
 		min: addToCart?.minimum ?? 1,
 		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
 		step: addToCart?.multiple_of ?? 1,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -110,21 +110,14 @@ export const getProductData = (
 		}
 	}
 
-	const {
-		id: productId,
-		type,
-		is_purchasable: isPurchasable,
-		is_in_stock: isInStock,
-		sold_individually: soldIndividually,
-		add_to_cart: addToCart,
-	} = product;
+	const { add_to_cart: addToCart } = product;
 	const maximum = addToCart?.maximum ?? 0;
 
 	return {
-		id: productId,
-		type,
-		is_in_stock: isPurchasable && isInStock,
-		sold_individually: soldIndividually,
+		id: product.id,
+		type: product.type,
+		is_in_stock: product.is_purchasable && product.is_in_stock,
+		sold_individually: product.sold_individually,
 		min: addToCart?.minimum ?? 1,
 		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
 		step: addToCart?.multiple_of ?? 1,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -11,7 +11,6 @@ import '@woocommerce/stores/woocommerce/products';
 import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
 import type { ProductsStore } from '@woocommerce/stores/woocommerce/products';
-import type { ProductResponseItem } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -76,29 +75,6 @@ const { state: productsState } = store< ProductsStore >(
 	{ lock: universalLock }
 );
 
-/**
- * Normalize a Store API product into the format expected by consumers.
- *
- * @param product The product in Store API format.
- * @return Normalized product data.
- */
-const normalizeProductFromStore = (
-	product: ProductResponseItem
-): NormalizedProductData | NormalizedVariationData => {
-	const addToCart = product.add_to_cart;
-	const maximum = addToCart?.maximum ?? 0;
-
-	return {
-		id: product.id,
-		type: product.type,
-		is_in_stock: product.is_purchasable && product.is_in_stock,
-		sold_individually: product.sold_individually,
-		min: addToCart?.minimum ?? 1,
-		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
-		step: addToCart?.multiple_of ?? 1,
-	};
-};
-
 export const getProductData = (
 	id: number,
 	selectedAttributes: SelectedAttributes[]
@@ -123,7 +99,22 @@ export const getProductData = (
 			const variation =
 				productsState.productVariations[ matchedVariation.id ];
 			if ( variation ) {
-				return normalizeProductFromStore( variation );
+				const variationAddToCart = variation.add_to_cart;
+				const variationMaximum = variationAddToCart?.maximum ?? 0;
+
+				return {
+					id: variation.id,
+					type: variation.type,
+					is_in_stock:
+						variation.is_purchasable && variation.is_in_stock,
+					sold_individually: variation.sold_individually,
+					min: variationAddToCart?.minimum ?? 1,
+					max:
+						variationMaximum > 0
+							? variationMaximum
+							: Number.MAX_SAFE_INTEGER,
+					step: variationAddToCart?.multiple_of ?? 1,
+				};
 			}
 			// Variation was matched but its data isn't in the store.
 			// Return null to prevent using stale parent product data.
@@ -131,7 +122,19 @@ export const getProductData = (
 		}
 	}
 
-	return normalizeProductFromStore( productFromStore );
+	const addToCart = productFromStore.add_to_cart;
+	const maximum = addToCart?.maximum ?? 0;
+
+	return {
+		id: productFromStore.id,
+		type: productFromStore.type,
+		is_in_stock:
+			productFromStore.is_purchasable && productFromStore.is_in_stock,
+		sold_individually: productFromStore.sold_individually,
+		min: addToCart?.minimum ?? 1,
+		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
+		step: addToCart?.multiple_of ?? 1,
+	};
 };
 
 export const getNewQuantity = (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -38,38 +38,6 @@ export type AddToCartError = {
 };
 
 /**
- * Quantity constraints normalized from the Store API format.
- */
-type QuantityConstraints = {
-	min: number;
-	max: number;
-	step: number;
-};
-
-/**
- * Extract quantity constraints from a product in Store API format.
- *
- * @param product The product in Store API format.
- * @return Normalized quantity constraints.
- */
-const getQuantityConstraints = (
-	product: ProductResponseItem | null
-): QuantityConstraints => {
-	if ( ! product ) {
-		return { min: 1, max: Number.MAX_SAFE_INTEGER, step: 1 };
-	}
-
-	const addToCart = product.add_to_cart;
-	const maximum = addToCart?.maximum ?? 0;
-
-	return {
-		min: addToCart?.minimum ?? 1,
-		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
-		step: addToCart?.multiple_of ?? 1,
-	};
-};
-
-/**
  * Manually dispatches a 'change' event on the quantity input element.
  *
  * When users click the plus/minus stepper buttons, no 'change' event is fired
@@ -117,14 +85,17 @@ const { state: productsState } = store< ProductsStore >(
 const normalizeProductFromStore = (
 	product: ProductResponseItem
 ): NormalizedProductData | NormalizedVariationData => {
-	const constraints = getQuantityConstraints( product );
+	const addToCart = product.add_to_cart;
+	const maximum = addToCart?.maximum ?? 0;
 
 	return {
 		id: product.id,
 		type: product.type,
 		is_in_stock: product.is_purchasable && product.is_in_stock,
 		sold_individually: product.sold_individually,
-		...constraints,
+		min: addToCart?.minimum ?? 1,
+		max: maximum > 0 ? maximum : Number.MAX_SAFE_INTEGER,
+		step: addToCart?.multiple_of ?? 1,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -6,8 +6,6 @@ import {
 	VariationData,
 } from '@woocommerce/stores/woocommerce/cart';
 
-export type QuantitySelectorStyleProps = 'input' | 'stepper';
-
 export interface Attributes {
 	className?: string;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #63028  .

This PR inlines `getQuantityConstraints` and `normalizeProductFromStore` helper functions directly into `getProductData`, reducing indirection and improving readability.

The `getQuantityConstraints` and `normalizeProductFromStore` helper functions were only used in one place and added unnecessary abstraction layers. Inlining them into `getProductData` makes the code flow easier to follow without jumping between functions.

Additionally, it removes the unused `QuantitySelectorStyleProps` type and `ProductResponseItem` import.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It is only a refactor. E2e tests should cover it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Refactor `getQuantityConstraints` and `normalizeProductFromStore` in iAPI cart store

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
