### PR TITLE
Add copy shipping address action

### DIFF
--- a/plugins/woocommerce/changelog/add-copy-shipping-address
+++ b/plugins/woocommerce/changelog/add-copy-shipping-address
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a copy icon next to the shipping address on the order edit screen and order preview, allowing admins to quickly copy the full shipping address to the clipboard.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1959,6 +1959,37 @@ ul.wc_coupon_list_block {
 			display: block;
 		}
 
+		> h3 a.wc-copy-shipping-address {
+			width: 14px;
+			height: 0;
+			padding: 14px 0 0;
+			margin: 0 0 0 6px;
+			overflow: hidden;
+			position: relative;
+			color: #999;
+			border: 0;
+			float: right;
+
+			&:hover,
+			&:focus {
+				color: #000;
+			}
+
+			&::after {
+				font-family: "Dashicons";
+				content: "\f105";
+				position: absolute;
+				top: 0;
+				left: 0;
+				text-align: center;
+				vertical-align: top;
+				line-height: 14px;
+				font-size: 14px;
+				font-weight: 400;
+			}
+		}
+
+
 		&:last-child {
 			padding-right: 0;
 		}
@@ -3489,6 +3520,7 @@ body.woocommerce_page_wc-orders {
 				margin-top: 0;
 			}
 		}
+
 	}
 
 	footer {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1974,21 +1974,7 @@ ul.wc_coupon_list_block {
 			&:focus {
 				color: #000;
 			}
-
-			&::after {
-				font-family: "Dashicons";
-				content: "\f105";
-				position: absolute;
-				top: 0;
-				left: 0;
-				text-align: center;
-				vertical-align: top;
-				line-height: 14px;
-				font-size: 14px;
-				font-weight: 400;
-			}
 		}
-
 
 		&:last-child {
 			padding-right: 0;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -35,8 +35,8 @@ jQuery( function ( $ ) {
 			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );
 			$( document.body )
 				.on( 'click', '.wc-copy-shipping-address', this.copy_shipping_address )
-				.on( 'aftercopy', '.wc-copy-shipping-address', this.copy_shipping_success )
-				.on( 'aftercopyfailure', '.wc-copy-shipping-address', this.copy_shipping_failure );
+				.on( 'aftercopy', '.wc-copy-shipping-address', this.copy_success )
+				.on( 'aftercopyfailure', '.wc-copy-shipping-address', this.copy_fail );
 			$( '#customer_user' ).on( 'change', this.change_customer_user );
 		},
 
@@ -279,39 +279,34 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			$button.addClass( 'is-copying' );
 			wcClearClipboard();
 			wcSetClipboard( shippingAddress, $button );
 		},
 
 		/**
-		 * Display copied feedback.
+		 * Display a "Copied!" tip when success copying.
 		 */
-		copy_shipping_success: function() {
-			var $button = $( this ),
-				originalText = $button.data( 'copy-text' ) || '',
-				copiedText = $button.data( 'copied-text' ) || originalText;
-
-			$button.addClass( 'is-copied' );
-			if ( copiedText ) {
-				$button.attr( 'title', copiedText );
-			}
-
-			window.setTimeout( function() {
-				$button.removeClass( 'is-copied is-copying' );
-				if ( originalText ) {
-					$button.attr( 'title', originalText );
-				} else {
-					$button.removeAttr( 'title' );
-				}
-			}, 2000 );
+		copy_success: function() {
+			$( this ).tipTip( {
+				'attribute':  'data-tip',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			} ).trigger( 'focus' );
 		},
 
 		/**
-		 * Reset UI on copy failure.
+		 * Display a failure tip when copy fails.
 		 */
-		copy_shipping_failure: function() {
-			$( this ).removeClass( 'is-copying' );
+		copy_fail: function() {
+			$( this ).tipTip( {
+				'attribute':  'data-tip-failed',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			} ).trigger( 'focus' );
 		}
 	};
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -33,6 +33,10 @@ jQuery( function ( $ ) {
 			$( 'a.billing-same-as-shipping' ).on( 'click', this.copy_billing_to_shipping );
 			$( 'a.load_customer_billing' ).on( 'click', this.load_billing );
 			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );
+			$( document.body )
+				.on( 'click', '.wc-copy-shipping-address', this.copy_shipping_address )
+				.on( 'aftercopy', '.wc-copy-shipping-address', this.copy_shipping_success )
+				.on( 'aftercopyfailure', '.wc-copy-shipping-address', this.copy_shipping_failure );
 			$( '#customer_user' ).on( 'change', this.change_customer_user );
 		},
 
@@ -258,6 +262,56 @@ jQuery( function ( $ ) {
 				});
 			}
 			return false;
+		},
+
+		/**
+		 * Copy shipping address from order edit screen.
+		 *
+		 * @param {Object} event Copy event.
+		 */
+		copy_shipping_address: function( event ) {
+			event.preventDefault();
+
+			var $button = $( this ),
+				shippingAddress = $button.data( 'shipping-address' ) || '';
+
+			if ( ! shippingAddress ) {
+				return;
+			}
+
+			$button.addClass( 'is-copying' );
+			wcClearClipboard();
+			wcSetClipboard( shippingAddress, $button );
+		},
+
+		/**
+		 * Display copied feedback.
+		 */
+		copy_shipping_success: function() {
+			var $button = $( this ),
+				originalText = $button.data( 'copy-text' ) || '',
+				copiedText = $button.data( 'copied-text' ) || originalText;
+
+			$button.addClass( 'is-copied' );
+			if ( copiedText ) {
+				$button.attr( 'title', copiedText );
+			}
+
+			window.setTimeout( function() {
+				$button.removeClass( 'is-copied is-copying' );
+				if ( originalText ) {
+					$button.attr( 'title', originalText );
+				} else {
+					$button.removeAttr( 'title' );
+				}
+			}, 2000 );
+		},
+
+		/**
+		 * Reset UI on copy failure.
+		 */
+		copy_shipping_failure: function() {
+			$( this ).removeClass( 'is-copying' );
 		}
 	};
 

--- a/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
@@ -25,7 +25,9 @@ jQuery( function( $ ) {
 				this.onRowClick
 			)
 			.on( 'click', '.order-preview:not(.disabled)', this.onPreview )
-			.on( 'click', '.wc-copy-shipping-address', this.copyShippingAddress );
+			.on( 'click', '.wc-copy-shipping-address', this.copyShippingAddress )
+			.on( 'aftercopy', '.wc-copy-shipping-address', this.copySuccess )
+			.on( 'aftercopyfailure', '.wc-copy-shipping-address', this.copyFail );
 	};
 
 	/**
@@ -110,34 +112,35 @@ jQuery( function( $ ) {
 			return;
 		}
 
-		$button.addClass( 'is-copying' );
 		wcClearClipboard();
 		wcSetClipboard( shippingAddress, $button );
 	};
 
-	$( document.body )
-		.on( 'aftercopy', '.wc-copy-shipping-address', function() {
-			var $button = $( this ),
-				originalText = $button.data( 'copy-text' ) || '',
-				copiedText = $button.data( 'copied-text' ) || originalText;
+	/**
+	 * Display a "Copied!" tip when success copying.
+	 */
+	WCOrdersTable.copySuccess = function() {
+		$( this ).tipTip( {
+			'attribute':  'data-tip',
+			'activation': 'focus',
+			'fadeIn':     50,
+			'fadeOut':    50,
+			'delay':      0
+		} ).trigger( 'focus' );
+	};
 
-			$button.addClass( 'is-copied' );
-			if ( copiedText ) {
-				$button.attr( 'title', copiedText );
-			}
-
-			window.setTimeout( function() {
-				$button.removeClass( 'is-copied is-copying' );
-				if ( originalText ) {
-					$button.attr( 'title', originalText );
-				} else {
-					$button.removeAttr( 'title' );
-				}
-			}, 2000 );
-		} )
-		.on( 'aftercopyfailure', '.wc-copy-shipping-address', function() {
-			$( this ).removeClass( 'is-copying' );
-		} );
+	/**
+	 * Display a failure tip when copy fails.
+	 */
+	WCOrdersTable.copyFail = function() {
+		$( this ).tipTip( {
+			'attribute':  'data-tip-failed',
+			'activation': 'focus',
+			'fadeIn':     50,
+			'fadeOut':    50,
+			'delay':      0
+		} ).trigger( 'focus' );
+	};
 
 	/**
 	 * Init WCOrdersTable.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
@@ -24,7 +24,8 @@ jQuery( function( $ ) {
 				SELECTORS.join( ', ' ),
 				this.onRowClick
 			)
-			.on( 'click', '.order-preview:not(.disabled)', this.onPreview );
+			.on( 'click', '.order-preview:not(.disabled)', this.onPreview )
+			.on( 'click', '.wc-copy-shipping-address', this.copyShippingAddress );
 	};
 
 	/**
@@ -93,6 +94,50 @@ jQuery( function( $ ) {
 		return false;
 
 	};
+
+	/**
+	 * Copy shipping address from order preview modal.
+	 *
+	 * @param {Object} event Copy event.
+	 */
+	WCOrdersTable.prototype.copyShippingAddress = function( event ) {
+		event.preventDefault();
+
+		var $button = $( this ),
+			shippingAddress = $button.data( 'shipping-address' ) || '';
+
+		if ( ! shippingAddress ) {
+			return;
+		}
+
+		$button.addClass( 'is-copying' );
+		wcClearClipboard();
+		wcSetClipboard( shippingAddress, $button );
+	};
+
+	$( document.body )
+		.on( 'aftercopy', '.wc-copy-shipping-address', function() {
+			var $button = $( this ),
+				originalText = $button.data( 'copy-text' ) || '',
+				copiedText = $button.data( 'copied-text' ) || originalText;
+
+			$button.addClass( 'is-copied' );
+			if ( copiedText ) {
+				$button.attr( 'title', copiedText );
+			}
+
+			window.setTimeout( function() {
+				$button.removeClass( 'is-copied is-copying' );
+				if ( originalText ) {
+					$button.attr( 'title', originalText );
+				} else {
+					$button.removeAttr( 'title' );
+				}
+			}, 2000 );
+		} )
+		.on( 'aftercopyfailure', '.wc-copy-shipping-address', function() {
+			$( this ).removeClass( 'is-copying' );
+		} );
 
 	/**
 	 * Init WCOrdersTable.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -447,7 +447,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			$suffix       = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 			$version      = Constants::get_constant( 'WC_VERSION' );
 
-			wp_register_script( 'wc-orders', WC()->plugin_url() . '/assets/js/admin/wc-orders' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-jquery-blockui' ), $version, array( 'in_footer' => false ) );
+			wp_register_script( 'wc-orders', WC()->plugin_url() . '/assets/js/admin/wc-orders' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-jquery-blockui', 'wc-clipboard' ), $version, array( 'in_footer' => false ) );
 			wp_localize_script(
 				'wc-orders',
 				'wc_orders_params',

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -432,14 +432,9 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 		$billing_address         = $order->get_formatted_billing_address();
 		$shipping_address        = $order->get_formatted_shipping_address();
-		$shipping_address_plain  = $shipping_address
-			? wc_clean( wp_strip_all_tags( preg_replace( '/<br\s*\/?\s*>/i', "\n", $shipping_address ) ) )
+		$shipping_address_plain  = $order->has_shipping_address()
+			? \WC_Meta_Box_Order_Data::normalize_address_to_plain_text( $shipping_address )
 			: '';
-		$shipping_address_plain  = $shipping_address_plain && $shipping_address_plain !== 'N/A'
-			? $shipping_address_plain
-			: ( $billing_address
-				? wc_clean( wp_strip_all_tags( preg_replace( '/<br\s*\/?\s*>/i', "\n", $billing_address ) ) )
-				: '' );
 
 		$wp_post_type = get_post_type_object( $order->get_type() ) ?? get_post_type_object( 'shop_order' );
 		$is_editable  = current_user_can( $wp_post_type->cap->edit_post, $order->get_id() );

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -430,8 +430,16 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			}
 		}
 
-		$billing_address  = $order->get_formatted_billing_address();
-		$shipping_address = $order->get_formatted_shipping_address();
+		$billing_address         = $order->get_formatted_billing_address();
+		$shipping_address        = $order->get_formatted_shipping_address();
+		$shipping_address_plain  = $shipping_address
+			? wc_clean( wp_strip_all_tags( preg_replace( '/<br\s*\/?\s*>/i', "\n", $shipping_address ) ) )
+			: '';
+		$shipping_address_plain  = $shipping_address_plain && $shipping_address_plain !== 'N/A'
+			? $shipping_address_plain
+			: ( $billing_address
+				? wc_clean( wp_strip_all_tags( preg_replace( '/<br\s*\/?\s*>/i', "\n", $billing_address ) ) )
+				: '' );
 
 		$wp_post_type = get_post_type_object( $order->get_type() ) ?? get_post_type_object( 'shop_order' );
 		$is_editable  = current_user_can( $wp_post_type->cap->edit_post, $order->get_id() );
@@ -454,6 +462,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				'needs_shipping'             => $order->needs_shipping_address(),
 				'formatted_billing_address'  => $billing_address ? $billing_address : __( 'N/A', 'woocommerce' ),
 				'formatted_shipping_address' => $shipping_address ? $shipping_address : __( 'N/A', 'woocommerce' ),
+				'shipping_address_plain'     => $shipping_address_plain,
 				'shipping_address_map_url'   => $order->get_shipping_address_map_url(),
 				'payment_via'                => $payment_via,
 				'shipping_via'               => $order->get_shipping_method(),

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -648,17 +648,47 @@ class WC_Meta_Box_Order_Data {
 					</div>
 					<div class="order_data_column order_data_column_shipping">
 					<?php
-					$shipping_address_plain = $order->get_formatted_shipping_address();
-					$shipping_address_plain = $shipping_address_plain
-						? wp_strip_all_tags( preg_replace( '/<br\s*\/\?\s*>/i', "\n", $shipping_address_plain ) )
-						: '';
+					$show_copy_button    = false;
+					$shipping_raw        = '';
+					$shipping_plain_text = '';
+
+					if ( $order->get_user_id() !== 0 && is_wp_error( $user ) ) {
+						// User not available on this site — suppress details.
+						$hide_core_shipping_details = false;
+					} else {
+						$hide_core_shipping_details = 'store-api' === $order->get_created_via()
+							&& self::order_has_no_shipping( $order )
+							&& self::order_has_only_virtual_products( $order )
+							&& self::order_shipping_matches_billing( $order );
+
+						/**
+						 * Filters whether billing-derived shipping details are hidden in the order admin summary.
+						 *
+						 * @param bool     $hide_core_shipping_details Whether core shipping details are hidden.
+						 * @param WC_Order $order                      Order object.
+						 *
+						 * @since 11.1.0
+						 */
+						$hide_core_shipping_details = apply_filters( 'woocommerce_hide_order_admin_shipping_details', $hide_core_shipping_details, $order );
+
+						if ( ! $hide_core_shipping_details && $order->has_shipping_address() ) {
+							$user_check = Users::get_user_in_current_site( $order->get_user_id() );
+							if ( $order->get_user_id() === 0 || ! is_wp_error( $user_check ) ) {
+								$shipping_raw        = $order->get_formatted_shipping_address();
+								$shipping_plain_text = self::normalize_address_to_plain_text( $shipping_raw );
+								$show_copy_button    = (bool) $shipping_plain_text;
+							}
+						}
+					}
 					?>
 					<h3>
 						<?php esc_html_e( 'Shipping', 'woocommerce' ); ?>
-						<a href="#" class="wc-copy-shipping-address" data-shipping-address="<?php echo esc_attr( $shipping_address_plain ); ?>">
+						<?php if ( $show_copy_button ) : ?>
+						<a href="#" class="wc-copy-shipping-address" data-shipping-address="<?php echo esc_attr( $shipping_plain_text ); ?>" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>" data-tip-failed="<?php esc_attr_e( 'Unable to copy.', 'woocommerce' ); ?>">
 							<span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
 							<span class="screen-reader-text"><?php esc_html_e( 'Copy', 'woocommerce' ); ?></span>
 						</a>
+						<?php endif; ?>
 						<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 						<span>
 							<a href="#" class="load_customer_shipping" style="display:none;"><?php esc_html_e( 'Load shipping address', 'woocommerce' ); ?></a>
@@ -672,21 +702,7 @@ class WC_Meta_Box_Order_Data {
 							if ( $order->get_user_id() !== 0 && is_wp_error( $user ) ) {
 								echo '<p>' . esc_html( $details_not_available_message ) . '</p>';
 							} else {
-								$hide_core_shipping_details = 'store-api' === $order->get_created_via()
-									&& self::order_has_no_shipping( $order )
-									&& self::order_has_only_virtual_products( $order )
-									&& self::order_shipping_matches_billing( $order );
-
-								/**
-								 * Filters whether billing-derived shipping details are hidden in the order admin summary.
-								 *
-								 * @param bool     $hide_core_shipping_details Whether core shipping details are hidden.
-								 * @param WC_Order $order                      Order object.
-								 *
-								 * @since 11.1.0
-								 */
-								$hide_core_shipping_details = apply_filters( 'woocommerce_hide_order_admin_shipping_details', $hide_core_shipping_details, $order );
-								$shipping_address           = $hide_core_shipping_details ? '' : $order->get_formatted_shipping_address();
+								$shipping_address = $hide_core_shipping_details ? '' : $shipping_raw;
 
 								if ( $shipping_address ) {
 									echo '<p>' . wp_kses( $shipping_address, array( 'br' => array() ) ) . '</p>';
@@ -952,5 +968,18 @@ class WC_Meta_Box_Order_Data {
 		$order->save();
 
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Normalize formatted address HTML to plain text by converting <br> variants to newlines.
+	 *
+	 * Handles <br>, <br/>, <br />, and <br> with attributes (e.g. <br class="foo">).
+	 *
+	 * @param string $formatted_address HTML string from get_formatted_*_address().
+	 * @return string Plain text with newlines preserving line breaks.
+	 */
+	public static function normalize_address_to_plain_text( $formatted_address ) {
+		$with_newlines = preg_replace( '/<br\s*[^>]*>/i', "\n", $formatted_address );
+		return wp_specialchars_decode( wp_strip_all_tags( $with_newlines ), ENT_QUOTES );
 	}
 }

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -647,14 +647,24 @@ class WC_Meta_Box_Order_Data {
 						<?php do_action( 'woocommerce_admin_order_data_after_billing_address', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment ?>
 					</div>
 					<div class="order_data_column order_data_column_shipping">
-						<h3>
-							<?php esc_html_e( 'Shipping', 'woocommerce' ); ?>
-							<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
-							<span>
-								<a href="#" class="load_customer_shipping" style="display:none;"><?php esc_html_e( 'Load shipping address', 'woocommerce' ); ?></a>
-								<a href="#" class="billing-same-as-shipping" style="display:none;"><?php esc_html_e( 'Copy billing address', 'woocommerce' ); ?></a>
-							</span>
-						</h3>
+					<?php
+					$shipping_address_plain = $order->get_formatted_shipping_address();
+					$shipping_address_plain = $shipping_address_plain
+						? wp_strip_all_tags( preg_replace( '/<br\s*\/\?\s*>/i', "\n", $shipping_address_plain ) )
+						: '';
+					?>
+					<h3>
+						<?php esc_html_e( 'Shipping', 'woocommerce' ); ?>
+						<a href="#" class="wc-copy-shipping-address" data-shipping-address="<?php echo esc_attr( $shipping_address_plain ); ?>">
+							<span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
+							<span class="screen-reader-text"><?php esc_html_e( 'Copy', 'woocommerce' ); ?></span>
+						</a>
+						<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
+						<span>
+							<a href="#" class="load_customer_shipping" style="display:none;"><?php esc_html_e( 'Load shipping address', 'woocommerce' ); ?></a>
+							<a href="#" class="billing-same-as-shipping" style="display:none;"><?php esc_html_e( 'Copy billing address', 'woocommerce' ); ?></a>
+						</span>
+					</h3>
 						<div class="address">
 							<?php
 							// Display values.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1746,10 +1746,12 @@ class ListTable extends WP_List_Table {
 								<div class="wc-order-preview-address">
 									<h2>
 										<?php esc_html_e( 'Shipping details', 'woocommerce' ); ?>
-										<a href="#" class="wc-copy-shipping-address" data-shipping-address="{{ data.shipping_address_plain }}" data-copy-text="<?php esc_attr_e( 'Copy', 'woocommerce' ); ?>" data-copied-text="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>">
+										<# if ( data.shipping_address_plain ) { #>
+										<a href="#" class="wc-copy-shipping-address" data-shipping-address="{{ data.shipping_address_plain }}" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>" data-tip-failed="<?php esc_attr_e( 'Unable to copy.', 'woocommerce' ); ?>">
 											<span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
 											<span class="screen-reader-text"><?php esc_html_e( 'Copy', 'woocommerce' ); ?></span>
 										</a>
+										<# } #>
 									</h2>
 										<# if ( data.ship_to_billing ) { #>
 											{{{ data.formatted_billing_address }}}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1743,8 +1743,14 @@ class ListTable extends WP_List_Table {
 									<# } #>
 								</div>
 								<# if ( data.needs_shipping ) { #>
-									<div class="wc-order-preview-address">
-										<h2><?php esc_html_e( 'Shipping details', 'woocommerce' ); ?></h2>
+								<div class="wc-order-preview-address">
+									<h2>
+										<?php esc_html_e( 'Shipping details', 'woocommerce' ); ?>
+										<a href="#" class="wc-copy-shipping-address" data-shipping-address="{{ data.shipping_address_plain }}" data-copy-text="<?php esc_attr_e( 'Copy', 'woocommerce' ); ?>" data-copied-text="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>">
+											<span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
+											<span class="screen-reader-text"><?php esc_html_e( 'Copy', 'woocommerce' ); ?></span>
+										</a>
+									</h2>
 										<# if ( data.ship_to_billing ) { #>
 											{{{ data.formatted_billing_address }}}
 										<# } else { #>


### PR DESCRIPTION
Adds copy action for shipping details on the order edit screen, including clipboard handling and feedback. Also prepares shipping address plain text for order preview data.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- Adds a copy-to-clipboard action for shipping details on the order edit screen.
- Preserves line breaks in copied shipping address text.
- Adds clipboard handling + feedback messaging.
- Prepares plain-text shipping address data for the order preview payload.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #27051.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before 
<img width="904" height="547" alt="screenshot-before" src="https://github.com/user-attachments/assets/20fe6a83-45a3-4b76-a460-3f0a02bf6343" />
| After
<img width="845" height="360" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/abe96d6c-d055-4b3e-834a-10bfd6c80461" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce → Orders**, open any order.
2. In the **Shipping** header, click the **copy** icon.
3. Paste into a text editor and verify the full address is copied with line breaks.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Manual checks on local dev environment.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds a copy icon for shipping details on the order edit screen.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>