### PR TITLE
[Performance] Admin: optimize SQL fetching dates for month filter on orders page

### DIFF
--- a/plugins/woocommerce/changelog/performance-54579-slow-sql-months-filter
+++ b/plugins/woocommerce/changelog/performance-54579-slow-sql-months-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Admin: optimized SQL fetching dates for month filter on orders page

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -870,12 +870,12 @@ class ListTable extends WP_List_Table {
 
 		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
+				'SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
 				 FROM (
 					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id DESC LIMIT 1 )
 					UNION ALL
 					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id ASC LIMIT 1 )
-				 ) d;",
+				 ) d;',
 				OrdersTableDataStore::get_orders_table_name(),
 				$this->order_type,
 				OrderStatus::TRASH,

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -868,21 +868,21 @@ class ListTable extends WP_List_Table {
 	protected function get_months_filter_options(): array {
 		global $wpdb;
 
-		$orders_table   = esc_sql( OrdersTableDataStore::get_orders_table_name() );
 		$min_max_months = $wpdb->get_row(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is escaped above.
 			$wpdb->prepare(
-				"
-					SELECT MIN( t.date_created_gmt ) as min_date_gmt,
-					       MAX( t.date_created_gmt ) as max_date_gmt
-					FROM `{$orders_table}` t
-					WHERE type = %s
-					AND status != %s
-				",
+				"SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
+				 FROM (
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id DESC LIMIT 1 )
+					UNION ALL
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id ASC LIMIT 1 )
+				 ) d;",
+				OrdersTableDataStore::get_orders_table_name(),
+				$this->order_type,
+				OrderStatus::TRASH,
+				OrdersTableDataStore::get_orders_table_name(),
 				$this->order_type,
 				OrderStatus::TRASH
 			)
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		);
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -868,6 +868,10 @@ class ListTable extends WP_List_Table {
 	protected function get_months_filter_options(): array {
 		global $wpdb;
 
+		// Optimization note: We improved SQL performance by selecting the first and last order rows instead of scanning all orders
+		// for minimum and maximum dates. This approach assumes that orders and table entries are chronologically aligned. If the
+		// initial assumptions are not met, such as when the store is customized or order dates are in disarray, the worst-case scenario
+		// is that the month filter values will be inaccurate. In this case, additional customization will be required on the store side.
 		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -868,18 +868,14 @@ class ListTable extends WP_List_Table {
 	protected function get_months_filter_options(): array {
 		global $wpdb;
 
-		// Optimization note: We improved SQL performance by selecting the first and last order rows instead of scanning all orders
-		// for minimum and maximum dates. This approach assumes that orders and table entries are chronologically aligned. If the
-		// initial assumptions are not met, such as when the store is customized or order dates are in disarray, the worst-case scenario
-		// is that the month filter values will be inaccurate. In this case, additional customization will be required on the store side.
 		$table_name     = OrdersTableDataStore::get_orders_table_name();
 		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
 				 FROM (
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id DESC LIMIT 1 )
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt DESC LIMIT 1 )
 					UNION ALL
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id ASC LIMIT 1 )
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt ASC LIMIT 1 )
 				 ) d",
 				$table_name,
 				$this->order_type,

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -872,20 +872,19 @@ class ListTable extends WP_List_Table {
 		// for minimum and maximum dates. This approach assumes that orders and table entries are chronologically aligned. If the
 		// initial assumptions are not met, such as when the store is customized or order dates are in disarray, the worst-case scenario
 		// is that the month filter values will be inaccurate. In this case, additional customization will be required on the store side.
+		$table_name     = OrdersTableDataStore::get_orders_table_name();
 		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
+				"SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
 				 FROM (
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id DESC LIMIT 1 )
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id DESC LIMIT 1 )
 					UNION ALL
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != %s ORDER BY id ASC LIMIT 1 )
-				 ) d;',
-				OrdersTableDataStore::get_orders_table_name(),
+					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id ASC LIMIT 1 )
+				 ) d;",
+				$table_name,
 				$this->order_type,
-				OrderStatus::TRASH,
-				OrdersTableDataStore::get_orders_table_name(),
-				$this->order_type,
-				OrderStatus::TRASH
+				$table_name,
+				$this->order_type
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -880,7 +880,7 @@ class ListTable extends WP_List_Table {
 					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id DESC LIMIT 1 )
 					UNION ALL
 					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY id ASC LIMIT 1 )
-				 ) d;",
+				 ) d",
 				$table_name,
 				$this->order_type,
 				$table_name,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Re-iterates on #54579, WOOPLUG-3012.

Inspite of https://github.com/woocommerce/woocommerce/pull/55510 and https://github.com/woocommerce/woocommerce/pull/56879, the SQL is still slow. We are updating the SQL to fetch oldest + newest orders dates (index-based) instead of scanning complete table.

```sql
EXPLAIN SELECT SQL_NO_CACHE MIN( t.date_created_gmt ) as min_date_gmt, MAX( t.date_created_gmt ) as max_date_gmt
FROM `wp_wc_orders` t
WHERE type = 'shop_order'
  AND status != 'trash';
# 1,SIMPLE,t,range,"status,type_status_date",type_status_date,166,,51831,Using where; Using index

# 1 row retrieved starting from 1 in 452 ms (execution: 85 ms, fetching: 367 ms)
# 1 row retrieved starting from 1 in 433 ms (execution: 61 ms, fetching: 372 ms)
# 1 row retrieved starting from 1 in 427 ms (execution: 75 ms, fetching: 352 ms)
# 1 row retrieved starting from 1 in 431 ms (execution: 54 ms, fetching: 377 ms)
# 1 row retrieved starting from 1 in 465 ms (execution: 57 ms, fetching: 408 ms)
# avg execution:  66 ms


EXPLAIN SELECT SQL_NO_CACHE MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
FROM (
     ( SELECT date_created_gmt FROM wp_wc_orders WHERE type = 'shop_order' AND status != 'trash' ORDER BY date_created_gmt DESC LIMIT 1 )
     UNION ALL
     ( SELECT date_created_gmt FROM wp_wc_orders WHERE type = 'shop_order' AND status != 'trash' ORDER BY date_created_gmt ASC LIMIT 1 )
 ) d;
# 1,PRIMARY,<derived2>,ALL,,,,,2,""
# 2,DERIVED,wp_wc_orders,index,"status,type_status_date",date_created,6,,51831,Using where
# 3,UNION,wp_wc_orders,index,"status,type_status_date",date_created,6,,51831,Using where

# 1 row retrieved starting from 1 in 455 ms (execution: 10 ms, fetching: 445 ms)
# 1 row retrieved starting from 1 in 427 ms (execution: 15 ms, fetching: 412 ms)
# 1 row retrieved starting from 1 in 431 ms (execution: 11 ms, fetching: 420 ms)
# 1 row retrieved starting from 1 in 415 ms (execution: 14 ms, fetching: 401 ms)
# 1 row retrieved starting from 1 in 429 ms (execution: 12 ms, fetching: 417 ms)
# avg execution:  12 ms (82% faster)
```

### How to test the changes in this Pull Request:

- Ensure your testing site has a sufficient number of orders
- Using trunk, navigate to the admin area: `WooCommerce -> Orders` and verify options under `All dates` filter.
- Switch to this branch, refresh the page, and verify the options are the  same

For verifying SQL's performance, you can execute them directly or examine execution times with the Query Monitor plugin during manual testing.