### PR TITLE
[Performance] Optimize slow SQL on order confirmation page

### DIFF
--- a/plugins/woocommerce/changelog/performance-63042-slow-SQL-order-confirmation
+++ b/plugins/woocommerce/changelog/performance-63042-slow-SQL-order-confirmation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Orders: optimized a slow SQL query executed on the order confirmation page, checking for the existence of downloadable products.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -58648,12 +58648,6 @@ parameters:
 			path: src/Blocks/BlockTypes/OrderConfirmation/Downloads.php
 
 		-
-			message: '#^Function get_transient invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\OrderConfirmation\\DownloadsWrapper\:\:enqueue_data\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -61020,12 +61014,6 @@ parameters:
 		-
 			message: '#^Callback expects 1 parameter, \$accepted_args is set to 2\.$#'
 			identifier: arguments.count
-			count: 1
-			path: src/Blocks/BlockTypesController.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypesController\:\:delete_product_transients\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Blocks/BlockTypesController.php
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -43,10 +43,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 			$has_downloadable_products = 'yes' === $has_downloadable_products;
 		} else {
 			$has_downloadable_products = (bool) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT product_id FROM %i WHERE downloadable = 1 LIMIT 1',
-					$wpdb->wc_product_meta_lookup
-				)
+				"SELECT product_id FROM {$wpdb->wc_product_meta_lookup} WHERE downloadable = 1 LIMIT 1",
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -31,7 +31,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 						FROM {$wpdb->posts} as posts
 						INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
 					 WHERE
-						postmeta.meta_key   = '_downloadable'
+						    postmeta.meta_key   = '_downloadable'
 						AND postmeta.meta_value = 'yes'
 						AND posts.post_type     = 'product'
 						AND posts.post_status   = 'publish'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -36,8 +36,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 							AND postmeta.meta_value = 'yes'
 							AND posts.post_type     = 'product'
 							AND posts.post_status   = 'publish'
-							LIMIT 1",
-						$wpdb->wc_product_meta_lookup,
+							LIMIT 1"
 					)
 				);
 				$has_downloadable_products = $has_downloadable_products ? 'yes' : 'no';
@@ -48,7 +47,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 			$has_downloadable_products = (bool) $wpdb->get_var(
 				$wpdb->prepare(
 					'SELECT product_id FROM %i WHERE downloadable = 1 LIMIT 1',
-					$wpdb->wc_product_meta_lookup,
+					$wpdb->wc_product_meta_lookup
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -23,9 +23,10 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 		global $wpdb;
 
 		if ( get_option( 'woocommerce_product_lookup_table_is_generating' ) ) {
-			$has_downloadable_product = wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' );
-			if ( false === $has_downloadable_product ) {
-				$has_downloadable_product = (bool) $wpdb->get_var(
+			// The underlying SQL is slower than querying `wc_product_meta_lookup`, so caching is used for performance.
+			$has_downloadable_products = wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' );
+			if ( false === $has_downloadable_products ) {
+				$has_downloadable_products = (bool) $wpdb->get_var(
 					$wpdb->prepare(
 						"SELECT posts.ID
 							FROM {$wpdb->posts} as posts
@@ -39,11 +40,12 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 						$wpdb->wc_product_meta_lookup,
 					)
 				);
-				wp_cache_set( 'woocommerce_has_downloadable_products', $has_downloadable_product ? 'yes' : 'no', 'woocommerce', HOUR_IN_SECONDS );
+				$has_downloadable_products = $has_downloadable_products ? 'yes' : 'no';
+				wp_cache_set( 'woocommerce_has_downloadable_products', $has_downloadable_products, 'woocommerce', HOUR_IN_SECONDS );
 			}
-			$has_downloadable_product = 'yes' === $has_downloadable_product;
+			$has_downloadable_products = 'yes' === $has_downloadable_products;
 		} else {
-			$has_downloadable_product = (bool) $wpdb->get_var(
+			$has_downloadable_products = (bool) $wpdb->get_var(
 				$wpdb->prepare(
 					'SELECT product_id FROM %i WHERE downloadable = 1 LIMIT 1',
 					$wpdb->wc_product_meta_lookup,
@@ -51,7 +53,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 			);
 		}
 
-		return $has_downloadable_product;
+		return $has_downloadable_products;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -27,17 +27,15 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 			$has_downloadable_products = wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' );
 			if ( false === $has_downloadable_products ) {
 				$has_downloadable_products = (bool) $wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT posts.ID
-							FROM {$wpdb->posts} as posts
-							INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
-						 WHERE
-							AND postmeta.meta_key   = '_downloadable'
-							AND postmeta.meta_value = 'yes'
-							AND posts.post_type     = 'product'
-							AND posts.post_status   = 'publish'
-							LIMIT 1"
-					)
+					"SELECT posts.ID
+						FROM {$wpdb->posts} as posts
+						INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
+					 WHERE
+						AND postmeta.meta_key   = '_downloadable'
+						AND postmeta.meta_value = 'yes'
+						AND posts.post_type     = 'product'
+						AND posts.post_status   = 'publish'
+						LIMIT 1"
 				);
 				$has_downloadable_products = $has_downloadable_products ? 'yes' : 'no';
 				wp_cache_set( 'woocommerce_has_downloadable_products', $has_downloadable_products, 'woocommerce', HOUR_IN_SECONDS );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -31,7 +31,7 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 						FROM {$wpdb->posts} as posts
 						INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
 					 WHERE
-						AND postmeta.meta_key   = '_downloadable'
+						postmeta.meta_key   = '_downloadable'
 						AND postmeta.meta_value = 'yes'
 						AND posts.post_type     = 'product'
 						AND posts.post_status   = 'publish'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -20,30 +20,38 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 	 * @return boolean
 	 */
 	protected function store_has_downloadable_products() {
-		$has_downloadable_product = get_transient( 'wc_blocks_has_downloadable_product', false );
+		global $wpdb;
 
-		if ( false === $has_downloadable_product ) {
-			$product_ids              = get_posts(
-				array(
-					'post_type'   => 'product',
-					'numberposts' => 1,
-					'post_status' => 'publish',
-					'fields'      => 'ids',
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'meta_query'  => array(
-						array(
-							'key'     => '_downloadable',
-							'value'   => 'yes',
-							'compare' => '=',
-						),
-					),
+		if ( get_option( 'woocommerce_product_lookup_table_is_generating' ) ) {
+			$has_downloadable_product = wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' );
+			if ( false === $has_downloadable_product ) {
+				$has_downloadable_product = (bool) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT posts.ID
+							FROM {$wpdb->posts} as posts
+							INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
+						 WHERE
+							AND postmeta.meta_key   = '_downloadable'
+							AND postmeta.meta_value = 'yes'
+							AND posts.post_type     = 'product'
+							AND posts.post_status   = 'publish'
+							LIMIT 1",
+						$wpdb->wc_product_meta_lookup,
+					)
+				);
+				wp_cache_set( 'woocommerce_has_downloadable_products', $has_downloadable_product ? 'yes' : 'no', 'woocommerce', HOUR_IN_SECONDS );
+			}
+			$has_downloadable_product = 'yes' === $has_downloadable_product;
+		} else {
+			$has_downloadable_product = (bool) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT product_id FROM %i WHERE downloadable = 1 LIMIT 1',
+					$wpdb->wc_product_meta_lookup,
 				)
 			);
-			$has_downloadable_product = ! empty( $product_ids );
-			set_transient( 'wc_blocks_has_downloadable_product', $has_downloadable_product ? '1' : '0', MONTH_IN_SECONDS );
 		}
 
-		return (bool) $has_downloadable_product;
+		return $has_downloadable_product;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -61,7 +61,6 @@ final class BlockTypesController {
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
-		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
 		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
 		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 3 );
 		add_filter( 'block_core_breadcrumbs_items', array( $this, 'apply_woocommerce_breadcrumb_filters' ), 10, 1 );
@@ -360,9 +359,12 @@ final class BlockTypesController {
 
 	/**
 	 * Delete product transients when a product is deleted.
+	 *
+	 * @deprecated since 10.6.0
+	 * @return void
 	 */
 	public function delete_product_transients() {
-		delete_transient( 'wc_blocks_has_downloadable_product' );
+		wc_deprecated_function( __METHOD__, '10.6.0' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -19,8 +19,10 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 		};
 
 		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
-		// TODO: create downloadable product
+		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
+
+		$product->delete();
 	}
 
 	/**
@@ -34,12 +36,13 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 		};
 		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
 
-		// TODO: create downloadable product
+		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
 		$this->assertSame( 'yes', wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' ) );
 
 		delete_option( 'woocommerce_product_lookup_table_is_generating' );
 		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
+		$product->delete();
 	}
 
 	/**
@@ -54,10 +57,11 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
 		wp_cache_set( 'woocommerce_has_downloadable_products', 'no', 'woocommerce' );
 
-		// TODO: create downloadable product
+		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
 
 		delete_option( 'woocommerce_product_lookup_table_is_generating' );
 		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
+		$product->delete();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -14,6 +14,9 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	public function test_store_has_downloadable_products_via_product_meta_lookup_table(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();
 			}
@@ -31,6 +34,9 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 */
 	public function test_store_has_downloadable_products_via_posts_meta_table(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();
@@ -52,6 +58,9 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 */
 	public function test_store_has_downloadable_products_via_cache(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -31,6 +31,7 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 * Test `store_has_downloadable_products`: query product meta lookup table.
 	 *
 	 * @dataProvider provider_downloadable_products
+	 * @param \WC_Product $product The product instance.
 	 */
 	public function test_store_has_downloadable_products_via_product_meta_lookup_table_with_downloadable( \WC_Product $product ): void {
 		$proxy = new class() extends DownloadsWrapperClass {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -36,8 +36,10 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 
 		// TODO: create downloadable product
 		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
-		// TODO: test cache value
-		// TODO: clean cache/option values
+		$this->assertSame( 'yes', wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' ) );
+
+		delete_option( 'woocommerce_product_lookup_table_is_generating' );
+		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
 	}
 
 	/**
@@ -54,6 +56,8 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 
 		// TODO: create downloadable product
 		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
-		// TODO: clean cache/option values
+
+		delete_option( 'woocommerce_product_lookup_table_is_generating' );
+		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
 
-use \Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\DownloadsWrapper as DownloadsWrapperClass;
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\DownloadsWrapper as DownloadsWrapperClass;
 
 /**
  * Test DownloadsWrapper class.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -1,0 +1,59 @@
+<?php declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use \Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\DownloadsWrapper as DownloadsWrapperClass;
+
+/**
+ * Test DownloadsWrapper class.
+ */
+final class DownloadsWrapper extends \WP_UnitTestCase {
+	/**
+	 * Test `store_has_downloadable_products`: query product meta lookup table.
+	 */
+	public function test_store_has_downloadable_products_via_product_meta_lookup_table(): void {
+		$proxy = new class() extends DownloadsWrapperClass {
+			public function store_has_downloadable_products_proxy(): bool {
+				return $this->store_has_downloadable_products();
+			}
+		};
+
+		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
+		// TODO: create downloadable product
+		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
+	}
+
+	/**
+	 * Test `store_has_downloadable_products`: query post meta table.
+	 */
+	public function test_store_has_downloadable_products_via_posts_meta_table(): void {
+		$proxy = new class() extends DownloadsWrapperClass {
+			public function store_has_downloadable_products_proxy(): bool {
+				return $this->store_has_downloadable_products();
+			}
+		};
+		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
+
+		// TODO: create downloadable product
+		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
+		// TODO: test cache value
+		// TODO: clean cache/option values
+	}
+
+	/**
+	 * Test `store_has_downloadable_products`: picking up the cached value.
+	 */
+	public function test_store_has_downloadable_products_via_cache(): void {
+		$proxy = new class() extends DownloadsWrapperClass {
+			public function store_has_downloadable_products_proxy(): bool {
+				return $this->store_has_downloadable_products();
+			}
+		};
+		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
+		wp_cache_set( 'woocommerce_has_downloadable_products', 'no', 'woocommerce' );
+
+		// TODO: create downloadable product
+		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
+		// TODO: clean cache/option values
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -9,9 +9,30 @@ use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\DownloadsWrapper 
  */
 final class DownloadsWrapper extends \WP_UnitTestCase {
 	/**
-	 * Test `store_has_downloadable_products`: query product meta lookup table.
+	 * Perform products/options/cache cleanup.
 	 */
-	public function test_store_has_downloadable_products_via_product_meta_lookup_table(): void {
+	public function tear_down() {
+		global $wpdb;
+
+		/** @var \WC_Product[] $products */
+		$products = ( new \WC_Product_Query() )->get_products();
+		foreach ( $products as $product ) {
+			$product->delete();
+		}
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->wc_product_meta_lookup}" );
+
+		delete_option( 'woocommerce_product_lookup_table_is_generating' );
+		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test `store_has_downloadable_products`: query product meta lookup table.
+	 *
+	 * @dataProvider provider_downloadable_products
+	 */
+	public function test_store_has_downloadable_products_via_product_meta_lookup_table_with_downloadable( \WC_Product $product ): void {
 		$proxy = new class() extends DownloadsWrapperClass {
 			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function __construct() {
@@ -22,11 +43,19 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 			}
 		};
 
-		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
-		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
-		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
+		$this->assertSame( $product->is_downloadable(), $proxy->store_has_downloadable_products_proxy() );
+	}
 
-		$product->delete();
+	/**
+	 * A data provider.
+	 *
+	 * @return array
+	 */
+	public function provider_downloadable_products(): array {
+		return array(
+			array( \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) ) ),
+			array( \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => false ) ) ),
+		);
 	}
 
 	/**
@@ -44,13 +73,9 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 		};
 		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
 
-		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
+		\WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertTrue( $proxy->store_has_downloadable_products_proxy() );
 		$this->assertSame( 'yes', wp_cache_get( 'woocommerce_has_downloadable_products', 'woocommerce' ) );
-
-		delete_option( 'woocommerce_product_lookup_table_is_generating' );
-		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
-		$product->delete();
 	}
 
 	/**
@@ -69,11 +94,7 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 		add_option( 'woocommerce_product_lookup_table_is_generating', 'yes' );
 		wp_cache_set( 'woocommerce_has_downloadable_products', 'no', 'woocommerce' );
 
-		$product = \WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
+		\WC_Helper_Product::create_simple_product( true, array( 'downloadable' => true ) );
 		$this->assertFalse( $proxy->store_has_downloadable_products_proxy() );
-
-		delete_option( 'woocommerce_product_lookup_table_is_generating' );
-		wp_cache_delete( 'woocommerce_has_downloadable_products', 'woocommerce' );
-		$product->delete();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -13,6 +13,7 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 */
 	public function test_store_has_downloadable_products_via_product_meta_lookup_table(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();
 			}
@@ -30,6 +31,7 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 */
 	public function test_store_has_downloadable_products_via_posts_meta_table(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();
 			}
@@ -50,6 +52,7 @@ final class DownloadsWrapper extends \WP_UnitTestCase {
 	 */
 	public function test_store_has_downloadable_products_via_cache(): void {
 		$proxy = new class() extends DownloadsWrapperClass {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function store_has_downloadable_products_proxy(): bool {
 				return $this->store_has_downloadable_products();
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #63042, WOOPLUG-6213.

Leverage product attribute lookup tables for the query, with fallback to an optimized version of the posts meta querying SQL (cached with standard caching APIs).

In the case of a lookup table query, priming the transient options takes approximately the same time as the lookup table query; caching is not necessary.

```sql
EXPLAIN SELECT SQL_NO_CACHE wp_posts.ID
        FROM wp_posts
                 INNER JOIN wp_postmeta
                            ON ( wp_posts.ID = wp_postmeta.post_id )
        WHERE 1=1
          AND ( ( wp_postmeta.meta_key = '_downloadable'
            AND wp_postmeta.meta_value = 'yes' ) )
          AND wp_posts.post_type = 'product'
          AND ((wp_posts.post_status = 'publish'))
        GROUP BY wp_posts.ID
        ORDER BY wp_posts.post_date DESC
        LIMIT 0, 1;
# 1,SIMPLE,wp_posts,ref,"PRIMARY,type_status_date,type_status_author",type_status_date,164,"const,const",1002,Using where; Using index; Using temporary; Using filesort
# 1,SIMPLE,wp_postmeta,ref|filter,"post_id,meta_key",post_id|meta_key,8|767,wordpress.wp_posts.ID,36 (0%),Using where; Using rowid filter

# 0 rows retrieved in 462 ms (execution: 51 ms, fetching: 411 ms)
# 0 rows retrieved in 566 ms (execution: 65 ms, fetching: 501 ms)
# 0 rows retrieved in 481 ms (execution: 56 ms, fetching: 425 ms)
# 0 rows retrieved in 468 ms (execution: 66 ms, fetching: 402 ms)
# 0 rows retrieved in 429 ms (execution: 37 ms, fetching: 392 ms)
# avg. execution:  55 ms

EXPLAIN SELECT SQL_NO_CACHE wp_posts.ID
        FROM wp_posts
                 INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id )
        WHERE
            wp_postmeta.meta_key = '_downloadable'
          AND wp_postmeta.meta_value = 'yes'
          AND wp_posts.post_type = 'product'
          AND wp_posts.post_status = 'publish'
        LIMIT 1;
# 1,SIMPLE,wp_posts,ref,"PRIMARY,type_status_date,type_status_author",type_status_date,164,"const,const",1002,Using where; Using index
# 1,SIMPLE,wp_postmeta,ref|filter,"post_id,meta_key",post_id|meta_key,8|767,wordpress.wp_posts.ID,36 (0%),Using where; Using rowid filter

# 0 rows retrieved in 431 ms (execution: 39 ms, fetching: 392 ms)
# 0 rows retrieved in 524 ms (execution: 49 ms, fetching: 475 ms)
# 0 rows retrieved in 485 ms (execution: 51 ms, fetching: 434 ms)
# 0 rows retrieved in 494 ms (execution: 46 ms, fetching: 448 ms)
# 0 rows retrieved in 482 ms (execution: 46 ms, fetching: 436 ms)
# avg. execution:  46ms (16% faster)

EXPLAIN SELECT SQL_NO_CACHE product_id FROM wp_wc_product_meta_lookup WHERE downloadable = 1 LIMIT 1;
# 1,SIMPLE,wp_wc_product_meta_lookup,ref,downloadable,downloadable,2,const,1,Using index

# 0 rows retrieved in 380 ms (execution: 8 ms, fetching: 372 ms)
# 0 rows retrieved in 470 ms (execution: 11 ms, fetching: 459 ms)
# 0 rows retrieved in 370 ms (execution: 8 ms, fetching: 362 ms)
# 0 rows retrieved in 420 ms (execution: 10 ms, fetching: 410 ms)
# 0 rows retrieved in 421 ms (execution: 12 ms, fetching: 409 ms)
# avg. execution:  10 ms (82% faster)
```

### Testing steps

- The testing site will need Query Monitor, HPOS compatibility mode is enabled, and some downloadable products
- Using this branch, place an order via the storefront
- On the order confirmation page, verify the lookup table query and its execution time
- Add "woocommerce_product_lookup_table_is_generating" option with "yes" value to options table
- place an order via the storefront
- On the order confirmation page, verify the postmeta table query and its execution time
- Remove 'woocommerce_product_lookup_table_is_generating' option

For verifying SQLs timings, execute the queries above against heavily populated system tables.