### PR TITLE
Fix tax rounding error in v4 refunds API

### DIFF
--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
 use WP_Error;
 use WC_Order;
 use WC_Tax;
@@ -69,13 +70,23 @@ class DataUtils {
 							$tax_rates
 						);
 
+						// Round extracted taxes to display precision to match how original taxes were stored.
+						// This prevents rounding errors where internal precision (6DP) differs from storage precision (2DP).
+						$price_decimals   = wc_get_price_decimals();
+						$calculated_taxes = array_map(
+							function ( $tax ) use ( $price_decimals ) {
+								return NumberUtil::round( $tax, $price_decimals );
+							},
+							$calculated_taxes
+						);
+
 						$line_item['refund_tax'] = $this->convert_proportional_taxes_to_schema_format(
 							$calculated_taxes
 						);
 
 						// Subtract extracted tax from refund_total to get the amount excluding tax.
 						$total_tax                 = array_sum( $calculated_taxes );
-						$line_item['refund_total'] = $line_item['refund_total'] - $total_tax;
+						$line_item['refund_total'] = NumberUtil::round( $line_item['refund_total'] - $total_tax, $price_decimals );
 					}
 				}
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Round extracted taxes to display precision (`wc_get_price_decimals`) before calculating the refund base amount. This prevents 0.01 discrepancies when multiple tax rates with decimal percentages are extracted from an inclusive total.

When testing the V4 refunds API in a store with complex tax rates setup, we noticed a 0.01 discrepancy between requested amount and the one applied to the line item. See:

<img width="3122" height="610" alt="CleanShot 2026-01-30 at 16 06 10@2x" src="https://github.com/user-attachments/assets/9d2c0d95-9546-44d0-b102-87d087d88f16" />

Notice that the refunded amount is 50.01 instead of 50.00.

I've supplied information about the tax rates, store settings, and order for Claude to prepare a testing case replicating this issue. With test in place it was easy for Claude to figure out the fix and iterate on it.

### How to test the changes in this Pull Request:

## Testing Steps

### Prerequisites
- WooCommerce with REST API v4 enabled
- A REST API client (Postman, curl, or WP REST API testing tool)

### Setup Tax Rates

1. Go to **WooCommerce > Settings > Tax > Standard rates**
2. Add the following rates for US, CA (all with **Priority 1**, non-compound):

| Country | State | Rate % | Tax Name | Priority |
|---------|-------|--------|----------|----------|
| US | CA | 1.0000 | County Tax | 1 |
| US | CA | 3.2500 | Special Tax | 1 |
| US | CA | 6.2500 | State Sales Tax | 1 |

3. Set **Calculate tax based on** to "Customer shipping address"

### Create Test Order

1. Create a simple product priced at **$50.00**
2. Create an order with:
   - 1x the $50 product
   - Shipping address: Any CA address (e.g., "Test City, CA 90001")
3. Verify the order shows:
   - Subtotal: $50.00
   - County Tax: $0.50
   - Special Tax: $1.63
   - State Sales Tax: $3.13
   - **Total: $55.26**

### Test the Refund

Using the REST API, create a full refund:

```bash
curl -X POST "https://your-site.com/wp-json/wc/v4/refunds" \
  -u consumer_key:consumer_secret \
  -H "Content-Type: application/json" \
  -d '{
    "order_id": ORDER_ID,
    "amount": 55.26,
    "reason": "Testing rounding fix",
    "line_items": [{
      "line_item_id": LINE_ITEM_ID,
      "quantity": 1,
      "refund_total": 55.26
    }]
  }'
```

### Expected Result (with fix)
- Refund line item total: **-$50.00**
- County Tax refund: -$0.50
- Special Tax refund: -$1.63
- State Sales Tax refund: -$3.13

### Previous Behavior (bug)
- Refund line item total: **-$50.01** ❌ (1 cent error)

### Alternative: Run the Unit Test

```bash
pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env --filter test_refunds_create_with_automatic_tax_extraction_rounding_precision
```

This test replicates the exact scenario and will fail if the bug is reintroduced.

### Testing that has already taken place:

The above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

The V4 API for refunds is not public yet and is a work in progress. No need for a public changelog yet.

</details>
