### PR TITLE
Fix: Empty email subject for "Order Refunded" (partially refunded) email in block editor

### DIFF
--- a/plugins/woocommerce/changelog/63047-stomail-7771-order-refunded-email-subject-is-empty
+++ b/plugins/woocommerce/changelog/63047-stomail-7771-order-refunded-email-subject-is-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix empty email subject for "Partially refunded order" email in the block email editor by properly retrieving the subject_partial option.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -8,6 +8,7 @@ import {
 	PanelRow,
 	TextControl,
 	ToggleControl,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -81,6 +82,24 @@ const SidebarSettings = ( {
 	};
 
 	const previewTextLength = woocommerce_email_data?.preheader?.length ?? 0;
+
+	if (
+		woocommerce_email_data.email_type ===
+		'customer_partially_refunded_order'
+	) {
+		return (
+			<>
+				<br />
+				<Text>
+					{ __(
+						'Update this email configuration in the "Refunded order" email.',
+						'woocommerce'
+					) }
+				</Text>
+				<br />
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -92,7 +92,7 @@ const SidebarSettings = ( {
 				<br />
 				<Text>
 					{ __(
-						'Update this email configuration in the "Refunded order" email.',
+						'Update this email configuration in the "Order refunded" email.',
 						'woocommerce'
 					) }
 				</Text>

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-partially-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-partially-refunded-order.php
@@ -68,6 +68,42 @@ if ( ! class_exists( 'WC_Email_Customer_Partially_Refunded_Order', false ) ) :
 				)
 			);
 		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @return string
+		 */
+		public function get_subject() {
+			$subject = $this->get_option( 'subject_partial', $this->get_default_subject( true ) );
+			/**
+			 * Filter the email subject for customer refunded order.
+			 *
+			 * @param string $subject The email subject.
+			 * @param WC_Order $order Order object.
+			 * @param WC_Email_Customer_Refunded_Order $email Email object.
+			 * @since 3.7.0
+			 */
+			$subject = apply_filters( 'woocommerce_email_subject_customer_refunded_order', $this->format_string( $subject ), $this->object, $this );
+			if ( $this->block_email_editor_enabled ) {
+				$subject = $this->personalizer->personalize_transactional_content( $subject, $this );
+			}
+			return $subject;
+		}
+
+		/**
+		 * Return the name of the option in the WP DB.
+		 *
+		 * @since 2.6.0
+		 * @return string
+		 */
+		public function get_option_key() {
+			$id = 'customer_refunded_order';
+			// we need to continue using the parent class's id because we want to maintain backwards compatibility
+			// and allow the parent class continue managing the settings options for this class.
+			// We can remove this once we have migrated all the settings options to this class.
+			return $this->plugin_id . $id . '_settings';
+		}
 	}
 
 endif;

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-partially-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-partially-refunded-order.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Email_Customer_Partially_Refunded_Order', false ) ) :
 			 * Filter the email subject for customer refunded order.
 			 *
 			 * @param string $subject The email subject.
-			 * @param WC_Order $order Order object.
+			 * @param object|bool $order Order object.
 			 * @param WC_Email_Customer_Refunded_Order $email Email object.
 			 * @since 3.7.0
 			 */

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -294,14 +294,14 @@ class EmailsSettingsSchema extends AbstractSchema {
 
 			// Handle customer_refunded_order email type because it has two different subjects.
 			if ( 'customer_refunded_order' === $email->id && 'subject_full' === $id ) {
-				if ( ! isset( $values[ 'subject' ] ) ) {
-					$values[ 'subject' ] = $value;
+				if ( ! isset( $values['subject'] ) ) {
+					$values['subject'] = $value;
 				}
 			}
 
 			if ( 'customer_partially_refunded_order' === $email->id && 'subject_partial' === $id ) {
-				if ( ! isset( $values[ 'subject' ] ) ) {
-					$values[ 'subject' ] = $value;
+				if ( ! isset( $values['subject'] ) ) {
+					$values['subject'] = $value;
 				}
 			}
 		}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -37,7 +37,7 @@ class EmailsSettingsSchema extends AbstractSchema {
 	 *
 	 * @var array
 	 */
-	const FIELDS_SUPPORTING_PERSONALIZATION_TAGS = array( 'subject', 'preheader' );
+	const FIELDS_SUPPORTING_PERSONALIZATION_TAGS = array( 'subject', 'preheader', 'subject_full', 'subject_partial' );
 
 	/**
 	 * Personalization tags registry.
@@ -291,6 +291,19 @@ class EmailsSettingsSchema extends AbstractSchema {
 			}
 
 			$values[ $id ] = $value;
+
+			// Handle customer_refunded_order email type because it has two different subjects.
+			if ( 'customer_refunded_order' === $email->id && 'subject_full' === $id ) {
+				if ( ! isset( $values[ 'subject' ] ) ) {
+					$values[ 'subject' ] = $value;
+				}
+			}
+
+			if ( 'customer_partially_refunded_order' === $email->id && 'subject_partial' === $id ) {
+				if ( ! isset( $values[ 'subject' ] ) ) {
+					$values[ 'subject' ] = $value;
+				}
+			}
 		}
 
 		return $values;


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/STOMAIL-7771/order-refunded-email-subject-is-empty.

WooCommerce created a new settings option for the partially refunded orders email. Since the triggers, subject, preheader, etc are still managed by the parent refunded orders email class, any new values entered into the partially refunded orders email options will be **ignored**.

We still need to be cautious about migrating to the new partially refunded orders class, so for now, we defer the subject, etc., to continue fetching its Database options using the refunded orders email class id.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="1728" height="957" alt="Screenshot 2026-01-30 at 5 26 12 PM" src="https://github.com/user-attachments/assets/1e9f1f89-4ce1-4a16-b288-a0ba03f8acbf" /> |    <img width="1728" height="956" alt="Screenshot 2026-01-30 at 5 14 19 PM" src="https://github.com/user-attachments/assets/0de837fd-4d5d-4886-a6cf-c951cb9f457c" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block email editor feature in WooCommerce settings.
2. Go to **WooCommerce > Settings > Emails**.
3. Click on the **"Partially refunded order"** email to open it in the block email editor.
4. Verify the sidebar shows the informational text: "Update this email configuration in the 'Refunded order' email."
5. Go back and open the **"Refunded order"** email.
6. Change the subject for partial refunds and verify the changes are reflected in the "Partially refunded order" email preview.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix empty email subject for "Partially refunded order" email in the block email editor by properly retrieving the subject_partial option.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
