### PR TITLE
Now we use the tk_ai token as the id for fraud protection customers

### DIFF
--- a/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
+++ b/plugins/woocommerce/src/Internal/FraudProtection/SessionClearanceManager.php
@@ -7,6 +7,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\FraudProtection;
 
+use WC_Tracks_Client;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -134,14 +136,6 @@ class SessionClearanceManager {
 		}
 
 		WC()->session->set( self::SESSION_KEY, $status );
-
-		// Ensure session cookie is set so the session persists across page loads.
-		// This is important because fraud protection may set session status before
-		// any cart action triggers the cookie to be set.
-		// Skip cookie setting if headers have already been sent (e.g., in test environment).
-		if ( WC()->session instanceof \WC_Session_Handler ) {
-			WC()->session->set_customer_session_cookie( true );
-		}
 	}
 
 	/**
@@ -183,17 +177,8 @@ class SessionClearanceManager {
 	 * @return string Session identifier.
 	 */
 	public function get_session_id(): string {
-		if ( ! $this->is_session_available() ) {
-			return 'no-session';
-		}
-
-		// Use or generate a stable session ID for tracking consistency.
-		$fraud_customer_session_id = WC()->session->get( '_fraud_protection_customer_session_id' );
-		if ( ! $fraud_customer_session_id ) {
-			$fraud_customer_session_id = WC()->call_function( 'wc_rand_hash', 'customer_', 30 );
-			WC()->session->set( '_fraud_protection_customer_session_id', $fraud_customer_session_id );
-		}
-		return $fraud_customer_session_id;
+		$identity = WC_Tracks_Client::get_identity( get_current_user_id() );
+		return $identity['_ui'] ?? 'no-session';
 	}
 
 	/**


### PR DESCRIPTION
## Use Tracks identity (`tk_ai`) as session ID for fraud protection

Closes WOOSUBS-1391

### What

This PR changes the fraud protection session identifier to use the WooCommerce Tracks identity (`_ui` / `tk_ai`) instead of generating a custom random hash stored in the WC session.

### Why

- **Consistency**: The Tracks identity is already used across WooCommerce for user identification and analytics. Using it for fraud protection ensures the same user is tracked consistently across different systems.
- **Persistence**: The Tracks identity persists in browser storage independently of the WC session cookie, providing more reliable identification across sessions.
- **Simplicity**: Removes the need to generate, store, and manage a separate custom session ID.

### Changes

1. **`get_session_id()`**: Now uses `WC_Tracks_Client::get_identity()` to retrieve the existing Tracks user identity instead of generating a custom random hash.
2. **Removed explicit session cookie setting**: The `set_customer_session_cookie()` call is no longer needed since the Tracks identity is managed independently of the WC session lifecycle.

## Manual Testing

### Prerequisites
- Enable fraud protection on a test store
- Have browser dev tools open to monitor cookies/storage

### Test 1: Session ID consistency across page loads
1. Open the store in an incognito window
2. Navigate to the shop page
3. Add a product to cart
4. Note the fraud protection session ID in logs (enable `WC_LOG_HANDLER` or check `wc-logs`)
5. Navigate to checkout
6. Verify the session ID remains the same

**Expected**: Session ID should be consistent across all pages.
### Test 2: Logged-in user identification
1. Log in as a customer
2. Add a product to cart
3. Note the session ID
4. Log out
5. Log back in with the same account
6. Check the session ID

**Expected**: Same user should have the same session ID when logged in.

### Test 3: Guest user identification
1. Open the store in incognito mode (guest)
2. Add product to cart and trigger fraud protection
3. Verify session status is stored correctly
4. Refresh the page multiple times
5. Verify session status persists

**Expected**: Guest session status should persist across page refreshes.

### Test 4: Blocked session behavior
1. Trigger a blocked session (via test endpoint or manually setting status)
2. Verify the cart is emptied
3. Refresh the page
4. Verify the blocked status persists

**Expected**: Blocked status should persist and prevent checkout.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
