### PR TITLE
Fix fatal error when REST controllers are instantiated before WooCommerce is loaded

### DIFF
--- a/plugins/woocommerce/changelog/63066-fix-rest-api-cache-early-instantiation
+++ b/plugins/woocommerce/changelog/63066-fix-rest-api-cache-early-instantiation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when third-party plugins instantiate REST controllers before WooCommerce is fully initialized.

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -188,6 +188,13 @@ trait RestApiCache {
 	 * @since 10.5.0
 	 */
 	protected function initialize_rest_api_cache(): void {
+		// Guard against early instantiation before WooCommerce is fully initialized.
+		// Some third-party plugins instantiate REST controllers during plugin loading,
+		// before the WooCommerce container is available.
+		if ( ! function_exists( 'wc_get_container' ) ) {
+			return;
+		}
+
 		$features_controller = wc_get_container()->get( FeaturesController::class );
 
 		$this->rest_api_caching_feature_enabled = $features_controller->feature_is_enabled( 'rest_api_caching' );


### PR DESCRIPTION
Fixes WOOPLUG-6224

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a guard in `RestApiCache::initialize_rest_api_cache()` to check if `wc_get_container()` exists before calling it.

**Problem:** In WooCommerce 10.5, the `RestApiCache` trait was added to REST controllers (e.g., `WC_REST_Products_V2_Controller`). The trait's `initialize_rest_api_cache()` method is called from the controller constructor and uses `wc_get_container()`. Some third-party plugins instantiate these controllers during plugin loading, before the WooCommerce container is available, causing a fatal error:

```
PHP Fatal error: Uncaught Error: Call to undefined function Automattic\WooCommerce\Internal\Traits\wc_get_container() in .../src/Internal/Traits/RestApiCache.php:160
```

**Affected plugins:** TikTok for WooCommerce (1.3.7) and potentially others that extend or instantiate WC REST controllers early.

Closes # .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the TikTok for WooCommerce plugin (version 1.3.7)
2. Ensure WooCommerce 10.5 is active
3. Load any page on the site
4. **Before fix:** Fatal error occurs
5. **After fix:** Site loads normally without errors
6. Verify REST API caching still functions correctly by making REST API requests to `/wp-json/wc/v3/products`

### Testing that has already taken place:

Code review and static analysis. The fix is minimal and defensive - it only adds an early return when `wc_get_container()` doesn't exist, which preserves existing behavior for normal use cases.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix fatal error when third-party plugins instantiate REST controllers before WooCommerce is fully initialized.

</details>