### PR TITLE
Remove orphaned email tracker REST endpoint

### DIFF
--- a/plugins/woocommerce/changelog/remove-orphaned-email-tracker-endpoint
+++ b/plugins/woocommerce/changelog/remove-orphaned-email-tracker-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove orphaned email tracker REST endpoint that was missed in #55660

--- a/plugins/woocommerce/changelog/remove-orphaned-email-tracker-endpoint
+++ b/plugins/woocommerce/changelog/remove-orphaned-email-tracker-endpoint
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Remove orphaned email tracker REST endpoint that was missed in #55660
+Remove orphaned email tracker REST endpoint and deprecate track_opened_email method (follow-up to #55660)

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -44712,13 +44712,7 @@ parameters:
 		-
 			message: '#^Call to method get_param\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
 			identifier: class.notFound
-			count: 15
-			path: src/Admin/API/Notes.php
-
-		-
-			message: '#^Cannot call method get_name\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
+			count: 13
 			path: src/Admin/API/Notes.php
 
 		-
@@ -44896,12 +44890,6 @@ parameters:
 			path: src/Admin/API/Notes.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:track_opened_email\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Admin/API/Notes.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:update_item\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\WP_Error\.$#'
 			identifier: class.notFound
 			count: 1
@@ -45071,12 +45059,6 @@ parameters:
 
 		-
 			message: '#^Parameter \$request of method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:prepare_objects_query\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Notes.php
-
-		-
-			message: '#^Parameter \$request of method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:track_opened_email\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Admin/API/Notes.php

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -44712,7 +44712,13 @@ parameters:
 		-
 			message: '#^Call to method get_param\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
 			identifier: class.notFound
-			count: 13
+			count: 15
+			path: src/Admin/API/Notes.php
+
+		-
+			message: '#^Cannot call method get_name\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
+			identifier: method.nonObject
+			count: 1
 			path: src/Admin/API/Notes.php
 
 		-
@@ -44890,6 +44896,12 @@ parameters:
 			path: src/Admin/API/Notes.php
 
 		-
+			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:track_opened_email\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Admin/API/Notes.php
+
+		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:update_item\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\WP_Error\.$#'
 			identifier: class.notFound
 			count: 1
@@ -45059,6 +45071,12 @@ parameters:
 
 		-
 			message: '#^Parameter \$request of method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:prepare_objects_query\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Admin/API/Notes.php
+
+		-
+			message: '#^Parameter \$request of method Automattic\\WooCommerce\\Admin\\API\\Notes\:\:track_opened_email\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Admin/API/Notes.php

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -597,6 +597,17 @@ class Notes extends \WC_REST_CRUD_Controller {
 	}
 
 	/**
+	 * Track opened emails.
+	 *
+	 * @deprecated 10.6.0 This method is no longer functional as the email tracking feature was removed in WooCommerce 9.9.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	public function track_opened_email( $request ) {
+		wc_deprecated_function( __METHOD__, '10.6.0' );
+	}
+
+	/**
 	 * Get the query params for collections.
 	 *
 	 * @return array

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -116,19 +116,6 @@ class Notes extends \WC_REST_CRUD_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/tracker/(?P<note_id>[\d-]+)/user/(?P<user_id>[\d-]+)',
-			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'track_opened_email' ),
-					'permission_callback' => '__return_true',
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
 			'/' . $this->rest_base . '/update',
 			array(
 				array(
@@ -607,21 +594,6 @@ class Notes extends \WC_REST_CRUD_Controller {
 		 * @since 3.9.0
 		 */
 		return apply_filters( 'woocommerce_rest_prepare_note', $response, $data, $request );
-	}
-
-
-	/**
-	 * Track opened emails.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 */
-	public function track_opened_email( $request ) {
-		$note = NotesRepository::get_note( $request->get_param( 'note_id' ) );
-		if ( ! $note ) {
-			return;
-		}
-
-		NotesRepository::record_tracks_event_with_user( $request->get_param( 'user_id' ), 'email_note_opened', array( 'note_name' => $note->get_name() ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #55660 which removed the merchant email notes feature.

The `/wc-analytics/admin/notes/tracker/{note_id}/user/{user_id}` REST endpoint and its `track_opened_email` handler were missed during that cleanup. This endpoint was originally used to track email opens via an embedded tracking pixel in merchant notification emails, but since the email notification system was completely removed in #55660, this endpoint no longer serves any purpose.

This PR removes:
- The orphaned REST route registration
- The `track_opened_email()` callback method

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh WooCommerce install or use an existing test site
2. Before applying this PR, verify the endpoint exists by visiting: `/?rest_route=/wc-analytics/admin/notes/tracker/1/user/1` - you should get an empty 200 response
3. Apply this PR
4. Visit the same URL - you should now get a 404 "No route was found matching the URL and request method" error
5. Verify the admin notes functionality still works normally in WooCommerce > Home (inbox notifications should display and be dismissable)

### Testing that has already taken place:

- Verified endpoint registration is removed
- Verified no other code references the removed `track_opened_email` method
- Ran PHP linting with no errors

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message
Remove orphaned email tracker REST endpoint that was missed in #55660

</details>