### PR TITLE
Fix prevent false "Quantity changed to 1" notices and add optimistic "Removed" notice

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -176,24 +176,24 @@ const getInfoNoticesFromCartUpdates = (
 		cartItemsPendingDelete: pendingDelete = [],
 	} = quantityChanges;
 
-	const autoDeletedToNotify = oldItems.filter(
-		( old ) =>
-			old.key &&
-			isCartItem( old ) &&
-			! newItems.some( ( item ) => old.key === item.key ) &&
-			! pendingDelete.includes( old.key )
-	);
+    const autoDeletedToNotify = oldItems.filter(
+        ( old ) =>
+            old.key &&
+            isCartItem( old ) &&
+            ! newItems.some( ( item ) => old.key === item.key )
+    );
 
-	const autoUpdatedToNotify = newItems.filter( ( item ) => {
-		if ( ! isCartItem( item ) ) {
-			return false;
-		}
-		const old = oldItems.find( ( o ) => o.key === item.key );
-		return old
-			? ! pendingQuantity.includes( item.key ) &&
-					item.quantity !== old.quantity
-			: ! pendingAdd.includes( item.id );
-	} );
+    const autoUpdatedToNotify = newItems.filter( ( item ) => {
+        if ( ! isCartItem( item ) ) {
+            return false;
+        }
+        const old = oldItems.find( ( o ) => o.key === item.key );
+        return old
+            ? ! pendingQuantity.includes( item.key ) &&
+                    item.quantity !== old.quantity &&
+                    old.quantity > 0
+            : false;
+    } );
 	return [
 		...autoDeletedToNotify.map( ( item ) =>
 			// TODO: move the message template to iAPI config.
@@ -329,58 +329,76 @@ const { state, actions } = store< Store >(
 	'woocommerce',
 	{
 		actions: {
-			*removeCartItem( key: string ) {
-				// Track what changes we're making for notice comparison.
-				const quantityChanges: QuantityChanges = {
-					cartItemsPendingDelete: [ key ],
-				};
+            *removeCartItem( key: string ) {
+                // Find the item to be removed
+                const itemToRemove = state.cart.items.find(
+                    ( item ) => item.key === key
+                );
 
-				// Capture cart state after optimistic updates for notice comparison.
-				let cartAfterOptimistic: typeof state.cart | null = null;
+                // FIX 1: Evaluate state BEFORE server request
+                // If there is 1 item in the cart, this is the last one.
+                const isLastItem = state.cart.items.length === 1;
 
-				try {
-					const result = yield sendCartRequest( state, {
-						path: '/wc/store/v1/cart/remove-item',
-						method: 'POST',
-						body: { key },
-						applyOptimistic: () => {
-							state.cart.items = state.cart.items.filter(
-								( item ) => item.key !== key
-							);
-							// Capture state after optimistic update.
-							cartAfterOptimistic = JSON.parse(
-								JSON.stringify( state.cart )
-							);
-						},
-						// Side effects run synchronously during reconciliation,
-						// before isProcessing clears. This prevents
-						// refreshCartItems from running during these events.
-						onSettled: ( { success } ) => {
-							if ( success ) {
-								emitSyncEvent( { quantityChanges } );
-							}
-						},
-					} );
+                // FIX 2: Instant notice handling (before waiting for server response)
+                if ( isLastItem ) {
+                    // Removing the last item:
+                    // 1. Do not show "Removed" banner.
+                    // 2. CLEAR ALL old notices (true) instantly to prevent race conditions.
+                    yield actions.updateNotices( [], true );
+                } else if ( itemToRemove && itemToRemove.name ) {
+                    // Removing a non-last item:
+                    // 1. Show "Removed" banner INSTANTLY.
+                    // 2. Do not delete old notices (false) to see list on rapid deletions.
+                    const message = '"%s" was removed from your cart.'.replace(
+                        '%s',
+                        itemToRemove.name
+                    );
+                    yield actions.updateNotices( [ generateInfoNotice( message ) ], false );
+                }
 
-					// Show notices from server response.
-					const cart = result.data as Cart;
-					if ( cart && cartAfterOptimistic ) {
-						const infoNotices = getInfoNoticesFromCartUpdates(
-							cartAfterOptimistic,
-							cart,
-							quantityChanges
-						);
-						const errorNotices =
-							cart.errors.map( generateErrorNotice );
-						yield actions.updateNotices(
-							[ ...infoNotices, ...errorNotices ],
-							true
-						);
-					}
-				} catch ( error ) {
-					actions.showNoticeError( error as Error );
-				}
-			},
+                const quantityChanges: QuantityChanges = {
+                    cartItemsPendingDelete: [ key ],
+                };
+
+                // Capture cart state after optimistic updates for notice comparison (retained for consistency, though not used for info notices anymore).
+                let cartAfterOptimistic: typeof state.cart | null = null;
+
+                try {
+                    const result = yield sendCartRequest( state, {
+                        path: '/wc/store/v1/cart/remove-item',
+                        method: 'POST',
+                        body: { key },
+                        applyOptimistic: () => {
+                            state.cart.items = state.cart.items.filter(
+                                ( item ) => item.key !== key
+                            );
+                            cartAfterOptimistic = JSON.parse(
+                                JSON.stringify( state.cart )
+                            );
+                        },
+                        // Side effects run synchronously during reconciliation,
+                        // before isProcessing clears. This prevents
+                        // refreshCartItems from running during these events.
+                        onSettled: ( { success } ) => {
+                            if ( success ) {
+                                emitSyncEvent( { quantityChanges } );
+                            }
+                        },
+                    } );
+
+                    // After server response, handle only errors
+                    const cart = result.data as Cart;
+                    if ( cart ) {
+                        const errorNotices =
+                            cart.errors.map( generateErrorNotice );
+                        if ( errorNotices.length > 0 ) {
+                            yield actions.updateNotices( errorNotices, false );
+                        }
+                    }
+                } catch ( error ) {
+                    actions.showNoticeError( error as Error );
+                }
+            },
 
 			*addCartItem(
 				{


### PR DESCRIPTION
### Summary
This PR fixes critical UX gaps in the cart notices system. It resolves the issue where no notice appeared when removing items and prevents false "Quantity changed to 1" messages during rapid interactions.

### Context & Relation to other PRs
This PR addresses UX issues discovered during testing of **#62766** (Implement request batching/queueing for cart operations). The fixes are designed to work with the new batching logic to ensure a smooth user experience during rapid add/remove flows.

### Changes proposed

**1. Fix for false "Quantity changed to 1" notices**
When items are rapidly deleted and re-added, the system previously treated the re-add as a quantity update. I adjusted the logic in `getInfoNoticesFromCartUpdates` to strictly check if the item existed in the old snapshot and had `old.quantity > 0`. This prevents incorrect "changed to 1" notices on rapid delete/re-add flows.

**2. Implemented Optimistic "Item Removed" notices**
Previously, **no notice was displayed** when an item was removed from the cart. I updated `removeCartItem` to trigger the "Removed" notice instantly alongside the DOM update (before the server response).
*   **If deleting the last item:** The system detects this is the last item, clears all notices immediately, and allows the "Your cart is currently empty!" placeholder to appear cleanly. This ensures that adding a new item afterwards starts with a fresh state, without showing outdated "removed" notices from the previous session.

### UI/UX Recommendations for Future Improvements
While this PR fixes the logic of the notices, the current notification system has UX drawbacks that should be addressed to make the Mini-Cart feel modern and stable:

*   **Move Notice Banner to Bottom:** Currently, notices appear at the top of the Mini-Cart. This causes the entire item list to jump up and down whenever a notice appears or disappears (layout shift). I recommend moving the notice container to the **bottom of the mini-cart**, just before the "View Cart" and "Checkout" buttons, to stop the content from jumping.
*   **Auto-dismissal:** Notices should automatically disappear after a short duration (e.g., **2 seconds**) instead of staying visible until the page reloads or manual close. This keeps the interface clean.
*   **Remove Manual Close Buttons:** For transient success messages, the "X" (close) buttons are redundant and clutter the UI. A modern approach relies on auto-dismissal or context clearing.

### How to test the changes

**Manual Testing Artifact:**
For faster manual testing, you can use the following compiled `cart.js` file based on the logic in PR #62766:
[cart.js](https://github.com/user-attachments/files/25039734/cart.js)

**Test Steps:**

1.  **Test Fix 1 (False notices):**
    *   Add 5-6 different simple products to the cart.
    *   Open the Mini-Cart.
    *   Rapidly delete all 5-6 items one by one.
    *   Immediately re-add them quickly.
    *   **Expected:** You should **NOT** see a notice saying "The quantity of [Product] was changed to 1".

2.  **Test Fix 2 (Instant feedback):**
    *   Add items again to the cart.
    *   Click "Remove" on one item.
    *   **Expected:** The notice "was removed from your cart." should appear **instantly** with your click. The item disappears from the list, and the notice appears *before* the server responds (Optimistic UI), confirming the action without lag.

3.  **Test Last Item & Clean State:**
    *   Delete the last remaining item in the cart.
    *   **Expected:** All previous notices should clear **immediately** as the "Your cart is currently empty!" placeholder appears.
    *   Add a new product to this empty cart.
    *   **Expected:** The new item appears. There should be **no** lingering "removed" notices from the previous deletion session.