### PR TITLE
Re-add the AccessiblePrivateMethods trait

### DIFF
--- a/plugins/woocommerce/changelog/pr-63087
+++ b/plugins/woocommerce/changelog/pr-63087
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Re-add the AccessiblePrivateMethods trait

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -77575,6 +77575,12 @@ parameters:
 			path: src/Internal/StockNotifications/StockSyncController.php
 
 		-
+			message: '#^Trait Automattic\\WooCommerce\\Internal\\Traits\\AccessiblePrivateMethods is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Internal/Traits/AccessiblePrivateMethods.php
+
+		-
 			message: '#^Cannot call method format\(\) on DateTime\|false\.$#'
 			identifier: method.nonObject
 			count: 4

--- a/plugins/woocommerce/src/Internal/Traits/AccessiblePrivateMethods.php
+++ b/plugins/woocommerce/src/Internal/Traits/AccessiblePrivateMethods.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Traits;
+
+/**
+ * DON'T USE THIS TRAIT. It's DEPRECATED and will be REMOVED in a future version of WooCommerce.
+ *
+ * If you have class methods that are public solely because they are the target of WordPress hooks,
+ * make the methods public and mark them with an @internal annotation.
+ *
+ * @deprecated 9.6.0 Make the hook target methods public and mark them with an @internal annotation. This trait will be REMOVED in a future version of WooCommerce.
+ */
+trait AccessiblePrivateMethods {
+    // phpcs:disable
+
+	private $_accessible_private_methods = array();
+
+	private static $_accessible_static_private_methods = array();
+
+	protected static function add_action( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		self::process_callback_before_hooking( $callback );
+		add_action( $hook_name, $callback, $priority, $accepted_args );
+	}
+
+	protected static function add_filter( string $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		self::process_callback_before_hooking( $callback );
+		add_filter( $hook_name, $callback, $priority, $accepted_args );
+	}
+
+	protected static function process_callback_before_hooking( $callback ): void {
+		if ( ! is_array( $callback ) || count( $callback ) < 2 ) {
+			return;
+		}
+
+		$first_item = $callback[0];
+		if ( __CLASS__ === $first_item ) {
+			static::mark_static_method_as_accessible( $callback[1] );
+		} elseif ( is_object( $first_item ) && get_class( $first_item ) === __CLASS__ ) {
+			$first_item->mark_method_as_accessible( $callback[1] );
+		}
+	}
+
+	protected function mark_method_as_accessible( string $method_name ): bool {
+		if ( method_exists( $this, $method_name ) ) {
+			$this->_accessible_private_methods[ $method_name ] = $method_name;
+			return true;
+		}
+
+		return false;
+	}
+
+	protected static function mark_static_method_as_accessible( string $method_name ): bool {
+		if ( method_exists( __CLASS__, $method_name ) ) {
+			static::$_accessible_static_private_methods[ $method_name ] = $method_name;
+			return true;
+		}
+
+		return false;
+	}
+
+	public function __call( $name, $arguments ) {
+		if ( isset( $this->_accessible_private_methods[ $name ] ) ) {
+			return call_user_func_array( array( $this, $name ), $arguments );
+		} elseif ( is_callable( array( 'parent', '__call' ) ) ) {
+			return parent::__call( $name, $arguments );
+		} elseif ( method_exists( $this, $name ) ) {
+			throw new \Error( 'Call to private method ' . get_class( $this ) . '::' . $name );
+		} else {
+			throw new \Error( 'Call to undefined method ' . get_class( $this ) . '::' . $name );
+		}
+	}
+
+	public static function __callStatic( $name, $arguments ) {
+		if ( isset( static::$_accessible_static_private_methods[ $name ] ) ) {
+			return call_user_func_array( array( __CLASS__, $name ), $arguments );
+		} elseif ( is_callable( array( 'parent', '__callStatic' ) ) ) {
+			return parent::__callStatic( $name, $arguments );
+		} elseif ( 'add_action' === $name || 'add_filter' === $name ) {
+			$proper_method_name = 'add_static_' . substr( $name, 4 );
+			throw new \Error( __CLASS__ . '::' . $name . " can't be called statically, did you mean '$proper_method_name'?" );
+		} elseif ( method_exists( __CLASS__, $name ) ) {
+			throw new \Error( 'Call to private method ' . __CLASS__ . '::' . $name );
+		} else {
+			throw new \Error( 'Call to undefined method ' . __CLASS__ . '::' . $name );
+		}
+	}
+
+    // phpcs:enable
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `AccessiblePrivateMethods` trait was introduced in WooCommerce 7.0 inside the `Internal` namespace, so intended for usage inside WooCommerce core only. In WooCommerce 9.6 it was marked as deprecated, with its docblock indicating that it would be removed in 10.5. The removal was done in https://github.com/woocommerce/woocommerce/pull/52937.

Unfortunately, there's at least one instance of a plugin using the trait. The plugin has been upgraded to remove its usage, but sites with an older version of the plugin will crash. So this pull request re-adds the trait.

### How to test the changes in this Pull Request:

Add the following snippet:

```php
class Test {
	use \Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;

	public function __construct() {
		echo "If you can read this, it works.\n";
	}
}
```

...then run `wp eval "new Test();"`.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
