### PR TITLE
Add email editor development skill

### DIFF
--- a/.ai/skills/woocommerce-email-editor/SKILL.md
+++ b/.ai/skills/woocommerce-email-editor/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: woocommerce-email-editor
+description: Setup and develop the WooCommerce block email editor. Use when working on email templates, transactional emails, or the email editor feature.
+---
+
+# WooCommerce Email Editor Development
+
+This skill provides guidance for developing the WooCommerce block email editor.
+
+## When to Use This Skill
+
+Invoke this skill when:
+
+- Setting up local development for the email editor
+- Working on email templates or transactional emails
+- Modifying the email editor PHP or JS packages
+- Testing email sending functionality
+
+## Development Environment Setup
+
+### 1. Start WooCommerce wp-env
+
+```sh
+pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env start
+```
+
+Site runs at <http://localhost:8888>
+
+### 2. Start the watcher
+
+Watches and builds admin JS files (including the email editor JS package) and syncs Email Editor PHP package changes:
+
+```sh
+pnpm --filter=@woocommerce/plugin-woocommerce watch:build:admin
+```
+
+### 3. Enable the block email editor feature
+
+Visit <http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features> and enable the block email editor.
+
+### 4. Edit transactional emails
+
+Visit <http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=email>
+
+## Email Testing with Mailpit
+
+To test email sending locally, use Mailpit as a local SMTP server.
+
+### Configure SMTP
+
+Add to `plugins/woocommerce/.wp-env.override.json`:
+
+```json
+{
+    "lifecycleScripts": {
+        "afterStart": "./tests/e2e-pw/bin/test-env-setup.sh && wp-env run cli wp plugin install wp-mail-smtp --activate"
+    },
+    "config": {
+        "WPMS_ON": true,
+        "WPMS_MAILER": "smtp",
+        "WPMS_SMTP_HOST": "host.docker.internal",
+        "WPMS_SMTP_PORT": "1025",
+        "WPMS_SMTP_AUTH": false,
+        "WPMS_SMTP_SECURE": ""
+    }
+}
+```
+
+### Start Mailpit
+
+```sh
+docker run --rm --name=mailpit -p 1025:1025 -p 8025:8025 -d axllent/mailpit
+```
+
+Or if the container already exists:
+
+```sh
+docker start mailpit
+```
+
+### View emails
+
+Open <http://localhost:8025> to see captured emails.
+
+### Restart wp-env
+
+After creating or modifying `.wp-env.override.json`, restart the environment:
+
+```sh
+pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env start --update
+```
+
+## Key Paths
+
+| Path | Description |
+| ---- | ----------- |
+| `packages/php/email-editor/` | Email Editor PHP package |
+| `packages/js/email-editor/` | Email Editor JS package |
+| `plugins/woocommerce/.wp-env.override.json` | Local wp-env config (gitignored) |
+
+## Building the Email Editor Package
+
+To rebuild the JS package after changes:
+
+```sh
+pnpm --filter=@woocommerce/email-editor build
+```
+
+## Testing the PHP Package
+
+Run tests from the `packages/php/email-editor/` directory.
+
+### Setup
+
+```sh
+cd packages/php/email-editor
+wp-env start
+composer dump-autoload
+```
+
+### Run integration tests
+
+```sh
+wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist
+```
+
+### Run a specific test
+
+```sh
+wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist --filter Table_Test
+```
+
+## Linting the PHP Package
+
+Run from the `packages/php/email-editor/` directory.
+
+### PHPStan
+
+```sh
+cd tasks/phpstan && ./run-phpstan.sh
+```
+
+For PHP 7 compatibility:
+
+```sh
+cd tasks/phpstan && ./run-phpstan.sh php7
+```
+
+### PHPCS
+
+```sh
+composer run phpcs
+```

--- a/.ai/skills/woocommerce-email-editor/SKILL.md
+++ b/.ai/skills/woocommerce-email-editor/SKILL.md
@@ -24,7 +24,7 @@ Invoke this skill when:
 pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env start
 ```
 
-Site runs at <http://localhost:8888>
+Site runs at `http://localhost:8888` by default. If port 8888 is unavailable, wp-env assigns a different port. Check the startup output or run `wp-env info` to see your actual URL.
 
 ### 2. Start the watcher
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ The `.ai/skills/` directory contains procedural HOW-TO instructions:
 - **`woocommerce-code-review`** - Code review standards and critical violations to flag
 - **`woocommerce-markdown`** - Markdown writing and editing guidelines
 - **`woocommerce-git`** - Guidelines for git and GitHub operations
+- **`woocommerce-email-editor`** - Email editor development setup and Mailpit configuration
 
 **CRITICAL:** After reading a skill, check if a personal skill override file exists at
 `~/.ai/skills/{skill-name}-personal/SKILL.md` and apply it too. For example, for the


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a Claude Code skill for setting up and developing the WooCommerce block email editor. This includes:

- Development environment setup instructions (wp-env, watcher)
- Mailpit configuration for local email testing
- PHP package testing and linting commands
- Key paths and build commands

### How to test the changes in this Pull Request:

1. Verify the skill file exists at `.ai/skills/woocommerce-email-editor/SKILL.md`
2. Confirm the skill is listed in `CLAUDE.md` under Available Skills
3. If using Claude Code, verify the skill can be invoked with `/woocommerce-email-editor`

### Testing that has already taken place:

- Verified skill file structure matches existing skills in the repo
- Tested the documented commands locally

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR only adds Claude Code skill documentation in the `.ai/skills/` directory. It does not affect WooCommerce functionality or user-facing features.

</details>