### PR TITLE
Enable customer cancelled order email notification by default for new stores

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7769-notification-order-canceled-deactivated-by-default
+++ b/plugins/woocommerce/changelog/stomail-7769-notification-order-canceled-deactivated-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable customer cancelled order email notification by default for new installations

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
@@ -185,7 +185,7 @@ if ( ! class_exists( 'WC_Email_Customer_Cancelled_Order', false ) ) :
 					'title'   => __( 'Enable/Disable', 'woocommerce' ),
 					'type'    => 'checkbox',
 					'label'   => __( 'Enable this email notification', 'woocommerce' ),
-					'default' => 'yes',
+					'default' => $this->block_email_editor_enabled ? 'yes' : 'no',
 				),
 				'subject'            => array(
 					'title'       => __( 'Subject', 'woocommerce' ),

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
@@ -185,7 +185,7 @@ if ( ! class_exists( 'WC_Email_Customer_Cancelled_Order', false ) ) :
 					'title'   => __( 'Enable/Disable', 'woocommerce' ),
 					'type'    => 'checkbox',
 					'label'   => __( 'Enable this email notification', 'woocommerce' ),
-					'default' => 'no',
+					'default' => 'yes',
 				),
 				'subject'            => array(
 					'title'       => __( 'Subject', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR enables the "Customer Cancelled Order" email notification by default for new WooCommerce installations.

**Why this change is needed:**

The customer order cancellation email was introduced in WooCommerce 10.0.0 ([PR #57987](https://github.com/woocommerce/woocommerce/pull/57987)), but was disabled by default at the time to avoid automatically sending cancellation emails to existing stores' customers without explicit opt-in.

However, for **new stores**, having this email enabled by default provides a better customer experience:
- Customers are notified when their order has been cancelled
- This aligns with industry standards
- It improves communication and transparency between store owners and their customers

**What this change does:**

Changes the default value of the `enabled` setting in `WC_Email_Customer_Cancelled_Order` from `'no'` to `'yes'`.

This change **only affects new WooCommerce installations**. Existing stores will retain their current settings.

Closes https://linear.app/a8c/issue/STOMAIL-7769/notification-order-canceled-deactivated-by-default

(For Bug Fixes) Bug introduced in PR # .



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh WooCommerce installation (or reset your existing installation to simulate a new store)
2. Navigate to **WooCommerce > Settings > Emails**
3. Find the "Cancelled order" email
4. Verify that the email is **enabled** by default (checkbox should be checked)

**For existing stores:**
1. If you have an existing store with the "Cancelled order" email disabled
2. After updating to this version, verify that your existing setting is preserved (email remains disabled)
3. The change should only affect the default value for new installations

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
