### PR TITLE
Prevent Concurrent Installations

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-install-atomicity
+++ b/plugins/woocommerce/changelog/fix-wc-install-atomicity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Use atomic locking to prevent WC_Install::install() from running concurrently.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -692,7 +692,7 @@ class WC_Install {
 
 	/**
 	 * Releases the installation lock.
-	 * 
+	 *
 	 * @return bool True if the lock was released, false otherwise. (False could also mean the lock was not present).
 	 */
 	private static function release_lock() {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -692,6 +692,8 @@ class WC_Install {
 
 	/**
 	 * Releases the installation lock.
+	 * 
+	 * @return bool True if the lock was released, false otherwise. (False could also mean the lock was not present).
 	 */
 	private static function release_lock() {
 		return delete_option( 'wc_installing' );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -662,31 +662,32 @@ class WC_Install {
 	 *
 	 * @return bool True if a lock was acquired, otherwise false.
 	 */
-	private static function create_lock() {
+	private static function create_lock(): bool {
 		global $wpdb;
 
 		// Insert will fail if it already exists so this functions as a mutex.
-		$inserted = $wpdb->query(
+		$created_lock = $wpdb->query(
 			$wpdb->prepare(
 				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES ('wc_installing', %d, 'no')",
 				time()
 			)
 		);
-		if ( $inserted ) {
+
+		// Take over the lock if it's stale (older than 10 minutes).
+		if ( ! $created_lock ) {
+			$created_lock = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->options} SET option_value = %d WHERE option_name = 'wc_installing' AND option_value < %d",
+					time(),
+					time() - ( MINUTE_IN_SECONDS * 10 )
+				)
+			);
+		}
+
+		if ( $created_lock ) {
 			// Set the transient for backward compatibility in case others are relying on it to signal an ongoing install.
 			set_transient( 'wc_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 			return true;
-		}
-
-		// Atomically delete the lock and try again if it is stale.
-		$deleted = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM {$wpdb->options} WHERE option_name = 'wc_installing' AND option_value < %d",
-				time() - ( MINUTE_IN_SECONDS * 10 )
-			)
-		);
-		if ( $deleted ) {
-			return self::create_lock();
 		}
 
 		return false;
@@ -694,10 +695,8 @@ class WC_Install {
 
 	/**
 	 * Releases the installation lock.
-	 *
-	 * @return bool True if the lock was released, false otherwise. (False could also mean the lock was not present).
 	 */
-	private static function release_lock() {
+	private static function release_lock(): void {
 		// Delete the transient BEFORE the option to avoid races that might result in an active lock with an empty transient.
 		delete_transient( 'wc_installing' );
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -673,6 +673,8 @@ class WC_Install {
 			)
 		);
 		if ( $inserted ) {
+			// Set the transient for backward compatibility in case others are relying on it to signal an ongoing install.
+			set_transient( 'wc_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 			return true;
 		}
 
@@ -696,7 +698,10 @@ class WC_Install {
 	 * @return bool True if the lock was released, false otherwise. (False could also mean the lock was not present).
 	 */
 	private static function release_lock() {
-		return delete_option( 'wc_installing' );
+		// Delete the transient BEFORE the option to avoid races that might result in an active lock with an empty transient.
+		delete_transient( 'wc_installing' );
+
+		delete_option( 'wc_installing' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -700,7 +700,8 @@ class WC_Install {
 		// Delete the transient BEFORE the option to avoid races that might result in an active lock with an empty transient.
 		delete_transient( 'wc_installing' );
 
-		delete_option( 'wc_installing' );
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name = 'wc_installing'" );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -586,19 +586,16 @@ class WC_Install {
 			return;
 		}
 
-		// Check if we are not already running this routine.
-		if ( self::is_installing() ) {
+		// Create a lock to prevent multiple installs from running simultaneously.
+		if ( ! self::create_lock() ) {
 			return;
 		}
 
-		// If we made it till here nothing is running yet, lets set the transient now.
-		set_transient( 'wc_installing', 'yes', MINUTE_IN_SECONDS * 10 );
-		wc_maybe_define_constant( 'WC_INSTALLING', true );
-
 		try {
+			wc_maybe_define_constant( 'WC_INSTALLING', true );
 			self::install_core();
 		} finally {
-			delete_transient( 'wc_installing' );
+			self::release_lock();
 		}
 
 		// Use add_option() here to avoid overwriting this value with each
@@ -661,12 +658,43 @@ class WC_Install {
 	}
 
 	/**
-	 * Returns true if we're installing.
+	 * Attempts to acquire an installation lock.
 	 *
-	 * @return bool
+	 * @return bool True if a lock was acquired, otherwise false.
 	 */
-	private static function is_installing() {
-		return 'yes' === get_transient( 'wc_installing' );
+	private static function create_lock() {
+		global $wpdb;
+
+		// Insert will fail if it already exists so this functions as a mutex.
+		$inserted = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES ('wc_installing', %d, 'no')",
+				time()
+			)
+		);
+		if ( $inserted ) {
+			return true;
+		}
+
+		// Atomically delete the lock and try again if it is stale.
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = 'wc_installing' AND option_value < %d",
+				time() - ( MINUTE_IN_SECONDS * 10 )
+			)
+		);
+		if ( $deleted ) {
+			return self::create_lock();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Releases the installation lock.
+	 */
+	private static function release_lock() {
+		return delete_option( 'wc_installing' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -190,5 +190,6 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 		include dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/uninstall.php';
 		delete_transient( 'wc_installing' );
+		delete_option( 'wc_installing' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/category-lookup.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/category-lookup.php
@@ -26,7 +26,9 @@ class WC_Admin_Tests_Category_Lookup extends WP_UnitTestCase {
 	 */
 
 	public function setUp(): void {
-		delete_transient('wc_installing');
+		delete_transient( 'wc_installing' );
+		delete_option( 'wc_installing' );
+
 		parent::setUp();
 		$parent                = wp_insert_term( 'test_parent', 'product_cat' );
 		$parent2               = wp_insert_term( 'test_parent_2', 'product_cat' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -139,6 +139,8 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 */
 	public function test_options_are_set() {
 		delete_transient( 'wc_installing' );
+		delete_option( 'wc_installing' );
+
 		WC_Install::install();
 
 		$options = array(
@@ -157,6 +159,8 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 */
 	public function test_woocommerce_admin_installed_action() {
 		delete_transient( 'wc_installing' );
+		delete_option( 'wc_installing' );
+
 		WC_Install::install();
 		$this->assertTrue( did_action( 'woocommerce_admin_installed' ) > 0 );
 	}
@@ -229,6 +233,8 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 */
 	public function test_migrate_options() {
 		delete_transient( 'wc_installing' );
+		delete_option( 'wc_installing' );
+
 		WC_Install::install();
 		$this->assertTrue( defined( 'WC_ADMIN_MIGRATING_OPTIONS' ) );
 		$migrated_options = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request swaps out the transient locking mechanism in `WC_Install::install()` with direct database queries. Previously, it was possible for more than one process to enter the install function because of the time gap between checking for the lock and setting it.

This new mutex relies on database atomicity to prevent more than one request from entering the install function at a time. This is done by relying on the unique key of `option_name` and `INSERT`ing a lock. The first request will set the lock and the rest will fail. I have also maintained the 10 minute transient timeout by storing a timestamp and clearing stale locks.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Unfortunately, by their nature, race conditions are quite difficult to test. In cases like this, code correctness and verifying existing functionality are the best we can hope for. I considered creating a unit test to make sure that the lock worked, however, the fact that the PHPUnit and E2E suites run at all is a test of that behavior.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
