### PR TITLE
Move `handleSubmit` inside `addToCart` in `add-to-cart-with-options` store

### DIFF
--- a/plugins/woocommerce/changelog/63105-wooplug-6240-unify-submit-actions-in-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/63105-wooplug-6240-unify-submit-actions-in-add-to-cart-with-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move `handleSubmit` inside `addToCart` in `add-to-cart-with-options` store.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
@@ -28,6 +28,7 @@ jest.mock(
 			}
 			return { state: {} };
 		} ),
+		withSyncEvent: jest.fn( ( fn ) => fn ),
 	} ),
 	{ virtual: true }
 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { store, getContext, getConfig } from '@wordpress/interactivity';
+import {
+	store,
+	getContext,
+	getConfig,
+	withSyncEvent,
+} from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
 	SelectedAttributes,
@@ -330,7 +335,7 @@ const { actions, state } = store<
 					validationErrors.length = 0;
 				}
 			},
-			*addToCart( event: SubmitEvent ) {
+			addToCart: withSyncEvent( function* ( event: SubmitEvent ) {
 				event.preventDefault();
 
 				const { isFormValid } = state;
@@ -416,7 +421,7 @@ const { actions, state } = store<
 						showCartUpdatesNotices: false,
 					}
 				);
-			},
+			} ),
 		},
 	},
 	{ lock: universalLock }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -167,8 +167,7 @@ export type AddToCartWithOptionsStore = {
 		setQuantity: ( productId: number, value: number ) => void;
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
-		addToCart: () => void;
-		handleSubmit: ( event: SubmitEvent ) => void;
+		addToCart: ( event: SubmitEvent ) => void;
 	};
 };
 
@@ -331,7 +330,46 @@ const { actions, state } = store<
 					validationErrors.length = 0;
 				}
 			},
-			*addToCart() {
+			*addToCart( event: SubmitEvent ) {
+				event.preventDefault();
+
+				const { isFormValid } = state;
+
+				if ( ! isFormValid ) {
+					// Dynamically import the store module first
+					yield import( '@woocommerce/stores/store-notices' );
+
+					const { actions: noticeActions } = store< StoreNotices >(
+						'woocommerce/store-notices',
+						{},
+						{
+							lock: universalLock,
+						}
+					);
+
+					const { noticeIds, validationErrors } = state;
+
+					// Clear previous notices.
+					noticeIds.forEach( ( id ) => {
+						noticeActions.removeNotice( id );
+					} );
+					noticeIds.splice( 0, noticeIds.length );
+
+					// Add new notices and track their IDs.
+					const newNoticeIds = validationErrors.map( ( error ) =>
+						noticeActions.addNotice( {
+							notice: error.message,
+							type: 'error',
+							dismissible: true,
+						} )
+					);
+
+					// Store the new IDs in-place.
+					noticeIds.push( ...newNoticeIds );
+
+					return;
+				}
+
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.
 				yield import( '@woocommerce/stores/woocommerce/cart' );
@@ -378,48 +416,6 @@ const { actions, state } = store<
 						showCartUpdatesNotices: false,
 					}
 				);
-			},
-			*handleSubmit( event: SubmitEvent ) {
-				event.preventDefault();
-
-				const { isFormValid } = state;
-
-				if ( ! isFormValid ) {
-					// Dynamically import the store module first
-					yield import( '@woocommerce/stores/store-notices' );
-
-					const { actions: noticeActions } = store< StoreNotices >(
-						'woocommerce/store-notices',
-						{},
-						{
-							lock: universalLock,
-						}
-					);
-
-					const { noticeIds, validationErrors } = state;
-
-					// Clear previous notices.
-					noticeIds.forEach( ( id ) => {
-						noticeActions.removeNotice( id );
-					} );
-					noticeIds.splice( 0, noticeIds.length );
-
-					// Add new notices and track their IDs.
-					const newNoticeIds = validationErrors.map( ( error ) =>
-						noticeActions.addNotice( {
-							notice: error.message,
-							type: 'error',
-							dismissible: true,
-						} )
-					);
-
-					// Store the new IDs in-place.
-					noticeIds.push( ...newNoticeIds );
-
-					return;
-				}
-
-				yield actions.addToCart();
 			},
 		},
 	},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -539,7 +539,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			} else {
 				// Otherwise, we use the Interactivity API.
 				$form_attributes = array(
-					'data-wp-on--submit' => 'actions.handleSubmit',
+					'data-wp-on--submit' => 'actions.addToCart',
 				);
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #63104 .

This PR simplifies the Add to Cart with Options block by consolidating two separate actions (`handleSubmit` and `addToCart`) into a single unified `addToCart` action.

Additionally, I took the opportunity to wrap the action with `withSyncEvent`, which removes a console warning and ensures it will work correctly after WordPress 7.0.

#### Reasoning

Previously, the form submission flow was split across two actions:
- `handleSubmit` - Called on form submit, handled `preventDefault()`, form validation, and error notices
- `addToCart` - Handled the actual cart addition logic

This separation added unnecessary indirection since `handleSubmit` always called `addToCart` at the end when validation passed. By merging them, we:

1. **Reduce complexity** - One action instead of two for the same user interaction
2. **Improve code clarity** - The complete submission flow is now visible in a single function
3. **Simplify the public API** - One fewer action exposed in the store type definition

### How to test the changes in this Pull Request:

The Add to cart with options should keep working as before, and e2e tests should pass. You can test manually with different types of products like simple, variation, or grouped.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Move `handleSubmit` inside `addToCart` in `add-to-cart-with-options` store.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
