### PR TITLE
Fix: Ensure POS catalog cleanup action is scheduled for each file

### DIFF
--- a/plugins/woocommerce/changelog/63107-wooplug-6241-pos-catalog-cleanup-job-isnt-scheduled
+++ b/plugins/woocommerce/changelog/63107-wooplug-6241-pos-catalog-cleanup-job-isnt-scheduled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix POS catalog cleanup job to schedule deletion for each generated file instead of only the first one.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -207,7 +207,7 @@ class AsyncGenerator {
 					$feed->get_file_path(),
 				),
 				'woo-product-feed',
-				true
+				false
 			);
 		} catch ( \Throwable $e ) {
 			wc_get_logger()->error(


### PR DESCRIPTION
Closes WOOPLUG-6241


### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WooCommerce creates a catalog file for each unique set of product/variation fields provided in the request. However, the cleanup job was previously marked as unique (`$unique = true` in `as_schedule_single_action`), which resulted in only the first file's cleanup action being scheduled, while subsequent files would not get their cleanup scheduled.

This PR changes the `$unique` parameter to `false` in the `as_schedule_single_action` call at `AsyncGenerator.php:210`, ensuring that a cleanup action is scheduled for each individual catalog file.



### Screenshots or screen recordings:

N/A - Backend logic change with no UI impact.

### How to test the changes in this Pull Request:

1. Make a POST request to `/wp-json/wc/pos/v1/catalog/create` with:
   ```json
   {
     "_product_fields": "sku"
   }
   ```
2. Make another POST request to `/wp-json/wc/pos/v1/catalog/create` with a different set of fields:
   ```json
   {
     "_product_fields": "id"
   }
   ```
3. Go to **WP Admin → WooCommerce → Status → Scheduled Actions → Pending**
4. Search for "feed"
5. **Expected:** Two separate cleanup jobs should be scheduled (one for each catalog file)
6. **Before this fix:** Only one cleanup job was scheduled for the first file

### Testing that has already taken place:

Code review and logic analysis confirming the fix addresses the root cause.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix POS catalog cleanup job to schedule deletion for each generated file instead of only the first one.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)