### PR TITLE
`release-compile-changelog.yml`: do not show empty changelog warning when appending

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -5,6 +5,10 @@ on:
       version:
         description: 'Version (in X.Y or X.Y.Z format). Branch "release/{x.y.z}" or "release/{x.y}" should already exist.'
         required: true
+      release_date:
+        description: 'Release date in YYYY-MM-DD format. If not provided, the current date will be used.'
+        required: false
+        default: ''        
       append_changelog:
         description: 'Append or replace entries in changelog?'
         type: choice
@@ -14,10 +18,6 @@ on:
           - append
         required: false
         default: auto
-      release_date:
-        description: 'Release date in YYYY-MM-DD format. If not provided, the current date will be used.'
-        required: false
-        default: ''
 
 concurrency:
   group: release-compile-changelog-${{ inputs.version }}

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -273,9 +273,10 @@ export const updateReleaseBranchChangelogs = async (
 			};
 		}
 		Logger.notice( `Creating PR for ${ branch }` );
-		const warningMessage = noEntriesWritten
-			? '> [!CAUTION]\n> No entries were written to the changelog. You will be required to manually add a changelog entry before releasing.\n\n'
-			: '';
+		const warningMessage =
+			noEntriesWritten && ! options.appendChangelog
+				? '> [!CAUTION]\n> No entries were written to the changelog. You will be required to manually add a changelog entry before releasing.\n\n'
+				: '';
 		const pullRequest = await createPullRequest( {
 			owner,
 			name,


### PR DESCRIPTION
### Submission Review Guidelines:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #62110 we added a warning to the PR generated by the `release-compile-changelog.yml` workflow when no entry was written to the changelog. This to ensure that no release goes out with an empty changelog section.

However, the warning is appearing even when compiling the changelog between pre-release versions (say, `beta.1` to `beta.2` or `rc.1` to `rc.2`) which is unnecessary, given the changelog for pre-releases is additive and it's ok that a particular pre-release doesn't write any changelog entries (the first changelog for `beta.1` will be checked, though).


<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository, including the `trunk` branch and merge this branch into it.
1. Ensure your repository has milestone `10.6.0` created.
1. In your fork, create `release/10.6` off the `trunk` branch.
1. Go to **Actions > Release: Bump version number** and run the workflow with inputs `release/10.6` and `beta`. Merge the resulting PR.
1. Go to **Actions > Release: Compile changelog** and run the workflow with input `10.6`. Merge the resulting PRs. No warning should appear in the changelog PR.
1. Go to **Actions > Release: Bump version number** and run with inputs `release/10.6` and `rc`. Merge the resulting PR.
1. Go to **Actions > Release: Compile changelog** and run the workflow with input `10.6`. Merge the resulting PR. No warning should appear in the changelog PR despite no new changelog entries.
1. Go to **Actions > Release: Bump version number** and run with inputs `release/10.6` and `stable`. Merge the resulting PR.
1. Go to **Actions > Release: Compile changelog** and run the workflow with input `10.6`. Merge the resulting PR. No warning should appear in the changelog PR despite no new changelog entries.
1. Go to **Actions > Release: Bump version number** and run with inputs `release/10.6` and `stable`. Merge the resulting PR. Version should now be `10.6.1`.
1. Go to **Actions > Release: Compile changelog** and run the workflow with input `10.6`. This PR should have a warning about the empty changelog.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.