### PR TITLE
Allow using main version (`X.Y`) as input in release workflows

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -48,8 +48,10 @@ jobs:
     steps:
       - name: Normalize branch input
         id: normalize-branch
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
         run: |
-          branch="${{ inputs.branch }}"
+          branch="$INPUT_BRANCH"
           if [[ "$branch" =~ ^[0-9]+\.[0-9]+$ ]]; then
             branch="release/$branch"
           fi
@@ -69,7 +71,7 @@ jobs:
 
       - name: Workflow checks
         env:
-          BRANCH: ${{ steps.normalize-branch.outputs.branch || github.ref }}
+          BRANCH: ${{ steps.normalize-branch.outputs.branch }}
         run: |
           # No special checks when running as a reusable workflow.
           if [ "${{ ! contains( github.workflow_ref, 'release-build-zip-file.yml' ) }}" = "true" ]; then
@@ -108,7 +110,7 @@ jobs:
         # Checkout branch.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.normalize-branch.outputs.branch || github.ref }}
+          ref: ${{ steps.normalize-branch.outputs.branch }}
           path: checkout-branch
           sparse-checkout: |
             /plugins/woocommerce/woocommerce.php
@@ -120,7 +122,7 @@ jobs:
         id: pre-build-verification
         if: ${{ ! inputs.skip_verify }}
         env:
-          BRANCH: ${{ steps.normalize-branch.outputs.branch || github.ref }}
+          BRANCH: ${{ steps.normalize-branch.outputs.branch }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch (e.g.: release/x.y).'
+        description: 'Release branch (e.g. "release/9.8" or just "9.8").'
         required: true
       skip_verify:
         description: 'Skip verification steps.'
@@ -43,18 +43,38 @@ jobs:
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
+    outputs:
+      branch: ${{ steps.normalize-branch.outputs.branch }}
     steps:
+      - name: Normalize branch input
+        id: normalize-branch
+        run: |
+          branch="${{ inputs.branch }}"
+          if [[ "$branch" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            branch="release/$branch"
+          fi
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+
+      - run: |
+          echo "Building WooCommerce ZIP: branch=${{ steps.normalize-branch.outputs.branch }}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"          
+
+      - name: Verify release branch
+        env:
+          BRANCH: ${{ steps.normalize-branch.outputs.branch }}
+        run: |
+          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
+            echo "::error::Source branch '$BRANCH' does not exist."
+            exit 1
+          fi
+
       - name: Workflow checks
         env:
-          BRANCH: ${{ inputs.branch || github.ref }}
+          BRANCH: ${{ steps.normalize-branch.outputs.branch || github.ref }}
         run: |
           # No special checks when running as a reusable workflow.
           if [ "${{ ! contains( github.workflow_ref, 'release-build-zip-file.yml' ) }}" = "true" ]; then
             exit 0
           fi
-
-          # Log inputs to console.
-          echo "Building WooCommerce ZIP: branch=${BRANCH}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"
 
           # Write summary header.
           options=""
@@ -88,7 +108,7 @@ jobs:
         # Checkout branch.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ steps.normalize-branch.outputs.branch || github.ref }}
           path: checkout-branch
           sparse-checkout: |
             /plugins/woocommerce/woocommerce.php
@@ -100,7 +120,7 @@ jobs:
         id: pre-build-verification
         if: ${{ ! inputs.skip_verify }}
         env:
-          BRANCH: ${{ inputs.branch || github.ref }}
+          BRANCH: ${{ steps.normalize-branch.outputs.branch || github.ref }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
@@ -181,7 +201,7 @@ jobs:
         with:
           script: |
             const { run } = require( './checkout-trunk/.github/workflows/scripts/release-check-db-updates' );
-            await run( `${{ inputs.branch }}`, { github, context } );
+            await run( `${{ steps.normalize-branch.outputs.branch }}`, { github, context } );
 
   build:
     name: Build release zip file
@@ -193,18 +213,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Verify release branch.
-        env:
-          BRANCH: ${{ inputs.branch || github.ref }}
-        run: |
-          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
-            echo "::error::Source branch '$BRANCH' does not exist."
-            exit 1
-          fi
-
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ needs.verify.outputs.branch }}
 
       - name: Setup WooCommerce Monorepo
         uses: ./.github/actions/setup-woocommerce-monorepo
@@ -235,7 +247,7 @@ jobs:
           echo "artifact-url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
 
           # Fetch commit hash for this build.
-          commit_hash=$(git rev-parse "${{ inputs.branch || github.ref }}")
+          commit_hash=$(git rev-parse "${{ needs.verify.outputs.branch }}")
           echo "commit-hash=$commit_hash" >> $GITHUB_OUTPUT
 
           # Write artifact to summary.

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch'
+        description: 'Release branch (e.g. "release/9.8" or just "9.8")'
         type: string
         required: true
         default: ''
@@ -20,7 +20,7 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: Release branch
+        description: 'Release branch (e.g. "release/9.8" or just "9.8")'
         type: string
         required: true
       bump-type:
@@ -40,17 +40,35 @@ jobs:
     name: Bump WooCommerce Version
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
+      - name: Normalize branch input
+        id: normalize-branch
+        run: |
+          branch="${{ inputs.branch }}"
+          if [[ "$branch" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            branch="release/$branch"
+          fi
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+
+          # Log inputs to console.
+          echo "Bumping version: branch=${branch}, bump-type=${{ inputs.bump-type }}"
+
+      - name: Verify branch exists
+        env:
+          BRANCH: ${{ steps.normalize-branch.outputs.branch }}
+        run: |
+          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${{ steps.normalize-branch.outputs.branch }} > /dev/null; then
+            echo "::error::Source branch '$BRANCH' does not exist."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ steps.normalize-branch.outputs.branch }}
 
       - name: Get current version
         id: get-current-version
         run: |
-          # Log inputs to console.
-          echo "Bumping version: branch=${{ inputs.branch }}, bump-type=${{ inputs.bump-type }}"
-
           version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
           echo "Current version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
@@ -60,7 +78,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = `${{ inputs.branch }}`;
+            const branch = `${{ steps.normalize-branch.outputs.branch }}`;
             const bumpType = `${{ inputs.bump-type }}`;
             const currentVersion = '${{ steps.get-current-version.outputs.version }}';
 
@@ -227,9 +245,9 @@ jobs:
 
           # Create PR and capture URL.
           pr_url=$(gh pr create \
-            --title 'Bump WooCommerce version to `${{ steps.compute-new-version.outputs.nextVersion }}` on `${{ inputs.branch }}`' \
-            --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.'$'\n\n''<!-- [x] This Pull Request does not require a changelog -->' \
-            --base ${{ inputs.branch }} \
+            --title 'Bump WooCommerce version to `${{ steps.compute-new-version.outputs.nextVersion }}` on `${{ steps.normalize-branch.outputs.branch }}`' \
+            --body 'This PR updates the versions in ${{ steps.normalize-branch.outputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.'$'\n\n''<!-- [x] This Pull Request does not require a changelog -->' \
+            --base ${{ steps.normalize-branch.outputs.branch }} \
             --head ${branch_name} \
             --label Release \
             ${reviewer_arg} \

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -42,8 +42,10 @@ jobs:
     steps:
       - name: Normalize branch input
         id: normalize-branch
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
         run: |
-          branch="${{ inputs.branch }}"
+          branch="$INPUT_BRANCH"
           if [[ "$branch" =~ ^[0-9]+\.[0-9]+$ ]]; then
             branch="release/$branch"
           fi
@@ -56,7 +58,7 @@ jobs:
         env:
           BRANCH: ${{ steps.normalize-branch.outputs.branch }}
         run: |
-          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${{ steps.normalize-branch.outputs.branch }} > /dev/null; then
+          if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} "$BRANCH" > /dev/null; then
             echo "::error::Source branch '$BRANCH' does not exist."
             exit 1
           fi


### PR DESCRIPTION
### Submission Review Guidelines:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For simplicity and consistency with the `Release: Compile Changelog` workflow, now the other workflows used while building a release admit the main version (`x.y`) to be specified as input, in addition to an existing branch as usual.

This will let us slightly simplify the release instructions.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->


1. Fork this repository, including `trunk` and merge this branch (`enhancement/release-workflows-use-main-version`) into it.
1. In your fork, Create branch `release/10.6` off of `trunk`.
1. Go to **Actions > Release: Bump version number** and run with inputs `trunk` and type `dev`. This should create a PR bumping `trunk`'s version to `10.7.0-dev`. Close the PR.
1. Go to **Actions > Release: Bump version number** and run with inputs `release/10.6` and type `beta`. This should create a PR bumping on the release branch to `10.6.0-beta.1`. Merge the PR.
1. Go to **Actions > Release: Bump version number** and run with an invalid version number like `10.6.1` or `10.8` and any type. Workflow should fail.
1. Go to **Actions > Release: Bump version number** and run with inputs `10.6` and type `rc`. This should create a PR bumping on the release branch to `10.6.0-rc.1`. Merge the PR.
1. Go to **Actions > Release: Build ZIP file** and run with input `10.6.0` or `foobar` and confirm that the workflow fails.
1. Go to **Actions > Release: Build ZIP file** and run with input `release/10.6` and check `[x] Skip verification steps.` . Confirm a build of `10.6.0-rc.1` is created and attached to the workflow.
1. Go to **Actions > Release: Build ZIP file** and run with input `10.6` and check `[x] Skip verification steps.`. Confirm that `10.6.0-rc.1` is built again and attached to the workflow results.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.