### PR TITLE
Fix PHPStan baseline after email tracker endpoint removal

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpstan-baseline-notes-api
+++ b/plugins/woocommerce/changelog/fix-phpstan-baseline-notes-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix PHPStan baseline after email tracker endpoint removal

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -44712,13 +44712,7 @@ parameters:
 		-
 			message: '#^Call to method get_param\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_REST_Request\.$#'
 			identifier: class.notFound
-			count: 15
-			path: src/Admin/API/Notes.php
-
-		-
-			message: '#^Cannot call method get_name\(\) on Automattic\\WooCommerce\\Admin\\Notes\\Note\|true\.$#'
-			identifier: method.nonObject
-			count: 1
+			count: 13
 			path: src/Admin/API/Notes.php
 
 		-


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Follow-up to #63071 which removed the orphaned email tracker REST endpoint.

The PHPStan baseline contained entries for `src/Admin/API/Notes.php` that no longer match after the `track_opened_email` method was removed:

- Removed the `get_name()` error entry (method call no longer exists in the code)
- Updated `get_param()` count from 15 to 13 (two calls were removed with the endpoint)

Bug introduced in PR #63071.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce phpstan`
3. Verify PHPStan passes with no errors

### Testing that has already taken place:

- Ran full PHPStan analysis locally - passes with no errors
- Verified the baseline changes match the actual errors in the codebase

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Manually created changelog entry