### PR TITLE
Add missing @return PHPDoc annotations to reduce PHPStan baseline

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpstan-add-return-type-annotations
+++ b/plugins/woocommerce/changelog/fix-phpstan-add-return-type-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add missing @return PHPDoc annotations to reduce PHPStan baseline by 374 errors.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -33,6 +33,8 @@ class WC_AJAX {
 
 	/**
 	 * Hook in ajax handlers.
+	 *
+	 * @return void
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'define_ajax' ), 0 );
@@ -53,6 +55,8 @@ class WC_AJAX {
 
 	/**
 	 * Set the 'wc-ajax' argument in $wp_query.
+	 *
+	 * @return void
 	 */
 	private static function set_wc_ajax_argument_in_query() {
 		global $wp_query;
@@ -66,6 +70,8 @@ class WC_AJAX {
 
 	/**
 	 * Set WC AJAX constant and headers.
+	 *
+	 * @return void
 	 */
 	public static function define_ajax() {
 		global $wp_query;
@@ -87,6 +93,8 @@ class WC_AJAX {
 	 * Send headers for WC Ajax Requests.
 	 *
 	 * @since 2.5.0
+	 *
+	 * @return void
 	 */
 	private static function wc_ajax_headers() {
 		if ( ! headers_sent() ) {
@@ -104,6 +112,8 @@ class WC_AJAX {
 
 	/**
 	 * Check for WC Ajax request and fire action.
+	 *
+	 * @return void
 	 */
 	public static function do_wc_ajax() {
 		global $wp_query;
@@ -124,6 +134,8 @@ class WC_AJAX {
 
 	/**
 	 * Hook in methods - uses WordPress ajax handlers (admin-ajax).
+	 *
+	 * @return void
 	 */
 	public static function add_ajax_events() {
 		$ajax_events_nopriv = array(
@@ -243,6 +255,8 @@ class WC_AJAX {
 
 	/**
 	 * Get a refreshed cart fragment, including the mini cart HTML.
+	 *
+	 * @return void
 	 */
 	public static function get_refreshed_fragments() {
 		ob_start();
@@ -266,6 +280,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX apply coupon on checkout page.
+	 *
+	 * @return void
 	 */
 	public static function apply_coupon() {
 
@@ -290,6 +306,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX remove coupon on cart and checkout page.
+	 *
+	 * @return void
 	 */
 	public static function remove_coupon() {
 		check_ajax_referer( 'remove-coupon', 'security' );
@@ -309,6 +327,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX update shipping method on cart page.
+	 *
+	 * @return void
 	 */
 	public static function update_shipping_method() {
 		check_ajax_referer( 'update-shipping-method', 'security' );
@@ -334,6 +354,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX receive updated cart_totals div.
+	 *
+	 * @return void
 	 */
 	public static function get_cart_totals() {
 		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
@@ -344,6 +366,8 @@ class WC_AJAX {
 
 	/**
 	 * Session has expired.
+	 *
+	 * @return void
 	 */
 	private static function update_order_review_expired() {
 		wp_send_json(
@@ -365,6 +389,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX update order review on checkout.
+	 *
+	 * @return void
 	 */
 	public static function update_order_review() {
 		check_ajax_referer( 'update-order-review', 'security' );
@@ -482,6 +508,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX add to cart.
+	 *
+	 * @return void
 	 */
 	public static function add_to_cart() {
 		ob_start();
@@ -530,6 +558,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX remove from cart.
+	 *
+	 * @return void
 	 */
 	public static function remove_from_cart() {
 		ob_start();
@@ -546,6 +576,8 @@ class WC_AJAX {
 
 	/**
 	 * Process ajax checkout form.
+	 *
+	 * @return void
 	 */
 	public static function checkout() {
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
@@ -555,6 +587,8 @@ class WC_AJAX {
 
 	/**
 	 * Get a matching variation based on posted attributes.
+	 *
+	 * @return void
 	 */
 	public static function get_variation() {
 		ob_start();
@@ -579,6 +613,8 @@ class WC_AJAX {
 
 	/**
 	 * Locate user via AJAX.
+	 *
+	 * @return void
 	 */
 	public static function get_customer_location() {
 		$location_hash = WC_Cache_Helper::geolocation_ajax_get_location_hash();
@@ -587,6 +623,8 @@ class WC_AJAX {
 
 	/**
 	 * Toggle Featured status of a product from admin.
+	 *
+	 * @return void
 	 */
 	public static function feature_product() {
 		if ( current_user_can( 'edit_products' ) && check_admin_referer( 'woocommerce-feature-product' ) && isset( $_GET['product_id'] ) ) {
@@ -604,6 +642,8 @@ class WC_AJAX {
 
 	/**
 	 * Mark an order with a status.
+	 *
+	 * @return void
 	 */
 	public static function mark_order_status() {
 		if ( current_user_can( 'edit_shop_orders' ) && check_admin_referer( 'woocommerce-mark-order-status' ) && isset( $_GET['status'], $_GET['order_id'] ) ) {
@@ -625,6 +665,8 @@ class WC_AJAX {
 
 	/**
 	 * Get order details.
+	 *
+	 * @return void
 	 */
 	public static function get_order_details() {
 		check_admin_referer( 'woocommerce-preview-order', 'security' );
@@ -645,6 +687,8 @@ class WC_AJAX {
 
 	/**
 	 * Add an attribute row.
+	 *
+	 * @return void
 	 */
 	public static function add_attribute() {
 		ob_start();
@@ -685,6 +729,8 @@ class WC_AJAX {
 
 	/**
 	 * Add a new attribute via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function add_new_attribute() {
 		check_ajax_referer( 'add-attribute', 'security' );
@@ -720,6 +766,8 @@ class WC_AJAX {
 
 	/**
 	 * Delete variations via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function remove_variations() {
 		check_ajax_referer( 'delete-variations', 'security' );
@@ -740,6 +788,8 @@ class WC_AJAX {
 
 	/**
 	 * Save attributes via ajax.
+	 *
+	 * @return void
 	 */
 	public static function save_attributes() {
 		check_ajax_referer( 'save-attributes', 'security' );
@@ -787,6 +837,8 @@ class WC_AJAX {
 
 	/**
 	 * Save attributes and variations via ajax.
+	 *
+	 * @return void
 	 */
 	public static function add_attributes_and_variations() {
 		check_ajax_referer( 'add-attributes-and-variations', 'security' );
@@ -846,6 +898,8 @@ class WC_AJAX {
 
 	/**
 	 * Add variation via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function add_variation() {
 		check_ajax_referer( 'add-variation', 'security' );
@@ -870,6 +924,8 @@ class WC_AJAX {
 
 	/**
 	 * Link all variations via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function link_all_variations() {
 		check_ajax_referer( 'link-variations', 'security' );
@@ -897,6 +953,8 @@ class WC_AJAX {
 
 	/**
 	 * Delete download permissions via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function revoke_access_to_download() {
 		check_ajax_referer( 'revoke-access', 'security' );
@@ -918,6 +976,8 @@ class WC_AJAX {
 
 	/**
 	 * Grant download permissions via ajax function.
+	 *
+	 * @return void
 	 */
 	public static function grant_access_to_download() {
 
@@ -994,6 +1054,8 @@ class WC_AJAX {
 
 	/**
 	 * Get customer details via ajax.
+	 *
+	 * @return void
 	 */
 	public static function get_customer_details() {
 		$legacy_proxy = wc_get_container()->get( LegacyProxy::class );
@@ -1030,6 +1092,8 @@ class WC_AJAX {
 	 * Add order item via ajax. Used on the edit order screen in WP Admin.
 	 *
 	 * @throws Exception If order is invalid.
+	 *
+	 * @return void
 	 */
 	public static function add_order_item() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1148,6 +1212,8 @@ class WC_AJAX {
 	 * Add order fee via ajax.
 	 *
 	 * @throws Exception If order is invalid.
+	 *
+	 * @return void
 	 */
 	public static function add_order_fee() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1212,6 +1278,8 @@ class WC_AJAX {
 	 * Add order shipping cost via ajax.
 	 *
 	 * @throws Exception If order is invalid.
+	 *
+	 * @return void
 	 */
 	public static function add_order_shipping() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1254,6 +1322,8 @@ class WC_AJAX {
 	 * Add order tax column via ajax.
 	 *
 	 * @throws Exception If order or tax rate is invalid.
+	 *
+	 * @return void
 	 */
 	public static function add_order_tax() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1301,6 +1371,8 @@ class WC_AJAX {
 	 * Add order discount via ajax.
 	 *
 	 * @throws Exception If order or coupon is invalid.
+	 *
+	 * @return void
 	 */
 	public static function add_coupon_discount() {
 		wc_get_container()->get( CouponsController::class )->add_coupon_discount_via_ajax();
@@ -1310,6 +1382,8 @@ class WC_AJAX {
 	 * Remove coupon from an order via ajax.
 	 *
 	 * @throws Exception If order or coupon is invalid.
+	 *
+	 * @return void
 	 */
 	public static function remove_order_coupon() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1368,6 +1442,8 @@ class WC_AJAX {
 	 * Remove an order item.
 	 *
 	 * @throws Exception If order is invalid.
+	 *
+	 * @return void
 	 */
 	public static function remove_order_item() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1481,6 +1557,8 @@ class WC_AJAX {
 	 * Remove an order tax.
 	 *
 	 * @throws Exception If there is an error whilst deleting the rate.
+	 *
+	 * @return void
 	 */
 	public static function remove_order_tax() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1519,6 +1597,8 @@ class WC_AJAX {
 
 	/**
 	 * Calc line tax.
+	 *
+	 * @return void
 	 */
 	public static function calc_line_taxes() {
 		wc_get_container()->get( TaxesController::class )->calc_line_taxes_via_ajax();
@@ -1526,6 +1606,8 @@ class WC_AJAX {
 
 	/**
 	 * Save order items via ajax.
+	 *
+	 * @return void
 	 */
 	public static function save_order_items() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1569,6 +1651,8 @@ class WC_AJAX {
 
 	/**
 	 * Load order items via ajax.
+	 *
+	 * @return void
 	 */
 	public static function load_order_items() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -1586,6 +1670,8 @@ class WC_AJAX {
 
 	/**
 	 * Add order note via ajax.
+	 *
+	 * @return void
 	 */
 	public static function add_order_note() {
 		check_ajax_referer( 'add-order-note', 'security' );
@@ -1639,6 +1725,8 @@ class WC_AJAX {
 
 	/**
 	 * Delete order note via ajax.
+	 *
+	 * @return void
 	 */
 	public static function delete_order_note() {
 		check_ajax_referer( 'delete-order-note', 'security' );
@@ -1660,6 +1748,8 @@ class WC_AJAX {
 	 *
 	 * @param string $term (default: '') Term to search for.
 	 * @param bool   $include_variations in search or not.
+	 *
+	 * @return void
 	 */
 	public static function json_search_products( $term = '', $include_variations = false ) {
 		check_ajax_referer( 'search-products', 'security' );
@@ -1734,6 +1824,8 @@ class WC_AJAX {
 	 * Search for product variations and return json.
 	 *
 	 * @see WC_AJAX::json_search_products()
+	 *
+	 * @return void
 	 */
 	public static function json_search_products_and_variations() {
 		self::json_search_products( '', true );
@@ -1743,6 +1835,8 @@ class WC_AJAX {
 	 * Search for downloadable product variations and return json.
 	 *
 	 * @see WC_AJAX::json_search_products()
+	 *
+	 * @return void
 	 */
 	public static function json_search_downloadable_products_and_variations() {
 		check_ajax_referer( 'search-products', 'security' );
@@ -1772,6 +1866,8 @@ class WC_AJAX {
 
 	/**
 	 * Search for customers and return json.
+	 *
+	 * @return void
 	 */
 	public static function json_search_customers() {
 		ob_start();
@@ -1843,6 +1939,8 @@ class WC_AJAX {
 
 	/**
 	 * Search for categories and return json.
+	 *
+	 * @return void
 	 */
 	public static function json_search_categories() {
 		ob_start();
@@ -1898,6 +1996,8 @@ class WC_AJAX {
 
 	/**
 	 * Search for categories and return json.
+	 *
+	 * @return void
 	 */
 	public static function json_search_categories_tree() {
 		ob_start();
@@ -1967,6 +2067,8 @@ class WC_AJAX {
 
 	/**
 	 * Search for taxonomy terms and return json.
+	 *
+	 * @return void
 	 */
 	public static function json_search_taxonomy_terms() {
 		ob_start();
@@ -2014,6 +2116,8 @@ class WC_AJAX {
 
 	/**
 	 * Search for product attributes and return json.
+	 *
+	 * @return void
 	 */
 	public static function json_search_product_attributes() {
 		ob_start();
@@ -2060,6 +2164,8 @@ class WC_AJAX {
 
 	/**
 	 * Ajax request handling for page searching.
+	 *
+	 * @return void
 	 */
 	public static function json_search_pages() {
 		ob_start();
@@ -2101,6 +2207,8 @@ class WC_AJAX {
 
 	/**
 	 * Ajax request handling for categories ordering.
+	 *
+	 * @return void
 	 */
 	public static function term_ordering() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
@@ -2133,6 +2241,8 @@ class WC_AJAX {
 	 * Ajax request handling for product ordering.
 	 *
 	 * Based on Simple Page Ordering by 10up (https://wordpress.org/plugins/simple-page-ordering/).
+	 *
+	 * @return void
 	 */
 	public static function product_ordering() {
 		global $wpdb;
@@ -2197,6 +2307,8 @@ class WC_AJAX {
 	 * Handle a refund via the edit order screen.
 	 *
 	 * @throws Exception To return errors.
+	 *
+	 * @return void
 	 */
 	public static function refund_line_items() {
 		ob_start();
@@ -2281,6 +2393,8 @@ class WC_AJAX {
 
 	/**
 	 * Delete a refund.
+	 *
+	 * @return void
 	 */
 	public static function delete_refund() {
 		check_ajax_referer( 'order-item', 'security' );
@@ -2303,6 +2417,8 @@ class WC_AJAX {
 
 	/**
 	 * Triggered when clicking the rating footer.
+	 *
+	 * @return void
 	 */
 	public static function rated() {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
@@ -2316,6 +2432,8 @@ class WC_AJAX {
 	 * Create/Update API key.
 	 *
 	 * @throws Exception On invalid or empty description, user, or permissions.
+	 *
+	 * @return void
 	 */
 	public static function update_api_key() {
 		ob_start();
@@ -2423,6 +2541,8 @@ class WC_AJAX {
 
 	/**
 	 * Load variations via AJAX.
+	 *
+	 * @return void
 	 */
 	public static function load_variations() {
 		ob_start();
@@ -2471,6 +2591,8 @@ class WC_AJAX {
 
 	/**
 	 * Save variations via AJAX.
+	 *
+	 * @return void
 	 */
 	public static function save_variations() {
 		ob_start();
@@ -2513,6 +2635,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_toggle_enabled( $variations, $data ) {
 		foreach ( $variations as $variation_id ) {
@@ -2529,6 +2653,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_toggle_downloadable( $variations, $data ) {
 		self::variation_bulk_toggle( $variations, 'downloadable' );
@@ -2541,6 +2667,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_toggle_virtual( $variations, $data ) {
 		self::variation_bulk_toggle( $variations, 'virtual' );
@@ -2553,6 +2681,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_toggle_manage_stock( $variations, $data ) {
 		self::variation_bulk_toggle( $variations, 'manage_stock' );
@@ -2565,6 +2695,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_regular_price( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'regular_price', $data['value'] );
@@ -2577,6 +2709,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_sale_price( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'sale_price', $data['value'] );
@@ -2589,6 +2723,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_stock_status_instock( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'stock_status', ProductStockStatus::IN_STOCK );
@@ -2601,6 +2737,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_stock_status_outofstock( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'stock_status', ProductStockStatus::OUT_OF_STOCK );
@@ -2613,6 +2751,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_stock_status_onbackorder( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'stock_status', ProductStockStatus::ON_BACKORDER );
@@ -2625,6 +2765,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_stock( $variations, $data ) {
 		if ( ! isset( $data['value'] ) ) {
@@ -2651,6 +2793,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_low_stock_amount( $variations, $data ) {
 		if ( ! isset( $data['value'] ) ) {
@@ -2677,6 +2821,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_weight( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'weight', $data['value'] );
@@ -2689,6 +2835,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_length( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'length', $data['value'] );
@@ -2701,6 +2849,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_width( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'width', $data['value'] );
@@ -2713,6 +2863,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_height( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'height', $data['value'] );
@@ -2725,6 +2877,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_download_limit( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'download_limit', $data['value'] );
@@ -2737,6 +2891,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_download_expiry( $variations, $data ) {
 		self::variation_bulk_set( $variations, 'download_expiry', $data['value'] );
@@ -2749,6 +2905,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_delete_all( $variations, $data ) {
 		if ( isset( $data['allowed'] ) && 'true' === $data['allowed'] ) {
@@ -2766,6 +2924,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_sale_schedule( $variations, $data ) {
 		if ( ! isset( $data['date_from'] ) && ! isset( $data['date_to'] ) ) {
@@ -2796,6 +2956,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_regular_price_increase( $variations, $data ) {
 		self::variation_bulk_adjust_price( $variations, 'regular_price', '+', wc_clean( $data['value'] ) );
@@ -2808,6 +2970,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_regular_price_decrease( $variations, $data ) {
 		self::variation_bulk_adjust_price( $variations, 'regular_price', '-', wc_clean( $data['value'] ) );
@@ -2820,6 +2984,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_sale_price_increase( $variations, $data ) {
 		self::variation_bulk_adjust_price( $variations, 'sale_price', '+', wc_clean( $data['value'] ) );
@@ -2832,6 +2998,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_sale_price_decrease( $variations, $data ) {
 		self::variation_bulk_adjust_price( $variations, 'sale_price', '-', wc_clean( $data['value'] ) );
@@ -2845,6 +3013,8 @@ class WC_AJAX {
 	 * @param array $data Data to set.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_action_variable_unset_cogs_value( $variations, $data ) {
 		if ( ! wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled() ) {
@@ -2868,6 +3038,8 @@ class WC_AJAX {
 	 * @param string $value Price or Percent.
 	 *
 	 * @used-by bulk_edit_variations
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_adjust_price( $variations, $field, $operator, $value ) {
 		foreach ( $variations as $variation_id ) {
@@ -2897,6 +3069,8 @@ class WC_AJAX {
 	 * @param array  $variations List of variations.
 	 * @param string $field Field to set.
 	 * @param string $value to set.
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_set( $variations, $field, $value ) {
 		foreach ( $variations as $variation_id ) {
@@ -2911,6 +3085,8 @@ class WC_AJAX {
 	 *
 	 * @param array  $variations List of variations.
 	 * @param string $field Field to toggle.
+	 *
+	 * @return void
 	 */
 	private static function variation_bulk_toggle( $variations, $field ) {
 		foreach ( $variations as $variation_id ) {
@@ -2946,6 +3122,8 @@ class WC_AJAX {
 	 * @uses WC_AJAX::variation_bulk_action_toggle_downloadable()
 	 * @uses WC_AJAX::variation_bulk_action_toggle_enabled
 	 * @uses WC_AJAX::variation_bulk_action_variable_low_stock_amount()
+	 *
+	 * @return void
 	 */
 	public static function bulk_edit_variations() {
 		ob_start();
@@ -2988,6 +3166,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/settings-views-html-settings-tax.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function tax_rates_save_changes() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
@@ -3070,6 +3250,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/wc-shipping-zones.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function shipping_zones_save_changes() {
 		if ( ! isset( $_POST['wc_shipping_zones_nonce'], $_POST['changes'] ) ) {
@@ -3158,6 +3340,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/wc-shipping-zone-methods.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function shipping_zone_add_method() {
 		if ( ! isset( $_POST['wc_shipping_zones_nonce'], $_POST['zone_id'], $_POST['method_id'] ) ) {
@@ -3228,6 +3412,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/wc-shipping-zone-methods.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function shipping_zone_remove_method() {
 		if ( ! isset( $_POST['wc_shipping_zones_nonce'], $_POST['instance_id'], $_POST['zone_id'] ) ) {
@@ -3285,6 +3471,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/wc-shipping-zone-methods.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function shipping_zone_methods_save_changes() {
 		if ( ! isset( $_POST['wc_shipping_zones_nonce'], $_POST['zone_id'], $_POST['changes'] ) ) {
@@ -3454,6 +3642,8 @@ class WC_AJAX {
 
 	/**
 	 * Save method settings
+	 *
+	 * @return void
 	 */
 	public static function shipping_zone_methods_save_settings() {
 		if ( ! isset( $_POST['wc_shipping_zones_nonce'], $_POST['instance_id'], $_POST['data'] ) ) {
@@ -3506,6 +3696,8 @@ class WC_AJAX {
 
 	/**
 	 * Handle submissions from assets/js/wc-shipping-classes.js Backbone model.
+	 *
+	 * @return void
 	 */
 	public static function shipping_classes_save_changes() {
 		if ( ! isset( $_POST['wc_shipping_classes_nonce'], $_POST['changes'] ) ) {
@@ -3636,6 +3828,8 @@ class WC_AJAX {
 	 * Toggle payment gateway on or off via AJAX.
 	 *
 	 * @since 3.4.0
+	 *
+	 * @return void
 	 */
 	public static function toggle_gateway_enabled() {
 		if ( current_user_can( 'manage_woocommerce' ) && check_ajax_referer( 'woocommerce-toggle-payment-gateway-enabled', 'security' ) && isset( $_POST['gateway_id'] ) ) {
@@ -3687,6 +3881,8 @@ class WC_AJAX {
 
 	/**
 	 * AJAX handler for asynchronously loading the status widget content.
+	 *
+	 * @return void
 	 */
 	public static function load_status_widget() {
 		check_ajax_referer( 'wc-status-widget', 'security' );
@@ -3706,6 +3902,8 @@ class WC_AJAX {
 
 	/**
 	 * Reimplementation of WP core's `wp_ajax_add_meta` method to support order custom meta updates with custom tables.
+	 *
+	 * @return void
 	 */
 	private static function order_add_meta() {
 		wc_get_container()->get( CustomMetaBox::class )->add_meta_ajax();
@@ -3765,6 +3963,8 @@ class WC_AJAX {
 	 * @param WC_Product $variation_object Variation being edited.
 	 * @param int        $loop Index of the variation being rendered.
 	 * @param float|null $base_cost Default cost for variations, null if the Cost of Goods Sold feature is disabled.
+	 *
+	 * @return void
 	 */
 	private static function render_variation_html( WC_Product $product_object, WC_Product $variation_object, $loop, ?float $base_cost ) {
 		$variation_id   = $variation_object->get_id();

--- a/plugins/woocommerce/includes/wc-deprecated-functions.php
+++ b/plugins/woocommerce/includes/wc-deprecated-functions.php
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $version     The version of WooCommerce that deprecated the hook.
  * @param string $replacement The hook that should have been used.
  * @param string $message     A message regarding the change.
+ * @return void
  */
 function wc_do_deprecated_action( $tag, $args, $version, $replacement = null, $message = null ) {
 	if ( ! has_action( $tag ) ) {
@@ -44,6 +45,7 @@ function wc_do_deprecated_action( $tag, $args, $version, $replacement = null, $m
  * @param string $function Function used.
  * @param string $version Version the message was added in.
  * @param string $replacement Replacement for the called function.
+ * @return void
  */
 function wc_deprecated_function( $function, $version, $replacement = null ) {
 	// @codingStandardsIgnoreStart
@@ -66,6 +68,7 @@ function wc_deprecated_function( $function, $version, $replacement = null ) {
  * @param string $version     The version of WordPress that deprecated the hook.
  * @param string $replacement The hook that should have been used.
  * @param string $message     A message regarding the change.
+ * @return void
  */
 function wc_deprecated_hook( $hook, $version, $replacement = null, $message = null ) {
 	// @codingStandardsIgnoreStart
@@ -90,6 +93,7 @@ function wc_deprecated_hook( $hook, $version, $replacement = null, $message = nu
  * @param Exception $exception_object The exception object.
  * @param string    $function The function which threw exception.
  * @param array     $args The args passed to the function.
+ * @return void
  */
 function wc_caught_exception( $exception_object, $function = '', $args = array() ) {
 	// @codingStandardsIgnoreStart
@@ -108,6 +112,7 @@ function wc_caught_exception( $exception_object, $function = '', $args = array()
  * @param string $function Function used.
  * @param string $message Message to log.
  * @param string $version Version the message was added in.
+ * @return void
  */
 function wc_doing_it_wrong( $function, $message, $version ) {
 	// @codingStandardsIgnoreStart
@@ -129,6 +134,7 @@ function wc_doing_it_wrong( $function, $message, $version ) {
  * @param  string $argument
  * @param  string $version
  * @param  string $replacement
+ * @return void
  */
 function wc_deprecated_argument( $argument, $version, $message = null ) {
 	if ( wp_doing_ajax() || WC()->is_rest_api_request() ) {
@@ -141,6 +147,7 @@ function wc_deprecated_argument( $argument, $version, $message = null ) {
 
 /**
  * @deprecated 2.1
+ * @return void
  */
 function woocommerce_show_messages() {
 	wc_deprecated_function( 'woocommerce_show_messages', '2.1', 'wc_print_notices' );
@@ -149,6 +156,7 @@ function woocommerce_show_messages() {
 
 /**
  * @deprecated 2.1
+ * @return void
  */
 function woocommerce_weekend_area_js() {
 	wc_deprecated_function( 'woocommerce_weekend_area_js', '2.1' );
@@ -156,6 +164,7 @@ function woocommerce_weekend_area_js() {
 
 /**
  * @deprecated 2.1
+ * @return void
  */
 function woocommerce_tooltip_js() {
 	wc_deprecated_function( 'woocommerce_tooltip_js', '2.1' );
@@ -163,6 +172,7 @@ function woocommerce_tooltip_js() {
 
 /**
  * @deprecated 2.1
+ * @return void
  */
 function woocommerce_datepicker_js() {
 	wc_deprecated_function( 'woocommerce_datepicker_js', '2.1' );
@@ -170,6 +180,7 @@ function woocommerce_datepicker_js() {
 
 /**
  * @deprecated 2.1
+ * @return void
  */
 function woocommerce_admin_scripts() {
 	wc_deprecated_function( 'woocommerce_admin_scripts', '2.1' );
@@ -177,6 +188,7 @@ function woocommerce_admin_scripts() {
 
 /**
  * @deprecated 2.1
+ * @return int
  */
 function woocommerce_create_page( $slug, $option = '', $page_title = '', $page_content = '', $post_parent = 0 ) {
 	wc_deprecated_function( 'woocommerce_create_page', '2.1', 'wc_create_page' );
@@ -185,6 +197,7 @@ function woocommerce_create_page( $slug, $option = '', $page_title = '', $page_c
 
 /**
  * @deprecated 2.1
+ * @return bool
  */
 function woocommerce_readfile_chunked( $file, $retbytes = true ) {
 	wc_deprecated_function( 'woocommerce_readfile_chunked', '2.1', 'WC_Download_Handler::readfile_chunked()' );
@@ -221,6 +234,7 @@ function woocommerce_get_formatted_product_name( $product ) {
  * Handle IPN requests for the legacy paypal gateway by calling gateways manually if needed.
  *
  * @access public
+ * @return void
  */
 function woocommerce_legacy_paypal_ipn() {
 	if ( ! empty( $_GET['paypalListener'] ) && 'paypal_standard_IPN' === $_GET['paypalListener'] ) {
@@ -232,6 +246,7 @@ add_action( 'init', 'woocommerce_legacy_paypal_ipn' );
 
 /**
  * @deprecated 3.0
+ * @return WC_Product|null|false
  */
 function get_product( $the_product = false, $args = array() ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product' );
@@ -240,6 +255,7 @@ function get_product( $the_product = false, $args = array() ) {
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_protected_product_add_to_cart( $passed, $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_protected_product_add_to_cart' );
@@ -248,6 +264,7 @@ function woocommerce_protected_product_add_to_cart( $passed, $product_id ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_empty_cart() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_empty_cart' );
@@ -256,14 +273,16 @@ function woocommerce_empty_cart() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_load_persistent_cart( $user_login, $user = 0 ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_load_persistent_cart' );
-	return wc_load_persistent_cart( $user_login, $user );
+	wc_load_persistent_cart( $user_login, $user );
 }
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_add_to_cart_message( $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_to_cart_message' );
@@ -272,6 +291,7 @@ function woocommerce_add_to_cart_message( $product_id ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_clear_cart_after_payment() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_clear_cart_after_payment' );
@@ -280,6 +300,7 @@ function woocommerce_clear_cart_after_payment() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cart_totals_subtotal_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_subtotal_html' );
@@ -288,6 +309,7 @@ function woocommerce_cart_totals_subtotal_html() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cart_totals_shipping_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_shipping_html' );
@@ -296,6 +318,7 @@ function woocommerce_cart_totals_shipping_html() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cart_totals_coupon_html( $coupon ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_coupon_html' );
@@ -304,6 +327,7 @@ function woocommerce_cart_totals_coupon_html( $coupon ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cart_totals_order_total_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_order_total_html' );
@@ -312,6 +336,7 @@ function woocommerce_cart_totals_order_total_html() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cart_totals_fee_html( $fee ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_fee_html' );
@@ -320,6 +345,7 @@ function woocommerce_cart_totals_fee_html( $fee ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_cart_totals_shipping_method_label( $method ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_shipping_method_label' );
@@ -328,6 +354,7 @@ function woocommerce_cart_totals_shipping_method_label( $method ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_get_template_part( $slug, $name = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_template_part' );
@@ -336,6 +363,7 @@ function woocommerce_get_template_part( $slug, $name = '' ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_template' );
@@ -344,6 +372,7 @@ function woocommerce_get_template( $template_name, $args = array(), $template_pa
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_locate_template( $template_name, $template_path = '', $default_path = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_locate_template' );
@@ -352,6 +381,7 @@ function woocommerce_locate_template( $template_name, $template_path = '', $defa
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = "" ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_mail' );
@@ -360,6 +390,7 @@ function woocommerce_mail( $to, $subject, $message, $headers = "Content-Type: te
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_disable_admin_bar( $show_admin_bar ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_disable_admin_bar' );
@@ -368,6 +399,7 @@ function woocommerce_disable_admin_bar( $show_admin_bar ) {
 
 /**
  * @deprecated 3.0
+ * @return int|WP_Error
  */
 function woocommerce_create_new_customer( $email, $username = '', $password = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_create_new_customer' );
@@ -376,6 +408,7 @@ function woocommerce_create_new_customer( $email, $username = '', $password = ''
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_set_customer_auth_cookie( $customer_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_set_customer_auth_cookie' );
@@ -384,6 +417,7 @@ function woocommerce_set_customer_auth_cookie( $customer_id ) {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_update_new_customer_past_orders( $customer_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_update_new_customer_past_orders' );
@@ -392,6 +426,7 @@ function woocommerce_update_new_customer_past_orders( $customer_id ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_paying_customer( $order_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_paying_customer' );
@@ -400,6 +435,7 @@ function woocommerce_paying_customer( $order_id ) {
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_customer_bought_product( $customer_email, $user_id, $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_bought_product' );
@@ -408,6 +444,7 @@ function woocommerce_customer_bought_product( $customer_email, $user_id, $produc
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_has_capability' );
@@ -416,6 +453,7 @@ function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_sanitize_taxonomy_name( $taxonomy ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_sanitize_taxonomy_name' );
@@ -424,6 +462,7 @@ function woocommerce_sanitize_taxonomy_name( $taxonomy ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_get_filename_from_url( $file_url ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_filename_from_url' );
@@ -432,6 +471,7 @@ function woocommerce_get_filename_from_url( $file_url ) {
 
 /**
  * @deprecated 3.0
+ * @return float
  */
 function woocommerce_get_dimension( $dim, $to_unit ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_dimension' );
@@ -440,6 +480,7 @@ function woocommerce_get_dimension( $dim, $to_unit ) {
 
 /**
  * @deprecated 3.0
+ * @return float
  */
 function woocommerce_get_weight( $weight, $to_unit ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_weight' );
@@ -448,6 +489,7 @@ function woocommerce_get_weight( $weight, $to_unit ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_trim_zeros( $price ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_trim_zeros' );
@@ -456,6 +498,7 @@ function woocommerce_trim_zeros( $price ) {
 
 /**
  * @deprecated 3.0
+ * @return float
  */
 function woocommerce_round_tax_total( $tax ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_round_tax_total' );
@@ -464,6 +507,7 @@ function woocommerce_round_tax_total( $tax ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_format_decimal' );
@@ -472,6 +516,7 @@ function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false )
 
 /**
  * @deprecated 3.0
+ * @return string|array
  */
 function woocommerce_clean( $var ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_clean' );
@@ -480,6 +525,7 @@ function woocommerce_clean( $var ) {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_array_overlay( $a1, $a2 ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_array_overlay' );
@@ -488,6 +534,7 @@ function woocommerce_array_overlay( $a1, $a2 ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_price( $price, $args = array() ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_price' );
@@ -496,6 +543,7 @@ function woocommerce_price( $price, $args = array() ) {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_let_to_num( $size ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_let_to_num' );
@@ -504,6 +552,7 @@ function woocommerce_let_to_num( $size ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_date_format() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_date_format' );
@@ -512,6 +561,7 @@ function woocommerce_date_format() {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_time_format() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_time_format' );
@@ -520,6 +570,7 @@ function woocommerce_time_format() {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_timezone_string() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_timezone_string' );
@@ -529,6 +580,7 @@ function woocommerce_timezone_string() {
 if ( ! function_exists( 'woocommerce_rgb_from_hex' ) ) {
 	/**
 	 * @deprecated 3.0
+	 * @return array
 	 */
 	function woocommerce_rgb_from_hex( $color ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_rgb_from_hex' );
@@ -539,6 +591,7 @@ if ( ! function_exists( 'woocommerce_rgb_from_hex' ) ) {
 if ( ! function_exists( 'woocommerce_hex_darker' ) ) {
 	/**
 	 * @deprecated 3.0
+	 * @return string
 	 */
 	function woocommerce_hex_darker( $color, $factor = 30 ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_hex_darker' );
@@ -549,6 +602,7 @@ if ( ! function_exists( 'woocommerce_hex_darker' ) ) {
 if ( ! function_exists( 'woocommerce_hex_lighter' ) ) {
 	/**
 	 * @deprecated 3.0
+	 * @return string
 	 */
 	function woocommerce_hex_lighter( $color, $factor = 30 ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_hex_lighter' );
@@ -559,6 +613,7 @@ if ( ! function_exists( 'woocommerce_hex_lighter' ) ) {
 if ( ! function_exists( 'woocommerce_light_or_dark' ) ) {
 	/**
 	 * @deprecated 3.0
+	 * @return string
 	 */
 	function woocommerce_light_or_dark( $color, $dark = '#000000', $light = '#FFFFFF' ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_light_or_dark' );
@@ -569,6 +624,7 @@ if ( ! function_exists( 'woocommerce_light_or_dark' ) ) {
 if ( ! function_exists( 'woocommerce_format_hex' ) ) {
 	/**
 	 * @deprecated 3.0
+	 * @return string|null
 	 */
 	function woocommerce_format_hex( $hex ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_format_hex' );
@@ -578,6 +634,7 @@ if ( ! function_exists( 'woocommerce_format_hex' ) ) {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_get_order_id_by_order_key( $order_key ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_order_id_by_order_key' );
@@ -586,6 +643,7 @@ function woocommerce_get_order_id_by_order_key( $order_key ) {
 
 /**
  * @deprecated 3.0
+ * @return int|bool
  */
 function woocommerce_downloadable_file_permission( $download_id, $product_id, $order ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_downloadable_file_permission' );
@@ -594,6 +652,7 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_downloadable_product_permissions( $order_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_downloadable_product_permissions' );
@@ -602,6 +661,7 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 
 /**
  * @deprecated 3.0
+ * @return int|bool
  */
 function woocommerce_add_order_item( $order_id, $item ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_order_item' );
@@ -610,6 +670,7 @@ function woocommerce_add_order_item( $order_id, $item ) {
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_delete_order_item( $item_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_delete_order_item' );
@@ -618,6 +679,7 @@ function woocommerce_delete_order_item( $item_id ) {
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_value = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_update_order_item_meta' );
@@ -626,6 +688,7 @@ function woocommerce_update_order_item_meta( $item_id, $meta_key, $meta_value, $
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_order_item_meta' );
@@ -634,6 +697,7 @@ function woocommerce_add_order_item_meta( $item_id, $meta_key, $meta_value, $uni
 
 /**
  * @deprecated 3.0
+ * @return bool
  */
 function woocommerce_delete_order_item_meta( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_delete_order_item_meta' );
@@ -642,6 +706,7 @@ function woocommerce_delete_order_item_meta( $item_id, $meta_key, $meta_value = 
 
 /**
  * @deprecated 3.0
+ * @return mixed
  */
 function woocommerce_get_order_item_meta( $item_id, $key, $single = true ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_order_item_meta' );
@@ -650,6 +715,7 @@ function woocommerce_get_order_item_meta( $item_id, $key, $single = true ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_cancel_unpaid_orders() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cancel_unpaid_orders' );
@@ -658,6 +724,7 @@ function woocommerce_cancel_unpaid_orders() {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_processing_order_count() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_processing_order_count' );
@@ -666,6 +733,7 @@ function woocommerce_processing_order_count() {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_get_page_id( $page ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_page_id' );
@@ -674,6 +742,7 @@ function woocommerce_get_page_id( $page ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_endpoint_url' );
@@ -682,6 +751,7 @@ function woocommerce_get_endpoint_url( $endpoint, $value = '', $permalink = '' )
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_lostpassword_url( $url ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_lostpassword_url' );
@@ -690,6 +760,7 @@ function woocommerce_lostpassword_url( $url ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_customer_edit_account_url() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_edit_account_url' );
@@ -698,6 +769,7 @@ function woocommerce_customer_edit_account_url() {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_nav_menu_items( $items, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_nav_menu_items' );
@@ -706,6 +778,7 @@ function woocommerce_nav_menu_items( $items, $args ) {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_nav_menu_item_classes' );
@@ -714,6 +787,7 @@ function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_list_pages( $pages ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_list_pages' );
@@ -722,6 +796,7 @@ function woocommerce_list_pages( $pages ) {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_product_dropdown_categories( $args = array(), $deprecated_hierarchical = 1, $deprecated_show_uncategorized = 1, $deprecated_orderby = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_product_dropdown_categories' );
@@ -730,6 +805,7 @@ function woocommerce_product_dropdown_categories( $args = array(), $deprecated_h
 
 /**
  * @deprecated 3.0
+ * @return mixed
  */
 function woocommerce_walk_category_dropdown_tree( $a1 = '', $a2 = '', $a3 = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_walk_category_dropdown_tree' );
@@ -738,6 +814,7 @@ function woocommerce_walk_category_dropdown_tree( $a1 = '', $a2 = '', $a3 = '' )
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_taxonomy_metadata_wpdbfix() {
 	wc_deprecated_function( __FUNCTION__, '3.0' );
@@ -745,6 +822,7 @@ function woocommerce_taxonomy_metadata_wpdbfix() {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function wc_taxonomy_metadata_wpdbfix() {
 	wc_deprecated_function( __FUNCTION__, '3.0' );
@@ -752,6 +830,7 @@ function wc_taxonomy_metadata_wpdbfix() {
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_order_terms( $the_term, $next_id, $taxonomy, $index = 0, $terms = null ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_reorder_terms' );
@@ -760,6 +839,7 @@ function woocommerce_order_terms( $the_term, $next_id, $taxonomy, $index = 0, $t
 
 /**
  * @deprecated 3.0
+ * @return int
  */
 function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_set_term_order' );
@@ -768,6 +848,7 @@ function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = f
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_terms_clauses( $clauses, $taxonomies, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_terms_clauses' );
@@ -776,22 +857,25 @@ function woocommerce_terms_clauses( $clauses, $taxonomies, $args ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function _woocommerce_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', '_wc_term_recount' );
-	return _wc_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids );
+	_wc_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids );
 }
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_recount_after_stock_change( $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_recount_after_stock_change' );
-	return wc_recount_after_stock_change( $product_id );
+	wc_recount_after_stock_change( $product_id );
 }
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_change_term_counts' );
@@ -800,6 +884,7 @@ function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_get_product_ids_on_sale() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product_ids_on_sale' );
@@ -808,6 +893,7 @@ function woocommerce_get_product_ids_on_sale() {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_get_featured_product_ids() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_featured_product_ids' );
@@ -816,6 +902,7 @@ function woocommerce_get_featured_product_ids() {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product_terms' );
@@ -824,6 +911,7 @@ function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' )
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_product_post_type_link( $permalink, $post ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_product_post_type_link' );
@@ -832,6 +920,7 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_placeholder_img_src() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_placeholder_img_src' );
@@ -840,6 +929,7 @@ function woocommerce_placeholder_img_src() {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_placeholder_img' );
@@ -848,6 +938,7 @@ function woocommerce_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 
 /**
  * @deprecated 3.0
+ * @return string
  */
 function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_formatted_variation' );
@@ -856,14 +947,16 @@ function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_scheduled_sales() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_scheduled_sales' );
-	return wc_scheduled_sales();
+	wc_scheduled_sales();
 }
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_get_attachment_image_attributes( $attr ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_attachment_image_attributes' );
@@ -872,6 +965,7 @@ function woocommerce_get_attachment_image_attributes( $attr ) {
 
 /**
  * @deprecated 3.0
+ * @return array
  */
 function woocommerce_prepare_attachment_for_js( $response ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_prepare_attachment_for_js' );
@@ -880,14 +974,16 @@ function woocommerce_prepare_attachment_for_js( $response ) {
 
 /**
  * @deprecated 3.0
+ * @return void
  */
 function woocommerce_track_product_view() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_track_product_view' );
-	return wc_track_product_view();
+	wc_track_product_view();
 }
 
 /**
  * @deprecated 2.3 has no replacement
+ * @return void
  */
 function woocommerce_compile_less_styles() {
 	wc_deprecated_function( 'woocommerce_compile_less_styles', '2.3' );
@@ -949,6 +1045,7 @@ function woocommerce_get_product_schema() {
  * @param float $sale_price
  * @param string $date_from
  * @param string $date_to
+ * @return void
  */
 function _wc_save_product_price( $product_id, $regular_price, $sale_price = '', $date_from = '', $date_to = '' ) {
 	wc_doing_it_wrong( '_wc_save_product_price()', 'This function is not for developer use and is deprecated.', '3.0' );
@@ -1050,6 +1147,7 @@ function wc_get_min_max_price_meta_query( $args ) {
  * @param  int    $new_term_id      New term ID.
  * @param  string $term_taxonomy_id Term taxonomy ID.
  * @param  string $taxonomy         Taxonomy.
+ * @return void
  */
 function wc_taxonomy_metadata_update_content_for_split_terms( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
 	wc_deprecated_function( 'wc_taxonomy_metadata_update_content_for_split_terms', '3.6' );
@@ -1186,6 +1284,7 @@ function wc_get_log_file_name( $handle ) {
  * @param string  $user_login User login.
  * @param WP_User $user       User data.
  * @deprecated 2.3
+ * @return void
  */
 function wc_load_persistent_cart( $user_login, $user ) {
 	if ( ! $user || ! apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
@@ -1263,6 +1362,7 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
  * Products RSS Feed.
  *
  * @deprecated 2.6
+ * @return void
  */
 function wc_products_rss_feed() {
 	wc_deprecated_function( 'wc_products_rss_feed', '2.6' );
@@ -1274,6 +1374,7 @@ if ( ! function_exists( 'woocommerce_reset_loop' ) ) {
 	 * Reset the loop's index and columns when we're done outputting a product loop.
 	 *
 	 * @deprecated 3.3
+	 * @return void
 	 */
 	function woocommerce_reset_loop() {
 		wc_reset_loop();
@@ -1285,6 +1386,7 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 	 * Output the reviews tab content.
 	 *
 	 * @deprecated 2.4.0 Unused.
+	 * @return void
 	 */
 	function woocommerce_product_reviews_tab() {
 		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -22,6 +22,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Handle redirects before content is output - hooked into template_redirect so is_page works.
+ *
+ * @return void
  */
 function wc_template_redirect() {
 	global $wp_query, $wp;
@@ -98,6 +100,7 @@ add_action( 'template_redirect', 'wc_template_redirect' );
  * Can be disabled with: remove_action( 'template_redirect', 'wc_send_frame_options_header' );
  *
  * @since  2.3.10
+ * @return void
  */
 function wc_send_frame_options_header() {
 
@@ -112,6 +115,7 @@ add_action( 'template_redirect', 'wc_send_frame_options_header' );
  * Prevent indexing pages like order-received.
  *
  * @since 2.5.3
+ * @return void
  */
 function wc_prevent_endpoint_indexing() {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.PHP.NoSilencedErrors.Discouraged
@@ -126,6 +130,7 @@ add_action( 'template_redirect', 'wc_prevent_endpoint_indexing' );
  * Remove adjacent_posts_rel_link_wp_head - pointless for products.
  *
  * @since 3.0.0
+ * @return void
  */
 function wc_prevent_adjacent_posts_rel_link_wp_head() {
 	if ( is_singular( 'product' ) ) {
@@ -138,6 +143,7 @@ add_action( 'template_redirect', 'wc_prevent_adjacent_posts_rel_link_wp_head' );
  * Show the gallery if JS is disabled.
  *
  * @since 3.0.6
+ * @return void
  */
 function wc_gallery_noscript() {
 	?>
@@ -174,6 +180,7 @@ add_action( 'the_post', 'wc_setup_product_data' );
  *
  * @since 3.3.0
  * @param array $args Args to pass into the global.
+ * @return void
  */
 function wc_setup_loop( $args = array() ) {
 	$default_args = array(
@@ -218,6 +225,7 @@ add_action( 'woocommerce_before_shop_loop', 'wc_setup_loop' );
  * Resets the woocommerce_loop global.
  *
  * @since 3.3.0
+ * @return void
  */
 function wc_reset_loop() {
 	unset( $GLOBALS['woocommerce_loop'] );
@@ -244,6 +252,7 @@ function wc_get_loop_prop( $prop, $default = '' ) {
  * @since 3.3.0
  * @param string $prop Prop to set.
  * @param string $value Value to set.
+ * @return void
  */
 function wc_set_loop_prop( $prop, $value = '' ) {
 	if ( ! isset( $GLOBALS['woocommerce_loop'] ) ) {
@@ -258,6 +267,7 @@ function wc_set_loop_prop( $prop, $value = '' ) {
  * @since 4.4.0
  * @param int  $product_id Product it to cache visibility for.
  * @param bool $value The product visibility value to cache.
+ * @return void
  */
 function wc_set_loop_product_visibility( $product_id, $value ) {
 	wc_set_loop_prop( "product_visibility_$product_id", $value );
@@ -386,6 +396,7 @@ function wc_body_class( $classes ) {
  * NO JS handling.
  *
  * @since 3.4.0
+ * @return void
  */
 function wc_no_js() {
 	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
@@ -406,6 +417,7 @@ function wc_no_js() {
  * @since 2.4.0
  * @param string|array $class One or more classes to add to the class list.
  * @param object       $category object Optional.
+ * @return void
  */
 function wc_product_cat_class( $class = '', $category = null ) {
 	// Separates classes with a single space, collates classes for post DIV.
@@ -468,6 +480,7 @@ function wc_get_default_product_rows_per_page() {
  * Reset the product grid settings when a new theme is activated.
  *
  * @since 3.3.0
+ * @return void
  */
 function wc_reset_product_grid_settings() {
 	$product_grid = wc_get_theme_support( 'product_grid' );
@@ -759,6 +772,7 @@ function wc_get_product_class( $class = '', $product = null ) {
  * @since 3.4.0
  * @param string|array           $class      One or more classes to add to the class list.
  * @param int|WP_Post|WC_Product $product_id Product ID or product object.
+ * @return void
  */
 function wc_product_class( $class = '', $product_id = null ) {
 	echo 'class="' . esc_attr( implode( ' ', wc_get_product_class( $class, $product_id ) ) ) . '"';
@@ -898,6 +912,7 @@ function wc_get_privacy_policy_text( $type = '' ) {
  * Output t&c checkbox text.
  *
  * @since 3.4.0
+ * @return void
  */
 function wc_terms_and_conditions_checkbox_text() {
 	$text = wc_get_terms_and_conditions_checkbox_text();
@@ -913,6 +928,7 @@ function wc_terms_and_conditions_checkbox_text() {
  * Output t&c page's content (if set). The page can be set from checkout settings.
  *
  * @since 3.4.0
+ * @return void
  */
 function wc_terms_and_conditions_page_content() {
 	$terms_page_id = wc_terms_and_conditions_page_id();
@@ -933,6 +949,7 @@ function wc_terms_and_conditions_page_content() {
  * Render privacy policy text on the checkout.
  *
  * @since 3.4.0
+ * @return void
  */
 function wc_checkout_privacy_policy_text() {
 	echo '<div class="woocommerce-privacy-policy-text">';
@@ -944,6 +961,7 @@ function wc_checkout_privacy_policy_text() {
  * Render privacy policy text on the register forms.
  *
  * @since 3.4.0
+ * @return void
  */
 function wc_registration_privacy_policy_text() {
 	echo '<div class="woocommerce-privacy-policy-text">';
@@ -958,6 +976,7 @@ function wc_registration_privacy_policy_text() {
  *
  * @since 3.4.0
  * @param string $type Type of policy to load. Valid values include registration and checkout.
+ * @return void
  */
 function wc_privacy_policy_text( $type = 'checkout' ) {
 	if ( ! wc_privacy_policy_page_id() ) {
@@ -999,6 +1018,8 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 	 * This function is only used in the optional 'woocommerce.php' template.
 	 * which people can add to their themes to add basic woocommerce support.
 	 * without hooks or modifying core templates.
+	 *
+	 * @return void
 	 */
 	function woocommerce_content() {
 
@@ -1053,6 +1074,8 @@ if ( ! function_exists( 'woocommerce_output_content_wrapper' ) ) {
 
 	/**
 	 * Output the start of the page wrapper.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_content_wrapper() {
 		wc_get_template( 'global/wrapper-start.php' );
@@ -1062,6 +1085,8 @@ if ( ! function_exists( 'woocommerce_output_content_wrapper_end' ) ) {
 
 	/**
 	 * Output the end of the page wrapper.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_content_wrapper_end() {
 		wc_get_template( 'global/wrapper-end.php' );
@@ -1072,6 +1097,8 @@ if ( ! function_exists( 'woocommerce_get_sidebar' ) ) {
 
 	/**
 	 * Get the shop sidebar template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_get_sidebar() {
 		wc_get_template( 'global/sidebar.php' );
@@ -1082,6 +1109,8 @@ if ( ! function_exists( 'woocommerce_demo_store' ) ) {
 
 	/**
 	 * Adds a demo store banner to the site if enabled.
+	 *
+	 * @return void
 	 */
 	function woocommerce_demo_store() {
 		if ( ! is_store_notice_showing() ) {
@@ -1203,6 +1232,8 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 
 	/**
 	 * Show the product title in the product loop. By default this is an H2.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_product_title() {
 		echo '<h2 class="' . esc_attr( apply_filters( 'woocommerce_product_loop_title_classes', 'woocommerce-loop-product__title' ) ) . '">' . get_the_title() . '</h2>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1214,6 +1245,7 @@ if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
 	 * Show the subcategory title in the product loop.
 	 *
 	 * @param object $category Category object.
+	 * @return void
 	 */
 	function woocommerce_template_loop_category_title( $category ) {
 		?>
@@ -1234,6 +1266,8 @@ if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
 if ( ! function_exists( 'woocommerce_template_loop_product_link_open' ) ) {
 	/**
 	 * Insert the opening anchor tag for products in the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_product_link_open() {
 		global $product;
@@ -1251,6 +1285,8 @@ if ( ! function_exists( 'woocommerce_template_loop_product_link_open' ) ) {
 if ( ! function_exists( 'woocommerce_template_loop_product_link_close' ) ) {
 	/**
 	 * Insert the closing anchor tag for products in the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_product_link_close() {
 		echo '</a>';
@@ -1262,6 +1298,7 @@ if ( ! function_exists( 'woocommerce_template_loop_category_link_open' ) ) {
 	 * Insert the opening anchor tag for categories in the loop.
 	 *
 	 * @param int|object|string $category Category ID, Object or String.
+	 * @return void
 	 */
 	function woocommerce_template_loop_category_link_open( $category ) {
 		$category_term = get_term( $category, 'product_cat' );
@@ -1274,6 +1311,8 @@ if ( ! function_exists( 'woocommerce_template_loop_category_link_open' ) ) {
 if ( ! function_exists( 'woocommerce_template_loop_category_link_close' ) ) {
 	/**
 	 * Insert the closing anchor tag for categories in the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_category_link_close() {
 		echo '</a>';
@@ -1283,6 +1322,8 @@ if ( ! function_exists( 'woocommerce_template_loop_category_link_close' ) ) {
 if ( ! function_exists( 'woocommerce_product_taxonomy_archive_header' ) ) {
 	/**
 	 * Output the products header on taxonomy archives.
+	 *
+	 * @return void
 	 */
 	function woocommerce_product_taxonomy_archive_header() {
 		wc_get_template( 'loop/header.php' );
@@ -1292,6 +1333,8 @@ if ( ! function_exists( 'woocommerce_product_taxonomy_archive_header' ) ) {
 if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	/**
 	 * Show an archive description on taxonomy archives.
+	 *
+	 * @return void
 	 */
 	function woocommerce_taxonomy_archive_description() {
 		if ( is_product_taxonomy() && 0 === absint( get_query_var( 'paged' ) ) ) {
@@ -1320,6 +1363,8 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 
 	/**
 	 * Show a shop page description on product archives.
+	 *
+	 * @return void
 	 */
 	function woocommerce_product_archive_description() {
 		// Don't display the description on search results page.
@@ -1392,6 +1437,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 	 * Get the add to cart template for the loop.
 	 *
 	 * @param array $args Arguments.
+	 * @return void
 	 */
 	function woocommerce_template_loop_add_to_cart( $args = array() ) {
 		global $product;
@@ -1468,6 +1514,8 @@ if ( ! function_exists( 'woocommerce_template_loop_product_thumbnail' ) ) {
 
 	/**
 	 * Get the product thumbnail for the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_product_thumbnail() {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1478,6 +1526,8 @@ if ( ! function_exists( 'woocommerce_template_loop_price' ) ) {
 
 	/**
 	 * Get the product price for the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_price() {
 		wc_get_template( 'loop/price.php' );
@@ -1487,6 +1537,8 @@ if ( ! function_exists( 'woocommerce_template_loop_rating' ) ) {
 
 	/**
 	 * Display the average rating in the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_loop_rating() {
 		wc_get_template( 'loop/rating.php' );
@@ -1496,6 +1548,8 @@ if ( ! function_exists( 'woocommerce_show_product_loop_sale_flash' ) ) {
 
 	/**
 	 * Get the sale flash for the loop.
+	 *
+	 * @return void
 	 */
 	function woocommerce_show_product_loop_sale_flash() {
 		wc_get_template( 'loop/sale-flash.php' );
@@ -1537,6 +1591,8 @@ if ( ! function_exists( 'woocommerce_result_count' ) ) {
 
 	/**
 	 * Output the result count text (Showing x - x of x results).
+	 *
+	 * @return void
 	 */
 	function woocommerce_result_count() {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
@@ -1596,6 +1652,7 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 	 * Output the product sorting options.
 	 *
 	 * @param array|null $attributes Block attributes.
+	 * @return void
 	 */
 	function woocommerce_catalog_ordering( $attributes = null ) {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
@@ -1687,6 +1744,8 @@ if ( ! function_exists( 'woocommerce_pagination' ) ) {
 
 	/**
 	 * Output the pagination.
+	 *
+	 * @return void
 	 */
 	function woocommerce_pagination() {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
@@ -1717,6 +1776,8 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 
 	/**
 	 * Output the product image before the single product summary.
+	 *
+	 * @return void
 	 */
 	function woocommerce_show_product_images() {
 		wc_get_template( 'single-product/product-image.php' );
@@ -1726,6 +1787,8 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 
 	/**
 	 * Output the product thumbnails.
+	 *
+	 * @return void
 	 */
 	function woocommerce_show_product_thumbnails() {
 		wc_get_template( 'single-product/product-thumbnails.php' );
@@ -1821,6 +1884,8 @@ if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {
 
 	/**
 	 * Output the product tabs.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_product_data_tabs() {
 		wc_get_template( 'single-product/tabs/tabs.php' );
@@ -1830,6 +1895,8 @@ if ( ! function_exists( 'woocommerce_template_single_title' ) ) {
 
 	/**
 	 * Output the product title.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_title() {
 		wc_get_template( 'single-product/title.php' );
@@ -1839,6 +1906,8 @@ if ( ! function_exists( 'woocommerce_template_single_rating' ) ) {
 
 	/**
 	 * Output the product rating.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_rating() {
 		if ( ! post_type_supports( 'product', 'comments' ) || ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
@@ -1852,6 +1921,8 @@ if ( ! function_exists( 'woocommerce_template_single_price' ) ) {
 
 	/**
 	 * Output the product price.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_price() {
 		if ( ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
@@ -1865,6 +1936,8 @@ if ( ! function_exists( 'woocommerce_template_single_excerpt' ) ) {
 
 	/**
 	 * Output the product short description (excerpt).
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_excerpt() {
 		if ( ! isset( $GLOBALS['post']->post_excerpt ) ) {
@@ -1878,6 +1951,8 @@ if ( ! function_exists( 'woocommerce_template_single_meta' ) ) {
 
 	/**
 	 * Output the product meta.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_meta() {
 		if ( ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
@@ -1891,6 +1966,8 @@ if ( ! function_exists( 'woocommerce_template_single_sharing' ) ) {
 
 	/**
 	 * Output the product sharing.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_sharing() {
 		wc_get_template( 'single-product/share.php' );
@@ -1900,6 +1977,8 @@ if ( ! function_exists( 'woocommerce_show_product_sale_flash' ) ) {
 
 	/**
 	 * Output the product sale flash.
+	 *
+	 * @return void
 	 */
 	function woocommerce_show_product_sale_flash() {
 		wc_get_template( 'single-product/sale-flash.php' );
@@ -1910,6 +1989,8 @@ if ( ! function_exists( 'woocommerce_template_single_add_to_cart' ) ) {
 
 	/**
 	 * Trigger the single product add to cart action.
+	 *
+	 * @return void
 	 */
 	function woocommerce_template_single_add_to_cart() {
 		global $product;
@@ -1928,6 +2009,8 @@ if ( ! function_exists( 'woocommerce_simple_add_to_cart' ) ) {
 
 	/**
 	 * Output the simple product add to cart area.
+	 *
+	 * @return void
 	 */
 	function woocommerce_simple_add_to_cart() {
 		wc_get_template( 'single-product/add-to-cart/simple.php' );
@@ -1937,6 +2020,8 @@ if ( ! function_exists( 'woocommerce_grouped_add_to_cart' ) ) {
 
 	/**
 	 * Output the grouped product add to cart area.
+	 *
+	 * @return void
 	 */
 	function woocommerce_grouped_add_to_cart() {
 		global $product;
@@ -1963,6 +2048,8 @@ if ( ! function_exists( 'woocommerce_variable_add_to_cart' ) ) {
 
 	/**
 	 * Output the variable product add to cart area.
+	 *
+	 * @return void
 	 */
 	function woocommerce_variable_add_to_cart() {
 		global $product;
@@ -1992,6 +2079,8 @@ if ( ! function_exists( 'woocommerce_external_add_to_cart' ) ) {
 
 	/**
 	 * Output the external product add to cart area.
+	 *
+	 * @return void
 	 */
 	function woocommerce_external_add_to_cart() {
 		global $product;
@@ -2045,6 +2134,8 @@ if ( ! function_exists( 'woocommerce_product_description_tab' ) ) {
 
 	/**
 	 * Output the description tab content.
+	 *
+	 * @return void
 	 */
 	function woocommerce_product_description_tab() {
 		wc_get_template( 'single-product/tabs/description.php' );
@@ -2054,6 +2145,8 @@ if ( ! function_exists( 'woocommerce_product_additional_information_tab' ) ) {
 
 	/**
 	 * Output the attributes tab content.
+	 *
+	 * @return void
 	 */
 	function woocommerce_product_additional_information_tab() {
 		wc_get_template( 'single-product/tabs/additional-information.php' );
@@ -2162,6 +2255,7 @@ if ( ! function_exists( 'woocommerce_comments' ) ) {
 	 * @param WP_Comment $comment Comment object.
 	 * @param array      $args Arguments.
 	 * @param int        $depth Depth.
+	 * @return void
 	 */
 	function woocommerce_comments( $comment, $args, $depth ) {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -2217,6 +2311,8 @@ if ( ! function_exists( 'woocommerce_review_display_comment_text' ) ) {
 
 	/**
 	 * Display the review content.
+	 *
+	 * @return void
 	 */
 	function woocommerce_review_display_comment_text() {
 		echo '<div class="description">';
@@ -2229,6 +2325,8 @@ if ( ! function_exists( 'woocommerce_output_related_products' ) ) {
 
 	/**
 	 * Output the related products.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_related_products() {
 
@@ -2248,6 +2346,7 @@ if ( ! function_exists( 'woocommerce_related_products' ) ) {
 	 * Output the related products.
 	 *
 	 * @param array $args Provided arguments.
+	 * @return void
 	 */
 	function woocommerce_related_products( $args = array() ) {
 		global $product;
@@ -2298,6 +2397,7 @@ if ( ! function_exists( 'woocommerce_upsell_display' ) ) {
 	 * @param int    $columns (default: 4).
 	 * @param string $orderby Supported values - rand, title, ID, date, modified, menu_order, price.
 	 * @param string $order Sort direction.
+	 * @return void
 	 */
 	function woocommerce_upsell_display( $limit = -1, $columns = 4, $orderby = 'rand', $order = 'desc' ) {
 		global $product;
@@ -2366,6 +2466,7 @@ if ( ! function_exists( 'woocommerce_shipping_calculator' ) ) {
 	 * Output the cart shipping calculator.
 	 *
 	 * @param string $button_text Text for the shipping calculation toggle.
+	 * @return void
 	 */
 	function woocommerce_shipping_calculator( $button_text = '' ) {
 		if ( 'no' === get_option( 'woocommerce_enable_shipping_calc' ) || ! WC()->cart->needs_shipping() ) {
@@ -2385,6 +2486,8 @@ if ( ! function_exists( 'woocommerce_cart_totals' ) ) {
 
 	/**
 	 * Output the cart totals.
+	 *
+	 * @return void
 	 */
 	function woocommerce_cart_totals() {
 		if ( is_checkout() ) {
@@ -2403,6 +2506,7 @@ if ( ! function_exists( 'woocommerce_cross_sell_display' ) ) {
 	 * @param  int    $columns (default: 2).
 	 * @param  string $orderby (default: 'rand').
 	 * @param  string $order (default: 'desc').
+	 * @return void
 	 */
 	function woocommerce_cross_sell_display( $limit = 2, $columns = 2, $orderby = 'rand', $order = 'desc' ) {
 		if ( is_checkout() ) {
@@ -2448,6 +2552,8 @@ if ( ! function_exists( 'woocommerce_button_proceed_to_checkout' ) ) {
 
 	/**
 	 * Output the proceed to checkout button.
+	 *
+	 * @return void
 	 */
 	function woocommerce_button_proceed_to_checkout() {
 		wc_get_template( 'cart/proceed-to-checkout-button.php' );
@@ -2458,6 +2564,8 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_button_view_cart' ) ) 
 
 	/**
 	 * Output the view cart button.
+	 *
+	 * @return void
 	 */
 	function woocommerce_widget_shopping_cart_button_view_cart() {
 		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
@@ -2472,6 +2580,8 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_proceed_to_checkout' )
 
 	/**
 	 * Output the proceed to checkout button.
+	 *
+	 * @return void
 	 */
 	function woocommerce_widget_shopping_cart_proceed_to_checkout() {
 		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
@@ -2484,6 +2594,7 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_subtotal' ) ) {
 	 * Output to view cart subtotal.
 	 *
 	 * @since 3.7.0
+	 * @return void
 	 */
 	function woocommerce_widget_shopping_cart_subtotal() {
 		echo '<strong>' . esc_html__( 'Subtotal:', 'woocommerce' ) . '</strong> ' . WC()->cart->get_cart_subtotal(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -2498,6 +2609,7 @@ if ( ! function_exists( 'woocommerce_mini_cart' ) ) {
 	 * Output the Mini-cart - used by cart widget.
 	 *
 	 * @param array $args Arguments.
+	 * @return void
 	 */
 	function woocommerce_mini_cart( $args = array() ) {
 
@@ -2519,6 +2631,7 @@ if ( ! function_exists( 'woocommerce_login_form' ) ) {
 	 * Output the WooCommerce Login Form.
 	 *
 	 * @param array $args Arguments.
+	 * @return void
 	 */
 	function woocommerce_login_form( $args = array() ) {
 
@@ -2538,6 +2651,8 @@ if ( ! function_exists( 'woocommerce_checkout_login_form' ) ) {
 
 	/**
 	 * Output the WooCommerce Checkout Login Form.
+	 *
+	 * @return void
 	 */
 	function woocommerce_checkout_login_form() {
 		wc_get_template(
@@ -2555,6 +2670,7 @@ if ( ! function_exists( 'woocommerce_breadcrumb' ) ) {
 	 * Output the WooCommerce Breadcrumb.
 	 *
 	 * @param array $args Arguments.
+	 * @return void
 	 */
 	function woocommerce_breadcrumb( $args = array() ) {
 		$args = wp_parse_args(
@@ -2597,6 +2713,7 @@ if ( ! function_exists( 'woocommerce_order_review' ) ) {
 	 * Output the Order review table for the checkout.
 	 *
 	 * @param bool $deprecated Deprecated param.
+	 * @return void
 	 */
 	function woocommerce_order_review( $deprecated = false ) {
 		wc_get_template(
@@ -2612,6 +2729,8 @@ if ( ! function_exists( 'woocommerce_checkout_payment' ) ) {
 
 	/**
 	 * Output the Payment Methods on the checkout.
+	 *
+	 * @return void
 	 */
 	function woocommerce_checkout_payment() {
 		if ( ! WC()->cart ) {
@@ -2645,6 +2764,8 @@ if ( ! function_exists( 'woocommerce_checkout_coupon_form' ) ) {
 
 	/**
 	 * Output the Coupon form for the checkout.
+	 *
+	 * @return void
 	 */
 	function woocommerce_checkout_coupon_form() {
 		if ( is_user_logged_in() || WC()->checkout()->is_registration_enabled() || ! WC()->checkout()->is_registration_required() ) {
@@ -2854,6 +2975,7 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 	 * Show subcategory thumbnails.
 	 *
 	 * @param mixed $category Category.
+	 * @return void
 	 */
 	function woocommerce_subcategory_thumbnail( $category ) {
 		$small_thumbnail_size = apply_filters( 'subcategory_archive_thumbnail_size', 'woocommerce_thumbnail' );
@@ -2900,6 +3022,7 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 	 * Displays order details in a table.
 	 *
 	 * @param mixed $order_id Order ID.
+	 * @return void
 	 */
 	function woocommerce_order_details_table( $order_id ) {
 		if ( ! $order_id ) {
@@ -2952,6 +3075,7 @@ if ( ! function_exists( 'woocommerce_order_downloads_table' ) ) {
 	 *
 	 * @since 3.2.0
 	 * @param array $downloads Downloads.
+	 * @return void
 	 */
 	function woocommerce_order_downloads_table( $downloads ) {
 		if ( ! $downloads ) {
@@ -2972,6 +3096,7 @@ if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 	 * Display an 'order again' button on the view order page.
 	 *
 	 * @param object $order Order.
+	 * @return void
 	 */
 	function woocommerce_order_again_button( $order ) {
 		/**
@@ -3332,6 +3457,8 @@ if ( ! function_exists( 'woocommerce_output_auth_header' ) ) {
 
 	/**
 	 * Output the Auth header.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_auth_header() {
 		wc_get_template( 'auth/header.php' );
@@ -3342,6 +3469,8 @@ if ( ! function_exists( 'woocommerce_output_auth_footer' ) ) {
 
 	/**
 	 * Output the Auth footer.
+	 *
+	 * @return void
 	 */
 	function woocommerce_output_auth_footer() {
 		wc_get_template( 'auth/footer.php' );
@@ -3352,6 +3481,8 @@ if ( ! function_exists( 'woocommerce_single_variation' ) ) {
 
 	/**
 	 * Output placeholders for the single variation.
+	 *
+	 * @return void
 	 */
 	function woocommerce_single_variation() {
 		echo '<div class="woocommerce-variation single_variation" role="alert" aria-relevant="additions"></div>';
@@ -3362,6 +3493,8 @@ if ( ! function_exists( 'woocommerce_single_variation_add_to_cart_button' ) ) {
 
 	/**
 	 * Output the add to cart button for variations.
+	 *
+	 * @return void
 	 */
 	function woocommerce_single_variation_add_to_cart_button() {
 		wc_get_template( 'single-product/add-to-cart/variation-add-to-cart-button.php' );
@@ -3375,6 +3508,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 	 *
 	 * @param array $args Arguments.
 	 * @since 2.4.0
+	 * @return void
 	 */
 	function wc_dropdown_variation_attribute_options( $args = array() ) {
 		$args = wp_parse_args(
@@ -3455,6 +3589,8 @@ if ( ! function_exists( 'woocommerce_account_content' ) ) {
 
 	/**
 	 * My Account content output.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_content() {
 		global $wp;
@@ -3487,6 +3623,8 @@ if ( ! function_exists( 'woocommerce_account_navigation' ) ) {
 
 	/**
 	 * My Account navigation template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_navigation() {
 		wc_get_template( 'myaccount/navigation.php' );
@@ -3499,6 +3637,7 @@ if ( ! function_exists( 'woocommerce_account_orders' ) ) {
 	 * My Account > Orders template.
 	 *
 	 * @param int $current_page Current page number.
+	 * @return void
 	 */
 	function woocommerce_account_orders( $current_page ) {
 		$current_page    = empty( $current_page ) ? 1 : absint( $current_page );
@@ -3531,6 +3670,7 @@ if ( ! function_exists( 'woocommerce_account_view_order' ) ) {
 	 * My Account > View order template.
 	 *
 	 * @param int $order_id Order ID.
+	 * @return void
 	 */
 	function woocommerce_account_view_order( $order_id ) {
 		WC_Shortcode_My_Account::view_order( absint( $order_id ) );
@@ -3541,6 +3681,8 @@ if ( ! function_exists( 'woocommerce_account_downloads' ) ) {
 
 	/**
 	 * My Account > Downloads template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_downloads() {
 		wc_get_template( 'myaccount/downloads.php' );
@@ -3553,6 +3695,7 @@ if ( ! function_exists( 'woocommerce_account_edit_address' ) ) {
 	 * My Account > Edit address template.
 	 *
 	 * @param string $type Type of address; 'billing' or 'shipping'.
+	 * @return void
 	 */
 	function woocommerce_account_edit_address( $type ) {
 		$type = wc_edit_address_i18n( sanitize_title( $type ), true );
@@ -3565,6 +3708,8 @@ if ( ! function_exists( 'woocommerce_account_payment_methods' ) ) {
 
 	/**
 	 * My Account > Downloads template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_payment_methods() {
 		wc_get_template( 'myaccount/payment-methods.php' );
@@ -3575,6 +3720,8 @@ if ( ! function_exists( 'woocommerce_account_add_payment_method' ) ) {
 
 	/**
 	 * My Account > Add payment method template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_add_payment_method() {
 		WC_Shortcode_My_Account::add_payment_method();
@@ -3585,6 +3732,8 @@ if ( ! function_exists( 'woocommerce_account_edit_account' ) ) {
 
 	/**
 	 * My Account > Edit account template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_account_edit_account() {
 		WC_Shortcode_My_Account::edit_account();
@@ -3595,6 +3744,8 @@ if ( ! function_exists( 'wc_no_products_found' ) ) {
 
 	/**
 	 * Handles the loop when no products were found/no product exist.
+	 *
+	 * @return void
 	 */
 	function wc_no_products_found() {
 		if ( ! function_exists( 'wc_print_notice' ) ) {
@@ -3867,6 +4018,8 @@ if ( ! function_exists( 'woocommerce_photoswipe' ) ) {
 
 	/**
 	 * Get the shop sidebar template.
+	 *
+	 * @return void
 	 */
 	function woocommerce_photoswipe() {
 		if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
@@ -3880,6 +4033,7 @@ if ( ! function_exists( 'woocommerce_photoswipe' ) ) {
  *
  * @since  3.0.0
  * @param  WC_Product $product Product Object.
+ * @return void
  */
 function wc_display_product_attributes( $product ) {
 	$product_attributes = array();
@@ -4075,6 +4229,7 @@ function wc_logout_url( $redirect = '' ) {
  * Show notice if cart is empty.
  *
  * @since 3.1.0
+ * @return void
  */
 function wc_empty_cart_message() {
 	$notice = wc_print_notice(
@@ -4106,6 +4261,7 @@ function wc_empty_cart_message() {
  *
  * @todo Deprecated this function after dropping support for WP 5.6.
  * @since 3.2.0
+ * @return void
  */
 function wc_page_noindex() {
 	// wp_no_robots is deprecated since WP 5.7.
@@ -4255,6 +4411,7 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  * Outputs all queued notices on WC pages.
  *
  * @since 3.5.0
+ * @return void
  */
 function woocommerce_output_all_notices() {
 	if ( ! function_exists( 'wc_print_notices' ) ) {
@@ -4275,6 +4432,7 @@ function woocommerce_output_all_notices() {
  * Display pay buttons HTML.
  *
  * @since 3.9.0
+ * @return void
  */
 function wc_get_pay_buttons() {
 	$supported_gateways = array();

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2361,6 +2361,7 @@ function wc_update_500_db_version() {
 	WC_Install::update_db_version( '5.0.0' );
 }
 
+// phpcs:disable Squiz.Commenting.FunctionComment.InvalidReturnVoid -- return statement is in a nested function, not this one.
 /**
  * Creates the refund and returns policy page.
  *
@@ -2369,10 +2370,12 @@ function wc_update_500_db_version() {
  * @return void
  */
 function wc_update_560_create_refund_returns_page() {
+// phpcs:enable Squiz.Commenting.FunctionComment.InvalidReturnVoid
 	/**
 	 * Filter on the pages created to return what we expect.
 	 *
 	 * @param array $pages The default WC pages.
+	 * @return array
 	 */
 	function filter_created_pages( $pages ) {
 		$page_to_create = array( 'refund_returns' );

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -1252,6 +1252,8 @@ function wc_update_300_webhooks() {
 /**
  * Add an index to the field comment_type to improve the response time of the query
  * used by WC_Comments::wp_count_comments() to get the number of comments by type.
+ *
+ * @return void
  */
 function wc_update_300_comment_type_index() {
 	global $wpdb;
@@ -1316,6 +1318,8 @@ function wc_update_300_settings() {
 
 /**
  * Convert meta values into term for product visibility.
+ *
+ * @return void
  */
 function wc_update_300_product_visibility() {
 	global $wpdb;
@@ -1379,6 +1383,8 @@ function wc_update_300_product_visibility() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_300_db_version() {
 	WC_Install::update_db_version( '3.0.0' );
@@ -1386,6 +1392,8 @@ function wc_update_300_db_version() {
 
 /**
  * Add an index to the downloadable product permissions table to improve performance of update_user_by_order_id.
+ *
+ * @return void
  */
 function wc_update_310_downloadable_products() {
 	global $wpdb;
@@ -1399,6 +1407,8 @@ function wc_update_310_downloadable_products() {
 
 /**
  * Find old order notes and ensure they have the correct type for exclusion.
+ *
+ * @return void
  */
 function wc_update_310_old_comments() {
 	global $wpdb;
@@ -1408,6 +1418,8 @@ function wc_update_310_old_comments() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_310_db_version() {
 	WC_Install::update_db_version( '3.1.0' );
@@ -1415,6 +1427,8 @@ function wc_update_310_db_version() {
 
 /**
  * Update shop_manager capabilities.
+ *
+ * @return void
  */
 function wc_update_312_shop_manager_capabilities() {
 	$role = get_role( 'shop_manager' );
@@ -1423,6 +1437,8 @@ function wc_update_312_shop_manager_capabilities() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_312_db_version() {
 	WC_Install::update_db_version( '3.1.2' );
@@ -1430,6 +1446,8 @@ function wc_update_312_db_version() {
 
 /**
  * Update state codes for Mexico.
+ *
+ * @return void
  */
 function wc_update_320_mexican_states() {
 	global $wpdb;
@@ -1503,6 +1521,8 @@ function wc_update_320_mexican_states() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_320_db_version() {
 	WC_Install::update_db_version( '3.2.0' );
@@ -1510,6 +1530,8 @@ function wc_update_320_db_version() {
 
 /**
  * Update image settings to use new aspect ratios and widths.
+ *
+ * @return void
  */
 function wc_update_330_image_options() {
 	$old_thumbnail_size = get_option( 'shop_catalog_image_size', array() );
@@ -1555,6 +1577,8 @@ function wc_update_330_image_options() {
 
 /**
  * Migrate webhooks from post type to CRUD.
+ *
+ * @return void
  */
 function wc_update_330_webhooks() {
 	register_post_type( 'shop_webhook' );
@@ -1594,6 +1618,8 @@ function wc_update_330_webhooks() {
 
 /**
  * Assign default cat to all products with no cats.
+ *
+ * @return void
  */
 function wc_update_330_set_default_product_cat() {
 	/*
@@ -1606,6 +1632,8 @@ function wc_update_330_set_default_product_cat() {
 
 /**
  * Update product stock status to use the new onbackorder status.
+ *
+ * @return void
  */
 function wc_update_330_product_stock_status() {
 	global $wpdb;
@@ -1649,6 +1677,8 @@ function wc_update_330_product_stock_status() {
 
 /**
  * Clear addons page transients
+ *
+ * @return void
  */
 function wc_update_330_clear_transients() {
 	delete_transient( 'wc_addons_sections' );
@@ -1657,6 +1687,8 @@ function wc_update_330_clear_transients() {
 
 /**
  * Set PayPal's sandbox credentials.
+ *
+ * @return void
  */
 function wc_update_330_set_paypal_sandbox_credentials() {
 
@@ -1675,6 +1707,8 @@ function wc_update_330_set_paypal_sandbox_credentials() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_330_db_version() {
 	WC_Install::update_db_version( '3.3.0' );
@@ -1682,6 +1716,8 @@ function wc_update_330_db_version() {
 
 /**
  * Update state codes for Ireland and BD.
+ *
+ * @return void
  */
 function wc_update_340_states() {
 	$country_states = array(
@@ -1825,6 +1861,8 @@ function wc_update_340_state() {
 
 /**
  * Set last active prop for users.
+ *
+ * @return void
  */
 function wc_update_340_last_active() {
 	global $wpdb;
@@ -1845,6 +1883,8 @@ function wc_update_340_last_active() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_340_db_version() {
 	WC_Install::update_db_version( '3.4.0' );
@@ -1900,6 +1940,8 @@ function wc_update_344_db_version() {
 
 /**
  * Set the comment type to 'review' for product reviews that don't have a comment type.
+ *
+ * @return void
  */
 function wc_update_350_reviews_comment_type() {
 	global $wpdb;
@@ -1911,6 +1953,8 @@ function wc_update_350_reviews_comment_type() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_350_db_version() {
 	WC_Install::update_db_version( '3.5.0' );
@@ -1936,6 +1980,8 @@ function wc_update_352_drop_download_log_fk() {
 /**
  * Remove edit_user capabilities from shop managers and use "translated" capabilities instead.
  * See wc_shop_manager_has_capability function.
+ *
+ * @return void
  */
 function wc_update_354_modify_shop_manager_caps() {
 	global $wp_roles;
@@ -1953,6 +1999,8 @@ function wc_update_354_modify_shop_manager_caps() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_354_db_version() {
 	WC_Install::update_db_version( '3.5.4' );
@@ -1960,6 +2008,8 @@ function wc_update_354_db_version() {
 
 /**
  * Update product lookup tables in bulk.
+ *
+ * @return void
  */
 function wc_update_360_product_lookup_tables() {
 	wc_update_product_lookup_tables();
@@ -1967,6 +2017,8 @@ function wc_update_360_product_lookup_tables() {
 
 /**
  * Renames ordering meta to be consistent across taxonomies.
+ *
+ * @return void
  */
 function wc_update_360_term_meta() {
 	global $wpdb;
@@ -1991,6 +2043,8 @@ function wc_update_360_downloadable_product_permissions_index() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_360_db_version() {
 	WC_Install::update_db_version( '3.6.0' );
@@ -2063,6 +2117,8 @@ function wc_update_370_mro_std_currency() {
 
 /**
  * Update DB Version.
+ *
+ * @return void
  */
 function wc_update_370_db_version() {
 	WC_Install::update_db_version( '3.7.0' );
@@ -2071,6 +2127,8 @@ function wc_update_370_db_version() {
 /**
  * We've moved the MaxMind database to a new location, as per the TOS' requirement that the database not
  * be publicly accessible.
+ *
+ * @return void
  */
 function wc_update_390_move_maxmind_database() {
 	// Make sure to use all of the correct filters to pull the local database path.
@@ -2092,6 +2150,8 @@ function wc_update_390_move_maxmind_database() {
 
 /**
  * So that we can best meet MaxMind's TOS, the geolocation database update cron should run once per 15 days.
+ *
+ * @return void
  */
 function wc_update_390_change_geolocation_database_update_cron() {
 	wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
@@ -2100,6 +2160,8 @@ function wc_update_390_change_geolocation_database_update_cron() {
 
 /**
  * Update DB version.
+ *
+ * @return void
  */
 function wc_update_390_db_version() {
 	WC_Install::update_db_version( '3.9.0' );
@@ -2107,6 +2169,8 @@ function wc_update_390_db_version() {
 
 /**
  * Increase column size
+ *
+ * @return void
  */
 function wc_update_400_increase_size_of_column() {
 	global $wpdb;
@@ -2116,6 +2180,8 @@ function wc_update_400_increase_size_of_column() {
 
 /**
  * Reset ActionScheduler migration status. Needs AS >= 3.0 shipped with WC >= 4.0.
+ *
+ * @return void
  */
 function wc_update_400_reset_action_scheduler_migration_status() {
 	if (
@@ -2128,6 +2194,8 @@ function wc_update_400_reset_action_scheduler_migration_status() {
 
 /**
  * Update DB version.
+ *
+ * @return void
  */
 function wc_update_400_db_version() {
 	WC_Install::update_db_version( '4.0.0' );
@@ -2149,6 +2217,8 @@ function wc_update_440_insert_attribute_terms_for_variable_products() {
 
 /**
  * Update DB version.
+ *
+ * @return void
  */
 function wc_update_440_db_version() {
 	WC_Install::update_db_version( '4.4.0' );
@@ -2156,6 +2226,8 @@ function wc_update_440_db_version() {
 
 /**
  * Update DB version to 4.5.0.
+ *
+ * @return void
  */
 function wc_update_450_db_version() {
 	WC_Install::update_db_version( '4.5.0' );
@@ -2225,6 +2297,8 @@ function wc_update_450_sanitize_coupons_code() {
  * Fixes product review count that might have been incorrect.
  *
  * See @link https://github.com/woocommerce/woocommerce/issues/27688.
+ *
+ * @return bool True to run again, false if completed.
  */
 function wc_update_500_fix_product_review_count() {
 	global $wpdb;
@@ -2280,6 +2354,8 @@ function wc_update_500_fix_product_review_count() {
 
 /**
  * Update DB version to 5.0.0.
+ *
+ * @return void
  */
 function wc_update_500_db_version() {
 	WC_Install::update_db_version( '5.0.0' );
@@ -2289,6 +2365,8 @@ function wc_update_500_db_version() {
  * Creates the refund and returns policy page.
  *
  * See @link https://github.com/woocommerce/woocommerce/issues/29235.
+ *
+ * @return void
  */
 function wc_update_560_create_refund_returns_page() {
 	/**
@@ -2311,6 +2389,8 @@ function wc_update_560_create_refund_returns_page() {
 
 /**
  * Update DB version to 5.6.0.
+ *
+ * @return void
  */
 function wc_update_560_db_version() {
 	WC_Install::update_db_version( '5.6.0' );
@@ -2320,6 +2400,8 @@ function wc_update_560_db_version() {
  * Migrate rate limit options to the new table.
  *
  * See @link https://github.com/woocommerce/woocommerce/issues/27103.
+ *
+ * @return void
  */
 function wc_update_600_migrate_rate_limit_options() {
 	global $wpdb;
@@ -2349,6 +2431,8 @@ function wc_update_600_migrate_rate_limit_options() {
 
 /**
  * Update DB version to 6.0.0.
+ *
+ * @return void
  */
 function wc_update_600_db_version() {
 	WC_Install::update_db_version( '6.0.0' );
@@ -2378,6 +2462,8 @@ function wc_update_630_create_product_attributes_lookup_table() {
 /**
  *
  * Update DB version to 6.3.0.
+ *
+ * @return void
  */
 function wc_update_630_db_version() {
 	WC_Install::update_db_version( '6.3.0' );
@@ -2397,6 +2483,8 @@ function wc_update_640_add_primary_key_to_product_attributes_lookup_table() {
 /**
  *
  * Update DB version to 6.4.0.
+ *
+ * @return void
  */
 function wc_update_640_db_version() {
 	WC_Install::update_db_version( '6.4.0' );
@@ -2406,6 +2494,8 @@ function wc_update_640_db_version() {
  * Add the standard WooCommerce upload directories to the Approved Product Download Directories list
  * and start populating it based on existing product download URLs, but do not enable the feature
  * (for existing installations, a site admin should review and make a conscious decision to enable).
+ *
+ * @return void
  */
 function wc_update_650_approved_download_directories() {
 	$directory_sync = wc_get_container()->get( Download_Directories_Sync::class );
@@ -2416,6 +2506,8 @@ function wc_update_650_approved_download_directories() {
 /**
  * In some cases, the approved download directories table may not have been successfully created during the update to
  * 6.5.0. If this was the case we will need to re-initialize the feature.
+ *
+ * @return void
  */
 function wc_update_651_approved_download_directories() {
 	global $wpdb;
@@ -2441,6 +2533,8 @@ function wc_update_651_approved_download_directories() {
 
 /**
  * Purges the comments count cache after 6.7.0 split reviews from the comments page.
+ *
+ * @return void
  */
 function wc_update_670_purge_comments_count_cache() {
 	if ( ! is_callable( 'WC_Comments::delete_comments_count_cache' ) ) {
@@ -2470,6 +2564,8 @@ function wc_update_700_remove_download_log_fk() {
 
 /**
  * Remove the transient data for recommended marketing extensions.
+ *
+ * @return void
  */
 function wc_update_700_remove_recommended_marketing_plugins_transient() {
 	delete_transient( 'wc_marketing_recommended_plugins' );
@@ -2478,6 +2574,8 @@ function wc_update_700_remove_recommended_marketing_plugins_transient() {
 /**
  * Update the New Zealand state codes in the database
  * after they were updated in code to the CLDR standard.
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
  */
 function wc_update_721_adjust_new_zealand_states() {
 	return MigrationHelper::migrate_country_states(
@@ -2506,6 +2604,8 @@ function wc_update_721_adjust_new_zealand_states() {
 /**
  * Update the Ukraine state codes in the database
  * after they were updated in code to the CLDR standard.
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
  */
 function wc_update_721_adjust_ukraine_states() {
 	return MigrationHelper::migrate_country_states(
@@ -2545,6 +2645,8 @@ function wc_update_721_adjust_ukraine_states() {
  * This is a simple wrapper for the corresponding 7.2.1 update function. The reason we do this (instead of
  * reusing the original function directly) is for better traceability in the Action Scheduler log, in case
  * of problems.
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
  */
 function wc_update_722_adjust_new_zealand_states() {
 	return wc_update_721_adjust_new_zealand_states();
@@ -2556,6 +2658,8 @@ function wc_update_722_adjust_new_zealand_states() {
  * This is a simple wrapper for the corresponding 7.2.1 update function. The reason we do this (instead of
  * reusing the original function directly) is for better traceability in the Action Scheduler log, in case
  * of problems.
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
  */
 function wc_update_722_adjust_ukraine_states() {
 	return wc_update_721_adjust_ukraine_states();
@@ -2564,6 +2668,8 @@ function wc_update_722_adjust_ukraine_states() {
 /**
  * Add new columns date_paid and date_completed to wp_wc_order_stats table in order to provide the option
  * of using the dates in the reports
+ *
+ * @return void
  */
 function wc_update_750_add_columns_to_order_stats_table() {
 	global $wpdb;
@@ -2598,6 +2704,8 @@ function wc_update_750_disable_new_product_management_experience() {
 
 /**
  * Remove the multichannel marketing feature flag and options. This feature is now enabled by default.
+ *
+ * @return void
  */
 function wc_update_770_remove_multichannel_marketing_feature_options() {
 	delete_option( 'woocommerce_multichannel_marketing_enabled' );
@@ -2606,6 +2714,8 @@ function wc_update_770_remove_multichannel_marketing_feature_options() {
 
 /**
  * Set a flag to indicate whether the blockified Product Grid Block should be used as a template.
+ *
+ * @return void
  */
 function wc_update_790_blockified_product_grid_block() {
 	update_option( BlockOptions::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE, wc_bool_to_string( false ) );
@@ -2660,6 +2770,8 @@ LIMIT 250
 
 /**
  * Rename the checkout template to page-checkout.
+ *
+ * @return void
  */
 function wc_update_830_rename_checkout_template() {
 	$template = get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//checkout', 'wp_template' );
@@ -2679,6 +2791,8 @@ function wc_update_830_rename_checkout_template() {
 
 /**
  * Rename the cart template to page-cart.
+ *
+ * @return void
  */
 function wc_update_830_rename_cart_template() {
 	$template = get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//cart', 'wp_template' );
@@ -2701,6 +2815,8 @@ function wc_update_830_rename_cart_template() {
  *
  * This is removed because it is not used anymore.
  * It is replaced by `woocommerce_admin_marketing_recommendations_specs` transient that is created by `MarketingRecommendationsDataSourcePoller`.
+ *
+ * @return void
  */
 function wc_update_860_remove_recommended_marketing_plugins_transient() {
 	delete_transient( 'wc_marketing_recommended_plugins' );
@@ -2709,6 +2825,8 @@ function wc_update_860_remove_recommended_marketing_plugins_transient() {
 /**
  * Create an .htaccess file and an empty index.html file to prevent listing of the default transient files directory,
  * if the directory exists.
+ *
+ * @return void
  */
 function wc_update_870_prevent_listing_of_transient_files_directory() {
 	global $wp_filesystem;
@@ -2726,6 +2844,8 @@ function wc_update_870_prevent_listing_of_transient_files_directory() {
 
 /**
  * If it exists, remove the inbox note that asks users to connect to `Woo.com`.
+ *
+ * @return void
  */
 function wc_update_890_update_connect_to_woocommerce_note() {
 	$note = Notes::get_note_by_name( WooSubscriptionsNotes::CONNECTION_NOTE_NAME );
@@ -2749,6 +2869,8 @@ function wc_update_890_update_connect_to_woocommerce_note() {
  * to reduce the amount of new connections to the legacy gateway.
  *
  * Shows an admin notice to inform the store owner that PayPal Standard has been disabled and suggests installing PayPal Payments.
+ *
+ * @return void
  */
 function wc_update_890_update_paypal_standard_load_eligibility() {
 	$paypal = class_exists( 'WC_Gateway_Paypal' ) ? WC_Gateway_Paypal::get_instance() : null;
@@ -2766,6 +2888,8 @@ function wc_update_890_update_paypal_standard_load_eligibility() {
 /**
  * Create the woocommerce_history_of_autoinstalled_plugins option if it doesn't exist
  * as a copy of woocommerce_autoinstalled_plugins if it exists.
+ *
+ * @return void
  */
 function wc_update_891_create_plugin_autoinstall_history_option() {
 	$autoinstalled_plugins_history_info = get_site_option( 'woocommerce_history_of_autoinstalled_plugins' );
@@ -2779,6 +2903,8 @@ function wc_update_891_create_plugin_autoinstall_history_option() {
 
 /**
  * Add woocommerce_show_lys_tour.
+ *
+ * @return void
  */
 function wc_update_910_add_launch_your_store_tour_option() {
 	add_option( 'woocommerce_show_lys_tour', 'yes' );
@@ -2786,6 +2912,8 @@ function wc_update_910_add_launch_your_store_tour_option() {
 
 /**
  * Add woocommerce_hooked_blocks_version option for existing stores that are using a theme that supports the Block Hooks API
+ *
+ * @return void
  */
 function wc_update_920_add_wc_hooked_blocks_version_option() {
 	if ( ! wp_is_block_theme() && ! current_theme_supports( 'block-template-parts' ) ) {
@@ -2874,6 +3002,8 @@ function wc_update_910_remove_obsolete_user_meta() {
 
 /**
  * Add woocommerce_coming_soon option when it is not currently present.
+ *
+ * @return void
  */
 function wc_update_930_add_woocommerce_coming_soon_option() {
 	add_option( 'woocommerce_coming_soon', 'no' );
@@ -2881,6 +3011,8 @@ function wc_update_930_add_woocommerce_coming_soon_option() {
 
 /**
  * Migrate Launch Your Store tour meta keys to the woocommerce_meta user data fields.
+ *
+ * @return void
  */
 function wc_update_930_migrate_user_meta_for_launch_your_store_tour() {
 	// Rename `woocommerce_launch_your_store_tour_hidden` meta key to `woocommerce_admin_launch_your_store_tour_hidden`.
@@ -2909,6 +3041,8 @@ function wc_update_930_migrate_user_meta_for_launch_your_store_tour() {
 
 /**
  * Recreate FTS index if it already exists, so that phone number can be added to the index.
+ *
+ * @return void
  */
 function wc_update_940_add_phone_to_order_address_fts_index(): void {
 	$fts_already_exists = get_option( CustomOrdersTableController::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION ) === 'yes';
@@ -3002,6 +3136,8 @@ function wc_update_1000_multisite_visibility_setting(): void {
 
 /**
  * Autoloads woocommerce_allow_tracking option.
+ *
+ * @return void
  */
 function wc_update_950_tracking_option_autoload() {
 	$options = array(
@@ -3013,6 +3149,8 @@ function wc_update_950_tracking_option_autoload() {
 /**
  * Update the base color for emails as part of the WooCommerce rebranding,
  * but only if the user hasn't specified a custom color.
+ *
+ * @return void
  */
 function wc_update_961_migrate_default_email_base_color() {
 	$color = get_option( 'woocommerce_email_base_color' );
@@ -3023,6 +3161,8 @@ function wc_update_961_migrate_default_email_base_color() {
 
 /**
  * Add old refunded order items to the product_lookup_table.
+ *
+ * @return void
  */
 function wc_update_1020_add_old_refunded_order_items_to_product_lookup_table() {
 	global $wpdb;
@@ -3063,6 +3203,8 @@ function wc_update_1020_add_old_refunded_order_items_to_product_lookup_table() {
 /**
  * Remove the option woocommerce_order_attribution_install_banner_dismissed.
  * This data is now stored in the user meta table in the PR #55715.
+ *
+ * @return void
  */
 function wc_update_980_remove_order_attribution_install_banner_dismissed_option() {
 	delete_option( 'woocommerce_order_attribution_install_banner_dismissed' );
@@ -3070,6 +3212,8 @@ function wc_update_980_remove_order_attribution_install_banner_dismissed_option(
 
 /**
  * One-time force enable the new Payments Settings page feature for all stores.
+ *
+ * @return void
  */
 function wc_update_985_enable_new_payments_settings_page_feature() {
 	update_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled', 'yes' );
@@ -3077,6 +3221,8 @@ function wc_update_985_enable_new_payments_settings_page_feature() {
 
 /**
  * Remove the transient wc_count_comments as this has migrated to use cache.
+ *
+ * @return void
  */
 function wc_update_990_remove_wc_count_comments_transient() {
 	delete_transient( 'wc_count_comments' );
@@ -3144,6 +3290,8 @@ function wc_update_1040_cleanup_legacy_ptk_patterns_fetching() {
  * This migration ensures any installations that still have this old option set will have their brand permalink updated appropriately.
  *
  * @since 10.5.0
+ *
+ * @return void
  */
 function wc_update_1050_migrate_brand_permalink_setting() {
 	if ( 'yes' !== get_option( 'woocommerce_prepend_shop_page_to_urls' ) ) {

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -40288,12 +40288,6 @@ parameters:
 			path: includes/wc-update-functions.php
 
 		-
-			message: '#^Function filter_created_pages\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
 			message: '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
 			identifier: function.inner
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -10147,607 +10147,7 @@ parameters:
 			path: includes/class-wc-ajax.php
 
 		-
-			message: '#^Method WC_AJAX\:\:add_ajax_events\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_attribute\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_attributes_and_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_coupon_discount\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_new_attribute\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_order_fee\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_order_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_order_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_order_shipping\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_order_tax\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:add_variation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:apply_coupon\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:bulk_edit_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:calc_line_taxes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:checkout\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
 			message: '#^Method WC_AJAX\:\:create_all_product_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:define_ajax\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:delete_order_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:delete_refund\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:do_wc_ajax\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:feature_product\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_cart_totals\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_customer_details\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_customer_location\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_order_details\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_refreshed_fragments\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:get_variation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:grant_access_to_download\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:init\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_categories\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_categories_tree\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_customers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_downloadable_products_and_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_pages\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_product_attributes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_products\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_products_and_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:json_search_taxonomy_terms\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:link_all_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:load_order_items\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:load_status_widget\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:load_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:mark_order_status\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:order_add_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:product_ordering\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:rated\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:refund_line_items\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_coupon\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_from_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_order_coupon\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_order_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_order_tax\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:remove_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:render_variation_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:revoke_access_to_download\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:save_attributes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:save_order_items\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:save_variations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:set_wc_ajax_argument_in_query\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_classes_save_changes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_zone_add_method\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_zone_methods_save_changes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_zone_methods_save_settings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_zone_remove_method\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:shipping_zones_save_changes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:tax_rates_save_changes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:term_ordering\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:toggle_gateway_enabled\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:update_api_key\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:update_order_review\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:update_order_review_expired\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:update_shipping_method\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_delete_all\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_toggle_downloadable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_toggle_enabled\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_toggle_manage_stock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_toggle_virtual\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_download_expiry\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_download_limit\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_height\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_length\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_low_stock_amount\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_regular_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_regular_price_decrease\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_regular_price_increase\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_sale_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_sale_price_decrease\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_sale_price_increase\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_sale_schedule\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_stock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_stock_status_instock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_stock_status_onbackorder\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_stock_status_outofstock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_unset_cogs_value\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_weight\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_action_variable_width\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_adjust_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_set\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:variation_bulk_toggle\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
-			message: '#^Method WC_AJAX\:\:wc_ajax_headers\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-ajax.php
@@ -38140,18 +37540,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function _wc_save_product_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function _woocommerce_term_recount\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function _woocommerce_term_recount\(\) has parameter \$callback with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -38182,12 +37570,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function get_product\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function get_product\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -38206,44 +37588,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function wc_caught_exception\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_deprecated_argument\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function wc_deprecated_argument\(\) has parameter \$message with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_deprecated_function\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_deprecated_hook\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_do_deprecated_action\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_doing_it_wrong\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38254,38 +37600,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function wc_load_persistent_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function wc_product_dropdown_categories invoked with 4 parameters, 0\-1 required\.$#'
 			identifier: arguments.count
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_products_rss_feed\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_taxonomy_metadata_update_content_for_split_terms\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function wc_taxonomy_metadata_wpdbfix\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_add_order_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38298,12 +37614,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_add_order_item\(\) has parameter \$order_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_add_order_item_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38332,26 +37642,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_add_to_cart_message\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_add_to_cart_message\(\) has parameter \$product_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_admin_scripts\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_array_overlay\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38374,26 +37666,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_cancel_unpaid_orders\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals_coupon_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_cart_totals_coupon_html\(\) has parameter \$coupon with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals_fee_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38404,38 +37678,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_cart_totals_order_total_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals_shipping_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals_shipping_method_label\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_cart_totals_shipping_method_label\(\) has parameter \$method with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals_subtotal_html\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_change_term_counts\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38458,32 +37702,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_clean\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_clean\(\) has parameter \$var with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_clear_cart_after_payment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_compile_less_styles\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_create_new_customer\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38502,12 +37722,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_create_new_customer\(\) has parameter \$username with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_create_page\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38542,12 +37756,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_customer_bought_product\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_customer_bought_product\(\) has parameter \$customer_email with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -38562,18 +37770,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_customer_bought_product\(\) has parameter \$user_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_customer_edit_account_url\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_customer_has_capability\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38596,32 +37792,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_date_format\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_datepicker_js\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_delete_order_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_delete_order_item\(\) has parameter \$item_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_delete_order_item_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38650,20 +37822,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_disable_admin_bar\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_disable_admin_bar\(\) has parameter \$show_admin_bar with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_downloadable_file_permission\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38686,26 +37846,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_downloadable_product_permissions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_downloadable_product_permissions\(\) has parameter \$order_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_empty_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_format_decimal\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38728,32 +37870,14 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_format_hex\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_format_hex\(\) has parameter \$hex with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_get_attachment_image_attributes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_get_attachment_image_attributes\(\) has parameter \$attr with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_dimension\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38766,12 +37890,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_get_dimension\(\) has parameter \$to_unit with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_endpoint_url\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38794,26 +37912,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_get_featured_product_ids\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_filename_from_url\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_get_filename_from_url\(\) has parameter \$file_url with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_formatted_variation\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38830,20 +37930,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_get_order_id_by_order_key\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_get_order_id_by_order_key\(\) has parameter \$order_key with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_order_item_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38866,26 +37954,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_get_page_id\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_get_page_id\(\) has parameter \$page with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_product_ids_on_sale\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_product_terms\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38904,12 +37974,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_get_product_terms\(\) has parameter \$taxonomy with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_template\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38938,12 +38002,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_get_template_part\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_get_template_part\(\) has parameter \$name with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -38952,12 +38010,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_get_template_part\(\) has parameter \$slug with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_get_weight\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -38974,12 +38026,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_hex_darker\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_hex_darker\(\) has parameter \$color with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -38988,12 +38034,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_hex_darker\(\) has parameter \$factor with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_hex_lighter\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39010,26 +38050,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_legacy_paypal_ipn\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_let_to_num\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_let_to_num\(\) has parameter \$size with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_light_or_dark\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39052,20 +38074,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_list_pages\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_list_pages\(\) has parameter \$pages with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_load_persistent_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39078,12 +38088,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_load_persistent_cart\(\) has parameter \$user_login with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_locate_template\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39106,20 +38110,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_lostpassword_url\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_lostpassword_url\(\) has parameter \$url with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_mail\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39154,12 +38146,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_nav_menu_item_classes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_nav_menu_item_classes\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39172,12 +38158,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_nav_menu_items\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_nav_menu_items\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39186,12 +38166,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_nav_menu_items\(\) has parameter \$items with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_order_terms\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39226,20 +38200,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_paying_customer\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_paying_customer\(\) has parameter \$order_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_placeholder_img\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39250,26 +38212,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_placeholder_img_src\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_prepare_attachment_for_js\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_prepare_attachment_for_js\(\) has parameter \$response with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39282,18 +38226,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_price\(\) has parameter \$price with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_processing_order_count\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_product_dropdown_categories\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39322,12 +38254,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_product_post_type_link\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_product_post_type_link\(\) has parameter \$permalink with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39340,20 +38266,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_product_reviews_tab\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_product_subcategories\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_protected_product_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39370,12 +38284,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_readfile_chunked\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_readfile_chunked\(\) has parameter \$file with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39388,26 +38296,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_recount_after_stock_change\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_recount_after_stock_change\(\) has parameter \$product_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_reset_loop\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_rgb_from_hex\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39418,20 +38308,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_round_tax_total\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_round_tax_total\(\) has parameter \$tax with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_sanitize_taxonomy_name\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39442,26 +38320,8 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_scheduled_sales\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_set_customer_auth_cookie\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_set_customer_auth_cookie\(\) has parameter \$customer_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_set_term_order\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39490,24 +38350,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_show_messages\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_taxonomy_metadata_wpdbfix\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_terms_clauses\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_terms_clauses\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39526,56 +38368,14 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_time_format\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_timezone_string\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_tooltip_js\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_track_product_view\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_trim_zeros\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_trim_zeros\(\) has parameter \$price with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_update_new_customer_past_orders\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_update_new_customer_past_orders\(\) has parameter \$customer_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_update_order_item_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -39604,12 +38404,6 @@ parameters:
 			path: includes/wc-deprecated-functions.php
 
 		-
-			message: '#^Function woocommerce_walk_category_dropdown_tree\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
 			message: '#^Function woocommerce_walk_category_dropdown_tree\(\) has parameter \$a1 with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -39624,12 +38418,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_walk_category_dropdown_tree\(\) has parameter \$a3 with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/wc-deprecated-functions.php
-
-		-
-			message: '#^Function woocommerce_weekend_area_js\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-deprecated-functions.php
 
@@ -41092,140 +39880,14 @@ parameters:
 			path: includes/wc-template-functions.php
 
 		-
-			message: '#^Function wc_checkout_privacy_policy_text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_display_product_attributes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_dropdown_variation_attribute_options\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_empty_cart_message\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_gallery_noscript\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
 			message: '#^Function wc_get_formatted_cart_item_data\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/wc-template-functions.php
 
 		-
-			message: '#^Function wc_get_pay_buttons\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_no_js\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_no_products_found\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_page_noindex\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_prevent_adjacent_posts_rel_link_wp_head\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_prevent_endpoint_indexing\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_privacy_policy_text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_product_cat_class\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_product_class\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
 			message: '#^Function wc_query_string_form_fields\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_registration_privacy_policy_text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_reset_loop\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_reset_product_grid_settings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_send_frame_options_header\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_set_loop_product_visibility\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_set_loop_prop\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_setup_loop\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-template-functions.php
 
@@ -41242,278 +39904,14 @@ parameters:
 			path: includes/wc-template-functions.php
 
 		-
-			message: '#^Function wc_template_redirect\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_terms_and_conditions_checkbox_text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function wc_terms_and_conditions_page_content\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_add_payment_method\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_content\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_downloads\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_edit_account\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_edit_address\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_navigation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_orders\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_payment_methods\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_account_view_order\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_breadcrumb\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_button_proceed_to_checkout\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_cart_totals\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_catalog_ordering\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_checkout_coupon_form\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_checkout_login_form\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_checkout_payment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_comments\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_content\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_cross_sell_display\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_demo_store\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_external_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
 			message: '#^Function woocommerce_form_field\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1
 			path: includes/wc-template-functions.php
 
 		-
-			message: '#^Function woocommerce_get_sidebar\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_grouped_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_login_form\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_mini_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_order_again_button\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_order_details_table\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_order_downloads_table\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_order_review\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_all_notices\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_auth_footer\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_auth_header\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_content_wrapper\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_content_wrapper_end\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_product_data_tabs\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_output_related_products\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
 			message: '#^Function woocommerce_page_title\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_pagination\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_photoswipe\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_product_additional_information_tab\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_product_archive_description\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_product_description_tab\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-template-functions.php
 
@@ -41530,12 +39928,6 @@ parameters:
 			path: includes/wc-template-functions.php
 
 		-
-			message: '#^Function woocommerce_product_taxonomy_archive_header\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
 			message: '#^Function woocommerce_quantity_input\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1
@@ -41544,216 +39936,6 @@ parameters:
 		-
 			message: '#^Function woocommerce_quantity_input\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_related_products\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_result_count\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_review_display_comment_text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_shipping_calculator\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_show_product_images\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_show_product_loop_sale_flash\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_show_product_sale_flash\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_show_product_thumbnails\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_simple_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_single_variation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_single_variation_add_to_cart_button\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_subcategory_thumbnail\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_taxonomy_archive_description\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_category_link_close\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_category_link_open\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_category_title\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_product_link_close\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_product_link_open\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_product_thumbnail\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_product_title\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_loop_rating\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_excerpt\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_price\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_rating\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_sharing\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_template_single_title\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_upsell_display\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_variable_add_to_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_widget_shopping_cart_button_view_cart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_widget_shopping_cart_proceed_to_checkout\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-template-functions.php
-
-		-
-			message: '#^Function woocommerce_widget_shopping_cart_subtotal\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/wc-template-functions.php
 
@@ -42107,444 +40289,6 @@ parameters:
 
 		-
 			message: '#^Function filter_created_pages\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_1020_add_old_refunded_order_items_to_product_lookup_table\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_1050_migrate_brand_permalink_setting\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_300_comment_type_index\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_300_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_300_product_visibility\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_310_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_310_downloadable_products\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_310_old_comments\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_312_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_312_shop_manager_capabilities\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_320_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_320_mexican_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_clear_transients\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_image_options\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_product_stock_status\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_set_default_product_cat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_set_paypal_sandbox_credentials\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_330_webhooks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_340_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_340_last_active\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_340_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_350_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_350_reviews_comment_type\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_354_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_354_modify_shop_manager_caps\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_360_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_360_product_lookup_tables\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_360_term_meta\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_370_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_390_change_geolocation_database_update_cron\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_390_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_390_move_maxmind_database\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_400_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_400_increase_size_of_column\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_400_reset_action_scheduler_migration_status\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_440_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_450_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_500_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_500_fix_product_review_count\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_560_create_refund_returns_page\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_560_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_600_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_600_migrate_rate_limit_options\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_630_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_640_db_version\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_650_approved_download_directories\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_651_approved_download_directories\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_670_purge_comments_count_cache\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_700_remove_recommended_marketing_plugins_transient\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_721_adjust_new_zealand_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_721_adjust_ukraine_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_722_adjust_new_zealand_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_722_adjust_ukraine_states\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_750_add_columns_to_order_stats_table\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_770_remove_multichannel_marketing_feature_options\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_790_blockified_product_grid_block\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_830_rename_cart_template\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_830_rename_checkout_template\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_860_remove_recommended_marketing_plugins_transient\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_870_prevent_listing_of_transient_files_directory\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_890_update_connect_to_woocommerce_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_890_update_paypal_standard_load_eligibility\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_891_create_plugin_autoinstall_history_option\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_910_add_launch_your_store_tour_option\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_920_add_wc_hooked_blocks_version_option\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_930_add_woocommerce_coming_soon_option\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_930_migrate_user_meta_for_launch_your_store_tour\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_950_tracking_option_autoload\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_961_migrate_default_email_base_color\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_980_remove_order_attribution_install_banner_dismissed_option\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_985_enable_new_payments_settings_page_feature\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/wc-update-functions.php
-
-		-
-			message: '#^Function wc_update_990_remove_wc_count_comments_transient\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/wc-update-functions.php


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds missing \`@return\` PHPDoc type annotations to 376 functions across 4 files to reduce the PHPStan baseline. No functional code changes — only documentation annotations and removal of 5 unnecessary \`return\` statements in deprecated wrapper functions that were returning void function results.

Partially addresses WOOPRD-2129.

**Files modified:**

| File | Functions annotated |
|---|---|
| \`includes/wc-deprecated-functions.php\` | 102 |
| \`includes/class-wc-ajax.php\` | 100 |
| \`includes/wc-template-functions.php\` | 101 |
| \`includes/wc-update-functions.php\` | 73 |

**PHPStan baseline reduction:** 16,767 → 16,393 errors (**-374 errors**)

This is the first batch addressing the \`missingType.return\` identifier, which accounts for 4,136 of the 16,767 baselined errors (24.7%). These 4 files were the top offenders.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Run \`composer exec -- phpstan analyse --memory-limit=4G --no-progress\` from \`plugins/woocommerce/\`
3. Verify PHPStan passes with no errors beyond the baseline
4. Optionally, run \`composer exec -- phpstan analyse includes/wc-deprecated-functions.php includes/class-wc-ajax.php includes/wc-template-functions.php includes/wc-update-functions.php --memory-limit=2G --no-progress\` to verify the modified files individually produce no \`missingType.return\` errors

### Testing that has already taken place:

- PHPStan analysis run individually on each modified file — all pass with zero errors
- Full PHPStan baseline regenerated and verified

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry was created manually and is included in the branch.