### PR TITLE
Product Reviews block: add support for replies

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-reviews-add-back-support-for-replies
+++ b/plugins/woocommerce/changelog/fix-product-reviews-add-back-support-for-replies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Reviews block: add support for replies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
@@ -204,7 +204,7 @@ export default function ReviewTemplateEdit( {
 							commentQuery
 					  ) as ( WPComment & {
 							// eslint-disable-next-line @typescript-eslint/naming-convention
-							_embedded?: { children?: WPComment[] };
+							_embedded?: { children?: WPComment[][] };
 					  } )[] )
 					: null,
 				blocks: getBlocks( clientId ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
@@ -133,27 +133,25 @@ const ReviewTemplateInnerBlocks = memo( function ReviewTemplateInnerBlocks( {
 			/>
 			{ comment.children && comment.children.length > 0 ? (
 				<ol>
-					{ comment.children.map(
-						(
-							{ commentId, ...childComment }: Comment,
-							index: number
-						) => (
-							<BlockContextProvider
-								key={ commentId || index }
-								value={ {
-									commentId: commentId < 0 ? null : commentId,
-								} }
-							>
-								<ReviewTemplateInnerBlocks
-									comment={ { commentId, ...childComment } }
-									activeCommentId={ activeCommentId }
-									setActiveCommentId={ setActiveCommentId }
-									blocks={ blocks }
-									firstCommentId={ firstCommentId }
-								/>
-							</BlockContextProvider>
-						)
-					) }
+					{ comment.children.map( ( child, index ) => (
+						<BlockContextProvider
+							key={ child.commentId || index }
+							value={ {
+								commentId:
+									child.commentId < 0
+										? null
+										: child.commentId,
+							} }
+						>
+							<ReviewTemplateInnerBlocks
+								comment={ child }
+								activeCommentId={ activeCommentId }
+								setActiveCommentId={ setActiveCommentId }
+								blocks={ blocks }
+								firstCommentId={ firstCommentId }
+							/>
+						</BlockContextProvider>
+					) ) }
 				</ol>
 			) : null }
 		</li>
@@ -265,27 +263,25 @@ export default function ReviewTemplateEdit( {
 	return (
 		<ol { ...blockProps }>
 			{ commentTree &&
-				commentTree.map(
-					(
-						{ commentId, ...commentData }: Comment,
-						index: number
-					) => (
-						<BlockContextProvider
-							key={ commentId || index }
-							value={ {
-								commentId: commentId < 0 ? null : commentId,
-							} }
-						>
-							<ReviewTemplateInnerBlocks
-								comment={ { commentId, ...commentData } }
-								activeCommentId={ activeCommentId }
-								setActiveCommentId={ setActiveCommentId }
-								blocks={ blocks }
-								firstCommentId={ commentTree[ 0 ]?.commentId }
-							/>
-						</BlockContextProvider>
-					)
-				) }
+				commentTree.map( ( comment, index ) => (
+					<BlockContextProvider
+						key={ comment.commentId || index }
+						value={ {
+							commentId:
+								comment.commentId < 0
+									? null
+									: comment.commentId,
+						} }
+					>
+						<ReviewTemplateInnerBlocks
+							comment={ comment }
+							activeCommentId={ activeCommentId }
+							setActiveCommentId={ setActiveCommentId }
+							blocks={ blocks }
+							firstCommentId={ commentTree[ 0 ]?.commentId }
+						/>
+					</BlockContextProvider>
+				) ) }
 		</ol>
 	);
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { BlockInstance, BlockEditProps } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+import type { Comment as WPComment } from '@wordpress/core-data';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -23,10 +24,11 @@ import {
 /**
  * Internal dependencies
  */
-import { useCommentQueryArgs, useCommentList } from './hooks';
+import { useCommentQueryArgs, useCommentTree } from './hooks';
 
-interface Comment {
+export interface Comment {
 	commentId: number;
+	children?: Comment[];
 }
 
 interface ReviewTemplateInnerBlocksProps {
@@ -63,7 +65,7 @@ interface ReviewSettings {
 const getCommentsPlaceholder = ( {
 	perPage,
 	pageComments,
-}: ReviewSettings ) => {
+}: ReviewSettings ): Comment[] => {
 	const numberOfComments = pageComments ? Math.min( perPage, 3 ) : 3;
 
 	return Array.from( { length: numberOfComments }, ( _, i ) => ( {
@@ -129,6 +131,31 @@ const ReviewTemplateInnerBlocks = memo( function ReviewTemplateInnerBlocks( {
 					comment.commentId === ( activeCommentId || firstCommentId )
 				}
 			/>
+			{ comment.children && comment.children.length > 0 ? (
+				<ol>
+					{ comment.children.map(
+						(
+							{ commentId, ...childComment }: Comment,
+							index: number
+						) => (
+							<BlockContextProvider
+								key={ commentId || index }
+								value={ {
+									commentId: commentId < 0 ? null : commentId,
+								} }
+							>
+								<ReviewTemplateInnerBlocks
+									comment={ { commentId, ...childComment } }
+									activeCommentId={ activeCommentId }
+									setActiveCommentId={ setActiveCommentId }
+									blocks={ blocks }
+									firstCommentId={ firstCommentId }
+								/>
+							</BlockContextProvider>
+						)
+					) }
+				</ol>
+			) : null }
 		</li>
 	);
 } );
@@ -171,7 +198,14 @@ export default function ReviewTemplateEdit( {
 			};
 			return {
 				topLevelComments: commentQuery
-					? getEntityRecords( 'root', 'comment', commentQuery )
+					? ( getEntityRecords(
+							'root',
+							'comment',
+							commentQuery
+					  ) as ( WPComment & {
+							// eslint-disable-next-line @typescript-eslint/naming-convention
+							_embedded?: { children?: WPComment[] };
+					  } )[] )
 					: null,
 				blocks: getBlocks( clientId ),
 			};
@@ -179,17 +213,30 @@ export default function ReviewTemplateEdit( {
 		[ clientId, commentQuery ]
 	);
 
-	let commentTree = useCommentList(
-		// Reverse the order of top comments if needed.
-		commentOrder === 'desc' && topLevelComments
-			? [
-					...( topLevelComments as Array< {
-						id: number;
-					} > ),
-			  ].reverse()
-			: ( topLevelComments as Array< {
-					id: number;
-			  } > )
+	let commentTree = useCommentTree(
+		Array.isArray( topLevelComments )
+			? topLevelComments.map( ( comment ) => {
+					const children = comment._embedded?.children;
+
+					if (
+						Array.isArray( children ) &&
+						children.length >= 1 &&
+						Array.isArray( children[ 0 ] )
+					) {
+						return {
+							id: comment.id,
+							children: children[ 0 ].map( ( child ) => ( {
+								id: child.id,
+							} ) ),
+						};
+					}
+
+					return {
+						id: comment.id,
+					};
+			  } )
+			: [],
+		commentOrder
 	);
 
 	if ( ! topLevelComments ) {
@@ -220,11 +267,7 @@ export default function ReviewTemplateEdit( {
 			{ commentTree &&
 				commentTree.map(
 					(
-						{
-							commentId,
-						}: {
-							commentId: number;
-						},
+						{ commentId, ...commentData }: Comment,
 						index: number
 					) => (
 						<BlockContextProvider
@@ -234,7 +277,7 @@ export default function ReviewTemplateEdit( {
 							} }
 						>
 							<ReviewTemplateInnerBlocks
-								comment={ { commentId } }
+								comment={ { commentId, ...commentData } }
 								activeCommentId={ activeCommentId }
 								setActiveCommentId={ setActiveCommentId }
 								blocks={ blocks }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -169,22 +169,16 @@ export const useCommentTree = (
 	commentOrder: string
 ) => {
 	const commentTree = useMemo( () => {
-		const comments = topLevelComments.map(
-			( {
-				id,
-				children,
-			}: {
-				id: number;
-				children?: Array< { id: number } >;
-			} ) => {
+		const comments: Comment[] = topLevelComments.map(
+			( { id, children } ) => {
 				return {
 					commentId: id,
 					children: Array.isArray( children )
-						? children.map( ( child: { id: number } ) => ( {
+						? children.map( ( child ) => ( {
 								commentId: child.id,
 						  } ) )
 						: [],
-				} as Comment;
+				};
 			}
 		);
 		if ( commentOrder === 'desc' ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -168,9 +168,8 @@ export const useCommentTree = (
 	} >,
 	commentOrder: string
 ) => {
-	console.log( 'topLevelComments', topLevelComments );
 	const commentTree = useMemo( () => {
-		let comms = topLevelComments?.map(
+		const comments = topLevelComments?.map(
 			( {
 				id,
 				children,
@@ -189,9 +188,9 @@ export const useCommentTree = (
 			}
 		);
 		if ( commentOrder === 'desc' ) {
-			comms = comms?.reverse();
+			return comments.reverse();
 		}
-		return comms;
+		return comments;
 	}, [ topLevelComments, commentOrder ] );
 
 	return commentTree;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -7,6 +7,11 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
+import type { Comment } from './edit';
+
 // This is limited by WP REST API
 const MAX_COMMENTS_PER_PAGE = 100;
 
@@ -23,6 +28,8 @@ export const useCommentQueryArgs = ( { postId }: { postId: number } ) => {
 			context: 'embed',
 			parent: 0,
 			type: 'review',
+			// Request embedded children so we can show direct replies.
+			_embed: 'children',
 		} ),
 		[]
 	);
@@ -152,23 +159,40 @@ export const useCommentQueryArgs = ( { postId }: { postId: number } ) => {
 };
 
 /**
- * Generate a list of IDs from a list of review entities.
+ * Generate a tree structure of comment IDs from a list of review entities.
  */
-export const useCommentList = (
-	// eslint-disable-next-line @typescript-eslint/naming-convention
+export const useCommentTree = (
 	topLevelComments: Array< {
 		id: number;
-	} >
+		children?: Array< { id: number } >;
+	} >,
+	commentOrder: string
 ) => {
-	const commentList = useMemo(
-		() =>
-			topLevelComments?.map( ( { id }: { id: number } ) => {
+	console.log( 'topLevelComments', topLevelComments );
+	const commentTree = useMemo( () => {
+		let comms = topLevelComments?.map(
+			( {
+				id,
+				children,
+			}: {
+				id: number;
+				children?: Array< { id: number } >;
+			} ) => {
 				return {
 					commentId: id,
-				};
-			} ),
-		[ topLevelComments ]
-	);
+					children: Array.isArray( children )
+						? children.map( ( child: { id: number } ) => ( {
+								commentId: child.id,
+						  } ) )
+						: [],
+				} as Comment;
+			}
+		);
+		if ( commentOrder === 'desc' ) {
+			comms = comms?.reverse();
+		}
+		return comms;
+	}, [ topLevelComments, commentOrder ] );
 
-	return commentList;
+	return commentTree;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -169,7 +169,7 @@ export const useCommentTree = (
 	commentOrder: string
 ) => {
 	const commentTree = useMemo( () => {
-		const comments = topLevelComments?.map(
+		const comments = topLevelComments.map(
 			( {
 				id,
 				children,

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -55966,18 +55966,6 @@ parameters:
 			path: src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
 
 		-
-			message: '#^Access to property \$comment_ID on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\WP_Comment\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
-
-		-
-			message: '#^Access to property \$comment_post_ID on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\WP_Comment\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\ProductReviewTemplate\:\:render\(\) should return string but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1
@@ -55992,12 +55980,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\<int\|WP_Comment\>\|int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
-
-		-
-			message: '#^Parameter \$comments of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\ProductReviewTemplate\:\:block_product_review_template_render_comments\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\Reviews\\WP_Comment\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
@@ -35,11 +35,10 @@ class ProductReviewTemplate extends AbstractBlock {
 	 *
 	 * @param WP_Comment[] $comments      The array of comments.
 	 * @param WP_Block     $block         Block instance.
-	 * @param int          $current_depth Current depth of comments, defaults to 1.
 	 *
 	 * @return string
 	 */
-	protected function block_product_review_template_render_comments( array $comments, WP_Block $block, int $current_depth = 1 ): string {
+	protected function block_product_review_template_render_comments( array $comments, WP_Block $block ): string {
 		$content = '';
 
 		foreach ( $comments as $comment ) {
@@ -94,7 +93,6 @@ class ProductReviewTemplate extends AbstractBlock {
 				$inner_content  = $this->block_product_review_template_render_comments(
 					$children,
 					$block,
-					$current_depth + 1
 				);
 				$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
@@ -33,10 +33,13 @@ class ProductReviewTemplate extends AbstractBlock {
 	 *
 	 * @param WP_Comment[] $comments        The array of comments.
 	 * @param WP_Block     $block           Block instance.
+	 * @param int          $current_depth   Current depth of comments, defaults to 1.
+	 *
 	 * @return string
 	 */
-	protected function block_product_review_template_render_comments( $comments, $block ) {
+	protected function block_product_review_template_render_comments( $comments, $block, $current_depth = 1 ) {
 		$content = '';
+
 		foreach ( $comments as $comment ) {
 			$comment_id           = $comment->comment_ID;
 			$filter_block_context = static function ( $context ) use ( $comment_id ) {
@@ -45,24 +48,46 @@ class ProductReviewTemplate extends AbstractBlock {
 			};
 
 			/*
-			* We set commentId context through the `render_block_context` filter so
-			* that dynamically inserted blocks (at `render_block` filter stage)
-			* will also receive that context.
-			*
-			* Use an early priority to so that other 'render_block_context' filters
-			* have access to the values.
-			*/
+			 * We set commentId context through the `render_block_context` filter so
+			 * that dynamically inserted blocks (at `render_block` filter stage)
+			 * will also receive that context.
+			 *
+			 * Use an early priority so that other 'render_block_context' filters
+			 * have access to the values.
+			 */
 			add_filter( 'render_block_context', $filter_block_context, 1 );
 
 			/*
-			* We construct a new WP_Block instance from the parsed block so that
-			* it'll receive any changes made by the `render_block_data` filter.
-			*/
+			 * We construct a new WP_Block instance from the parsed block so that
+			 * it'll receive any changes made by the `render_block_data` filter.
+			 */
 			$block_content = ( new WP_Block( $block->parsed_block ) )->render( array( 'dynamic' => false ) );
 
 			remove_filter( 'render_block_context', $filter_block_context, 1 );
 
+			$children = $comment->get_children();
+
+			/*
+			 * We need to create the CSS classes BEFORE recursing into the children.
+			 * This is because comment_class() uses globals like `$comment_alt`
+			 * and `$comment_thread_alt` which are order-sensitive.
+			 *
+			 * The `false` parameter at the end means that we do NOT want the function
+			 * to `echo` the output but to return a string.
+			 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+			 */
 			$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
+
+			// If the comment has children, recurse to create the HTML for the nested
+			// comments, respecting the configured thread depth.
+			if ( ! empty( $children ) ) {
+				$inner_content  = $this->block_product_review_template_render_comments(
+					$children,
+					$block,
+					$current_depth + 1
+				);
+				$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
+			}
 
 			$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
@@ -4,6 +4,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use WP_Comment_Query;
 use WP_Block;
+use WP_Comment;
+
 /**
  * ProductReviewTemplate class.
  */
@@ -31,16 +33,20 @@ class ProductReviewTemplate extends AbstractBlock {
 	 *
 	 * @since 6.3.0 Changed render_block_context priority to `1`.
 	 *
-	 * @param WP_Comment[] $comments        The array of comments.
-	 * @param WP_Block     $block           Block instance.
-	 * @param int          $current_depth   Current depth of comments, defaults to 1.
+	 * @param WP_Comment[] $comments      The array of comments.
+	 * @param WP_Block     $block         Block instance.
+	 * @param int          $current_depth Current depth of comments, defaults to 1.
 	 *
 	 * @return string
 	 */
-	protected function block_product_review_template_render_comments( $comments, $block, $current_depth = 1 ) {
+	protected function block_product_review_template_render_comments( array $comments, WP_Block $block, int $current_depth = 1 ): string {
 		$content = '';
 
 		foreach ( $comments as $comment ) {
+			if ( ! $comment instanceof WP_Comment ) {
+				continue;
+			}
+
 			$comment_id           = $comment->comment_ID;
 			$filter_block_context = static function ( $context ) use ( $comment_id ) {
 				$context['commentId'] = $comment_id;
@@ -68,18 +74,22 @@ class ProductReviewTemplate extends AbstractBlock {
 			$children = $comment->get_children();
 
 			/*
-			 * We need to create the CSS classes BEFORE recursing into the children.
-			 * This is because comment_class() uses globals like `$comment_alt`
-			 * and `$comment_thread_alt` which are order-sensitive.
-			 *
-			 * The `false` parameter at the end means that we do NOT want the function
-			 * to `echo` the output but to return a string.
-			 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
-			 */
-			$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
+			* We need to create the CSS classes BEFORE recursing into the children.
+			* This is because comment_class() uses globals like `$comment_alt`
+			* and `$comment_thread_alt` which are order-sensitive.
+			*
+			* The `false` parameter at the end means that we do NOT want the function
+			* to `echo` the output but to return a string.
+			* See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+			*/
+			$comment_classes = comment_class(
+				'',
+				(int) $comment->comment_ID,
+				(int) $comment->comment_post_ID,
+				false
+			);
 
-			// If the comment has children, recurse to create the HTML for the nested
-			// comments, respecting the configured thread depth.
+			// If the comment has children, recurse to create the HTML for the nested comments.
 			if ( ! empty( $children ) ) {
 				$inner_content  = $this->block_product_review_template_render_comments(
 					$children,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/63157.
Closes WOOPLUG-6261.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57865.

### How to test the changes in this Pull Request:

1. Add a review to a product.
2. In Products > Reviews add a reply to that review.
3. In the page editor, add the _Product_ block, inside it, add the _Product Reviews_ block. Verify it renders the reply.
4. In the frontend of that page, verify it renders the reply as well.

Editor | Frontend
--- | ---
<img width="1201" height="825" alt="imatge" src="https://github.com/user-attachments/assets/97cd7688-e9bb-4eb5-b59b-d0786466ef12" /> | <img width="1201" height="825" alt="imatge" src="https://github.com/user-attachments/assets/51454710-975e-4b94-84f2-6167a6f784bc" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->