### PR TITLE
Add filters for validated email settings in V4 Emails REST API

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7686-users-can-set-from-address-to-match-any-domain
+++ b/plugins/woocommerce/changelog/stomail-7686-users-can-set-from-address-to-match-any-domain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add filters `woocommerce_emails_api_settings_schema_validate_and_sanitize_settings` and `woocommerce_emails_settings_schema_validate_and_sanitize_settings` to allow customization of email settings validation in the REST API.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Email/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Email/Controller.php
@@ -213,6 +213,28 @@ class Controller extends AbstractController {
 			$reply_to_enabled = wc_bool_to_string( $values_to_update['woocommerce_email_reply_to_enabled'] );
 		}
 
+		/**
+		 * Filters the values to update before validation and sanitization.
+		 *
+		 * @param array $values_to_update Values to update.
+		 * @param array $settings_by_id Settings by ID.
+		 * @return array Values to update.
+		 * @since 10.6.0
+		 */
+		$values_to_update = apply_filters( 'woocommerce_emails_api_settings_schema_validate_and_sanitize_settings', $values_to_update, $settings_by_id );
+
+		if ( is_wp_error( $values_to_update ) ) {
+			return $values_to_update;
+		}
+
+		if ( ! is_array( $values_to_update ) ) {
+			return new WP_Error(
+				'rest_invalid_filter_result',
+				__( 'Invalid result from filter.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
 		// Process each setting in the payload.
 		foreach ( $values_to_update as $setting_id => $setting_value ) {
 			// Sanitize the setting ID.
@@ -236,20 +258,6 @@ class Controller extends AbstractController {
 
 			// Store validated values first.
 			$validated_settings[ $setting_id ] = $sanitized_value;
-		}
-
-		/**
-		 * Filters the validated settings before updating.
-		 *
-		 * @param array $validated_settings Validated settings.
-		 * @param array $settings_by_id Settings by ID.
-		 * @param array $values_to_update Values to update.
-		 * @return array Validated settings.
-		 * @since 10.6.0
-		 */
-		$validated_settings = apply_filters( 'woocommerce_emails_api_settings_schema_validate_and_sanitize_settings', $validated_settings, $settings_by_id, $values_to_update );
-		if ( is_wp_error( $validated_settings ) ) {
-			return $validated_settings;
 		}
 
 		// After validation loop, update all settings.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Email/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Email/Controller.php
@@ -238,6 +238,20 @@ class Controller extends AbstractController {
 			$validated_settings[ $setting_id ] = $sanitized_value;
 		}
 
+		/**
+		 * Filters the validated settings before updating.
+		 *
+		 * @param array $validated_settings Validated settings.
+		 * @param array $settings_by_id Settings by ID.
+		 * @param array $values_to_update Values to update.
+		 * @return array Validated settings.
+		 * @since 10.6.0
+		 */
+		$validated_settings = apply_filters( 'woocommerce_emails_api_settings_schema_validate_and_sanitize_settings', $validated_settings, $settings_by_id, $values_to_update );
+		if ( is_wp_error( $validated_settings ) ) {
+			return $validated_settings;
+		}
+
 		// After validation loop, update all settings.
 		$updated_settings = array();
 		foreach ( $validated_settings as $setting_id => $value ) {

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -505,6 +505,14 @@ class EmailsSettingsSchema extends AbstractSchema {
 			return $validated;
 		}
 
+		if ( ! is_array( $validated ) ) {
+			return new WP_Error(
+				'rest_invalid_filter_result',
+				__( 'Invalid result from filter.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
 		return $validated;
 	}
 

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/Emails/Schema/EmailsSettingsSchema.php
@@ -491,6 +491,20 @@ class EmailsSettingsSchema extends AbstractSchema {
 			$validated[ $field_id ] = $sanitized;
 		}
 
+		/**
+		 * Filters the validated settings after validation and sanitization.
+		 *
+		 * @param array $validated Validated settings.
+		 * @param WC_Email $email Email instance.
+		 * @param array $values Values to validate and sanitize.
+		 * @return array Validated settings.
+		 * @since 10.6.0
+		 */
+		$validated = apply_filters( 'woocommerce_emails_settings_schema_validate_and_sanitize_settings', $validated, $email, $values );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
 		return $validated;
 	}
 


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

#### Why

Currently, the WooCommerce email settings REST API does not provide extension points for developers to customize the validation and sanitization process for email settings. This limitation prevents third-party plugins and extensions from implementing custom validation rules.

Closes STOMAIL-7686



### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

None.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

None.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
