### PR TITLE
Only disable add-to-cart button in variable products when wc-add-to-cart-variation is enqueued

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-10.5-variable-add-to-cart-button-disabled
+++ b/plugins/woocommerce/changelog/fix-wc-10.5-variable-add-to-cart-button-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only disable add-to-cart button in variable products when wc-add-to-cart-variation is enqueued

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -11,7 +11,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.5.0
+ * @version 10.5.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -2,6 +2,13 @@
 /**
  * Single variation cart button
  *
+ * Variables available to callers of wc_get_template() for this template:
+ *
+ * @var bool $add_to_cart_button_disabled Optional. When provided, overrides whether the add to cart button
+ *                                        is initially disabled. If not set, defaults to true when the
+ *                                        wc-add-to-cart-variation script is enqueued (so the button can be
+ *                                        enabled once a variation is selected).
+ *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 10.5.0
@@ -10,6 +17,10 @@
 defined( 'ABSPATH' ) || exit;
 
 global $product;
+
+$is_add_to_cart_button_disabled = isset( $add_to_cart_button_disabled )
+	? (bool) $add_to_cart_button_disabled
+	: wp_script_is( 'wc-add-to-cart-variation', 'enqueued' );
 ?>
 <div class="woocommerce-variation-add-to-cart variations_button">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
@@ -28,7 +39,7 @@ global $product;
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
 
-	<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" disabled><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"<?php echo $is_add_to_cart_button_disabled ? ' disabled' : ''; ?>><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -2,13 +2,6 @@
 /**
  * Single variation cart button
  *
- * Variables available to callers of wc_get_template() for this template:
- *
- * @var bool $add_to_cart_button_disabled Optional. When provided, overrides whether the add to cart button
- *                                        is initially disabled. If not set, defaults to true when the
- *                                        wc-add-to-cart-variation script is enqueued (so the button can be
- *                                        enabled once a variation is selected).
- *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 10.5.1
@@ -18,9 +11,13 @@ defined( 'ABSPATH' ) || exit;
 
 global $product;
 
-$is_add_to_cart_button_disabled = isset( $add_to_cart_button_disabled )
-	? (bool) $add_to_cart_button_disabled
-	: wp_script_is( 'wc-add-to-cart-variation', 'enqueued' );
+/*
+ * By default, the add to cart button is disabled to prevent shoppers from interacting with it
+ * while the WooCommerce variation script is still loading. If the default variation script
+ * (wc-add-to-cart-variation) is not enqueued, the button remains enabled to ensure compatibility
+ * with stores that use this template without the script.
+ */
+$is_add_to_cart_button_disabled = wp_script_is( 'wc-add-to-cart-variation', 'enqueued' );
 ?>
 <div class="woocommerce-variation-add-to-cart variations_button">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>

--- a/plugins/woocommerce/tests/php/includes/class-wc-variation-add-to-cart-button-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-variation-add-to-cart-button-test.php
@@ -40,13 +40,12 @@ class WC_Variation_Add_To_Cart_Button_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Renders the variation add-to-cart button template and returns HTML.
 	 *
-	 * @param array $args Optional template arguments (e.g. add_to_cart_button_disabled).
 	 * @return string
 	 */
-	private function render_template( array $args = array() ): string {
+	private function render_template(): string {
 		global $product;
 		$product = $this->product;
-		return wc_get_template_html( 'single-product/add-to-cart/variation-add-to-cart-button.php', $args );
+		return wc_get_template_html( 'single-product/add-to-cart/variation-add-to-cart-button.php' );
 	}
 
 	/**
@@ -86,35 +85,19 @@ class WC_Variation_Add_To_Cart_Button_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox When add_to_cart_button_disabled is true, the button is disabled.
+	 * @testdox When wc-add-to-cart-variation is not enqueued, the button is enabled.
 	 */
-	public function test_override_disabled_true_renders_disabled_button(): void {
-		$html = $this->render_template( array( 'add_to_cart_button_disabled' => true ) );
-		$this->assert_button_is_disabled( $html );
-	}
-
-	/**
-	 * @testdox When add_to_cart_button_disabled is false, the button is enabled.
-	 */
-	public function test_override_disabled_false_renders_enabled_button(): void {
-		$html = $this->render_template( array( 'add_to_cart_button_disabled' => false ) );
+	public function test_when_script_not_enqueued_renders_enabled_button(): void {
+		$html = $this->render_template();
 		$this->assert_button_is_enabled( $html );
 	}
 
 	/**
-	 * @testdox When no override is passed and wc-add-to-cart-variation is not enqueued, the button is enabled.
+	 * @testdox When wc-add-to-cart-variation is enqueued, the button is disabled.
 	 */
-	public function test_fallback_when_script_not_enqueued_renders_enabled_button(): void {
-		$html = $this->render_template( array() );
-		$this->assert_button_is_enabled( $html );
-	}
-
-	/**
-	 * @testdox When no override is passed and wc-add-to-cart-variation is enqueued, the button is disabled.
-	 */
-	public function test_fallback_when_script_enqueued_renders_disabled_button(): void {
+	public function test_when_script_enqueued_renders_disabled_button(): void {
 		$this->register_and_enqueue_variation_script();
-		$html = $this->render_template( array() );
+		$html = $this->render_template();
 		$this->assert_button_is_disabled( $html );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-variation-add-to-cart-button-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-variation-add-to-cart-button-test.php
@@ -1,0 +1,120 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Unit tests for the variation add-to-cart button template and disabled state.
+ *
+ * @package WooCommerce\Tests\Includes
+ */
+
+/**
+ * Class WC_Variation_Add_To_Cart_Button_Test
+ */
+class WC_Variation_Add_To_Cart_Button_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Variable product for template tests.
+	 *
+	 * @var WC_Product_Variable
+	 */
+	private $product;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->product = WC_Helper_Product::create_variation_product();
+	}
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		global $product;
+		$product = null;
+		wp_dequeue_script( 'wc-add-to-cart-variation' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Renders the variation add-to-cart button template and returns HTML.
+	 *
+	 * @param array $args Optional template arguments (e.g. add_to_cart_button_disabled).
+	 * @return string
+	 */
+	private function render_template( array $args = array() ): string {
+		global $product;
+		$product = $this->product;
+		return wc_get_template_html( 'single-product/add-to-cart/variation-add-to-cart-button.php', $args );
+	}
+
+	/**
+	 * Asserts the rendered button has the disabled attribute.
+	 *
+	 * @param string $html Rendered template HTML.
+	 */
+	private function assert_button_is_disabled( string $html ): void {
+		$this->assertStringContainsString( 'single_add_to_cart_button', $html );
+		$this->assertStringContainsString( ' disabled>', $html, 'Add to cart button should be disabled' );
+	}
+
+	/**
+	 * Asserts the rendered button does not have the disabled attribute.
+	 *
+	 * @param string $html Rendered template HTML.
+	 */
+	private function assert_button_is_enabled( string $html ): void {
+		$this->assertStringContainsString( 'single_add_to_cart_button', $html );
+		$this->assertStringNotContainsString( ' disabled>', $html, 'Add to cart button should not be disabled' );
+	}
+
+	/**
+	 * Registers and enqueues the wc-add-to-cart-variation script so wp_script_is( 'wc-add-to-cart-variation', 'enqueued' ) is true.
+	 */
+	private function register_and_enqueue_variation_script(): void {
+		if ( ! wp_script_is( 'wc-add-to-cart-variation', 'registered' ) ) {
+			wp_register_script(
+				'wc-add-to-cart-variation',
+				'https://example.com/wc-add-to-cart-variation.js',
+				array( 'jquery' ),
+				WC_VERSION,
+				true
+			);
+		}
+		wp_enqueue_script( 'wc-add-to-cart-variation' );
+	}
+
+	/**
+	 * @testdox When add_to_cart_button_disabled is true, the button is disabled.
+	 */
+	public function test_override_disabled_true_renders_disabled_button(): void {
+		$html = $this->render_template( array( 'add_to_cart_button_disabled' => true ) );
+		$this->assert_button_is_disabled( $html );
+	}
+
+	/**
+	 * @testdox When add_to_cart_button_disabled is false, the button is enabled.
+	 */
+	public function test_override_disabled_false_renders_enabled_button(): void {
+		$html = $this->render_template( array( 'add_to_cart_button_disabled' => false ) );
+		$this->assert_button_is_enabled( $html );
+	}
+
+	/**
+	 * @testdox When no override is passed and wc-add-to-cart-variation is not enqueued, the button is enabled.
+	 */
+	public function test_fallback_when_script_not_enqueued_renders_enabled_button(): void {
+		$html = $this->render_template( array() );
+		$this->assert_button_is_enabled( $html );
+	}
+
+	/**
+	 * @testdox When no override is passed and wc-add-to-cart-variation is enqueued, the button is disabled.
+	 */
+	public function test_fallback_when_script_enqueued_renders_disabled_button(): void {
+		$this->register_and_enqueue_variation_script();
+		$html = $this->render_template( array() );
+		$this->assert_button_is_disabled( $html );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/62631.

Since WooCommerce 10.5 was released, several users reported it's not possible to add variable products to cart in their store. Even though a [dev advisory](https://developer.woocommerce.com/2026/01/16/add-to-cart-button-disabled-by-default-in-variable-products-in-woocommerce-10-5/) was published about this, it's likely it didn't reach all plugin authors or stores impacts. This PR implements a more conservative approach, so we only disable the button if we detect `wc-add-to-cart-variation` is enqueued.

Kudos to @kmanijak for suggesting this approach.

Note: the `Highlight Template Changes` job is expected to fail as this PR is targeting `10.5.1` and the job expects the version to be `10.6.0`.

### How to test the changes in this Pull Request:

1. Add this code snippet to your site:

```PHP
wp_deregister_script( 'wc-add-to-cart-variation' );
add_shortcode( 'wc_variation_add_to_cart_button', function ( $atts ) {
	global $product;
	$product = wc_get_product( 85 ); // Change this ID with the ID of a variable product.
	wp_deregister_script( 'wc-add-to-cart-variation' );
	ob_start();
	woocommerce_variable_add_to_cart();
	return ob_get_clean();
} );
```

2. Create a post with this content: `[wc_variation_add_to_cart_button]`.
3. In the frontend, verify the Add to Cart button is not disabled and you can click on it.

* Note: the add to cart won't work, as it's expected another script will handle the match between the UI and the selected variation, so testing is simply about making sure the button can be clicked and you are redirected to the product page.

Before | After
--- | ---
<img width="944" height="395" alt="imatge" src="https://github.com/user-attachments/assets/fefad637-9b0a-46ae-b99c-e2a920a0a0b4" /> | <img width="944" height="395" alt="imatge" src="https://github.com/user-attachments/assets/13d8fdfd-5d91-406e-a117-e5744cb64211" />