### PR TITLE
HPOS: disable sync-on-read by default

### DIFF
--- a/plugins/woocommerce/changelog/deprecate-hpos-sync-on-read
+++ b/plugins/woocommerce/changelog/deprecate-hpos-sync-on-read
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable HPOS sync-on-read by default and add admin notice for affected sites.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -45,6 +45,7 @@ class WC_Admin_Notices {
 		'uploads_directory_is_unprotected'   => 'uploads_directory_is_unprotected_notice',
 		'base_tables_missing'                => 'base_tables_missing_notice',
 		'download_directories_sync_complete' => 'download_directories_sync_complete',
+		'hpos_sync_on_read_disabled'         => 'sync_on_read_disabled_notice',
 	);
 
 	/**
@@ -713,6 +714,26 @@ class WC_Admin_Notices {
 		}
 
 		include __DIR__ . '/views/html-notice-base-table-missing.php';
+	}
+
+	/**
+	 * Notice about HPOS sync-on-read being disabled by default.
+	 *
+	 * @since 10.7.0
+	 * @return void
+	 */
+	public static function sync_on_read_disabled_notice() {
+		$dismiss =
+			! \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled()
+			|| ! wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class )->data_sync_is_enabled()
+			|| get_user_meta( get_current_user_id(), 'dismissed_hpos_sync_on_read_disabled_notice', true );
+
+		if ( $dismiss ) {
+			self::remove_notice( 'hpos_sync_on_read_disabled' );
+			return;
+		}
+
+		include __DIR__ . '/views/html-notice-sync-on-read-disabled.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/views/html-notice-sync-on-read-disabled.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-sync-on-read-disabled.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 				sprintf(
 					/* translators: %s: URL to blog post about this change. */
 					__( 'Compatibility mode for HPOS no longer pulls order changes made to the posts database back into your orders automatically. If your site uses custom code or plugins that modify orders outside of WooCommerce, this may affect how order data is handled. <a href="%s">Learn more about this change and what to do</a>.', 'woocommerce' ),
-					'https://developer.woocommerce.com/PLACEHOLDER'
+					'https://developer.woocommerce.com/2026/02/16/hpos-sync-on-read-to-be-disabled-by-default-in-woocommerce-10-7/'
 				)
 			);
 			?>

--- a/plugins/woocommerce/includes/admin/views/html-notice-sync-on-read-disabled.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-sync-on-read-disabled.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Admin View: Notice - HPOS sync-on-read disabled.
+ *
+ * @package WooCommerce\Admin\Notices
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="message" class="updated woocommerce-message">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'hpos_sync_on_read_disabled' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+	<p>
+		<strong><?php esc_html_e( 'HPOS order "sync on read" has been disabled', 'woocommerce' ); ?></strong><br />
+		<?php
+			echo wp_kses_post(
+				sprintf(
+					/* translators: %s: URL to blog post about this change. */
+					__( 'Compatibility mode for HPOS no longer pulls order changes made to the posts database back into your orders automatically. If your site uses custom code or plugins that modify orders outside of WooCommerce, this may affect how order data is handled. <a href="%s">Learn more about this change and what to do</a>.', 'woocommerce' ),
+					'https://developer.woocommerce.com/PLACEHOLDER'
+				)
+			);
+			?>
+	</p>
+</div>

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -322,6 +322,9 @@ class WC_Install {
 		'10.6.0' => array(
 			'wc_update_1060_add_woo_idx_comment_approved_type_index',
 		),
+		'10.7.0' => array(
+			'wc_update_1070_disable_hpos_sync_on_read',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3398,3 +3398,23 @@ function wc_update_1060_add_woo_idx_comment_approved_type_index(): void {
 		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_approved_type (comment_approved, comment_type, comment_post_ID)" );
 	}
 }
+
+/**
+ * Add an admin notice about HPOS sync-on-read being disabled by default for sites
+ * that have both HPOS and data synchronization enabled.
+ *
+ * @since 10.7.0
+ *
+ * @return void
+ */
+function wc_update_1070_disable_hpos_sync_on_read(): void {
+	if ( 'yes' !== get_option( 'woocommerce_custom_orders_table_enabled' ) ) {
+		return;
+	}
+
+	if ( 'yes' !== get_option( 'woocommerce_custom_orders_table_data_sync_enabled' ) ) {
+		return;
+	}
+
+	WC_Admin_Notices::add_notice( 'hpos_sync_on_read_disabled' );
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -480,6 +480,7 @@ class DataSynchronizerTests extends \HposTestCase {
 		// Sync enabled and CPT authoritative.
 		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+		add_filter( 'woocommerce_hpos_enable_sync_on_read', '__return_true' );
 
 		$order = OrderHelper::create_order();
 		$order->add_meta_data( 'foo', 'bar' );
@@ -503,6 +504,7 @@ class DataSynchronizerTests extends \HposTestCase {
 			'',
 			'Meta data deleted from the CPT datastore should also be deleted from the HPOS datastore.'
 		);
+		remove_all_filters( 'woocommerce_hpos_enable_sync_on_read' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR disables HPOS sync-on-read by default, which can cause issues with stale data overwriting HPOS data or even infinite loops of syncs as we've seen in the past (see #62514, for example).

Sync-on-read is inherently risky (a full sync during a read!) and moving away from it would be for the best, now that HPOS has been out for a while.

Related to p6q7sZ-l1O-p2.

> [!WARNING]
> Do not merge this PR before 10.6.0's feature freeze.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. **Test the update notice for those in HPOS + compat mode:**
   1. Enable HPOS and compat mode:
      ```
      wp wc hpos sync
      wp wc hpos enable --with-sync
      ```
   1. Simulate an update to 10.7.0:
      ```
      wp option update woocommerce_version 10.6.0
      wp option update woocommerce_db_version 10.6.0
      wp wc update
      ```
   1. Visit **WooCommerce > Settings** on the admin and confirm that you see a notice about sync-on-read being disabled.
   <img width="1464" height="107" alt="Screenshot 2026-02-13 at 14 49 31" src="https://github.com/user-attachments/assets/79848cca-3999-4e08-a9b4-91df6c293835" />
1. **Confirm that sync-on-read no longer occurs by default but can be enabled via filter:**
   1. Create an order in "processing" status and take note of its ID:
      ```
      wp wc shop_order create --status=processing --user=1
      ```
   1. Modify the order to "on hold" outside of WC:
      ```
      wp post update <order_id> --post_status=wc-on-hold
      ```
   1. Confirm that the order status is still "processing":
      ```
      wp eval "echo wc_get_order( <order_id> )->get_status();"
      ```
   1. Add the following snippet on your site as a mu-plugin or similar to enable "sync-on-read":
      ```php
      <?php
      add_filter( 'woocommerce_hpos_enable_sync_on_read', '__return_true' );
      ```
   1. Repeat steps i-iii above but confirm that this time on the last step the order status is "on-hold".
1. **Confirm that the notice doesn't appear while upgrading with compat mode disabled:**
   1. Disable compatibility mode:
      ```
      wp wc hpos compatibility-mode disable
      ```
   1. Simulate an update to 10.7.0:
      ```
      wp option update woocommerce_version 10.6.0
      wp option update woocommerce_db_version 10.6.0
      wp wc update
      ```
   1. Visit **WooCommerce > Settings** on the admin. No notice should be visible.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.