### PR TITLE
Fix spacing issues in email editor product collection rendering

### DIFF
--- a/packages/php/email-editor/changelog/63177-fix-email-editor-product-collection-spacing
+++ b/packages/php/email-editor/changelog/63177-fix-email-editor-product-collection-spacing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix spacing issues in email editor product collection rendering.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
@@ -65,7 +65,13 @@ abstract class Abstract_Block_Renderer implements Block_Renderer {
 	 * @return string
 	 */
 	protected function add_spacer( $content, $email_attrs ): string {
-		$gap_style     = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) ), '' ) ?? '';
+		// Filter out empty margin-top values to prevent malformed CSS output.
+		$margin_top_attrs = array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) );
+		if ( isset( $margin_top_attrs['margin-top'] ) && '' === trim( $margin_top_attrs['margin-top'] ) ) {
+			$margin_top_attrs = array();
+		}
+
+		$gap_style     = WP_Style_Engine::compile_css( $margin_top_attrs, '' ) ?? '';
 		$padding_style = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
 
 		$table_attrs = array(

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
@@ -197,8 +197,7 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 	 * @return string
 	 */
 	private function render_product_content( ?\WC_Product $product, array $template_block, string $collection_type, ?int $cell_width = null ): string {
-		$content             = '';
-		$previous_block_name = null;
+		$content = '';
 
 		if ( ! $product ) {
 			return $content;
@@ -209,12 +208,6 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 			if ( null !== $cell_width ) {
 				$inner_block['email_attrs']          = $inner_block['email_attrs'] ?? array();
 				$inner_block['email_attrs']['width'] = $cell_width . 'px';
-			}
-
-			// Adjust spacing between image and title for better visual hierarchy.
-			if ( 'core/post-title' === $inner_block['blockName'] && 'woocommerce/product-image' === $previous_block_name ) {
-				$inner_block['email_attrs']               = $inner_block['email_attrs'] ?? array();
-				$inner_block['email_attrs']['margin-top'] = '32px';
 			}
 
 			switch ( $inner_block['blockName'] ) {
@@ -248,8 +241,6 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 				default:
 					break;
 			}
-
-			$previous_block_name = $inner_block['blockName'];
 		}
 
 		return $content;

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
@@ -101,11 +101,19 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 		if ( 1 === $columns ) {
 			// Single column layout - render products vertically.
 			$content = '';
+			$index   = 0;
 			foreach ( $products as $product ) {
+				// For the first product, use the original email_attrs.
+				// For subsequent products, add margin-top for spacing between items.
+				$email_attrs = $inner_block['email_attrs'] ?? array();
+				if ( $index > 0 && ! isset( $email_attrs['margin-top'] ) ) {
+					$email_attrs['margin-top'] = '32px';
+				}
 				$content .= $this->add_spacer(
 					$this->render_product_content( $product, $inner_block, $collection_type ),
-					$inner_block['email_attrs'] ?? array()
+					$email_attrs
 				);
+				++$index;
 			}
 			return $content;
 		}
@@ -189,7 +197,8 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 	 * @return string
 	 */
 	private function render_product_content( ?\WC_Product $product, array $template_block, string $collection_type, ?int $cell_width = null ): string {
-		$content = '';
+		$content             = '';
+		$previous_block_name = null;
 
 		if ( ! $product ) {
 			return $content;
@@ -200,6 +209,12 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 			if ( null !== $cell_width ) {
 				$inner_block['email_attrs']          = $inner_block['email_attrs'] ?? array();
 				$inner_block['email_attrs']['width'] = $cell_width . 'px';
+			}
+
+			// Adjust spacing between image and title for better visual hierarchy.
+			if ( 'core/post-title' === $inner_block['blockName'] && 'woocommerce/product-image' === $previous_block_name ) {
+				$inner_block['email_attrs']               = $inner_block['email_attrs'] ?? array();
+				$inner_block['email_attrs']['margin-top'] = '32px';
 			}
 
 			switch ( $inner_block['blockName'] ) {
@@ -233,6 +248,8 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 				default:
 					break;
 			}
+
+			$previous_block_name = $inner_block['blockName'];
 		}
 
 		return $content;

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
@@ -98,6 +98,10 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 		// Limit columns to max 2 for email compatibility.
 		$columns = min( max( $columns, 1 ), 2 );
 
+		// Get the block gap from theme styles to match the editor spacing.
+		$theme_styles = $rendering_context->get_theme_styles();
+		$block_gap    = $theme_styles['spacing']['blockGap'] ?? '16px';
+
 		if ( 1 === $columns ) {
 			// Single column layout - render products vertically.
 			$content = '';
@@ -107,7 +111,7 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 				// For subsequent products, add margin-top for spacing between items.
 				$email_attrs = $inner_block['email_attrs'] ?? array();
 				if ( $index > 0 && ! isset( $email_attrs['margin-top'] ) ) {
-					$email_attrs['margin-top'] = '32px';
+					$email_attrs['margin-top'] = $block_gap;
 				}
 				$content .= $this->add_spacer(
 					$this->render_product_content( $product, $inner_block, $collection_type ),
@@ -121,7 +125,7 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 		// Two-column layout using HTML tables for email compatibility.
 		// Wrap with add_spacer to match single-column spacing behavior.
 		return $this->add_spacer(
-			$this->render_two_column_grid( $products, $inner_block, $collection_type, $rendering_context ),
+			$this->render_two_column_grid( $products, $inner_block, $collection_type, $rendering_context, $block_gap ),
 			$inner_block['email_attrs'] ?? array()
 		);
 	}
@@ -133,9 +137,10 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 	 * @param array             $inner_block Inner block data.
 	 * @param string            $collection_type Collection type identifier.
 	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @param string            $block_gap Block gap value from theme styles.
 	 * @return string
 	 */
-	private function render_two_column_grid( array $products, array $inner_block, string $collection_type, Rendering_Context $rendering_context ): string {
+	private function render_two_column_grid( array $products, array $inner_block, string $collection_type, Rendering_Context $rendering_context, string $block_gap = '16px' ): string {
 		$content = '';
 
 		// Calculate the cell width from the actual layout width.
@@ -178,7 +183,7 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 
 			// Add spacing between rows (except after the last row).
 			if ( $row_index < count( $product_chunks ) - 1 ) {
-				$content .= '<tr><td colspan="2" style="height: 20px;"></td></tr>';
+				$content .= sprintf( '<tr><td colspan="2" style="height: %s;"></td></tr>', esc_attr( $block_gap ) );
 			}
 		}
 

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
@@ -21,7 +21,7 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 	 * of the site theme's blockGap, because the editor does not apply blockGap
 	 * between inner product elements.
 	 */
-	private const INNER_BLOCK_SPACING = '16px';
+	private const INNER_BLOCK_SPACING = '8px';
 
 	/**
 	 * Render the product collection block content for email.

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-collection.php
@@ -16,6 +16,14 @@ use WP_Query;
  */
 class Product_Collection extends Abstract_Product_Block_Renderer {
 	/**
+	 * Default spacing between inner product elements (image, title, price).
+	 * This is a fixed value from the email editor's base theme.json, independent
+	 * of the site theme's blockGap, because the editor does not apply blockGap
+	 * between inner product elements.
+	 */
+	private const INNER_BLOCK_SPACING = '16px';
+
+	/**
 	 * Render the product collection block content for email.
 	 *
 	 * @param string            $block_content Block content.
@@ -208,13 +216,25 @@ class Product_Collection extends Abstract_Product_Block_Renderer {
 			return $content;
 		}
 
+		$inner_index = 0;
 		foreach ( $template_block['innerBlocks'] as $inner_block ) {
+			// Override the preprocessor-applied blockGap margin-top for inner blocks.
+			// The editor does not vary spacing between inner product elements
+			// (image, title, price) when blockGap changes, so we use a fixed value
+			// to keep editor and preview consistent.
+			$inner_block['email_attrs'] = $inner_block['email_attrs'] ?? array();
+			if ( 0 === $inner_index ) {
+				unset( $inner_block['email_attrs']['margin-top'] );
+			} else {
+				$inner_block['email_attrs']['margin-top'] = self::INNER_BLOCK_SPACING;
+			}
+
 			// Set cell width context for multi-column layouts.
 			if ( null !== $cell_width ) {
-				$inner_block['email_attrs']          = $inner_block['email_attrs'] ?? array();
 				$inner_block['email_attrs']['width'] = $cell_width . 'px';
 			}
 
+			++$inner_index;
 			switch ( $inner_block['blockName'] ) {
 				case 'woocommerce/product-price':
 				case 'woocommerce/product-button':

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
@@ -433,6 +433,12 @@ class Product_Image extends Abstract_Product_Block_Renderer {
 			'vertical-align' => 'top',
 		);
 
+		// Apply padding from block styles (e.g., padding-top, padding-bottom).
+		$padding_styles = Styles_Helper::get_block_styles( $parsed_block['attrs'] ?? array(), $rendering_context, array( 'spacing' ) );
+		if ( ! empty( $padding_styles['declarations'] ) ) {
+			$cell_styles = array_merge( $cell_styles, $padding_styles['declarations'] );
+		}
+
 		$align                     = $parsed_block['attrs']['align'] ?? 'left';
 		$cell_styles['text-align'] = $align;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/STOMAIL-7637/mismatching-block-spacing-in-email-editor-and-browser-preview

  - Use theme blockGap for spacing between product items in both single-column and two-column layouts (replaces the previous hardcoded 20px row spacer in two-column grids)                                 
  - Apply block padding styles (padding-top/bottom) to product images _(Note there's still a CSS issue in the editor that causes the padding to look even larger, could address that separately)_
  - Filter out empty margin-top values to prevent malformed CSS output
  - Hardcode inner-block spacing (8px) to decouple it from theme blockGap, matching the editor behavior

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="677" height="327" alt="Screenshot 2026-02-06 at 5 42 12 PM" src="https://github.com/user-attachments/assets/196f3abe-b1d6-4f82-8d63-107fdc1786ad" /> | <img width="740" height="465" alt="Screenshot 2026-02-06 at 5 16 07 PM" src="https://github.com/user-attachments/assets/f2231398-fa6d-462d-9dbf-d67ec4a5a9c0" /> |
| <img width="679" height="270" alt="Screenshot 2026-02-06 at 5 42 05 PM" src="https://github.com/user-attachments/assets/2e7bc40d-28c1-4bcc-a534-cfa81f2ff141" /> | <img width="763" height="404" alt="Screenshot 2026-02-06 at 5 16 01 PM" src="https://github.com/user-attachments/assets/36745fce-7d39-4703-b823-6d12b805a27e" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an abandoned cart email campaign.
2. Add a cart contents block to it.
3. Preview the email and check that the rendered spacing matches the editor spacing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix spacing issues in email editor product collection rendering.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
