### PR TITLE
Remove heading from Product Collection block in email editor

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7792-inserting-handpicked-products-block-inserts-recommended
+++ b/plugins/woocommerce/changelog/stomail-7792-inserting-handpicked-products-block-inserts-recommended
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove heading block from Product Collection when used in the email editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -34,6 +34,7 @@ import {
 import useCarouselLayoutAdjustments from './use-carousel-layout-adjustments';
 import useEmailPaginationAdjustments from './use-email-pagination-adjustments';
 import useEmailColumnAdjustments from './use-email-column-adjustments';
+import useEmailHeadingAdjustments from './use-email-heading-adjustments';
 import DefaultQueryOrderByControl from './order-by-control/default-query-order-by-control';
 import CustomQueryOrderByControl from './order-by-control/custom-query-order-by-control';
 import OnSaleControl from './on-sale-control';
@@ -89,6 +90,7 @@ const ProductCollectionInspectorControls = (
 	useCarouselLayoutAdjustments( clientId, attributes );
 	useEmailPaginationAdjustments( clientId, attributes );
 	useEmailColumnAdjustments( attributes, setAttributes );
+	useEmailHeadingAdjustments( clientId );
 
 	const showCustomQueryControls = inherit === false;
 	const showInheritQueryControl =

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-email-heading-adjustments.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-email-heading-adjustments.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useIsEmailEditor } from '@woocommerce/email-editor';
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+interface Block {
+	clientId: string;
+	name: string;
+	innerBlocks: Block[];
+}
+
+/**
+ * Custom hook to remove heading blocks when in the email editor.
+ * Headings are included in collection inner block templates but are
+ * not needed in the email context.
+ *
+ * @param {string} clientId - The client ID of the product collection block.
+ */
+const useEmailHeadingAdjustments = ( clientId: string ) => {
+	const actions = useDispatch( blockEditorStore );
+	const isEmail = useIsEmailEditor();
+
+	const { productCollectionBlock } = useSelect(
+		( select ) => ( {
+			productCollectionBlock:
+				// @ts-expect-error getBlock is not typed.
+				select( blockEditorStore ).getBlock( clientId ) as Block | null,
+		} ),
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		if ( ! clientId || ! productCollectionBlock || ! isEmail ) {
+			return;
+		}
+
+		if (
+			! productCollectionBlock.innerBlocks ||
+			! Array.isArray( productCollectionBlock.innerBlocks )
+		) {
+			return;
+		}
+
+		const headingBlocks = productCollectionBlock.innerBlocks.filter(
+			( block: Block ) => block && block.name === 'core/heading'
+		);
+
+		headingBlocks.forEach( ( headingBlock: Block ) => {
+			if ( headingBlock && headingBlock.clientId ) {
+				try {
+					actions.removeBlock( headingBlock.clientId );
+				} catch ( error ) {
+					// Silently handle cases where block might already be removed
+					// or in an inconsistent state during block editor operations
+				}
+			}
+		} );
+	}, [ clientId, actions, productCollectionBlock, isEmail ] );
+};
+
+export default useEmailHeadingAdjustments;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

  When inserting a Product Collection block variant (e.g., Featured Products, Hand-Picked Products, Cart Contents) in the email editor, the collection heading (e.g., "Featured products", "Your Cart") was included as part of the inner block
  template. This heading is not needed in the email context.

  This PR adds a `useEmailHeadingAdjustments` hook that automatically removes `core/heading` inner blocks from the Product Collection when used in the email editor. It follows the same pattern as the existing `useEmailPaginationAdjustments`
  and `useEmailColumnAdjustments` hooks.

Closes STOMAIL-7792

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

  1. Set up the email editor environment (see `woocommerce-email-editor` skill or development docs).
  2. Open the email editor and insert a Product Collection block variant (e.g., "Featured Products" or "Hand-Picked Products").
  3. Verify that the collection heading block (e.g., "Featured products", "Recommended products") is **not** inserted.
  4. Open the regular post/page editor and insert the same Product Collection variant.
  5. Verify that the collection heading block **is** present as usual.

<!-- End testing instructions -->

### Testing that has already taken place:

  - Manually tested in the email editor via browser DevTools console logging.
  - Verified the hook fires correctly, removes the heading, and stabilizes without infinite loops.
  - Verified heading blocks remain in the regular (non-email) editor.
  - JS linting passed (`pnpm run lint:changes:branch:js`).

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
