### PR TITLE
Analytics stock totals: include private products

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics-private
+++ b/plugins/woocommerce/changelog/fix-analytics-private
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Analytics stock totals: include private products
+
+

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/DataStore.php
@@ -120,7 +120,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				SELECT count( DISTINCT posts.ID ) FROM {$wpdb->posts} posts
 				LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
 				WHERE posts.post_type IN ( 'product', 'product_variation' )
-				AND posts.post_status = 'publish'
+				AND posts.post_status IN ( 'publish', 'private' )
 				AND wc_product_meta_lookup.stock_status = %s
 				",
 				$status

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/DataStore.php
@@ -80,7 +80,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
 				LEFT JOIN {$wpdb->postmeta} low_stock_amount_meta ON posts.ID = low_stock_amount_meta.post_id AND low_stock_amount_meta.meta_key = '_low_stock_amount'
 				WHERE posts.post_type IN ( 'product', 'product_variation' )
-				AND posts.post_status = 'publish'
+				AND posts.post_status IN ( 'publish', 'private' )
 				AND wc_product_meta_lookup.stock_quantity IS NOT NULL
 				AND wc_product_meta_lookup.stock_status = 'instock'
 				AND (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I was a bit too fast merging #63160 and didn't realize that we should also include `private` products into the total counts. This PR fixes that, so _Stock_ table footer includes published and private products, as the rest of the table does.

### How to test the changes in this Pull Request:

1. Set one product as "Out of Stock" and private.
2. Go to WooCommerce > Analytics > Stock.
3. Verify the product is listed as out-of-stock and the footer totals are correct and include that product even if it's private.

Before | After
--- | ---
<img width="1362" height="323" alt="imatge" src="https://github.com/user-attachments/assets/a790ee1d-795b-4761-8e30-ef7795cbbd1b" /> | <img width="1362" height="323" alt="imatge" src="https://github.com/user-attachments/assets/0873ff4e-fa9a-424d-a40a-ce760fea3339" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->