### PR TITLE
Remove created_via requirement from POS email templates

### DIFF
--- a/plugins/woocommerce/changelog/pos-email-templates-remove-created-via-requirement
+++ b/plugins/woocommerce/changelog/pos-email-templates-remove-created-via-requirement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove created_via requirement from POS email templates and make all POS emails manual-only via REST API.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-completed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-completed-order.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Internal\Email\OrderPriceFormatter;
-use Automattic\WooCommerce\Internal\Orders\PointOfSaleOrderUtil;
 use Automattic\WooCommerce\Internal\Settings\PointOfSaleDefaultSettings;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
@@ -43,7 +42,7 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Completed_Order', false ) ) :
 				'{order_number}' => '',
 			);
 
-			$this->enable_order_email_actions_for_pos_orders();
+			$this->enable_order_email_actions();
 
 			// Call parent constructor.
 			parent::__construct();
@@ -191,11 +190,12 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Completed_Order', false ) ) :
 		}
 
 		/**
-		 * Enable order email actions for POS orders.
+		 * Enable order email actions for completed orders via REST API.
+		 *
+		 * @since 10.6.0
 		 */
-		private function enable_order_email_actions_for_pos_orders() {
-			$this->enable_email_template_for_pos_orders();
-			// Enable send email when requested.
+		private function enable_order_email_actions() {
+			$this->enable_email_template_for_completed_orders();
 			add_action( 'woocommerce_rest_order_actions_email_send', array( $this, 'trigger' ), 10, 2 );
 		}
 
@@ -354,21 +354,26 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Completed_Order', false ) ) :
 		}
 
 		/**
-		 * Enable email template for REST API order valid templates for POS orders.
+		 * Enable email template for REST API order valid templates for completed orders.
+		 *
+		 * @since 10.6.0
 		 */
-		private function enable_email_template_for_pos_orders() {
+		private function enable_email_template_for_completed_orders() {
 			add_filter( 'woocommerce_rest_order_actions_email_valid_template_classes', array( $this, 'add_to_valid_template_classes' ), 10, 2 );
 		}
 
 		/**
-		 * Add this email template to the list of valid templates for POS orders.
+		 * Add this email template to the list of valid templates for completed orders.
 		 *
 		 * @param array    $valid_template_classes Array of valid template class names.
 		 * @param WC_Order $order                  The order.
 		 * @return array Modified array of valid template class names.
+		 *
+		 * @since 10.6.0
+		 * @internal
 		 */
 		public function add_to_valid_template_classes( $valid_template_classes, $order ) {
-			if ( ! PointOfSaleOrderUtil::is_pos_order( $order ) ) {
+			if ( 'completed' !== $order->get_status( 'edit' ) ) {
 				return $valid_template_classes;
 			}
 			$valid_template_classes[] = get_class( $this );

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-pos-refunded-order.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\WooCommerce\Internal\Email\OrderPriceFormatter;
-use Automattic\WooCommerce\Internal\Orders\PointOfSaleOrderUtil;
 use Automattic\WooCommerce\Internal\Settings\PointOfSaleDefaultSettings;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
@@ -57,6 +56,8 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 				'{order_number}' => '',
 			);
 
+			$this->enable_order_email_actions();
+
 			// Call parent constructor.
 			parent::__construct();
 
@@ -65,8 +66,7 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 				? __( 'Let customers know when a full or partial refund is on its way to them for their POS order.', 'woocommerce' )
 				: __( 'Order refunded emails are sent to customers when their POS orders are refunded.', 'woocommerce' );
 
-			$this->disable_default_refund_emails_for_pos_orders();
-			$this->register_refund_email_triggers();
+			$this->manual = true;
 
 			if ( $this->block_email_editor_enabled ) {
 				$this->title       = __( 'POS order refunded', 'woocommerce' );
@@ -164,60 +164,40 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 		public function set_email_strings( $partial_refund = false ) {}
 
 		/**
-		 * Full refund notification.
+		 * Trigger the sending of this email.
 		 *
-		 * @param int $order_id Order ID.
-		 * @param int $refund_id Refund ID.
+		 * @param int    $order_id    The order ID.
+		 * @param string $template_id The email template ID.
 		 *
-		 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+		 * @since 10.6.0
 		 */
-		public function trigger_full( $order_id, $refund_id = null ) {
-			$this->trigger( $order_id, false, $refund_id );
-		}
+		public function trigger( $order_id, $template_id ) {
+			if ( $this->id !== $template_id ) {
+				return;
+			}
 
-		/**
-		 * Partial refund notification.
-		 *
-		 * @param int $order_id Order ID.
-		 * @param int $refund_id Refund ID.
-		 *
-		 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
-		 */
-		public function trigger_partial( $order_id, $refund_id = null ) {
-			$this->trigger( $order_id, true, $refund_id );
-		}
-
-		/**
-		 * Trigger.
-		 *
-		 * @param int  $order_id Order ID.
-		 * @param bool $partial_refund Whether it is a partial refund or a full refund.
-		 * @param int  $refund_id Refund ID.
-		 */
-		private function trigger( $order_id, $partial_refund = false, $refund_id = null ) {
 			if ( ! $order_id ) {
 				return;
 			}
-			// Only trigger for POS orders.
+
 			$order = wc_get_order( $order_id );
-			if ( ! $order || ! PointOfSaleOrderUtil::is_pos_order( $order ) ) {
+			if ( ! is_a( $order, 'WC_Order' ) ) {
 				return;
 			}
+
 			$this->setup_locale();
-			$this->partial_refund = $partial_refund;
 
-			$this->object                         = $order;
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			$this->partial_refund = $order->get_remaining_refund_amount() > 0;
+			$this->object         = $order;
+			$this->recipient      = $order->get_billing_email();
 
-			if ( ! empty( $refund_id ) ) {
-				$this->refund = wc_get_order( $refund_id );
-			} else {
-				$this->refund = false;
-			}
+			$this->placeholders['{order_date}']   = wc_format_datetime( $order->get_date_created() );
+			$this->placeholders['{order_number}'] = $order->get_order_number();
 
-			if ( $this->is_enabled() && $this->get_recipient() ) {
+			$refunds      = $order->get_refunds();
+			$this->refund = ! empty( $refunds ) ? reset( $refunds ) : false;
+
+			if ( $this->get_recipient() ) {
 				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 			}
 
@@ -315,12 +295,6 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 			/* translators: %s: list of placeholders */
 			$placeholder_text  = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
 			$this->form_fields = array(
-				'enabled'            => array(
-					'title'   => __( 'Enable/Disable', 'woocommerce' ),
-					'type'    => 'checkbox',
-					'label'   => __( 'Enable this email notification', 'woocommerce' ),
-					'default' => 'yes',
-				),
 				'subject_full'       => array(
 					'title'       => __( 'Full refund subject', 'woocommerce' ),
 					'type'        => 'text',
@@ -449,44 +423,40 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 		}
 
 		/**
-		 * Disable default WooCommerce refund emails for POS orders.
-		 * The core refund email IDs are in WC_Email_Customer_Refunded_Order's trigger method.
+		 * Enable order email actions for refunded orders via REST API.
 		 *
-		 * This method adds filters to prevent the default WooCommerce refund emails
-		 * from being sent for orders created through the Point of Sale system.
-		 * Instead, the POS-specific refund emails will be used.
+		 * @since 10.6.0
 		 */
-		private function disable_default_refund_emails_for_pos_orders() {
-			add_filter( 'woocommerce_email_enabled_customer_partially_refunded_order', array( $this, 'disable_default_refund_email_for_pos_orders' ), 10, 3 );
-			add_filter( 'woocommerce_email_enabled_customer_refunded_order', array( $this, 'disable_default_refund_email_for_pos_orders' ), 10, 3 );
+		private function enable_order_email_actions() {
+			$this->enable_email_template_for_refunded_orders();
+			add_action( 'woocommerce_rest_order_actions_email_send', array( $this, 'trigger' ), 10, 2 );
 		}
 
 		/**
-		 * Disable the default WooCommerce refund email for POS orders.
+		 * Enable email template for REST API order valid templates for orders with refunds.
 		 *
-		 * @param bool          $enabled Whether the email is enabled.
-		 * @param WC_Order|null $order   The order object.
-		 * @param WC_Email|null $email   The email object.
-		 * @return bool
-		 *
-		 * @internal For exclusive usage within this class, backwards compatibility not guaranteed.
+		 * @since 10.6.0
 		 */
-		public function disable_default_refund_email_for_pos_orders( $enabled, $order, $email ) {
-			if ( $order && PointOfSaleOrderUtil::is_pos_order( $order ) ) {
-				return false;
+		private function enable_email_template_for_refunded_orders() {
+			add_filter( 'woocommerce_rest_order_actions_email_valid_template_classes', array( $this, 'add_to_valid_template_classes' ), 10, 2 );
+		}
+
+		/**
+		 * Add this email template to the list of valid templates for orders with refunds.
+		 *
+		 * @param array    $valid_template_classes Array of valid template class names.
+		 * @param WC_Order $order                  The order.
+		 * @return array Modified array of valid template class names.
+		 *
+		 * @since 10.6.0
+		 * @internal
+		 */
+		public function add_to_valid_template_classes( $valid_template_classes, $order ) {
+			if ( 0 === count( $order->get_refunds() ) ) {
+				return $valid_template_classes;
 			}
-			return $enabled;
-		}
-
-		/**
-		 * Register triggers for POS refund emails.
-		 *
-		 * This method adds actions to trigger the refund emails for POS orders.
-		 * It ensures that the emails are sent correctly when a full or partial refund is made.
-		 */
-		private function register_refund_email_triggers() {
-			add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
-			add_action( 'woocommerce_order_partially_refunded_notification', array( $this, 'trigger_partial' ), 10, 2 );
+			$valid_template_classes[] = get_class( $this );
+			return $valid_template_classes;
 		}
 
 		/**
@@ -572,7 +542,6 @@ if ( ! class_exists( 'WC_Email_Customer_POS_Refunded_Order', false ) ) :
 				get_option( 'woocommerce_pos_refund_returns_policy' )
 			);
 		}
-
 
 		/**
 		 * Replace footer text placeholders with POS-specific values.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -19837,13 +19837,13 @@ parameters:
 			path: includes/emails/class-wc-email-customer-pos-completed-order.php
 
 		-
-			message: '#^Method WC_Email_Customer_POS_Completed_Order\:\:enable_email_template_for_pos_orders\(\) has no return type specified\.$#'
+			message: '#^Method WC_Email_Customer_POS_Completed_Order\:\:enable_email_template_for_completed_orders\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-completed-order.php
 
 		-
-			message: '#^Method WC_Email_Customer_POS_Completed_Order\:\:enable_order_email_actions_for_pos_orders\(\) has no return type specified\.$#'
+			message: '#^Method WC_Email_Customer_POS_Completed_Order\:\:enable_order_email_actions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-completed-order.php
@@ -19933,8 +19933,20 @@ parameters:
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
 
 		-
-			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:disable_default_refund_emails_for_pos_orders\(\) has no return type specified\.$#'
+			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:enable_email_template_for_refunded_orders\(\) has no return type specified\.$#'
 			identifier: missingType.return
+			count: 1
+			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
+
+		-
+			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:enable_order_email_actions\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
+
+		-
+			message: '#^Parameter \#1 \$object_or_string of function is_a expects object, WC_Order\|WC_Order_Refund\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
 
@@ -19952,12 +19964,6 @@ parameters:
 
 		-
 			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:init_form_fields\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
-
-		-
-			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:register_refund_email_triggers\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
@@ -19981,18 +19987,6 @@ parameters:
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
 
 		-
-			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:trigger_full\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
-
-		-
-			message: '#^Method WC_Email_Customer_POS_Refunded_Order\:\:trigger_partial\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
-
-		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Email\)\: Unexpected token "\\n\\t ", expected ''\<'' at offset 267 on line 9$#'
 			identifier: phpDoc.parseError
 			count: 1
@@ -20011,7 +20005,7 @@ parameters:
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
 
 		-
-			message: '#^Property WC_Email_Customer_POS_Refunded_Order\:\:\$refund \(bool\|WC_Order\) does not accept WC_Order\|WC_Order_Refund\|false\.$#'
+			message: '#^Property WC_Email_Customer_POS_Refunded_Order\:\:\$refund \(bool\|WC_Order\) does not accept WC_Order_Refund\|false\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-pos-completed-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-pos-completed-order-test.php
@@ -444,4 +444,46 @@ class WC_Email_Customer_POS_Completed_Order_Test extends \WC_Unit_Test_Case {
 		// And plain text email should not include refund & returns policy.
 		$this->assertStringNotContainsString( esc_html__( 'Refund & Returns Policy', 'woocommerce' ), $plain_text_content );
 	}
+
+	/**
+	 * @testdox add_to_valid_template_classes adds template for completed orders regardless of created_via.
+	 */
+	public function test_add_to_valid_template_classes_adds_template_for_any_completed_order() {
+		// Given a completed order not created via POS.
+		$order = OrderHelper::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+		$email = new WC_Email_Customer_POS_Completed_Order();
+
+		// When filtering valid template classes.
+		$result = $email->add_to_valid_template_classes( array(), $order );
+
+		// Then the template class is added.
+		$this->assertContains( 'WC_Email_Customer_POS_Completed_Order', $result );
+	}
+
+	/**
+	 * @testdox add_to_valid_template_classes does not add template for non-completed orders.
+	 */
+	public function test_add_to_valid_template_classes_does_not_add_template_for_non_completed_order() {
+		// Given a processing order.
+		$order = OrderHelper::create_order();
+		$order->set_status( 'processing' );
+		$order->save();
+		$email = new WC_Email_Customer_POS_Completed_Order();
+
+		// When filtering valid template classes.
+		$result = $email->add_to_valid_template_classes( array(), $order );
+
+		// Then the template class is not added.
+		$this->assertNotContains( 'WC_Email_Customer_POS_Completed_Order', $result );
+	}
+
+	/**
+	 * @testdox POS completed order email is set as manual.
+	 */
+	public function test_pos_completed_order_email_is_manual() {
+		$email = new WC_Email_Customer_POS_Completed_Order();
+		$this->assertTrue( $email->manual );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-pos-refunded-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-pos-refunded-order-test.php
@@ -422,4 +422,68 @@ class WC_Email_Customer_POS_Refunded_Order_Test extends \WC_Unit_Test_Case {
 		// And plain text email should not include refund & returns policy.
 		$this->assertStringNotContainsString( esc_html__( 'Refund & Returns Policy', 'woocommerce' ), $plain_text_content );
 	}
+
+	/**
+	 * @testdox add_to_valid_template_classes adds template for orders with refunds regardless of created_via.
+	 */
+	public function test_add_to_valid_template_classes_adds_template_for_any_order_with_refunds() {
+		// Given an order with a refund, not created via POS.
+		$order = \WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->save();
+		wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => '5.00',
+				'reason'   => 'Test refund',
+			)
+		);
+		$email = new WC_Email_Customer_POS_Refunded_Order();
+
+		// When filtering valid template classes.
+		$result = $email->add_to_valid_template_classes( array(), $order );
+
+		// Then the template class is added.
+		$this->assertContains( 'WC_Email_Customer_POS_Refunded_Order', $result );
+	}
+
+	/**
+	 * @testdox add_to_valid_template_classes does not add template for orders without refunds.
+	 */
+	public function test_add_to_valid_template_classes_does_not_add_template_for_order_without_refunds() {
+		// Given an order without refunds.
+		$order = OrderHelper::create_order();
+		$order->save();
+		$email = new WC_Email_Customer_POS_Refunded_Order();
+
+		// When filtering valid template classes.
+		$result = $email->add_to_valid_template_classes( array(), $order );
+
+		// Then the template class is not added.
+		$this->assertNotContains( 'WC_Email_Customer_POS_Refunded_Order', $result );
+	}
+
+	/**
+	 * @testdox POS refunded order email is set as manual.
+	 */
+	public function test_pos_refunded_order_email_is_manual() {
+		$email = new WC_Email_Customer_POS_Refunded_Order();
+		$this->assertTrue( $email->manual );
+	}
+
+	/**
+	 * @testdox Default refund emails are not disabled for POS orders after making POS refund email manual.
+	 */
+	public function test_default_refund_emails_are_not_disabled_for_pos_orders() {
+		// Given a POS refunded email is instantiated.
+		new WC_Email_Customer_POS_Refunded_Order();
+
+		// Then the default refund email filters should not be registered.
+		$this->assertFalse(
+			has_filter( 'woocommerce_email_enabled_customer_partially_refunded_order' )
+		);
+		$this->assertFalse(
+			has_filter( 'woocommerce_email_enabled_customer_refunded_order' )
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
@@ -369,6 +369,65 @@ class OrderActionsRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox POS completed order email template is available for non-POS completed orders.
+	 */
+	public function test_pos_completed_template_available_for_non_pos_completed_order() {
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email-customer-pos-completed-order.php';
+
+		// Manually load the POS email class into WC_Emails.
+		$pos_email = new \WC_Email_Customer_POS_Completed_Order();
+		WC()->mailer()->emails['WC_Email_Customer_POS_Completed_Order'] = $pos_email;
+
+		$order = wc_create_order();
+		$order->set_billing_email( 'customer@example.org' );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		wp_set_current_user( $this->user['shop_manager'] );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/actions/email_templates' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$item_ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertContains( 'customer_pos_completed_order', $item_ids );
+
+		unset( WC()->mailer()->emails['WC_Email_Customer_POS_Completed_Order'] );
+	}
+
+	/**
+	 * @testdox POS refunded order email template is available for non-POS orders with refunds.
+	 */
+	public function test_pos_refunded_template_available_for_non_pos_order_with_refunds() {
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email-customer-pos-refunded-order.php';
+
+		$pos_email = new \WC_Email_Customer_POS_Refunded_Order();
+		WC()->mailer()->emails['WC_Email_Customer_POS_Refunded_Order'] = $pos_email;
+
+		$order = \WC_Helper_Order::create_order();
+		$order->set_billing_email( 'customer@example.org' );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$this->do_partial_refund( $order );
+
+		wp_set_current_user( $this->user['shop_manager'] );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/actions/email_templates' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$item_ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertContains( 'customer_pos_refunded_order', $item_ids );
+
+		unset( WC()->mailer()->emails['WC_Email_Customer_POS_Refunded_Order'] );
+	}
+
+	/**
 	 * Test sending order details email.
 	 */
 	public function test_send_order_details() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

POS email templates (`customer_pos_completed_order` and `customer_pos_refunded_order`) currently require orders to have `created_via=pos-rest-api`. This removes that requirement so POS email templates are available for any order that meets the status/refund criteria via the REST API `send_email` endpoint.

Additionally, all POS emails are now manual-only (sent exclusively via REST API, never automatically).

## Changes

### 1. POS Completed Order Email (`class-wc-email-customer-pos-completed-order.php`)

- Removed `is_pos_order()` check from `add_to_valid_template_classes()` filter callback
- Added completed order status check instead — template is available for any completed order
- Renamed internal methods to reflect broader scope (`enable_order_email_actions`, `enable_email_template_for_completed_orders`)
- Removed unused `PointOfSaleOrderUtil` import

### 2. POS Refunded Order Email (`class-wc-email-customer-pos-refunded-order.php`)

- Removed automatic refund email triggers (`register_refund_email_triggers`) — no longer hooks into `woocommerce_order_fully_refunded_notification` / `woocommerce_order_partially_refunded_notification`
- Removed default refund email suppression for POS orders (`disable_default_refund_emails_for_pos_orders`) — default WC refund emails now send normally for all orders
- Added REST API integration via `woocommerce_rest_order_actions_email_send` action (same pattern as completed email)
- Added `add_to_valid_template_classes()` filter — template available for any order with refunds
- Set `$this->manual = true` — email can only be sent via REST API
- Removed enabled/disabled form field (manual emails don't need it)
- Replaced `trigger()` method with REST-compatible signature `trigger($order_id, $template_id)` that determines partial/full refund from order state
- Removed unused `PointOfSaleOrderUtil` import

### 3. Tests

- Added tests for completed email template availability for non-POS completed orders
- Added tests for refunded email template availability for non-POS orders with refunds
- Added tests confirming both POS emails are manual-only
- Added test confirming default refund email filters are no longer registered
- Added REST controller integration tests for POS templates on non-POS orders

---

### How to test the changes in this Pull Request:

Set these variables for your environment:

```bash
SITE_URL="http://localhost:8888"
AUTH="admin:password"
PRODUCT_ID=1
EMAIL="customer@example.com"
```

<details>
<summary><strong>1. Create a regular (non-POS) completed order</strong></summary>

```bash
curl -X POST "$SITE_URL/wp-json/wc/v3/orders" \
  -u "$AUTH" \
  -H "Content-Type: application/json" \
  -d '{
    "status": "completed",
    "billing": {
      "first_name": "John",
      "last_name": "Doe"
    },
    "line_items": [{ "product_id": '"$PRODUCT_ID"', "quantity": 2 }]
  }'
```

Save the returned `id` as `ORDER_ID`.

</details>

<details>
<summary><strong>2. Verify POS completed template is available</strong></summary>

```bash
curl "$SITE_URL/wp-json/wc/v3/orders/$ORDER_ID/actions/email_templates" \
  -u "$AUTH"
```

Expected: Response includes `customer_pos_completed_order` in the list.

</details>

<details>
<summary><strong>3. Send POS completed order email</strong></summary>

```bash
curl -X POST "$SITE_URL/wp-json/wc/v3/orders/$ORDER_ID/actions/send_email" \
  -u "$AUTH" \
  -H "Content-Type: application/json" \
  -d '{ "template_id": "customer_pos_completed_order", "email": "'"$EMAIL"'", "force_email_update": true }'
```

Expected: `200 OK` with success message.

</details>

<details>
<summary><strong>4. Create a partial refund and send POS refunded email</strong></summary>

```bash
curl -X POST "$SITE_URL/wp-json/wc/v3/orders/$ORDER_ID/refunds" \
  -u "$AUTH" \
  -H "Content-Type: application/json" \
  -d '{ "amount": "5.00", "reason": "Test partial refund", "api_refund": false }'

curl -X POST "$SITE_URL/wp-json/wc/v3/orders/$ORDER_ID/actions/send_email" \
  -u "$AUTH" \
  -H "Content-Type: application/json" \
  -d '{ "template_id": "customer_pos_refunded_order", "email": "'"$EMAIL"'", "force_email_update": true }'
```

Expected: `200 OK` with success message.

</details>

<details>
<summary><strong>5. Run automated tests</strong></summary>

```bash
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Email_Customer_POS_Completed_Order_Test
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Email_Customer_POS_Refunded_Order_Test
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter OrderActionsRestControllerTest
```

</details>

---

### Testing that has already taken place:

- PHP linting passes (`pnpm lint:php:changes`)
- PHPStan analysis passes on all modified files
- Code reviewed against existing patterns in PR #62976

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- Added `plugins/woocommerce/changelog/pos-email-templates-remove-created-via-requirement`