### PR TITLE
Add to Cart + Options: add default margin between inner elements

### DIFF
--- a/plugins/woocommerce/changelog/fix-63217-add-to-cart-with-options-default-margin
+++ b/plugins/woocommerce/changelog/fix-63217-add-to-cart-with-options-default-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: add default margin between inner elements

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -573,6 +573,15 @@ class AddToCartWithOptions extends AbstractBlock {
 									array(
 										isset( $wrapper_attributes['class'] ) ? $wrapper_attributes['class'] : '',
 										isset( $form_attributes['class'] ) ? $form_attributes['class'] : '',
+										// Add the `is-layout-flow` class so inner elements automatically get the
+										// default vertical margin from the theme. That's especially useful for
+										// elements added by extensions like express payment method buttons.
+										// In the future, we want to use `supports.layout` in block.json instead
+										// of hardcoding the class here. However, right now that wouldn't work
+										// because the wrapper element of the block is the notices `<div>`, so the
+										// `is-layout-flow` class would be applied to the notices container instead
+										// of the `<form>` as we want.
+										'is-layout-flow',
 									)
 								)
 							),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #63217.

This PR adds the `is-layout-flow` class to the _Add to Cart + Options_ block so we get the default theme spacing between inner elements. Ideally we would use `supports.layout` in block.json, but that's not possible as explained in the inline comment, so we are hard-coding the class name for now.

### How to test the changes in this Pull Request:

1. Install WooPayments.
2. In the frontend of a single product, verify there is spacing between the form elements and the WooPayments express payment buttons.
3. Test other product types to make sure there are no regressions in the form styling.

Legacy Add to Cart with Options | `trunk`'s Add to Cart + Options | This branch Add to Cart + Options
--- | --- | ---
<img width="1295" height="878" alt="imatge" src="https://github.com/user-attachments/assets/76f7b16c-f071-44c7-8336-80fb03d2bb0e" /> | <img width="1295" height="878" alt="imatge" src="https://github.com/user-attachments/assets/de8132c7-353b-4bf7-88ee-b9092c3b1e90" /> | <img width="1295" height="878" alt="imatge" src="https://github.com/user-attachments/assets/7f7c0fae-3168-432d-a328-2c57539a2e70" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->