### PR TITLE
[Performance] Recent Reviews widget: address slow SQL query (take 2)

### DIFF
--- a/plugins/woocommerce/changelog/perfromance-60194-optimize-recent-reviews-widget-take-2
+++ b/plugins/woocommerce/changelog/perfromance-60194-optimize-recent-reviews-widget-take-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Performance: reintroduced the optimized and hardened version of the recent reviews widget.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-recent-reviews-widget-async.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-recent-reviews-widget-async.js
@@ -1,0 +1,43 @@
+/**
+ * WooCommerce Recent reviews widget async loading
+ */
+jQuery(function($) {
+    'use strict';
+
+    // Only run on admin dashboard
+    if ( ! $( '#wc-recent-reviews-widget-loading' ).length ) {
+        return;
+    }
+
+    // Load the widget content via AJAX
+    function loadRecentReviewsWidget() {
+        $.ajax({
+            url: wc_recent_reviews_widget_params.ajax_url,
+            data: {
+                action: 'woocommerce_load_recent_reviews_widget',
+                security: wc_recent_reviews_widget_params.security
+            },
+            type: 'GET',
+            dataType: 'json',
+            success: function(response) {
+                if ( response && response.success && response.data.content ) {
+                    $( '#wc-recent-reviews-widget-content' ).html( response.data.content ).show();
+                    $( '#wc-recent-reviews-widget-loading' ).hide();
+                } else {
+                    showErrorMessage();
+                }
+            },
+            error: function() {
+                showErrorMessage();
+            }
+        });
+    }
+
+    function showErrorMessage() {
+        $( '#wc-recent-reviews-widget-loading' ).html( '<p>' + 'Error loading widget' + '</p>' );
+    }
+
+    // Start loading the widget after a very short delay
+    // This allows the dashboard to render quickly first
+    setTimeout( loadRecentReviewsWidget, 100 );
+});

--- a/plugins/woocommerce/client/legacy/js/admin/wc-recent-reviews-widget-async.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-recent-reviews-widget-async.js
@@ -34,7 +34,8 @@ jQuery(function($) {
     }
 
     function showErrorMessage() {
-        $( '#wc-recent-reviews-widget-loading' ).html( '<p>' + 'Error loading widget' + '</p>' );
+		const message = wc_recent_reviews_widget_params.error_message || 'Error loading widget';
+        $( '#wc-recent-reviews-widget-loading' ).html( '<p>' + message + '</p>' );
     }
 
     // Start loading the widget after a very short delay

--- a/plugins/woocommerce/client/legacy/js/admin/wc-status-widget-async.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-status-widget-async.js
@@ -3,12 +3,12 @@
  */
 jQuery(function($) {
     'use strict';
-    
+
     // Only run on admin dashboard
     if (!$('#wc-status-widget-loading').length) {
         return;
     }
-    
+
     // Load the widget content via AJAX
     function loadStatusWidget() {
         $.ajax({
@@ -32,11 +32,12 @@ jQuery(function($) {
             }
         });
     }
-    
+
     function showErrorMessage() {
-        $('#wc-status-widget-loading').html('<p>' + 'Error loading widget' + '</p>');
+		const message = wc_status_widget_params.error_message || 'Error loading widget';
+        $('#wc-status-widget-loading').html('<p>' + message + '</p>');
     }
-    
+
     // Start loading the widget after a very short delay
     // This allows the dashboard to render quickly first
     setTimeout(loadStatusWidget, 100);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -529,7 +529,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			);
 			$comments = array_filter(
 				$comments,
-				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID ) && ! post_password_required( $comment->comment_post_ID )
+				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID ) && ! post_password_required( (int) $comment->comment_post_ID )
 			);
 			if ( $comments ) {
 				echo '<ul>';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -529,7 +529,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			);
 			$comments = array_filter(
 				$comments,
-				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID )
+				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID ) && ! post_password_required( $comment->comment_post_ID )
 			);
 			if ( $comments ) {
 				echo '<ul>';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -148,8 +148,6 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				)
 			);
 
-			// Where to copy from
-
 			// Display loading placeholder.
 			echo '<div id="wc-status-widget-loading" class="wc-status-widget-loading">';
 			echo '<p>' . esc_html__( 'Loading status data...', 'woocommerce' ) . ' <span class="spinner is-active"></span></p>';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -525,24 +525,31 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				array(
 					'type'                      => 'review',
 					'status'                    => 'approve',
-					'number'                    => 5,
+					'number'                    => 25,
 					'update_comment_post_cache' => true,
 				)
 			);
 			$comments = array_filter(
 				$comments,
-				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID ) && ! post_password_required( $comment->comment_post_ID )
+				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID )
 			);
 			if ( $comments ) {
 				echo '<ul>';
+				$count_rendered = 0;
 				foreach ( $comments as $comment ) {
-					wc_get_template(
-						'dashboard-widget-reviews.php',
-						array(
-							'product' => wc_get_product( $comment->comment_post_ID ),
-							'comment' => $comment,
-						)
-					);
+					$product = wc_get_product( $comment->comment_post_ID );
+					if ( $product ) {
+						wc_get_template(
+							'dashboard-widget-reviews.php',
+							array(
+								'product' => $product,
+								'comment' => $comment,
+							)
+						);
+						if ( 5 === ++$count_rendered ) {
+							break;
+						}
+					}
 				}
 				echo '</ul>';
 			} else {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -143,8 +143,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				'wc-status-widget-async',
 				'wc_status_widget_params',
 				array(
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
-					'security' => wp_create_nonce( 'wc-status-widget' ),
+					'ajax_url'      => admin_url( 'admin-ajax.php' ),
+					'security'      => wp_create_nonce( 'wc-status-widget' ),
+					'error_message' => esc_html__( 'Error loading widget', 'woocommerce' ),
 				)
 			);
 
@@ -485,8 +486,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				'wc-recent-reviews-widget-async',
 				'wc_recent_reviews_widget_params',
 				array(
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
-					'security' => wp_create_nonce( 'wc-recent-reviews-widget' ),
+					'ajax_url'      => admin_url( 'admin-ajax.php' ),
+					'security'      => wp_create_nonce( 'wc-recent-reviews-widget' ),
+					'error_message' => esc_html__( 'Error loading widget', 'woocommerce' ),
 				)
 			);
 
@@ -523,6 +525,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				array(
 					'type'                      => 'review',
 					'status'                    => 'approve',
+					'parent'                    => 0,
 					'number'                    => 25,
 					'update_comment_post_cache' => true,
 				)

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -500,7 +500,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		/**
 		 * Recent reviews widget: content.
 		 */
-		public function recent_reviews_content() {
+		public function recent_reviews_content(): void {
 			// Backward compatibility mode: if any of the checked below hooks are in use, use the legacy implementation.
 			$has_legacy_query_filter         = has_filter( 'woocommerce_report_recent_reviews_query_from' );
 			$has_legacy_product_title_filter = has_filter( 'woocommerce_admin_dashboard_recent_reviews' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -503,7 +503,51 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * Recent reviews widget: content.
 		 */
 		public function recent_reviews_content() {
-			$this->legacy_recent_reviews();
+			// Backward compatibility mode: if any of the checked below hooks are in use, use the legacy implementation.
+			$has_legacy_query_filter         = has_filter( 'woocommerce_report_recent_reviews_query_from' );
+			$has_legacy_product_title_filter = has_filter( 'woocommerce_admin_dashboard_recent_reviews' );
+			$use_legacy_implementation       = $has_legacy_query_filter || $has_legacy_product_title_filter;
+			if ( $use_legacy_implementation ) {
+				if ( $has_legacy_query_filter ) {
+					wc_deprecated_hook( 'woocommerce_report_recent_reviews_query_from', '10.5.0' );
+				}
+				if ( $has_legacy_product_title_filter ) {
+					wc_deprecated_hook( 'woocommerce_admin_dashboard_recent_reviews', '10.5.0', 'dashboard-widget-reviews.php template' );
+				}
+				$this->legacy_recent_reviews();
+
+				return;
+			}
+
+			// Optimized version of the widget: faster SQL queries and templates-based rendering for customization.
+			/** @var \WP_Comment[] $comments */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			$comments = get_comments(
+				array(
+					'type'                      => 'review',
+					'status'                    => 'approve',
+					'number'                    => 5,
+					'update_comment_post_cache' => true,
+				)
+			);
+			$comments = array_filter(
+				$comments,
+				static fn( \WP_Comment $comment ) => current_user_can( 'read_product', $comment->comment_post_ID ) && ! post_password_required( $comment->comment_post_ID )
+			);
+			if ( $comments ) {
+				echo '<ul>';
+				foreach ( $comments as $comment ) {
+					wc_get_template(
+						'dashboard-widget-reviews.php',
+						array(
+							'product' => wc_get_product( $comment->comment_post_ID ),
+							'comment' => $comment,
+						)
+					);
+				}
+				echo '</ul>';
+			} else {
+				echo '<p>' . esc_html__( 'There are no product reviews yet.', 'woocommerce' ) . '</p>';
+			}
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -148,6 +148,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				)
 			);
 
+			// Where to copy from
+
 			// Display loading placeholder.
 			echo '<div id="wc-status-widget-loading" class="wc-status-widget-loading">';
 			echo '<p>' . esc_html__( 'Loading status data...', 'woocommerce' ) . ' <span class="spinner is-active"></span></p>';
@@ -474,9 +476,33 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		}
 
 		/**
-		 * Recent reviews widget.
+		 * Recent reviews widget: placeholder.
 		 */
 		public function recent_reviews() {
+			$suffix  = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
+			$version = Constants::get_constant( 'WC_VERSION' );
+
+			wp_enqueue_script( 'wc-recent-reviews-widget-async', WC()->plugin_url() . '/assets/js/admin/wc-recent-reviews-widget-async' . $suffix . '.js', array( 'jquery' ), $version, true );
+			wp_localize_script(
+				'wc-recent-reviews-widget-async',
+				'wc_recent_reviews_widget_params',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'security' => wp_create_nonce( 'wc-recent-reviews-widget' ),
+				)
+			);
+
+			// Display loading placeholder.
+			echo '<div id="wc-recent-reviews-widget-loading" class="wc-recent-reviews-widget-loading">';
+			echo '<p>' . esc_html__( 'Loading reviews data...', 'woocommerce' ) . ' <span class="spinner is-active"></span></p>';
+			echo '</div>';
+			echo '<div id="wc-recent-reviews-widget-content" style="display:none;"></div>';
+		}
+
+		/**
+		 * Recent reviews widget: content.
+		 */
+		public function recent_reviews_content() {
 			$this->legacy_recent_reviews();
 		}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -215,6 +215,7 @@ class WC_AJAX {
 			'shipping_classes_save_changes',
 			'toggle_gateway_enabled',
 			'load_status_widget',
+			'load_recent_reviews_widget',
 		);
 
 		foreach ( $ajax_events as $ajax_event ) {
@@ -3896,6 +3897,27 @@ class WC_AJAX {
 		ob_start();
 		$wc_admin_dashboard = new WC_Admin_Dashboard();
 		$wc_admin_dashboard->status_widget_content();
+		$content = ob_get_clean();
+		wp_send_json_success( array( 'content' => $content ) );
+	}
+
+	/**
+	 * AJAX handler for asynchronously loading the status widget content.
+	 *
+	 * @return void
+	 */
+	public static function load_recent_reviews_widget() {
+		check_ajax_referer( 'wc-recent-reviews-widget', 'security' );
+
+		if ( ! current_user_can( 'publish_shop_orders' ) || ! post_type_supports( 'product', 'comments' ) ) {
+			wp_send_json_error( 'missing_permissions' );
+			wp_die();
+		}
+
+		include_once __DIR__ . '/admin/class-wc-admin-dashboard.php';
+		ob_start();
+		$wc_admin_dashboard = new WC_Admin_Dashboard();
+		$wc_admin_dashboard->recent_reviews_content();
 		$content = ob_get_clean();
 		wp_send_json_success( array( 'content' => $content ) );
 	}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3911,7 +3911,6 @@ class WC_AJAX {
 
 		if ( ! current_user_can( 'publish_shop_orders' ) || ! post_type_supports( 'product', 'comments' ) ) {
 			wp_send_json_error( 'missing_permissions' );
-			wp_die();
 		}
 
 		include_once __DIR__ . '/admin/class-wc-admin-dashboard.php';

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3902,7 +3902,7 @@ class WC_AJAX {
 	}
 
 	/**
-	 * AJAX handler for asynchronously loading the status widget content.
+	 * AJAX handler for asynchronously loading the recent reviews widget content.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -9345,7 +9345,7 @@ parameters:
 		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
-			count: 28
+			count: 29
 			path: includes/class-wc-ajax.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -9345,7 +9345,7 @@ parameters:
 		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
-			count: 29
+			count: 28
 			path: includes/class-wc-ajax.php
 
 		-

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -55,9 +55,9 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 		$product     = WC_Helper_Product::create_simple_product();
 		$product_id  = $product->get_id();
 		$comment_id1 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id2 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id3 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id4 = WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
 		$comment_id5 = WC_Helper_Product::create_product_review( $product_id );
 
 		wp_set_current_user( $this->user );
@@ -79,9 +79,9 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 		$product     = WC_Helper_Product::create_simple_product();
 		$product_id  = $product->get_id();
 		$comment_id1 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id2 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id3 = WC_Helper_Product::create_product_review( $product_id );
-		$comment_id4 = WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
+		WC_Helper_Product::create_product_review( $product_id );
 		$comment_id5 = WC_Helper_Product::create_product_review( $product_id );
 
 		wp_set_current_user( $this->user );

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -38,6 +38,32 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: recent reviews widget placeholder.
+	 */
+	public function test_recent_reviews_widget_placeholder() {
+		wp_set_current_user( $this->user );
+		( new WC_Admin_Dashboard() )->recent_reviews();
+		$this->expectOutputRegex( '/Loading reviews data.../' );
+		$this->expectOutputRegex( '/wc-recent-reviews-widget-loading/' );
+		$this->expectOutputRegex( '/wc-recent-reviews-widget-content/' );
+	}
+
+	/**
+	 * Test: recent reviews widget placeholder.
+	 */
+	public function test_recent_reviews_widget_content() {
+		$product    = WC_Helper_Product::create_simple_product();
+		$comment_id = WC_Helper_Product::create_product_review( $product->get_id());
+
+		wp_set_current_user( $this->user );
+		( new WC_Admin_Dashboard() )->recent_reviews_content();
+		$this->expectOutputRegex( "/#comment-{$comment_id}/" );
+		$this->expectOutputRegex( '/reviewed by/' );
+
+		$product->delete();
+	}
+
+	/**
 	 * Test: status_widget placeholder
 	 */
 	public function test_status_widget_placeholder() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -51,16 +51,47 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	/**
 	 * Test: recent reviews widget placeholder.
 	 */
-	public function test_recent_reviews_widget_content() {
-		$product    = WC_Helper_Product::create_simple_product();
-		$comment_id = WC_Helper_Product::create_product_review( $product->get_id());
+	public function test_recent_reviews_widget_content_new_version() {
+		$product     = WC_Helper_Product::create_simple_product();
+		$product_id  = $product->get_id();
+		$comment_id1 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id2 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id3 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id4 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id5 = WC_Helper_Product::create_product_review( $product_id );
 
 		wp_set_current_user( $this->user );
 		( new WC_Admin_Dashboard() )->recent_reviews_content();
-		$this->expectOutputRegex( "/#comment-{$comment_id}/" );
+		$this->expectOutputRegex( "/#comment-{$comment_id1}/" );
+		$this->expectOutputRegex( "/#comment-{$comment_id5}/" );
 		$this->expectOutputRegex( '/reviewed by/' );
 
 		$product->delete();
+	}
+
+	/**
+	 * Test: recent reviews widget placeholder.
+	 */
+	public function test_recent_reviews_widget_content_legacy_version() {
+		add_filter( 'woocommerce_report_recent_reviews_query_from', $legacy_filter = fn( string $sql ) => $sql );
+		$this->expected_deprecated = array_merge( $this->expected_deprecated, array( 'woocommerce_report_recent_reviews_query_from' ) );
+
+		$product     = WC_Helper_Product::create_simple_product();
+		$product_id  = $product->get_id();
+		$comment_id1 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id2 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id3 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id4 = WC_Helper_Product::create_product_review( $product_id );
+		$comment_id5 = WC_Helper_Product::create_product_review( $product_id );
+
+		wp_set_current_user( $this->user );
+		( new WC_Admin_Dashboard() )->recent_reviews_content();
+		$this->expectOutputRegex( "/#comment-{$comment_id1}/" );
+		$this->expectOutputRegex( "/#comment-{$comment_id5}/" );
+		$this->expectOutputRegex( '/reviewed by/' );
+
+		$product->delete();
+		remove_filter( 'woocommerce_report_recent_reviews_query_from', $legacy_filter );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -49,7 +49,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: recent reviews widget placeholder.
+	 * Test: recent reviews widget content (new).
 	 */
 	public function test_recent_reviews_widget_content_new_version() {
 		$product     = WC_Helper_Product::create_simple_product();
@@ -70,7 +70,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: recent reviews widget placeholder.
+	 * Test: recent reviews widget content (legacy).
 	 */
 	public function test_recent_reviews_widget_content_legacy_version() {
 		add_filter( 'woocommerce_report_recent_reviews_query_from', $legacy_filter = fn( string $sql ) => $sql );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Re-iterate on https://github.com/woocommerce/woocommerce/pull/62680:
- make the widget loading with ajax (so if it encounters errors, those are isolated behind failing Ajax and not locking the admin out)
- add explicit check if product object was populated (`current_user_can( 'read_product', ... )` was not enough)
- while hardening the widget, adding UTs coverage

### How to test the changes in this Pull Request:

- ensure to freshly build the core plugin
- as per the original PR testing instructions
