### PR TITLE
Cache Store API products last modified timestamp

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6264-cache-products-last-modified
+++ b/plugins/woocommerce/changelog/wooplug-6264-cache-products-last-modified
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Cache Store API products last modified timestamp in the object cache to avoid a database query on every request.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -35,6 +35,7 @@ class WC_Post_Data {
 	 * Hook in methods.
 	 */
 	public static function init() {
+		add_action( 'clean_post_cache', array( __CLASS__, 'invalidate_products_last_modified' ), 10, 2 );
 		add_filter( 'post_type_link', array( __CLASS__, 'variation_post_link' ), 10, 2 );
 		add_action( 'shutdown', array( __CLASS__, 'do_deferred_product_sync' ), 10 );
 		add_action( 'set_object_terms', array( __CLASS__, 'force_default_term' ), 10, 5 );
@@ -144,6 +145,28 @@ class WC_Post_Data {
 	 */
 	public static function delete_product_query_transients() {
 		WC_Cache_Helper::get_transient_version( 'product_query', true );
+	}
+
+	/**
+	 * Invalidate the cached products last modified timestamp when a product post cache is cleaned.
+	 *
+	 * This does not use wp_cache_set_last_changed() because the cached value is exposed to
+	 * clients via the Last-Modified HTTP header for collection cache invalidation. WordPress
+	 * core's last_changed pattern auto-seeds with the current time on cache miss, which is
+	 * acceptable for opaque cache-key salts but would force all clients to unnecessarily
+	 * invalidate their local caches. Instead, invalidating the cache here allows the read side
+	 * in ProductQuery::get_last_modified() to fall back to the DB and re-seed with the real
+	 * last modification time.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public static function invalidate_products_last_modified( $post_id, $post ) {
+		if ( $post instanceof WP_Post && in_array( $post->post_type, array( 'product', 'product_variation' ), true ) ) {
+			wp_cache_delete( 'last_modified', 'wc_products' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -163,7 +163,7 @@ class WC_Post_Data {
 	 * @param int     $post_id Post ID.
 	 * @param WP_Post $post    Post object.
 	 */
-	public static function invalidate_products_last_modified( $post_id, $post ) {
+	public static function invalidate_products_last_modified( $post_id, $post ): void {
 		if ( $post instanceof WP_Post && in_array( $post->post_type, array( 'product', 'product_variation' ), true ) ) {
 			wp_cache_delete( 'last_modified', 'wc_products' );
 		}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -75817,12 +75817,6 @@ parameters:
 			path: src/StoreApi/Routes/V1/Products.php
 
 		-
-			message: '#^Parameter \#2 \$value of method WP_HTTP_Response\:\:header\(\) expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/StoreApi/Routes/V1/Products.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\StoreApi\\Routes\\V1\\ProductsById\:\:get_route_response\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -77409,12 +77403,6 @@ parameters:
 		-
 			message: '#^Call to function is_callable\(\) with ''_prime_post_caches'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/StoreApi/Utilities/ProductQuery.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\StoreApi\\Utilities\\ProductQuery\:\:get_last_modified\(\) should return int but returns int\|false\|null\.$#'
-			identifier: return.type
 			count: 1
 			path: src/StoreApi/Utilities/ProductQuery.php
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
@@ -5,12 +5,11 @@ namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
 
 use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Unit tests for the ProductQuery::get_last_modified() caching behavior.
  */
-class ProductQueryTest extends TestCase {
+class ProductQueryTest extends \WC_Unit_Test_Case {
 
 	/**
 	 * @var ProductQuery
@@ -20,7 +19,7 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * Setup test data. Called before every test.
 	 */
-	protected function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 		$this->product_query = new ProductQuery();
 		wp_cache_delete( 'last_modified', 'wc_products' );
@@ -29,7 +28,7 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox get_last_modified returns null when no products exist.
 	 */
-	public function test_get_last_modified_returns_null_when_no_products() {
+	public function test_get_last_modified_returns_null_when_no_products(): void {
 		global $wpdb;
 
 		// Temporarily remove all product posts to test the null case.
@@ -58,9 +57,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox get_last_modified returns an HTTP-date formatted string.
 	 */
-	public function test_get_last_modified_returns_http_date_format() {
+	public function test_get_last_modified_returns_http_date_format(): void {
 		$fixtures = new FixtureData();
-		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		$result = $this->product_query->get_last_modified();
 
@@ -73,9 +77,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox get_last_modified caches the result in the object cache.
 	 */
-	public function test_get_last_modified_caches_result() {
+	public function test_get_last_modified_caches_result(): void {
 		$fixtures = new FixtureData();
-		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		// First call seeds the cache.
 		$result = $this->product_query->get_last_modified();
@@ -89,7 +98,7 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox get_last_modified returns cached value without querying the database.
 	 */
-	public function test_get_last_modified_uses_cached_value() {
+	public function test_get_last_modified_uses_cached_value(): void {
 		$sentinel = 'Thu, 01 Jan 2099 00:00:00 GMT';
 		wp_cache_set( 'last_modified', $sentinel, 'wc_products' );
 
@@ -101,9 +110,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox Cache is invalidated when a product post cache is cleaned.
 	 */
-	public function test_cache_invalidated_on_product_change() {
+	public function test_cache_invalidated_on_product_change(): void {
 		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		// Seed the cache.
 		$this->product_query->get_last_modified();
@@ -118,9 +132,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox Cache is invalidated when a product variation post cache is cleaned.
 	 */
-	public function test_cache_invalidated_on_variation_change() {
+	public function test_cache_invalidated_on_variation_change(): void {
 		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		// Create a variation post directly to avoid complex variable product setup.
 		$variation_id = wp_insert_post(
@@ -144,9 +163,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox Cache is NOT invalidated when a non-product post cache is cleaned.
 	 */
-	public function test_cache_not_invalidated_on_non_product_change() {
+	public function test_cache_not_invalidated_on_non_product_change(): void {
 		$fixtures = new FixtureData();
-		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		// Seed the cache.
 		$this->product_query->get_last_modified();
@@ -154,7 +178,13 @@ class ProductQueryTest extends TestCase {
 		$this->assertNotFalse( $cached_value );
 
 		// Create and clean a regular post.
-		$post_id = wp_insert_post( array( 'post_title' => 'Regular Post', 'post_type' => 'post', 'post_status' => 'publish' ) );
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Regular Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
 		clean_post_cache( $post_id );
 
 		$this->assertSame( $cached_value, wp_cache_get( 'last_modified', 'wc_products' ) );
@@ -163,9 +193,14 @@ class ProductQueryTest extends TestCase {
 	/**
 	 * @testdox get_last_modified re-seeds cache from DB after invalidation.
 	 */
-	public function test_get_last_modified_reseeds_after_invalidation() {
+	public function test_get_last_modified_reseeds_after_invalidation(): void {
 		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
 
 		// Seed the cache.
 		$first_result = $this->product_query->get_last_modified();

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ProductQueryTest.php
@@ -1,0 +1,182 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
+
+use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Unit tests for the ProductQuery::get_last_modified() caching behavior.
+ */
+class ProductQueryTest extends TestCase {
+
+	/**
+	 * @var ProductQuery
+	 */
+	private ProductQuery $product_query;
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->product_query = new ProductQuery();
+		wp_cache_delete( 'last_modified', 'wc_products' );
+	}
+
+	/**
+	 * @testdox get_last_modified returns null when no products exist.
+	 */
+	public function test_get_last_modified_returns_null_when_no_products() {
+		global $wpdb;
+
+		// Temporarily remove all product posts to test the null case.
+		$original_posts = $wpdb->get_results(
+			"SELECT ID, post_type, post_status FROM {$wpdb->posts} WHERE post_type IN ('product', 'product_variation')"
+		);
+		$wpdb->query(
+			"UPDATE {$wpdb->posts} SET post_type = '_tmp_hidden' WHERE post_type IN ('product', 'product_variation')"
+		);
+
+		$result = $this->product_query->get_last_modified();
+
+		// Restore original posts.
+		$wpdb->query(
+			"UPDATE {$wpdb->posts} SET post_type = REPLACE(post_type, '_tmp_hidden', '') WHERE post_type = '_tmp_hidden'"
+		);
+
+		// Restore correct post types from the saved data.
+		foreach ( $original_posts as $post ) {
+			$wpdb->update( $wpdb->posts, array( 'post_type' => $post->post_type ), array( 'ID' => $post->ID ) );
+		}
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @testdox get_last_modified returns an HTTP-date formatted string.
+	 */
+	public function test_get_last_modified_returns_http_date_format() {
+		$fixtures = new FixtureData();
+		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		$result = $this->product_query->get_last_modified();
+
+		$this->assertNotNull( $result );
+		$this->assertStringEndsWith( 'GMT', $result );
+		// Verify it parses as a valid date.
+		$this->assertNotFalse( strtotime( $result ) );
+	}
+
+	/**
+	 * @testdox get_last_modified caches the result in the object cache.
+	 */
+	public function test_get_last_modified_caches_result() {
+		$fixtures = new FixtureData();
+		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		// First call seeds the cache.
+		$result = $this->product_query->get_last_modified();
+
+		// Verify cache is populated.
+		$cached = wp_cache_get( 'last_modified', 'wc_products' );
+		$this->assertNotFalse( $cached );
+		$this->assertSame( $result, $cached );
+	}
+
+	/**
+	 * @testdox get_last_modified returns cached value without querying the database.
+	 */
+	public function test_get_last_modified_uses_cached_value() {
+		$sentinel = 'Thu, 01 Jan 2099 00:00:00 GMT';
+		wp_cache_set( 'last_modified', $sentinel, 'wc_products' );
+
+		$result = $this->product_query->get_last_modified();
+
+		$this->assertSame( $sentinel, $result );
+	}
+
+	/**
+	 * @testdox Cache is invalidated when a product post cache is cleaned.
+	 */
+	public function test_cache_invalidated_on_product_change() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		// Seed the cache.
+		$this->product_query->get_last_modified();
+		$this->assertNotFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+
+		// Simulate product change — clean_post_cache fires WC_Post_Data::invalidate_products_last_modified.
+		clean_post_cache( $product->get_id() );
+
+		$this->assertFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+	}
+
+	/**
+	 * @testdox Cache is invalidated when a product variation post cache is cleaned.
+	 */
+	public function test_cache_invalidated_on_variation_change() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		// Create a variation post directly to avoid complex variable product setup.
+		$variation_id = wp_insert_post(
+			array(
+				'post_type'   => 'product_variation',
+				'post_parent' => $product->get_id(),
+				'post_status' => 'publish',
+			)
+		);
+
+		// Seed the cache.
+		$this->product_query->get_last_modified();
+		$this->assertNotFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+
+		// Clean variation post cache.
+		clean_post_cache( $variation_id );
+
+		$this->assertFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+	}
+
+	/**
+	 * @testdox Cache is NOT invalidated when a non-product post cache is cleaned.
+	 */
+	public function test_cache_not_invalidated_on_non_product_change() {
+		$fixtures = new FixtureData();
+		$fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		// Seed the cache.
+		$this->product_query->get_last_modified();
+		$cached_value = wp_cache_get( 'last_modified', 'wc_products' );
+		$this->assertNotFalse( $cached_value );
+
+		// Create and clean a regular post.
+		$post_id = wp_insert_post( array( 'post_title' => 'Regular Post', 'post_type' => 'post', 'post_status' => 'publish' ) );
+		clean_post_cache( $post_id );
+
+		$this->assertSame( $cached_value, wp_cache_get( 'last_modified', 'wc_products' ) );
+	}
+
+	/**
+	 * @testdox get_last_modified re-seeds cache from DB after invalidation.
+	 */
+	public function test_get_last_modified_reseeds_after_invalidation() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product( array( 'name' => 'Test Product', 'regular_price' => 10 ) );
+
+		// Seed the cache.
+		$first_result = $this->product_query->get_last_modified();
+
+		// Invalidate.
+		clean_post_cache( $product->get_id() );
+
+		// Next call should re-query DB and re-seed.
+		$second_result = $this->product_query->get_last_modified();
+
+		$this->assertNotNull( $second_result );
+		$this->assertNotFalse( wp_cache_get( 'last_modified', 'wc_products' ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`ProductQuery::get_last_modified()` runs a `SELECT MAX(post_modified_gmt)` query against the posts table on every Store API `/wc/store/v1/products` request to populate the `Last-Modified` response header. This adds unnecessary database overhead on every request since products change infrequently relative to how often they are read.

This PR caches the result in the object cache (`last_modified` key in `wc_products` group) and invalidates it via the `clean_post_cache` hook in `WC_Post_Data`. On cache hit, the DB query is skipped entirely. On cache miss (first request or after a product change), the query runs and the result is cached.

The implementation uses `wp_cache_delete()` / `wp_cache_get()` / `wp_cache_set()` rather than WordPress core's `wp_cache_*_last_changed()` pattern. Core's `last_changed` pattern auto-seeds with the current time on cache miss, which is fine for opaque cache-key salts but would cause incorrect behavior here — the value is exposed to clients via the `Last-Modified` header, and auto-seeding with "now" would force all clients to unnecessarily invalidate their local caches. Instead, on a cache miss we fall back to the database for the real last modification time.

Also normalizes the `Last-Modified` header value to RFC 7232 HTTP-date format (previously a raw unix timestamp).

Closes WOOPLUG-6264 / #63164

### How to test the changes in this Pull Request:

1. Open a WooCommerce store with products and navigate to a page that uses the Store API products endpoint (e.g., a page with a Products block, or call `/wp-json/wc/store/v1/products` directly).
2. Check the response headers — the `Last-Modified` header should now be in HTTP-date format, e.g., `Wed, 09 Oct 2024 08:28:00 GMT`.
3. Enable query logging (e.g., Query Monitor plugin) and reload the page twice. On the second load, confirm the `SELECT MAX(post_modified_gmt)` query is no longer present.
4. Edit any product in WP Admin (e.g., change the title) and save.
5. Reload the products endpoint and confirm the `Last-Modified` header value has updated to reflect the change. The DB query should run once on this first request after the change, then be cached again.
6. Create a new product, then check the endpoint — `Last-Modified` should update.
7. Trash a product, then check the endpoint — `Last-Modified` should update.
8. Edit a non-product post (e.g., a page) and confirm the `Last-Modified` header on the products endpoint does NOT change.

### Testing that has already taken place:

- 8 unit tests added and passing (`pnpm test:php:env -- --filter ProductQueryTest`)
- Covers: HTTP-date format, caching behavior, cache invalidation on product/variation/non-product changes, DB fallback on cache miss

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry is included in this PR at `plugins/woocommerce/changelog/wooplug-6264-cache-products-last-modified`.

</details>