### PR TITLE
Fix blank modal when swapping email templates

### DIFF
--- a/packages/js/email-editor/changelog/fix-swap-template-blank-modal
+++ b/packages/js/email-editor/changelog/fix-swap-template-blank-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blank modal when using swap template action in email editor

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -103,12 +103,18 @@ function SelectTemplateBody( {
 	}, [ displayCategories, selectedCategory ] );
 
 	return (
-		<div className="block-editor-block-patterns-explorer">
-			<TemplateCategoriesListSidebar
-				templateCategories={ displayCategories }
-				selectedCategory={ selectedCategory }
-				onClickCategory={ handleCategorySelection }
-			/>
+		<div
+			className={ `block-editor-block-patterns-explorer${
+				displayCategories.length === 0 ? ' no-sidebar' : ''
+			}` }
+		>
+			{ displayCategories.length > 0 && (
+				<TemplateCategoriesListSidebar
+					templateCategories={ displayCategories }
+					selectedCategory={ selectedCategory }
+					onClickCategory={ handleCategorySelection }
+				/>
+			) }
 
 			<TemplateList
 				templates={ templates }

--- a/packages/js/email-editor/src/components/template-select/style.scss
+++ b/packages/js/email-editor/src/components/template-select/style.scss
@@ -39,7 +39,8 @@
 	}
 }
 
-.block-editor-block-patterns-explorer.no-sidebar .block-editor-block-patterns-explorer__list {
+.block-editor-block-patterns-explorer.no-sidebar
+	.block-editor-block-patterns-explorer__list {
 	margin-left: 0;
 	padding-left: 2rem;
 }

--- a/packages/js/email-editor/src/components/template-select/style.scss
+++ b/packages/js/email-editor/src/components/template-select/style.scss
@@ -39,6 +39,11 @@
 	}
 }
 
+.block-editor-block-patterns-explorer.no-sidebar .block-editor-block-patterns-explorer__list {
+	margin-left: 0;
+	padding-left: 2rem;
+}
+
 .email-editor-modal-footer {
 	background-color: #fff;
 	bottom: 0;

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -139,9 +139,11 @@ export function TemplateList( {
 }: Props ) {
 	const filteredTemplates = useMemo(
 		() =>
-			templates.filter(
-				( template ) => template.category === selectedCategory
-			),
+			selectedCategory !== null && selectedCategory !== undefined
+				? templates.filter(
+						( template ) => template.category === selectedCategory
+				  )
+				: templates,
 		[ selectedCategory, templates ]
 	);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes https://linear.app/a8c/issue/STOMAIL-7723/swap-template-opens-a-blank-template-picker

When clicking "Swap template" in the email editor sidebar, the template picker modal opens but displays a blank content area. This happens because in swap mode, template previews are generated from custom email content which has no pattern categories. The category-based filtering then matches nothing, resulting in an empty list.

Before | After
---- | ---
<img width="1876" height="832" alt="Screenshot 2026-02-10 at 11 11 11 AM" src="https://github.com/user-attachments/assets/dc9815ef-223f-43df-8d0a-34965a0f5a4b" /> | <img width="1876" height="830" alt="Screenshot 2026-02-10 at 9 46 21 AM" src="https://github.com/user-attachments/assets/34d6a4f6-2a86-45a9-80a7-9d9d91dd7461" />


This PR fixes the issue by:
- **`template-list.tsx`**: Skipping category filtering when no category is selected (showing all templates)
- **`select-modal.tsx`**: Conditionally hiding the empty category sidebar when there are no categories
- **`style.scss`**: Adding CSS so the template list fills the full width when the sidebar is absent

### How to test the changes in this Pull Request:

<img width="305" height="229" alt="Screenshot 2026-02-10 at 10 59 20 AM" src="https://github.com/user-attachments/assets/6fba4a23-627e-4148-981d-fd83a329af63" />

1. Open the email editor on a site with more than one template.
4. In the editor sidebar, find the Settings > **Template** section and click the template name to open the dropdown.
5. Click **Swap template**.
6. Verify the modal opens with all available templates displayed (no blank content area).
7. Verify there is no empty sidebar gap on the left side of the modal.
8. Click a template to confirm selection works as expected.
9. Verify that the "new template" flow (initial template selection when creating a new email) still works correctly with categories.

### Testing that has already taken place:

- Tested manually on the new env.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry was created manually in `packages/js/email-editor/changelog/fix-swap-template-blank-modal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)