### PR TITLE
iAPI: Remove `needsRefreshForInteractivityAPI` in favor of `core/router`'s `clientNavigationDisabled`

### DIFF
--- a/plugins/woocommerce/changelog/63230-iapi-remove-needsrefreshforinteractivityapi-in-favor-of-clientnavigationdisabled
+++ b/plugins/woocommerce/changelog/63230-iapi-remove-needsrefreshforinteractivityapi-in-favor-of-clientnavigationdisabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace custom `needsRefreshForInteractivityAPI` with native `clientNavigationDisabled` from WordPress core's Interactivity Router.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/__tests__/frontend.test.ts
@@ -133,13 +133,6 @@ describe( 'product filters interactivity store', () => {
 					if ( key === 'woocommerce/product-filters' ) {
 						return {
 							canonicalUrl,
-							isProductArchive: true,
-						};
-					}
-					if ( key === 'woocommerce' ) {
-						return {
-							isBlockTheme: true,
-							needsRefreshForInteractivityAPI: false,
 						};
 					}
 					return {};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -227,21 +227,6 @@ const productFiltersStore = {
 				return;
 			}
 
-			const sharedSettings = getConfig( 'woocommerce' );
-			const productFilterSettings = getConfig( BLOCK_NAME );
-			const isBlockTheme = sharedSettings?.isBlockTheme || false;
-			const isProductArchive =
-				productFilterSettings?.isProductArchive || false;
-			const needsRefreshForInteractivityAPI =
-				sharedSettings?.needsRefreshForInteractivityAPI || false;
-
-			if (
-				needsRefreshForInteractivityAPI ||
-				( ! isBlockTheme && isProductArchive )
-			) {
-				return ( window.location.href = url.href );
-			}
-
 			const routerModule: typeof import('@wordpress/interactivity-router') =
 				yield import( '@wordpress/interactivity-router' );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -50,12 +50,12 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );
 
-		// Indicate to interactivity powered components that this block is on the page
-		// and needs refresh to update data.
+		// Disable client-side navigation so that interactivity powered
+		// components fall back to full page reload.
 		wp_interactivity_config(
-			'woocommerce',
+			'core/router',
 			array(
-				'needsRefreshForInteractivityAPI' => true,
+				'clientNavigationDisabled' => true,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -41,12 +41,12 @@ class ProductFilters extends AbstractBlock {
 
 		BlocksSharedState::load_store_config( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 
-		wp_interactivity_config(
-			$this->get_full_block_name(),
-			[
-				'isProductArchive' => is_shop() || is_product_taxonomy() || ( is_search() && 'product' === get_post_type() ),
-			]
-		);
+		// Classic themes do not support client-side navigation on product
+		// archive pages, so disable it globally for the Interactivity Router.
+		$is_product_archive = is_shop() || is_product_taxonomy() || ( is_search() && 'product' === get_post_type() );
+		if ( ! wp_is_block_theme() && $is_product_archive ) {
+			wp_interactivity_config( 'core/router', array( 'clientNavigationDisabled' => true ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -180,12 +180,12 @@ class ProductQuery extends AbstractBlock {
 		$this->parsed_block = $parsed_block;
 
 		if ( self::is_woocommerce_variation( $parsed_block ) ) {
-			// Indicate to interactivity powered components that this block is on the page
-			// and needs refresh to update data.
+			// Disable client-side navigation so that interactivity powered
+			// components fall back to full page reload.
 			wp_interactivity_config(
-				'woocommerce',
+				'core/router',
 				[
-					'needsRefreshForInteractivityAPI' => true,
+					'clientNavigationDisabled' => true,
 				]
 			);
 			// Set this so that our product filters can detect if it's a PHP template.

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -87,7 +87,6 @@ class BlocksSharedState {
 
 		wp_interactivity_config( self::$settings_namespace, self::get_currency_data() );
 		wp_interactivity_config( self::$settings_namespace, self::get_locale_data() );
-		wp_interactivity_config( self::$settings_namespace, self::get_core_data() );
 	}
 
 	/**
@@ -124,17 +123,6 @@ class BlocksSharedState {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Get core data to include in settings.
-	 *
-	 * @return array
-	 */
-	private static function get_core_data(): array {
-		return array(
-			'isBlockTheme' => wp_is_block_theme(),
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Replace the custom `needsRefreshForInteractivityAPI` config flag with WordPress core's native `clientNavigationDisabled` mechanism on the `core/router` namespace. This is the same approach used by Gutenberg's `core/query` block ([reference](https://github.com/WordPress/gutenberg/blob/705cb2617b5b870bd2b09a61df7fcc3de6e58d26/packages/block-library/src/query/index.php#L123)) and WooCommerce's own Product Collection block (`disable_enhanced_pagination`).

Previously, the Product Filters block's frontend `navigate` action manually checked three config values (`needsRefreshForInteractivityAPI`, `isBlockTheme`, `isProductArchive`) to decide between a full page reload and client-side Interactivity API navigation. Now, all three conditions are handled server-side by setting `clientNavigationDisabled` on `core/router`, and the frontend simply calls `routerModule.actions.navigate()` — which natively falls back to a full page reload when `clientNavigationDisabled` is `true`.

**Server-side changes:**

-   `ClassicTemplate.php`: Sets `clientNavigationDisabled` on `core/router` instead of `needsRefreshForInteractivityAPI` on `woocommerce`.
-   `ProductQuery.php`: Same replacement.
-   `ProductFilters.php`: Moves the `!isBlockTheme && isProductArchive` check from the client to the server, setting `clientNavigationDisabled` when appropriate. Removes the now-unused `isProductArchive` config.
-   `BlocksSharedState.php`: Removes the `isBlockTheme` from the interactivity config (`get_core_data()`), as its only consumer was the Product Filters frontend code that no longer needs it. Note: the `isBlockTheme` values set via `asset_data_registry` in Cart, Checkout, AddToCartForm, and ProductImage are unrelated and untouched.

**Client-side changes:**

-   `frontend.ts`: Removes the entire decision block (~14 lines) that checked the three config values. The `navigate` action now always delegates to the Interactivity Router.
-   `frontend.test.ts`: Simplifies test mocks to remove the now-unused config values.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Prerequisites:** Use a block theme (e.g., Twenty Twenty-Five) with a few products that have a filterable attribute (e.g., Color with values Red, Blue, Green).

1. **Block theme + Product Collection (client-side navigation):**

    1. Go to **Appearance > Editor > Templates > Product Catalog**.
    2. Ensure the template has a **Product Collection** block and a **Product Filters** block (add them if missing). Save.
    3. Visit the shop on the frontend and change a filter value.
    4. **Expected:** The URL updates without the page flashing — client-side navigation is used.

2. **Block theme + Classic Template (full page reload):**

    1. Go to **Appearance > Editor > Templates > Product Catalog**.
    2. Open the **Options menu** (three dots top-right) and select **"Code editor"**.
    3. Replace the template content with:
        ```html
        <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
        <main class="wp-block-group">
        	<!-- wp:woocommerce/legacy-template {"template":"archive-product"} /-->
        </main>
        <!-- /wp:group -->
        ```
    4. Add a **Product Filters** block.
    5. Click **"Exit code editor"**, then **Save**.
    6. Visit the shop on the frontend and change a filter value.
    7. **Expected:** A **full page reload** occurs (the page flashes).

3. **Block theme + Products (Beta) / Product Query (full page reload):**

    1. Same as above, but replace the template content in the Code editor with:
        ```html
        <!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
        <main class="wp-block-group">
        	<!-- wp:query {"queryId":19,"query":{"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"namespace":"woocommerce/product-query"} -->
        	<div class="wp-block-query">
        		<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
        		<!-- wp:post-title {"isLink":true,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
        		<!-- /wp:post-template -->
        	</div>
        	<!-- /wp:query -->
        </main>
        <!-- /wp:group -->
        ```
    2. Add a **Product Filters** block.
    3. Save, visit the shop, and change a filter value.
    4. **Expected:** A **full page reload** occurs.

4. **Classic theme + product archive (full page reload):**
    1. Switch to a classic theme (e.g., Twenty Twenty-One or Storefront).
    2. Add Product Filters as a widget to the shop sidebar (**Appearance > Widgets**).
    3. Visit the shop page and change a filter value.
    4. **Expected:** A **full page reload** occurs.

### Milestone

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Replace custom `needsRefreshForInteractivityAPI` with native `clientNavigationDisabled` from WordPress core's Interactivity Router.

</details>
