### PR TITLE
Move email context filter to allow overwrite values from core

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-2246-preserve-wp_user
+++ b/plugins/woocommerce/changelog/wooprd-2246-preserve-wp_user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update woocommerce_email_editor_integration_personalizer_context_data filter to allow overwrite values from core

--- a/plugins/woocommerce/src/Internal/EmailEditor/TransactionalEmailPersonalizer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/TransactionalEmailPersonalizer.php
@@ -67,20 +67,6 @@ class TransactionalEmailPersonalizer {
 	public function prepare_context_data( array $previous_context, \WC_Email $email ): array {
 		$context = $previous_context;
 
-		/**
-		 * Filters the context data for email personalization.
-		 *
-		 * @since 10.5.0
-		 * @param array     $context Previous version of context data.
-		 * @param \WC_Email $email The WooCommerce email object.
-		 * @return array Context data for personalization
-		 */
-		$context = apply_filters( 'woocommerce_email_editor_integration_personalizer_context_data', $context, $email );
-
-		if ( ! is_array( $context ) ) {
-			$context = $previous_context;
-		}
-
 		$context['recipient_email'] = $email->get_recipient();
 		$context['order']           = $email->object instanceof \WC_Order ? $email->object : null;
 		// For emails of type new_user or reset_password we want to set user directly from the object.
@@ -92,6 +78,25 @@ class TransactionalEmailPersonalizer {
 			$context['wp_user'] = null;
 		}
 		$context['wc_email'] = $email;
+
+		$core_context = $context;
+
+		/**
+		 * Filters the context data for email personalization.
+		 *
+		 * This filter fires after core defaults are set, allowing extensions
+		 * to override values like wp_user for custom email types (e.g., WooCommerce Bookings).
+		 *
+		 * @since 10.5.0
+		 * @param array     $context Context data including core defaults.
+		 * @param \WC_Email $email The WooCommerce email object.
+		 * @return array Context data for personalization
+		 */
+		$context = apply_filters( 'woocommerce_email_editor_integration_personalizer_context_data', $context, $email );
+
+		if ( ! is_array( $context ) ) {
+			$context = $core_context;
+		}
 
 		return $context;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/TransactionalEmailPersonalizerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/TransactionalEmailPersonalizerTest.php
@@ -1,0 +1,135 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
+
+use Automattic\WooCommerce\Internal\EmailEditor\TransactionalEmailPersonalizer;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the TransactionalEmailPersonalizer class.
+ */
+class TransactionalEmailPersonalizerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var TransactionalEmailPersonalizer
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new TransactionalEmailPersonalizer();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_email_editor_integration_personalizer_context_data' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should preserve wp_user set by the filter when core cannot derive it from the email object.
+	 */
+	public function test_wp_user_set_by_filter_is_preserved(): void {
+		$mock_user  = $this->createMock( \WP_User::class );
+		$mock_email = $this->createMock( \WC_Email::class );
+		$mock_email->method( 'get_recipient' )->willReturn( 'test@example.com' );
+		$mock_email->object = new \stdClass();
+
+		add_filter(
+			'woocommerce_email_editor_integration_personalizer_context_data',
+			function ( $context ) use ( $mock_user ) {
+				$context['wp_user'] = $mock_user;
+				return $context;
+			}
+		);
+
+		$result = $this->sut->prepare_context_data( array(), $mock_email );
+
+		$this->assertSame( $mock_user, $result['wp_user'], 'wp_user set by the filter should be preserved' );
+	}
+
+	/**
+	 * @testdox Should set wp_user from WP_User email object when no filter overrides it.
+	 */
+	public function test_wp_user_set_from_wp_user_object(): void {
+		$mock_user  = $this->createMock( \WP_User::class );
+		$mock_email = $this->createMock( \WC_Email::class );
+		$mock_email->method( 'get_recipient' )->willReturn( 'test@example.com' );
+		$mock_email->object = $mock_user;
+
+		$result = $this->sut->prepare_context_data( array(), $mock_email );
+
+		$this->assertSame( $mock_user, $result['wp_user'], 'wp_user should be set from WP_User email object' );
+	}
+
+	/**
+	 * @testdox Should set wp_user to null when email object is not WP_User or WC_Order and no filter overrides.
+	 */
+	public function test_wp_user_null_for_unknown_object_type(): void {
+		$mock_email = $this->createMock( \WC_Email::class );
+		$mock_email->method( 'get_recipient' )->willReturn( 'test@example.com' );
+		$mock_email->object = new \stdClass();
+
+		$result = $this->sut->prepare_context_data( array(), $mock_email );
+
+		$this->assertNull( $result['wp_user'], 'wp_user should be null when object type is unknown and no filter overrides' );
+	}
+
+	/**
+	 * @testdox Should provide core defaults to the filter callback.
+	 */
+	public function test_filter_receives_core_defaults(): void {
+		$received_context = null;
+		$mock_email       = $this->createMock( \WC_Email::class );
+		$mock_email->method( 'get_recipient' )->willReturn( 'test@example.com' );
+		$mock_email->object = new \stdClass();
+
+		add_filter(
+			'woocommerce_email_editor_integration_personalizer_context_data',
+			function ( $context ) use ( &$received_context ) {
+				$received_context = $context;
+				return $context;
+			}
+		);
+
+		$this->sut->prepare_context_data( array(), $mock_email );
+
+		$this->assertArrayHasKey( 'recipient_email', $received_context, 'Filter should receive recipient_email' );
+		$this->assertSame( 'test@example.com', $received_context['recipient_email'] );
+		$this->assertArrayHasKey( 'wp_user', $received_context, 'Filter should receive wp_user' );
+		$this->assertArrayHasKey( 'wc_email', $received_context, 'Filter should receive wc_email' );
+		$this->assertArrayHasKey( 'order', $received_context, 'Filter should receive order' );
+	}
+
+	/**
+	 * @testdox Should fall back to core context when filter returns non-array.
+	 */
+	public function test_fallback_to_core_context_when_filter_returns_non_array(): void {
+		$mock_email = $this->createMock( \WC_Email::class );
+		$mock_email->method( 'get_recipient' )->willReturn( 'test@example.com' );
+		$mock_email->object = new \stdClass();
+
+		add_filter(
+			'woocommerce_email_editor_integration_personalizer_context_data',
+			function () {
+				return 'not_an_array';
+			}
+		);
+
+		$result = $this->sut->prepare_context_data( array(), $mock_email );
+
+		$this->assertArrayHasKey( 'recipient_email', $result, 'Fallback should contain core defaults' );
+		$this->assertSame( 'test@example.com', $result['recipient_email'] );
+		$this->assertArrayHasKey( 'wp_user', $result, 'Fallback should contain wp_user from core' );
+		$this->assertArrayHasKey( 'wc_email', $result, 'Fallback should contain wc_email from core' );
+		$this->assertArrayHasKey( 'order', $result, 'Fallback should contain order from core' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `woocommerce_email_editor_integration_personalizer_context_data` filter was previously applied before core context defaults (like `recipient_email`, `order`, `wp_user`, `wc_email`) were set in
  `TransactionalEmailPersonalizer::prepare_context_data()`. This meant extensions could not override core-derived values — for example, a plugin like WooCommerce Bookings could not set a `wp_user` for
  its own email types, because core would overwrite it immediately after the filter ran.

  This PR moves the filter to fire after core defaults are populated, so that:
  1. Filter callbacks receive the full core context (including `recipient_email`, `order`, `wp_user`, `wc_email`).
  2. Extensions can override any core-derived value (e.g., set `wp_user` for custom email types where core cannot derive it).
  3. The fallback on invalid filter return now restores core defaults instead of the bare $previous_context.

Closes WOOPRD-2246.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

There is an integration test that covers the functionality.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
