### PR TITLE
Allow the Products onboarding task to revert to incomplete when all products are removed

### DIFF
--- a/plugins/woocommerce/changelog/63239-fix-56534-revert-products-task
+++ b/plugins/woocommerce/changelog/63239-fix-56534-revert-products-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow the Products onboarding task to revert to incomplete when all products are removed #63239

--- a/plugins/woocommerce/changelog/63239-fix-56534-revert-products-task
+++ b/plugins/woocommerce/changelog/63239-fix-56534-revert-products-task
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Allow the Products onboarding task to revert to incomplete when all products are removed #63239
+Allow the Products onboarding task to revert to incomplete when all products are removed

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -186,6 +186,7 @@ class Products extends Task {
 	 * Handle product trashing via the trashed_post hook.
 	 *
 	 * @param int $post_id Post ID.
+	 * @return void
 	 */
 	public function on_product_removed( $post_id ) {
 		if ( get_post_type( $post_id ) !== 'product' ) {
@@ -197,6 +198,8 @@ class Products extends Task {
 
 	/**
 	 * Handle permanent product deletion via the deleted_post_product hook.
+	 *
+	 * @return void
 	 */
 	public function on_product_deleted() {
 		$this->revert_task_completion();
@@ -204,6 +207,8 @@ class Products extends Task {
 
 	/**
 	 * Re-check whether valid products still exist and revert task completion if none remain.
+	 *
+	 * @return void
 	 */
 	private function revert_task_completion() {
 		delete_transient( self::HAS_PRODUCT_TRANSIENT );

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -27,6 +27,9 @@ class Products extends Task {
 		add_action( 'woocommerce_new_product', array( $this, 'maybe_set_has_product_transient' ), 10, 2 );
 		add_action( 'untrashed_post', array( $this, 'maybe_set_has_product_transient_on_untrashed_post' ) );
 		add_action( 'current_screen', array( $this, 'maybe_redirect_to_add_product_tasklist' ), 30, 0 );
+
+		add_action( 'trashed_post', array( $this, 'on_product_removed' ) );
+		add_action( 'deleted_post_product', array( $this, 'on_product_deleted' ) );
 	}
 
 	/**
@@ -176,6 +179,45 @@ class Products extends Task {
 		if ( ! $this->has_previously_completed() && $this->is_valid_product( $product ) ) {
 			set_transient( self::HAS_PRODUCT_TRANSIENT, 'yes' );
 			$this->possibly_track_completion();
+		}
+	}
+
+	/**
+	 * Handle product trashing via the trashed_post hook.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function on_product_removed( $post_id ) {
+		if ( get_post_type( $post_id ) !== 'product' ) {
+			return;
+		}
+
+		$this->revert_task_completion();
+	}
+
+	/**
+	 * Handle permanent product deletion via the deleted_post_product hook.
+	 */
+	public function on_product_deleted() {
+		$this->revert_task_completion();
+	}
+
+	/**
+	 * Re-check whether valid products still exist and revert task completion if none remain.
+	 */
+	private function revert_task_completion() {
+		delete_transient( self::HAS_PRODUCT_TRANSIENT );
+
+		if ( self::has_products() ) {
+			return;
+		}
+
+		$completed_tasks = get_option( self::COMPLETED_OPTION, array() );
+		$task_id         = $this->get_id();
+
+		if ( in_array( $task_id, $completed_tasks, true ) ) {
+			$completed_tasks = array_values( array_diff( $completed_tasks, array( $task_id ) ) );
+			update_option( self::COMPLETED_OPTION, $completed_tasks );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -28,7 +28,7 @@ class Products extends Task {
 		add_action( 'untrashed_post', array( $this, 'maybe_set_has_product_transient_on_untrashed_post' ) );
 		add_action( 'current_screen', array( $this, 'maybe_redirect_to_add_product_tasklist' ), 30, 0 );
 
-		add_action( 'trashed_post', array( $this, 'on_product_removed' ) );
+		add_action( 'trashed_post', array( $this, 'on_product_trashed' ) );
 		add_action( 'deleted_post_product', array( $this, 'on_product_deleted' ) );
 	}
 
@@ -188,7 +188,7 @@ class Products extends Task {
 	 * @param int $post_id Post ID.
 	 * @return void
 	 */
-	public function on_product_removed( $post_id ) {
+	public function on_product_trashed( $post_id ) {
 		if ( get_post_type( $post_id ) !== 'product' ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, once the Products task was marked complete via has_previously_completed(), it could not be reverted, even if all products were trashed or deleted. This contradicts the expected behavior, where the task should reflect the actual store state.

This PR adds hooks for `trashed_post` and `deleted_post_product` that clear the product transient cache and remove the task from the tracked completed list when no valid products remain.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #56534

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Pre-requisites
Start from a fresh install or reset your store by completely removing all products and running:
```
wp option delete woocommerce_task_list_tracked_completed_tasks
wp transient delete woocommerce_product_task_has_product_transient
```

### Test 1: Trashing the only product

1. Go to `WooCommerce > Home`, ensure all tasks from the list show as incomplete.
<img width="350" height="270" alt="Screenshot 2026-02-11 at 11 33 49" src="https://github.com/user-attachments/assets/cdbf79c0-e48f-48ba-9ce3-d72dc2616d43" />

2. Create a new product.
3. Go to `WooCommerce > Home`, ensure the `Add your products` task shows as completed.
4. Trash the product you created in step 2.
5. Go to `WooCommerce > Home`, ensure the products task shows as incomplete.
6. Go to `Products > All Products > Trash` tab, click `Restore` on the trashed product.
7. Go to `WooCommerce > Home`, ensure the task shows as completed again.


### Test 2: Force-deleting the only product
1. Remove all products, if any, and reset the task list with:
```
wp option delete woocommerce_task_list_tracked_completed_tasks
wp transient delete woocommerce_product_task_has_product_transient
```
2. Create a new product.
3. Go to `WooCommerce > Home`, ensure the products task shows as completed.
4. Run: `wp post delete <PRODUCT_ID> --force`.
5. Go to `WooCommerce > Home`, ensure the products task shows as incomplete.

### Test 3: Trashing one product when others remain

1. Ensure you have at least two published products.
2. Go to `WooCommerce > Home`, ensure the products task shows as completed.
3. Go to `Products > All Products`, and trash one product.
4. Go to `WooCommerce > Home`, ensure the products task still shows as completed.

### Test 4: Force-deleting one product when others remain

1. Ensure you have at least two published products, note one ID.
2. Go to `WooCommerce > Home`, ensure the products task shows as completed.
3. Run: `wp post delete <PRODUCT_ID> --force`.
4. Go to `WooCommerce > Home`, ensure the products task still shows as completed.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Allow the Products onboarding task to revert to incomplete when all products are removed
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
