### PR TITLE
Proof of concept - Email editor as a plugin

### DIFF
--- a/packages/js/email-editor/package.json
+++ b/packages/js/email-editor/package.json
@@ -97,6 +97,7 @@
 		"@wordpress/url": "wp-6.6",
 		"clsx": "2.1.x",
 		"deepmerge": "^4.3.1",
+		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
 		"react": "18.3.x",
 		"react-dom": "18.3.x"

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -31,12 +31,7 @@ import { enhanceSiteLogoBlock } from './core/site-logo';
 
 export { getAllowedBlockNames } from './utils';
 
-export function initBlocks() {
-	// Check if core blocks are already registered by looking for a fundamental core block
-	// 'core/paragraph' is always included in core blocks
-	if ( ! getBlockType( 'core/paragraph' ) ) {
-		registerCoreBlocks();
-	}
+function applyEmailBlockEnhancements() {
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();
 	hideExpandOnClick();
@@ -53,4 +48,17 @@ export function initBlocks() {
 	enhanceSocialLinksBlock();
 	enhanceSiteLogoBlock();
 	removeBlockStylesFromAllBlocks();
+}
+
+export function initBlocks() {
+	// Check if core blocks are already registered by looking for a fundamental core block
+	// 'core/paragraph' is always included in core blocks
+	if ( ! getBlockType( 'core/paragraph' ) ) {
+		registerCoreBlocks();
+	}
+	applyEmailBlockEnhancements();
+}
+
+export function initBlocksForPlugin() {
+	applyEmailBlockEnhancements();
 }

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -39,9 +39,10 @@ const siteIconVariants = {
 };
 
 /**
- * Back button content component with animation effects.
+ * Inner button component with animation effects for the back button.
+ * Exported separately for use in plugin mode where BackButton wrapper is not needed.
  */
-const DefaultBackButtonContent = () => {
+export const BackButtonInnerButton = () => {
 	const { urls } = useSelect(
 		( select ) => ( {
 			urls: select( storeName ).getUrls(),
@@ -98,6 +99,8 @@ const DefaultBackButtonContent = () => {
 		</motion.div>
 	);
 };
+
+const DefaultBackButtonContent = BackButtonInnerButton;
 
 export const BackButtonContent = () => {
 	const BackButtonUsedContent = applyFilters(

--- a/packages/js/email-editor/src/editor-plugin.tsx
+++ b/packages/js/email-editor/src/editor-plugin.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
-import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useSelect, useDispatch, dispatch, select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { registerPlugin, PluginArea } from '@wordpress/plugins';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -32,6 +32,7 @@ import {
 import { FullscreenMode } from './private-apis';
 import { BackButtonInnerButton } from './components/header/back-button-content';
 import { getEditorConfigFromWindow } from './store/settings';
+import { cleanupConfigurationChanges } from './config-tools';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './components/styles-sidebar';
 import { SendPreview } from './components/preview';
@@ -71,6 +72,22 @@ export function ExperimentEmailEditorPlugin() {
 		},
 		[]
 	);
+
+	// Snapshot editor settings on mount; restore and clean up on unmount
+	useEffect( () => {
+		const backupEditorSettings =
+			select( editorStore ).getEditorSettings();
+		return () => {
+			try {
+				cleanupConfigurationChanges();
+			} finally {
+				dispatch( editorStore ).updateEditorSettings(
+					backupEditorSettings
+				);
+			}
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	// Push email CSS styles to the WordPress editor settings
 	const [ styles ] = useEmailCss();

--- a/packages/js/email-editor/src/editor-plugin.tsx
+++ b/packages/js/email-editor/src/editor-plugin.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { registerPlugin } from '@wordpress/plugins';
+import { registerPlugin, PluginArea } from '@wordpress/plugins';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore -- fast-deep-equal has no type declarations
 import deepEqual from 'fast-deep-equal';
@@ -32,6 +32,15 @@ import {
 import { FullscreenMode } from './private-apis';
 import { BackButtonInnerButton } from './components/header/back-button-content';
 import { getEditorConfigFromWindow } from './store/settings';
+import { TemplateSelection } from './components/template-select';
+import { StylesSidebar } from './components/styles-sidebar';
+import { SendPreview } from './components/preview';
+import { PreviewSaveGuard } from './components/preview/preview-save-guard';
+import { SettingsPanel } from './components/sidebar/settings-panel';
+import { TemplateSettingsPanel } from './components/sidebar/template-settings-panel';
+import { PublishSave } from './hacks/publish-save';
+import { EditorNotices } from './components/notices';
+import { BlockCompatibilityWarnings } from './components/sidebar';
 
 // @ts-expect-error __experimentalMainDashboardButton is not in types.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -50,12 +59,16 @@ export function EditorPlugin() {
  * Pushes email CSS to editor settings, restricts blocks, and renders email-specific UI.
  */
 export function ExperimentEmailEditorPlugin() {
-	const { isFullScreenForced } = useSelect(
-		( sel ) => ( {
-			isFullScreenForced:
-				sel( storeName ).getInitialEditorSettings()
-					?.isFullScreenForced ?? false,
-		} ),
+	const { isFullScreenForced, displaySendEmailButton, postType } = useSelect(
+		( sel ) => {
+			const settings = sel( storeName ).getInitialEditorSettings();
+			return {
+				isFullScreenForced: settings?.isFullScreenForced ?? false,
+				displaySendEmailButton:
+					settings?.displaySendEmailButton ?? true,
+				postType: sel( storeName ).getEmailPostType(),
+			};
+		},
 		[]
 	);
 
@@ -95,6 +108,19 @@ export function ExperimentEmailEditorPlugin() {
 					<BackButtonInnerButton />
 				</MainDashboardButton>
 			) }
+			<TemplateSelection />
+			<StylesSidebar />
+			<SendPreview />
+			<PreviewSaveGuard />
+			{ postType === 'wp_template' ? (
+				<TemplateSettingsPanel />
+			) : (
+				<SettingsPanel />
+			) }
+			{ displaySendEmailButton && <PublishSave /> }
+			<EditorNotices />
+			<BlockCompatibilityWarnings />
+			<PluginArea scope="woocommerce-email-editor" />
 		</>
 	);
 }

--- a/packages/js/email-editor/src/editor-plugin.tsx
+++ b/packages/js/email-editor/src/editor-plugin.tsx
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { registerPlugin } from '@wordpress/plugins';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- fast-deep-equal has no type declarations
+import deepEqual from 'fast-deep-equal';
+import '@wordpress/format-library'; // Enables text formatting capabilities
+
+/**
+ * Internal dependencies
+ */
+import { getAllowedBlockNames, initBlocksForPlugin } from './blocks';
+import { initializeLayout } from './layouts/flex-email';
+import { createStore, storeName } from './store';
+import { initTextHooks } from './text-hooks';
+import {
+	initEventCollector,
+	initStoreTracking,
+	initDomTracking,
+} from './events';
+import { initContentValidationMiddleware } from './middleware/content-validation';
+import { initHacks } from './hacks';
+import {
+	useEmailCss,
+	useContentValidation,
+	useRemoveSavingFailedNotices,
+} from './hooks';
+import { FullscreenMode } from './private-apis';
+import { BackButtonInnerButton } from './components/header/back-button-content';
+import { getEditorConfigFromWindow } from './store/settings';
+
+// @ts-expect-error __experimentalMainDashboardButton is not in types.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
+
+/**
+ * Basic editor plugin component.
+ * Can be extended by integrators for custom plugin implementations.
+ */
+export function EditorPlugin() {
+	return null;
+}
+
+/**
+ * Email editor plugin component that runs inside the standard WordPress post editor.
+ * Pushes email CSS to editor settings, restricts blocks, and renders email-specific UI.
+ */
+export function ExperimentEmailEditorPlugin() {
+	const { isFullScreenForced } = useSelect(
+		( sel ) => ( {
+			isFullScreenForced:
+				sel( storeName ).getInitialEditorSettings()
+					?.isFullScreenForced ?? false,
+		} ),
+		[]
+	);
+
+	// Push email CSS styles to the WordPress editor settings
+	const [ styles ] = useEmailCss();
+	const prevStylesRef = useRef( styles );
+	const { updateEditorSettings } = useDispatch( editorStore );
+
+	useEffect( () => {
+		if ( ! deepEqual( prevStylesRef.current, styles ) ) {
+			prevStylesRef.current = styles;
+			updateEditorSettings( { styles } );
+		}
+	}, [ styles, updateEditorSettings ] );
+
+	// Set allowed block types for email editing
+	useEffect( () => {
+		updateEditorSettings( {
+			allowedBlockTypes: getAllowedBlockNames(),
+		} );
+	}, [ updateEditorSettings ] );
+
+	// Remove the post-status panel (not relevant for email editing)
+	useEffect( () => {
+		dispatch( 'core/edit-post' ).removeEditorPanel( 'post-status' );
+	}, [] );
+
+	// Run email-specific hooks
+	useContentValidation();
+	useRemoveSavingFailedNotices();
+
+	return (
+		<>
+			{ isFullScreenForced && <FullscreenMode isActive /> }
+			{ MainDashboardButton && (
+				<MainDashboardButton>
+					<BackButtonInnerButton />
+				</MainDashboardButton>
+			) }
+		</>
+	);
+}
+
+/**
+ * Initialize the email editor plugin within the WordPress post editor.
+ * This is the "batteries-included" init that registers the plugin and initializes all subsystems.
+ * Call this before bootstrapping the WordPress editor via @wordpress/edit-post.
+ */
+export function experimentInitEmailEditorPlugin() {
+	// Initialize all subsystems
+	initEventCollector();
+	initStoreTracking();
+	initDomTracking();
+	createStore();
+	initContentValidationMiddleware();
+	initBlocksForPlugin();
+	initHacks();
+	initTextHooks();
+	initializeLayout();
+
+	// Set configuration from window object
+	const editorConfig = getEditorConfigFromWindow();
+	dispatch( storeName ).setEditorConfig( editorConfig );
+
+	// Set email post from window globals
+	const { current_post_id, current_post_type } =
+		window.WooCommerceEmailEditor;
+	if ( current_post_id && current_post_type ) {
+		dispatch( storeName ).setEmailPost(
+			current_post_id,
+			current_post_type
+		);
+	}
+
+	// Register the plugin with WordPress
+	registerPlugin( 'email-editor', {
+		render: ExperimentEmailEditorPlugin,
+	} );
+}

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -199,6 +199,13 @@ export type {
  */
 export { SendPreviewEmail } from './components/preview';
 
+export { EditorPlugin as ExperimentalEditorPlugin } from './editor-plugin';
+
+export {
+	ExperimentEmailEditorPlugin,
+	experimentInitEmailEditorPlugin,
+} from './editor-plugin';
+
 /**
  * A rich text input component with personalization tags support.
  *

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -41,6 +41,8 @@ export type EmailEditorSettings = EditorSettings &
 		isPreviewMode: boolean;
 		allowedIframeStyleHandles?: string[];
 		styles?: EmailBuiltStyles[];
+		isFullScreenForced?: boolean;
+		displaySendEmailButton?: boolean;
 	};
 
 export type EmailTheme = Omit< GlobalStylesConfig, 'styles' > & {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
@@ -7,6 +7,7 @@ interface Window {
 	WooCommerceEmailEditor: {
 		current_post_type: string;
 		current_post_id: string;
+		editor_settings: Record< string, unknown >;
 		email_types: {
 			value: string;
 			label: string;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -5,7 +5,10 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { initializeEditor } from '@woocommerce/email-editor';
+import { experimentInitEmailEditorPlugin } from '@woocommerce/email-editor';
+// @ts-expect-error initializeEditor is not in types for @wordpress/edit-post.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { initializeEditor } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -68,4 +71,21 @@ addFilter( 'woocommerce_email_editor_create_coupon_handler', NAME_SPACE, () => {
 modifySidebar();
 modifyTemplateSidebar();
 registerEmailValidationRules();
-initializeEditor( 'woocommerce-email-editor' );
+
+// Register the email editor plugin (initializes store, blocks, events, etc.)
+experimentInitEmailEditorPlugin();
+
+// Bootstrap the WordPress post editor (integrator's responsibility)
+window.addEventListener(
+	'DOMContentLoaded',
+	() => {
+		initializeEditor(
+			'woocommerce-email-editor',
+			window.WooCommerceEmailEditor.current_post_type,
+			window.WooCommerceEmailEditor.current_post_id,
+			window.WooCommerceEmailEditor.editor_settings,
+			[]
+		);
+	},
+	{ once: true }
+);

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -99,8 +99,10 @@ class PageRenderer {
 
 		$localized_data['email_types'] = $email_types;
 		// Modify email editor settings.
-		$localized_data['editor_settings']['isFullScreenForced']     = true;
-		$localized_data['editor_settings']['displaySendEmailButton'] = false;
+		$localized_data['editor_settings']['isFullScreenForced']       = true;
+		$localized_data['editor_settings']['displaySendEmailButton']   = false;
+		$localized_data['editor_settings']['supportsTemplateMode']     = true;
+		$localized_data['editor_settings']['defaultRenderingMode']     = 'template-locked';
 
 		return $localized_data;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1243,6 +1243,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -51926,7 +51929,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.69.5
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   sass@1.69.5:
     dependencies:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds plugin mode to the email editor, allowing it to run as a WordPress plugin inside the standard @wordpress/edit-post editor instead of only as a standalone replacement editor.

  #### Why

  The standalone mode (initializeEditor) replaces the entire WordPress editor with a custom React root. Plugin mode lets the email editor hook into the standard post editor via registerPlugin, which
  provides better compatibility with the WordPress ecosystem and allows the integrator (WooCommerce) to bootstrap the editor using `@wordpress/edit-post` or jsut register a plugin for the block editor.

Note: we currently initialize `@wordpress/edit-post` manually to be able to open the email editor for template only. The default core's route will not allow open editor for string IDs.

  #### What changed

  **New exports from `@woocommerce/email-editor`:**

  **`experimentInitEmailEditorPlugin()`** — A "batteries-included" initialization function. It creates the email editor store, initializes events/tracking, applies email-specific block enhancements (without
   re-registering core blocks), sets up layout/hacks/text hooks, loads editor config from `window.WooCommerceEmailEditor`, and calls `registerPlugin()` to register the plugin component. Call this *before*
  bootstrapping the WordPress editor.

  **`ExperimentEmailEditorPlugin`** — The React component registered as the plugin. It:
  - Pushes email CSS styles to the WordPress editor settings (with deep-equal optimization to avoid unnecessary updates)
  - Restricts blocks to email-compatible block types
  - Forces fullscreen mode and renders the back button via `__experimentalMainDashboardButton` (when `isFullScreenForced` is set)
  - Removes the `post-status` panel
  - Renders all email-specific UI: `TemplateSelection`, `StylesSidebar`, `SendPreview`, `PreviewSaveGuard`, `SettingsPanel`/`TemplateSettingsPanel`, `PublishSave`, `EditorNotices`,
  `BlockCompatibilityWarnings`, and a scoped `PluginArea`
  - Runs content validation and saving-failed-notice removal hooks
  - Cleans up on unmount: calls `cleanupConfigurationChanges()` and restores original editor settings

  **`ExperimentalEditorPlugin`** — A basic plugin component for integrators who want a minimal starting point.

  #### Example usage (integrator)

  ```typescript
  import { experimentInitEmailEditorPlugin } from '@woocommerce/email-editor';

  // Register the email editor plugin (initializes store, blocks, events, etc.)
  experimentInitEmailEditorPlugin();
```

####  Example usage (custom plugin registration)
  For integrators who want to wrap the component or combine it with additional UI.
  This is an approach for adding the email editor plugin to the site editor or other apps that share multiple editors.
  It allows to add mechanism for detectin wheter the editor plugin should be active based on the context

  ```typescript
  import { ExperimentEmailEditorPlugin } from '@woocommerce/email-editor';
  import { registerPlugin } from '@wordpress/plugins';

  registerPlugin('my-email-editor', {
      render: () => {
         // Here we can check if we are in email context
         if ( ! isEditingEmail() ) {
           return null;
         }
         return (
            <>
              <ExperimentEmailEditorPlugin />
              <MyCustomSidebarPanel />
            </>
        );
      },
  });
  ```

  #### Other changes

  - initBlocksForPlugin() — New function in blocks/index.ts that applies email-specific block enhancements without calling registerCoreBlocks() (core blocks are already registered by @wordpress/edit-post)
  - BackButtonInnerButton — Extracted from BackButtonContent for reuse in plugin mode where the <BackButton> wrapper is not needed
  - EmailEditorSettings type — Added optional isFullScreenForced and displaySendEmailButton properties
  - WooCommerce integration — Updated to use plugin mode instead of standalone initializeEditor
  - fast-deep-equal — Added as dependency for efficient style comparison

  All existing exports (initializeEditor, ExperimentalEmailEditor, useEmailCss, etc.) are preserved unchanged.

  #### TODO / Known gaps vs standalone mode

  Most of the standalone editor's infrastructure (autosave, unsaved changes warning, keyboard shortcuts, post locking, error boundary, command palette) is provided out of the box by the @wordpress/edit-post
   host editor. The following items may need attention:

  - useFilterEditorContentStylesheets — Standalone mode attaches a contentRef that removes non-email stylesheets from the editor iframe. Plugin mode does not filter iframe stylesheets.
  - recordEventOnce('editor_layout_loaded') — The standalone editor fires this tracking event once the editor layout renders. Plugin mode does not fire it.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

  1. Check out this branch and run pnpm install && pnpm --filter=@woocommerce/plugin-woocommerce build:admin
  2. Navigate to http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=/settings/email and click edit on any email
  3. Verify the WordPress post editor loads (via @wordpress/edit-post) with the email editor plugin active
  4. Verify email-specific UI is present: styles sidebar, settings panel, send preview modal, template selection
  5. Verify the back button (WordPress icon) appears in the top-left corner
  6. Verify blocks are restricted to email-compatible blocks only
  7. Verify save/publish works correctly
  8. Verify editing a template (wp_template post type) shows TemplateSettingsPanel instead of SettingsPanel

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
