### PR TITLE
Change Cache Product Objects default plugin compatibility to COMPATIBLE

### DIFF
--- a/plugins/woocommerce/changelog/change-product-cache-default-compatibility
+++ b/plugins/woocommerce/changelog/change-product-cache-default-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change Cache Product Objects feature default plugin compatibility to COMPATIBLE so extensions that haven't explicitly declared compatibility are no longer shown as incompatible.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -586,7 +586,7 @@ class FeaturesController {
 					'[Performance] Speeds up your store by caching product objects during each request, preventing duplicate product loads. Can improve page load times on product-heavy pages.',
 					'woocommerce'
 				),
-				'default_plugin_compatibility' => FeaturePluginCompatibility::INCOMPATIBLE,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'enabled_by_default'           => false,
 				'is_experimental'              => true,
 				'disable_ui'                   => false,


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Cache Product Objects feature (`product_instance_caching`) currently sets `default_plugin_compatibility` to `INCOMPATIBLE`, causing every extension without an explicit compatibility declaration to appear as "incompatible" in the admin UI. Since no compatibility issues have been discovered with this feature, switch the default to `COMPATIBLE` for 10.6.

Closes #63242.

### How to test the changes in this Pull Request:

1. Enable the **Cache Product Objects** feature under **WooCommerce > Settings > Advanced > Features**
2. Install any WooCommerce extension that has not declared compatibility with this feature (e.g. a third-party shipping or payment plugin)
3. Go to **WooCommerce > Settings > Advanced > Features** and check the compatibility section
4. Verify the extension is listed as "compatible" (not "incompatible")

### Testing that has already taken place:

Local verification of the code change. The change is a single enum value swap with no logic changes.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request includes a manually created changelog entry.