### PR TITLE
Email preview alignment

### DIFF
--- a/plugins/woocommerce/changelog/63248-cursor-WOOPLUG-6291-email-preview-alignment-0dc3
+++ b/plugins/woocommerce/changelog/63248-cursor-WOOPLUG-6291-email-preview-alignment-0dc3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes alignment of sender details in the email preview header on the email settings page.

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -269,10 +269,23 @@ body {
 	padding-top: 24px;
 }
 
+#body_content .order-item-data {
+	table-layout: fixed;
+	width: 100%;
+}
+
 #body_content .order-item-data td {
 	border: 0 !important;
 	padding: 0 !important;
 	vertical-align: middle;
+}
+
+#body_content .order-item-data td:first-child {
+	width: <?php echo $email_improvements_enabled ? '72px' : '48px'; ?>;
+}
+
+#body_content .order-item-data td:last-child {
+	width: auto;
 }
 
 #body_content .email-order-details .order-totals td,

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -281,7 +281,7 @@ body {
 }
 
 #body_content .order-item-data td:first-child {
-	width: <?php echo $email_improvements_enabled ? '72px' : '48px'; ?>;
+	width: 60px;
 }
 
 #body_content .order-item-data td:last-child {

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.5.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\Email\EmailFont;

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -288,6 +288,10 @@ body {
 	width: auto;
 }
 
+#body_content .order-item-data h3 {
+	margin: 8px 0;
+}
+
 #body_content .email-order-details .order-totals td,
 #body_content .email-order-details .order-totals th {
 	font-weight: normal;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses an alignment issue in the email preview on the WooCommerce email settings page. Previously, the order item titles gradually moved closer to the item image on mobile screens, causing a misalignment.

The changes ensure that the order item titles are consistently aligned on all screen sizes.

Closes #63238

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="794" height="1792" alt="CleanShot 2026-02-17 at 10 46 19@2x" src="https://github.com/user-attachments/assets/bdeb6456-d594-473d-b6ae-ead61bd94e06" /> | <img width="760" height="1786" alt="CleanShot 2026-02-17 at 12 21 31@2x" src="https://github.com/user-attachments/assets/da3e97f3-bfc4-4ae9-adba-a32cc1c43227" /> |

### How to test the changes in this Pull Request:

1. Enable "Email improvements" under `WooCommerce > Settings > Advanced > Features`.  
2. Navigate to `WooCommerce > Settings > Emails` in your WordPress admin.
3. Click `Manage` on the `New Order` email.
4. Switch the Preview to mobile.
5. Verify that the order item titles are now formatted correctly.

### Testing that has already taken place:

I have tested these changes locally to verify the CSS fix.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->
Fixes alignment of sender details in the email preview header on the email settings page.

</details>
