### PR TITLE
Integrate payment gateway notification into WC_Email system with block editor support

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7801-payment-gateway-enabled-email-styling
+++ b/plugins/woocommerce/changelog/stomail-7801-payment-gateway-enabled-email-styling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Integrate the payment gateway admin notification into the WooCommerce email system with full support for email styling, customizable settings, and block email editor.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -119,6 +119,7 @@ class WC_Emails {
 				'woocommerce_order_partially_refunded',
 				'woocommerce_new_customer_note',
 				'woocommerce_created_customer',
+				'woocommerce_payment_gateway_enabled',
 			)
 		);
 

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -282,19 +282,20 @@ class WC_Emails {
 		include_once __DIR__ . '/emails/class-wc-email.php';
 
 		$emails = array(
-			'WC_Email_New_Order'                 => __DIR__ . '/emails/class-wc-email-new-order.php',
-			'WC_Email_Cancelled_Order'           => __DIR__ . '/emails/class-wc-email-cancelled-order.php',
-			'WC_Email_Customer_Cancelled_Order'  => __DIR__ . '/emails/class-wc-email-customer-cancelled-order.php',
-			'WC_Email_Failed_Order'              => __DIR__ . '/emails/class-wc-email-failed-order.php',
-			'WC_Email_Customer_Failed_Order'     => __DIR__ . '/emails/class-wc-email-customer-failed-order.php',
-			'WC_Email_Customer_On_Hold_Order'    => __DIR__ . '/emails/class-wc-email-customer-on-hold-order.php',
-			'WC_Email_Customer_Processing_Order' => __DIR__ . '/emails/class-wc-email-customer-processing-order.php',
-			'WC_Email_Customer_Completed_Order'  => __DIR__ . '/emails/class-wc-email-customer-completed-order.php',
-			'WC_Email_Customer_Refunded_Order'   => __DIR__ . '/emails/class-wc-email-customer-refunded-order.php',
-			'WC_Email_Customer_Invoice'          => __DIR__ . '/emails/class-wc-email-customer-invoice.php',
-			'WC_Email_Customer_Note'             => __DIR__ . '/emails/class-wc-email-customer-note.php',
-			'WC_Email_Customer_Reset_Password'   => __DIR__ . '/emails/class-wc-email-customer-reset-password.php',
-			'WC_Email_Customer_New_Account'      => __DIR__ . '/emails/class-wc-email-customer-new-account.php',
+			'WC_Email_New_Order'                     => __DIR__ . '/emails/class-wc-email-new-order.php',
+			'WC_Email_Cancelled_Order'               => __DIR__ . '/emails/class-wc-email-cancelled-order.php',
+			'WC_Email_Customer_Cancelled_Order'      => __DIR__ . '/emails/class-wc-email-customer-cancelled-order.php',
+			'WC_Email_Failed_Order'                  => __DIR__ . '/emails/class-wc-email-failed-order.php',
+			'WC_Email_Customer_Failed_Order'         => __DIR__ . '/emails/class-wc-email-customer-failed-order.php',
+			'WC_Email_Customer_On_Hold_Order'        => __DIR__ . '/emails/class-wc-email-customer-on-hold-order.php',
+			'WC_Email_Customer_Processing_Order'     => __DIR__ . '/emails/class-wc-email-customer-processing-order.php',
+			'WC_Email_Customer_Completed_Order'      => __DIR__ . '/emails/class-wc-email-customer-completed-order.php',
+			'WC_Email_Customer_Refunded_Order'       => __DIR__ . '/emails/class-wc-email-customer-refunded-order.php',
+			'WC_Email_Customer_Invoice'              => __DIR__ . '/emails/class-wc-email-customer-invoice.php',
+			'WC_Email_Customer_Note'                 => __DIR__ . '/emails/class-wc-email-customer-note.php',
+			'WC_Email_Customer_Reset_Password'       => __DIR__ . '/emails/class-wc-email-customer-reset-password.php',
+			'WC_Email_Customer_New_Account'          => __DIR__ . '/emails/class-wc-email-customer-new-account.php',
+			'WC_Email_Admin_Payment_Gateway_Enabled' => __DIR__ . '/emails/class-wc-email-admin-payment-gateway-enabled.php',
 		);
 		if ( FeaturesUtil::feature_is_enabled( 'point_of_sale' ) ) {
 			$emails['WC_Email_Customer_POS_Completed_Order'] = __DIR__ . '/emails/class-wc-email-customer-pos-completed-order.php';

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -187,12 +187,14 @@ class WC_Payment_Gateways {
 			 * Fires when a payment gateway has been enabled.
 			 *
 			 * Used by WC_Email_Admin_Payment_Gateway_Enabled to send an admin notification email.
+			 * This action is registered as a transactional email action in WC_Emails::init_transactional_emails(),
+			 * which ensures WC_Emails is instantiated before the _notification variant is fired.
 			 *
 			 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
 			 *
-			 * @since 10.6.0
+			 * @since 10.7.0
 			 */
-			do_action( 'woocommerce_payment_gateway_enabled_notification', $gateway );
+			do_action( 'woocommerce_payment_gateway_enabled', $gateway );
 
 			// Track the gateway enable.
 			$this->record_gateway_event( 'enable', $gateway );

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -180,9 +180,19 @@ class WC_Payment_Gateways {
 	 */
 	private function payment_gateway_settings_option_changed( $gateway, $value, $option, $old_value = null ) {
 		if ( $this->was_gateway_enabled( $value, $old_value ) ) {
-			// This is a change to a payment gateway's settings and it was just enabled. Let's send an email to the admin.
-			// "untitled" shouldn't happen, but just in case.
-			$this->notify_admin_payment_gateway_enabled( $gateway );
+			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+			$logger->info( sprintf( 'Payment gateway enabled: "%s"', $gateway->get_method_title() ) );
+
+			/**
+			 * Fires when a payment gateway has been enabled.
+			 *
+			 * Used by WC_Email_Admin_Payment_Gateway_Enabled to send an admin notification email.
+			 *
+			 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
+			 *
+			 * @since 10.6.0
+			 */
+			do_action( 'woocommerce_payment_gateway_enabled_notification', $gateway );
 
 			// Track the gateway enable.
 			$this->record_gateway_event( 'enable', $gateway );
@@ -192,90 +202,6 @@ class WC_Payment_Gateways {
 			// This is a change to a payment gateway's settings and it was just disabled. Let's track it.
 			$this->record_gateway_event( 'disable', $gateway );
 		}
-	}
-
-	/**
-	 * Email the site admin when a payment gateway has been enabled.
-	 *
-	 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
-	 * @return bool Whether the email was sent or not.
-	 * @since 8.5.0
-	 */
-	private function notify_admin_payment_gateway_enabled( $gateway ) {
-		$admin_email          = get_option( 'admin_email' );
-		$user                 = get_user_by( 'email', $admin_email );
-		$username             = $user ? $user->user_login : $admin_email;
-		$gateway_title        = $gateway->get_method_title();
-		$gateway_settings_url = esc_url_raw( self_admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id ) );
-		$site_name            = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-		$site_url             = home_url();
-		/**
-		 * Allows adding to the addresses that receive payment gateway enabled notifications.
-		 *
-		 * @param array              $email_addresses The array of email addresses to notify.
-		 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
-		 * @return array             The augmented array of email addresses to notify.
-		 * @since 8.5.0
-		 */
-		$email_addresses   = apply_filters( 'wc_payment_gateway_enabled_notification_email_addresses', array(), $gateway );
-		$email_addresses[] = $admin_email;
-		$email_addresses   = array_unique(
-			array_filter(
-				$email_addresses,
-				function ( $email_address ) {
-					return filter_var( $email_address, FILTER_VALIDATE_EMAIL );
-				}
-			)
-		);
-
-		$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
-		$logger->info( sprintf( 'Payment gateway enabled: "%s"', $gateway_title ) );
-
-		$email_text = sprintf(
-			/* translators: Payment gateway enabled notification email. 1: Username, 2: Gateway Title, 3: Site URL, 4: Gateway Settings URL, 5: Admin Email, 6: Site Name, 7: Site URL. */
-			__(
-				'Howdy %1$s,
-
-The payment gateway "%2$s" was just enabled on this site:
-%3$s
-
-If this was intentional you can safely ignore and delete this email.
-
-If you did not enable this payment gateway, please log in to your site and consider disabling it here:
-%4$s
-
-This email has been sent to %5$s
-
-Regards,
-All at %6$s
-%7$s',
-				'woocommerce'
-			),
-			$username,
-			$gateway_title,
-			$site_url,
-			$gateway_settings_url,
-			$admin_email,
-			$site_name,
-			$site_url
-		);
-
-		if ( '' !== get_option( 'blogname' ) ) {
-			$site_title = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-		} else {
-			$site_title = wp_parse_url( home_url(), PHP_URL_HOST );
-		}
-
-		return wp_mail(
-			$email_addresses,
-			sprintf(
-				/* translators: Payment gateway enabled notification email subject. %s1: Site title, $s2: Gateway title. */
-				__( '[%1$s] Payment gateway "%2$s" enabled', 'woocommerce' ),
-				$site_title,
-				$gateway_title
-			),
-			$email_text
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
@@ -69,6 +69,10 @@ if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
 			// Trigger for this email.
 			add_action( 'woocommerce_payment_gateway_enabled_notification', array( $this, 'trigger' ), 10, 1 );
 
+			// Block email editor hooks.
+			add_action( 'woocommerce_email_general_block_content', array( $this, 'block_content' ), 10, 3 );
+			add_filter( 'woocommerce_emails_general_block_content_emails_without_order_details', array( $this, 'exclude_from_order_details' ) );
+
 			// Call parent constructor.
 			parent::__construct();
 
@@ -247,6 +251,52 @@ if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
 					'email'                => $this,
 				)
 			);
+		}
+
+		/**
+		 * Output dynamic block content for this email.
+		 *
+		 * Hooked into `woocommerce_email_general_block_content` to render the gateway
+		 * title, security notice, and gateway settings URL inside the ##WOO_CONTENT## area.
+		 *
+		 * @since 10.6.0
+		 * @param bool     $sent_to_admin Whether the email is being sent to admin.
+		 * @param bool     $plain_text    Whether the email is being sent as plain text.
+		 * @param WC_Email $email         The email object.
+		 * @return void
+		 */
+		public function block_content( $sent_to_admin, $plain_text, $email ): void {
+			if ( $this->id !== $email->id ) {
+				return;
+			}
+
+			$gateway_title        = $this->gateway_title ?: 'Dummy Gateway';
+			$gateway_settings_url = $this->gateway_settings_url ?: 'Dummy Settings URL';
+
+			// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- Template-like output.
+			// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- Template-like output.
+			?>
+			<p><?php
+				/* translators: %s: gateway title */
+				printf( esc_html__( 'The payment gateway "%s" has been enabled.', 'woocommerce' ), esc_html( $gateway_title ) );
+			?></p>
+			<p><?php esc_html_e( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', 'woocommerce' ); ?></p>
+			<p><a href="<?php echo esc_url( $gateway_settings_url ); ?>"><?php echo esc_url( $gateway_settings_url ); ?></a></p>
+			<?php
+			// phpcs:enable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen
+			// phpcs:enable Squiz.PHP.EmbeddedPhp.ContentAfterEnd
+		}
+
+		/**
+		 * Add this email to the list of emails without order details.
+		 *
+		 * @since 10.6.0
+		 * @param array $emails_without_order_details Array of email IDs.
+		 * @return array
+		 */
+		public function exclude_from_order_details( $emails_without_order_details ) {
+			$emails_without_order_details[] = 'admin_payment_gateway_enabled';
+			return $emails_without_order_details;
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Class WC_Email_Admin_Payment_Gateway_Enabled file.
+ *
+ * @package WooCommerce\Emails
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
+
+	/**
+	 * Payment Gateway Enabled Email.
+	 *
+	 * An email sent to the admin when a payment gateway is enabled.
+	 *
+	 * @class   WC_Email_Admin_Payment_Gateway_Enabled
+	 * @version 10.6.0
+	 * @package WooCommerce\Classes\Emails
+	 */
+	class WC_Email_Admin_Payment_Gateway_Enabled extends WC_Email {
+
+		/**
+		 * Gateway title.
+		 *
+		 * @var string
+		 */
+		public $gateway_title = '';
+
+		/**
+		 * Gateway settings URL.
+		 *
+		 * @var string
+		 */
+		public $gateway_settings_url = '';
+
+		/**
+		 * Admin username.
+		 *
+		 * @var string
+		 */
+		public $username = '';
+
+		/**
+		 * Admin email address.
+		 *
+		 * @var string
+		 */
+		public $admin_email = '';
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'admin_payment_gateway_enabled';
+			$this->title          = __( 'Payment gateway enabled', 'woocommerce' );
+			$this->email_group    = 'payments';
+			$this->template_html  = 'emails/admin-payment-gateway-enabled.php';
+			$this->template_plain = 'emails/plain/admin-payment-gateway-enabled.php';
+			$this->placeholders   = array(
+				'{gateway_title}' => '',
+				'{site_title}'    => '',
+			);
+
+			// Trigger for this email.
+			add_action( 'woocommerce_payment_gateway_enabled_notification', array( $this, 'trigger' ), 10, 1 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			// Must be after parent's constructor which sets `email_improvements_enabled` and `block_email_editor_enabled` properties.
+			$this->description = __( 'Payment gateway enabled emails are sent to chosen recipient(s) when a payment gateway is enabled.', 'woocommerce' );
+
+			if ( $this->block_email_editor_enabled ) {
+				$this->description = __( 'Notifies admins when a payment gateway has been enabled.', 'woocommerce' );
+			}
+
+			// Other settings.
+			$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( '[{site_title}] Payment gateway "{gateway_title}" enabled', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Payment gateway "{gateway_title}" enabled', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @since 10.6.0
+		 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
+		 * @return void
+		 */
+		public function trigger( $gateway ) {
+			$this->setup_locale();
+
+			if ( is_a( $gateway, 'WC_Payment_Gateway' ) ) {
+				$this->object        = $gateway;
+				$this->gateway_title = $gateway->get_method_title();
+
+				$this->gateway_settings_url = esc_url_raw(
+					self_admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id )
+				);
+
+				$this->admin_email = get_option( 'admin_email' );
+				$user              = get_user_by( 'email', $this->admin_email );
+				$this->username    = $user ? $user->user_login : $this->admin_email;
+
+				$this->placeholders['{gateway_title}'] = $this->gateway_title;
+				$this->placeholders['{site_title}']    = $this->get_blogname();
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get valid recipients.
+		 *
+		 * Merges addresses from the `wc_payment_gateway_enabled_notification_email_addresses` filter
+		 * for backward compatibility.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_recipient() {
+			$recipient = parent::get_recipient();
+
+			if ( $this->object instanceof WC_Payment_Gateway ) {
+				/**
+				 * Allows adding to the addresses that receive payment gateway enabled notifications.
+				 *
+				 * @param array              $email_addresses The array of email addresses to notify.
+				 * @param WC_Payment_Gateway $gateway The gateway that was enabled.
+				 * @return array             The augmented array of email addresses to notify.
+				 *
+				 * @since 8.5.0
+				 */
+				$extra_addresses = apply_filters( 'wc_payment_gateway_enabled_notification_email_addresses', array(), $this->object );
+
+				if ( ! empty( $extra_addresses ) && is_array( $extra_addresses ) ) {
+					$extra_valid = array_filter(
+						$extra_addresses,
+						function ( $email_address ): bool {
+							return (bool) filter_var( $email_address, FILTER_VALIDATE_EMAIL );
+						}
+					);
+
+					if ( ! empty( $extra_valid ) ) {
+						$existing  = array_map( 'trim', explode( ',', $recipient ) );
+						$merged    = array_unique( array_merge( $existing, $extra_valid ) );
+						$recipient = implode( ', ', array_filter( $merged ) );
+					}
+				}
+			}
+
+			return $recipient;
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html,
+				array(
+					'gateway'              => $this->object,
+					'gateway_title'        => $this->gateway_title,
+					'gateway_settings_url' => $this->gateway_settings_url,
+					'username'             => $this->username,
+					'admin_email'          => $this->admin_email,
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => true,
+					'plain_text'           => false,
+					'email'                => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain,
+				array(
+					'gateway'              => $this->object,
+					'gateway_title'        => $this->gateway_title,
+					'gateway_settings_url' => $this->gateway_settings_url,
+					'username'             => $this->username,
+					'admin_email'          => $this->admin_email,
+					'email_heading'        => $this->get_heading(),
+					'additional_content'   => $this->get_additional_content(),
+					'sent_to_admin'        => true,
+					'plain_text'           => true,
+					'email'                => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get block editor email template content.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_block_editor_email_template_content() {
+			return wc_get_template_html(
+				$this->template_block_content,
+				array(
+					'gateway'              => $this->object,
+					'gateway_title'        => $this->gateway_title,
+					'gateway_settings_url' => $this->gateway_settings_url,
+					'username'             => $this->username,
+					'admin_email'          => $this->admin_email,
+					'sent_to_admin'        => true,
+					'plain_text'           => false,
+					'email'                => $this,
+				)
+			);
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 10.6.0
+		 * @return string
+		 */
+		public function get_default_additional_content() {
+			return __( 'If this was intentional, you can safely ignore and delete this email.', 'woocommerce' );
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 *
+		 * @since 10.6.0
+		 * @return void
+		 */
+		public function init_form_fields() {
+			/* translators: %s: list of placeholders */
+			$placeholder_text  = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
+			$this->form_fields = array(
+				'enabled'            => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'recipient'          => array(
+					'title'       => __( 'Recipient(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				),
+				'subject'            => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					'description' => $placeholder_text,
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'            => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					'description' => $placeholder_text,
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'additional_content' => array(
+					'title'       => __( 'Additional content', 'woocommerce' ),
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'css'         => 'width:400px; height: 75px;',
+					'placeholder' => __( 'N/A', 'woocommerce' ),
+					'type'        => 'textarea',
+					'default'     => $this->get_default_additional_content(),
+					'desc_tip'    => true,
+				),
+				'email_type'         => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
+			}
+			if ( $this->block_email_editor_enabled ) {
+				$this->form_fields['preheader'] = $this->get_preheader_field();
+			}
+		}
+	}
+
+endif;
+
+return new WC_Email_Admin_Payment_Gateway_Enabled();

--- a/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
@@ -125,6 +125,17 @@ if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
 					self_admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id )
 				);
 
+				/**
+				 * Filters the payment gateway settings URL for the admin payment gateway enabled email.
+				 *
+				 * @param string           $gateway_settings_url The payment gateway settings URL.
+				 * @param WC_Payment_Gateway $gateway The payment gateway object.
+				 * @return string The filtered payment gateway settings URL.
+				 *
+				 * @since 10.7.0
+				 */
+				$this->gateway_settings_url = apply_filters( 'woocommerce_payment_gateway_enabled_notification_settings_url', $this->gateway_settings_url, $gateway );
+
 				$this->admin_email = get_option( 'admin_email' );
 				$user              = get_user_by( 'email', $this->admin_email );
 				$this->username    = $user ? $user->user_login : $this->admin_email;
@@ -270,7 +281,8 @@ if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
 				return;
 			}
 
-			$gateway_title        = ! empty( $this->gateway_title ) ? $this->gateway_title : __( 'Dummy Gateway', 'woocommerce' );
+			$gateway_title = ! empty( $this->gateway_title ) ? $this->gateway_title : __( 'Dummy Gateway', 'woocommerce' );
+
 			$gateway_settings_url = ! empty( $this->gateway_settings_url ) ? $this->gateway_settings_url : __( 'Dummy Settings URL', 'woocommerce' );
 
 			// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- Template-like output.

--- a/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-admin-payment-gateway-enabled.php
@@ -270,8 +270,8 @@ if ( ! class_exists( 'WC_Email_Admin_Payment_Gateway_Enabled', false ) ) :
 				return;
 			}
 
-			$gateway_title        = $this->gateway_title ?: 'Dummy Gateway';
-			$gateway_settings_url = $this->gateway_settings_url ?: 'Dummy Settings URL';
+			$gateway_title        = ! empty( $this->gateway_title ) ? $this->gateway_title : __( 'Dummy Gateway', 'woocommerce' );
+			$gateway_settings_url = ! empty( $this->gateway_settings_url ) ? $this->gateway_settings_url : __( 'Dummy Settings URL', 'woocommerce' );
 
 			// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- Template-like output.
 			// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- Template-like output.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -13507,12 +13507,6 @@ parameters:
 			path: includes/class-wc-payment-gateways.php
 
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(mixed\)\: \(non\-falsy\-string\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-payment-gateways.php
-
-		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_metadata\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -20,6 +20,7 @@ class WCTransactionalEmails {
 	 * @var array
 	 */
 	public static $core_transactional_emails = array(
+		'admin_payment_gateway_enabled',
 		'cancelled_order',
 		'customer_cancelled_order',
 		'customer_completed_order',

--- a/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -25,7 +25,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
  * Output the email header.
  *
  * @hooked WC_Emails::email_header() Output the email header.
- * @since 10.6.0
+ * @since 10.7.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 

--- a/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Admin payment gateway enabled email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-payment-gateway-enabled.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\HTML
+ * @version 10.6.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p><?php
+	/* translators: %s: Username */
+	printf( esc_html__( 'Howdy %s,', 'woocommerce' ), esc_html( $username ) );
+?></p>
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<p><?php
+	/* translators: 1: gateway title, 2: site URL */
+	printf(
+		esc_html__( 'The payment gateway "%1$s" was just enabled on this site: %2$s', 'woocommerce' ),
+		esc_html( $gateway_title ),
+		esc_html( home_url() )
+	);
+?></p>
+
+<p><?php esc_html_e( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', 'woocommerce' ); ?></p>
+<p><a href="<?php echo esc_url( $gateway_settings_url ); ?>"><?php echo esc_url( $gateway_settings_url ); ?></a></p>
+
+<p><?php
+	/* translators: %s: admin email address */
+	printf( esc_html__( 'This email has been sent to %s', 'woocommerce' ), esc_html( $admin_email ) );
+?></p>
+
+<?php
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/admin-payment-gateway-enabled.php
@@ -21,34 +21,43 @@ defined( 'ABSPATH' ) || exit;
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-/*
- * @hooked WC_Emails::email_header() Output the email header
+/**
+ * Output the email header.
+ *
+ * @hooked WC_Emails::email_header() Output the email header.
+ * @since 10.6.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<p><?php
+<p>
+<?php
 	/* translators: %s: Username */
 	printf( esc_html__( 'Howdy %s,', 'woocommerce' ), esc_html( $username ) );
-?></p>
+?>
+</p>
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
-<p><?php
-	/* translators: 1: gateway title, 2: site URL */
+<p>
+<?php
 	printf(
+		/* translators: 1: gateway title, 2: site URL */
 		esc_html__( 'The payment gateway "%1$s" was just enabled on this site: %2$s', 'woocommerce' ),
 		esc_html( $gateway_title ),
 		esc_html( home_url() )
 	);
-?></p>
+	?>
+	</p>
 
 <p><?php esc_html_e( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', 'woocommerce' ); ?></p>
 <p><a href="<?php echo esc_url( $gateway_settings_url ); ?>"><?php echo esc_url( $gateway_settings_url ); ?></a></p>
 
-<p><?php
+<p>
+<?php
 	/* translators: %s: admin email address */
 	printf( esc_html__( 'This email has been sent to %s', 'woocommerce' ), esc_html( $admin_email ) );
-?></p>
+?>
+</p>
 
 <?php
 
@@ -61,7 +70,10 @@ if ( $additional_content ) {
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
-/*
- * @hooked WC_Emails::email_footer() Output the email footer
+/**
+ * Output the email footer.
+ *
+ * @hooked WC_Emails::email_footer() Output the email footer.
+ * @since 10.6.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Admin payment gateway enabled email (initial block content)
+ *
+ * This template can be overridden by editing it in the WooCommerce email editor.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 10.6.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"><?php echo esc_html__( 'Payment gateway enabled', 'woocommerce' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+	/* translators: %s: Site title */
+	printf( esc_html__( 'A payment gateway was just enabled on %s.', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woocommerce-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woocommerce/email-content -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"> <?php echo esc_html__( 'If this was intentional, you can safely ignore and delete this email.', 'woocommerce' ); ?> </p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/block/admin-payment-gateway-enabled.php
@@ -28,6 +28,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
+<p><?php echo esc_html__( 'Hello,', 'woocommerce' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p><?php
 	/* translators: %s: Site title */
 	printf( esc_html__( 'A payment gateway was just enabled on %s.', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );

--- a/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
@@ -24,8 +24,8 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 /* translators: %s: Username */
 echo sprintf( esc_html__( 'Howdy %s,', 'woocommerce' ), esc_html( $username ) ) . "\n\n";
 
-/* translators: 1: gateway title, 2: site URL */
 echo sprintf(
+	/* translators: 1: gateway title, 2: site URL */
 	esc_html__( 'The payment gateway "%1$s" was just enabled on this site: %2$s', 'woocommerce' ),
 	esc_html( $gateway_title ),
 	esc_html( home_url() )
@@ -47,4 +47,9 @@ if ( $additional_content ) {
 	echo "\n\n----------------------------------------\n\n";
 }
 
+/**
+ * Filter the email footer text.
+ *
+ * @since 3.7.0
+ */
 echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
+++ b/plugins/woocommerce/templates/emails/plain/admin-payment-gateway-enabled.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Admin payment gateway enabled email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-payment-gateway-enabled.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 10.6.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: Username */
+echo sprintf( esc_html__( 'Howdy %s,', 'woocommerce' ), esc_html( $username ) ) . "\n\n";
+
+/* translators: 1: gateway title, 2: site URL */
+echo sprintf(
+	esc_html__( 'The payment gateway "%1$s" was just enabled on this site: %2$s', 'woocommerce' ),
+	esc_html( $gateway_title ),
+	esc_html( home_url() )
+) . "\n\n";
+
+echo esc_html__( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', 'woocommerce' ) . "\n";
+echo esc_url( $gateway_settings_url ) . "\n\n";
+
+/* translators: %s: admin email address */
+echo sprintf( esc_html__( 'This email has been sent to %s', 'woocommerce' ), esc_html( $admin_email ) ) . "\n\n";
+
+echo "\n----------------------------------------\n\n";
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -62,20 +62,11 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Ensure the email system is initialized so the email listener is registered.
-		WC_Emails::instance();
-
 		$action_fired   = array();
 		$action_watcher = function ( $gateway ) use ( &$action_fired ) {
 			$action_fired[] = $gateway;
 		};
 		add_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
-
-		$email_details = array();
-		$mail_watcher  = function ( $args ) use ( &$email_details ) {
-			$email_details = $args;
-		};
-		add_filter( 'wp_mail', $mail_watcher );
 
 		foreach ( $this->sut->payment_gateways() as $gateway ) {
 			$gateway->settings['enabled'] = 'no';
@@ -85,20 +76,18 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 			$gateway->settings['enabled'] = 'yes';
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
-			$this->assertEquals( 'Payment gateway enabled: "' . $gateway->get_method_title() . '"', end( $fake_logger->infos )['message'] );
+			$this->assertEquals(
+				'Payment gateway enabled: "' . $gateway->get_method_title() . '"',
+				end( $fake_logger->infos )['message'],
+				'Logger should record the gateway enable event'
+			);
 
 			$last_fired = end( $action_fired );
 			$this->assertInstanceOf( WC_Payment_Gateway::class, $last_fired, 'Action should fire with a gateway object' );
 			$this->assertEquals( $gateway->id, $last_fired->id, 'Action should fire with the correct gateway' );
-
-			$this->assertNotEmpty( $email_details, 'An email should have been sent via the WC_Email system' );
-			$this->assertStringContainsString( $gateway->get_method_title(), $email_details['subject'] );
-
-			$email_details = array();
 		}
 
 		remove_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
-		remove_filter( 'wp_mail', $mail_watcher );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -66,7 +66,7 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 		$action_watcher = function ( $gateway ) use ( &$action_fired ) {
 			$action_fired[] = $gateway;
 		};
-		add_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
+		add_action( 'woocommerce_payment_gateway_enabled', $action_watcher );
 
 		foreach ( $this->sut->payment_gateways() as $gateway ) {
 			$gateway->settings['enabled'] = 'no';
@@ -87,7 +87,7 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 			$this->assertEquals( $gateway->id, $last_fired->id, 'Action should fire with the correct gateway' );
 		}
 
-		remove_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
+		remove_action( 'woocommerce_payment_gateway_enabled', $action_watcher );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -39,10 +39,9 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that enabling a gateway sends an email to the site admin and logs the event.
+	 * @testdox Enabling a gateway fires the notification action and logs the event.
 	 */
-	public function test_wc_payment_gateway_enabled_notification() {
-		// Create a fake logger to capture log entries.
+	public function test_wc_payment_gateway_enabled_notification(): void {
 		// phpcs:disable Squiz.Commenting
 		$fake_logger = new class() {
 			public $infos = array();
@@ -57,45 +56,49 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 		// phpcs:enable Squiz.Commenting
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_logger' => function() use ( $fake_logger ) {
+				'wc_get_logger' => function () use ( $fake_logger ) {
 					return $fake_logger;
 				},
 			)
 		);
 
-		// Register a watcher for wp_mail to capture email details.
+		// Ensure the email system is initialized so the email listener is registered.
+		WC_Emails::instance();
+
+		$action_fired   = array();
+		$action_watcher = function ( $gateway ) use ( &$action_fired ) {
+			$action_fired[] = $gateway;
+		};
+		add_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
+
 		$email_details = array();
-		$watcher       = function( $args ) use ( &$email_details ) {
+		$mail_watcher  = function ( $args ) use ( &$email_details ) {
 			$email_details = $args;
 		};
-		add_filter( 'wp_mail', $watcher );
+		add_filter( 'wp_mail', $mail_watcher );
 
-		// Enable each gateway and check that the email and log entry are created.
 		foreach ( $this->sut->payment_gateways() as $gateway ) {
-			// Disable the gateway and save the settings.
 			$gateway->settings['enabled'] = 'no';
 			$gateway->settings['title']   = null;
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
-			// Enable the gateway and save its settings; this should send the email and add a log entry.
 			$gateway->settings['enabled'] = 'yes';
 			update_option( $gateway->get_option_key(), $gateway->settings );
 
-			// Check that the log entry was created.
 			$this->assertEquals( 'Payment gateway enabled: "' . $gateway->get_method_title() . '"', end( $fake_logger->infos )['message'] );
 
-			// Check that the email was sent correctly.
-			$this->assertStringContainsString( '@', $email_details['to'][0] );
-			$this->assertEquals( get_option( 'admin_email' ), $email_details['to'][0] );
-			$this->assertEquals( '[Test Blog] Payment gateway "' . $gateway->get_method_title() . '" enabled', $email_details['subject'] );
-			$this->assertStringContainsString( 'The payment gateway "' . $gateway->get_method_title() . '" was just enabled on this site', $email_details['message'] );
-			$this->assertStringContainsString( 'If you did not enable this payment gateway, please log in to your site and consider disabling it here:', $email_details['message'] );
-			$this->assertStringContainsString( '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=' . $gateway->id, $email_details['message'] );
+			$last_fired = end( $action_fired );
+			$this->assertInstanceOf( WC_Payment_Gateway::class, $last_fired, 'Action should fire with a gateway object' );
+			$this->assertEquals( $gateway->id, $last_fired->id, 'Action should fire with the correct gateway' );
 
-			// Reset the email details.
+			$this->assertNotEmpty( $email_details, 'An email should have been sent via the WC_Email system' );
+			$this->assertStringContainsString( $gateway->get_method_title(), $email_details['subject'] );
+
 			$email_details = array();
 		}
-		remove_filter( 'wp_mail', $watcher );
+
+		remove_action( 'woocommerce_payment_gateway_enabled_notification', $action_watcher );
+		remove_filter( 'wp_mail', $mail_watcher );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-admin-payment-gateway-enabled-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-admin-payment-gateway-enabled-test.php
@@ -1,0 +1,291 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * WC_Email_Admin_Payment_Gateway_Enabled test.
+ *
+ * @covers WC_Email_Admin_Payment_Gateway_Enabled
+ */
+class WC_Email_Admin_Payment_Gateway_Enabled_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Email_Admin_Payment_Gateway_Enabled
+	 */
+	private $sut;
+
+	/**
+	 * Load up the email classes and create the SUT.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email.php';
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email-admin-payment-gateway-enabled.php';
+
+		$this->sut = new WC_Email_Admin_Payment_Gateway_Enabled();
+	}
+
+	/**
+	 * @testdox Email has correct ID set to 'admin_payment_gateway_enabled'.
+	 */
+	public function test_email_has_correct_id(): void {
+		$this->assertEquals( 'admin_payment_gateway_enabled', $this->sut->id );
+	}
+
+	/**
+	 * @testdox Email has correct title.
+	 */
+	public function test_email_has_correct_title(): void {
+		$this->assertEquals( 'Payment gateway enabled', $this->sut->title );
+	}
+
+	/**
+	 * @testdox Email belongs to the payments group.
+	 */
+	public function test_email_belongs_to_payments_group(): void {
+		$this->assertEquals( 'payments', $this->sut->email_group );
+	}
+
+	/**
+	 * @testdox Email is not a customer email.
+	 */
+	public function test_email_is_not_customer_email(): void {
+		$this->assertFalse( $this->sut->is_customer_email() );
+	}
+
+	/**
+	 * @testdox Email has the correct HTML template path.
+	 */
+	public function test_email_has_correct_html_template(): void {
+		$this->assertEquals( 'emails/admin-payment-gateway-enabled.php', $this->sut->template_html );
+	}
+
+	/**
+	 * @testdox Email has the correct plain text template path.
+	 */
+	public function test_email_has_correct_plain_template(): void {
+		$this->assertEquals( 'emails/plain/admin-payment-gateway-enabled.php', $this->sut->template_plain );
+	}
+
+	/**
+	 * @testdox Email has gateway_title and site_title placeholders.
+	 */
+	public function test_email_has_correct_placeholders(): void {
+		$this->assertArrayHasKey( '{gateway_title}', $this->sut->placeholders );
+		$this->assertArrayHasKey( '{site_title}', $this->sut->placeholders );
+	}
+
+	/**
+	 * @testdox Default subject contains gateway_title placeholder.
+	 */
+	public function test_default_subject_contains_gateway_title_placeholder(): void {
+		$subject = $this->sut->get_default_subject();
+
+		$this->assertStringContainsString( '{gateway_title}', $subject );
+		$this->assertStringContainsString( '{site_title}', $subject );
+	}
+
+	/**
+	 * @testdox Default heading contains gateway_title placeholder.
+	 */
+	public function test_default_heading_contains_gateway_title_placeholder(): void {
+		$heading = $this->sut->get_default_heading();
+
+		$this->assertStringContainsString( '{gateway_title}', $heading );
+	}
+
+	/**
+	 * @testdox Default recipient is the admin email.
+	 */
+	public function test_default_recipient_is_admin_email(): void {
+		$recipient = $this->sut->get_recipient();
+
+		$this->assertEquals( get_option( 'admin_email' ), $recipient );
+	}
+
+	/**
+	 * @testdox Trigger sets gateway data and sends email when enabled.
+	 */
+	public function test_trigger_sends_email_when_enabled(): void {
+		$email_sent = false;
+		$watcher    = function ( $args ) use ( &$email_sent ) {
+			$email_sent = true;
+			return $args;
+		};
+		add_filter( 'wp_mail', $watcher );
+
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->trigger( $gateway );
+
+		$this->assertTrue( $email_sent, 'Email should be sent when trigger is called with a valid gateway' );
+
+		remove_filter( 'wp_mail', $watcher );
+	}
+
+	/**
+	 * @testdox Trigger populates gateway_title placeholder correctly.
+	 */
+	public function test_trigger_populates_gateway_title(): void {
+		add_filter( 'wp_mail', '__return_empty_array' );
+
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->trigger( $gateway );
+
+		$this->assertEquals( $gateway->get_method_title(), $this->sut->gateway_title );
+		$this->assertEquals( $gateway->get_method_title(), $this->sut->placeholders['{gateway_title}'] );
+
+		remove_filter( 'wp_mail', '__return_empty_array' );
+	}
+
+	/**
+	 * @testdox Trigger computes the gateway settings URL.
+	 */
+	public function test_trigger_computes_gateway_settings_url(): void {
+		add_filter( 'wp_mail', '__return_empty_array' );
+
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->trigger( $gateway );
+
+		$this->assertStringContainsString( 'page=wc-settings&tab=checkout&section=bacs', $this->sut->gateway_settings_url );
+
+		remove_filter( 'wp_mail', '__return_empty_array' );
+	}
+
+	/**
+	 * @testdox Trigger does not send email when email is disabled.
+	 */
+	public function test_trigger_does_not_send_when_disabled(): void {
+		$this->sut->update_option( 'enabled', 'no' );
+		$this->sut->enabled = 'no';
+
+		$email_sent = false;
+		$watcher    = function ( $args ) use ( &$email_sent ) {
+			$email_sent = true;
+			return $args;
+		};
+		add_filter( 'wp_mail', $watcher );
+
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->trigger( $gateway );
+
+		$this->assertFalse( $email_sent, 'Email should not be sent when email notification is disabled' );
+
+		remove_filter( 'wp_mail', $watcher );
+
+		$this->sut->update_option( 'enabled', 'yes' );
+		$this->sut->enabled = 'yes';
+	}
+
+	/**
+	 * @testdox Email subject resolves gateway_title placeholder after trigger.
+	 */
+	public function test_subject_resolves_placeholder_after_trigger(): void {
+		add_filter( 'wp_mail', '__return_empty_array' );
+
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->trigger( $gateway );
+
+		$subject = $this->sut->get_subject();
+
+		$this->assertStringContainsString( $gateway->get_method_title(), $subject );
+		$this->assertStringNotContainsString( '{gateway_title}', $subject );
+
+		remove_filter( 'wp_mail', '__return_empty_array' );
+	}
+
+	/**
+	 * @testdox get_recipient merges addresses from backward-compat filter.
+	 */
+	public function test_get_recipient_merges_backward_compat_filter_addresses(): void {
+		$gateway = new WC_Gateway_BACS();
+		$this->sut->object = $gateway;
+
+		$extra_watcher = function () {
+			return array( 'extra@example.com' );
+		};
+		add_filter( 'wc_payment_gateway_enabled_notification_email_addresses', $extra_watcher );
+
+		$recipient = $this->sut->get_recipient();
+
+		$this->assertStringContainsString( 'extra@example.com', $recipient );
+		$this->assertStringContainsString( get_option( 'admin_email' ), $recipient );
+
+		remove_filter( 'wc_payment_gateway_enabled_notification_email_addresses', $extra_watcher );
+	}
+
+	/**
+	 * @testdox HTML content includes gateway title and settings URL.
+	 */
+	public function test_html_content_includes_gateway_details(): void {
+		$gateway                    = new WC_Gateway_BACS();
+		$this->sut->object          = $gateway;
+		$this->sut->gateway_title   = $gateway->get_method_title();
+		$this->sut->gateway_settings_url = 'http://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs';
+		$this->sut->username        = 'admin';
+		$this->sut->admin_email     = 'admin@example.com';
+
+		$content = $this->sut->get_content_html();
+
+		$this->assertStringContainsString( $gateway->get_method_title(), $content );
+		$this->assertStringContainsString( 'wc-settings', $content );
+		$this->assertStringContainsString( 'If you did not enable this payment gateway', $content );
+	}
+
+	/**
+	 * @testdox Plain text content includes gateway title and settings URL.
+	 */
+	public function test_plain_text_content_includes_gateway_details(): void {
+		$gateway                    = new WC_Gateway_BACS();
+		$this->sut->object          = $gateway;
+		$this->sut->gateway_title   = $gateway->get_method_title();
+		$this->sut->gateway_settings_url = 'http://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs';
+		$this->sut->username        = 'admin';
+		$this->sut->admin_email     = 'admin@example.com';
+
+		$this->sut->update_option( 'email_type', 'plain' );
+
+		$content = $this->sut->get_content_plain();
+
+		$this->assertStringContainsString( $gateway->get_method_title(), $content );
+		$this->assertStringContainsString( 'wc-settings', $content );
+		$this->assertStringContainsString( 'If you did not enable this payment gateway', $content );
+
+		$this->sut->update_option( 'email_type', 'html' );
+	}
+
+	/**
+	 * @testdox Form fields are initialized correctly.
+	 */
+	public function test_form_fields_are_initialized(): void {
+		$this->sut->init_form_fields();
+
+		$this->assertArrayHasKey( 'enabled', $this->sut->form_fields );
+		$this->assertArrayHasKey( 'recipient', $this->sut->form_fields );
+		$this->assertArrayHasKey( 'subject', $this->sut->form_fields );
+		$this->assertArrayHasKey( 'heading', $this->sut->form_fields );
+		$this->assertArrayHasKey( 'additional_content', $this->sut->form_fields );
+		$this->assertArrayHasKey( 'email_type', $this->sut->form_fields );
+	}
+
+	/**
+	 * @testdox Email is registered in WC_Emails.
+	 */
+	public function test_email_is_registered_in_wc_emails(): void {
+		$emails = new WC_Emails();
+
+		$this->assertArrayHasKey( 'WC_Email_Admin_Payment_Gateway_Enabled', $emails->emails );
+		$this->assertInstanceOf( WC_Email_Admin_Payment_Gateway_Enabled::class, $emails->emails['WC_Email_Admin_Payment_Gateway_Enabled'] );
+	}
+
+	/**
+	 * @testdox Default additional content is not empty.
+	 */
+	public function test_default_additional_content_is_not_empty(): void {
+		$content = $this->sut->get_default_additional_content();
+
+		$this->assertNotEmpty( $content );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-admin-payment-gateway-enabled-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-admin-payment-gateway-enabled-test.php
@@ -200,7 +200,7 @@ class WC_Email_Admin_Payment_Gateway_Enabled_Test extends WC_Unit_Test_Case {
 	 * @testdox get_recipient merges addresses from backward-compat filter.
 	 */
 	public function test_get_recipient_merges_backward_compat_filter_addresses(): void {
-		$gateway = new WC_Gateway_BACS();
+		$gateway           = new WC_Gateway_BACS();
 		$this->sut->object = $gateway;
 
 		$extra_watcher = function () {
@@ -220,12 +220,12 @@ class WC_Email_Admin_Payment_Gateway_Enabled_Test extends WC_Unit_Test_Case {
 	 * @testdox HTML content includes gateway title and settings URL.
 	 */
 	public function test_html_content_includes_gateway_details(): void {
-		$gateway                    = new WC_Gateway_BACS();
-		$this->sut->object          = $gateway;
-		$this->sut->gateway_title   = $gateway->get_method_title();
+		$gateway                         = new WC_Gateway_BACS();
+		$this->sut->object               = $gateway;
+		$this->sut->gateway_title        = $gateway->get_method_title();
 		$this->sut->gateway_settings_url = 'http://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs';
-		$this->sut->username        = 'admin';
-		$this->sut->admin_email     = 'admin@example.com';
+		$this->sut->username             = 'admin';
+		$this->sut->admin_email          = 'admin@example.com';
 
 		$content = $this->sut->get_content_html();
 
@@ -238,12 +238,12 @@ class WC_Email_Admin_Payment_Gateway_Enabled_Test extends WC_Unit_Test_Case {
 	 * @testdox Plain text content includes gateway title and settings URL.
 	 */
 	public function test_plain_text_content_includes_gateway_details(): void {
-		$gateway                    = new WC_Gateway_BACS();
-		$this->sut->object          = $gateway;
-		$this->sut->gateway_title   = $gateway->get_method_title();
+		$gateway                         = new WC_Gateway_BACS();
+		$this->sut->object               = $gateway;
+		$this->sut->gateway_title        = $gateway->get_method_title();
 		$this->sut->gateway_settings_url = 'http://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs';
-		$this->sut->username        = 'admin';
-		$this->sut->admin_email     = 'admin@example.com';
+		$this->sut->username             = 'admin';
+		$this->sut->admin_email          = 'admin@example.com';
 
 		$this->sut->update_option( 'email_type', 'plain' );
 
@@ -287,5 +287,37 @@ class WC_Email_Admin_Payment_Gateway_Enabled_Test extends WC_Unit_Test_Case {
 		$content = $this->sut->get_default_additional_content();
 
 		$this->assertNotEmpty( $content );
+	}
+
+	/**
+	 * @testdox block_content outputs gateway title and settings URL for this email.
+	 */
+	public function test_block_content_outputs_gateway_details(): void {
+		$gateway                         = new WC_Gateway_BACS();
+		$this->sut->object               = $gateway;
+		$this->sut->gateway_title        = $gateway->get_method_title();
+		$this->sut->gateway_settings_url = 'http://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs';
+
+		ob_start();
+		$this->sut->block_content( true, false, $this->sut );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $gateway->get_method_title(), $output, 'Block content should include gateway title' );
+		$this->assertStringContainsString( 'wc-settings', $output, 'Block content should include gateway settings URL' );
+		$this->assertStringContainsString( 'If you did not enable this payment gateway', $output, 'Block content should include security notice' );
+	}
+
+	/**
+	 * @testdox block_content does not output for other email types.
+	 */
+	public function test_block_content_skips_other_email_ids(): void {
+		$other_email     = new WC_Email();
+		$other_email->id = 'customer_new_order';
+
+		ob_start();
+		$this->sut->block_content( true, false, $other_email );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Block content should not output anything for other email types' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

**Why:** The "payment gateway enabled" admin notification email was previously sent via a raw `wp_mail()` call inside `WC_Payment_Gateways::notify_admin_payment_gateway_enabled()`. This bypassed the WooCommerce email system entirely, meaning the email did not use configured email styling (header/footer templates, email improvements feature, colors, etc.) and could not be customized through the WooCommerce email settings UI. It also lacked support for the block email editor.

**What this PR does:**

1. **New `WC_Email_Admin_Payment_Gateway_Enabled` class** — A proper `WC_Email` subclass that integrates with the WooCommerce email system. It supports:
   - Configurable recipients, subject, heading, and additional content
   - HTML, plain text, and block editor email templates
   - WooCommerce email styling (header, footer, colors)
   - Backward-compatible `wc_payment_gateway_enabled_notification_email_addresses` filter for extra recipients
   - Email improvements feature support
   - CC/BCC fields when email improvements are enabled

2. **Refactored `WC_Payment_Gateways`** — Replaced the inline `notify_admin_payment_gateway_enabled()` method with a `woocommerce_payment_gateway_enabled_notification` action hook that the new email class listens to.

3. **Email templates** — Created three templates:
   - `emails/admin-payment-gateway-enabled.php` (HTML)
   - `emails/plain/admin-payment-gateway-enabled.php` (plain text)
   - `emails/block/admin-payment-gateway-enabled.php` (block editor)

4. **Block email editor integration** — The email is registered in `WCTransactionalEmails` and includes:
   - A block template using `<!--[woocommerce/site-title]-->` personalization tag
   - Dynamic content via `woocommerce_email_general_block_content` action for gateway-specific details (title, settings URL, security notice)
   - Exclusion from order details via `woocommerce_emails_general_block_content_emails_without_order_details` filter




<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/STOMAIL-7801/payment-gateway-enabled-email-does-not-use-configured-email-styling
Closes https://linear.app/a8c/issue/STOMAIL-7800/payment-gateway-enabled-emails-dont-use-the-configured-from


(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1015" height="533" alt="Screenshot 2026-02-11 at 4 53 46 PM" src="https://github.com/user-attachments/assets/6f9e84d1-ebbf-4e10-a98c-a45f0a4c0e13" />  |   <img width="1303" height="855" alt="Screenshot 2026-02-11 at 4 54 34 PM" src="https://github.com/user-attachments/assets/8f1617c2-6f89-4e10-b2b4-deea6c5bec5a" />  |
| Email Editor |  <img width="1291" height="878" alt="Screenshot 2026-02-11 at 4 55 20 PM" src="https://github.com/user-attachments/assets/bfbbeac5-86c8-4892-a77b-24a0e5b4c1c0" /> | 



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Test traditional email rendering:**
   - Navigate to **WooCommerce > Settings > Payments**.
   - Enable a payment gateway (e.g., "Direct bank transfer") that is currently disabled.
   - Verify that an admin notification email is sent with proper WooCommerce email styling (header, footer, colors).
   - Confirm the email contains: a greeting, gateway title, site URL, gateway settings link, security notice, and additional content.

2. **Test email settings customization:**
   - Navigate to **WooCommerce > Settings > Emails**.
   - Find "Payment gateway enabled" in the email list.
   - Customize the recipient, subject, heading, and additional content.
   - Enable a payment gateway and verify the customized settings are used.

3. **Test backward-compatible recipient filter:**
   - Add a filter on `wc_payment_gateway_enabled_notification_email_addresses` that returns an additional email address.
   - Enable a payment gateway and verify both the configured recipient and the extra address receive the notification.

4. **Test block email editor (requires `email_improvements` feature flag enabled):**
   - Enable the block email editor feature.
   - Navigate to the WooCommerce email editor for the "Payment gateway enabled" email.
   - Verify the block template renders correctly with the heading, "Hello," greeting, site title tag, dynamic content block, and closing paragraph.
   - Enable a payment gateway and verify the sent email includes the gateway title, settings URL link, and security notice in the dynamic content area.

5. **Test plain text email:**
   - Change the email type to "Plain text" in the email settings.
   - Enable a payment gateway and verify the plain text version is sent correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
