### PR TITLE
Docs: Cleanup old internal wiki links and confirm everything is accessible in the monorepo docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ WooCommerce powers many online stores across the internet, and your help making 
 
 There are many ways to contribute to the project!
 
-- [Translating strings into your language](https://github.com/woocommerce/woocommerce/wiki/Translating-WooCommerce).
+- [Translating strings into your language](https://developer.woocommerce.com/docs/best-practices/localization-translation/translating-woocommerce/).
 - Answering questions on the various WooCommerce communities like the [WP.org support forums](https://wordpress.org/support/plugin/woocommerce/).
 - Testing open [issues](https://github.com/woocommerce/woocommerce/issues) or [pull requests](https://github.com/woocommerce/woocommerce/pulls) and sharing your findings in a comment.
 - Testing WooCommerce beta versions and release candidates. Those are announced in the [WooCommerce development blog](https://developer.woocommerce.com/blog/).
@@ -23,18 +23,18 @@ If you have questions about the process to contribute code or want to discuss de
 
 Please take a moment to review the [project readme](https://github.com/woocommerce/woocommerce/blob/trunk/README.md) and our [development notes](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md), which cover the basics needed to start working on this project. You may also be interested in the following resources:
 
-- [How to set up WooCommerce development environment](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment)
-- [Git Flow](https://github.com/woocommerce/woocommerce/wiki/WooCommerce-Git-Flow)
-- [Minification of SCSS and JS](https://github.com/woocommerce/woocommerce/wiki/Minification-of-SCSS-and-JS)
-- [Naming conventions](https://github.com/woocommerce/woocommerce/wiki/Naming-conventions)
-- [String localisation guidelines](https://github.com/woocommerce/woocommerce/wiki/String-localisation-guidelines)
+- [How to set up WooCommerce development environment](https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment)
+- [Git Flow](https://developer.woocommerce.com/docs/contribution/contributing/woocommerce-git-flow/)
+- [Minification of SCSS and JS](https://developer.woocommerce.com/docs/contribution/contributing/minification-of-SCSS-and-JS/)
+- [Naming conventions](https://developer.woocommerce.com/docs/contribution/contributing/naming-conventions/)
+- [String localisation guidelines](https://developer.woocommerce.com/docs/contribution/contributing/string-localisation-guidelines/)
 - [Running unit tests](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/README.md)
 - [Running e2e tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#guide-for-writing-e2e-tests)
 
 ## Coding Guidelines and Development 🛠
 
 - Ensure you stick to the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/).
-- Run our build process described in the document on [how to set up WooCommerce development environment](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment), it will install our pre-commit hook, code sniffs, dependencies, and more.
+- Run our build process described in the document on [how to set up WooCommerce development environment](https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment), it will install our pre-commit hook, code sniffs, dependencies, and more.
 - Before pushing commits to GitHub, check your code against our code standards. For PHP code in the WooCommerce Core project you can do this by running `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes:branch`.
 - Whenever possible, please fix pre-existing code standards errors in code that you change.
 - Please consider adding appropriate tests related to your change if applicable such as unit, API and E2E tests. You can check the following guides for this purpose:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ Closes # .
 
 <!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->
 
-Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
+Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:
 
 1.
 2.

--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -130,7 +130,7 @@ jobs:
                   ## Testing Guidelines
                   Hi ${{ env.REVIEWERS }} ${{ env.TEAMS }},
 
-                  Apart from reviewing the code changes, please make sure to **review the testing instructions** ([Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)) and verify that relevant tests (E2E, Unit, Integration, etc.) have been added or updated as needed.
+                  Apart from reviewing the code changes, please make sure to **review the testing instructions** ([Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions)) and verify that relevant tests (E2E, Unit, Integration, etc.) have been added or updated as needed.
 
                   **Reminder:** PR reviewers are required to document testing performed. This includes:
                   - 🖼️ **Screenshots or screen recordings**.

--- a/docs/code-snippets/useful-functions.md
+++ b/docs/code-snippets/useful-functions.md
@@ -147,7 +147,7 @@ This function is the standard way of retrieving orders based on certain paramete
 wc_get_orders( $args )
 ```
 
-[Arguments and usage](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query)
+[Arguments and usage](/docs/extensions/core-concepts/wc-get-orders/)
 
 ### wc_get_order
 
@@ -203,7 +203,7 @@ This function is the standard way of retrieving products based on certain parame
 wc_get_products( $args )
 ```
 
-[Arguments and usage](https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query)
+[Arguments and usage](/docs/extensions/core-concepts/wc-get-products/)
 
 ### wc_get_product
 

--- a/docs/contribution/contributing/README.md
+++ b/docs/contribution/contributing/README.md
@@ -15,11 +15,17 @@ The WooCommerce core plugin code can be found in our [monorepo](https://github.c
 - [WooCommerce Core Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce)
 - [WooCommerce Blocks](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks) 
 
-### Code of Conduct
+## Setting up your development environment
+
+Please check out [our getting started guide](https://github.com/woocommerce/woocommerce#getting-started) for information about prerequisites and initial setup.
+
+We also have [more in-depth documentation](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md) on how to develop in our repository. This also includes information about how to set up the development environment.
+
+## Code of Conduct
 
 Contributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.
 
-### Contributor Guidelines
+## Contributor Guidelines
 
 Our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) layout the first steps to contributing.
 
@@ -27,7 +33,7 @@ Our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/tru
 - [PNPM commands, plugin development environment packages, and troubleshooting](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md)
 - [Coding standards, E2E testing links](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) 
 
-### Templates, Bug Reports, and Feature Requests
+## Templates, Bug Reports, and Feature Requests
 
 - [Pull Request template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md)
 - [Core Issue template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE.md)
@@ -35,7 +41,7 @@ Our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/tru
 - [Enhancement template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/2-enhancement.yml)
 - [Feature requests](https://woocommerce.com/feature-requests/woocommerce/)
 
-### Security
+## Security
 
 Security and safety for data management are incredibly important to us at Woo. Please check out the [Automattic security policy](https://automattic.com/security/) to learn about our foundational requirements.
 

--- a/docs/contribution/contributing/README.md
+++ b/docs/contribution/contributing/README.md
@@ -23,7 +23,7 @@ We also have [more in-depth documentation](https://github.com/woocommerce/woocom
 
 ## Code of Conduct
 
-Contributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.
+Contributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/CODE_OF_CONDUCT.md) to get familiar with our standards and processes.
 
 ## Contributor Guidelines
 

--- a/docs/contribution/contributing/deciding-pr-high-impact.md
+++ b/docs/contribution/contributing/deciding-pr-high-impact.md
@@ -13,7 +13,7 @@ On this page, we will share some guidelines to help you assess the impact degree
 ## You should mark a Pull Request as High-Impact if
 
 - It adds a **new feature** to WooCommerce, except if it's behind a feature flag.
-- Modifies **critical functionality** (see the [critical flows list](https://github.com/woocommerce/woocommerce/wiki/Critical-Flows)).
+- Modifies **critical functionality** (see the [critical flows list](/docs/contribution/contributing/api-critical-flows/)).
 - It fixes a **high-priority bug** (this includes Blocks fix releases core version bumps).
 - It contains a **security fix**.
 - Updates **SQL queries**.

--- a/docs/contribution/contributing/minification-of-SCSS-and-JS.md
+++ b/docs/contribution/contributing/minification-of-SCSS-and-JS.md
@@ -10,7 +10,7 @@ sidebar_label: Minification of SCSS and JS
 
 When updating SCSS files in the WooCommerce project, please **commit only your changes to unminified SCSS files**. The minification will be handled as part of the release process.
 
-To get the minified CSS files, run `pnpm --filter='@woocommerce/classic-assets' build` from the repository root directory. To set up the development environment from scratch, see the section on [how to install dependencies and generate assets](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment#install-dependencies-and-generate-assets) in the guide to set up a WooCommerce development environment.
+To get the minified CSS files, run `pnpm --filter='@woocommerce/classic-assets' build` from the repository root directory. To set up the development environment from scratch, see the section on [how to install dependencies and generate assets](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md) in the guide to set up a WooCommerce development environment.
 
 ## Javascript
 

--- a/docs/contribution/contributing/naming-conventions.md
+++ b/docs/contribution/contributing/naming-conventions.md
@@ -49,4 +49,4 @@ Hook name example (actions or filters):
 
 ## CSS and SASS
 
-See [CSS SASS coding guidelines and naming conventions](https://github.com/woocommerce/woocommerce/wiki/CSS-SASS-coding-guidelines-and-naming-conventions).
+See [CSS SASS coding guidelines and naming conventions](/docs/contribution/contributing/CSS-SASS-coding-guidelines-and-naming-conventions/).

--- a/docs/extensions/core-concepts/wc-get-products.md
+++ b/docs/extensions/core-concepts/wc-get-products.md
@@ -162,7 +162,9 @@ $page_2_products = wc_get_products( $args );
 $results = wc_get_products( array( 'paginate' => true ) );
 echo $results->total . " products found\n";
 echo 'Page 1 of ' . $results->max_num_pages . "\n";
-echo 'First product id is: ' . $results->products[0]->get_id() . "\n";
+if ( count( $results->products ) > 0 ) {
+    echo 'First product id is: ' . $results->products[0]->get_id() . "\n";
+}
 ```
 
 ```php

--- a/docs/extensions/core-concepts/wc-get-products.md
+++ b/docs/extensions/core-concepts/wc-get-products.md
@@ -5,7 +5,7 @@ sidebar_label: Product Querying
 
 # `wc_get_products` and product queries
 
-`wc_get_products` and `WC_Product_Query` provide a standard way of retrieving products that is safe to use and will not break due to database changes in future WooCommerce versions. Building custom WP_Queries or database queries is likely to break your code in future versions of WooCommerce as data moves towards custom tables for better performance. This is the best-practices way for plugin and theme developers to retrieve multiple products. `wc_get_products` and `WC_Product_Query` are similar to WordPress [`get_posts` and `WP_Query`](https://codex.wordpress.org/Class_Reference/WP_Query). Just like those, you pass in an array of arguments defining the criteria for the search.
+`wc_get_products` and `WC_Product_Query` provide a standard way of retrieving products that is safe to use and will not break due to database changes in future WooCommerce versions. Building custom WP_Queries or database queries is likely to break your code in future versions of WooCommerce as data moves towards custom tables for better performance. This is the best-practices way for plugin and theme developers to retrieve multiple products. `wc_get_products` and `WC_Product_Query` are similar to WordPress [`get_posts` and `WP_Query`](https://developer.wordpress.org/reference/classes/wp_query/). Just like those, you pass in an array of arguments defining the criteria for the search.
 
 ## Basic usage
 
@@ -45,7 +45,7 @@ Note that `wc_get_products()` is mostly a shortcut to `WC_Product_Query::get_pro
 ## API reference
 
 | Method | Description |
-|--------|-------------|
+| ------ | ----------- |
 | `wc_get_products( $args )` | Retrieve products matching query `$args`. |
 | `WC_Product_Query::get_query_vars()` | Get an array of all of the current query variables set on the query object. |
 | `WC_Product_Query::get( string $key, mixed $default = '' )` | Get the value of a query variable or the default if the query variable is not set. |
@@ -59,7 +59,7 @@ Query parameters/arguments that can be used with these functions are described b
 ### General
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **status** | Accepts a string or array of strings: one or more of `'draft'`, `'pending'`, `'private'`, `'publish'`, or a custom status. See [ProductStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductStatus.php). |
 | **type** | Accepts a string or array of strings: one or more of `'external'`, `'grouped'`, `'simple'`, `'variable'`, or a custom type. See [ProductType constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductType.php). |
 | **include** | Accepts an array of integers: only includes products with IDs in the array. |
@@ -128,7 +128,7 @@ $products = wc_get_products( array( 'return' => 'ids' ) );
 ### Pagination
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **limit** | Accepts an integer: maximum number of results to retrieve or `-1` for unlimited. Default: site `posts_per_page` setting. |
 | **page** | Accepts an integer: page of results to retrieve. Does nothing if `'offset'` is used. |
 | **offset** | Accepts an integer: amount to offset product results. |
@@ -177,7 +177,7 @@ $products = wc_get_products( $args );
 ### Product lookup
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **sku** | Accepts a string: product SKU to match on. Does partial matching on the SKU. |
 | **name** | Accepts a string: the product name (title) to match on. Case sensitivity depends on the collation of the WordPress posts table. |
 | **tag** | Accepts an array: limit results to products assigned to specific tags by slug. |
@@ -220,7 +220,7 @@ $products = wc_get_products( array( 'product_category_id' => array( 17, 23 ) ) )
 ### Dimensions & pricing
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **weight** | Accepts a float: the weight measurement to match on. |
 | **length** | Accepts a float: the length measurement to match on. |
 | **width** | Accepts a float: the width measurement to match on. |
@@ -254,7 +254,7 @@ $products = wc_get_products( array( 'total_sales' => 0 ) );
 ### Product settings
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **virtual** | Accepts a boolean: limit to virtual products. |
 | **downloadable** | Accepts a boolean: limit to downloadable products. |
 | **featured** | Accepts a boolean: limit to featured products. |
@@ -300,7 +300,7 @@ $products = wc_get_products( array( 'download_limit' => -1 ) );
 ### Stock & inventory
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **stock_quantity** | Accepts an integer: the quantity of a product in stock. |
 | **stock_status** | Accepts a string: `'outofstock'`, `'instock'`, or `'onbackorder'`. See [ProductStockStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductStockStatus.php). |
 
@@ -324,7 +324,7 @@ $products = wc_get_products( array( 'stock_status' => ProductStockStatus::OUT_OF
 ### Tax & shipping
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **tax_status** | Accepts a string: `'taxable'`, `'shipping'`, or `'none'`. See [ProductTaxStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductTaxStatus.php). |
 | **tax_class** | Accepts a string: a tax class slug. |
 | **shipping_class** | Accepts a string or array of strings: one or more shipping class slugs. |
@@ -354,7 +354,7 @@ $products = wc_get_products( array( 'shipping_class' => 'bulky' ) );
 ### Reviews & ratings
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **average_rating** | Accepts a float: the average rating. |
 | **review_count** | Accepts an integer: the number of reviews. |
 
@@ -375,7 +375,7 @@ $products = wc_get_products( array( 'review_count' => 1 ) );
 Date arguments receive values following the standard format described below, allowing for more flexible queries.
 
 | Parameter | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | **date_created** | Matches product creation date. Accepts a string in standard format. |
 | **date_modified** | Matches product modification date. Accepts a string in standard format. |
 | **date_on_sale_from** | Matches sale start date. Accepts a string in standard format. |

--- a/docs/extensions/core-concepts/wc-get-products.md
+++ b/docs/extensions/core-concepts/wc-get-products.md
@@ -1,0 +1,437 @@
+---
+post_title: wc_get_products and product queries
+sidebar_label: Product Querying
+---
+
+# `wc_get_products` and product queries
+
+`wc_get_products` and `WC_Product_Query` provide a standard way of retrieving products that is safe to use and will not break due to database changes in future WooCommerce versions. Building custom WP_Queries or database queries is likely to break your code in future versions of WooCommerce as data moves towards custom tables for better performance. This is the best-practices way for plugin and theme developers to retrieve multiple products. `wc_get_products` and `WC_Product_Query` are similar to WordPress [`get_posts` and `WP_Query`](https://codex.wordpress.org/Class_Reference/WP_Query). Just like those, you pass in an array of arguments defining the criteria for the search.
+
+## Basic usage
+
+### Examples
+
+Here are a few examples:
+
+```php
+// Get downloadable products created in the year 2016.
+$products = wc_get_products( array(
+    'downloadable' => true,
+    'date_created' => '2016-01-01...2016-12-31',
+) );
+```
+
+```php
+// Get 10 most recent product IDs in date descending order.
+$query = new WC_Product_Query( array(
+    'limit' => 10,
+    'orderby' => 'date',
+    'order' => 'DESC',
+    'return' => 'ids',
+) );
+$products = $query->get_products();
+```
+
+```php
+// Get products containing a specific SKU.
+// Does partial matching, so this will get products with SKUs "PRDCT-1", "PRDCT-2", etc.
+$query = new WC_Product_Query();
+$query->set( 'sku', 'PRDCT' );
+$products = $query->get_products();
+```
+
+Note that `wc_get_products()` is mostly a shortcut to `WC_Product_Query::get_products()`.
+
+## API reference
+
+| Method | Description |
+|--------|-------------|
+| `wc_get_products( $args )` | Retrieve products matching query `$args`. |
+| `WC_Product_Query::get_query_vars()` | Get an array of all of the current query variables set on the query object. |
+| `WC_Product_Query::get( string $key, mixed $default = '' )` | Get the value of a query variable or the default if the query variable is not set. |
+| `WC_Product_Query::set( string $key, mixed $value )` | Set a query variable to a value. |
+| `WC_Product_Query::get_products()` | Get all products matching the current query variables. |
+
+Query parameters/arguments that can be used with these functions are described below.
+
+## Query parameters reference
+
+### General
+
+| Parameter | Description |
+|-----------|-------------|
+| **status** | Accepts a string or array of strings: one or more of `'draft'`, `'pending'`, `'private'`, `'publish'`, or a custom status. See [ProductStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductStatus.php). |
+| **type** | Accepts a string or array of strings: one or more of `'external'`, `'grouped'`, `'simple'`, `'variable'`, or a custom type. See [ProductType constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductType.php). |
+| **include** | Accepts an array of integers: only includes products with IDs in the array. |
+| **exclude** | Accepts an array of integers: excludes products with IDs in the array. |
+| **parent** | Accepts an integer: post ID of the product parent. |
+| **parent_exclude** | Accepts an array of integers: excludes products with parent IDs in the array. |
+| **order** | Accepts a string: `'DESC'` or `'ASC'`. Use with `'orderby'`. Default: `'DESC'`. |
+| **orderby** | Accepts a string: `'none'`, `'ID'`, `'name'`, `'type'`, `'rand'`, `'date'`, `'modified'`. Default: `'date'`. |
+| **return** | Return type. Accepts a string: `'ids'` or `'objects'`. Default: `'objects'`. |
+
+#### Examples
+
+```php
+// Get draft products.
+$products = wc_get_products( array( 'status' => 'draft' ) );
+```
+
+```php
+// Using constant class for status.
+$products = wc_get_products( array( 'status' => ProductStatus::DRAFT ) );
+```
+
+```php
+// Get external products.
+$products = wc_get_products( array( 'type' => 'external' ) );
+```
+
+```php
+// Get external products limited to specific IDs.
+$args = array(
+    'type' => 'external',
+    'include' => array( 134, 200, 210, 340 ),
+);
+$products = wc_get_products( $args );
+```
+
+```php
+// Get products that aren't the current product.
+$products = wc_get_products( array( 'exclude' => array( $product->get_id() ) ) );
+```
+
+```php
+// Get products with a specific parent.
+$products = wc_get_products( array( 'parent' => 20 ) );
+```
+
+```php
+// Get most recently modified products.
+$args = array(
+    'orderby' => 'modified',
+    'order' => 'DESC',
+);
+$products = wc_get_products( $args );
+```
+
+```php
+// Get some random products.
+$products = wc_get_products( array( 'orderby' => 'rand' ) );
+```
+
+```php
+// Return only product IDs.
+$products = wc_get_products( array( 'return' => 'ids' ) );
+```
+
+### Pagination
+
+| Parameter | Description |
+|-----------|-------------|
+| **limit** | Accepts an integer: maximum number of results to retrieve or `-1` for unlimited. Default: site `posts_per_page` setting. |
+| **page** | Accepts an integer: page of results to retrieve. Does nothing if `'offset'` is used. |
+| **offset** | Accepts an integer: amount to offset product results. |
+| **paginate** | Accepts a boolean: true for pagination, or false for not. Default: `false`. If enabled, modifies the return results to give an object with fields: `products` (array of found products), `total` (number of found products), and `max_num_pages` (total number of pages). |
+
+#### Examples
+
+```php
+// Get latest 3 products.
+$products = wc_get_products( array( 'limit' => 3 ) );
+```
+
+```php
+// First 3 products.
+$args = array(
+    'limit' => 3,
+    'page'  => 1,
+);
+$page_1_products = wc_get_products( $args );
+
+// Second 3 products.
+$args = array(
+    'limit' => 3,
+    'page'  => 2,
+);
+$page_2_products = wc_get_products( $args );
+```
+
+```php
+// Get products with extra info about the results.
+$results = wc_get_products( array( 'paginate' => true ) );
+echo $results->total . " products found\n";
+echo 'Page 1 of ' . $results->max_num_pages . "\n";
+echo 'First product id is: ' . $results->products[0]->get_id() . "\n";
+```
+
+```php
+// Get second to fifth most-recent products.
+$args = array(
+    'limit' => 4,
+    'offset' => 1,
+);
+$products = wc_get_products( $args );
+```
+
+### Product lookup
+
+| Parameter | Description |
+|-----------|-------------|
+| **sku** | Accepts a string: product SKU to match on. Does partial matching on the SKU. |
+| **name** | Accepts a string: the product name (title) to match on. Case sensitivity depends on the collation of the WordPress posts table. |
+| **tag** | Accepts an array: limit results to products assigned to specific tags by slug. |
+| **product_tag_id** | Accepts an integer or array of integers: limit results to products assigned to specific tags by ID. |
+| **category** | Accepts an array: limit results to products assigned to specific categories by slug. |
+| **product_category_id** | Accepts an integer or array of integers: limit results to products assigned to specific categories by ID. |
+
+#### Examples
+
+```php
+// Get products with "PRDCT" in their SKU (e.g. PRDCT-1 and PRDCT-2).
+$products = wc_get_products( array( 'sku' => 'PRDCT' ) );
+```
+
+```php
+// Get a product named "Test Product".
+$products = wc_get_products( array( 'name' => 'Test Product' ) );
+```
+
+```php
+// Get products with the "Excellent" or "Modern" tags.
+$products = wc_get_products( array( 'tag' => array( 'excellent', 'modern' ) ) );
+```
+
+```php
+// Get products by tag IDs.
+$products = wc_get_products( array( 'product_tag_id' => array( 17, 23 ) ) );
+```
+
+```php
+// Get shirts.
+$products = wc_get_products( array( 'category' => array( 'shirts' ) ) );
+```
+
+```php
+// Get products by category IDs.
+$products = wc_get_products( array( 'product_category_id' => array( 17, 23 ) ) );
+```
+
+### Dimensions & pricing
+
+| Parameter | Description |
+|-----------|-------------|
+| **weight** | Accepts a float: the weight measurement to match on. |
+| **length** | Accepts a float: the length measurement to match on. |
+| **width** | Accepts a float: the width measurement to match on. |
+| **height** | Accepts a float: the height measurement to match on. |
+| **price** | Accepts a float: the current price to match on. |
+| **regular_price** | Accepts a float: the regular price to match on. |
+| **sale_price** | Accepts a float: the sale price to match on. |
+| **total_sales** | Accepts an integer: gets products with that many sales. |
+
+#### Examples
+
+```php
+// Get products 5.5 units wide and 10 units long.
+$args = array(
+    'width' => 5.5,
+    'length' => 10,
+);
+$products = wc_get_products( $args );
+```
+
+```php
+// Get products that currently cost 9.99.
+$products = wc_get_products( array( 'price' => 9.99 ) );
+```
+
+```php
+// Get products that have never been purchased.
+$products = wc_get_products( array( 'total_sales' => 0 ) );
+```
+
+### Product settings
+
+| Parameter | Description |
+|-----------|-------------|
+| **virtual** | Accepts a boolean: limit to virtual products. |
+| **downloadable** | Accepts a boolean: limit to downloadable products. |
+| **featured** | Accepts a boolean: limit to featured products. |
+| **sold_individually** | Accepts a boolean: limit to products sold individually. |
+| **manage_stock** | Accepts a boolean: limit to products with stock management enabled. |
+| **reviews_allowed** | Accepts a boolean: limit to products that allow reviews. |
+| **backorders** | Accepts a string: `'yes'`, `'no'`, or `'notify'`. |
+| **visibility** | Accepts a string: `'visible'`, `'catalog'`, `'search'`, or `'hidden'`. See [CatalogVisibility constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/CatalogVisibility.php). |
+| **download_limit** | Accepts an integer: the download limit or `-1` for unlimited. |
+| **download_expiry** | Accepts an integer: the download expiry (days) or `-1` for unlimited. |
+
+#### Examples
+
+```php
+// Get downloadable products that don't allow reviews.
+$args = array(
+    'downloadable' => true,
+    'reviews_allowed' => false,
+);
+$products = wc_get_products( $args );
+```
+
+```php
+// Get products that allow backorders.
+$products = wc_get_products( array( 'backorders' => 'yes' ) );
+```
+
+```php
+// Get products that show in the catalog.
+$products = wc_get_products( array( 'visibility' => 'catalog' ) );
+```
+
+```php
+// Using constant class for visibility.
+$products = wc_get_products( array( 'visibility' => CatalogVisibility::CATALOG ) );
+```
+
+```php
+// Get products with unlimited downloads.
+$products = wc_get_products( array( 'download_limit' => -1 ) );
+```
+
+### Stock & inventory
+
+| Parameter | Description |
+|-----------|-------------|
+| **stock_quantity** | Accepts an integer: the quantity of a product in stock. |
+| **stock_status** | Accepts a string: `'outofstock'`, `'instock'`, or `'onbackorder'`. See [ProductStockStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductStockStatus.php). |
+
+#### Examples
+
+```php
+// Get products that only have one left in stock.
+$products = wc_get_products( array( 'stock_quantity' => 1 ) );
+```
+
+```php
+// Get out of stock products.
+$products = wc_get_products( array( 'stock_status' => 'outofstock' ) );
+```
+
+```php
+// Using constant class for stock status.
+$products = wc_get_products( array( 'stock_status' => ProductStockStatus::OUT_OF_STOCK ) );
+```
+
+### Tax & shipping
+
+| Parameter | Description |
+|-----------|-------------|
+| **tax_status** | Accepts a string: `'taxable'`, `'shipping'`, or `'none'`. See [ProductTaxStatus constant class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/ProductTaxStatus.php). |
+| **tax_class** | Accepts a string: a tax class slug. |
+| **shipping_class** | Accepts a string or array of strings: one or more shipping class slugs. |
+
+#### Examples
+
+```php
+// Get taxable products.
+$products = wc_get_products( array( 'tax_status' => 'taxable' ) );
+```
+
+```php
+// Using constant class for tax status.
+$products = wc_get_products( array( 'tax_status' => ProductTaxStatus::TAXABLE ) );
+```
+
+```php
+// Get products in the "Reduced Rate" tax class.
+$products = wc_get_products( array( 'tax_class' => 'reduced-rate' ) );
+```
+
+```php
+// Get products in the "Bulky" shipping class.
+$products = wc_get_products( array( 'shipping_class' => 'bulky' ) );
+```
+
+### Reviews & ratings
+
+| Parameter | Description |
+|-----------|-------------|
+| **average_rating** | Accepts a float: the average rating. |
+| **review_count** | Accepts an integer: the number of reviews. |
+
+#### Examples
+
+```php
+// Get products with all 5-star ratings.
+$products = wc_get_products( array( 'average_rating' => 5.0 ) );
+```
+
+```php
+// Get products with 1 review.
+$products = wc_get_products( array( 'review_count' => 1 ) );
+```
+
+### Date
+
+Date arguments receive values following the standard format described below, allowing for more flexible queries.
+
+| Parameter | Description |
+|-----------|-------------|
+| **date_created** | Matches product creation date. Accepts a string in standard format. |
+| **date_modified** | Matches product modification date. Accepts a string in standard format. |
+| **date_on_sale_from** | Matches sale start date. Accepts a string in standard format. |
+| **date_on_sale_to** | Matches sale end date. Accepts a string in standard format. |
+
+#### Standard format
+
+- `YYYY-MM-DD` - Matches on products during that one day in site timezone.
+- `>YYYY-MM-DD` - Matches on products after that one day in site timezone.
+- `>=YYYY-MM-DD` - Matches on products during or after that one day in site timezone.
+- `<YYYY-MM-DD` - Matches on products before that one day in site timezone.
+- `<=YYYY-MM-DD` - Matches on products during or before that one day in site timezone.
+- `YYYY-MM-DD...YYYY-MM-DD` - Matches on products during or in between the days in site timezone.
+- `TIMESTAMP` - Matches on products during that one second in UTC timezone.
+- `>TIMESTAMP` - Matches on products after that one second in UTC timezone.
+- `>=TIMESTAMP` - Matches on products during or after that one second in UTC timezone.
+- `<TIMESTAMP` - Matches on products before that one second in UTC timezone.
+- `<=TIMESTAMP` - Matches on products during or before that one second in UTC timezone.
+- `TIMESTAMP...TIMESTAMP` - Matches on products during or in between the seconds in UTC timezone.
+
+#### Examples
+
+```php
+// Get downloadable products created in the year 2016.
+$products = wc_get_products( array(
+    'downloadable' => true,
+    'date_created' => '2016-01-01...2016-12-31',
+) );
+```
+
+## Adding support for custom parameters
+
+It is possible to add support for custom parameters in `wc_get_products()` or `WC_Product_Query`. To do this you need to filter the generated query.
+
+```php
+/**
+ * Handle a custom 'customvar' query var to get products with the 'customvar' meta.
+ * @param array $query - Args for WP_Query.
+ * @param array $query_vars - Query vars from WC_Product_Query.
+ * @return array modified $query
+ */
+function handle_custom_query_var( $query, $query_vars ) {
+	if ( ! empty( $query_vars['customvar'] ) ) {
+		$query['meta_query'][] = array(
+			'key' => 'customvar',
+			'value' => esc_attr( $query_vars['customvar'] ),
+		);
+	}
+
+	return $query;
+}
+add_filter( 'woocommerce_product_data_store_cpt_get_products_query', 'handle_custom_query_var', 10, 2 );
+```
+
+Usage:
+
+```php
+$products = wc_get_products( array( 'customvar' => 'somevalue' ) );
+```

--- a/docs/extensions/core-concepts/wc-get-products.md
+++ b/docs/extensions/core-concepts/wc-get-products.md
@@ -79,7 +79,7 @@ $products = wc_get_products( array( 'status' => 'draft' ) );
 
 ```php
 // Using constant class for status.
-$products = wc_get_products( array( 'status' => ProductStatus::DRAFT ) );
+$products = wc_get_products( array( 'status' => \Automattic\WooCommerce\Enums\ProductStatus::DRAFT ) );
 ```
 
 ```php
@@ -291,7 +291,7 @@ $products = wc_get_products( array( 'visibility' => 'catalog' ) );
 
 ```php
 // Using constant class for visibility.
-$products = wc_get_products( array( 'visibility' => CatalogVisibility::CATALOG ) );
+$products = wc_get_products( array( 'visibility' => \Automattic\WooCommerce\Enums\CatalogVisibility::CATALOG ) );
 ```
 
 ```php
@@ -320,7 +320,7 @@ $products = wc_get_products( array( 'stock_status' => 'outofstock' ) );
 
 ```php
 // Using constant class for stock status.
-$products = wc_get_products( array( 'stock_status' => ProductStockStatus::OUT_OF_STOCK ) );
+$products = wc_get_products( array( 'stock_status' => \Automattic\WooCommerce\Enums\ProductStockStatus::OUT_OF_STOCK ) );
 ```
 
 ### Tax & shipping
@@ -340,7 +340,7 @@ $products = wc_get_products( array( 'tax_status' => 'taxable' ) );
 
 ```php
 // Using constant class for tax status.
-$products = wc_get_products( array( 'tax_status' => ProductTaxStatus::TAXABLE ) );
+$products = wc_get_products( array( 'tax_status' => \Automattic\WooCommerce\Enums\ProductTaxStatus::TAXABLE ) );
 ```
 
 ```php

--- a/docs/extensions/core-concepts/wc-get-products.md
+++ b/docs/extensions/core-concepts/wc-get-products.md
@@ -421,9 +421,12 @@ It is possible to add support for custom parameters in `wc_get_products()` or `W
  */
 function handle_custom_query_var( $query, $query_vars ) {
 	if ( ! empty( $query_vars['customvar'] ) ) {
+		if ( ! isset( $query['meta_query'] ) ) {
+			$query['meta_query'] = array();
+		}
 		$query['meta_query'][] = array(
-			'key' => 'customvar',
-			'value' => esc_attr( $query_vars['customvar'] ),
+			'key'   => 'customvar',
+			'value' => sanitize_text_field( $query_vars['customvar'] ),
 		);
 	}
 

--- a/docs/theming/theme-development/template-structure.md
+++ b/docs/theming/theme-development/template-structure.md
@@ -75,7 +75,7 @@ The copied file will now override the WooCommerce default template file, so you 
 
 ## Declare Theme Support for Custom Templates
 
-If you are a theme developer or using a theme with custom templates, you must declare WooCommerce theme support using the `add_theme_support` function. See [Declaring WooCommerce Support in Themes](https://developer.woocommerce.com/docs/theming/theme-development/classic-theme-developer-handbook/#declaring-woocommerce-support) at GitHub.
+If you are a theme developer or using a theme with custom templates, you must declare WooCommerce theme support using the `add_theme_support` function. See [Declaring WooCommerce Support in Themes](/docs/theming/theme-development/classic-theme-developer-handbook/#declaring-woocommerce-support).
 
 If your theme has `woocommerce.php`, you will be unable to override `woocommerce/archive-product.php` custom template in your theme, as `woocommerce.php` has priority over other template files. This is intended to prevent display issues.
 

--- a/docs/theming/theme-development/template-structure.md
+++ b/docs/theming/theme-development/template-structure.md
@@ -75,7 +75,7 @@ The copied file will now override the WooCommerce default template file, so you 
 
 ## Declare Theme Support for Custom Templates
 
-If you are a theme developer or using a theme with custom templates, you must declare WooCommerce theme support using the `add_theme_support` function. See [Declaring WooCommerce Support in Themes](https://github.com/woocommerce/woocommerce/wiki/Declaring-WooCommerce-support-in-themes) at GitHub.
+If you are a theme developer or using a theme with custom templates, you must declare WooCommerce theme support using the `add_theme_support` function. See [Declaring WooCommerce Support in Themes](https://developer.woocommerce.com/docs/theming/theme-development/classic-theme-developer-handbook/#declaring-woocommerce-support) at GitHub.
 
 If your theme has `woocommerce.php`, you will be unable to override `woocommerce/archive-product.php` custom template in your theme, as `woocommerce.php` has priority over other template files. This is intended to prevent display issues.
 

--- a/docs/wc-cli/wc-cli-examples.md
+++ b/docs/wc-cli/wc-cli-examples.md
@@ -172,3 +172,13 @@ Response:
 | meta_data                   | []                  |
 +-----------------------------+---------------------+
 ```
+
+## Upgrading the database using WP CLI
+
+When new versions of WooCommerce are released, often you'll be prompted to run a database upgrade. Whilst it's possible to do this through WP admin, advanced users may prefer to run these upgrades via the CLI, for example, on busy stores where timeouts could occur.
+
+To update the database, use the following CLI command:
+
+`$ wp wc update`
+
+There are no extra arguments needed, and only the pending upgrades will be ran. Once the updates have been ran, the new version will be shown.

--- a/docs/wc-cli/wc-cli-examples.md
+++ b/docs/wc-cli/wc-cli-examples.md
@@ -181,4 +181,4 @@ To update the database, use the following CLI command:
 
 `$ wp wc update`
 
-There are no extra arguments needed, and only the pending upgrades will be ran. Once the updates have been ran, the new version will be shown.
+There are no extra arguments needed, and only the pending upgrades will be run. Once the updates have been run, the new version will be shown.

--- a/plugins/woocommerce/changelog/63251-docs-wiki-cleanup
+++ b/plugins/woocommerce/changelog/63251-docs-wiki-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace internal wiki links with updated developer docs links

--- a/plugins/woocommerce/client/admin/README.md
+++ b/plugins/woocommerce/client/admin/README.md
@@ -4,7 +4,7 @@ This is a javascript-driven, React-based admin interface for WooCommerce.
 
 ## Development
 
-Please refer to the [WooCommerce Admin Development](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment#wooCommerce-admin-development).
+Please refer to the [WooCommerce Admin Development](https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment).
 
 ## End-to-end tests
 

--- a/plugins/woocommerce/client/admin/docs/stylesheets.md
+++ b/plugins/woocommerce/client/admin/docs/stylesheets.md
@@ -8,4 +8,4 @@
 
 ## Naming: Component classes
 
-Please refer to [CSS SASS coding guidelines and naming conventions](https://github.com/woocommerce/woocommerce/wiki/CSS-SASS-coding-guidelines-and-naming-conventions)
+Please refer to [CSS SASS coding guidelines and naming conventions](https://developer.woocommerce.com/docs/contribution/contributing/CSS-SASS-coding-guidelines-and-naming-conventions/)

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -95,7 +95,7 @@ class WC_Brands_Admin {
 		add_action( 'current_screen', array( $this, 'add_brand_base_setting' ) );
 
 		// CSV Import/Export Support.
-		// https://github.com/woocommerce/woocommerce/wiki/Product-CSV-Importer-&-Exporter
+		// https://woocommerce.com/document/product-csv-importer-exporter/
 		// Import.
 		add_filter( 'woocommerce_csv_product_import_mapping_options', array( $this, 'add_column_to_importer_exporter' ), 10 );
 		add_filter( 'woocommerce_csv_product_import_mapping_default_columns', array( $this, 'add_default_column_mapping' ), 10 );

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -176,7 +176,7 @@ class WC_Notes_Run_Db_Update {
 		$note->set_content(
 			__( 'WooCommerce has been updated! To keep things running smoothly, we have to update your database to the newest version.', 'woocommerce' )
 			/* translators: %1$s: opening <a> tag %2$s: closing </a> tag*/
-			. sprintf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' )
+			. sprintf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://developer.woocommerce.com/docs/wc-cli/wc-cli-examples/#upgrading-the-database-using-wp-cli">', '</a>' )
 		);
 		$note->set_type( Note::E_WC_ADMIN_NOTE_UPDATE );
 		$note->set_name( self::NOTE_NAME );
@@ -345,5 +345,4 @@ class WC_Notes_Run_Db_Update {
 			}
 		}
 	}
-
 }

--- a/plugins/woocommerce/includes/admin/views/html-notice-update.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-update.php
@@ -25,7 +25,7 @@ $update_url = wp_nonce_url(
 			esc_html_e( 'WooCommerce has been updated! To keep things running smoothly, we have to update your database to the newest version.', 'woocommerce' );
 
 			/* translators: 1: Link to docs 2: Close link. */
-			printf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' );
+			printf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://developer.woocommerce.com/docs/wc-cli/wc-cli-examples/#upgrading-the-database-using-wp-cli">', '</a>' );
 		?>
 	</p>
 	<p class="submit">

--- a/plugins/woocommerce/includes/class-wc-order-query.php
+++ b/plugins/woocommerce/includes/class-wc-order-query.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Parameter-based Order querying
- * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query
+ * Args and usage: https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/
  *
  * @package WooCommerce\Classes
  * @version 3.1.0

--- a/plugins/woocommerce/includes/class-wc-product-query.php
+++ b/plugins/woocommerce/includes/class-wc-product-query.php
@@ -2,7 +2,7 @@
 /**
  * Class for parameter-based Product querying
  *
- * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query
+ * Args and usage: https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-products/
  *
  * @package  WooCommerce\Classes
  * @version  3.2.0

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * This function should be used for order retrieval so that when we move to
  * custom tables, functions still work.
  *
- * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query
+ * Args and usage: https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/
  *
  * @since  2.6.0
  * @param  array $args Array of args (above).

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * This function should be used for product retrieval so that we have a data agnostic
  * way to get a list of products.
  *
- * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query
+ * Args and usage: https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-products/
  *
  * @since  3.0.0
  * @param  array $args Array of args (above).

--- a/plugins/woocommerce/packages/README.md
+++ b/plugins/woocommerce/packages/README.md
@@ -4,7 +4,7 @@ This directory holds Composer packages containing functionality developed outsid
 
 ## Installing Composer
 
-You need Composer to use the packages. If you don't have it installed, go and check how to [install Composer](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment) and then continue here.
+You need Composer to use the packages. If you don't have it installed, go and check how to [install Composer](https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment) and then continue here.
 
 ## Developing new packages
 

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -49,12 +49,12 @@ class Autoloader {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			// This message is not translated as at this point it's too early to load translations.
 			error_log(  // phpcs:ignore
-				esc_html( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, please refer to this document to set up your development environment: https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment' )
+				esc_html( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, please refer to this document to set up your development environment: https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment' )
 			);
 		}
 		add_action(
 			'admin_notices',
-			function() {
+			function () {
 				?>
 				<div class="notice notice-error">
 					<p>
@@ -62,7 +62,7 @@ class Autoloader {
 						printf(
 							/* translators: 1: is a link to a support document. 2: closing link */
 							esc_html__( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, %1$splease refer to this document%2$s to set up your development environment.', 'woocommerce' ),
-							'<a href="' . esc_url( 'https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment' ) . '" target="_blank" rel="noopener noreferrer">',
+							'<a href="' . esc_url( 'https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment' ) . '" target="_blank" rel="noopener noreferrer">',
 							'</a>'
 						);
 						?>

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -98,7 +98,7 @@ class CLIRunner {
 					sprintf(
 						// translators: %s - link to testing instructions webpage.
 						__( 'Custom order table usage is not enabled. If you are testing, you can enable it by following the testing instructions in %s', 'woocommerce' ),
-						'https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book'
+						'https://developer.woocommerce.com/docs/features/high-performance-order-storage/recipe-book/'
 					)
 				);
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -359,7 +359,7 @@ class OrdersTableQuery {
 			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( 'UTC' ) );
 			$precision = 'second';
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
-			// For backwards compat (see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date)
+			// For backwards compat (see https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/#date)
 			// only YYYY-MM-DD is considered for date values. Timestamps do support second precision.
 			$date      = wc_string_to_datetime( date( 'Y-m-d', strtotime( $date ) ) );
 			$precision = 'day';
@@ -392,7 +392,7 @@ class OrdersTableQuery {
 	private function local_time_to_gmt_date_query( $dates_raw, $operator ) {
 		$result = array();
 
-		// Convert YYYY-MM-DD to UTC timestamp. Per https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date only date is relevant (time is ignored).
+		// Convert YYYY-MM-DD to UTC timestamp. Per https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/#date only date is relevant (time is ignored).
 		foreach ( $dates_raw as &$raw_date ) {
 			$raw_date = is_numeric( $raw_date ) ? $raw_date : strtotime( get_gmt_from_date( date( 'Y-m-d', strtotime( $raw_date ) ) ) );
 		}
@@ -508,7 +508,7 @@ class OrdersTableQuery {
 				$date_key = $local_to_gmt_date_keys[ $date_key ];
 
 				if ( ! is_numeric( $dates_raw[0] ) && ( ! isset( $dates_raw[1] ) || ! is_numeric( $dates_raw[1] ) ) ) {
-					// Only non-numeric args can be considered local time. Timestamps are assumed to be UTC per https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date.
+					// Only non-numeric args can be considered local time. Timestamps are assumed to be UTC per https://developer.woocommerce.com/docs/extensions/core-concepts/wc-get-orders/#date.
 					$date_queries[] = array_merge(
 						array(
 							'column' => $date_key,

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -330,7 +330,7 @@ class Packages {
 					/* Translators: %s package name. */
 					esc_html__( 'Missing the WooCommerce %s package', 'woocommerce' ),
 					'<code>' . esc_html( $package ) . '</code>'
-				) . ' - ' . esc_html__( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, please refer to this document to set up your development environment: https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment', 'woocommerce' )
+				) . ' - ' . esc_html__( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, please refer to this document to set up your development environment: https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment', 'woocommerce' )
 			);
 		}
 		add_action(
@@ -353,7 +353,7 @@ class Packages {
 						printf(
 							/* translators: 1: is a link to a support document. 2: closing link */
 							esc_html__( 'Your installation of WooCommerce is incomplete. If you installed WooCommerce from GitHub, %1$splease refer to this document%2$s to set up your development environment.', 'woocommerce' ),
-							'<a href="' . esc_url( 'https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment' ) . '" target="_blank" rel="noopener noreferrer">',
+							'<a href="' . esc_url( 'https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment' ) . '" target="_blank" rel="noopener noreferrer">',
 							'</a>'
 						);
 						?>

--- a/plugins/woocommerce/src/README.md
+++ b/plugins/woocommerce/src/README.md
@@ -40,7 +40,7 @@ See also [the README file for the `Internal` folder](Internal/README.md).
 
 Composer is used to generate autoload class-maps for the files here. The stable release of WooCommerce comes with the autoloader, however, if you're running a development version you'll need to use Composer.
 
-If you don't have Composer installed, go and check how to [install Composer](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment) and then continue here.
+If you don't have Composer installed, go and check how to [install Composer](https://developer.woocommerce.com/docs/contribution/contributing/#setting-up-your-development-environment) and then continue here.
 
 ### Updating the autoloader class maps
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Wiki URL Migration to Developer Docs

  Replaced 43 GitHub wiki links with proper developer.woocommerce.com URLs
  across the codebase:

  GitHub templates & workflows:
  - .github/CONTRIBUTING.md - 7 wiki links updated
  - .github/PULL_REQUEST_TEMPLATE.md - Testing instructions guide link
  - .github/workflows/automate-team-review-assignment.yml - Testing instructions
   guide link

  PHP source code (user-facing):
  - src/Autoloader.php - Dev environment setup link (shown in error messages)
  - src/Packages.php - Dev environment setup link (shown in error messages)
  - includes/admin/notes/class-wc-notes-run-db-update.php - WP-CLI upgrade link
  - includes/admin/views/html-notice-update.php - WP-CLI upgrade link
  - src/Database/Migrations/CustomOrderTable/CLIRunner.php - HPOS upgrade guide
  link

  PHP source code (developer comments):
  - includes/class-wc-order-query.php - API docs reference
  - includes/class-wc-product-query.php - API docs reference
  - includes/wc-order-functions.php - API docs reference
  - includes/wc-product-functions.php - API docs reference
  - src/Internal/DataStores/Orders/OrdersTableQuery.php - API docs reference (3
  locations)

  Documentation files:
  - docs/code-snippets/useful-functions.md - Query function links
  - docs/contribution/contributing/deciding-pr-high-impact.md - Critical flows
  link
  - docs/contribution/contributing/minification-of-SCSS-and-JS.md - Dev setup
  link
  - docs/contribution/contributing/naming-conventions.md - CSS/SASS guidelines
  link
  - docs/theming/theme-development/template-structure.md - Theme support link
  - plugins/woocommerce/client/admin/README.md - Dev setup and common issues
  links
  - plugins/woocommerce/client/admin/docs/stylesheets.md - CSS/SASS guidelines
  link
  - plugins/woocommerce/packages/README.md - Composer setup link
  - plugins/woocommerce/src/README.md - Composer setup link
  - includes/admin/class-wc-admin-brands.php - CSV importer docs link

### Migrated Product Query Documentation

  Moved comprehensive docs/extensions/core-concepts/wc-get-products.md from the wiki with:
  - Refactored structure matching wc-get-orders.md format
  - API reference table for WC_Product_Query methods
  - Parameter tables organized by category:
    - General, Pagination, Product lookup, Dimensions & pricing
    - Product settings, Stock & inventory, Tax & shipping
    - Reviews & ratings, Date
  - All code blocks with proper php language declarations
  - Examples grouped under each parameter section

### Contributing Documentation Improvements

  Updated docs/contribution/contributing/README.md:
  - Added new "Setting up your development environment" section
  - Links to getting started guide and DEVELOPMENT.md
  - Improved heading hierarchy (### → ##)

### CLI Documentation

  Added content to docs/wc-cli/wc-cli-examples.md (10 new lines)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To see changes to the docs, run:

1. cd docs/_docu-tools
2. npm run build
3. npm run serve

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Replace internal wiki links with updated developer docs links

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
