### PR TITLE
Add full-width alignment support for product image in email editor

### DIFF
--- a/packages/js/email-editor/changelog/add-product-image-full-width-alignment
+++ b/packages/js/email-editor/changelog/add-product-image-full-width-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add full-width alignment support for product image block

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -28,6 +28,7 @@ import { enhanceQuoteBlock } from './core/quote';
 import { filterSetUrlAttribute } from './core/block-edit';
 import { enhanceSocialLinksBlock } from './core/social-links';
 import { enhanceSiteLogoBlock } from './core/site-logo';
+import { enableProductImageAlignment } from './woocommerce/product-image';
 
 export { getAllowedBlockNames } from './utils';
 
@@ -52,5 +53,6 @@ export function initBlocks() {
 	alterSupportConfiguration();
 	enhanceSocialLinksBlock();
 	enhanceSiteLogoBlock();
+	enableProductImageAlignment();
 	removeBlockStylesFromAllBlocks();
 }

--- a/packages/js/email-editor/src/blocks/woocommerce/product-image.ts
+++ b/packages/js/email-editor/src/blocks/woocommerce/product-image.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { updateBlockSettings } from '../../config-tools/block-config';
+
+/**
+ * Enable alignment support for the product image block.
+ */
+function enableProductImageAlignment() {
+	updateBlockSettings( 'woocommerce/product-image', ( current ) => ( {
+		...current,
+		supports: {
+			...( current.supports || {} ),
+			align: [ 'full' ],
+		},
+	} ) );
+}
+
+export { enableProductImageAlignment };

--- a/packages/php/email-editor/changelog/add-product-image-full-width-alignment
+++ b/packages/php/email-editor/changelog/add-product-image-full-width-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add full-width alignment support for product image block and enable wide/full alignment options in editor settings

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -78,7 +78,8 @@ class Settings_Controller {
 		$settings['__experimentalFeatures'] = $theme_settings;
 		// Controls which alignment options are available for blocks.
 		$settings['supportsLayout']              = true; // Allow using default layouts.
-		$settings['__unstableIsBlockBasedTheme'] = true; // For default setting this to true disables wide and full alignments.
+		$settings['alignWide']                   = true; // Enable wide and full alignment options.
+		$settings['__unstableIsBlockBasedTheme'] = false; // Setting to true disables wide and full alignments in flow layouts.
 		return $settings;
 	}
 

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -14,7 +14,7 @@
     },
     "layout": {
       "contentSize": "660px",
-      "wideSize": "",
+      "wideSize": "660px",
       "allowEditing": false,
       "allowCustomContentAndWideSize": false
     },

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
@@ -427,7 +427,7 @@ class Product_Image extends Abstract_Product_Block_Renderer {
 
 		// Map block alignment to valid HTML/CSS alignment values.
 		// "full" is not a valid text-align or table align value.
-		$css_align = $is_full ? 'center' : ( $align ?: 'left' );
+		$css_align = $is_full ? 'center' : ( $align ? $align : 'left' );
 
 		$wrapper_styles = array(
 			'border-collapse' => 'separate',

--- a/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/Renderer/Blocks/class-product-image.php
@@ -420,8 +420,14 @@ class Product_Image extends Abstract_Product_Block_Renderer {
 	 */
 	private function apply_email_wrapper( string $image_html, array $parsed_block, Rendering_Context $rendering_context ): string {
 		$width         = $parsed_block['attrs']['width'] ?? '';
-		$wrapper_width = ( $width && '100%' !== $width ) ? $width : 'auto';
+		$align         = $parsed_block['attrs']['align'] ?? '';
+		$is_full       = 'full' === $align;
+		$wrapper_width = $is_full ? '100%' : ( ( $width && '100%' !== $width ) ? $width : 'auto' );
 		$image_height  = $this->extract_image_height( $image_html ) . 'px';
+
+		// Map block alignment to valid HTML/CSS alignment values.
+		// "full" is not a valid text-align or table align value.
+		$css_align = $is_full ? 'center' : ( $align ?: 'left' );
 
 		$wrapper_styles = array(
 			'border-collapse' => 'separate',
@@ -433,8 +439,7 @@ class Product_Image extends Abstract_Product_Block_Renderer {
 			'vertical-align' => 'top',
 		);
 
-		$align                     = $parsed_block['attrs']['align'] ?? 'left';
-		$cell_styles['text-align'] = $align;
+		$cell_styles['text-align'] = $css_align;
 
 		$outer_table_attrs = array(
 			'style' => \WP_Style_Engine::compile_css(
@@ -450,7 +455,7 @@ class Product_Image extends Abstract_Product_Block_Renderer {
 		);
 
 		$outer_cell_attrs = array(
-			'align' => $align,
+			'align' => $css_align,
 		);
 
 		$inner_table_attrs = array(

--- a/packages/php/email-editor/src/Integrations/WooCommerce/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/WooCommerce/class-initializer.php
@@ -52,6 +52,11 @@ class Initializer {
 			$settings['render_email_callback'] = array( $this, 'render_block' );
 		}
 
+		// Enable full-width alignment support for the product image block.
+		if ( 'woocommerce/product-image' === $settings['name'] ) {
+			$settings['supports']['align'] = array( 'full' );
+		}
+
 		return $settings;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes https://linear.app/a8c/issue/WOOPRD-1120/add-support-for-alignment-in-the-product-image-block

Some email pattern designs contain the `woocommerce/product-image` block with full-width alignment, but the block did not declare alignment support and the editor settings prevented wide/full alignment options from appearing. Note that this email settings change will add more alignment options for all blocks that support alignment (I can follow up to remove these if needed):

>   **Blocks that now gain wide/full options from our       
  change:**                                               
>   - core/image — align: true (all options including     
>   wide/full)                                            
>   - core/buttons — align: ["wide", "full"]              
>   - woocommerce/product-collection — align: ["wide",    
>   "full"]
>   - woocommerce/product-button — align: ["wide", "full"]
>   - woocommerce/product-sale-badge — align: true        
>   - woocommerce/coupon-code — align: true               
> 

Editor | Rendered email
---- | ----
<img width="572" height="245" alt="Screenshot 2026-02-11 at 3 17 12 PM" src="https://github.com/user-attachments/assets/acf59feb-ff0b-4b2e-bbcd-7949f3212dc2" /> | <img width="627" height="575" alt="Screenshot 2026-02-11 at 3 17 36 PM" src="https://github.com/user-attachments/assets/0ff1bf38-8b7b-4d75-b2e0-9860d19f30d3" />

The email pattern will need additional customization to look like the design:

<img width="362" height="536" alt="Screenshot 2026-02-11 at 11 34 46 AM" src="https://github.com/user-attachments/assets/e6b6b380-bc05-4209-83f2-8c2ac9774e61" />



This PR enables full-width alignment for the product image block in the email editor:

- **Editor settings** (`class-settings-controller.php`): Added `alignWide = true` and changed `__unstableIsBlockBasedTheme` to `false`. The previous `true` value disabled wide/full alignment options in flow layouts, which the email editor uses.
- **Theme config** (`theme.json`): Set `wideSize` to `660px` (was empty). WordPress requires a non-empty `wideSize` for wide/full alignment options to appear.
- **JS block customization** (`product-image.ts`): New file that enables `align: ['full']` on the product image block via the email editor's `updateBlockSettings` pattern.
- **PHP block registration** (`class-initializer.php`): Mirrors the JS change by adding `align` support to the product image block metadata.
- **PHP renderer** (`class-product-image.php`): Sets wrapper width to `100%` when alignment is `full`, and maps the `full` alignment value to valid HTML/CSS `center` for table align attributes and text-align styles.

### How to test the changes in this Pull Request:

1. Add a Product Collection block with Product Images inside it.
2. Select the Product Image block.
4. Verify the alignment toolbar shows "None" and "Full width" options.
5. Set the product image to "Full width" alignment.
6. Preview/send the email and verify the product image wrapper renders with `width: 100%` and valid `align="center"` / `text-align: center` attributes.

### Testing that has already taken place:

- Manual testing in the email editor: confirmed full-width alignment option appears and renders correctly.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Add - Adds functionality

#### Message
Add full-width alignment support for product image block in the email editor.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)