### PR TITLE
Additional information mobile layout

### DIFF
--- a/plugins/woocommerce/changelog/63255-cursor-WOOPLUG-6235-additional-information-mobile-layout-f8ce
+++ b/plugins/woocommerce/changelog/63255-cursor-WOOPLUG-6235-additional-information-mobile-layout-f8ce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes "Additional Information" tab content being cut off on mobile devices.

--- a/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
@@ -90,7 +90,6 @@
 	table.shop_attributes {
 		tr {
 			display: block;
-			margin-bottom: 1em;
 
 			th,
 			td {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
@@ -85,6 +85,33 @@
 	}
 
 	/**
+	 * Product attributes table
+	 */
+	table.shop_attributes {
+		tr {
+			display: block;
+			margin-bottom: 1em;
+
+			th,
+			td {
+				display: block;
+				width: 100%;
+				text-align: left;
+				padding: 8px;
+			}
+
+			th {
+				padding-bottom: 4px;
+				border-bottom: 0;
+			}
+
+			td {
+				padding-top: 4px;
+			}
+		}
+	}
+
+	/**
 	 * General layout
 	 */
 	.col2-set {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-smallscreen.scss
@@ -94,18 +94,31 @@
 			th,
 			td {
 				display: block;
-				width: 100%;
+				max-width: 100%;
+				width: auto;
 				text-align: left;
-				padding: 8px;
+				padding: 0.5em;
 			}
 
 			th {
-				padding-bottom: 4px;
+				padding-bottom: 0.25em;
 				border-bottom: 0;
 			}
 
 			td {
-				padding-top: 4px;
+				padding-top: 0.25em;
+			}
+
+			th > :first-child,
+			td > :first-child {
+				padding-top: 0;
+				margin-top: 0;
+			}
+
+			th > :last-child,
+			td > :last-child {
+				padding-bottom: 0;
+				margin-bottom: 0;
 			}
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses a mobile layout issue where the "Additional Information" tab content (product attributes table) on single product pages appears cut off.

The fix introduces responsive CSS to stack the product attribute table's label and value columns vertically on mobile devices (screens below 768px), ensuring all content is fully visible and accessible.

Closes #63092

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="828" height="1176" alt="CleanShot 2026-02-12 at 11 49 51@2x" src="https://github.com/user-attachments/assets/f2f2b5ac-f658-4fef-86d7-e559bfdb9e2f" /> | <img width="828" height="1184" alt="CleanShot 2026-02-12 at 11 50 11@2x" src="https://github.com/user-attachments/assets/25759e01-a9b2-40a3-b4d2-e0640451e600" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Install WordPress, WooCommerce, and the Storefront theme.
2.  Create a simple product with weight, dimensions, and custom attributes (e.g., Condition).
3.  View the product page on a mobile device or shrink your browser window below 768px.
4.  Tap the "Additional Information" tab.
5.  **Expected behavior:** The content of the "Additional Information" tab should be fully visible, with attribute labels and values stacked vertically, and no content should be cut off by the handheld footer bar.
6.  **Actual behavior (before fix):** The content appears "cut off," and users cannot scroll far enough to reveal the hidden content.

### Testing that has already taken place:

Local testing was performed by compiling the SCSS changes and verifying the visual output on a mobile viewport using the provided reproduction steps.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->
Fixes "Additional Information" tab content being cut off on mobile devices.

</details>

