### PR TITLE
Make VersionStringGenerator and RestApiCache more robust against bad-behaved object caches

### DIFF
--- a/plugins/woocommerce/changelog/pr-63259
+++ b/plugins/woocommerce/changelog/pr-63259
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make VersionStringGenerator and RestApiCache more robust against bad-behaved object caches

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -82,10 +82,9 @@ class VersionStringGenerator {
 		$this->validate_input( $id );
 
 		$cache_key = $this->get_cache_key( $id );
-		$found     = false;
-		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP );
 
-		if ( ! $found ) {
+		if ( false === $version ) {
 			if ( ! $generate ) {
 				return null;
 			}
@@ -144,14 +143,13 @@ class VersionStringGenerator {
 
 		// Some object cache implementations may return non-boolean values.
 		// Verify the store by reading the value back.
-		$found        = false;
-		$stored_value = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-		if ( $found && $stored_value === $version ) {
+		$stored_value = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		if ( $stored_value === $version ) {
 			return true;
 		}
 
 		// The stored value doesn't match; clean up and report failure.
-		if ( $found ) {
+		if ( false !== $stored_value ) {
 			wp_cache_delete( $cache_key, self::CACHE_GROUP );
 		}
 		return false;

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -136,7 +136,25 @@ class VersionStringGenerator {
 		$ttl = apply_filters( 'woocommerce_version_string_generator_ttl', DAY_IN_SECONDS, $id );
 		$ttl = max( 0, (int) $ttl );
 
-		return wp_cache_set( $cache_key, $version, self::CACHE_GROUP, $ttl );
+		$result = wp_cache_set( $cache_key, $version, self::CACHE_GROUP, $ttl );
+
+		if ( is_bool( $result ) ) {
+			return $result;
+		}
+
+		// Some object cache implementations may return non-boolean values.
+		// Verify the store by reading the value back.
+		$found        = false;
+		$stored_value = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		if ( $found && $stored_value === $version ) {
+			return true;
+		}
+
+		// The stored value doesn't match; clean up and report failure.
+		if ( $found ) {
+			wp_cache_delete( $cache_key, self::CACHE_GROUP );
+		}
+		return false;
 	}
 
 	/**
@@ -152,7 +170,10 @@ class VersionStringGenerator {
 		$this->validate_input( $id );
 
 		$cache_key = $this->get_cache_key( $id );
-		return wp_cache_delete( $cache_key, self::CACHE_GROUP );
+		$result    = wp_cache_delete( $cache_key, self::CACHE_GROUP );
+
+		// Some object cache implementations may return non-boolean values.
+		return ! is_bool( $result ) || $result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -1107,9 +1107,8 @@ trait RestApiCache {
 		// Try to get cached file check results to avoid filesystem calls on every request.
 		if ( $check_interval > 0 ) {
 			$file_check_cache_key = $this->get_file_check_cache_key( $file_paths, $allowed_directories );
-			$found                = false;
-			$files_data           = wp_cache_get( $file_check_cache_key, self::$cache_group, false, $found );
-			if ( ! $found ) {
+			$files_data           = wp_cache_get( $file_check_cache_key, self::$cache_group );
+			if ( false === $files_data ) {
 				$files_data = null;
 			}
 		}
@@ -1284,9 +1283,7 @@ trait RestApiCache {
 		if ( $suppression_ttl > 0 ) {
 			$warning_key = 'wc_rest_file_warning_' . md5( $file_path . '|' . $reason );
 
-			$found = false;
-			wp_cache_get( $warning_key, self::$warning_cache_group, false, $found );
-			if ( $found ) {
+			if ( false !== wp_cache_get( $warning_key, self::$warning_cache_group ) ) {
 				return;
 			}
 
@@ -1343,10 +1340,9 @@ trait RestApiCache {
 		$cache_ttl      = $cached_config['cache_ttl'];
 		$relevant_hooks = $cached_config['relevant_hooks'];
 
-		$found  = false;
-		$cached = wp_cache_get( $cache_key, self::$cache_group, false, $found );
+		$cached = wp_cache_get( $cache_key, self::$cache_group );
 
-		if ( ! $found || ! is_array( $cached ) || ! array_key_exists( 'data', $cached ) || ! isset( $cached['entity_versions'], $cached['created_at'] ) ) {
+		if ( ! is_array( $cached ) || ! array_key_exists( 'data', $cached ) || ! isset( $cached['entity_versions'], $cached['created_at'] ) ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -1107,8 +1107,9 @@ trait RestApiCache {
 		// Try to get cached file check results to avoid filesystem calls on every request.
 		if ( $check_interval > 0 ) {
 			$file_check_cache_key = $this->get_file_check_cache_key( $file_paths, $allowed_directories );
-			$files_data           = wp_cache_get( $file_check_cache_key, self::$cache_group );
-			if ( false === $files_data ) {
+			$found                = false;
+			$files_data           = wp_cache_get( $file_check_cache_key, self::$cache_group, false, $found );
+			if ( ! $found ) {
 				$files_data = null;
 			}
 		}
@@ -1283,7 +1284,9 @@ trait RestApiCache {
 		if ( $suppression_ttl > 0 ) {
 			$warning_key = 'wc_rest_file_warning_' . md5( $file_path . '|' . $reason );
 
-			if ( false !== wp_cache_get( $warning_key, self::$warning_cache_group ) ) {
+			$found = false;
+			wp_cache_get( $warning_key, self::$warning_cache_group, false, $found );
+			if ( $found ) {
 				return;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -305,13 +305,13 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 		try {
 			$mock_cache = $this->createMock( \WP_Object_Cache::class );
 			$mock_cache->method( 'delete' )->willReturn( null );
-			$wp_object_cache = $mock_cache;
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 			$result = $this->sut->delete_version( 'some-id' );
 
 			$this->assertTrue( $result, 'delete_version should return true when wp_cache_delete returns non-boolean' );
 		} finally {
-			$wp_object_cache = $original_cache;
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 	}
 
@@ -337,13 +337,13 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 					return $original_cache->get( $key, $group, $force, $found );
 				}
 			);
-			$wp_object_cache = $mock_cache;
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 			$version = $this->sut->generate_version( 'test-store-ok' );
 
 			$this->assertNotEmpty( $version, 'generate_version should return a version even when wp_cache_set returns non-boolean' );
 		} finally {
-			$wp_object_cache = $original_cache;
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 	}
 
@@ -373,14 +373,14 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 					return $original_cache->delete( $key, $group );
 				}
 			);
-			$wp_object_cache = $mock_cache;
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 			$version = $this->sut->generate_version( 'test-store-fail' );
 
 			// generate_version still returns a UUID string, but the store failed silently.
 			$this->assertNotEmpty( $version );
 		} finally {
-			$wp_object_cache = $original_cache;
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		// The corrupted value should have been cleaned up.

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -296,6 +296,100 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox delete_version returns true when wp_cache_delete returns a non-boolean value.
+	 */
+	public function test_delete_version_returns_true_for_non_bool_cache_delete(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+
+		try {
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache->method( 'delete' )->willReturn( null );
+			$wp_object_cache = $mock_cache;
+
+			$result = $this->sut->delete_version( 'some-id' );
+
+			$this->assertTrue( $result, 'delete_version should return true when wp_cache_delete returns non-boolean' );
+		} finally {
+			$wp_object_cache = $original_cache;
+		}
+	}
+
+	/**
+	 * @testdox store_version succeeds when wp_cache_set returns non-boolean but the value is correctly stored.
+	 */
+	public function test_store_version_succeeds_for_non_bool_cache_set_with_correct_value(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+
+		try {
+			// Mock that returns null from set() but delegates get() to the real cache,
+			// simulating a non-standard cache that stores correctly but returns null.
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache->method( 'set' )->willReturnCallback(
+				function ( $key, $data, $group, $expire ) use ( $original_cache ) {
+					$original_cache->set( $key, $data, $group, $expire );
+					return null;
+				}
+			);
+			$mock_cache->method( 'get' )->willReturnCallback(
+				function ( $key, $group, $force, &$found ) use ( $original_cache ) {
+					return $original_cache->get( $key, $group, $force, $found );
+				}
+			);
+			$wp_object_cache = $mock_cache;
+
+			$version = $this->sut->generate_version( 'test-store-ok' );
+
+			$this->assertNotEmpty( $version, 'generate_version should return a version even when wp_cache_set returns non-boolean' );
+		} finally {
+			$wp_object_cache = $original_cache;
+		}
+	}
+
+	/**
+	 * @testdox store_version fails and cleans up when wp_cache_set returns non-boolean and the stored value doesn't match.
+	 */
+	public function test_store_version_fails_for_non_bool_cache_set_with_wrong_value(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+
+		try {
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache->method( 'set' )->willReturnCallback(
+				function ( $key, $data, $group, $expire ) use ( $original_cache ) {
+					// Store a wrong value to simulate a corrupted write.
+					$original_cache->set( $key, 'wrong-value', $group, $expire );
+					return null;
+				}
+			);
+			$mock_cache->method( 'get' )->willReturnCallback(
+				function ( $key, $group, $force, &$found ) use ( $original_cache ) {
+					return $original_cache->get( $key, $group, $force, $found );
+				}
+			);
+			$mock_cache->method( 'delete' )->willReturnCallback(
+				function ( $key, $group ) use ( $original_cache ) {
+					return $original_cache->delete( $key, $group );
+				}
+			);
+			$wp_object_cache = $mock_cache;
+
+			$version = $this->sut->generate_version( 'test-store-fail' );
+
+			// generate_version still returns a UUID string, but the store failed silently.
+			$this->assertNotEmpty( $version );
+		} finally {
+			$wp_object_cache = $original_cache;
+		}
+
+		// The corrupted value should have been cleaned up.
+		$cache_key    = 'wc_version_string_' . md5( 'test-store-fail' );
+		$cached_value = wp_cache_get( $cache_key, $this->get_cache_group() );
+		$this->assertFalse( $cached_value, 'Mismatched cached value should have been deleted' );
+	}
+
+	/**
 	 * @testdox Negative TTL from filter is converted to 0 and cache operations still succeed.
 	 */
 	public function test_negative_ttl_is_converted_to_zero() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `delete_version` and `store_version` methods in `VersionStringGenerator` are defined as returning `bool`. They use `wp_cache_set` and `wp_cache_delete`, which are defined as returning bool too; so a simple `return wp_cache_...` was being used. However turns out that bad-behaved object caches can return `null` instead, causing an error due to the mismatching signatures.

This pull request adds some robustness agains these cases:

- If `wp_cache_delete` returns a non-boolean value, `delete_version` assumes success and returns true.
- If `wp_cache_set` returns a non-boolean value, `store_version` will use `wp_cache_get` to try to retrieve the stored value, and determine success only when both values match.

Closes #63189.

### How to test the changes in this Pull Request:

Unit tests should cover the changes, but to manually test the reported case (the version deletion) you can install an object cache and modify its `wp_cache_delete` method so that it returns null, e.g.:

```php
function wp_cache_delete( $key, $group = '' ) {
        global $wp_object_cache;

        $wp_object_cache->delete( $key, $group );

        return null;
}
```

Then run the following in wp shell, it should fail without the fix and yield `true` with the fix:

```php
$g = wc_get_container()->get(Automattic\WooCommerce\Internal\Caches\VersionStringGenerator::class)
$g->delete_version('foo')
```

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
