### PR TITLE
Defer `has_products()` check to shutdown hook for bulk delete/trash

### DIFF
--- a/plugins/woocommerce/changelog/63261-fix-products-task-bulk-trash-performance
+++ b/plugins/woocommerce/changelog/63261-fix-products-task-bulk-trash-performance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Defer has_products() check to shutdown hook for bulk delete/trash products.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When bulk-trashing or bulk-deleting products, `revert_task_completion()` was firing once per product, each triggering a `has_products()` DB query. This defers the check to a shutdown hook, using a static flag so that bulk operations run only a single query at the end of the request.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of https://github.com/woocommerce/woocommerce/issues/56534


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
### Pre-requisites

Enable debug logging in `wp-config.php` by adding `define( 'WP_DEBUG', true );` and `define( 'WP_DEBUG_LOG', true );`.

Add temporary log lines to `Products.php`:
- In `on_product_trashed()`, before `$this->revert_task_completion()`, add: `error_log( '[Products Task] on_product_trashed called for post ' . $post_id );`
- In `on_product_deleted()`, before `$this->revert_task_completion()`, add: `error_log( '[Products Task] on_product_deleted called' );`
- In `has_products()`, after the transient check and before the DB query, add: `error_log( '[Products Task] Running has_products() DB query' );`

### Test 1: Bulk trash triggers only one DB query

1. Create 5 products and publish them.
2. Go to `WooCommerce > Home`, ensure the products task shows as completed.
3. Clear `debug.log`.
4. Go to `Products > All Products`, select all 5 products, choose "Move to Trash" from the bulk actions dropdown, click "Apply".
5. Open `debug.log` and verify there are **5** `on_product_trashed called for post` entries but only **1** `Running has_products() DB query` entry.
6. Go to `WooCommerce > Home`, ensure the products task shows as **incomplete**.

### Test 2: Bulk trash with remaining products

1. Create 5 products and publish them.
2. Go to `WooCommerce > Home`, ensure the products task shows as completed.
3. Clear `debug.log`.
4. Select 3 of the 5 products, bulk trash them.
5. Open `debug.log` and verify there are **3** `on_product_trashed called for post` entries but only **1** `Running has_products() DB query` entry.
6. Go to `WooCommerce > Home`, ensure the products task **still shows as completed**.

### Test 3: Bulk permanent delete triggers only one DB query

3. Go to `Products > All Products`, select all 5, and bulk trash the remaining products.
4. Clear `debug.log`.
5. Go to the "Trash" tab, select all 5, choose "Delete Permanently" from the bulk actions dropdown, click "Apply".
6. Open `debug.log` and verify there are multiple `on_product_deleted called` entries (one per product) but only **1** `Running has_products() DB query` entry.
7. Go to `WooCommerce > Home`, ensure the products task shows as **incomplete**.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Defer has_products() check to shutdown hook for bulk delete/trash products.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
