### PR TITLE
Fix PHP warnings when product categories have non-sequential array keys

### DIFF
--- a/plugins/woocommerce/changelog/63263-fix-wooplug-6280-non-sequential-term-keys
+++ b/plugins/woocommerce/changelog/63263-fix-wooplug-6280-non-sequential-term-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP warnings when product categories have non-sequential array keys due to plugin filters.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -276,11 +276,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 		// Get the custom taxonomy terms in use by this post.
 		$terms = get_the_terms( $post->ID, 'product_cat' );
 
-		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-			// Normalize terms to an array in case filters return a single term object or other non-array value.
-			if ( ! is_array( $terms ) ) {
-				$terms = array( $terms );
-			}
+		if ( ! empty( $terms ) && ! is_wp_error( $terms ) && is_array( $terms ) ) {
 			// Re-index array to ensure sequential keys starting from 0 since filters may remove some keys.
 			$terms = array_values( $terms );
 

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -277,6 +277,9 @@ function wc_product_post_type_link( $permalink, $post ) {
 		$terms = get_the_terms( $post->ID, 'product_cat' );
 
 		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+			// Re-index array to ensure sequential keys starting from 0 since filters may remove some keys.
+			$terms = array_values( $terms );
+
 			// Find the deepest category (most ancestors) for the permalink.
 			$deepest_term      = $terms[0];
 			$deepest_ancestors = $deepest_term->parent ? get_ancestors( $deepest_term->term_id, 'product_cat' ) : array();

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -277,6 +277,10 @@ function wc_product_post_type_link( $permalink, $post ) {
 		$terms = get_the_terms( $post->ID, 'product_cat' );
 
 		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+			// Normalize terms to an array in case filters return a single term object or other non-array value.
+			if ( ! is_array( $terms ) ) {
+				$terms = array( $terms );
+			}
 			// Re-index array to ensure sequential keys starting from 0 since filters may remove some keys.
 			$terms = array_values( $terms );
 

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -607,40 +607,47 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			'product_cat'
 		);
 
-		update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
-		$product_post = get_post( $product->get_id() );
+		$original_permalinks = get_option( 'woocommerce_permalinks' );
+		$filter_callback     = null;
 
-		// Simulate a plugin filter that removes a term without re-indexing the array.
-		// This creates non-sequential keys (e.g., key 0 is removed, leaving only key 1).
-		$filter_callback = function ( $terms, $post_id, $taxonomy ) use ( $category1_term ) {
-			if ( 'product_cat' !== $taxonomy || ! is_array( $terms ) ) {
-				return $terms;
-			}
-			foreach ( $terms as $key => $term ) {
-				if ( $term->term_id === $category1_term['term_id'] ) {
-					unset( $terms[ $key ] ); // Intentionally don't re-index.
-					break;
+		try {
+			update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
+			$product_post = get_post( $product->get_id() );
+
+			// Simulate a plugin filter that removes a term without re-indexing the array.
+			// This creates non-sequential keys (e.g., key 0 is removed, leaving only key 1).
+			$filter_callback = function ( $terms, $post_id, $taxonomy ) use ( $category1_term, $product ) {
+				if ( 'product_cat' !== $taxonomy || ! is_array( $terms ) || $post_id !== $product->get_id() ) {
+					return $terms;
 				}
+				foreach ( $terms as $key => $term ) {
+					if ( $term->term_id === $category1_term['term_id'] ) {
+						unset( $terms[ $key ] ); // Intentionally don't re-index.
+						break;
+					}
+				}
+				return $terms; // Returns array with non-sequential keys.
+			};
+			add_filter( 'get_the_terms', $filter_callback, 10, 3 );
+
+			// This should not trigger PHP warnings about undefined array key 0.
+			$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
+
+			// Should use the remaining category (Category Two).
+			$category2_slug = get_term( $category2_term['term_id'], 'product_cat' )->slug;
+			$this->assertStringContainsString(
+				'/' . $category2_slug . '/',
+				$permalink,
+				'Permalink should contain the remaining category slug after filter removes one'
+			);
+		} finally {
+			if ( null !== $filter_callback ) {
+				remove_filter( 'get_the_terms', $filter_callback, 10 );
 			}
-			return $terms; // Returns array with non-sequential keys.
-		};
-		add_filter( 'get_the_terms', $filter_callback, 10, 3 );
-
-		// This should not trigger PHP warnings about undefined array key 0.
-		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
-
-		remove_filter( 'get_the_terms', $filter_callback, 10 );
-
-		// Should use the remaining category (Category Two).
-		$category2_slug = get_term( $category2_term['term_id'], 'product_cat' )->slug;
-		$this->assertStringContainsString(
-			'/' . $category2_slug . '/',
-			$permalink,
-			'Permalink should contain the remaining category slug after filter removes one'
-		);
-
-		WC_Helper_Product::delete_product( $product->get_id() );
-		wp_delete_term( $category2_term['term_id'], 'product_cat' );
-		wp_delete_term( $category1_term['term_id'], 'product_cat' );
+			update_option( 'woocommerce_permalinks', $original_permalinks );
+			WC_Helper_Product::delete_product( $product->get_id() );
+			wp_delete_term( $category2_term['term_id'], 'product_cat' );
+			wp_delete_term( $category1_term['term_id'], 'product_cat' );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -591,4 +591,56 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 		wp_delete_term( $category_term['term_id'], 'product_cat' );
 	}
+
+	/**
+	 * @testdox Product permalink handles non-sequential array keys from get_the_terms filters.
+	 */
+	public function test_wc_product_post_type_link_handles_non_sequential_term_array_keys() {
+		// Create categories.
+		$category1_term = wp_insert_term( 'Category One', 'product_cat' );
+		$category2_term = wp_insert_term( 'Category Two', 'product_cat' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		wp_set_object_terms(
+			$product->get_id(),
+			array( $category1_term['term_id'], $category2_term['term_id'] ),
+			'product_cat'
+		);
+
+		update_option( 'woocommerce_permalinks', array( 'product_base' => '/shop/%product_cat%' ) );
+		$product_post = get_post( $product->get_id() );
+
+		// Simulate a plugin filter that removes a term without re-indexing the array.
+		// This creates non-sequential keys (e.g., key 0 is removed, leaving only key 1).
+		$filter_callback = function ( $terms, $post_id, $taxonomy ) use ( $category1_term ) {
+			if ( 'product_cat' !== $taxonomy || ! is_array( $terms ) ) {
+				return $terms;
+			}
+			foreach ( $terms as $key => $term ) {
+				if ( $term->term_id === $category1_term['term_id'] ) {
+					unset( $terms[ $key ] ); // Intentionally don't re-index.
+					break;
+				}
+			}
+			return $terms; // Returns array with non-sequential keys.
+		};
+		add_filter( 'get_the_terms', $filter_callback, 10, 3 );
+
+		// This should not trigger PHP warnings about undefined array key 0.
+		$permalink = wc_product_post_type_link( '/shop/%product_cat%/' . $product_post->post_name . '/', $product_post );
+
+		remove_filter( 'get_the_terms', $filter_callback, 10 );
+
+		// Should use the remaining category (Category Two).
+		$category2_slug = get_term( $category2_term['term_id'], 'product_cat' )->slug;
+		$this->assertStringContainsString(
+			'/' . $category2_slug . '/',
+			$permalink,
+			'Permalink should contain the remaining category slug after filter removes one'
+		);
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wp_delete_term( $category2_term['term_id'], 'product_cat' );
+		wp_delete_term( $category1_term['term_id'], 'product_cat' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes PHP warnings in `wc-product-functions.php` that occur after WooCommerce 10.5 when plugins filter `get_the_terms` and remove elements without re-indexing the array:

- `Warning: Undefined array key 0`
- `Warning: Attempt to read property "parent" on null`
- `Warning: Attempt to read property "term_id" on null`

**Root Cause:** The code assumes `$terms[0]` exists after calling `get_the_terms()`. However, plugins like ["Hide Categories Products WooCommerce"](https://wordpress.org/plugins/hide-categories-products-woocommerce/) may filter out categories using `unset($terms[$key])` without calling `array_values()` to re-index, leaving non-sequential keys.

**Fix:** Add `$terms = array_values($terms);` before accessing `$terms[0]` to ensure sequential keys starting from 0.

Closes #63187 WOOPLUG-6280.

Bug introduced in PR #62321.

### How to test the changes in this Pull Request:

1. Set permalink structure to "Shop base with category" in Settings > Permalinks
2. Create a product with at least one category assigned.
3. Add a filter that simulates a plugin removing a category without re-indexing:
   ```php
   add_filter('get_the_terms', function($terms, $post_id, $taxonomy) {
       if ('product_cat' === $taxonomy && is_array($terms) && !empty($terms)) {
           $first_key = array_key_first($terms);
           unset($terms[$first_key]); // Remove without re-indexing
       }
       return $terms;
   }, 10, 3);
   ```
4. Visit the product page or any page that generates the product permalink.
5. **Before fix:** PHP warnings appear in error logs.
6. **After fix:** No PHP warnings, permalink generates correctly using the remaining category.

### Testing that has already taken place:

- PHP linting passed (`pnpm lint:php:changes`)
- PHPStan analysis passed with no errors
- Added unit test that simulates a plugin filter removing a term without re-indexing

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix PHP warnings when product categories have non-sequential array keys due to plugin filters.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>