### PR TITLE
Replaces @since annotations from library with @internal.

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -26,7 +26,7 @@ use WP_Http;
  * Controller for the REST endpoints associated with push notification device
  * tokens.
  *
- * @since 10.6.0
+ * @internal
  *
  * @internal
  */
@@ -48,7 +48,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the WooCommerce REST API namespace for the class.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @return string
 	 */
@@ -59,7 +59,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Register the REST API endpoints handled by this controller.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @return void
 	 */
@@ -96,7 +96,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Creates a push token record.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
@@ -135,7 +135,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Deletes a push token record.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
@@ -172,7 +172,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Validates the arguments from the request via PushTokenValidator.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed           $value The value being validated.
 	 * @param WP_REST_Request $request The request object.
@@ -187,7 +187,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the schema for the POST endpoint.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @return array[]
 	 */
@@ -217,7 +217,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Checks user is authorized to access this endpoint.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
@@ -252,7 +252,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Converts an exception to an instance of WP_Error.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param Exception $e The exception to convert.
 	 * @return WP_Error
@@ -289,7 +289,7 @@ class PushTokenRestController extends RestApiControllerBase {
 	/**
 	 * Get the accepted arguments for the POST request.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param string $context The context to return args for.
 	 * @return array

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -27,8 +27,6 @@ use WP_Http;
  * tokens.
  *
  * @internal
- *
- * @internal
  */
 class PushTokenRestController extends RestApiControllerBase {
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -20,7 +20,7 @@ use WP_Query;
 /**
  * Data store class for push tokens.
  *
- * @since 10.5.0
+ * @internal
  */
 class PushTokensDataStore {
 	const SUPPORTED_META = array(
@@ -33,7 +33,7 @@ class PushTokensDataStore {
 	/**
 	 * Creates a post representing the push token.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param array $data Token data with keys: user_id, token, platform, device_uuid (optional), origin.
 	 * @throws PushTokenInvalidDataException If the token data is invalid.
 	 * @throws WC_Data_Exception If the token creation fails.
@@ -76,7 +76,7 @@ class PushTokensDataStore {
 	/**
 	 * Gets post representing a push token.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param int $id The push token ID.
 	 * @throws PushTokenInvalidDataException If the ID is invalid.
 	 * @throws PushTokenNotFoundException If the token can't be found.
@@ -118,7 +118,7 @@ class PushTokensDataStore {
 	/**
 	 * Updates a post representing the push token.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param PushToken $push_token The push token to update.
 	 * @throws PushTokenInvalidDataException If the token can't be updated.
 	 * @throws WC_Data_Exception If the token update fails.
@@ -162,7 +162,7 @@ class PushTokensDataStore {
 	/**
 	 * Deletes a push token.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param int $id The push token ID.
 	 * @throws PushTokenNotFoundException If the token can't be found.
 	 * @return bool True on success.
@@ -184,7 +184,7 @@ class PushTokensDataStore {
 	 * per device, therefore if we already have one then we can update it to
 	 * avoid creating a duplicate.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param array $data Token data with keys: user_id, platform, origin, token (optional), device_uuid (optional).
 	 * @return null|PushToken
 	 * @throws PushTokenInvalidDataException If push token is missing data.
@@ -290,7 +290,7 @@ class PushTokensDataStore {
 	 * Returns an associative array of post meta as key => value pairs for the
 	 * keys defined in SUPPORTED_META; missing keys return null.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param int $id The push token ID.
 	 * @return array
 	 */
@@ -315,7 +315,7 @@ class PushTokensDataStore {
 	 * Returns an associative array of post meta as key => value pairs, built
 	 * using push token properties.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @param PushToken $push_token An instance of PushToken.
 	 * @return array
 	 */

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Validators\PushTokenValida
 /**
  * Object representation of a push token.
  *
- * @since 10.4.0
+ * @internal
  */
 class PushToken {
 	/**
@@ -128,7 +128,7 @@ class PushToken {
 	 * @param array $data Optional array with keys: id, user_id, token, device_uuid, platform, origin.
 	 * @throws PushTokenInvalidDataException If any of the provided values fail validation.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	public function __construct( array $data = array() ) {
 		if ( array_key_exists( 'id', $data ) ) {
@@ -163,7 +163,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If ID is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_id( int $id ): void {
 		$result = PushTokenValidator::validate( compact( 'id' ), array( 'id' ) );
@@ -183,7 +183,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If user ID is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_user_id( int $user_id ): void {
 		$result = PushTokenValidator::validate( compact( 'user_id' ), array( 'user_id' ) );
@@ -203,7 +203,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If token is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_token( string $token ): void {
 		$result = PushTokenValidator::validate( compact( 'token' ), array( 'token' ) );
@@ -223,7 +223,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If device UUID is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_device_uuid( ?string $device_uuid ): void {
 		$result = PushTokenValidator::validate( compact( 'device_uuid' ), array( 'device_uuid' ) );
@@ -247,7 +247,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If platform is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_platform( string $platform ): void {
 		$result = PushTokenValidator::validate( compact( 'platform' ), array( 'platform' ) );
@@ -267,7 +267,7 @@ class PushToken {
 	 * @throws PushTokenInvalidDataException If origin is not valid.
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function set_origin( string $origin ): void {
 		$result = PushTokenValidator::validate( compact( 'origin' ), array( 'origin' ) );
@@ -285,7 +285,7 @@ class PushToken {
 	 *
 	 * @return int|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_id(): ?int {
 		return $this->id;
@@ -296,7 +296,7 @@ class PushToken {
 	 *
 	 * @return int|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_user_id(): ?int {
 		return $this->user_id;
@@ -307,7 +307,7 @@ class PushToken {
 	 *
 	 * @return string|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_token(): ?string {
 		return $this->token;
@@ -318,7 +318,7 @@ class PushToken {
 	 *
 	 * @return string|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_device_uuid(): ?string {
 		return $this->device_uuid;
@@ -329,7 +329,7 @@ class PushToken {
 	 *
 	 * @return string|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_platform(): ?string {
 		return $this->platform;
@@ -340,7 +340,7 @@ class PushToken {
 	 *
 	 * @return string|null
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function get_origin(): ?string {
 		return $this->origin;
@@ -351,7 +351,7 @@ class PushToken {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function can_be_created(): bool {
 		return ! $this->get_id() && $this->has_required_parameters();
@@ -362,7 +362,7 @@ class PushToken {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function can_be_updated(): bool {
 		return $this->get_id() && $this->has_required_parameters();
@@ -373,7 +373,7 @@ class PushToken {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function can_be_read(): bool {
 		return (bool) $this->get_id();
@@ -384,7 +384,7 @@ class PushToken {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function can_be_deleted(): bool {
 		return (bool) $this->get_id();
@@ -395,7 +395,7 @@ class PushToken {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	private function has_required_parameters(): bool {
 		return $this->get_user_id()

--- a/plugins/woocommerce/src/Internal/PushNotifications/Exceptions/PushTokenInvalidDataException.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Exceptions/PushTokenInvalidDataException.php
@@ -15,13 +15,13 @@ use WP_Http;
 /**
  * Exception thrown when push token data is invalid.
  *
- * @since 10.6.0
+ * @internal
  */
 class PushTokenInvalidDataException extends WC_Data_Exception {
 	/**
 	 * Constructor.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 * @param string $message The validation error message.
 	 */
 	public function __construct( string $message ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Exceptions/PushTokenNotFoundException.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Exceptions/PushTokenNotFoundException.php
@@ -15,13 +15,13 @@ use WP_Http;
 /**
  * Exception thrown when a push token cannot be found.
  *
- * @since 10.5.0
+ * @internal
  */
 class PushTokenNotFoundException extends WC_Data_Exception {
 	/**
 	 * Constructor.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	public function __construct() {
 		parent::__construct(

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -19,7 +19,7 @@ use Exception;
  *
  * Class for setting up the WooCommerce-driven push notifications.
  *
- * @since 10.4.0
+ * @internal
  */
 class PushNotifications {
 	/**
@@ -49,7 +49,7 @@ class PushNotifications {
 	 *
 	 * @return void
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function register(): void {
 		add_action( 'init', array( $this, 'on_init' ) );
@@ -60,7 +60,7 @@ class PushNotifications {
 	 *
 	 * @return void
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	public function on_init(): void {
 		if ( ! $this->should_be_enabled() ) {
@@ -77,7 +77,7 @@ class PushNotifications {
 	/**
 	 * Registers the push token custom post type.
 	 *
-	 * @since 10.5.0
+	 * @internal
 	 * @return void
 	 */
 	public function register_post_types(): void {
@@ -112,7 +112,7 @@ class PushNotifications {
 	 *
 	 * @return bool
 	 *
-	 * @since 10.4.0
+	 * @internal
 	 */
 	public function should_be_enabled(): bool {
 		if ( null !== $this->enabled ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
@@ -15,7 +15,7 @@ use WP_Error;
 /**
  * Validator class for push tokens.
  *
- * @since 10.6.0
+ * @internal
  */
 class PushTokenValidator {
 	const VALIDATABLE_FIELDS = array(
@@ -30,42 +30,42 @@ class PushTokenValidator {
 	/**
 	 * The error code to return in WP_Errors.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const ERROR_CODE = 'woocommerce_invalid_data';
 
 	/**
 	 * The regex to use when validating device UUID format.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const DEVICE_UUID_FORMAT = '/^[A-Za-z0-9._:-]+$/';
 
 	/**
 	 * The length to validate the device UUID against.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const DEVICE_UUID_MAXIMUM_LENGTH = 255;
 
 	/**
 	 * The length to validate the token against.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const TOKEN_MAXIMUM_LENGTH = 4096;
 
 	/**
 	 * The regex to use when validating Apple token format.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const TOKEN_FORMAT_APPLE = '/^[A-Fa-f0-9]{64}$/';
 
 	/**
 	 * The regex to use when validating Android token format.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 */
 	const TOKEN_FORMAT_ANDROID = '/^[A-Za-z0-9=:_\-+\/]+$/';
 
@@ -73,7 +73,7 @@ class PushTokenValidator {
 	 * Validates the fields defined in `$fields`, or all the list of known
 	 * fields if `$fields` is empty.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param array $data The data to be validated.
 	 * @param array $fields The fields to validate.
@@ -105,7 +105,7 @@ class PushTokenValidator {
 	/**
 	 * Validates ID.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.
@@ -136,7 +136,7 @@ class PushTokenValidator {
 	/**
 	 * Validates user ID.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.
@@ -167,7 +167,7 @@ class PushTokenValidator {
 	/**
 	 * Validates origin.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.
@@ -207,7 +207,7 @@ class PushTokenValidator {
 	/**
 	 * Validates device UUID.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.
@@ -269,7 +269,7 @@ class PushTokenValidator {
 	/**
 	 * Validates platform.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.
@@ -309,7 +309,7 @@ class PushTokenValidator {
 	/**
 	 * Validates token value.
 	 *
-	 * @since 10.6.0
+	 * @internal
 	 *
 	 * @param mixed $value The value to validate.
 	 * @param array $context An array of other values included as context for the validation.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-1973
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change replaces `@since` annotations with `@internal` as CodeRabbit keeps complaining about `@since` annotations being present and `@internal` annotations being missing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
As these changes only touch code comments, there is no functionality to test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
