### PR TITLE
Add new slotfill to the email editor sidebar

### DIFF
--- a/packages/js/email-editor/changelog/stomail-7602-implement-design-for-the-email-post-summary-panel-v2
+++ b/packages/js/email-editor/changelog/stomail-7602-implement-design-for-the-email-post-summary-panel-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add EmailActionsFill allowing extenders to add custom email actions to the sidebar

--- a/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { useMemo } from '@wordpress/element';
+import { createSlotFill } from '@wordpress/components';
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
 	ErrorBoundary,
@@ -27,6 +28,17 @@ const tracking = {
 	recordEventOnce,
 	debouncedRecordEvent,
 };
+
+/**
+ * A slot fill for the email actions section of the email editor.
+ *
+ * This component is used to render the email actions section of the email editor.
+ */
+const { Fill: EmailActionsFill, Slot } = createSlotFill(
+	'WooCommerceEmailEditorPostSummarySection'
+);
+
+export { EmailActionsFill };
 
 export function SettingsPanel() {
 	const SidebarExtensionComponent = useMemo(
@@ -56,6 +68,7 @@ export function SettingsPanel() {
 			className="woocommerce-email-editor__settings-panel"
 		>
 			{ <EmailStatusComponent /> }
+			<Slot />
 			{ <TemplateSelection /> }
 			{ /* @ts-expect-error canCopyContent is missing in @types/wordpress__editor */ }
 			<ErrorBoundary canCopyContent>

--- a/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
@@ -51,23 +51,12 @@ export function SettingsPanel() {
 		[]
 	);
 
-	const EmailStatusComponent = useMemo(
-		() =>
-			applyFilters(
-				'woocommerce_email_editor_setting_sidebar_email_status_component',
-				() => null,
-				tracking
-			) as () => JSX.Element,
-		[]
-	);
-
 	return (
 		<PluginDocumentSettingPanel
 			name="email-settings-panel"
 			title={ __( 'Settings', 'woocommerce' ) }
 			className="woocommerce-email-editor__settings-panel"
 		>
-			{ <EmailStatusComponent /> }
 			<Slot />
 			{ <TemplateSelection /> }
 			{ /* @ts-expect-error canCopyContent is missing in @types/wordpress__editor */ }

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -341,3 +341,17 @@ export {
 	 */
 	isEventTrackingEnabled,
 } from './events';
+
+/**
+ * A slot fill for the post actions section of the email editor above Template Selection.
+ *
+ * This component is used to allow plugins to add content to the post action section of the email editor.
+ *
+ * @example
+ * ```jsx
+ * import { EmailActionsFill } from '@woocommerce/email-editor';
+ *
+ * <EmailActionsFill />
+ * ```
+ */
+export { EmailActionsFill } from './components/sidebar/settings-panel';

--- a/plugins/woocommerce/changelog/stomail-7602-implement-design-for-the-email-post-summary-panel-v2
+++ b/plugins/woocommerce/changelog/stomail-7602-implement-design-for-the-email-post-summary-panel-v2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Email status component in email editor is rendered via a slotfill
+
+

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -14,6 +14,11 @@ import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from '@wordpress/element';
+import {
+	EmailActionsFill,
+	recordEvent as emailEditorRecordEvent,
+} from '@woocommerce/email-editor';
+import { registerPlugin } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -286,13 +291,15 @@ const SidebarSettings = ( {
 };
 
 export function modifySidebar() {
-	addFilter(
-		'woocommerce_email_editor_setting_sidebar_email_status_component',
-		NAME_SPACE,
-		( _originalComponent, tracking ) => {
-			return () => <EmailStatus recordEvent={ tracking.recordEvent } />;
-		}
-	);
+	registerPlugin( 'woocommerce-email-editor-email-status', {
+		scope: 'woocommerce-email-editor',
+		render: () => (
+			<EmailActionsFill>
+				<EmailStatus recordEvent={ emailEditorRecordEvent } />
+			</EmailActionsFill>
+		),
+	} );
+
 	addFilter(
 		'woocommerce_email_editor_setting_sidebar_extension_component',
 		NAME_SPACE,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

  Adds a new `EmailActionsFill` SlotFill to the `@woocommerce/email-editor` package, giving extenders a standard way to inject custom actions into the email editor's sidebar settings panel (above Template
  Selection).

  **What changed:**

  - **`@woocommerce/email-editor`**: Created and exported a new `EmailActionsFill` component backed by a `createSlotFill` slot rendered in the settings panel.
  - **WooCommerce plugin (`email-editor-integration`)**: Migrated the internal `EmailStatus` component to use the new SlotFill via `registerPlugin`, serving as the first consumer and a usage example.

  **Note:** This removes the `woocommerce_email_editor_setting_sidebar_email_status_component` filter, which was used only internally within WooCommerce and was never documented in the list of available filters. The SlotFill is the intended public extensibility point going forward.

Related to STOMAIL-7602 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

  1. Enable the email editor feature (if behind a flag).
  2. Open the email editor for any WooCommerce transactional email.
  3. In the sidebar, open the **Settings** panel.
  4. Verify the **Email Status** component still renders correctly above the template selection.
  5. Verify no console errors related to SlotFill or missing components.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
