### PR TITLE
fix: selectWoo not initializing on layered nav dropdown widget

### DIFF
--- a/plugins/woocommerce/changelog/fix-selectwoo-layered-nav-dropdown
+++ b/plugins/woocommerce/changelog/fix-selectwoo-layered-nav-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix selectWoo not initializing on the layered nav dropdown widget when using the OR query type.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
@@ -297,7 +297,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			echo '</form>';
 
 			$handle = 'wc-widget-dropdown-layered-nav-' . $taxonomy_filter_name;
-			wp_register_script( $handle, '', array( 'jquery' ), WC_VERSION, array( 'in_footer' => true ) );
+			wp_register_script( $handle, '', array( 'jquery', 'selectWoo' ), WC_VERSION, array( 'in_footer' => true ) );
 			wp_enqueue_script( $handle );
 			wp_add_inline_script(
 				$handle,
@@ -306,13 +306,13 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 					jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).on( 'change', function() {
 						var slug = jQuery( this ).val();
 						jQuery( ':input[name=\"filter_" . esc_js( $taxonomy_filter_name ) . "\"]' ).val( slug );
-	
+
 						// Submit form on change if standard dropdown.
 						if ( ! jQuery( this ).attr( 'multiple' ) ) {
 							jQuery( this ).closest( 'form' ).trigger( 'submit' );
 						}
 					});
-	
+
 					// Use Select2 enhancement if possible
 					if ( jQuery().selectWoo ) {
 						var wc_layered_nav_select = function() {


### PR DESCRIPTION
## Summary

Fixes the layered nav dropdown widget (`WC_Widget_Layered_Nav`) widget not applying Select2/selectWoo enhancement when using `OR`

Since #40686 (WooCommerce 8.3.0), frontend scripts are registered with `array( 'strategy' => 'defer' )` by default. The dropdown widget inline scripts register their handles with only `jquery` as a dependency:

```php
wp_register_script( $handle, '', array( 'jquery' ), WC_VERSION, array( 'in_footer' => true ) );
```

In https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/widgets/class-wc-widget-product-categories.php#L244 this is already added.
