### PR TITLE
Email Editor: Move TemplateSelection to EmailActionsFill slot and export for extensibility

### DIFF
--- a/packages/js/email-editor/changelog/add-template-selection-to-email-actions-fill
+++ b/packages/js/email-editor/changelog/add-template-selection-to-email-actions-fill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Move TemplateSelection to EmailActionsFill slot and export TemplateSelection component for extensibility

--- a/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/settings-panel.tsx
@@ -16,7 +16,6 @@ import {
  * Internal dependencies
  */
 import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
-import { TemplateSelection } from './template-selection';
 import {
 	recordEvent,
 	recordEventOnce,
@@ -58,7 +57,6 @@ export function SettingsPanel() {
 			className="woocommerce-email-editor__settings-panel"
 		>
 			<Slot />
-			{ <TemplateSelection /> }
 			{ /* @ts-expect-error canCopyContent is missing in @types/wordpress__editor */ }
 			<ErrorBoundary canCopyContent>
 				{ <SidebarExtensionComponent /> }

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -343,15 +343,64 @@ export {
 } from './events';
 
 /**
- * A slot fill for the post actions section of the email editor above Template Selection.
+ * A Fill component for the email actions slot in the Settings panel.
  *
- * This component is used to allow plugins to add content to the post action section of the email editor.
+ * Use this Fill together with `registerPlugin` to render content in the
+ * email actions slot inside the email editor's Settings panel. Both
+ * EmailStatus and TemplateSelection are rendered through this slot by default.
+ * Registrations can be removed with `unregisterPlugin` and replaced with
+ * custom implementations.
  *
  * @example
  * ```jsx
- * import { EmailActionsFill } from '@woocommerce/email-editor';
+ * import { EmailActionsFill, TemplateSelection } from '@woocommerce/email-editor';
+ * import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
  *
- * <EmailActionsFill />
+ * // Remove the default TemplateSelection from the Settings panel
+ * unregisterPlugin( 'woocommerce-email-editor-template-selection' );
+ *
+ * // Render TemplateSelection in a custom location via registerPlugin
+ * registerPlugin( 'my-custom-template-selection', {
+ *   scope: 'woocommerce-email-editor',
+ *   render: () => (
+ *     <EmailActionsFill>
+ *       <TemplateSelection />
+ *     </EmailActionsFill>
+ *   ),
+ * } );
  * ```
+ *
+ * @since 1.0.0
  */
 export { EmailActionsFill } from './components/sidebar/settings-panel';
+
+/**
+ * A sidebar component for selecting and managing email templates.
+ *
+ * Displays the currently active template with options to edit or swap templates.
+ * This component is rendered by default inside the Settings panel via a
+ * `registerPlugin` registration using `EmailActionsFill`. Consumers can remove
+ * it with `unregisterPlugin` and re-render it in a custom location.
+ *
+ * @example
+ * ```jsx
+ * import { EmailActionsFill, TemplateSelection } from '@woocommerce/email-editor';
+ * import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
+ *
+ * // Remove the default TemplateSelection from the Settings panel
+ * unregisterPlugin( 'woocommerce-email-editor-template-selection' );
+ *
+ * // Render TemplateSelection in a custom location
+ * registerPlugin( 'my-custom-template-selection', {
+ *   scope: 'woocommerce-email-editor',
+ *   render: () => (
+ *     <EmailActionsFill>
+ *       <TemplateSelection />
+ *     </EmailActionsFill>
+ *   ),
+ * } );
+ * ```
+ *
+ * @since 1.0.0
+ */
+export { TemplateSelection } from './components/sidebar/template-selection';

--- a/plugins/woocommerce/changelog/add-template-selection-slotfill-registration
+++ b/plugins/woocommerce/changelog/add-template-selection-slotfill-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Register TemplateSelection via EmailActionsFill for extensibility

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import { useState } from '@wordpress/element';
 import {
 	EmailActionsFill,
+	TemplateSelection,
 	recordEvent as emailEditorRecordEvent,
 } from '@woocommerce/email-editor';
 import { registerPlugin } from '@wordpress/plugins';
@@ -296,6 +297,15 @@ export function modifySidebar() {
 		render: () => (
 			<EmailActionsFill>
 				<EmailStatus recordEvent={ emailEditorRecordEvent } />
+			</EmailActionsFill>
+		),
+	} );
+
+	registerPlugin( 'woocommerce-email-editor-template-selection', {
+		scope: 'woocommerce-email-editor',
+		render: () => (
+			<EmailActionsFill>
+				<TemplateSelection />
 			</EmailActionsFill>
 		),
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Related to https://linear.app/a8c/issue/STOMAIL-7601/toggle-the-email-design-modal-from-within-the-email-editor

Builds on #63269 (EmailActionsFill slot). Moves TemplateSelection into the same `EmailActionsFill` slot so that both EmailStatus and TemplateSelection are rendered via `registerPlugin`, making them individually removable/replaceable by consumers (e.g. woocommerce-next).

**Changes:**

1. **TemplateSelection via EmailActionsFill** — `settings-panel.tsx` no longer renders `<TemplateSelection />` directly. Instead, it goes through the `<Slot />` alongside EmailStatus.

2. **Plugin registration** — `sidebar_settings.tsx` registers `woocommerce-email-editor-template-selection` via `registerPlugin` wrapping `<TemplateSelection />` in `<EmailActionsFill>`, matching the pattern used for EmailStatus.

3. **Exports** — `TemplateSelection` is exported from `@woocommerce/email-editor` so consumers can build custom layouts. `EmailActionsFill` JSDoc updated with usage examples.

**Consumer usage (e.g. woocommerce-next):**

```tsx
import { unregisterPlugin, registerPlugin } from '@wordpress/plugins';
import { EmailActionsFill, TemplateSelection } from '@woocommerce/email-editor';

// Remove from default Settings panel location
unregisterPlugin('woocommerce-email-editor-template-selection', 'woocommerce-email-editor');

// Optionally render in a custom location
registerPlugin('my-custom-template-selection', {
  scope: 'woocommerce-email-editor',
  render: () => (
    <EmailActionsFill>
      <TemplateSelection />
    </EmailActionsFill>
  ),
});
```

### Screenshots or screen recordings:

No visual changes to the default email editor. TemplateSelection renders in its original position by default.

<img width="291" height="137" alt="Screenshot 2026-02-16 at 10 47 05 AM" src="https://github.com/user-attachments/assets/b2351d58-e10b-4136-a1a8-66428047460a" />


### How to test the changes in this Pull Request:

1. Open the email editor for a WooCommerce transactional email.
2. Verify the Settings panel shows EmailStatus, TemplateSelection, and Subject/Settings in the correct order.
3. Verify no console errors.
4. In browser console, test removing the TemplateSelection:
   ```js
   wp.plugins.unregisterPlugin('woocommerce-email-editor-template-selection', 'woocommerce-email-editor');
   ```
5. Verify the TemplateSelection row disappears from the Settings panel.

### Testing that has already taken place:

- ESLint: Clean (no new warnings)
- `pnpm --filter=@woocommerce/email-editor build`: Success
- Admin webpack bundle: No errors
- No PHP changes, so no phpcs/phpstan needed

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Move TemplateSelection to EmailActionsFill slot and export TemplateSelection component for extensible sidebar layouts

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)