### PR TITLE
Add Markdown Product Feed for AI-agent-friendly product data

### DIFF
--- a/plugins/woocommerce/changelog/add-markdown-product-feed
+++ b/plugins/woocommerce/changelog/add-markdown-product-feed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add experimental Markdown Product Feed feature: append ?feed=markdown to any product or archive URL for AI-agent-friendly structured markdown output with checkout links.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -397,6 +397,9 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\Admin\Agentic\AgenticController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ProductFeed\ProductFeed::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\MarkdownProductFeed\MarkdownProductFeedCache::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\MarkdownProductFeed\MarkdownProductFeedController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\MarkdownProductFeed\DiscoveryHandler::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -603,6 +603,18 @@ class FeaturesController {
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'markdown_product_feed'          => array(
+				'name'                         => __( 'Markdown Product Feed', 'woocommerce' ),
+				'description'                  => __(
+					'Enable structured markdown output for product pages. Append ?feed=markdown to any product or product archive URL to get AI-agent-friendly markdown instead of HTML.',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				'is_experimental'              => true,
+				'disable_ui'                   => false,
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 		);
 
 		if ( ! $tracking_enabled ) {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -603,7 +603,7 @@ class FeaturesController {
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
-			'markdown_product_feed'          => array(
+			'markdown_product_feed'              => array(
 				'name'                         => __( 'Markdown Product Feed', 'woocommerce' ),
 				'description'                  => __(
 					'Enable structured markdown output for product pages. Append ?feed=markdown to any product or product archive URL to get AI-agent-friendly markdown instead of HTML.',

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
@@ -11,6 +11,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
 
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
@@ -49,6 +50,7 @@ class DiscoveryHandler implements RegisterHooksInterface {
 		add_action( 'init', array( $this, 'handle_init' ) );
 		add_action( 'template_redirect', array( $this, 'handle_template_redirect' ) );
 		add_filter( 'query_vars', array( $this, 'handle_query_vars' ) );
+		add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_feature_toggle' ), 10, 2 );
 	}
 
 	/**
@@ -103,14 +105,27 @@ class DiscoveryHandler implements RegisterHooksInterface {
 	 * @return void
 	 */
 	public function handle_init(): void {
-		$regex = '^llms\.txt/?$';
+		add_rewrite_rule( '^llms\.txt/?$', 'index.php?wc_llms_txt=1', 'top' );
+	}
 
-		add_rewrite_rule( $regex, 'index.php?wc_llms_txt=1', 'top' );
-
-		if ( false === get_transient( 'wc_markdown_feed_rules_flushed' ) ) {
-			flush_rewrite_rules();
-			set_transient( 'wc_markdown_feed_rules_flushed', 1, DAY_IN_SECONDS );
+	/**
+	 * Flush rewrite rules when the markdown_product_feed feature is toggled.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param string $feature_id The feature that was toggled.
+	 * @param bool   $is_enabled Whether the feature is now enabled.
+	 * @return void
+	 */
+	public function handle_feature_toggle( string $feature_id, bool $is_enabled ): void {
+		unset( $is_enabled );
+		if ( 'markdown_product_feed' !== $feature_id ) {
+			return;
 		}
+
+		flush_rewrite_rules();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * DiscoveryHandler class file.
+ *
+ * Provides discovery mechanisms so AI agents can find the markdown product feed.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Discovery handler for the Markdown Product Feed feature.
+ *
+ * Implements three discovery mechanisms for AI agents:
+ * A) A `<link rel="alternate">` tag in the HTML `<head>` on product/archive pages.
+ * B) An HTTP `Link` response header on product/archive pages.
+ * C) An `llms.txt` endpoint describing the feed capabilities.
+ *
+ * @since 10.6.0
+ */
+class DiscoveryHandler implements RegisterHooksInterface {
+
+	/**
+	 * Register hooks for the discovery mechanisms.
+	 *
+	 * Bails early if the `markdown_product_feed` feature is not enabled.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( 'markdown_product_feed' ) ) {
+			return;
+		}
+
+		add_action( 'wp_head', array( $this, 'handle_wp_head' ) );
+		add_action( 'send_headers', array( $this, 'handle_send_headers' ) );
+		add_action( 'init', array( $this, 'handle_init' ) );
+		add_action( 'template_redirect', array( $this, 'handle_template_redirect' ) );
+		add_filter( 'query_vars', array( $this, 'handle_query_vars' ) );
+	}
+
+	/**
+	 * Output a `<link rel="alternate">` tag for the markdown feed on product and archive pages.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function handle_wp_head(): void {
+		if ( ! $this->is_product_or_archive() ) {
+			return;
+		}
+
+		$url = esc_url( add_query_arg( 'feed', 'markdown' ) );
+
+		echo '<link rel="alternate" type="text/markdown" href="' . $url . '" />' . "\n";
+	}
+
+	/**
+	 * Send an HTTP `Link` response header for the markdown feed on product and archive pages.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function handle_send_headers(): void {
+		if ( ! $this->is_product_or_archive() ) {
+			return;
+		}
+
+		if ( headers_sent() ) {
+			return;
+		}
+
+		$url = esc_url( add_query_arg( 'feed', 'markdown' ) );
+
+		header( 'Link: <' . $url . '>; rel="alternate"; type="text/markdown"' );
+	}
+
+	/**
+	 * Register the rewrite rule for the `llms.txt` endpoint.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function handle_init(): void {
+		$regex = '^llms\.txt/?$';
+
+		add_rewrite_rule( $regex, 'index.php?wc_llms_txt=1', 'top' );
+
+		if ( false === get_transient( 'wc_markdown_feed_rules_flushed' ) ) {
+			flush_rewrite_rules();
+			set_transient( 'wc_markdown_feed_rules_flushed', 1, DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Register the `wc_llms_txt` query variable.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param array $vars The registered query variables.
+	 * @return array The modified query variables.
+	 */
+	public function handle_query_vars( array $vars ): array {
+		$vars[] = 'wc_llms_txt';
+
+		return $vars;
+	}
+
+	/**
+	 * Serve the `llms.txt` content when the `wc_llms_txt` query variable is set.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function handle_template_redirect(): void {
+		if ( ! get_query_var( 'wc_llms_txt' ) ) {
+			return;
+		}
+
+		if ( ! FeaturesUtil::feature_is_enabled( 'markdown_product_feed' ) ) {
+			global $wp_query;
+			$wp_query->set_404();
+			status_header( 404 );
+			return;
+		}
+
+		$store_name  = get_bloginfo( 'name' );
+		$description = get_bloginfo( 'description' );
+		$site_url    = home_url();
+		$shop_url    = wc_get_page_permalink( 'shop' );
+
+		$content = "# {$store_name}\n\n";
+
+		if ( '' !== $description ) {
+			$content .= "> {$description}\n\n";
+		}
+
+		$content .= "## Markdown Product Feed\n\n";
+		$content .= "This store supports structured markdown output for product pages.\n";
+		$content .= "Append `?feed=markdown` to any product or product archive URL.\n\n";
+		$content .= "### URL Patterns\n";
+		$content .= "- Single product: {$site_url}/product/{slug}/?feed=markdown\n";
+		$content .= "- Shop archive: {$shop_url}?feed=markdown\n";
+		$content .= "- Category: {$site_url}/product-category/{slug}/?feed=markdown\n";
+		$content .= "- Tag: {$site_url}/product-tag/{slug}/?feed=markdown\n\n";
+		$content .= "### Response Format\n";
+		$content .= "- Content-Type: text/markdown\n";
+		$content .= "- YAML front matter with store metadata\n";
+		$content .= "- Structured sections: title, price, description, images, attributes, variations\n";
+		$content .= "- Checkout links for direct purchase\n";
+
+		/**
+		 * Filters the llms.txt content before output.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string $content The llms.txt content string.
+		 */
+		$content = apply_filters( 'woocommerce_llms_txt_content', $content );
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
+	}
+
+	/**
+	 * Check whether the current request is for a product page or a product archive.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return bool True if the current page is a single product, the shop, or a product taxonomy archive.
+	 */
+	private function is_product_or_archive(): bool {
+		return is_singular( 'product' ) || is_shop() || is_product_taxonomy();
+	}
+}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/DiscoveryHandler.php
@@ -67,7 +67,7 @@ class DiscoveryHandler implements RegisterHooksInterface {
 
 		$url = esc_url( add_query_arg( 'feed', 'markdown' ) );
 
-		echo '<link rel="alternate" type="text/markdown" href="' . $url . '" />' . "\n";
+		echo '<link rel="alternate" type="text/markdown" href="' . $url . '" />' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $url is escaped via esc_url() above.
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/HtmlToMarkdown.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/HtmlToMarkdown.php
@@ -1,0 +1,624 @@
+<?php
+/**
+ * HTML to Markdown converter for product descriptions.
+ *
+ * Uses WP_HTML_Processor to parse HTML and convert to clean markdown.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+use WP_HTML_Processor;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Converts product description HTML to clean markdown using WP_HTML_Processor.
+ *
+ * This class uses WordPress's HTML5-compliant streaming parser to iterate
+ * through HTML tokens and emit the corresponding markdown. It maintains a
+ * small state stack for list context, links, blockquotes, and table buffering.
+ *
+ * @since 10.6.0
+ */
+class HtmlToMarkdown {
+
+	/**
+	 * Stack tracking nested UL/OL contexts.
+	 *
+	 * Each entry is an associative array with:
+	 *   - 'type'    => 'ul' or 'ol'
+	 *   - 'counter' => int (only used for OL)
+	 *
+	 * @var array<int, array{type: string, counter: int}>
+	 */
+	private array $list_stack = array();
+
+	/**
+	 * Stashed href from the most recent <a> open tag.
+	 *
+	 * @var string|null
+	 */
+	private ?string $link_href = null;
+
+	/**
+	 * Whether the processor is currently inside a <blockquote>.
+	 *
+	 * @var bool
+	 */
+	private bool $in_blockquote = false;
+
+	/**
+	 * Nesting depth for blockquotes (supports nested blockquotes).
+	 *
+	 * @var int
+	 */
+	private int $blockquote_depth = 0;
+
+	/**
+	 * Buffer for accumulating table data.
+	 *
+	 * Structure:
+	 *   - 'rows'       => array of rows, each row is an array of cell strings
+	 *   - 'current_row' => array of cells in the current row
+	 *   - 'in_cell'    => bool whether currently inside a TD/TH
+	 *   - 'cell_text'  => string accumulating text for the current cell
+	 *   - 'has_header'  => bool whether a THEAD was encountered
+	 *   - 'in_thead'    => bool whether currently inside THEAD
+	 *
+	 * @var array|null
+	 */
+	private ?array $table_buffer = null;
+
+	/**
+	 * The markdown output being assembled.
+	 *
+	 * @var string
+	 */
+	private string $output = '';
+
+	/**
+	 * Convert HTML to markdown.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param string $html The HTML string to convert.
+	 * @return string The resulting markdown string.
+	 */
+	public function convert( string $html ): string {
+		$html = trim( $html );
+
+		if ( '' === $html ) {
+			return '';
+		}
+
+		$this->reset_state();
+
+		// Strip script and style elements before parsing — WP_HTML_Processor
+		// aborts when it encounters raw text elements it cannot fully handle.
+		$html = (string) preg_replace( '/<(script|style)\b[^>]*>.*?<\/\1>/si', '', $html );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+
+		if ( null === $processor ) {
+			// If the processor cannot be created, return stripped tags as fallback.
+			return wp_strip_all_tags( $html );
+		}
+
+		while ( $processor->next_token() ) {
+			$type = $processor->get_token_type();
+			$name = $processor->get_token_name();
+
+			if ( null === $name ) {
+				continue;
+			}
+
+			if ( '#text' === $type ) {
+				$this->handle_text( $processor->get_modifiable_text() );
+			} elseif ( '#tag' === $type && ! $processor->is_tag_closer() ) {
+				$this->handle_open_tag( $name, $processor );
+			} elseif ( '#tag' === $type && $processor->is_tag_closer() ) {
+				$this->handle_close_tag( $name );
+			}
+		}
+
+		// Flush any remaining table buffer.
+		if ( null !== $this->table_buffer ) {
+			$this->flush_table();
+		}
+
+		$result = $this->normalize_output( $this->output );
+
+		/**
+		 * Filters the markdown output after HTML-to-markdown conversion.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string $result The converted markdown string.
+		 * @param string $html   The original HTML input.
+		 */
+		return apply_filters( 'woocommerce_markdown_feed_html_convert', $result, $html );
+	}
+
+	/**
+	 * Reset all internal state for a new conversion.
+	 *
+	 * @return void
+	 */
+	private function reset_state(): void {
+		$this->list_stack         = array();
+		$this->link_href          = null;
+		$this->in_blockquote      = false;
+		$this->blockquote_depth   = 0;
+		$this->table_buffer = null;
+		$this->output       = '';
+	}
+
+	/**
+	 * Handle a text token.
+	 *
+	 * @param string $text The text content (already entity-decoded by WP_HTML_Processor).
+	 * @return void
+	 */
+	private function handle_text( string $text ): void {
+		// If we're inside a table cell, buffer the text.
+		if ( null !== $this->table_buffer && $this->table_buffer['in_cell'] ) {
+			$this->table_buffer['cell_text'] .= $text;
+			return;
+		}
+
+		// Apply blockquote line prefixing if needed.
+		if ( $this->in_blockquote ) {
+			$text = $this->prefix_blockquote_lines( $text );
+		}
+
+		$this->output .= $text;
+	}
+
+	/**
+	 * Handle an opening HTML tag.
+	 *
+	 * @param string            $tag_name  The uppercase tag name.
+	 * @param WP_HTML_Processor $processor The processor instance for reading attributes.
+	 * @return void
+	 */
+	private function handle_open_tag( string $tag_name, WP_HTML_Processor $processor ): void {
+		switch ( $tag_name ) {
+			case 'H1':
+			case 'H2':
+			case 'H3':
+			case 'H4':
+			case 'H5':
+			case 'H6':
+				$this->handle_heading_open( $tag_name );
+				break;
+
+			case 'P':
+				// No prefix needed; paragraph break is on close.
+				break;
+
+			case 'STRONG':
+			case 'B':
+				$this->output .= '**';
+				break;
+
+			case 'EM':
+			case 'I':
+				$this->output .= '*';
+				break;
+
+			case 'A':
+				$href            = $processor->get_attribute( 'href' );
+				$this->link_href = is_string( $href ) ? $href : null;
+				$this->output   .= '[';
+				break;
+
+			case 'IMG':
+				$this->handle_img( $processor );
+				break;
+
+			case 'UL':
+				$this->list_stack[] = array(
+					'type'    => 'ul',
+					'counter' => 0,
+				);
+				break;
+
+			case 'OL':
+				$this->list_stack[] = array(
+					'type'    => 'ol',
+					'counter' => 0,
+				);
+				break;
+
+			case 'LI':
+				$this->handle_li_open();
+				break;
+
+			case 'BLOCKQUOTE':
+				++$this->blockquote_depth;
+				$this->in_blockquote = true;
+				$this->output       .= "\n\n" . str_repeat( '> ', $this->blockquote_depth );
+				break;
+
+			case 'BR':
+				$this->output .= "\n";
+				if ( $this->in_blockquote ) {
+					$this->output .= str_repeat( '> ', $this->blockquote_depth );
+				}
+				break;
+
+			case 'TABLE':
+				$this->table_buffer = array(
+					'rows'        => array(),
+					'current_row' => array(),
+					'in_cell'     => false,
+					'cell_text'   => '',
+					'has_header'  => false,
+					'in_thead'    => false,
+				);
+				break;
+
+			case 'THEAD':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['in_thead']   = true;
+					$this->table_buffer['has_header'] = true;
+				}
+				break;
+
+			case 'TBODY':
+			case 'TFOOT':
+				// Structural elements; no markdown output needed.
+				break;
+
+			case 'TR':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['current_row'] = array();
+				}
+				break;
+
+			case 'TD':
+			case 'TH':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['in_cell']   = true;
+					$this->table_buffer['cell_text'] = '';
+				}
+				break;
+
+			case 'HR':
+				$this->output .= "\n\n---\n\n";
+				break;
+
+			case 'CODE':
+				$this->output .= '`';
+				break;
+
+			case 'PRE':
+				$this->output .= "\n\n```\n";
+				break;
+
+			case 'DEL':
+			case 'S':
+				$this->output .= '~~';
+				break;
+
+			case 'SUP':
+				$this->output .= '<sup>';
+				break;
+
+			case 'SUB':
+				$this->output .= '<sub>';
+				break;
+
+			default:
+				// Unknown tags: pass through, just emit text content.
+				break;
+		}
+	}
+
+	/**
+	 * Handle a closing HTML tag.
+	 *
+	 * @param string $tag_name The uppercase tag name.
+	 * @return void
+	 */
+	private function handle_close_tag( string $tag_name ): void {
+		switch ( $tag_name ) {
+			case 'H1':
+			case 'H2':
+			case 'H3':
+			case 'H4':
+			case 'H5':
+			case 'H6':
+				$this->output .= "\n\n";
+				break;
+
+			case 'P':
+				$this->output .= "\n\n";
+				break;
+
+			case 'STRONG':
+			case 'B':
+				$this->output .= '**';
+				break;
+
+			case 'EM':
+			case 'I':
+				$this->output .= '*';
+				break;
+
+			case 'A':
+				$href = $this->link_href ?? '';
+				if ( '' !== $href ) {
+					$this->output .= '](' . $href . ')';
+				} else {
+					$this->output .= ']()';
+				}
+				$this->link_href = null;
+				break;
+
+			case 'UL':
+			case 'OL':
+				if ( ! empty( $this->list_stack ) ) {
+					array_pop( $this->list_stack );
+				}
+				// Add trailing newline after list.
+				$this->output .= "\n";
+				break;
+
+			case 'LI':
+				// No suffix needed; content already emitted inline.
+				break;
+
+			case 'BLOCKQUOTE':
+				--$this->blockquote_depth;
+				$this->in_blockquote = $this->blockquote_depth > 0;
+				$this->output       .= "\n\n";
+				break;
+
+			case 'TABLE':
+				$this->flush_table();
+				break;
+
+			case 'THEAD':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['in_thead'] = false;
+				}
+				break;
+
+			case 'TBODY':
+			case 'TFOOT':
+				// Structural elements; no markdown output needed.
+				break;
+
+			case 'TR':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['rows'][]      = array(
+						'cells'     => $this->table_buffer['current_row'],
+						'is_header' => $this->table_buffer['in_thead'],
+					);
+					$this->table_buffer['current_row'] = array();
+				}
+				break;
+
+			case 'TD':
+			case 'TH':
+				if ( null !== $this->table_buffer ) {
+					$this->table_buffer['current_row'][] = trim( $this->table_buffer['cell_text'] );
+					$this->table_buffer['in_cell']       = false;
+					$this->table_buffer['cell_text']     = '';
+				}
+				break;
+
+			case 'CODE':
+				$this->output .= '`';
+				break;
+
+			case 'PRE':
+				$this->output .= "\n```\n\n";
+				break;
+
+			case 'DEL':
+			case 'S':
+				$this->output .= '~~';
+				break;
+
+			case 'SUP':
+				$this->output .= '</sup>';
+				break;
+
+			case 'SUB':
+				$this->output .= '</sub>';
+				break;
+
+			default:
+				// Unknown tags: no suffix.
+				break;
+		}
+	}
+
+	/**
+	 * Handle a heading open tag with level offset.
+	 *
+	 * Description headings are offset by +2 so they nest under the product title
+	 * in the markdown feed. H1 becomes ###, H2 becomes ####, etc.
+	 *
+	 * @param string $tag_name The heading tag name (H1-H6).
+	 * @return void
+	 */
+	private function handle_heading_open( string $tag_name ): void {
+		$level  = (int) substr( $tag_name, 1 );
+		$level  = min( $level + 2, 6 );
+		$hashes = str_repeat( '#', $level );
+
+		$this->output .= "\n\n" . $hashes . ' ';
+	}
+
+	/**
+	 * Handle an IMG tag (void element).
+	 *
+	 * @param WP_HTML_Processor $processor The processor for reading attributes.
+	 * @return void
+	 */
+	private function handle_img( WP_HTML_Processor $processor ): void {
+		$src = $processor->get_attribute( 'src' );
+		$alt = $processor->get_attribute( 'alt' );
+
+		if ( empty( $src ) || ! is_string( $src ) ) {
+			return;
+		}
+
+		$alt_text = is_string( $alt ) ? $alt : '';
+
+		// If inside a table cell, buffer the image markdown.
+		if ( null !== $this->table_buffer && $this->table_buffer['in_cell'] ) {
+			$this->table_buffer['cell_text'] .= '![' . $alt_text . '](' . $src . ')';
+			return;
+		}
+
+		$this->output .= '![' . $alt_text . '](' . $src . ')';
+	}
+
+	/**
+	 * Handle an LI open tag.
+	 *
+	 * Determines the correct list marker (- or 1.) based on the parent list type
+	 * and handles indentation for nested lists.
+	 *
+	 * @return void
+	 */
+	private function handle_li_open(): void {
+		if ( empty( $this->list_stack ) ) {
+			// No list context; emit as a plain dash.
+			$this->output .= "\n- ";
+			return;
+		}
+
+		$depth  = count( $this->list_stack ) - 1;
+		$indent = str_repeat( '  ', $depth );
+		$list   = &$this->list_stack[ count( $this->list_stack ) - 1 ];
+
+		if ( 'ol' === $list['type'] ) {
+			++$list['counter'];
+			$this->output .= "\n" . $indent . $list['counter'] . '. ';
+		} else {
+			$this->output .= "\n" . $indent . '- ';
+		}
+	}
+
+	/**
+	 * Prefix lines with blockquote markers for nested blockquotes.
+	 *
+	 * @param string $text The text to prefix.
+	 * @return string The text with blockquote prefixes on newlines.
+	 */
+	private function prefix_blockquote_lines( string $text ): string {
+		$prefix = str_repeat( '> ', $this->blockquote_depth );
+
+		return str_replace( "\n", "\n" . $prefix, $text );
+	}
+
+	/**
+	 * Flush the table buffer and emit a markdown table.
+	 *
+	 * @return void
+	 */
+	private function flush_table(): void {
+		if ( null === $this->table_buffer || empty( $this->table_buffer['rows'] ) ) {
+			$this->table_buffer = null;
+			return;
+		}
+
+		$rows               = $this->table_buffer['rows'];
+		$this->table_buffer = null;
+
+		// Determine column count from the widest row.
+		$col_count = 0;
+		foreach ( $rows as $row ) {
+			$cell_count = count( $row['cells'] );
+			if ( $cell_count > $col_count ) {
+				$col_count = $cell_count;
+			}
+		}
+
+		if ( 0 === $col_count ) {
+			return;
+		}
+
+		$has_header_rows = $this->has_header_rows( $rows );
+
+		// If no explicit header, inject a separator row after the first row.
+		if ( ! $has_header_rows ) {
+			$rows[0]['is_header'] = true;
+		}
+
+		$this->output .= "\n\n";
+
+		$header_emitted = false;
+
+		foreach ( $rows as $row ) {
+			$cells = $this->pad_cells( $row['cells'], $col_count );
+
+			$this->output .= '| ' . implode( ' | ', $cells ) . " |\n";
+
+			// Emit separator after the header row.
+			if ( $row['is_header'] && ! $header_emitted ) {
+				$this->output  .= '| ' . implode( ' | ', array_fill( 0, $col_count, '---' ) ) . " |\n";
+				$header_emitted = true;
+			}
+		}
+
+		$this->output .= "\n";
+	}
+
+	/**
+	 * Check if any rows in the table are header rows.
+	 *
+	 * @param array $rows The table rows.
+	 * @return bool Whether any rows are header rows.
+	 */
+	private function has_header_rows( array $rows ): bool {
+		foreach ( $rows as $row ) {
+			if ( $row['is_header'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Pad a cells array to the required column count.
+	 *
+	 * @param array $cells     The cells to pad.
+	 * @param int   $col_count The target column count.
+	 * @return array The padded cells array.
+	 */
+	private function pad_cells( array $cells, int $col_count ): array {
+		$cell_count = count( $cells );
+		while ( $cell_count < $col_count ) {
+			$cells[] = '';
+			++$cell_count;
+		}
+		return $cells;
+	}
+
+	/**
+	 * Normalize the final markdown output.
+	 *
+	 * Collapses excessive blank lines, trims leading/trailing whitespace.
+	 *
+	 * @param string $markdown The raw markdown output.
+	 * @return string The normalized markdown.
+	 */
+	private function normalize_output( string $markdown ): string {
+		// Collapse 3+ consecutive newlines into 2 (one blank line).
+		$markdown = (string) preg_replace( "/\n{3,}/", "\n\n", $markdown );
+
+		return trim( $markdown );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/HtmlToMarkdown.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/HtmlToMarkdown.php
@@ -151,12 +151,12 @@ class HtmlToMarkdown {
 	 * @return void
 	 */
 	private function reset_state(): void {
-		$this->list_stack         = array();
-		$this->link_href          = null;
-		$this->in_blockquote      = false;
-		$this->blockquote_depth   = 0;
-		$this->table_buffer = null;
-		$this->output       = '';
+		$this->list_stack       = array();
+		$this->link_href        = null;
+		$this->in_blockquote    = false;
+		$this->blockquote_depth = 0;
+		$this->table_buffer     = null;
+		$this->output           = '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownArchiveRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownArchiveRenderer.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * MarkdownArchiveRenderer class file.
+ *
+ * Renders archive pages (shop, category, tag) by wrapping multiple product
+ * summaries into a single structured markdown document.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+use WC_Product;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Archive renderer for WooCommerce product feeds.
+ *
+ * Combines individual product summaries from MarkdownRenderer into a
+ * paginated archive page with YAML front matter and navigation links.
+ *
+ * @since 10.6.0
+ */
+class MarkdownArchiveRenderer {
+
+	/**
+	 * The product renderer used for individual product summaries.
+	 *
+	 * @var MarkdownRenderer
+	 */
+	private MarkdownRenderer $renderer;
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param MarkdownRenderer $renderer The product renderer.
+	 */
+	final public function init( MarkdownRenderer $renderer ): void {
+		$this->renderer = $renderer;
+	}
+
+	/**
+	 * Render an archive page as markdown.
+	 *
+	 * Combines product summaries with front matter, heading, and pagination
+	 * navigation into a complete markdown document.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product[] $products Array of products to render as summaries.
+	 * @param array        $context  {
+	 *     Archive context.
+	 *
+	 *     @type string $title          Archive title (e.g., "Shop", "Clothing").
+	 *     @type int    $page           Current page number.
+	 *     @type int    $total_pages    Total number of pages.
+	 *     @type int    $total_products Total product count.
+	 *     @type string $base_url       Base URL for pagination links.
+	 * }
+	 * @return string The complete archive markdown.
+	 */
+	public function render( array $products, array $context ): string {
+		$title          = $context['title'];
+		$page           = $context['page'];
+		$total_pages    = $context['total_pages'];
+		$total_products = $context['total_products'];
+		$base_url       = $context['base_url'];
+
+		$sections = array();
+
+		// Front matter.
+		$sections[] = $this->render_front_matter( $context );
+
+		// Archive heading.
+		$display_total = max( 1, $total_pages );
+		$sections[]    = '# ' . $title . ' - Page ' . $page . ' of ' . $display_total;
+
+		// Product summaries separated by horizontal rules.
+		if ( empty( $products ) ) {
+			$sections[] = 'No products found.';
+		} else {
+			$summaries = array();
+			foreach ( $products as $product ) {
+				$summaries[] = $this->renderer->render_summary( $product );
+			}
+			$sections[] = implode( "\n\n---\n\n", $summaries );
+		}
+
+		// Navigation (only if more than one page).
+		if ( $total_pages > 1 ) {
+			$nav = $this->render_navigation( $page, $total_pages, $base_url );
+			if ( '' !== $nav ) {
+				$sections[] = $nav;
+			}
+		}
+
+		$markdown = implode( "\n\n", $sections );
+
+		/**
+		 * Filters the final archive markdown output.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string       $markdown The rendered archive markdown.
+		 * @param WC_Product[] $products The products that were rendered.
+		 * @param array        $context  The archive context array.
+		 */
+		return apply_filters( 'woocommerce_markdown_feed_archive', $markdown, $products, $context );
+	}
+
+	/**
+	 * Render the YAML front matter block for the archive.
+	 *
+	 * @param array $context The archive context.
+	 * @return string The front matter block including delimiters.
+	 */
+	private function render_front_matter( array $context ): string {
+		$meta = array(
+			'store'          => get_bloginfo( 'name' ),
+			'currency'       => get_woocommerce_currency(),
+			'generated'      => current_datetime()->format( 'c' ),
+			'type'           => 'product_archive',
+			'title'          => $context['title'],
+			'page'           => $context['page'],
+			'total_pages'    => $context['total_pages'],
+			'total_products' => $context['total_products'],
+		);
+
+		/**
+		 * Filters the YAML front matter metadata array.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param array<string, mixed> $meta    The metadata key-value pairs.
+		 * @param WC_Product|null      $product The product being rendered, or null for archives.
+		 */
+		$meta = apply_filters( 'woocommerce_markdown_feed_meta', $meta, null );
+
+		$lines = array( '---' );
+		foreach ( $meta as $key => $value ) {
+			$lines[] = sanitize_key( $key ) . ': ' . $this->sanitize_yaml_value( (string) $value );
+		}
+		$lines[] = '---';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Sanitize a value for YAML front matter output.
+	 *
+	 * Strips newlines and wraps in quotes if the value contains special
+	 * YAML characters that could break parsing.
+	 *
+	 * @param string $value The value to sanitize.
+	 * @return string The sanitized value.
+	 */
+	private function sanitize_yaml_value( string $value ): string {
+		// Strip newlines to prevent injection of additional YAML keys.
+		$value = str_replace( array( "\n", "\r" ), ' ', $value );
+
+		// Quote values that contain characters with special meaning in YAML.
+		if ( preg_match( '/[:#\[\]{}|>*&!%@`]/', $value ) ) {
+			$value = '"' . str_replace( '"', '\\"', $value ) . '"';
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Render the navigation section with previous/next page links.
+	 *
+	 * @param int    $page        Current page number.
+	 * @param int    $total_pages Total number of pages.
+	 * @param string $base_url    Base URL for pagination.
+	 * @return string The navigation section markdown.
+	 */
+	private function render_navigation( int $page, int $total_pages, string $base_url ): string {
+		$lines   = array();
+		$lines[] = '## Navigation';
+		$lines[] = '';
+
+		if ( $page > 1 ) {
+			$prev_url = add_query_arg( 'feed', 'markdown', get_pagenum_link( $page - 1 ) );
+			$lines[]  = '- Previous: [Page ' . ( $page - 1 ) . '](' . $prev_url . ')';
+		}
+
+		if ( $page < $total_pages ) {
+			$next_url = add_query_arg( 'feed', 'markdown', get_pagenum_link( $page + 1 ) );
+			$lines[]  = '- Next: [Page ' . ( $page + 1 ) . '](' . $next_url . ')';
+		}
+
+		return implode( "\n", $lines );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownArchiveRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownArchiveRenderer.php
@@ -95,7 +95,7 @@ class MarkdownArchiveRenderer {
 
 		// Navigation (only if more than one page).
 		if ( $total_pages > 1 ) {
-			$nav = $this->render_navigation( $page, $total_pages, $base_url );
+			$nav = $this->render_navigation( $page, $total_pages );
 			if ( '' !== $nav ) {
 				$sections[] = $nav;
 			}
@@ -176,12 +176,11 @@ class MarkdownArchiveRenderer {
 	/**
 	 * Render the navigation section with previous/next page links.
 	 *
-	 * @param int    $page        Current page number.
-	 * @param int    $total_pages Total number of pages.
-	 * @param string $base_url    Base URL for pagination.
+	 * @param int $page        Current page number.
+	 * @param int $total_pages Total number of pages.
 	 * @return string The navigation section markdown.
 	 */
-	private function render_navigation( int $page, int $total_pages, string $base_url ): string {
+	private function render_navigation( int $page, int $total_pages ): string {
 		$lines   = array();
 		$lines[] = '## Navigation';
 		$lines[] = '';

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownProductFeedCache.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownProductFeedCache.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * MarkdownProductFeedCache class file.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+/**
+ * Cache layer for the Markdown Product Feed feature.
+ *
+ * Uses wp_cache (object cache) with group `wc_markdown_feed` to avoid
+ * re-rendering markdown on every request. Single product caches are keyed
+ * per product ID; archive caches include a version counter so that any
+ * product change invalidates all archive pages at once.
+ *
+ * @since 10.6.0
+ */
+class MarkdownProductFeedCache implements RegisterHooksInterface {
+
+	/**
+	 * Cache group name.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'wc_markdown_feed';
+
+	/**
+	 * Cache key for the archive version counter.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @var string
+	 */
+	private const ARCHIVE_VERSION_KEY = 'md_archive_version';
+
+	/**
+	 * Register hooks for cache invalidation.
+	 *
+	 * Bails early if the `markdown_product_feed` feature is not enabled.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( 'markdown_product_feed' ) ) {
+			return;
+		}
+
+		add_action( 'woocommerce_update_product', array( $this, 'handle_product_change' ) );
+		add_action( 'woocommerce_new_product', array( $this, 'handle_product_change' ) );
+		add_action( 'woocommerce_trash_product', array( $this, 'handle_product_change' ) );
+		add_action( 'woocommerce_before_delete_product', array( $this, 'handle_product_change' ) );
+		add_action( 'woocommerce_update_product_variation', array( $this, 'handle_product_change' ) );
+		add_action( 'woocommerce_new_product_variation', array( $this, 'handle_product_change' ) );
+	}
+
+	/**
+	 * Get cached markdown for a single product.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int $product_id Product ID.
+	 * @return string|null Cached markdown string or null on cache miss.
+	 */
+	public function get_single( int $product_id ): ?string {
+		$cached = wp_cache_get( "md_single_{$product_id}", self::CACHE_GROUP );
+
+		return false === $cached ? null : $cached;
+	}
+
+	/**
+	 * Cache markdown for a single product.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int    $product_id Product ID.
+	 * @param string $content    Markdown content.
+	 * @return void
+	 */
+	public function set_single( int $product_id, string $content ): void {
+		wp_cache_set( "md_single_{$product_id}", $content, self::CACHE_GROUP, $this->get_ttl() );
+	}
+
+	/**
+	 * Get cached markdown for an archive page.
+	 *
+	 * The cache key includes the current archive version so that bumping the
+	 * version automatically causes all old archive keys to miss.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param string $type    Archive type (e.g. 'category', 'tag').
+	 * @param int    $term_id Term ID.
+	 * @param int    $page    Page number.
+	 * @return string|null Cached markdown string or null on cache miss.
+	 */
+	public function get_archive( string $type, int $term_id, int $page ): ?string {
+		$key    = $this->get_archive_cache_key( $type, $term_id, $page );
+		$cached = wp_cache_get( $key, self::CACHE_GROUP );
+
+		return false === $cached ? null : $cached;
+	}
+
+	/**
+	 * Cache markdown for an archive page.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param string $type    Archive type (e.g. 'category', 'tag').
+	 * @param int    $term_id Term ID.
+	 * @param int    $page    Page number.
+	 * @param string $content Markdown content.
+	 * @return void
+	 */
+	public function set_archive( string $type, int $term_id, int $page, string $content ): void {
+		$key = $this->get_archive_cache_key( $type, $term_id, $page );
+		wp_cache_set( $key, $content, self::CACHE_GROUP, $this->get_ttl() );
+	}
+
+	/**
+	 * Invalidate cache for a single product and bump the archive version.
+	 *
+	 * Deleting the single-product cache key and bumping the archive version
+	 * counter ensures that both the individual product page and all archive
+	 * pages are effectively invalidated.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int $product_id Product ID.
+	 * @return void
+	 */
+	public function invalidate_product( int $product_id ): void {
+		wp_cache_delete( "md_single_{$product_id}", self::CACHE_GROUP );
+		$this->bump_archive_version();
+	}
+
+	/**
+	 * Hook callback for product change actions.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int $product_id Product ID.
+	 * @return void
+	 */
+	public function handle_product_change( int $product_id ): void {
+		$this->invalidate_product( $product_id );
+	}
+
+	/**
+	 * Get the current archive version counter.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return int Current archive version, defaults to 1 if not set.
+	 */
+	private function get_archive_version(): int {
+		$version = wp_cache_get( self::ARCHIVE_VERSION_KEY, self::CACHE_GROUP );
+
+		return false === $version ? 1 : (int) $version;
+	}
+
+	/**
+	 * Bump the archive version counter by one.
+	 *
+	 * This causes all existing archive cache keys (which embed the old version)
+	 * to become stale on the next read.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	private function bump_archive_version(): void {
+		$result = wp_cache_incr( self::ARCHIVE_VERSION_KEY, 1, self::CACHE_GROUP );
+
+		if ( false === $result ) {
+			// Key doesn't exist yet; initialize it.
+			wp_cache_set( self::ARCHIVE_VERSION_KEY, 2, self::CACHE_GROUP );
+		}
+	}
+
+	/**
+	 * Build a cache key for an archive page including the current version.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param string $type    Archive type.
+	 * @param int    $term_id Term ID.
+	 * @param int    $page    Page number.
+	 * @return string Cache key.
+	 */
+	private function get_archive_cache_key( string $type, int $term_id, int $page ): string {
+		$version = $this->get_archive_version();
+
+		return "md_archive_{$type}_{$term_id}_{$page}_{$version}";
+	}
+
+	/**
+	 * Get the cache TTL in seconds.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return int Cache TTL in seconds.
+	 */
+	private function get_ttl(): int {
+		/**
+		 * Filter the cache TTL for the markdown product feed.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param int $ttl Cache TTL in seconds. Defaults to HOUR_IN_SECONDS.
+		 */
+		return (int) apply_filters( 'woocommerce_markdown_feed_cache_ttl', HOUR_IN_SECONDS );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownProductFeedController.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownProductFeedController.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * MarkdownProductFeedController class file.
+ *
+ * Main entry point for the markdown product feed feature. Hooks into
+ * template_redirect to intercept requests with ?feed=markdown and routes
+ * them to the appropriate renderer.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use WC_Product;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controller for the Markdown Product Feed feature.
+ *
+ * Intercepts requests with `?feed=markdown` on product and product archive
+ * pages, renders the appropriate markdown output, and serves it with the
+ * correct headers. Implements caching to avoid re-rendering on every request.
+ *
+ * @since 10.6.0
+ */
+class MarkdownProductFeedController implements RegisterHooksInterface {
+
+	/**
+	 * The single-product renderer.
+	 *
+	 * @var MarkdownRenderer
+	 */
+	private MarkdownRenderer $renderer;
+
+	/**
+	 * The archive renderer.
+	 *
+	 * @var MarkdownArchiveRenderer
+	 */
+	private MarkdownArchiveRenderer $archive_renderer;
+
+	/**
+	 * The cache layer.
+	 *
+	 * @var MarkdownProductFeedCache
+	 */
+	private MarkdownProductFeedCache $cache;
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param MarkdownRenderer         $renderer         The product renderer.
+	 * @param MarkdownArchiveRenderer  $archive_renderer The archive renderer.
+	 * @param MarkdownProductFeedCache $cache            The cache layer.
+	 */
+	final public function init(
+		MarkdownRenderer $renderer,
+		MarkdownArchiveRenderer $archive_renderer,
+		MarkdownProductFeedCache $cache
+	): void {
+		$this->renderer         = $renderer;
+		$this->archive_renderer = $archive_renderer;
+		$this->cache            = $cache;
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * Bails early if the `markdown_product_feed` feature is not enabled.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( 'markdown_product_feed' ) ) {
+			return;
+		}
+
+		add_action( 'template_redirect', array( $this, 'handle_template_redirect' ), 5 );
+	}
+
+	/**
+	 * Handle the template_redirect action.
+	 *
+	 * Routes markdown feed requests to the appropriate renderer based on
+	 * the current query context.
+	 *
+	 * @internal
+	 *
+	 * @since 10.6.0
+	 *
+	 * @return void
+	 */
+	public function handle_template_redirect(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$feed = sanitize_text_field( wp_unslash( $_GET['feed'] ?? '' ) );
+
+		if ( 'markdown' !== $feed ) {
+			return;
+		}
+
+		if ( is_singular( 'product' ) ) {
+			$this->serve_single_product();
+		} elseif ( is_shop() || is_product_taxonomy() ) {
+			$this->serve_archive();
+		} else {
+			$this->send_error( 404, 'The markdown feed is only available on product and product archive pages.' );
+		}
+	}
+
+	/**
+	 * Serve a single product as markdown.
+	 *
+	 * @return void
+	 */
+	private function serve_single_product(): void {
+		global $post;
+
+		$product = wc_get_product( $post );
+
+		if ( ! $product || ! $this->renderer->is_feed_visible( $product ) ) {
+			$this->send_error( 404, 'Product not found.' );
+			return;
+		}
+
+		$cached = $this->cache->get_single( $product->get_id() );
+
+		if ( null !== $cached ) {
+			$this->send_markdown( $cached );
+			return;
+		}
+
+		$markdown = $this->renderer->render( $product );
+
+		$this->cache->set_single( $product->get_id(), $markdown );
+
+		$this->send_markdown( $markdown );
+	}
+
+	/**
+	 * Serve an archive page as markdown.
+	 *
+	 * @return void
+	 */
+	private function serve_archive(): void {
+		global $wp_query;
+
+		$products = array();
+
+		if ( ! empty( $wp_query->posts ) ) {
+			foreach ( $wp_query->posts as $archive_post ) {
+				$product = wc_get_product( $archive_post );
+
+				if ( $product instanceof WC_Product && $this->renderer->is_feed_visible( $product ) ) {
+					$products[] = $product;
+				}
+			}
+		}
+
+		$queried_object = get_queried_object();
+
+		if ( $queried_object instanceof \WP_Term ) {
+			$type    = $queried_object->taxonomy;
+			$term_id = $queried_object->term_id;
+			$title   = wp_strip_all_tags( get_the_archive_title() );
+		} else {
+			$type    = 'shop';
+			$term_id = 0;
+			$title   = __( 'Shop', 'woocommerce' );
+		}
+
+		$page           = max( 1, get_query_var( 'paged', 1 ) );
+		$total_pages    = (int) $wp_query->max_num_pages;
+		$total_products = (int) $wp_query->found_posts;
+		$base_url       = add_query_arg( 'feed', 'markdown' );
+
+		// Check cache.
+		$cached = $this->cache->get_archive( $type, $term_id, $page );
+
+		if ( null !== $cached ) {
+			$this->send_markdown( $cached );
+			return;
+		}
+
+		$context = array(
+			'title'          => $title,
+			'page'           => $page,
+			'total_pages'    => $total_pages,
+			'total_products' => $total_products,
+			'base_url'       => $base_url,
+		);
+
+		$markdown = $this->archive_renderer->render( $products, $context );
+
+		$this->cache->set_archive( $type, $term_id, $page, $markdown );
+
+		$this->send_markdown( $markdown );
+	}
+
+	/**
+	 * Send a markdown response with appropriate headers.
+	 *
+	 * @param string $content The markdown content to output.
+	 * @return void
+	 */
+	private function send_markdown( string $content ): void {
+		header( 'Content-Type: text/markdown; charset=utf-8' );
+		header( 'X-Content-Type-Options: nosniff' );
+		header( 'X-Robots-Tag: noindex, nofollow' );
+		header( 'Cache-Control: public, max-age=3600' );
+		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
+	}
+
+	/**
+	 * Send an error response as markdown.
+	 *
+	 * @param int    $status  HTTP status code.
+	 * @param string $message Error message.
+	 * @return void
+	 */
+	private function send_error( int $status, string $message ): void {
+		status_header( $status );
+		$this->send_markdown( "# Error\n\n" . $message );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
@@ -531,7 +531,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
-		/** This filter is documented in wp-includes/post-template.php */
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- Core WP filter, documented in wp-includes/post-template.php.
 		$html = apply_filters( 'the_content', $raw );
 
 		return $this->html_to_markdown->convert( $html );
@@ -551,7 +551,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
-		/** This filter is documented in includes/wc-formatting-functions.php */
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- WC core filter, documented in includes/wc-formatting-functions.php.
 		$html = apply_filters( 'woocommerce_short_description', $raw );
 
 		return $this->html_to_markdown->convert( $html );

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
@@ -531,7 +531,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- Core WP filter, documented in wp-includes/post-template.php.
+		/** This filter is documented in wp-includes/post-template.php */
 		$html = apply_filters( 'the_content', $raw );
 
 		return $this->html_to_markdown->convert( $html );
@@ -551,7 +551,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment -- WC core filter, documented in includes/wc-formatting-functions.php.
+		/** This filter is documented in includes/wc-formatting-functions.php */
 		$html = apply_filters( 'woocommerce_short_description', $raw );
 
 		return $this->html_to_markdown->convert( $html );

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
@@ -531,6 +531,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
+		/** This filter is documented in wp-includes/post-template.php */
 		$html = apply_filters( 'the_content', $raw );
 
 		return $this->html_to_markdown->convert( $html );
@@ -550,6 +551,7 @@ class MarkdownRenderer {
 			return '';
 		}
 
+		/** This filter is documented in includes/wc-formatting-functions.php */
 		$html = apply_filters( 'woocommerce_short_description', $raw );
 
 		return $this->html_to_markdown->convert( $html );

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
@@ -519,20 +519,14 @@ class MarkdownRenderer {
 	/**
 	 * Convert the product full description HTML to markdown.
 	 *
-	 * Applies the_content filter before converting so that shortcodes and
-	 * embeds are expanded.
-	 *
 	 * @param WC_Product $product The product.
 	 * @return string The converted description markdown, or empty string.
 	 */
 	private function convert_description( WC_Product $product ): string {
-		$raw = $product->get_description();
-		if ( '' === $raw ) {
+		$html = $product->get_description();
+		if ( '' === $html ) {
 			return '';
 		}
-
-		/** This filter is documented in wp-includes/post-template.php */
-		$html = apply_filters( 'the_content', $raw );
 
 		return $this->html_to_markdown->convert( $html );
 	}
@@ -540,19 +534,14 @@ class MarkdownRenderer {
 	/**
 	 * Convert the product short description HTML to markdown.
 	 *
-	 * Applies the woocommerce_short_description filter before converting.
-	 *
 	 * @param WC_Product $product The product.
 	 * @return string The converted short description markdown, or empty string.
 	 */
 	private function convert_short_description( WC_Product $product ): string {
-		$raw = $product->get_short_description();
-		if ( '' === $raw ) {
+		$html = $product->get_short_description();
+		if ( '' === $html ) {
 			return '';
 		}
-
-		/** This filter is documented in includes/wc-formatting-functions.php */
-		$html = apply_filters( 'woocommerce_short_description', $raw );
 
 		return $this->html_to_markdown->convert( $html );
 	}

--- a/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
+++ b/plugins/woocommerce/src/Internal/MarkdownProductFeed/MarkdownRenderer.php
@@ -1,0 +1,626 @@
+<?php
+/**
+ * MarkdownRenderer class file.
+ *
+ * Transforms WC_Product objects into structured markdown for the product feed.
+ *
+ * @package Automattic\WooCommerce\Internal\MarkdownProductFeed
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MarkdownProductFeed;
+
+use WC_Product;
+use WC_Product_Variable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Core renderer for WooCommerce products as markdown.
+ *
+ * Converts a WC_Product into a structured markdown document suitable for
+ * AI consumption. Supports full single-product pages and short archive
+ * summaries.
+ *
+ * @since 10.6.0
+ */
+class MarkdownRenderer {
+
+	/**
+	 * HTML-to-markdown converter.
+	 *
+	 * @var HtmlToMarkdown
+	 */
+	private HtmlToMarkdown $html_to_markdown;
+
+	/**
+	 * Map of WooCommerce stock status values to human-readable labels.
+	 *
+	 * @var array<string, string>
+	 */
+	private const STOCK_STATUS_MAP = array(
+		'instock'     => 'In stock',
+		'outofstock'  => 'Out of stock',
+		'onbackorder' => 'On backorder',
+	);
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param HtmlToMarkdown $html_to_markdown The HTML-to-markdown converter.
+	 */
+	final public function init( HtmlToMarkdown $html_to_markdown ): void {
+		$this->html_to_markdown = $html_to_markdown;
+	}
+
+	/**
+	 * Render full product markdown for single product pages.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product $product The product to render.
+	 * @return string The full markdown representation of the product.
+	 */
+	public function render( WC_Product $product ): string {
+		$sections = array();
+
+		// Front matter.
+		$sections[] = $this->render_front_matter( $product );
+
+		// Title.
+		$name       = $product->get_name();
+		$sections[] = '# ' . ( '' !== $name ? $name : 'Product #' . $product->get_id() );
+
+		// Product meta block.
+		$sections[] = $this->render_meta_block( $product );
+
+		// Short description as blockquote.
+		$short_desc = $this->convert_short_description( $product );
+		if ( '' !== $short_desc ) {
+			$sections[] = '> ' . str_replace( "\n", "\n> ", $short_desc );
+		}
+
+		// Full description.
+		$description = $this->convert_description( $product );
+		if ( '' !== $description ) {
+			$sections[] = "## Description\n\n" . $description;
+		}
+
+		// Images.
+		$images = $this->render_images( $product );
+		if ( '' !== $images ) {
+			$sections[] = "## Images\n\n" . $images;
+		}
+
+		// Attributes.
+		$attributes = $this->render_attributes( $product );
+		if ( '' !== $attributes ) {
+			$sections[] = "## Attributes\n\n" . $attributes;
+		}
+
+		// Variations (variable products only).
+		if ( $product instanceof WC_Product_Variable ) {
+			$variations = $this->render_variations( $product );
+			if ( '' !== $variations ) {
+				$sections[] = "## Variations\n\n" . $variations;
+			}
+		}
+
+		// Buy link.
+		$sections[] = "## Buy\n\n[Add to cart](" . $this->get_checkout_link( $product->get_id() ) . ')';
+
+		/**
+		 * Filters the array of markdown sections before joining.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string[]   $sections Array of markdown section strings.
+		 * @param WC_Product $product  The product being rendered.
+		 */
+		$sections = apply_filters( 'woocommerce_markdown_feed_product_sections', $sections, $product );
+
+		$markdown = implode( "\n\n", $sections );
+
+		/**
+		 * Filters the final single-product markdown output.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string     $markdown The rendered markdown string.
+		 * @param WC_Product $product  The product that was rendered.
+		 */
+		return apply_filters( 'woocommerce_markdown_feed_single_product', $markdown, $product );
+	}
+
+	/**
+	 * Render a short summary for archive listings.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product $product The product to summarize.
+	 * @return string The summary markdown.
+	 */
+	public function render_summary( WC_Product $product ): string {
+		$lines = array();
+
+		// Title.
+		$name    = $product->get_name();
+		$lines[] = '## ' . ( '' !== $name ? $name : 'Product #' . $product->get_id() );
+
+		// Compact meta line.
+		$meta_parts = array();
+
+		$sku = $product->get_sku();
+		if ( '' !== $sku ) {
+			$meta_parts[] = '**SKU:** ' . $sku;
+		}
+
+		$price_str = $this->format_price_inline( $product );
+		if ( '' !== $price_str ) {
+			$meta_parts[] = '**Price:** ' . $price_str;
+		}
+
+		$meta_parts[] = '**Stock:** ' . $this->format_stock_status( $product->get_stock_status() );
+
+		$lines[] = implode( ' | ', $meta_parts );
+
+		// Categories.
+		$categories = $this->get_term_names( $product->get_category_ids(), 'product_cat' );
+		if ( '' !== $categories ) {
+			$lines[] = '**Categories:** ' . $categories;
+		}
+
+		// Short description.
+		$short_desc = $this->convert_short_description( $product );
+		if ( '' !== $short_desc ) {
+			$lines[] = '> ' . str_replace( "\n", "\n> ", $short_desc );
+		}
+
+		// Featured image only.
+		$image_id = (int) $product->get_image_id();
+		if ( $image_id ) {
+			$url = wp_get_attachment_image_url( $image_id, 'full' );
+			if ( $url ) {
+				$alt     = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+				$alt_str = is_string( $alt ) && '' !== $alt ? $alt : $product->get_name();
+				$lines[] = '![' . $alt_str . '](' . $url . ')';
+			}
+		}
+
+		// Buy and Details links.
+		$lines[] = '**Buy:** [Add to cart](' . $this->get_checkout_link( $product->get_id() ) . ')';
+		$lines[] = '**Details:** [View product](' . add_query_arg( 'feed', 'markdown', $product->get_permalink() ) . ')';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Check whether a product should be visible in the markdown feed.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product $product The product to check.
+	 * @return bool Whether the product is feed-visible.
+	 */
+	public function is_feed_visible( WC_Product $product ): bool {
+		$visible = 'publish' === $product->get_status()
+			&& 'hidden' !== $product->get_catalog_visibility()
+			&& '' === $product->get_post_password();
+
+		/**
+		 * Filters whether a product is visible in the markdown feed.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param bool       $visible Whether the product is visible.
+		 * @param WC_Product $product The product being checked.
+		 */
+		return (bool) apply_filters( 'woocommerce_markdown_feed_product_visible', $visible, $product );
+	}
+
+	/**
+	 * Render product images as a markdown list.
+	 *
+	 * Includes the featured image and all gallery images with alt text.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product $product The product whose images to render.
+	 * @return string The images as a markdown list, or empty string if none.
+	 */
+	public function render_images( WC_Product $product ): string {
+		$image_ids = array();
+
+		$featured_id = (int) $product->get_image_id();
+		if ( $featured_id ) {
+			$image_ids[] = $featured_id;
+		}
+
+		$gallery_ids = $product->get_gallery_image_ids();
+		if ( ! empty( $gallery_ids ) ) {
+			$image_ids = array_merge( $image_ids, $gallery_ids );
+		}
+
+		if ( empty( $image_ids ) ) {
+			return '';
+		}
+
+		$lines = array();
+		foreach ( $image_ids as $id ) {
+			$id  = (int) $id;
+			$url = wp_get_attachment_image_url( $id, 'full' );
+			if ( ! $url ) {
+				continue;
+			}
+
+			$alt     = get_post_meta( $id, '_wp_attachment_image_alt', true );
+			$alt_str = is_string( $alt ) && '' !== $alt ? $alt : 'Product image';
+
+			$lines[] = '- ![' . $alt_str . '](' . $url . ')' . "\n" . '  Alt: ' . $alt_str;
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Render variations for a variable product.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param WC_Product_Variable $product The variable product.
+	 * @return string The variations as markdown, or empty string if none.
+	 */
+	public function render_variations( WC_Product_Variable $product ): string {
+		$children = $product->get_children();
+
+		if ( empty( $children ) ) {
+			return '';
+		}
+
+		/**
+		 * Filters the maximum number of variations to render in the markdown feed.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param int $max_variations Maximum number of variations. Defaults to 50.
+		 */
+		$max_variations = (int) apply_filters( 'woocommerce_markdown_feed_max_variations', 50 );
+
+		$children = array_slice( $children, 0, $max_variations );
+		$blocks   = array();
+
+		foreach ( $children as $child_id ) {
+			$variation = wc_get_product( $child_id );
+			if ( ! $variation ) {
+				continue;
+			}
+
+			$attributes = $variation->get_attributes();
+			$attr_parts = ! empty( $attributes ) ? array_filter(
+				array_values( $attributes ),
+				static function ( $v ): bool {
+					return '' !== (string) $v;
+				}
+			) : array();
+			$attr_label = ! empty( $attr_parts ) ? implode( ' / ', $attr_parts ) : 'Variation #' . $child_id;
+
+			$lines   = array();
+			$lines[] = '### ' . $attr_label;
+
+			$sku = $variation->get_sku();
+			if ( '' !== $sku ) {
+				$lines[] = '- **SKU:** ' . $sku;
+			}
+
+			$price = $variation->get_price();
+			if ( '' !== $price && null !== $price ) {
+				$lines[] = '- **Price:** ' . $this->format_price( (float) $price );
+			}
+
+			$lines[] = '- **Stock Status:** ' . $this->format_stock_status( $variation->get_stock_status() );
+			$lines[] = '- **Buy:** [Add to cart](' . $this->get_checkout_link( $child_id ) . ')';
+
+			$blocks[] = implode( "\n", $lines );
+		}
+
+		return implode( "\n\n", $blocks );
+	}
+
+	/**
+	 * Generate a checkout link URL for a product.
+	 *
+	 * @since 10.6.0
+	 *
+	 * @param int $product_id The product ID.
+	 * @param int $quantity   The quantity. Defaults to 1.
+	 * @return string The checkout URL.
+	 */
+	public function get_checkout_link( int $product_id, int $quantity = 1 ): string {
+		$url = add_query_arg(
+			array(
+				'products' => $product_id . ':' . $quantity,
+			),
+			home_url( '/checkout-link' )
+		);
+
+		/**
+		 * Filters the checkout link URL for the markdown feed.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param string $url        The checkout URL.
+		 * @param int    $product_id The product ID.
+		 * @param int    $quantity   The quantity.
+		 */
+		return (string) apply_filters( 'woocommerce_markdown_feed_checkout_link', $url, $product_id, $quantity );
+	}
+
+	/**
+	 * Render the YAML front matter block.
+	 *
+	 * @param WC_Product $product The product for context.
+	 * @return string The front matter block including delimiters.
+	 */
+	private function render_front_matter( WC_Product $product ): string {
+		$meta = array(
+			'store'     => get_bloginfo( 'name' ),
+			'currency'  => get_woocommerce_currency(),
+			'generated' => current_datetime()->format( 'c' ),
+			'type'      => 'single_product',
+		);
+
+		/**
+		 * Filters the YAML front matter metadata array.
+		 *
+		 * @since 10.6.0
+		 *
+		 * @param array<string, string> $meta    The metadata key-value pairs.
+		 * @param WC_Product            $product The product being rendered.
+		 */
+		$meta = apply_filters( 'woocommerce_markdown_feed_meta', $meta, $product );
+
+		$lines = array( '---' );
+		foreach ( $meta as $key => $value ) {
+			$lines[] = sanitize_key( $key ) . ': ' . $this->sanitize_yaml_value( (string) $value );
+		}
+		$lines[] = '---';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Escape a string for safe inline markdown output.
+	 *
+	 * Escapes pipe characters (which break table cells) and leading hash
+	 * characters (which create unintended headings).
+	 *
+	 * @param string $text The text to escape.
+	 * @return string The escaped text.
+	 */
+	private function escape_markdown( string $text ): string {
+		$text = str_replace( '|', '\\|', $text );
+		// Escape leading '#' that could be interpreted as headings.
+		$text = (string) preg_replace( '/^(#+)/m', '\\\\$1', $text );
+		return $text;
+	}
+
+	/**
+	 * Sanitize a value for YAML front matter output.
+	 *
+	 * Strips newlines and wraps in quotes if the value contains special
+	 * YAML characters that could break parsing.
+	 *
+	 * @param string $value The value to sanitize.
+	 * @return string The sanitized value.
+	 */
+	private function sanitize_yaml_value( string $value ): string {
+		// Strip newlines to prevent injection of additional YAML keys.
+		$value = str_replace( array( "\n", "\r" ), ' ', $value );
+
+		// Quote values that contain characters with special meaning in YAML.
+		if ( preg_match( '/[:#\[\]{}|>*&!%@`]/', $value ) ) {
+			$value = '"' . str_replace( '"', '\\"', $value ) . '"';
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Render the product meta block (SKU, price, stock, categories, tags).
+	 *
+	 * @param WC_Product $product The product.
+	 * @return string The meta block markdown.
+	 */
+	private function render_meta_block( WC_Product $product ): string {
+		$lines = array();
+
+		$sku = $product->get_sku();
+		if ( '' !== $sku ) {
+			$lines[] = '**SKU:** ' . $sku;
+		}
+
+		$price = $product->get_price();
+		if ( '' !== $price && null !== $price ) {
+			$lines[] = '**Price:** ' . $this->format_price( (float) $price );
+		}
+
+		if ( $product->is_on_sale() ) {
+			$regular = $product->get_regular_price();
+			if ( '' !== $regular && null !== $regular ) {
+				$lines[] = '**Regular Price:** ' . $this->format_price( (float) $regular );
+			}
+
+			$sale = $product->get_sale_price();
+			if ( '' !== $sale && null !== $sale ) {
+				$lines[] = '**Sale Price:** ' . $this->format_price( (float) $sale );
+			}
+		}
+
+		$lines[] = '**Stock Status:** ' . $this->format_stock_status( $product->get_stock_status() );
+
+		$categories = $this->get_term_names( $product->get_category_ids(), 'product_cat' );
+		if ( '' !== $categories ) {
+			$lines[] = '**Categories:** ' . $categories;
+		}
+
+		$tags = $this->get_term_names( $product->get_tag_ids(), 'product_tag' );
+		if ( '' !== $tags ) {
+			$lines[] = '**Tags:** ' . $tags;
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Render the product attributes as a markdown table.
+	 *
+	 * @param WC_Product $product The product.
+	 * @return string The attributes table markdown, or empty string if no attributes.
+	 */
+	private function render_attributes( WC_Product $product ): string {
+		$attributes = $product->get_attributes();
+
+		if ( empty( $attributes ) ) {
+			return '';
+		}
+
+		$lines   = array();
+		$lines[] = '| Attribute | Options |';
+		$lines[] = '|-----------|---------|';
+
+		foreach ( $attributes as $attribute ) {
+			if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
+				$name = wc_attribute_label( $attribute->get_name() );
+
+				if ( $attribute->is_taxonomy() ) {
+					$terms   = wp_get_post_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'names' ) );
+					$options = is_array( $terms ) ? implode( ', ', $terms ) : '';
+				} else {
+					$options = implode( ', ', $attribute->get_options() );
+				}
+
+				$lines[] = '| ' . $this->escape_markdown( $name ) . ' | ' . $this->escape_markdown( $options ) . ' |';
+			}
+		}
+
+		// Only header rows means no attributes were valid.
+		if ( 2 === count( $lines ) ) {
+			return '';
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Convert the product full description HTML to markdown.
+	 *
+	 * Applies the_content filter before converting so that shortcodes and
+	 * embeds are expanded.
+	 *
+	 * @param WC_Product $product The product.
+	 * @return string The converted description markdown, or empty string.
+	 */
+	private function convert_description( WC_Product $product ): string {
+		$raw = $product->get_description();
+		if ( '' === $raw ) {
+			return '';
+		}
+
+		$html = apply_filters( 'the_content', $raw );
+
+		return $this->html_to_markdown->convert( $html );
+	}
+
+	/**
+	 * Convert the product short description HTML to markdown.
+	 *
+	 * Applies the woocommerce_short_description filter before converting.
+	 *
+	 * @param WC_Product $product The product.
+	 * @return string The converted short description markdown, or empty string.
+	 */
+	private function convert_short_description( WC_Product $product ): string {
+		$raw = $product->get_short_description();
+		if ( '' === $raw ) {
+			return '';
+		}
+
+		$html = apply_filters( 'woocommerce_short_description', $raw );
+
+		return $this->html_to_markdown->convert( $html );
+	}
+
+	/**
+	 * Format a stock status value to a human-readable string.
+	 *
+	 * @param string $status The stock status (instock, outofstock, onbackorder).
+	 * @return string The formatted stock status label.
+	 */
+	private function format_stock_status( string $status ): string {
+		return self::STOCK_STATUS_MAP[ $status ] ?? $status;
+	}
+
+	/**
+	 * Format price for inline display in summaries.
+	 *
+	 * Shows current price with strikethrough regular price if on sale.
+	 *
+	 * @param WC_Product $product The product.
+	 * @return string Formatted price string, or empty string if no price.
+	 */
+	private function format_price_inline( WC_Product $product ): string {
+		$price = $product->get_price();
+		if ( '' === $price || null === $price ) {
+			return '';
+		}
+
+		$formatted = $this->format_price( (float) $price );
+
+		if ( $product->is_on_sale() ) {
+			$regular = $product->get_regular_price();
+			if ( '' !== $regular && null !== $regular ) {
+				$formatted .= ' ~~' . $this->format_price( (float) $regular ) . '~~';
+			}
+		}
+
+		return $formatted;
+	}
+
+	/**
+	 * Format a WooCommerce price as plain text (no HTML, no entities).
+	 *
+	 * @param float $amount The price amount.
+	 * @return string The formatted price string.
+	 */
+	private function format_price( float $amount ): string {
+		return html_entity_decode( wp_strip_all_tags( wc_price( $amount ) ), ENT_QUOTES, 'UTF-8' );
+	}
+
+	/**
+	 * Get comma-separated term names for a list of term IDs.
+	 *
+	 * @param int[]  $term_ids The term IDs.
+	 * @param string $taxonomy The taxonomy name.
+	 * @return string Comma-separated term names, or empty string.
+	 */
+	private function get_term_names( array $term_ids, string $taxonomy ): string {
+		if ( empty( $term_ids ) ) {
+			return '';
+		}
+
+		$names = array();
+		foreach ( $term_ids as $term_id ) {
+			$term = get_term( $term_id, $taxonomy );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$names[] = $term->name;
+			}
+		}
+
+		return implode( ', ', $names );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/DiscoveryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/DiscoveryHandlerTest.php
@@ -1,0 +1,137 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\DiscoveryHandler;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the DiscoveryHandler class.
+ */
+class DiscoveryHandlerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var DiscoveryHandler
+	 */
+	private DiscoveryHandler $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new DiscoveryHandler();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_actions( 'wp_head' );
+		remove_all_actions( 'send_headers' );
+		remove_all_actions( 'init' );
+		remove_all_actions( 'template_redirect' );
+		remove_all_filters( 'query_vars' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not register any hooks when the feature is disabled.
+	 */
+	public function test_register_does_nothing_when_feature_disabled(): void {
+		$this->set_feature_enabled( false );
+
+		$this->sut->register();
+
+		$this->assertFalse(
+			has_action( 'wp_head', array( $this->sut, 'handle_wp_head' ) ),
+			'wp_head hook should not be registered when feature is disabled'
+		);
+		$this->assertFalse(
+			has_action( 'send_headers', array( $this->sut, 'handle_send_headers' ) ),
+			'send_headers hook should not be registered when feature is disabled'
+		);
+		$this->assertFalse(
+			has_filter( 'query_vars', array( $this->sut, 'handle_query_vars' ) ),
+			'query_vars filter should not be registered when feature is disabled'
+		);
+
+		$this->reset_feature_mock();
+	}
+
+	/**
+	 * @testdox Should register all hooks when the feature is enabled.
+	 */
+	public function test_register_hooks_when_feature_enabled(): void {
+		$this->set_feature_enabled( true );
+
+		$this->sut->register();
+
+		$this->assertNotFalse(
+			has_action( 'wp_head', array( $this->sut, 'handle_wp_head' ) ),
+			'wp_head hook should be registered when feature is enabled'
+		);
+		$this->assertNotFalse(
+			has_action( 'send_headers', array( $this->sut, 'handle_send_headers' ) ),
+			'send_headers hook should be registered when feature is enabled'
+		);
+		$this->assertNotFalse(
+			has_action( 'init', array( $this->sut, 'handle_init' ) ),
+			'init hook should be registered when feature is enabled'
+		);
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( $this->sut, 'handle_template_redirect' ) ),
+			'template_redirect hook should be registered when feature is enabled'
+		);
+		$this->assertNotFalse(
+			has_filter( 'query_vars', array( $this->sut, 'handle_query_vars' ) ),
+			'query_vars filter should be registered when feature is enabled'
+		);
+
+		$this->reset_feature_mock();
+	}
+
+	/**
+	 * @testdox Should add wc_llms_txt to the query vars array.
+	 */
+	public function test_handle_query_vars_adds_wc_llms_txt(): void {
+		$input  = array( 'existing_var' );
+		$result = $this->sut->handle_query_vars( $input );
+
+		$this->assertContains( 'wc_llms_txt', $result, 'handle_query_vars should add wc_llms_txt to the query vars' );
+		$this->assertContains( 'existing_var', $result, 'Existing query vars should be preserved' );
+	}
+
+	/**
+	 * Replace FeaturesController in the DI container with a mock that returns
+	 * the desired feature state for markdown_product_feed.
+	 *
+	 * @param bool $enabled Whether the feature should be reported as enabled.
+	 */
+	private function set_feature_enabled( bool $enabled ): void {
+		$mock = $this->getMockBuilder( FeaturesController::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'feature_is_enabled' ) )
+			->getMock();
+
+		$mock->method( 'feature_is_enabled' )
+			->willReturnCallback(
+				function ( string $feature_id ) use ( $enabled ) {
+					return 'markdown_product_feed' === $feature_id ? $enabled : false;
+				}
+			);
+
+		wc_get_container()->replace( FeaturesController::class, $mock );
+	}
+
+	/**
+	 * Reset the FeaturesController mock in the DI container.
+	 */
+	private function reset_feature_mock(): void {
+		wc_get_container()->reset_replacement( FeaturesController::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/HtmlToMarkdownTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/HtmlToMarkdownTest.php
@@ -1,0 +1,202 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\HtmlToMarkdown;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the HtmlToMarkdown class.
+ */
+class HtmlToMarkdownTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var HtmlToMarkdown
+	 */
+	private HtmlToMarkdown $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new HtmlToMarkdown();
+	}
+
+	/**
+	 * @testdox Should return empty string when given empty input.
+	 */
+	public function test_converts_empty_string(): void {
+		$result = $this->sut->convert( '' );
+
+		$this->assertSame( '', $result, 'Empty HTML input should produce empty string output' );
+	}
+
+	/**
+	 * @testdox Should convert headings with a level offset of +2.
+	 */
+	public function test_converts_headings_with_level_offset(): void {
+		$result_h1 = $this->sut->convert( '<h1>Title</h1>' );
+		$result_h2 = $this->sut->convert( '<h2>Subtitle</h2>' );
+		$result_h4 = $this->sut->convert( '<h4>Deep heading</h4>' );
+
+		$this->assertStringContainsString( '### Title', $result_h1, 'H1 should become ### (level + 2)' );
+		$this->assertStringContainsString( '#### Subtitle', $result_h2, 'H2 should become #### (level + 2)' );
+		$this->assertStringContainsString( '###### Deep heading', $result_h4, 'H4 should become ###### (capped at 6)' );
+	}
+
+	/**
+	 * @testdox Should convert paragraphs to text with double newlines.
+	 */
+	public function test_converts_paragraphs(): void {
+		$result = $this->sut->convert( '<p>Hello world</p>' );
+
+		$this->assertStringContainsString( 'Hello world', $result, 'Paragraph text should appear in output' );
+	}
+
+	/**
+	 * @testdox Should convert bold and italic inline formatting.
+	 */
+	public function test_converts_bold_and_italic(): void {
+		$result = $this->sut->convert( '<p><strong>bold</strong> and <em>italic</em></p>' );
+
+		$this->assertStringContainsString( '**bold**', $result, 'Strong tags should produce ** wrapping' );
+		$this->assertStringContainsString( '*italic*', $result, 'Em tags should produce * wrapping' );
+	}
+
+	/**
+	 * @testdox Should convert anchor tags to markdown links.
+	 */
+	public function test_converts_links(): void {
+		$result = $this->sut->convert( '<a href="https://example.com">Click here</a>' );
+
+		$this->assertStringContainsString( '[Click here](https://example.com)', $result, 'Anchor tags should become markdown links' );
+	}
+
+	/**
+	 * @testdox Should convert image tags to markdown images.
+	 */
+	public function test_converts_images(): void {
+		$result = $this->sut->convert( '<img src="https://example.com/photo.jpg" alt="A photo">' );
+
+		$this->assertStringContainsString( '![A photo](https://example.com/photo.jpg)', $result, 'Img tags should become markdown images' );
+	}
+
+	/**
+	 * @testdox Should convert unordered lists with dash prefix.
+	 */
+	public function test_converts_unordered_lists(): void {
+		$result = $this->sut->convert( '<ul><li>First</li><li>Second</li></ul>' );
+
+		$this->assertStringContainsString( '- First', $result, 'Unordered list items should have dash prefix' );
+		$this->assertStringContainsString( '- Second', $result, 'Second list item should also have dash prefix' );
+	}
+
+	/**
+	 * @testdox Should convert ordered lists with numbered prefix.
+	 */
+	public function test_converts_ordered_lists(): void {
+		$result = $this->sut->convert( '<ol><li>First</li><li>Second</li></ol>' );
+
+		$this->assertStringContainsString( '1. First', $result, 'First ordered list item should be numbered 1' );
+		$this->assertStringContainsString( '2. Second', $result, 'Second ordered list item should be numbered 2' );
+	}
+
+	/**
+	 * @testdox Should convert nested lists with 2-space indentation.
+	 */
+	public function test_converts_nested_lists(): void {
+		$html   = '<ul><li>Parent</li><ul><li>Child</li></ul></ul>';
+		$result = $this->sut->convert( $html );
+
+		$this->assertStringContainsString( '- Parent', $result, 'Parent list item should have no indentation' );
+		$this->assertStringContainsString( '  - Child', $result, 'Nested list item should have 2-space indentation' );
+	}
+
+	/**
+	 * @testdox Should convert blockquotes with angle bracket prefix.
+	 */
+	public function test_converts_blockquotes(): void {
+		$result = $this->sut->convert( '<blockquote>A quote</blockquote>' );
+
+		$this->assertStringContainsString( '> A quote', $result, 'Blockquote content should be prefixed with > ' );
+	}
+
+	/**
+	 * @testdox Should convert br tags to newlines.
+	 */
+	public function test_converts_line_breaks(): void {
+		$result = $this->sut->convert( '<p>Line one<br>Line two</p>' );
+
+		$this->assertStringContainsString( "Line one\nLine two", $result, 'BR tags should produce newlines' );
+	}
+
+	/**
+	 * @testdox Should convert HTML tables to markdown tables with separators.
+	 */
+	public function test_converts_tables(): void {
+		$html = '<table>'
+			. '<thead><tr><th>Name</th><th>Value</th></tr></thead>'
+			. '<tbody><tr><td>Color</td><td>Red</td></tr></tbody>'
+			. '</table>';
+
+		$result = $this->sut->convert( $html );
+
+		$this->assertStringContainsString( '| Name | Value |', $result, 'Table header row should appear' );
+		$this->assertStringContainsString( '| --- | --- |', $result, 'Table separator row should appear' );
+		$this->assertStringContainsString( '| Color | Red |', $result, 'Table data row should appear' );
+	}
+
+	/**
+	 * @testdox Should strip content inside script and style tags.
+	 */
+	public function test_skips_script_and_style_tags(): void {
+		$html = '<p>Visible</p><script>alert("evil")</script><style>.foo{color:red}</style><p>Also visible</p>';
+
+		$result = $this->sut->convert( $html );
+
+		$this->assertStringContainsString( 'Visible', $result, 'Text outside script/style should remain' );
+		$this->assertStringContainsString( 'Also visible', $result, 'Text after script/style should remain' );
+		$this->assertStringNotContainsString( 'alert', $result, 'Script content should be stripped' );
+		$this->assertStringNotContainsString( '.foo', $result, 'Style content should be stripped' );
+	}
+
+	/**
+	 * @testdox Should handle malformed HTML without crashing.
+	 */
+	public function test_handles_malformed_html(): void {
+		$html = '<p>Unclosed paragraph<div>Mixed <b>nesting</i></div>';
+
+		$result = $this->sut->convert( $html );
+
+		$this->assertIsString( $result, 'Malformed HTML should still produce a string result' );
+		$this->assertStringContainsString( 'Unclosed paragraph', $result, 'Text content should still be extracted from malformed HTML' );
+	}
+
+	/**
+	 * @testdox Should apply the woocommerce_markdown_feed_html_convert filter.
+	 */
+	public function test_applies_filter(): void {
+		$filter_called = false;
+
+		add_filter(
+			'woocommerce_markdown_feed_html_convert',
+			function ( $result, $html ) use ( &$filter_called ) {
+				$filter_called = true;
+				return $result . ' [filtered]';
+			},
+			10,
+			2
+		);
+
+		$result = $this->sut->convert( '<p>Test</p>' );
+
+		$this->assertTrue( $filter_called, 'The woocommerce_markdown_feed_html_convert filter should be called' );
+		$this->assertStringContainsString( '[filtered]', $result, 'Filter modification should be reflected in output' );
+
+		remove_all_filters( 'woocommerce_markdown_feed_html_convert' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/HtmlToMarkdownTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/HtmlToMarkdownTest.php
@@ -185,6 +185,7 @@ class HtmlToMarkdownTest extends WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_markdown_feed_html_convert',
 			function ( $result, $html ) use ( &$filter_called ) {
+				unset( $html ); // Avoid parameter not used PHPCS errors.
 				$filter_called = true;
 				return $result . ' [filtered]';
 			},

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownProductFeedCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownProductFeedCacheTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\MarkdownProductFeedCache;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the MarkdownProductFeedCache class.
+ */
+class MarkdownProductFeedCacheTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var MarkdownProductFeedCache
+	 */
+	private MarkdownProductFeedCache $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new MarkdownProductFeedCache();
+	}
+
+	/**
+	 * @testdox Should return null when no single product cache exists.
+	 */
+	public function test_get_single_returns_null_on_cache_miss(): void {
+		$result = $this->sut->get_single( 99999 );
+
+		$this->assertNull( $result, 'Fresh cache should return null for get_single' );
+	}
+
+	/**
+	 * @testdox Should store and retrieve single product cache correctly.
+	 */
+	public function test_set_and_get_single(): void {
+		$product_id = 12345;
+		$content    = '# Test Product Markdown';
+
+		$this->sut->set_single( $product_id, $content );
+		$result = $this->sut->get_single( $product_id );
+
+		$this->assertSame( $content, $result, 'Cached single product content should match what was stored' );
+	}
+
+	/**
+	 * @testdox Should return null when no archive cache exists.
+	 */
+	public function test_get_archive_returns_null_on_cache_miss(): void {
+		$result = $this->sut->get_archive( 'category', 1, 1 );
+
+		$this->assertNull( $result, 'Fresh cache should return null for get_archive' );
+	}
+
+	/**
+	 * @testdox Should store and retrieve archive cache correctly.
+	 */
+	public function test_set_and_get_archive(): void {
+		$content = '# Archive Page Markdown';
+
+		$this->sut->set_archive( 'category', 5, 1, $content );
+		$result = $this->sut->get_archive( 'category', 5, 1 );
+
+		$this->assertSame( $content, $result, 'Cached archive content should match what was stored' );
+	}
+
+	/**
+	 * @testdox Should return null for single product cache after invalidation.
+	 */
+	public function test_invalidate_product_clears_single_cache(): void {
+		$product_id = 777;
+		$this->sut->set_single( $product_id, '# Cached content' );
+
+		$this->sut->invalidate_product( $product_id );
+		$result = $this->sut->get_single( $product_id );
+
+		$this->assertNull( $result, 'Single product cache should be null after invalidation' );
+	}
+
+	/**
+	 * @testdox Should cause archive cache miss after product invalidation bumps version.
+	 */
+	public function test_invalidate_product_bumps_archive_version(): void {
+		$this->sut->set_archive( 'shop', 0, 1, '# Archive before invalidation' );
+
+		$this->sut->invalidate_product( 1 );
+		$result = $this->sut->get_archive( 'shop', 0, 1 );
+
+		$this->assertNull( $result, 'Archive cache should miss after product invalidation bumps the version' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownProductFeedControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownProductFeedControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\MarkdownProductFeedController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the MarkdownProductFeedController class.
+ */
+class MarkdownProductFeedControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var MarkdownProductFeedController
+	 */
+	private MarkdownProductFeedController $sut;
+
+	/**
+	 * Original FeaturesController instance, stored for tearDown restoration.
+	 *
+	 * @var FeaturesController|null
+	 */
+	private ?FeaturesController $original_features_controller = null;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new MarkdownProductFeedController();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_actions( 'template_redirect' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not register any hooks when the feature is disabled.
+	 */
+	public function test_register_does_nothing_when_feature_disabled(): void {
+		$this->set_feature_enabled( false );
+
+		$priority_before = has_action( 'template_redirect', array( $this->sut, 'handle_template_redirect' ) );
+
+		$this->sut->register();
+
+		$priority_after = has_action( 'template_redirect', array( $this->sut, 'handle_template_redirect' ) );
+
+		$this->assertFalse( $priority_before, 'Hook should not exist before register' );
+		$this->assertFalse( $priority_after, 'Hook should not be added when feature is disabled' );
+
+		$this->reset_feature_mock();
+	}
+
+	/**
+	 * @testdox Should hook template_redirect when the feature is enabled.
+	 */
+	public function test_register_hooks_template_redirect_when_enabled(): void {
+		$this->set_feature_enabled( true );
+
+		$this->sut->register();
+
+		$has_hook = has_action( 'template_redirect', array( $this->sut, 'handle_template_redirect' ) );
+
+		$this->assertNotFalse( $has_hook, 'template_redirect should be hooked when feature is enabled' );
+
+		$this->reset_feature_mock();
+	}
+
+	/**
+	 * Replace FeaturesController in the DI container with a mock that returns
+	 * the desired feature state for markdown_product_feed.
+	 *
+	 * @param bool $enabled Whether the feature should be reported as enabled.
+	 */
+	private function set_feature_enabled( bool $enabled ): void {
+		$mock = $this->getMockBuilder( FeaturesController::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'feature_is_enabled' ) )
+			->getMock();
+
+		$mock->method( 'feature_is_enabled' )
+			->willReturnCallback(
+				function ( string $feature_id ) use ( $enabled ) {
+					return 'markdown_product_feed' === $feature_id ? $enabled : false;
+				}
+			);
+
+		wc_get_container()->replace( FeaturesController::class, $mock );
+	}
+
+	/**
+	 * Reset the FeaturesController mock in the DI container.
+	 */
+	private function reset_feature_mock(): void {
+		wc_get_container()->reset_replacement( FeaturesController::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MarkdownProductFeed/MarkdownRendererTest.php
@@ -1,0 +1,194 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MarkdownProductFeed;
+
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\HtmlToMarkdown;
+use Automattic\WooCommerce\Internal\MarkdownProductFeed\MarkdownRenderer;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the MarkdownRenderer class.
+ */
+class MarkdownRendererTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var MarkdownRenderer
+	 */
+	private MarkdownRenderer $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new MarkdownRenderer();
+		$this->sut->init( new HtmlToMarkdown() );
+	}
+
+	/**
+	 * @testdox Should render a simple product with front matter, title, price, stock status, and buy link.
+	 */
+	public function test_render_simple_product(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Test Widget' );
+		$product->set_regular_price( '29.99' );
+		$product->save();
+
+		$result = $this->sut->render( $product );
+
+		$this->assertStringContainsString( '---', $result, 'Output should contain front matter delimiters' );
+		$this->assertStringContainsString( '# Test Widget', $result, 'Output should contain product name as H1 heading' );
+		$this->assertStringContainsString( '29.99', $result, 'Output should contain the product price' );
+		$this->assertStringContainsString( 'In stock', $result, 'Output should contain stock status' );
+		$this->assertStringContainsString( '/checkout-link', $result, 'Output should contain a checkout link' );
+		$this->assertStringContainsString( 'Add to cart', $result, 'Output should contain add-to-cart text' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should include SKU in the rendered output when product has one.
+	 */
+	public function test_render_includes_sku(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_name( 'SKU Product' );
+		$product->set_sku( 'TEST-001' );
+		$product->save();
+
+		$result = $this->sut->render( $product );
+
+		$this->assertStringContainsString( '**SKU:** TEST-001', $result, 'Output should contain the product SKU' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should include categories in the rendered output when product has them.
+	 */
+	public function test_render_includes_categories(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Categorized Product' );
+
+		$term = wp_insert_term( 'Electronics', 'product_cat' );
+		$product->set_category_ids( array( $term['term_id'] ) );
+		$product->save();
+
+		$result = $this->sut->render( $product );
+
+		$this->assertStringContainsString( '**Categories:** Electronics', $result, 'Output should contain the product category' );
+
+		$product->delete( true );
+		wp_delete_term( $term['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * @testdox Should render a compact summary with H2 heading and pipe-separated meta.
+	 */
+	public function test_render_summary(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Summary Product' );
+		$product->set_regular_price( '15.00' );
+		$product->set_sku( 'SUM-001' );
+		$product->save();
+
+		$result = $this->sut->render_summary( $product );
+
+		$this->assertStringContainsString( '## Summary Product', $result, 'Summary should use H2 heading' );
+		$this->assertStringContainsString( '|', $result, 'Summary meta should be pipe-separated' );
+		$this->assertStringContainsString( '**SKU:** SUM-001', $result, 'Summary should contain SKU' );
+		$this->assertStringContainsString( '15.00', $result, 'Summary should contain price' );
+		$this->assertStringContainsString( 'View product', $result, 'Summary should contain a details link' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should return true for a published product with default visibility.
+	 */
+	public function test_is_feed_visible_returns_true_for_published_product(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_status( 'publish' );
+		$product->set_catalog_visibility( 'visible' );
+		$product->save();
+
+		$result = $this->sut->is_feed_visible( $product );
+
+		$this->assertTrue( $result, 'Published product with visible catalog visibility should be feed-visible' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should return false for a draft product.
+	 */
+	public function test_is_feed_visible_returns_false_for_draft_product(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_status( 'draft' );
+		$product->save();
+
+		$result = $this->sut->is_feed_visible( $product );
+
+		$this->assertFalse( $result, 'Draft product should not be feed-visible' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should return false for a product with hidden catalog visibility.
+	 */
+	public function test_is_feed_visible_returns_false_for_hidden_product(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_status( 'publish' );
+		$product->set_catalog_visibility( 'hidden' );
+		$product->save();
+
+		$result = $this->sut->is_feed_visible( $product );
+
+		$this->assertFalse( $result, 'Hidden product should not be feed-visible' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should return empty string when product has no images.
+	 */
+	public function test_render_images_with_no_images(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_image_id( 0 );
+		$product->set_gallery_image_ids( array() );
+		$product->save();
+
+		$result = $this->sut->render_images( $product );
+
+		$this->assertSame( '', $result, 'Product with no images should return empty string' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should return a checkout link URL containing /checkout-link and products= parameter.
+	 */
+	public function test_get_checkout_link_format(): void {
+		$result = $this->sut->get_checkout_link( 42 );
+
+		$this->assertStringContainsString( '/checkout-link', $result, 'Checkout link should contain /checkout-link path' );
+		$this->assertStringContainsString( 'products=', $result, 'Checkout link should contain products query parameter' );
+		$this->assertStringContainsString( '42', $result, 'Checkout link should contain the product ID' );
+	}
+
+	/**
+	 * @testdox Should include a Variations section when rendering a variable product.
+	 */
+	public function test_render_variable_product_includes_variations(): void {
+		$product = \WC_Helper_Product::create_variation_product();
+
+		$result = $this->sut->render( $product );
+
+		$this->assertStringContainsString( '## Variations', $result, 'Variable product output should contain a Variations section' );
+
+		$product->delete( true );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Add an experimental **Markdown Product Feed** feature that makes WooCommerce product data trivially consumable by AI agents and automation tools.

When enabled (Settings > Advanced > Features), appending `?feed=markdown` to any product URL returns structured markdown instead of HTML, including:

- YAML front matter with store metadata (currency, generation time)
- Product details: name, SKU, price, stock status, categories, tags
- HTML descriptions converted to clean markdown via `WP_HTML_Processor`
- Images with alt text
- Attribute tables
- Variation listings with individual checkout links
- Paginated archive support (shop, category, tag pages)

**Discovery mechanisms** for AI agents:
- `<link rel="alternate" type="text/markdown">` in HTML `<head>` on product/archive pages
- HTTP `Link` response header on product/archive pages
- `/llms.txt` endpoint describing feed capabilities and URL patterns

**Architecture:**
- 6 new classes in `src/Internal/MarkdownProductFeed/`
- Object cache layer with version-based archive invalidation
- Feature-gated via `FeaturesController` (disabled by default, experimental)
- Follows existing `RegisterHooksInterface` pattern

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the feature: WooCommerce > Settings > Advanced > Features > check "Markdown Product Feed"
2. Visit any single product page with `?feed=markdown` appended to the URL
3. Verify the response is `Content-Type: text/markdown` with structured markdown output including front matter, product details, description, images, and a checkout link
4. Visit `/shop/?feed=markdown` — verify paginated archive listing with product summaries
5. Visit `/product-category/{slug}/?feed=markdown` — verify category archive works
6. View source on a product page — confirm `<link rel="alternate" type="text/markdown">` tag in `<head>`
7. `curl -I {product_url}` — confirm `Link:` header is present
8. Visit `/llms.txt` — verify store capability description is returned
9. Disable the feature and confirm: feed returns 404 error, discovery headers disappear, `/llms.txt` returns 404
10. Edit a product and re-request — verify the cached response is invalidated and updated data appears

<!-- End testing instructions -->

### Testing that has already taken place:

- 36 PHPUnit tests passing (68 assertions) covering HtmlToMarkdown conversion, MarkdownRenderer output, cache hit/miss/invalidation, controller routing, and discovery handler hooks
- PHPStan: 0 errors
- PHPCS: clean (only known PSR-4 sniff bug affecting all src/ files)
- Security review: YAML front matter sanitization, markdown escaping, esc_url on headers, nosniff header
- Architecture review: atomic cache version bumping, transient-guarded rewrite flush, edge case handling
- Manual browser testing of single products, archives, llms.txt endpoint

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add experimental Markdown Product Feed feature: append ?feed=markdown to any product or archive URL for AI-agent-friendly structured markdown output with checkout links.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>