### PR TITLE
Fix changelog significance regex to accept LF-only line endings

### DIFF
--- a/tools/monorepo-utils/src/changefile/lib/__tests__/github.ts
+++ b/tools/monorepo-utils/src/changefile/lib/__tests__/github.ts
@@ -231,6 +231,48 @@ describe( 'getChangelogSignificance', () => {
 		);
 	} );
 
+	it( 'should return the selected significance with LF-only line endings', () => {
+		const body =
+			'### Changelog entry\n' +
+			'\n' +
+			'<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->\n' +
+			'\n' +
+			'- [x] Automatically create a changelog entry from the details below.\n' +
+			'\n' +
+			'<details>\n' +
+			'\n' +
+			'#### Significance\n' +
+			'<!-- Choose only one -->\n' +
+			'- [ ] Patch\n' +
+			'- [x] Minor\n' +
+			'- [ ] Major\n' +
+			'\n' +
+			'#### Type\n' +
+			'<!-- Choose only one -->\n' +
+			'- [x] Fix - Fixes an existing bug\n' +
+			'- [ ] Add - Adds functionality\n' +
+			'- [ ] Update - Update existing functionality\n' +
+			'- [ ] Dev - Development related task\n' +
+			'- [ ] Tweak - A minor adjustment to the codebase\n' +
+			'- [ ] Performance - Address performance issues\n' +
+			'- [ ] Enhancement\n' +
+			'\n' +
+			'#### Message ' +
+			'<!-- Add a changelog message here -->\n' +
+			'This is a very useful fix.\n' +
+			'</details>\n' +
+			'<details>\n' +
+			'<summary>Changelog Entry Comment</summary>' +
+			'\n' +
+			'#### Comment ' +
+			`<!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->\n` +
+			'\n' +
+			'</details>';
+
+		const significance = getChangelogSignificance( body );
+		expect( significance ).toBe( 'minor' );
+	} );
+
 	it( 'should error when more than one significance selected', () => {
 		const body =
 			'### Changelog entry\r\n' +
@@ -637,6 +679,51 @@ describe( 'getChangelogDetails', () => {
 		const details = getChangelogDetails( body );
 		expect( details.comment ).toEqual( 'This is a very useful comment.' );
 		expect( details.significance ).toEqual( 'minor' );
+	} );
+
+	it( 'should return the changelog details with LF-only line endings', () => {
+		const body =
+			'### Changelog entry\n' +
+			'\n' +
+			'<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->\n' +
+			'\n' +
+			'- [x] Automatically create a changelog entry from the details below.\n' +
+			'- [ ] This Pull Request does not require a changelog entry. (Comment required below)\n' +
+			'\n' +
+			'<details>\n' +
+			'\n' +
+			'#### Significance\n' +
+			'<!-- Choose only one -->\n' +
+			'- [x] Patch\n' +
+			'- [ ] Minor\n' +
+			'- [ ] Major\n' +
+			'\n' +
+			'#### Type\n' +
+			'<!-- Choose only one -->\n' +
+			'- [x] Fix - Fixes an existing bug\n' +
+			'- [ ] Add - Adds functionality\n' +
+			'- [ ] Update - Update existing functionality\n' +
+			'- [ ] Dev - Development related task\n' +
+			'- [ ] Tweak - A minor adjustment to the codebase\n' +
+			'- [ ] Performance - Address performance issues\n' +
+			'- [ ] Enhancement\n' +
+			'\n' +
+			'#### Message ' +
+			'<!-- Add a changelog message here -->\n' +
+			'This is a very useful fix.\n' +
+			'</details>\n' +
+			'<details>\n' +
+			'<summary>Changelog Entry Comment</summary>' +
+			'\n' +
+			'#### Comment <!-- A comment explaining why there is no changelog --> ' +
+			'\n' +
+			'</details>';
+
+		const details = getChangelogDetails( body );
+		expect( details.significance ).toEqual( 'patch' );
+		expect( details.type ).toEqual( 'fix' );
+		expect( details.message ).toEqual( 'This is a very useful fix.' );
+		expect( details.comment ).toEqual( '' );
 	} );
 
 	it( 'should return details when no changelog required is checked', () => {

--- a/tools/monorepo-utils/src/changefile/lib/github.ts
+++ b/tools/monorepo-utils/src/changefile/lib/github.ts
@@ -68,7 +68,7 @@ export const shouldAutomateNoChangelog = ( body: string ) => {
  * @return {void|string} changelog significance.
  */
 export const getChangelogSignificance = ( body: string ) => {
-	const regex = /\[(?:x|X)\] (Patch|Minor|Major)\r\n/gm;
+	const regex = /\[(?:x|X)\] (Patch|Minor|Major)\r?\n/gm;
 	const matches = body.match( regex );
 
 	if ( matches === null ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `getChangelogSignificance()` function in the changelog automation tooling uses a regex that requires `\r\n` (CRLF) line endings to match the significance checkbox. When PR descriptions are set via `gh pr edit --body` or the GitHub API `PATCH /repos/.../pulls` endpoint, the body arrives with `\n` (LF) line endings instead of `\r\n`, causing the regex to fail with "No changelog significance found".

This PR changes the regex from `\r\n` to `\r?\n` so it accepts both CRLF and LF line endings. Two new test cases with LF-only PR bodies are added to prevent regression.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=monorepo-utils test:js` and verify all 28 tests pass
2. Review the new test cases in `src/changefile/lib/__tests__/github.ts` - they use `\n` instead of `\r\n` and exercise both `getChangelogSignificance` and `getChangelogDetails`
3. Verify the regex change in `src/changefile/lib/github.ts` line 71: `\r\n` became `\r?\n`

<!-- End testing instructions -->

### Testing that has already taken place:

- All 28 tests passing in `src/changefile/lib/__tests__/github.ts`
- Verified existing CRLF tests still pass (no regression)
- Root cause confirmed: `gh pr edit --body` produces LF-only bodies, which the old regex rejected

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Internal tooling fix - does not affect shipped WooCommerce code.

</details>
