### PR TITLE
Extract `get_primed_visible_children()` helper in `WC_Product_Grouped`

### DIFF
--- a/plugins/woocommerce/changelog/63284-refactor-grouped-product-extract-primed-children-helper
+++ b/plugins/woocommerce/changelog/63284-refactor-grouped-product-extract-primed-children-helper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Extract "get_primed_visible_children()" helper in "WC_Product_Grouped".

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -201,7 +201,9 @@ class WC_Product_Grouped extends WC_Product {
 	private function get_primed_visible_children( $context = 'view' ) {
 		$child_ids = $this->get_children( $context );
 		_prime_post_caches( $child_ids );
-		return array_filter( array_map( 'wc_get_product', $child_ids ), 'wc_products_array_filter_visible_grouped' );
+		$children = array_filter( array_map( 'wc_get_product', $child_ids ), 'wc_products_array_filter_visible_grouped' );
+		/** @var WC_Product[] $children */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		return $children;
 	}
 
 	/*

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -62,9 +62,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return bool
 	 */
 	public function is_on_sale( $context = 'view' ) {
-		$child_ids = $this->get_children( $context );
-		_prime_post_caches( $child_ids );
-		$children = array_filter( array_map( 'wc_get_product', $child_ids ), 'wc_products_array_filter_visible_grouped' );
+		$children = $this->get_primed_visible_children( $context );
 		$on_sale  = false;
 
 		foreach ( $children as $child ) {
@@ -95,7 +93,7 @@ class WC_Product_Grouped extends WC_Product {
 	public function get_price_html( $price = '' ) {
 		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
 		$child_prices     = array();
-		$children         = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$children         = $this->get_primed_visible_children();
 
 		foreach ( $children as $child ) {
 			if ( '' !== $child->get_price() ) {
@@ -157,11 +155,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return WC_Product[] Child products
 	 */
 	public function get_visible_children() {
-		$grouped_products = array_map( 'wc_get_product', $this->get_children() );
-		$grouped_products = array_filter( $grouped_products, 'wc_products_array_filter_visible_grouped' );
-		/** @var WC_Product[] $grouped_products */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-
-		return $grouped_products;
+		return $this->get_primed_visible_children();
 	}
 
 	/**
@@ -171,7 +165,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return string Minimum price or empty string if no children
 	 */
 	public function get_min_price() {
-		$children = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$children = $this->get_primed_visible_children();
 		$prices   = array_map( 'wc_get_price_to_display', $children );
 
 		if ( empty( $prices ) ) {
@@ -188,7 +182,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return string Maximum price or empty string if no children
 	 */
 	public function get_max_price() {
-		$children = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$children = $this->get_primed_visible_children();
 		$prices   = array_map( 'wc_get_price_to_display', $children );
 
 		if ( empty( $prices ) ) {
@@ -196,6 +190,18 @@ class WC_Product_Grouped extends WC_Product {
 		}
 
 		return wc_format_decimal( max( $prices ) );
+	}
+
+	/**
+	 * Get visible child products with post caches primed to avoid extra queries.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 * @return WC_Product[] Visible child products.
+	 */
+	private function get_primed_visible_children( $context = 'view' ) {
+		$child_ids = $this->get_children( $context );
+		_prime_post_caches( $child_ids );
+		return array_filter( array_map( 'wc_get_product', $child_ids ), 'wc_products_array_filter_visible_grouped' );
 	}
 
 	/*

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -14065,30 +14065,6 @@ parameters:
 			path: includes/class-wc-product-grouped.php
 
 		-
-			message: '#^Cannot call method get_price\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
-			message: '#^Cannot call method has_child\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
-			message: '#^Cannot call method is_on_sale\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
-			message: '#^Cannot call method is_purchasable\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
 			message: '#^Method WC_Product_Grouped\:\:set_children\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -14098,12 +14074,6 @@ parameters:
 			message: '#^Method WC_Product_Grouped\:\:sync\(\) should return WC_Product but returns WC_Product\|false\|null\.$#'
 			identifier: return.type
 			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
-			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(WC_Product\|false\|null\)\: mixed\)\|null, ''wc_get_price_to…'' given\.$#'
-			identifier: argument.type
-			count: 2
 			path: includes/class-wc-product-grouped.php
 
 		-
@@ -14131,21 +14101,9 @@ parameters:
 			path: includes/class-wc-product-grouped.php
 
 		-
-			message: '#^Parameter \#1 \$product of function wc_get_price_excluding_tax expects WC_Product, WC_Product\|false\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
-			message: '#^Parameter \#1 \$product of function wc_get_price_including_tax expects WC_Product, WC_Product\|false\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-product-grouped.php
-
-		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(WC_Product\|false\|null\)\: bool\)\|null, ''wc_products_array…'' given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 1
 			path: includes/class-wc-product-grouped.php
 
 		-


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Extracts a private `get_primed_visible_children()` helper that calls `_prime_post_caches()` before loading child products. This replaces the repeated `array_map( 'wc_get_product', $this->get_children() )` pattern across `is_on_sale()`, `get_price_html()`, `get_visible_children()`, `get_min_price()`, and `get_max_price()`, ensuring post caches are always primed.

Follow-up to #63267.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin.
2. Remove all existing products and create test products:
   ```bash
   for i in $(seq 1 50); do wp wc product create --name="Child Product $i" --type=simple --regular_price=10 --user=admin; done
   wp wc product create --name="Grouped Product" --type=grouped --grouped_products="$(wp wc product list --type=simple --field=id --user=admin | tr '\n' ',')" --user=admin
   ```
   Replace `admin` with any admin username on the site.

### Query count (no regression)

3. Visit the grouped product page and note the query count from Query Monitor.
4. Compare with `trunk`. The count should be the same or lower, not higher.

### Sale badge (`is_on_sale`)

5. Put one of the child products on sale (set a sale price in the admin).
6. Visit the grouped product page and confirm the sale badge appears.
7. Remove the sale price and confirm the sale badge disappears.

### Price display (`get_price_html`)

8. Set different regular prices on a few child products (e.g., $5, $10, $20).
9. Visit the grouped product page and confirm the price range displays correctly (e.g., "$5.00 – $20.00").
10. Set all children to the same price and confirm a single price displays instead of a range.

### Visible children (`get_visible_children`)

11. Set one of the child products to "Draft" status.
12. Visit the grouped product page as **a guest** and confirm the drafted product does not appear in the child product list.
13. Re-publish the product and confirm it reappears.

### Shop page

14. Visit the shop page and confirm the grouped product shows the correct price and sale badge.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Extract "get_primed_visible_children()" helper in "WC_Product_Grouped".
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
