### PR TITLE
Fix: Redact password-protected product data in Store API

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -525,6 +525,12 @@ class ProductSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $product ) {
+
+		// Check if the product is password protected and return a redacted response if so.
+		if ( post_password_required( $product->get_id() ) ) {
+			return $this->get_protected_product_response( $product );
+		}
+
 		$availability = ProductAvailabilityUtils::get_product_availability( $product );
 		return [
 			'id'                  => $product->get_id(),
@@ -571,6 +577,82 @@ class ProductSchema extends AbstractSchema {
 			self::EXTENDING_KEY   => $this->get_extended_data( self::IDENTIFIER, $product ),
 
 		];
+	}
+
+	/**
+	 * Get redacted response for password-protected products.
+	 * Maintains response structure while hiding sensitive data.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return array Redacted product data.
+	 */
+	protected function get_protected_product_response( $product ) {
+		return [
+			'id'                  => $product->get_id(),
+			'name'                => $this->prepare_html_response( $product->get_title() ),
+			'slug'                => $product->get_slug(),
+			'parent'              => $product->get_parent_id(),
+			'type'                => $product->get_type(),
+			'variation'           => '',
+			'permalink'           => $product->get_permalink(),
+			'sku'                 => '',
+			'short_description'   => '',
+			'description'         => '',
+			'on_sale'             => false,
+			'prices'              => (object) $this->get_empty_price_response(),
+			'price_html'          => '',
+			'average_rating'      => '0',
+			'review_count'        => 0,
+			'images'              => [],
+			'categories'          => [],
+			'tags'                => [],
+			'brands'              => [],
+			'attributes'          => [],
+			'variations'          => [],
+			'grouped_products'    => [],
+			'has_options'         => false,
+			'is_purchasable'      => false,
+			'is_in_stock'         => false,
+			'is_on_backorder'     => false,
+			'low_stock_remaining' => null,
+			'stock_availability'  => (object) [
+				'text'  => '',
+				'class' => '',
+			],
+			'sold_individually'   => false,
+			'add_to_cart'         => (object) [
+				'text'        => '',
+				'description' => '',
+				'url'         => '',
+				'single_text' => '',
+				'minimum'     => 1,
+				'maximum'     => 1,
+				'multiple_of' => 1,
+			],
+			'password_protected'  => true,
+			self::EXTENDING_KEY   => $this->get_extended_data( self::IDENTIFIER, $product ),
+		];
+	}
+
+	/**
+	 * Get empty price response for password-protected products.
+	 * Returns proper price structure with currency info but no actual prices.
+	 *
+	 * @return array Empty price data with currency information.
+	 */
+	protected function get_empty_price_response() {
+
+		$empty_money = $this->prepare_money_response( '', wc_get_price_decimals() );
+		
+		$prices = [
+			'price'         => $empty_money,
+			'regular_price' => $empty_money,
+			'sale_price'    => $empty_money,
+			'price_range'   => null,
+		];
+		
+		// Add currency data using the existing method
+		return $this->prepare_currency_response( $prices );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Added password protection check in `ProductSchema::get_item_response()`
- Created `get_protected_product_response()` method to return redacted product data
- Created `get_empty_price_response()` helper to maintain proper price structure with empty values
- Maintains API response schema while hiding sensitive fields (descriptions, prices, images, SKU, stock, attributes, variations)
- Adds `password_protected: true` flag to indicate protection status

Fixes the exposure of sensitive data for password-protected products in the Store API.

Closes Issue - https://github.com/woocommerce/woocommerce/issues/62980

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:
Response:
```
{
    "id": 72,
    "name": "4th test product",
    "slug": "4th-test-product",
    "parent": 0,
    "type": "simple",
    "variation": "",
    "permalink": "http://<>/product/4th-test-product/",
    "sku": "",
    "short_description": "",
    "description": "",
    "on_sale": false,
    "prices": {
        "price": "0",
        "regular_price": "0",
        "sale_price": "0",
        "price_range": null,
        "currency_code": "INR",
        "currency_symbol": "₹",
        "currency_minor_unit": 2,
        "currency_decimal_separator": ".",
        "currency_thousand_separator": ",",
        "currency_prefix": "₹",
        "currency_suffix": ""
    },
    "price_html": "",
    "average_rating": "0",
    "review_count": 0,
    "images": [],
    "categories": [],
    "tags": [],
    "brands": [],
    "attributes": [],
    "variations": [],
    "grouped_products": [],
    "has_options": false,
    "is_purchasable": false,
    "is_in_stock": false,
    "is_on_backorder": false,
    "low_stock_remaining": null,
    "stock_availability": {
        "text": "",
        "class": ""
    },
    "sold_individually": false,
    "add_to_cart": {
        "text": "",
        "description": "",
        "url": "",
        "single_text": "",
        "minimum": 1,
        "maximum": 1,
        "multiple_of": 1
    },
    "password_protected": true,
    "extensions": {}
}
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
- Create a product, set it as password protected. Note its ID.
- call `/wp-json/wc/store/products/$id`.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
