### PR TITLE
Fix undefined property warnings with HPOS Data Caching enabled

### DIFF
--- a/plugins/woocommerce/changelog/63295-fix_recorded_sales_warning
+++ b/plugins/woocommerce/changelog/63295-fix_recorded_sales_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP "Undefined property" warnings in `set_order_props_from_data` when HPOS Data Caching is enabled and cached objects have missing properties.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1762,7 +1762,7 @@ WHERE
 	protected function set_order_props_from_data( &$order, $order_data ) {
 		foreach ( $this->get_all_order_column_mappings() as $table_name => $column_mapping ) {
 			foreach ( $column_mapping as $column_name => $prop_details ) {
-				if ( ! isset( $prop_details['name'] ) ) {
+				if ( ! isset( $prop_details['name'] ) || ! is_string( $prop_details['name'] ) ) {
 					continue;
 				}
 				if ( ! property_exists( $order_data, $prop_details['name'] ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1765,6 +1765,9 @@ WHERE
 				if ( ! isset( $prop_details['name'] ) ) {
 					continue;
 				}
+				if ( ! property_exists( $order_data, $prop_details['name'] ) ) {
+					continue;
+				}
 				$prop_value = $order_data->{$prop_details['name']};
 				if ( is_null( $prop_value ) ) {
 					continue;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When **HPOS Data Caching** is enabled alongside **WooCommerce Subscriptions**, orders and subscriptions share the same cache group (`orders_data`). Subscription rows are stored with fewer columns than orders (e.g. no `transaction_id`, `cart_hash`, `recorded_sales`, etc.). When the order data store reads an order, it can receive a cached `stdClass` object that was originally stored for a subscription with a reduced column set. The `set_order_props_from_data` method then accesses `$order_data->{$prop_details['name']}` for properties that don't exist on the object, triggering PHP warnings like:

```
PHP Warning: Undefined property: stdClass::$recorded_sales in .../OrdersTableDataStore.php on line 1767
PHP Warning: Undefined property: stdClass::$transaction_id in .../OrdersTableDataStore.php on line 1767
```

This PR adds a `property_exists()` guard before accessing the property, skipping any properties that are missing from the cached data object.

Closes #63272.

### How to test the changes in this Pull Request:

#### Prerequisites
- WooCommerce Subscriptions plugin installed and activated
- HPOS enabled (WooCommerce → Settings → Advanced → Features)
- HPOS Data Caching enabled
- `WP_DEBUG` and `WP_DEBUG_LOG` set to `true` in `wp-config.php`

#### Steps
1. Create a simple subscription product and place an order for it.
2. Go to WooCommerce → Orders and open the order.
3. Click **Update** to save the order.
4. Check the debug log file — confirm there are **no** `Undefined property: stdClass::$recorded_sales` (or similar) warnings referencing `OrdersTableDataStore.php`.
5. Verify the order saved correctly and all data (payment method, dates, totals, etc.) is intact.

### Testing that has already taken place:

Tested on a WooCommerce 10.5.1 store with WooCommerce Subscriptions 8.4.0, PHP 8.3, HPOS + HPOS Data Caching enabled. Confirmed the warnings appear before the fix and are resolved after. Order data is saved correctly with no regressions.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Fix PHP "Undefined property" warnings in `set_order_props_from_data` when HPOS Data Caching is enabled and cached objects have missing properties.

</details>