### PR TITLE
registerCartItemAction registry system for cart item actions

### DIFF
--- a/plugins/woocommerce/changelog/issues-45537-cart-line-item-actions
+++ b/plugins/woocommerce/changelog/issues-45537-cart-line-item-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduce registry system registerCartItemAction for rendering components on the cart item level.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -31,6 +31,7 @@ import ProductImage from '../product-image';
 import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
 import ProductSaleBadge from '../product-sale-badge';
+import { CartItemActions } from './slotfills';
 
 /**
  * Convert a Dinero object with precision to store currency minor unit.
@@ -284,6 +285,10 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 							itemData={ itemData }
 							variation={ variation }
 						/>
+
+						<div className="wc-block-cart-item__actions">
+							<CartItemActions lineItem={ lineItem } cart={ cart } />
+						</div>
 
 						<div className="wc-block-cart-item__quantity">
 							{ ! soldIndividually && (

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/slotfills.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/slotfills.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { getCartItemActions } from '@woocommerce/blocks-checkout';
+import type { CartItem } from '@woocommerce/types';
+
+interface CartItemActionsProps {
+	lineItem: CartItem;
+	cart: Record< string, unknown >;
+}
+
+export const CartItemActions = ( { lineItem, cart }: CartItemActionsProps ): JSX.Element => {
+	const actions = getCartItemActions();
+	
+	return (
+		<>
+			{ actions.map( ( Component, index ) => (
+				<Component key={ index } lineItem={ lineItem } cart={ cart } />
+			) ) }
+		</>
+	);
+};

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/cart-item-actions/README.md
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/cart-item-actions/README.md
@@ -1,0 +1,129 @@
+# Cart Item Actions Registry
+
+A registry system for adding custom action components to cart line items in WooCommerce Blocks.
+
+## Overview
+
+The Cart Item Actions registry allows extensions to register custom components that will be rendered for each cart line item. This is useful for adding functionality like editing prices, removing items with custom logic, or displaying item-specific actions.
+
+## How It Works
+
+- **Registry Pattern**: Components are registered globally using `registerCartItemAction()`
+- **Per-Item Rendering**: Each registered component is rendered individually for every cart item
+- **Props Passing**: Components receive `lineItem` and `cart` props for context
+
+## API
+
+### `registerCartItemAction(component)`
+
+Register a component to be rendered for each cart line item.
+
+**Parameters:**
+- `component` (Function): A React component that receives `{ lineItem, cart }` props
+
+**Returns:** void
+
+### `getCartItemActions()`
+
+Get all registered cart item action components.
+
+**Returns:** Array of registered components
+
+## Usage Example
+
+```javascript
+import { registerCartItemAction } from '@woocommerce/blocks-checkout';
+import { __ } from '@wordpress/i18n';
+
+const MyCartItemAction = ( { lineItem, cart } ) => {
+	// Only show for specific products
+	if ( ! lineItem.extensions?.my_plugin?.show_action ) {
+		return null;
+	}
+
+	const handleClick = () => {
+		console.log( 'Action clicked for item:', lineItem.key );
+	};
+
+	return (
+		<button
+			className="my-custom-action"
+			onClick={ handleClick }
+		>
+			{ __( 'Custom Action', 'my-plugin' ) }
+		</button>
+	);
+};
+
+registerCartItemAction( MyCartItemAction );
+```
+
+## Component Props
+
+### `lineItem`
+
+The cart item object containing:
+- `key` - Unique identifier for the cart item
+- `name` - Product name
+- `quantity` - Item quantity
+- `prices` - Price data including raw_prices, currency info
+- `extensions` - Extension data for the item
+- And more...
+
+### `cart`
+
+The full cart object containing:
+- `items` - Array of all cart items
+- `totals` - Cart totals
+- `coupons` - Applied coupons
+- And more...
+
+## Conditional Rendering
+
+Components should return `null` when they don't want to render for a specific cart item:
+
+```javascript
+const MyAction = ( { lineItem } ) => {
+	// Don't render for certain product types
+	if ( lineItem.type !== 'simple' ) {
+		return null;
+	}
+
+	return <button>My Action</button>;
+};
+```
+
+## Best Practices
+
+1. **Conditional Rendering**: Always check if your action should display for the current item
+2. **Null Returns**: Return `null` when your action shouldn't render
+3. **Extension Data**: Use `lineItem.extensions.your_namespace` to pass custom data
+4. **Styling**: Use WooCommerce block component classes for consistency
+5. **Accessibility**: Follow accessibility best practices (keyboard support, ARIA labels)
+
+## Integration with Store API
+
+To pass custom data to your cart item actions, extend the Store API cart item schema:
+
+```php
+woocommerce_store_api_register_endpoint_data(
+	array(
+		'endpoint'        => CartItemSchema::IDENTIFIER,
+		'namespace'       => 'my_plugin',
+		'data_callback'   => function( $cart_item ) {
+			return array(
+				'show_action' => true,
+				'custom_data' => 'value',
+			);
+		},
+		'schema_callback' => function() {
+			return array(
+				'show_action' => array(
+					'type'     => 'boolean',
+					'readonly' => true,
+				),
+			);
+		},
+	)
+);
+```

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/cart-item-actions/registry.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/cart-item-actions/registry.ts
@@ -1,0 +1,32 @@
+/**
+ * Registry for cart item action components.
+ * This allows third-party plugins to register components that will be rendered
+ * for each cart line item.
+ */
+
+type CartItemActionComponent = React.ComponentType< {
+	lineItem: any;
+	cart: any;
+} >;
+
+const cartItemActionsRegistry: CartItemActionComponent[] = [];
+
+/**
+ * Register a component to be rendered for each cart item.
+ *
+ * @param component - React component that receives lineItem and cart props
+ */
+export const registerCartItemAction = (
+	component: CartItemActionComponent
+): void => {
+	cartItemActionsRegistry.push( component );
+};
+
+/**
+ * Get all registered cart item action components.
+ *
+ * @return Array of registered components
+ */
+export const getCartItemActions = (): CartItemActionComponent[] => {
+	return cartItemActionsRegistry;
+};

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/index.ts
@@ -1,5 +1,6 @@
 export * from '../../components/totals';
 export { default as TotalsWrapper } from '../../components/totals-wrapper';
+export { registerCartItemAction, getCartItemActions } from './cart-item-actions/registry';
 export { default as ExperimentalOrderMeta } from './order-meta';
 export { default as ExperimentalDiscountsMeta } from './discounts-meta';
 export { default as ExperimentalOrderShippingPackages } from './order-shipping-packages';


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Introduces `registerCartItemAction()` to allow 3rd party plugins to register components for displaying custom elements on a per cart item basis (such as "Edit" buttons, etc).

Closes #45537  .

### Screenshots or screen recordings:

<img width="691" height="464" alt="image" src="https://github.com/user-attachments/assets/ffc5adf0-704f-40fb-896a-e1eb4c885561" />

basic example:
https://www.loom.com/share/da27879bf53b408e938a8423454c7d14

Name Your price specific example:
https://www.loom.com/share/8768a13594164cd1b5791b2239ab501d

I would probably prefer a slightly different UI (for example an edit icon right next to the price), but I think this system is simpler as it only opens up one area of customization.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Need to compile a script and load it with the cart block. Could be done a few different ways... such as using `IntegrationInterface`. [Example plugin](https://github.com/helgatheviking/wc-test-cart-action)

```

const MyCartItemAction = ( { lineItem, cart } ) => {

	const handleClick = () => {
		alert( 'Action clicked for item:', lineItem.key );
	};

	return (
		<button
			className="my-custom-action"
			onClick={ handleClick }
		>
			{ __( 'Custom Action', 'my-plugin' ) }
		</button>
	);
};

registerCartItemAction( MyCartItemAction );
```

For simplicity this PR is only about displaying the components. But I think for more power we will need to 1. update the [`/cart/update-item` route](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php) to actually allow plugins to update the cart item without needing their own routes. and 2. simplify how to call a re-render for the cart block. I am not 100% certain I am doing this correctly. 

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
