### PR TITLE
Improve FTP handling in logging filesystem code

### DIFF
--- a/plugins/woocommerce/changelog/fix-58985
+++ b/plugins/woocommerce/changelog/fix-58985
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent fatal error when FTP filesystem connection fails during logging operations.

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -25,7 +25,7 @@ class FilesystemUtil {
 	 *
 	 * @since 10.7.0
 	 */
-	private const FTP_INIT_COOLDOWN_MINUTES = 5;
+	private const FTP_INIT_COOLDOWN_MINUTES = 2;
 
 	/**
 	 * Wrapper to retrieve the class instance contained in the $wp_filesystem global, after initializing if necessary.

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -12,6 +12,21 @@ use WP_Filesystem_Base;
  * FilesystemUtil class.
  */
 class FilesystemUtil {
+
+	/**
+	 * Transient key for tracking FTP filesystem initialization failures.
+	 *
+	 * @since 10.7.0
+	 */
+	private const FTP_INIT_FAILURE_TRANSIENT = 'wc_ftp_filesystem_init_failed';
+
+	/**
+	 * Cooldown period in minutes before retrying a failed FTP connection.
+	 *
+	 * @since 10.7.0
+	 */
+	private const FTP_INIT_COOLDOWN_MINUTES = 5;
+
 	/**
 	 * Wrapper to retrieve the class instance contained in the $wp_filesystem global, after initializing if necessary.
 	 *
@@ -112,12 +127,23 @@ class FilesystemUtil {
 		if ( 'direct' === $method ) {
 			$initialized = WP_Filesystem();
 		} elseif ( false !== $method ) {
+			if ( get_transient( self::FTP_INIT_FAILURE_TRANSIENT ) ) {
+				return false;
+			}
+
 			// See https://core.trac.wordpress.org/changeset/56341.
 			ob_start();
 			$credentials = request_filesystem_credentials( '' );
 			ob_end_clean();
 
 			$initialized = $credentials && WP_Filesystem( $credentials );
+
+			if ( ! $initialized ) {
+				set_transient( self::FTP_INIT_FAILURE_TRANSIENT, true, self::FTP_INIT_COOLDOWN_MINUTES * MINUTE_IN_SECONDS );
+				error_log( sprintf( 'WooCommerce: FTP filesystem connection failed. Please check your FTP credentials. Retrying in %d minutes.', self::FTP_INIT_COOLDOWN_MINUTES ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			} else {
+				delete_transient( self::FTP_INIT_FAILURE_TRANSIENT );
+			}
 		}
 
 		return is_null( $initialized ) ? false : $initialized;

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -135,7 +135,9 @@ class FilesystemUtil {
 			$initialized = $credentials && WP_Filesystem( $credentials );
 
 			if ( ! $initialized ) {
-				set_transient( self::FTP_INIT_FAILURE_TRANSIENT, true, self::FTP_INIT_COOLDOWN_MINUTES * MINUTE_IN_SECONDS );
+				// A fixed cooldown is used instead of exponential backoff since this handles a non-critical
+			// edge case (broken FTP filesystem during logging) that most sites will never encounter.
+			set_transient( self::FTP_INIT_FAILURE_TRANSIENT, true, self::FTP_INIT_COOLDOWN_MINUTES * MINUTE_IN_SECONDS );
 				error_log( sprintf( 'WooCommerce: FTP filesystem connection failed. Please check your FTP credentials. Retrying in %d minutes.', self::FTP_INIT_COOLDOWN_MINUTES ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			} else {
 				delete_transient( self::FTP_INIT_FAILURE_TRANSIENT );

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -136,8 +136,8 @@ class FilesystemUtil {
 
 			if ( ! $initialized ) {
 				// A fixed cooldown is used instead of exponential backoff since this handles a non-critical
-			// edge case (broken FTP filesystem during logging) that most sites will never encounter.
-			set_transient( self::FTP_INIT_FAILURE_TRANSIENT, true, self::FTP_INIT_COOLDOWN_MINUTES * MINUTE_IN_SECONDS );
+				// edge case (broken FTP filesystem during logging) that most sites will never encounter.
+				set_transient( self::FTP_INIT_FAILURE_TRANSIENT, true, self::FTP_INIT_COOLDOWN_MINUTES * MINUTE_IN_SECONDS );
 				error_log( sprintf( 'WooCommerce: FTP filesystem connection failed. Please check your FTP credentials. Retrying in %d minutes.', self::FTP_INIT_COOLDOWN_MINUTES ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			} else {
 				delete_transient( self::FTP_INIT_FAILURE_TRANSIENT );

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -21,12 +21,10 @@ class FilesystemUtil {
 	public static function get_wp_filesystem(): WP_Filesystem_Base {
 		global $wp_filesystem;
 
-		if ( ! $wp_filesystem instanceof WP_Filesystem_Base ) {
-			$initialized = self::initialize_wp_filesystem();
+		$initialized = ( $wp_filesystem instanceof WP_Filesystem_Base ) || self::initialize_wp_filesystem();
 
-			if ( false === $initialized ) {
-				throw new Exception( 'The WordPress filesystem could not be initialized.' );
-			}
+		if ( ! $initialized || ! self::is_usable_ftp_filesystem( $wp_filesystem ) ) {
+			throw new Exception( 'The WordPress filesystem could not be initialized.' );
 		}
 
 		return $wp_filesystem;
@@ -123,6 +121,23 @@ class FilesystemUtil {
 		}
 
 		return is_null( $initialized ) ? false : $initialized;
+	}
+
+	/**
+	 * Check if an FTP-based filesystem instance is usable.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @param WP_Filesystem_Base $wp_filesystem The filesystem instance to check.
+	 * @return bool False if FTP-based and has connection errors, true otherwise.
+	 */
+	private static function is_usable_ftp_filesystem( WP_Filesystem_Base $wp_filesystem ): bool {
+		if ( in_array( $wp_filesystem->method, array( 'ftpext', 'ftpsockets' ), true )
+			&& is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -156,20 +156,20 @@ class FilesystemUtil {
 	 * @return bool False if FTP-based and unusable, true otherwise.
 	 */
 	private static function is_usable_ftp_filesystem( WP_Filesystem_Base $wp_filesystem ): bool {
-		if ( 'ftpext' === $wp_filesystem->method && empty( $wp_filesystem->link ) ) {
-			return false;
+		$has_broken_state = false;
+		$has_errors       = false;
+
+		if ( 'ftpext' === $wp_filesystem->method ) {
+			$has_broken_state = empty( $wp_filesystem->link );
+			$has_errors       = is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors();
 		}
 
-		if ( 'ftpsockets' === $wp_filesystem->method && empty( $wp_filesystem->ftp ) ) {
-			return false;
+		if ( 'ftpsockets' === $wp_filesystem->method ) {
+			$has_broken_state = empty( $wp_filesystem->ftp );
+			$has_errors       = is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors();
 		}
 
-		if ( in_array( $wp_filesystem->method, array( 'ftpext', 'ftpsockets' ), true )
-			&& is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
-			return false;
-		}
-
-		return true;
+		return ! $has_broken_state && ! $has_errors;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -152,12 +152,24 @@ class FilesystemUtil {
 	/**
 	 * Check if an FTP-based filesystem instance is usable.
 	 *
+	 * Checks both the connection resource and the error state. The connection
+	 * resource can be null if PHP's max execution time interrupted ftp_connect()
+	 * before it completed, leaving the instance in a broken state without errors.
+	 *
 	 * @since 10.7.0
 	 *
 	 * @param WP_Filesystem_Base $wp_filesystem The filesystem instance to check.
-	 * @return bool False if FTP-based and has connection errors, true otherwise.
+	 * @return bool False if FTP-based and unusable, true otherwise.
 	 */
 	private static function is_usable_ftp_filesystem( WP_Filesystem_Base $wp_filesystem ): bool {
+		if ( 'ftpext' === $wp_filesystem->method && empty( $wp_filesystem->link ) ) {
+			return false;
+		}
+
+		if ( 'ftpsockets' === $wp_filesystem->method && empty( $wp_filesystem->ftp ) ) {
+			return false;
+		}
+
 		if ( in_array( $wp_filesystem->method, array( 'ftpext', 'ftpsockets' ), true )
 			&& is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -15,15 +15,11 @@ class FilesystemUtil {
 
 	/**
 	 * Transient key for tracking FTP filesystem initialization failures.
-	 *
-	 * @since 10.7.0
 	 */
 	private const FTP_INIT_FAILURE_TRANSIENT = 'wc_ftp_filesystem_init_failed';
 
 	/**
 	 * Cooldown period in minutes before retrying a failed FTP connection.
-	 *
-	 * @since 10.7.0
 	 */
 	private const FTP_INIT_COOLDOWN_MINUTES = 2;
 
@@ -155,8 +151,6 @@ class FilesystemUtil {
 	 * Checks both the connection resource and the error state. The connection
 	 * resource can be null if PHP's max execution time interrupted ftp_connect()
 	 * before it completed, leaving the instance in a broken state without errors.
-	 *
-	 * @since 10.7.0
 	 *
 	 * @param WP_Filesystem_Base $wp_filesystem The filesystem instance to check.
 	 * @return bool False if FTP-based and unusable, true otherwise.

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -20,6 +20,9 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
+		if ( ! class_exists( 'WP_Filesystem_Base' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+		}
 		unset( $GLOBALS['wp_filesystem'] );
 	}
 
@@ -60,6 +63,50 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 		FilesystemUtil::get_wp_filesystem();
 
 		remove_filter( 'filesystem_method', $callback );
+	}
+
+	/**
+	 * @testdox Check that get_wp_filesystem throws an exception when the FTP filesystem has connection errors.
+	 */
+	public function test_get_wp_filesystem_throws_for_ftp_with_errors(): void {
+		global $wp_filesystem;
+
+		$this->expectException( 'Exception' );
+
+		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
+		$mock_wp_filesystem->method = 'ftpext';
+		$mock_wp_filesystem->errors = new \WP_Error( 'connect', 'Failed to connect to FTP Server' );
+		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		FilesystemUtil::get_wp_filesystem();
+	}
+
+	/**
+	 * @testdox Check that get_wp_filesystem returns the instance when the FTP filesystem has no errors.
+	 */
+	public function test_get_wp_filesystem_returns_ftp_without_errors(): void {
+		global $wp_filesystem;
+
+		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
+		$mock_wp_filesystem->method = 'ftpext';
+		$mock_wp_filesystem->errors = new \WP_Error();
+		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );
+	}
+
+	/**
+	 * @testdox Check that get_wp_filesystem returns the instance for non-FTP filesystems even if errors are set.
+	 */
+	public function test_get_wp_filesystem_returns_direct_with_errors(): void {
+		global $wp_filesystem;
+
+		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
+		$mock_wp_filesystem->method = 'direct';
+		$mock_wp_filesystem->errors = new \WP_Error( 'some_error', 'Some error' );
+		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -82,7 +82,24 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Check that get_wp_filesystem returns the instance when the FTP filesystem has no errors.
+	 * @testdox Check that get_wp_filesystem throws when the FTP filesystem has a null connection (e.g. interrupted by timeout).
+	 */
+	public function test_get_wp_filesystem_throws_for_ftp_with_null_link(): void {
+		global $wp_filesystem;
+
+		$this->expectException( 'Exception' );
+
+		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
+		$mock_wp_filesystem->method = 'ftpext';
+		$mock_wp_filesystem->errors = new \WP_Error();
+		$mock_wp_filesystem->link   = null;
+		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		FilesystemUtil::get_wp_filesystem();
+	}
+
+	/**
+	 * @testdox Check that get_wp_filesystem returns the instance when the FTP filesystem has no errors and a valid connection.
 	 */
 	public function test_get_wp_filesystem_returns_ftp_without_errors(): void {
 		global $wp_filesystem;
@@ -90,6 +107,7 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
 		$mock_wp_filesystem->method = 'ftpext';
 		$mock_wp_filesystem->errors = new \WP_Error();
+		$mock_wp_filesystem->link   = true;
 		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -66,33 +66,23 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Check that get_wp_filesystem throws an exception when the FTP filesystem has connection errors.
+	 * @testdox Check that get_wp_filesystem throws for an unusable FTP filesystem.
+	 *
+	 * @testWith [true, false]
+	 *           [false, true]
+	 *
+	 * @param bool $has_errors Whether the mock should have connection errors.
+	 * @param bool $has_link   Whether the mock should have a connection link.
 	 */
-	public function test_get_wp_filesystem_throws_for_ftp_with_errors(): void {
+	public function test_get_wp_filesystem_throws_for_unusable_ftp( bool $has_errors, bool $has_link ): void {
 		global $wp_filesystem;
 
 		$this->expectException( 'Exception' );
 
 		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
 		$mock_wp_filesystem->method = 'ftpext';
-		$mock_wp_filesystem->errors = new \WP_Error( 'connect', 'Failed to connect to FTP Server' );
-		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		FilesystemUtil::get_wp_filesystem();
-	}
-
-	/**
-	 * @testdox Check that get_wp_filesystem throws when the FTP filesystem has a null connection (e.g. interrupted by timeout).
-	 */
-	public function test_get_wp_filesystem_throws_for_ftp_with_null_link(): void {
-		global $wp_filesystem;
-
-		$this->expectException( 'Exception' );
-
-		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
-		$mock_wp_filesystem->method = 'ftpext';
-		$mock_wp_filesystem->errors = new \WP_Error();
-		$mock_wp_filesystem->link   = null;
+		$mock_wp_filesystem->errors = $has_errors ? new \WP_Error( 'connect', 'Failed to connect to FTP Server' ) : new \WP_Error();
+		$mock_wp_filesystem->link   = $has_link ? true : null;
 		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		FilesystemUtil::get_wp_filesystem();
@@ -108,20 +98,6 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 		$mock_wp_filesystem->method = 'ftpext';
 		$mock_wp_filesystem->errors = new \WP_Error();
 		$mock_wp_filesystem->link   = true;
-		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );
-	}
-
-	/**
-	 * @testdox Check that get_wp_filesystem returns the instance for non-FTP filesystems even if errors are set.
-	 */
-	public function test_get_wp_filesystem_returns_direct_with_errors(): void {
-		global $wp_filesystem;
-
-		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
-		$mock_wp_filesystem->method = 'direct';
-		$mock_wp_filesystem->errors = new \WP_Error( 'some_error', 'Some error' );
 		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -66,18 +66,18 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Check that get_wp_filesystem throws for an unusable FTP filesystem.
+	 * @testdox Check that get_wp_filesystem validates FTP filesystem instances.
 	 *
-	 * @testWith [true, false]
-	 *           [false, true]
+	 * @testWith [true, true, true]
+	 *           [false, false, true]
+	 *           [false, true, false]
 	 *
-	 * @param bool $has_errors Whether the mock should have connection errors.
-	 * @param bool $has_link   Whether the mock should have a connection link.
+	 * @param bool $has_errors   Whether the mock should have connection errors.
+	 * @param bool $has_link     Whether the mock should have a connection link.
+	 * @param bool $should_throw Whether get_wp_filesystem should throw.
 	 */
-	public function test_get_wp_filesystem_throws_for_unusable_ftp( bool $has_errors, bool $has_link ): void {
+	public function test_get_wp_filesystem_validates_ftp( bool $has_errors, bool $has_link, bool $should_throw ): void {
 		global $wp_filesystem;
-
-		$this->expectException( 'Exception' );
 
 		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
 		$mock_wp_filesystem->method = 'ftpext';
@@ -85,22 +85,15 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 		$mock_wp_filesystem->link   = $has_link ? true : null;
 		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		FilesystemUtil::get_wp_filesystem();
-	}
+		if ( $should_throw ) {
+			$this->expectException( 'Exception' );
+		}
 
-	/**
-	 * @testdox Check that get_wp_filesystem returns the instance when the FTP filesystem has no errors and a valid connection.
-	 */
-	public function test_get_wp_filesystem_returns_ftp_without_errors(): void {
-		global $wp_filesystem;
+		$result = FilesystemUtil::get_wp_filesystem();
 
-		$mock_wp_filesystem         = $this->createMock( WP_Filesystem_Base::class );
-		$mock_wp_filesystem->method = 'ftpext';
-		$mock_wp_filesystem->errors = new \WP_Error();
-		$mock_wp_filesystem->link   = true;
-		$wp_filesystem              = $mock_wp_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$this->assertSame( $mock_wp_filesystem, FilesystemUtil::get_wp_filesystem() );
+		if ( ! $should_throw ) {
+			$this->assertSame( $mock_wp_filesystem, $result );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR adds some guards to our logging code when the underlying filesystem is FTP.
If the FTP connection fails, attempting to log something using `WC_Logger` will not result in a fatal error. 

The PR also adds a cooldown time: if the connection is attempted and fails at least twice in the last minute, we won't attempt to reconnect for at least 2 minutes. This should reduce timeouts and burden on the site as FTP connections usually take a while.

Read below for details on how WC logging can trigger fatals.

<details>
<summary><strong>Details on how WC logging can trigger fatals 😅</strong></summary>


When `ftpext` is used as filesystem method, our logging code will attempt to initialize the filesystem [as necessary](https://github.com/woocommerce/woocommerce/blob/aa3e97c25c572300a6b8dfc64bda1909700fe1a8/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php#L21-L33), but once this initialization happens, [we will trust](https://github.com/woocommerce/woocommerce/blob/aa3e97c25c572300a6b8dfc64bda1909700fe1a8/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php#L103-L107) the global `$wp_fileystem` object, even if the credentials are incorrect and the object is actually useless.

This happens because WordPress sets the `$wp_filesystem` global to the new filesystem instance _before_ attempting to `connect()`. If `connect()` fails, it populates the errors but the global is left pointing to a broken FTP object.

Further attempts to write to WooCommerce logs will make WordPress attempt to use this broken object with no connection, making FTP commands (like `ftp_nlist()`) fatal.

When WC is the only player, no fatals occur because we know whether the FTP object was correctly initialized or not, but when the object is initialized _before_ WC uses it, we have no visibility on its state. This can happen if some other plugin or even WP itself needs to operate on the filesystem before our logging code does.

One could argue that the proper fix belongs in WordPress, but we can at least do something about WC's logging, which is likely to trigger more I/O operations than other WP activitiy.

</details>

Closes #58985.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add some incorrect FTP credentials to your site. Do this in `wp-config.php`:
   ```php
   define( 'FS_METHOD', 'ftpext' );
   define( 'FTP_HOST', '127.0.0.1' );
   define( 'FTP_USER', 'fakeuser' );
   define( 'FTP_PASS', 'fakepass' );
   ```
1. Enable the following code as a snippet or a .php file in `wp-content/mu-plugins/`:
   ```php
   <?php
     add_action( 'admin_init', function() {
         require_once ABSPATH . 'wp-admin/includes/file.php';
         WP_Filesystem( request_filesystem_credentials( '' ) );
         wc_get_logger()->error( 'Test', array( 'source' => 'test-' . time() ) );
     } );
   ```

   This simulates _something_ triggering a FTP connection that fails, leaving a broken filesystem global that then WC tries to use during logging.
1. Confirm the bug on `trunk` by visiting any admin page. A fatal error will occur with an error message along these lines:

   > Uncaught Error: ftp_nlist(): Argument #1 ($ftp) must be of type FTP\Connection, false given in [...]
1. Check out this branch.
1. Visit any admin page. Page should load normally (no fatal error).
1. Check your server logs (`wp-content/debug.log` for example) for a message
   >  WooCommerce: FTP filesystem connection failed. Please check your FTP credentials. Retrying in 2 minutes.
   This proves the cooldown time is in effect.
1. Visit several admin pages in quick succession and confirm that no additional messages are written to your server logs for at least 2 minutes.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.