### PR TITLE
Refactor cart and checkout blocks to use isPreviewMode flag

### DIFF
--- a/plugins/woocommerce/changelog/63313-update-53125-implement-preview-mode-flag-cart-checkout
+++ b/plugins/woocommerce/changelog/63313-update-53125-implement-preview-mode-flag-cart-checkout
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: update
 
 Refactor cart, cart-link, mini-cart and checkout blocks to use isPreviewMode flag

--- a/plugins/woocommerce/changelog/63313-update-53125-implement-preview-mode-flag-cart-checkout
+++ b/plugins/woocommerce/changelog/63313-update-53125-implement-preview-mode-flag-cart-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refactor cart, cart-link, mini-cart and checkout blocks to use isPreviewMode flag

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/editor-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/editor-context.tsx
@@ -3,6 +3,7 @@
  */
 import { createContext, useContext, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 interface EditorContextType {
 	// Indicates whether in the editor context.
@@ -44,14 +45,13 @@ export const EditorProvider = ( {
 	currentPostId = 0,
 	previewData = {},
 	currentView = '',
-	isPreview = false,
 }: {
 	children: React.ReactNode;
 	currentPostId?: number | undefined;
 	previewData?: Record< string, unknown > | undefined;
 	currentView?: string | undefined;
-	isPreview?: boolean | undefined;
 } ) => {
+	const isPreviewMode = usePreviewMode();
 	const editingPostId = useSelect(
 		( select ): number =>
 			currentPostId
@@ -79,7 +79,7 @@ export const EditorProvider = ( {
 		currentView,
 		previewData,
 		getPreviewData,
-		isPreview,
+		isPreview: isPreviewMode,
 	};
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/index.js
@@ -11,3 +11,4 @@ export * from './use-style-props';
 export * from './use-observed-viewport';
 export * from './use-schema-parser';
 export * from './use-query-loop-product-context-validation';
+export * from './use-preview-mode';

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-preview-mode.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-preview-mode.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+type BlockEditorSettings = {
+	isPreviewMode?: boolean;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__unstableIsPreviewMode?: boolean;
+};
+
+export const usePreviewMode = (): boolean => {
+	return useSelect( ( select ) => {
+		try {
+			const { getSettings } = select( blockEditorStore ) as unknown as {
+				getSettings?: () => BlockEditorSettings;
+			};
+			const settings = getSettings?.() || {};
+
+			return Boolean(
+				settings.isPreviewMode ??
+					settings.__unstableIsPreviewMode ??
+					false
+			);
+		} catch ( error ) {
+			return false;
+		}
+	}, [] );
+};

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-preview-mode.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-preview-mode.ts
@@ -4,27 +4,10 @@
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-type BlockEditorSettings = {
-	isPreviewMode?: boolean;
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	__unstableIsPreviewMode?: boolean;
-};
-
 export const usePreviewMode = (): boolean => {
 	return useSelect( ( select ) => {
-		try {
-			const { getSettings } = select( blockEditorStore ) as unknown as {
-				getSettings?: () => BlockEditorSettings;
-			};
-			const settings = getSettings?.() || {};
-
-			return Boolean(
-				settings.isPreviewMode ??
-					settings.__unstableIsPreviewMode ??
-					false
-			);
-		} catch ( error ) {
-			return false;
-		}
+		// @ts-expect-error No types for this exist yet.
+		const { getSettings } = select( blockEditorStore );
+		return Boolean( getSettings()?.isPreviewMode ?? false );
 	}, [] );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/block.json
@@ -25,16 +25,11 @@
 	},
 	"example": {
 		"attributes": {
-			"isPreview": true,
 			"cartIcon": "cart",
 			"content": "Cart"
 		}
 	},
 	"attributes": {
-		"isPreview": {
-			"type": "boolean",
-			"default": false
-		},
 		"cartIcon": {
 			"type": "string",
 			"default": "cart"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/attributes.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/attributes.js
@@ -8,10 +8,6 @@ import { filledCart, removeCart } from '@woocommerce/icons';
 
 export const blockName = 'woocommerce/cart';
 export const blockAttributes = {
-	isPreview: {
-		type: 'boolean',
-		default: false,
-	},
 	currentView: {
 		type: 'string',
 		default: 'woocommerce/filled-cart-block',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/edit.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/edit.js
@@ -16,6 +16,7 @@ import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { useEffect, useRef } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { dispatch, select } from '@wordpress/data';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -41,14 +42,15 @@ const ALLOWED_BLOCKS = [
 ];
 
 export const Edit = ( { clientId, className, attributes, setAttributes } ) => {
-	const { hasDarkControls, currentView, isPreview = false } = attributes;
+	const { hasDarkControls, currentView } = attributes;
+	const isPreviewMode = usePreviewMode();
 	const defaultTemplate = [
 		[ 'woocommerce/filled-cart-block', {}, [] ],
 		[ 'woocommerce/empty-cart-block', {}, [] ],
 	];
 	const blockProps = useBlockPropsWithLocking( {
 		className: clsx( className, 'wp-block-woocommerce-cart', {
-			'is-editor-preview': isPreview,
+			'is-editor-preview': isPreviewMode,
 		} ),
 	} );
 
@@ -88,7 +90,6 @@ export const Edit = ( { clientId, className, attributes, setAttributes } ) => {
 				<EditorProvider
 					previewData={ { previewCart } }
 					currentView={ currentView }
-					isPreview={ !! isPreview }
 				>
 					<CartBlockContext.Provider
 						value={ {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/metadata.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/metadata.tsx
@@ -26,9 +26,6 @@ export const metadata: BlockConfiguration = {
 		multiple: false,
 	},
 	example: {
-		attributes: {
-			isPreview: true,
-		},
 		viewportWidth: 800,
 	},
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/types.ts
@@ -5,6 +5,5 @@ export type InnerBlockTemplate = [
 ];
 
 export interface Attributes {
-	isPreview: boolean;
 	hasDarkControls: boolean;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/block.json
@@ -15,17 +15,9 @@
 		"multiple": false
 	},
 	"example": {
-		"attributes": {
-			"isPreview": true
-		},
 		"viewportWidth": 800
 	},
 	"attributes": {
-		"isPreview": {
-			"type": "boolean",
-			"default": false,
-			"save": false
-		},
 		"align": {
 			"type": "string",
 			"default": "wide"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/edit.tsx
@@ -59,7 +59,6 @@ export const Edit = ( {
 		showReturnToCart,
 		showRateAfterTaxName,
 		cartPageId,
-		isPreview = false,
 		showFormStepNumbers = false,
 		hasDarkControls = false,
 	} = attributes;
@@ -132,7 +131,6 @@ export const Edit = ( {
 				/>
 			</InspectorControls>
 			<EditorProvider
-				isPreview={ !! isPreview }
 				previewData={ {
 					previewCart,
 					previewSavedPaymentMethods,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -25,7 +25,6 @@ export const Edit = ( {
 	clientId: string;
 	attributes: {
 		className?: string;
-		isPreview?: boolean;
 	};
 } ): JSX.Element => {
 	const blockProps = useBlockProps( {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
@@ -20,15 +20,10 @@
 	},
 	"example": {
 		"attributes": {
-			"isPreview": true,
 			"className": "wc-block-mini-cart--preview"
 		}
 	},
 	"attributes": {
-		"isPreview": {
-			"type": "boolean",
-			"default": false
-		},
 		"miniCartIcon": {
 			"type": "string",
 			"default": "cart"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/attributes.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/attributes.tsx
@@ -8,10 +8,6 @@ import { filledCart, removeCart } from '@woocommerce/icons';
 export const blockName = 'woocommerce/mini-cart-contents';
 
 export const attributes = {
-	isPreview: {
-		type: 'boolean',
-		default: false,
-	},
 	lock: {
 		type: 'object',
 		default: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
@@ -22,10 +22,6 @@
 		}
 	},
 	"attributes": {
-		"isPreview": {
-			"type": "boolean",
-			"default": false
-		},
 		"lock": {
 			"type": "object",
 			"default": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/metadata.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/metadata.tsx
@@ -35,9 +35,5 @@ export const metadata: BlockConfiguration = {
 			width: true,
 		},
 	},
-	example: {
-		attributes: {
-			isPreview: true,
-		},
-	},
+	example: {},
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Refactor cart, cart-link, mini-cart and checkout blocks to use isPreviewMode flag
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of #53125 .

### Screenshots or screen recordings:

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open the WordPress dashboard and navigate to **Posts → Add New** to create a new post.
2. In the post editor, click the **Block Inserter** button located in the top-left corner.
3. Use the search field in the Block Inserter to search for **“Checkout.”**
4. In the search results, hover your cursor over the **Checkout** block.
5. Confirm that a visual preview of the block appears when hovering.
6. Repeat steps 3–5 for the following blocks:

   * **Cart**
   * **Cart Link**
   * **Mini Cart**
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Refactor cart, cart-link, mini-cart and checkout blocks to use isPreviewMode flag
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
