### PR TITLE
Preload low stock count to avoid request on every admin page

### DIFF
--- a/plugins/woocommerce/changelog/63324-fix-54993-remove-low-stock-count-ajax
+++ b/plugins/woocommerce/changelog/63324-fix-54993-remove-low-stock-count-ajax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Preload low stock count in admin settings to eliminate unnecessary REST API call on every WooCommerce admin page load.

--- a/plugins/woocommerce/changelog/63324-fix-54993-remove-low-stock-count-ajax
+++ b/plugins/woocommerce/changelog/63324-fix-54993-remove-low-stock-count-ajax
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Preload low stock count in admin settings to eliminate unnecessary REST API call on every WooCommerce admin page load.
+Preload low stock count in admin settings to eliminate unnecessary REST API calls on every WooCommerce admin page load.

--- a/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
@@ -22,13 +22,15 @@ import {
  */
 import './style.scss';
 import { IconFlag } from './icon-flag';
-import { hasUnreadNotes as checkIfHasUnreadNotes } from './unread-indicators';
+import {
+	hasUnreadNotes as checkIfHasUnreadNotes,
+	getLowStockCount,
+} from './unread-indicators';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
 import { DisplayOptions } from './display-options';
 import { Panel } from './panel';
 import {
-	getLowStockCount as getLowStockProducts,
 	getOrderStatuses,
 	getUnreadOrders,
 } from '../homescreen/activity-panel/orders/utils';
@@ -132,7 +134,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				? getUnapprovedReviews( select )
 				: false;
 			const isLowStockCardVisible = setupTaskListHidden
-				? getLowStockProducts( select )
+				? getLowStockCount() > 0
 				: false;
 
 			return (

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
-use Automattic\WooCommerce\Internal\Admin\ProductStockIndicator;
+use Automattic\WooCommerce\Internal\Admin\LowStockCounter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -70,7 +70,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 * @return \WP_Error|\WP_HTTP_Response|\WP_REST_Response
 	 */
 	public function get_low_in_stock_count( $request ) {
-		$total_results = ProductStockIndicator::get_low_stock_count( $request->get_param( 'status' ) );
+		$total_results = LowStockCounter::get_low_stock_count( $request->get_param( 'status' ) );
 
 		$response = rest_ensure_response( array( 'total' => $total_results ) );
 		$response->header( 'X-WP-Total', $total_results );
@@ -188,7 +188,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$offset              = ( $page - 1 ) * $per_page;
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
-		$sidewide_stock_threshold_only = ProductStockIndicator::is_using_sitewide_stock_threshold_only( $low_stock_threshold );
+		$sidewide_stock_threshold_only = LowStockCounter::is_using_sitewide_stock_threshold_only( $low_stock_threshold );
 
 		$query_string = $this->get_query( $sidewide_stock_threshold_only );
 
@@ -198,7 +198,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			OBJECT_K
 		);
 
-		$total_results = ProductStockIndicator::get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
+		$total_results = LowStockCounter::get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
 
 		return array(
 			'results' => $query_results,
@@ -245,7 +245,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 * @return string
 	 */
 	protected function get_query( $sitewide_only = false ) {
-		$query = ProductStockIndicator::get_base_query(
+		$query = LowStockCounter::get_base_query(
 			array(
 				':selects'       => 'wp_posts.*, :postmeta_select wc_product_meta_lookup.stock_quantity',
 				':orderAndLimit' => 'order by wc_product_meta_lookup.product_id DESC limit %d, %d',
@@ -253,7 +253,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		);
 
 		if ( ! $sitewide_only ) {
-			return ProductStockIndicator::add_sitewide_stock_query_str( $query );
+			return LowStockCounter::add_sitewide_stock_query_str( $query );
 		}
 
 		return strtr(

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Admin\ProductStockIndicator;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -69,11 +70,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 * @return \WP_Error|\WP_HTTP_Response|\WP_REST_Response
 	 */
 	public function get_low_in_stock_count( $request ) {
-		$status              = $request->get_param( 'status' );
-		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
-
-		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only( $low_stock_threshold );
-		$total_results                 = $this->get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
+		$total_results = ProductStockIndicator::get_low_stock_count( $request->get_param( 'status' ) );
 
 		$response = rest_ensure_response( array( 'total' => $total_results ) );
 		$response->header( 'X-WP-Total', $total_results );
@@ -191,7 +188,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$offset              = ( $page - 1 ) * $per_page;
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
-		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only( $low_stock_threshold );
+		$sidewide_stock_threshold_only = ProductStockIndicator::is_using_sitewide_stock_threshold_only( $low_stock_threshold );
 
 		$query_string = $this->get_query( $sidewide_stock_threshold_only );
 
@@ -201,76 +198,13 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			OBJECT_K
 		);
 
-		$total_results = $this->get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
+		$total_results = ProductStockIndicator::get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
 
 		return array(
 			'results' => $query_results,
 			'total'   => (int) $total_results,
 			'pages'   => (int) ceil( $total_results / (int) $per_page ),
 		);
-	}
-
-	/**
-	 * Get the count of low in stock products.
-	 *
-	 * @param bool   $sidewide_stock_threshold_only Boolean to check if the store is using sitewide stock threshold only.
-	 * @param string $status Post status.
-	 * @param int    $low_stock_threshold Low stock threshold.
-	 *
-	 * @return int
-	 */
-	protected function get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold ) {
-		global $wpdb;
-		if ( $sidewide_stock_threshold_only ) {
-			$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
-			$count_query_results = $wpdb->get_results(
-				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-				$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
-			);
-
-			return (int) $count_query_results[0]->total;
-		}
-
-		// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
-		// Splitting the queries also speeds up the query.
-		$count_query_with_custom_stock_threshold_string    = $this->get_products_with_custom_stock_threshold_count_query_str();
-		$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
-		$count_query_with_custom_stock_threshold_results   = $wpdb->get_results(
-			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-			$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
-		);
-		$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
-			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-			$wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ),
-		);
-
-		return (int) $count_query_with_custom_stock_threshold_results[0]->total + (int) $count_query_without_custom_stock_threshold_results[0]->total;
-	}
-
-	/**
-	 * Check to see if store is using sitewide threshold only. Meaning that it does not have any custom
-	 * stock threshold for a product.
-	 *
-	 * @param int|null $low_stock_threshold Low stock threshold.
-	 * @return bool
-	 */
-	protected function is_using_sitewide_stock_threshold_only( $low_stock_threshold = null ) {
-		global $wpdb;
-		$query_string = "
-			select count(*) as total
-			from {$wpdb->postmeta}
-			where 
-			  meta_key='_low_stock_amount'
-			  AND meta_value > ''
-		";
-		$args         = array();
-		if ( $low_stock_threshold ) {
-			$query_string .= ' AND meta_value != %d';
-			$args[]        = $low_stock_threshold;
-		}
-		// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-		$count = $wpdb->get_var( $wpdb->prepare( $query_string, $args ) );
-		return 0 === (int) $count;
 	}
 
 	/**
@@ -304,145 +238,14 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	}
 
 	/**
-	 * Return a query string for low in stock products.
-	 * The query string includes the following replacement strings:
-	 * - :selects
-	 * - :postmeta_join
-	 * - :postmeta_wheres
-	 * - :orderAndLimit
-	 *
-	 * @param array $replacements  of replacement strings.
-	 *
-	 * @return string
-	 */
-	private function get_base_query( $replacements = array() ) {
-		global $wpdb;
-		$query = "
-			SELECT
-				:selects
-			FROM
-			  {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup
-			  LEFT JOIN {$wpdb->posts} wp_posts ON wp_posts.ID = wc_product_meta_lookup.product_id
-			  :postmeta_join
-			WHERE
-			  wp_posts.post_type IN ('product', 'product_variation')
-			  AND wp_posts.post_status = %s
-			  AND wc_product_meta_lookup.stock_quantity IS NOT NULL
-			  AND wc_product_meta_lookup.stock_status IN('instock', 'outofstock')
-			  :postmeta_wheres
-			  :orderAndLimit
-		";
-
-		return strtr( $query, $replacements );
-	}
-
-	/**
-	 * Add sitewide stock query string to base query string.
-	 *
-	 * @param string $query Base query string.
-	 *
-	 * @return string
-	 */
-	private function add_sitewide_stock_query_str( $query ) {
-		global $wpdb;
-		$postmeta = array(
-			'select' => 'meta.meta_value AS low_stock_amount,',
-			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id
-			  AND meta.meta_key = '_low_stock_amount'",
-			'wheres' => "AND (
-			    (
-			      meta.meta_value > ''
-			      AND wc_product_meta_lookup.stock_quantity <= CAST(
-			        meta.meta_value AS SIGNED
-			      )
-			    )
-			    OR (
-			      (
-			        meta.meta_value IS NULL
-			        OR meta.meta_value <= ''
-			      )
-			      AND wc_product_meta_lookup.stock_quantity <= %d
-			    )
-		    )",
-		);
-
-		return strtr(
-			$query,
-			array(
-				':postmeta_select' => $postmeta['select'],
-				':postmeta_join'   => $postmeta['join'],
-				':postmeta_wheres' => $postmeta['wheres'],
-			)
-		);
-	}
-
-	/**
-	 * Get a query string for products with a custom stock threshold.
-	 *
-	 * @return string
-	 */
-	private function get_products_with_custom_stock_threshold_count_query_str() {
-		global $wpdb;
-		$query    = $this->get_base_query(
-			array(
-				':selects'       => 'count(*) as total',
-				':orderAndLimit' => '',
-			)
-		);
-		$postmeta = array(
-			'select' => 'meta.meta_value AS low_stock_amount,',
-			'join'   => "JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
-			'wheres' => 'AND wc_product_meta_lookup.stock_quantity <= CAST(meta.meta_value AS SIGNED)',
-		);
-
-		return strtr(
-			$query,
-			array(
-				':postmeta_select' => $postmeta['select'],
-				':postmeta_join'   => $postmeta['join'],
-				':postmeta_wheres' => $postmeta['wheres'],
-			)
-		);
-	}
-
-	/**
-	 * Get a query string for products without a custom stock threshold.
-	 *
-	 * @return string
-	 */
-	private function get_products_without_custom_stock_threshold_count_query_str() {
-		global $wpdb;
-		$query    = $this->get_base_query(
-			array(
-				':selects'       => 'count(*) as total',
-				':orderAndLimit' => '',
-			)
-		);
-		$postmeta = array(
-			'select' => 'meta.meta_value AS low_stock_amount,',
-			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
-			'wheres' => 'AND meta.post_id IS NULL AND wc_product_meta_lookup.stock_quantity <= %d',
-		);
-
-		return strtr(
-			$query,
-			array(
-				':postmeta_select' => $postmeta['select'],
-				':postmeta_join'   => $postmeta['join'],
-				':postmeta_wheres' => $postmeta['wheres'],
-			)
-		);
-	}
-
-	/**
-	 * Generate a query.
+	 * Generate a query for listing low in stock products.
 	 *
 	 * @param bool $sitewide_only generates a query for sitewide low stock threshold only query.
 	 *
 	 * @return string
 	 */
 	protected function get_query( $sitewide_only = false ) {
-		$query = $this->get_base_query(
+		$query = ProductStockIndicator::get_base_query(
 			array(
 				':selects'       => 'wp_posts.*, :postmeta_select wc_product_meta_lookup.stock_quantity',
 				':orderAndLimit' => 'order by wc_product_meta_lookup.product_id DESC limit %d, %d',
@@ -450,36 +253,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		);
 
 		if ( ! $sitewide_only ) {
-			return $this->add_sitewide_stock_query_str( $query );
-		}
-
-		return strtr(
-			$query,
-			array(
-				':postmeta_select' => '',
-				':postmeta_join'   => '',
-				':postmeta_wheres' => 'AND wc_product_meta_lookup.stock_quantity <= %d',
-			)
-		);
-	}
-
-	/**
-	 * Generate a count query.
-	 *
-	 * @param bool $sitewide_only generates a query for sitewide low stock threshold only query.
-	 *
-	 * @return string
-	 */
-	protected function get_count_query( $sitewide_only = false ) {
-		$query = $this->get_base_query(
-			array(
-				':selects'       => 'count(*) as total',
-				':orderAndLimit' => '',
-			)
-		);
-
-		if ( ! $sitewide_only ) {
-			return $this->add_sitewide_stock_query_str( $query );
+			return ProductStockIndicator::add_sitewide_stock_query_str( $query );
 		}
 
 		return strtr(

--- a/plugins/woocommerce/src/Internal/Admin/LowStockCounter.php
+++ b/plugins/woocommerce/src/Internal/Admin/LowStockCounter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Internal\Admin;
 
 /**

--- a/plugins/woocommerce/src/Internal/Admin/LowStockCounter.php
+++ b/plugins/woocommerce/src/Internal/Admin/LowStockCounter.php
@@ -10,7 +10,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
  *
  * @since 10.6.0
  */
-class ProductStockIndicator {
+class LowStockCounter {
 
 	/**
 	 * Get the count of low in stock products.

--- a/plugins/woocommerce/src/Internal/Admin/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductStockIndicator.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+/**
+ * Helper class for querying low in stock product counts.
+ *
+ * Contains the counting and query-building logic extracted from ProductsLowInStock
+ * so it can be shared between the REST API endpoint and the admin settings preloader.
+ *
+ * @since 10.6.0
+ */
+class ProductStockIndicator {
+
+	/**
+	 * Get the count of low in stock products.
+	 *
+	 * @param string $status Post status to filter by.
+	 *
+	 * @return int
+	 */
+	public static function get_low_stock_count( $status = 'publish' ) {
+		$low_stock_threshold           = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+		$sidewide_stock_threshold_only = self::is_using_sitewide_stock_threshold_only( $low_stock_threshold );
+
+		return self::get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
+	}
+
+	/**
+	 * Check to see if store is using sitewide threshold only. Meaning that it does not have any custom
+	 * stock threshold for a product.
+	 *
+	 * @param int|null $low_stock_threshold Low stock threshold.
+	 * @return bool
+	 */
+	public static function is_using_sitewide_stock_threshold_only( $low_stock_threshold = null ) {
+		global $wpdb;
+		$query_string = "
+			select count(*) as total
+			from {$wpdb->postmeta}
+			where
+			  meta_key='_low_stock_amount'
+			  AND meta_value > ''
+		";
+		$args         = array();
+		if ( $low_stock_threshold ) {
+			$query_string .= ' AND meta_value != %d';
+			$args[]        = $low_stock_threshold;
+		}
+		// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+		$count = $wpdb->get_var( $wpdb->prepare( $query_string, $args ) );
+		return 0 === (int) $count;
+	}
+
+	/**
+	 * Get the count of low in stock products.
+	 *
+	 * @param bool   $sidewide_stock_threshold_only Boolean to check if the store is using sitewide stock threshold only.
+	 * @param string $status Post status.
+	 * @param int    $low_stock_threshold Low stock threshold.
+	 *
+	 * @return int
+	 */
+	public static function get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold ) {
+		global $wpdb;
+		if ( $sidewide_stock_threshold_only ) {
+			$count_query_string  = self::get_count_query( $sidewide_stock_threshold_only );
+			$count_query_results = $wpdb->get_results(
+				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+				$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
+			);
+
+			return (int) $count_query_results[0]->total;
+		}
+
+		// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
+		// Splitting the queries also speeds up the query.
+		$count_query_with_custom_stock_threshold_string    = self::get_products_with_custom_stock_threshold_count_query_str();
+		$count_query_without_custom_stock_threshold_string = self::get_products_without_custom_stock_threshold_count_query_str();
+		$count_query_with_custom_stock_threshold_results   = $wpdb->get_results(
+			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+			$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
+		);
+		$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
+			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+			$wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ),
+		);
+
+		return (int) $count_query_with_custom_stock_threshold_results[0]->total + (int) $count_query_without_custom_stock_threshold_results[0]->total;
+	}
+
+	/**
+	 * Return a query string for low in stock products.
+	 *
+	 * @param array $replacements  of replacement strings.
+	 *
+	 * @return string
+	 */
+	public static function get_base_query( $replacements = array() ) {
+		global $wpdb;
+		$query = "
+			SELECT
+				:selects
+			FROM
+			  {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup
+			  LEFT JOIN {$wpdb->posts} wp_posts ON wp_posts.ID = wc_product_meta_lookup.product_id
+			  :postmeta_join
+			WHERE
+			  wp_posts.post_type IN ('product', 'product_variation')
+			  AND wp_posts.post_status = %s
+			  AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+			  AND wc_product_meta_lookup.stock_status IN('instock', 'outofstock')
+			  :postmeta_wheres
+			  :orderAndLimit
+		";
+
+		return strtr( $query, $replacements );
+	}
+
+	/**
+	 * Add sitewide stock query string to base query string.
+	 *
+	 * @param string $query Base query string.
+	 *
+	 * @return string
+	 */
+	public static function add_sitewide_stock_query_str( $query ) {
+		global $wpdb;
+		$postmeta = array(
+			'select' => 'meta.meta_value AS low_stock_amount,',
+			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id
+			  AND meta.meta_key = '_low_stock_amount'",
+			'wheres' => "AND (
+			    (
+			      meta.meta_value > ''
+			      AND wc_product_meta_lookup.stock_quantity <= CAST(
+			        meta.meta_value AS SIGNED
+			      )
+			    )
+			    OR (
+			      (
+			        meta.meta_value IS NULL
+			        OR meta.meta_value <= ''
+			      )
+			      AND wc_product_meta_lookup.stock_quantity <= %d
+			    )
+		    )",
+		);
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => $postmeta['select'],
+				':postmeta_join'   => $postmeta['join'],
+				':postmeta_wheres' => $postmeta['wheres'],
+			)
+		);
+	}
+
+	/**
+	 * Generate a count query.
+	 *
+	 * @param bool $sitewide_only generates a query for sitewide low stock threshold only query.
+	 *
+	 * @return string
+	 */
+	private static function get_count_query( $sitewide_only = false ) {
+		$query = self::get_base_query(
+			array(
+				':selects'       => 'count(*) as total',
+				':orderAndLimit' => '',
+			)
+		);
+
+		if ( ! $sitewide_only ) {
+			return self::add_sitewide_stock_query_str( $query );
+		}
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => '',
+				':postmeta_join'   => '',
+				':postmeta_wheres' => 'AND wc_product_meta_lookup.stock_quantity <= %d',
+			)
+		);
+	}
+
+	/**
+	 * Get a query string for products with a custom stock threshold.
+	 *
+	 * @return string
+	 */
+	private static function get_products_with_custom_stock_threshold_count_query_str() {
+		global $wpdb;
+		$query    = self::get_base_query(
+			array(
+				':selects'       => 'count(*) as total',
+				':orderAndLimit' => '',
+			)
+		);
+		$postmeta = array(
+			'select' => 'meta.meta_value AS low_stock_amount,',
+			'join'   => "JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
+			'wheres' => 'AND wc_product_meta_lookup.stock_quantity <= CAST(meta.meta_value AS SIGNED)',
+		);
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => $postmeta['select'],
+				':postmeta_join'   => $postmeta['join'],
+				':postmeta_wheres' => $postmeta['wheres'],
+			)
+		);
+	}
+
+	/**
+	 * Get a query string for products without a custom stock threshold.
+	 *
+	 * @return string
+	 */
+	private static function get_products_without_custom_stock_threshold_count_query_str() {
+		global $wpdb;
+		$query    = self::get_base_query(
+			array(
+				':selects'       => 'count(*) as total',
+				':orderAndLimit' => '',
+			)
+		);
+		$postmeta = array(
+			'select' => 'meta.meta_value AS low_stock_amount,',
+			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
+			'wheres' => 'AND meta.post_id IS NULL AND wc_product_meta_lookup.stock_quantity <= %d',
+		);
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => $postmeta['select'],
+				':postmeta_join'   => $postmeta['join'],
+				':postmeta_wheres' => $postmeta['wheres'],
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -388,7 +388,7 @@ class Settings {
 	 */
 	private function get_low_stock_count() {
 		return 'yes' === get_option( 'woocommerce_manage_stock' )
-			? ProductStockIndicator::get_low_stock_count()
+			? LowStockCounter::get_low_stock_count()
 			: 0;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -181,6 +181,7 @@ class Settings {
 		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );
 		$settings['commentModeration']    = get_option( 'comment_moderation' );
 		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
+		$settings['lowStockCount']        = $this->get_low_stock_count();
 
 		/**
 		 * Deprecate wcAdminAssetUrl as we no longer need it after The Merge.
@@ -378,6 +379,17 @@ class Settings {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Get the count of low in stock products.
+	 *
+	 * @return int
+	 */
+	private function get_low_stock_count() {
+		return 'yes' === get_option( 'woocommerce_manage_stock' )
+			? ProductStockIndicator::get_low_stock_count()
+			: 0;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `/wc-analytics/products/count-low-in-stock` REST API endpoint is called on every WooCommerce admin page load to check whether to show the Activity tab unread indicator dot. This is unnecessary overhead since the count can be preloaded from PHP as part of the admin shared settings.

This PR:
- Extracts the low stock counting and query-building logic from `ProductsLowInStock` into a new `LowStockCounter` helper class to avoid code duplication.
- Updates `ProductsLowInStock` to delegate to the helper for both counting and query building.
- Preloads `lowStockCount` in the admin shared settings via `Settings.php`, using the new helper.
- Updates `activity-panel.js` to read the preloaded value from `getAdminSetting('lowStockCount')` instead of triggering the REST API call via the data store.

Part of #54993.

### How to test the changes in this Pull Request:

1. Set up a store with stock management enabled (WooCommerce > Settings > Products > Inventory > Manage stock checked).
2. Create a product with "Track stock quantity" enabled and set the stock quantity at or below the low stock threshold (default is 2).
3. Go to WooCommerce > Home, click the 3 dots, and click `Hide setup list` to dismiss the tasks (otherwise the inventory card won't show in the Activity tab).
4. Navigate to any WooCommerce admin page (e.g. Orders).
5. Open the browser Network tab and filter by `count-low-in-stock`.
6. Verify that **no** `count-low-in-stock` request is made.
7. Verify that the Activity tab unread indicator dot is visible (indicating low stock products exist).
8. Click on the Activity tab and verify that the low stock card shows and loads correctly.
9. In the browser console, run `wc.wcSettings.getSetting('admin').lowStockCount` and verify it returns the correct count.
10. Go back to the product and set the stock quantity to `> 2`.
11. Navigate to any WooCommerce admin page.
12. Verify that the Activity tab does not have the low stock card.

### Testing that has already taken place:

- Existing `WC_Admin_Tests_API_ProductsLowInStock` PHP tests pass (3 tests covering custom and global low stock thresholds).
- Manual testing confirmed `lowStockCount` is correctly preloaded and the unread dot shows when expected.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Performance - Address performance issues

#### Message
Preload low stock count in admin settings to eliminate unnecessary REST API calls on every WooCommerce admin page load.

</details>
