### PR TITLE
Add woocommerce_rest_pre_update_setting filter to V4 Settings Controller

### DIFF
--- a/plugins/woocommerce/changelog/63325-add-rest-api-pre-update-setting-filter
+++ b/plugins/woocommerce/changelog/63325-add-rest-api-pre-update-setting-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_rest_pre_update_setting filter to the V4 General Settings REST API controller, allowing plugins to validate or block setting updates before they are persisted.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
@@ -333,7 +333,7 @@ class Controller extends AbstractController {
 		 * @param true|WP_Error $result  True if validation passed, WP_Error to block the update.
 		 * @param array         $setting The setting being updated, with 'id' and 'new_value' keys.
 		 */
-		return apply_filters(
+		$result = apply_filters(
 			'woocommerce_rest_pre_update_setting',
 			true,
 			array(
@@ -341,6 +341,20 @@ class Controller extends AbstractController {
 				'new_value' => $value,
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( true !== $result ) {
+			return new WP_Error(
+				'rest_setting_update_blocked',
+				__( 'The setting update was blocked by a validation filter.', 'woocommerce' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/General/Controller.php
@@ -323,7 +323,24 @@ class Controller extends AbstractController {
 				break;
 		}
 
-		return true;
+		/**
+		 * Filters the validation result before a setting is updated via the REST API.
+		 *
+		 * Allows plugins to perform additional validation or block setting updates.
+		 *
+		 * @since 9.8.0
+		 *
+		 * @param true|WP_Error $result  True if validation passed, WP_Error to block the update.
+		 * @param array         $setting The setting being updated, with 'id' and 'new_value' keys.
+		 */
+		return apply_filters(
+			'woocommerce_rest_pre_update_setting',
+			true,
+			array(
+				'id'        => $setting_id,
+				'new_value' => $value,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a `woocommerce_rest_pre_update_setting` filter hook to the V4 General Settings REST API controller's `validate_setting_value` method. This allows plugins and extensions (e.g. CIAB admin) to perform additional validation or enforce business rules before a setting update is persisted.

The filter result is strictly validated: only `true` permits continuation, a `WP_Error` is returned as-is, and any other value (e.g. `false`) is converted into a generic `WP_Error` to block the update.

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Code review.
2. Verify existing setting updates via the V4 REST API (\`/wc/v4/settings/general\`) continue to work as before.
3. Register a filter on \`woocommerce_rest_pre_update_setting\` that returns a \`WP_Error\` for a specific setting and confirm the update is blocked with the expected error response.
4. Register a filter that returns \`true\` and confirm the update proceeds normally.
5. Register a filter that returns \`false\` and confirm it is treated as an error with a 403 response.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add \`woocommerce_rest_pre_update_setting\` filter to the V4 General Settings REST API controller, allowing plugins to validate or block setting updates before they are persisted.

</details>

<details>

<summary>Changelog Entry Comment</summary>

Add \`woocommerce_rest_pre_update_setting\` filter hook to V4 General Settings controller with strict result validation.

</details>