### PR TITLE
Redirect Shop page editor to Product Catalog template on block themes

### DIFF
--- a/plugins/woocommerce/changelog/63338-kmanijak-shop-page-redirect
+++ b/plugins/woocommerce/changelog/63338-kmanijak-shop-page-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Redirect Shop page editor to Product Catalog template in the Site Editor on block themes, so users land on the correct editing surface instead of an empty page.

--- a/plugins/woocommerce/changelog/kmanijak-shop-page-redirect
+++ b/plugins/woocommerce/changelog/kmanijak-shop-page-redirect
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Shop Page - redirect to Product Catalog in Editor

--- a/plugins/woocommerce/changelog/kmanijak-shop-page-redirect
+++ b/plugins/woocommerce/changelog/kmanijak-shop-page-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Shop Page - redirect to Product Catalog in Editor

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -25,6 +25,7 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	public function init() {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'current_theme_supports-block-templates', array( $this, 'remove_block_template_support_for_shop_page' ) );
+		add_action( 'admin_init', array( $this, 'redirect_shop_page_to_product_catalog_template' ) );
 	}
 
 	/**
@@ -85,5 +86,61 @@ class ProductCatalogTemplate extends AbstractTemplate {
 		}
 
 		return $is_support;
+	}
+
+	/**
+	 * Returns the Site Editor URL for the Product Catalog template if the current
+	 * request is editing the Shop page on a block theme.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @return string|null The Site Editor URL, or null if conditions are not met.
+	 */
+	public function get_product_catalog_template_editor_url() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( 'edit' !== ( $_GET['action'] ?? '' ) || empty( $_GET['post'] ) ) {
+			return null;
+		}
+
+		$post_id      = absint( $_GET['post'] );
+		$shop_page_id = wc_get_page_id( 'shop' );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( $post_id !== $shop_page_id ) {
+			return null;
+		}
+
+		if ( ! wp_is_block_theme() || ! current_user_can( 'edit_theme_options' ) ) {
+			return null;
+		}
+
+		$template_source = BlockTemplateUtils::theme_has_template( self::SLUG )
+			? wp_get_theme()->get_stylesheet()
+			: BlockTemplateUtils::PLUGIN_SLUG;
+
+		return add_query_arg(
+			array(
+				'postId'   => $template_source . '//' . self::SLUG,
+				'postType' => 'wp_template',
+				'canvas'   => 'edit',
+			),
+			admin_url( 'site-editor.php' )
+		);
+	}
+
+	/**
+	 * Redirects the Shop page editor to the Product Catalog template in the Site Editor.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @return void
+	 */
+	public function redirect_shop_page_to_product_catalog_template() {
+		$redirect_url = $this->get_product_catalog_template_editor_url();
+
+		if ( $redirect_url ) {
+			wp_safe_redirect( $redirect_url );
+			exit;
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
@@ -42,7 +42,7 @@ class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
 		$_GET['action'] = 'trash';
 		$_GET['post']   = (string) wc_get_page_id( 'shop' );
 
-		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+		$result = $this->sut->get_product_catalog_template_editor_url();
 
 		$this->assertNull( $result, 'Should not redirect when action is not edit' );
 	}
@@ -54,7 +54,7 @@ class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
 		$_GET['action'] = 'edit';
 		$_GET['post']   = '99999';
 
-		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+		$result = $this->sut->get_product_catalog_template_editor_url();
 
 		$this->assertNull( $result, 'Should not redirect for non-shop pages' );
 	}
@@ -66,7 +66,7 @@ class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
 		$_GET['action'] = 'edit';
 		$_GET['post']   = '-1';
 
-		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+		$result = $this->sut->get_product_catalog_template_editor_url();
 
 		$this->assertNull( $result, 'Should not redirect when shop page is not set' );
 	}
@@ -83,7 +83,7 @@ class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
 		$_GET['action'] = 'edit';
 		$_GET['post']   = (string) wc_get_page_id( 'shop' );
 
-		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+		$result = $this->sut->get_product_catalog_template_editor_url();
 
 		$this->assertNotNull( $result, 'Should return a redirect URL for the shop page' );
 		$this->assertStringContainsString( 'site-editor.php', $result );
@@ -103,7 +103,7 @@ class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
 		$_GET['action'] = 'edit';
 		$_GET['post']   = (string) wc_get_page_id( 'shop' );
 
-		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+		$result = $this->sut->get_product_catalog_template_editor_url();
 
 		$expected_post_id = BlockTemplateUtils::theme_has_template( 'archive-product' )
 			? wp_get_theme()->get_stylesheet() . '//archive-product'

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/ProductCatalogTemplateTest.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Templates;
+
+use Automattic\WooCommerce\Blocks\Templates\ProductCatalogTemplate;
+use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductCatalogTemplate class.
+ */
+class ProductCatalogTemplateTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ProductCatalogTemplate
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new ProductCatalogTemplate();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		unset( $_GET['post'], $_GET['action'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should return null when not on post.php edit screen.
+	 */
+	public function test_redirect_returns_null_when_not_on_edit_screen(): void {
+		$_GET['action'] = 'trash';
+		$_GET['post']   = (string) wc_get_page_id( 'shop' );
+
+		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+
+		$this->assertNull( $result, 'Should not redirect when action is not edit' );
+	}
+
+	/**
+	 * @testdox Should return null when post is not the shop page.
+	 */
+	public function test_redirect_returns_null_when_not_shop_page(): void {
+		$_GET['action'] = 'edit';
+		$_GET['post']   = '99999';
+
+		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+
+		$this->assertNull( $result, 'Should not redirect for non-shop pages' );
+	}
+
+	/**
+	 * @testdox Should return null when shop page is not configured.
+	 */
+	public function test_redirect_returns_null_when_shop_page_not_configured(): void {
+		$_GET['action'] = 'edit';
+		$_GET['post']   = '-1';
+
+		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+
+		$this->assertNull( $result, 'Should not redirect when shop page is not set' );
+	}
+
+	/**
+	 * @testdox Should return the site editor URL when editing the shop page on a block theme.
+	 */
+	public function test_redirect_returns_site_editor_url_for_shop_page(): void {
+		if ( ! wp_is_block_theme() ) {
+			$this->markTestSkipped( 'Requires a block theme.' );
+		}
+
+		wp_set_current_user( 1 );
+		$_GET['action'] = 'edit';
+		$_GET['post']   = (string) wc_get_page_id( 'shop' );
+
+		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+
+		$this->assertNotNull( $result, 'Should return a redirect URL for the shop page' );
+		$this->assertStringContainsString( 'site-editor.php', $result );
+		$this->assertStringContainsString( 'archive-product', $result );
+		$this->assertStringContainsString( 'wp_template', $result );
+	}
+
+	/**
+	 * @testdox Should build correct site editor URL with WooCommerce plugin slug.
+	 */
+	public function test_redirect_url_contains_correct_template_id(): void {
+		if ( ! wp_is_block_theme() ) {
+			$this->markTestSkipped( 'Requires a block theme.' );
+		}
+
+		wp_set_current_user( 1 );
+		$_GET['action'] = 'edit';
+		$_GET['post']   = (string) wc_get_page_id( 'shop' );
+
+		$result = $this->sut->redirect_shop_page_to_product_catalog_template();
+
+		$expected_post_id = BlockTemplateUtils::theme_has_template( 'archive-product' )
+			? wp_get_theme()->get_stylesheet() . '//archive-product'
+			: BlockTemplateUtils::PLUGIN_SLUG . '//archive-product';
+
+		$this->assertStringContainsString( urlencode( $expected_post_id ), $result );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On block themes, the Shop page is a placeholder — its content is empty because the actual rendering is handled by the Product Catalog (`archive-product`) template via `template_redirect`. When users navigate to Pages > Edit Shop Page in wp-admin, they see a blank editor, which is confusing.

This PR adds a redirect: when a user tries to edit the Shop page on a block theme, they are automatically redirected to the Product Catalog template in the Site Editor, where the actual layout lives.

**Why the Shop page can't follow the Cart/Checkout pattern:** Cart and Checkout pages have actual block content and use `page-{slug}` template naming that WordPress natively associates. The Shop page uses `archive-product` (an archive template), so a redirect is the most pragmatic solution.

Closes #42152.

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/09c90922-b257-46c6-b40b-ea0001b43365

### How to test the changes in this Pull Request:

1. Activate a block theme (e.g., Twenty Twenty-Four).
2. Ensure WooCommerce is set up with a Shop page configured (WooCommerce > Settings > Products > Shop page).
3. Navigate to Pages in wp-admin.
4. Click "Edit" on the Shop page.
5. **Expected:** You are redirected to the Site Editor, editing the Product Catalog template.
6. Verify the Site Editor URL contains `site-editor.php` with `postId` containing `archive-product` and `postType=wp_template`.
7. Switch to a classic theme and repeat steps 3-4.
8. **Expected:** No redirect — the page editor opens normally.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Enhancement - Improvement to existing functionality

#### Message
Redirect Shop page editor to Product Catalog template in the Site Editor on block themes, so users land on the correct editing surface instead of an empty page.

</details>