### PR TITLE
Always show payment method radio in checkout

### DIFF
--- a/plugins/woocommerce/changelog/update-pay-506-always-show-payment-radio
+++ b/plugins/woocommerce/changelog/update-pay-506-always-show-payment-radio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Always show radio for payment methods on checkout.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -7,7 +7,6 @@ import {
 } from '@woocommerce/base-context/hooks';
 import { cloneElement, useCallback } from '@wordpress/element';
 import { useEditorContext } from '@woocommerce/base-context';
-import clsx from 'clsx';
 import { RadioControlAccordion } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
@@ -29,7 +28,6 @@ const PaymentMethodOptions = () => {
 		activeSavedToken,
 		activePaymentMethod,
 		isExpressPaymentMethodActive,
-		savedPaymentMethods,
 		availablePaymentMethods,
 	} = useSelect( ( select ) => {
 		const store = select( paymentStore );
@@ -37,7 +35,6 @@ const PaymentMethodOptions = () => {
 			activeSavedToken: store.getActiveSavedToken(),
 			activePaymentMethod: store.getActivePaymentMethod(),
 			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
-			savedPaymentMethods: store.getSavedPaymentMethods(),
 			availablePaymentMethods: store.getAvailablePaymentMethods(),
 		};
 	} );
@@ -86,18 +83,10 @@ const PaymentMethodOptions = () => {
 		]
 	);
 
-	const isSinglePaymentMethod =
-		Object.keys( savedPaymentMethods ).length === 0 &&
-		Object.keys( availablePaymentMethods ).length === 1;
-
-	const singleOptionClass = clsx( {
-		'disable-radio-control': isSinglePaymentMethod,
-	} );
 	return isExpressPaymentMethodActive ? null : (
 		<RadioControlAccordion
 			highlightChecked={ true }
 			id={ 'wc-payment-method-options' }
-			className={ singleOptionClass }
 			selected={ activeSavedToken ? null : activePaymentMethod }
 			onChange={ onChange }
 			options={ options }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -46,16 +46,6 @@
 		}
 	}
 
-	.wc-block-components-radio-control.disable-radio-control {
-		.wc-block-components-radio-control__option {
-			padding-left: $gap;
-		}
-
-		.wc-block-components-radio-control__input {
-			display: none;
-		}
-	}
-
 	.wc-block-components-checkout-step__description-payments-aligned {
 		@include font-small-locked;
 		margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -37,9 +37,12 @@ jest.mock( '@woocommerce/blocks-components', () => {
 	return {
 		__esModule: true,
 		...originalModule,
-		RadioControlAccordion: ( { onChange } ) => (
+		RadioControlAccordion: ( { onChange, className = '' } ) => (
 			<>
 				<span>Payment method options</span>
+				<span data-testid="payment-method-options-class-name">
+					{ className }
+				</span>
 				<button onClick={ () => onChange( 'credit-card' ) }>
 					Select new payment
 				</button>
@@ -107,6 +110,24 @@ const registerMockExpressPaymentMethods = () => {
 		content: <div>A payment method</div>,
 		edit: <div>A payment method</div>,
 		canMakePayment: () => true,
+	} );
+	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
+};
+
+const registerMockSinglePaymentMethod = () => {
+	registerPaymentMethod( {
+		name: 'cod',
+		label: 'cod',
+		content: <div>A payment method</div>,
+		edit: <div>A payment method</div>,
+		icons: null,
+		canMakePayment: () => true,
+		supports: {
+			showSavedCards: true,
+			showSaveOption: true,
+			features: [ 'products' ],
+		},
+		ariaLabel: 'cod',
 	} );
 	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
 };
@@ -261,6 +282,38 @@ describe( 'PaymentMethods', () => {
 			);
 			expect( activePaymentMethod ).not.toBeNull();
 		} );
+
+		act( () => resetMockPaymentMethods() );
+	} );
+
+	test( 'should not apply single-method radio disable class when only one payment method is available', async () => {
+		act( () => {
+			registerMockSinglePaymentMethod();
+		} );
+
+		wpDataFunctions.dispatch( CART_STORE_KEY ).receiveCart( {
+			...previewCart,
+			payment_methods: [ 'cod' ],
+		} );
+
+		await waitFor( () => {
+			expect(
+				wpDataFunctions.select( paymentStore ).getActivePaymentMethod()
+			).toBe( 'cod' );
+		} );
+
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+
+		expect(
+			screen.getByTestId( 'payment-method-options-class-name' )
+		).not.toHaveTextContent( /disable-radio-control/ );
 
 		act( () => resetMockPaymentMethods() );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -83,8 +83,8 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
-const registerMockPaymentMethods = () => {
-	[ 'cod', 'credit-card' ].forEach( ( name ) => {
+const registerMockPaymentMethodsByName = ( names ) => {
+	names.forEach( ( name ) => {
 		registerPaymentMethod( {
 			name,
 			label: name,
@@ -103,6 +103,10 @@ const registerMockPaymentMethods = () => {
 	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
 };
 
+const registerMockPaymentMethods = () => {
+	registerMockPaymentMethodsByName( [ 'cod', 'credit-card' ] );
+};
+
 const registerMockExpressPaymentMethods = () => {
 	registerExpressPaymentMethod( {
 		name: 'dummy-express',
@@ -115,27 +119,21 @@ const registerMockExpressPaymentMethods = () => {
 };
 
 const registerMockSinglePaymentMethod = () => {
-	registerPaymentMethod( {
-		name: 'cod',
-		label: 'cod',
-		content: <div>A payment method</div>,
-		edit: <div>A payment method</div>,
-		icons: null,
-		canMakePayment: () => true,
-		supports: {
-			showSavedCards: true,
-			showSaveOption: true,
-			features: [ 'products' ],
-		},
-		ariaLabel: 'cod',
+	registerMockPaymentMethodsByName( [ 'cod' ] );
+};
+
+const resetMockPaymentMethodsByName = ( names ) => {
+	names.forEach( ( name ) => {
+		__experimentalDeRegisterPaymentMethod( name );
 	} );
-	dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
 };
 
 const resetMockPaymentMethods = () => {
-	[ 'cod', 'credit-card' ].forEach( ( name ) => {
-		__experimentalDeRegisterPaymentMethod( name );
-	} );
+	resetMockPaymentMethodsByName( [ 'cod', 'credit-card' ] );
+};
+
+const resetMockSinglePaymentMethod = () => {
+	resetMockPaymentMethodsByName( [ 'cod' ] );
 };
 
 const resetMockExpressPaymentMethods = () => {
@@ -315,6 +313,6 @@ describe( 'PaymentMethods', () => {
 			screen.getByTestId( 'payment-method-options-class-name' )
 		).not.toHaveTextContent( /disable-radio-control/ );
 
-		act( () => resetMockPaymentMethods() );
+		act( () => resetMockSinglePaymentMethod() );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is logic in WooCommerce core that hides the radio toggle when there is only one payment method. In an audit, this recently resulted in a situation like the following, where the payment method and the description end up looking the same, which is quite confusing. See before screenshot below.

Our design team has started to envision how we can better solve this. Here's an early design.

<img width="1662" height="1790" alt="CleanShot 2026-02-17 at 16 24 49@2x" src="https://github.com/user-attachments/assets/6afa71a6-b086-4443-a97e-d272a4695400" />

But, until we figure that out, this pull request removed the logic to hide the radio, which is in alignment with shipping options, which do not remove the radio, even for a single option.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->




| Before | After |
| ------ | ----- |
| <img width="1204" height="414" alt="image" src="https://github.com/user-attachments/assets/19875af1-2abf-4a80-86b0-a682dbd00943" /> | <img width="2786" height="2320" alt="CleanShot 2026-02-17 at 16 27 19@2x" src="https://github.com/user-attachments/assets/3a949e20-f95c-4aab-aabb-3185fb06959a" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Checkout pull request and build
2. Ensure that your site only has 1 payment method enabled
3. Add product to cart and go to checkout
4. Ensure that you see the radio

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Above manual testing
- Newly added unit tests

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
