### PR TITLE
[dev] CI: use the same environment for all performance jobs

### DIFF
--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -682,7 +682,7 @@
 						"@woocommerce/classic-assets"
 					],
 					"testEnv": {
-						"start": "env:test"
+						"start": "env:perf"
 					},
 					"events": [
 						"push",

--- a/plugins/woocommerce/tests/metrics/specs/frontend.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/frontend.spec.js
@@ -12,7 +12,7 @@ import { getTotalBlockingTime, median } from '../utils';
 
 // See https://github.com/WordPress/gutenberg/issues/51383#issuecomment-1613460429
 const BROWSER_IDLE_WAIT = 1000;
-const HOME = '/';
+const SHOP = '/shop/';
 
 const results = {
 	totalBlockingTime: [],
@@ -47,10 +47,10 @@ test.describe( 'Frontend Performance', () => {
 				page,
 				metrics,
 			} ) => {
-				await page.goto( HOME );
+				await page.goto( SHOP );
 
-				// Wait for the site title to load.
-				await page.locator( '[aria-current="page"]' ).first().waitFor();
+				// Wait for the products to load.
+				await page.locator( '[id="main"]' ).first().waitFor();
 
 				// Get the durations.
 				const loadingDurations = await metrics.getLoadingDurations();

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -31,4 +31,8 @@ wp-env run tests-cli wp import wp-content/plugins/woocommerce/sample-data/sample
 # install Storefront
 wp-env run tests-cli wp theme install storefront --activate
 
+# reduce the impact of background activities on the testing setup
+wp-env run tests-cli wp config set DISABLE_WP_CRON true --raw --type=constant
+wp-env run tests-cli wp config set WP_HTTP_BLOCK_EXTERNAL true --raw --type=constant
+
 echo "Success! Your E2E Test Environment is now ready."


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Extracting part of #63321, where:
- We use the same testing environment for our performance jobs
- Attempting to reduce swings in results by config tweaks aiming to reduce site background activity during benchmarks

### How to test the changes in this Pull Request:

- CI-checks shall pass

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
