### PR TITLE
Email Editor: fix memory leaks in vendor-prefixed CSS inlining

### DIFF
--- a/packages/php/email-editor/changelog/63354-update-email-editor-vendor-deps
+++ b/packages/php/email-editor/changelog/63354-update-email-editor-vendor-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Email Editor: fix memory leaks in CSS inlining vendor packages.

--- a/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/CssInliner.php
+++ b/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/CssInliner.php
@@ -389,6 +389,7 @@ final class CssInliner extends AbstractHtmlProcessor
             self::CACHE_KEY_SELECTOR => [],
             self::CACHE_KEY_COMBINED_STYLES => [],
         ];
+        DeclarationBlockParser::clearCache();
     }
 
     /**

--- a/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/Utilities/DeclarationBlockParser.php
+++ b/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/Utilities/DeclarationBlockParser.php
@@ -20,6 +20,14 @@ final class DeclarationBlockParser
     private static $cache = [];
 
     /**
+     * Clears the global declaration block cache.
+     */
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
      * CSS custom properties (variables) have case-sensitive names, so their case must be preserved.
      * Standard CSS properties have case-insensitive names, which are converted to lowercase.
      *

--- a/packages/php/email-editor/vendor-prefixed/packages/Symfony/Component/CssSelector/CssSelectorConverter.php
+++ b/packages/php/email-editor/vendor-prefixed/packages/Symfony/Component/CssSelector/CssSelectorConverter.php
@@ -26,6 +26,11 @@ use Automattic\WooCommerce\EmailEditorVendor\Symfony\Component\CssSelector\XPath
  */
 class CssSelectorConverter
 {
+    /**
+     * @var int Maximum number of cached items per cache (LRU eviction threshold).
+     */
+    public static $maxCachedItems = 200;
+
     private $translator;
     private $cache;
 
@@ -64,6 +69,20 @@ class CssSelectorConverter
      */
     public function toXPath(string $cssExpr, string $prefix = 'descendant-or-self::')
     {
-        return $this->cache[$prefix][$cssExpr] ?? $this->cache[$prefix][$cssExpr] = $this->translator->cssToXPath($cssExpr, $prefix);
+        if (isset($this->cache[$prefix][$cssExpr])) {
+            // LRU promotion: move accessed entry to end of array.
+            $value = $this->cache[$prefix][$cssExpr];
+            unset($this->cache[$prefix][$cssExpr]);
+            $this->cache[$prefix][$cssExpr] = $value;
+
+            return $value;
+        }
+
+        // Evict oldest entry when cache is full.
+        if (isset($this->cache[$prefix]) && \count($this->cache[$prefix]) >= self::$maxCachedItems) {
+            unset($this->cache[$prefix][\array_key_first($this->cache[$prefix])]);
+        }
+
+        return $this->cache[$prefix][$cssExpr] = $this->translator->cssToXPath($cssExpr, $prefix);
     }
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/NL-399/newsletter-digest-css-parsing-causes-memory-exhaustion-fatals

Both CSS inlining packages used by the email editor have unbounded static caches that cause memory exhaustion in long-running processes (e.g. newsletter digests). Instead of upgrading to dev branches (which pulls in sabberworm v8->v9, thecodingmachine/safe migration, and polyfill removal), this PR applies only the two specific memory leak fixes directly to the already-vendored Mozart output:

1. **`DeclarationBlockParser`** - Added `clearCache()` method to reset its unbounded static `$cache` array, called from `CssInliner::clearAllCaches()` so the cache is purged between documents.
2. **`CssSelectorConverter`** - Replaced the unbounded static cache in `toXPath()` with an LRU-capped version (max 200 entries per prefix). Promotes cache hits and evicts oldest entries when the limit is reached.

**3 files changed, 29 insertions, 1 deletion** - minimal and safe.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a post and preview the email from the editor.
2. Publish the post and view the email.
3. Check that the styling is identical and there are no regressions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->
Email Editor: fix memory leaks in CSS inlining vendor packages.

</details>
