### PR TITLE
Fix memory leaks in vendor-prefixed CSS inlining dependencies

### DIFF
--- a/packages/php/email-editor/changelog/fix-memory-leak-css-caches
+++ b/packages/php/email-editor/changelog/fix-memory-leak-css-caches
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unbounded static cache memory leaks in vendor-prefixed CSS inlining dependencies (emogrifier and symfony/css-selector) for long-running processes.

--- a/packages/php/email-editor/vendor-prefixed/composer.json
+++ b/packages/php/email-editor/vendor-prefixed/composer.json
@@ -16,10 +16,12 @@
 	},
 	"scripts": {
 		"post-install-cmd": [
-			"\"../../../../plugins/woocommerce/vendor/bin/mozart\" compose"
+			"\"../../../../plugins/woocommerce/vendor/bin/mozart\" compose",
+			"php patches/patch-memory-leaks.php"
 		],
 		"post-update-cmd": [
-			"\"../../../../plugins/woocommerce/vendor/bin/mozart\" compose"
+			"\"../../../../plugins/woocommerce/vendor/bin/mozart\" compose",
+			"php patches/patch-memory-leaks.php"
 		]
 	},
 	"extra": {

--- a/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/CssInliner.php
+++ b/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/CssInliner.php
@@ -389,6 +389,7 @@ final class CssInliner extends AbstractHtmlProcessor
             self::CACHE_KEY_SELECTOR => [],
             self::CACHE_KEY_COMBINED_STYLES => [],
         ];
+        DeclarationBlockParser::clearCache();
     }
 
     /**

--- a/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/Utilities/DeclarationBlockParser.php
+++ b/packages/php/email-editor/vendor-prefixed/packages/Pelago/Emogrifier/Utilities/DeclarationBlockParser.php
@@ -20,6 +20,17 @@ final class DeclarationBlockParser
     private static $cache = [];
 
     /**
+     * Clears the static declaration block cache.
+     *
+     * This should be called between processing separate HTML documents to prevent
+     * unbounded memory growth in long-running processes.
+     */
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
      * CSS custom properties (variables) have case-sensitive names, so their case must be preserved.
      * Standard CSS properties have case-insensitive names, which are converted to lowercase.
      *

--- a/packages/php/email-editor/vendor-prefixed/patches/patch-memory-leaks.php
+++ b/packages/php/email-editor/vendor-prefixed/patches/patch-memory-leaks.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Post-install patch for memory leak fixes in vendor-prefixed dependencies.
+ *
+ * Applies three patches:
+ * A) DeclarationBlockParser: adds clearCache() static method
+ * B) CssInliner: calls DeclarationBlockParser::clearCache() in clearAllCaches()
+ * C) CssSelectorConverter: replaces unbounded cache with LRU-capped version
+ *
+ * Based on upstream fixes:
+ * - https://github.com/symfony/symfony/pull/63400
+ * - https://github.com/MyIntervals/emogrifier/pull/1567
+ *
+ * @package WooCommerce\EmailEditor
+ */
+
+$base = __DIR__ . '/../packages';
+
+$patches = array();
+
+// --- Patch A: DeclarationBlockParser — add clearCache() method ---
+$patches[] = array(
+	'file'   => $base . '/Pelago/Emogrifier/Utilities/DeclarationBlockParser.php',
+	'marker' => 'public static function clearCache(): void',
+	'search' => '    private static $cache = [];
+
+    /**
+     * CSS custom properties (variables) have case-sensitive names, so their case must be preserved.',
+	'replace' => '    private static $cache = [];
+
+    /**
+     * Clears the static declaration block cache.
+     *
+     * This should be called between processing separate HTML documents to prevent
+     * unbounded memory growth in long-running processes.
+     */
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
+     * CSS custom properties (variables) have case-sensitive names, so their case must be preserved.',
+);
+
+// --- Patch B: CssInliner — call DeclarationBlockParser::clearCache() ---
+$patches[] = array(
+	'file'   => $base . '/Pelago/Emogrifier/CssInliner.php',
+	'marker' => 'DeclarationBlockParser::clearCache();',
+	'search' => '    private function clearAllCaches(): void
+    {
+        $this->caches = [
+            self::CACHE_KEY_SELECTOR => [],
+            self::CACHE_KEY_COMBINED_STYLES => [],
+        ];
+    }',
+	'replace' => '    private function clearAllCaches(): void
+    {
+        $this->caches = [
+            self::CACHE_KEY_SELECTOR => [],
+            self::CACHE_KEY_COMBINED_STYLES => [],
+        ];
+        DeclarationBlockParser::clearCache();
+    }',
+);
+
+// --- Patch C: CssSelectorConverter — LRU cache ---
+$patches[] = array(
+	'file'   => $base . '/Symfony/Component/CssSelector/CssSelectorConverter.php',
+	'marker' => 'maxCachedItems',
+	'search' => '    private $translator;
+    private $cache;
+
+    private static $xmlCache = [];
+    private static $htmlCache = [];',
+	'replace' => '    private $translator;
+    private $cache;
+
+    /**
+     * Maximum number of cached items per prefix before LRU eviction kicks in.
+     *
+     * @var int
+     */
+    public static $maxCachedItems = 200;
+
+    private static $xmlCache = [];
+    private static $htmlCache = [];',
+);
+
+$patches[] = array(
+	'file'   => $base . '/Symfony/Component/CssSelector/CssSelectorConverter.php',
+	'marker' => 'array_key_first',
+	'search' => '    public function toXPath(string $cssExpr, string $prefix = \'descendant-or-self::\')
+    {
+        return $this->cache[$prefix][$cssExpr] ?? $this->cache[$prefix][$cssExpr] = $this->translator->cssToXPath($cssExpr, $prefix);
+    }',
+	'replace' => '    public function toXPath(string $cssExpr, string $prefix = \'descendant-or-self::\')
+    {
+        if (isset($this->cache[$prefix][$cssExpr])) {
+            // Promote to most-recently-used position.
+            $value = $this->cache[$prefix][$cssExpr];
+            unset($this->cache[$prefix][$cssExpr]);
+
+            return $this->cache[$prefix][$cssExpr] = $value;
+        }
+
+        $value = $this->translator->cssToXPath($cssExpr, $prefix);
+
+        if (\count($this->cache[$prefix] ?? []) >= self::$maxCachedItems) {
+            // Evict least-recently-used entry.
+            unset($this->cache[$prefix][\array_key_first($this->cache[$prefix])]);
+        }
+
+        return $this->cache[$prefix][$cssExpr] = $value;
+    }',
+);
+
+$failed = false;
+
+foreach ( $patches as $patch ) {
+	$name = basename( $patch['file'] );
+
+	if ( ! file_exists( $patch['file'] ) ) {
+		echo "FAIL: File not found: {$patch['file']}\n";
+		$failed = true;
+		continue;
+	}
+
+	$content = file_get_contents( $patch['file'] );
+
+	if ( strpos( $content, $patch['marker'] ) !== false ) {
+		echo "SKIP: {$name} — already patched ({$patch['marker']})\n";
+		continue;
+	}
+
+	if ( strpos( $content, $patch['search'] ) === false ) {
+		echo "FAIL: {$name} — search string not found. File may have changed upstream.\n";
+		$failed = true;
+		continue;
+	}
+
+	$patched = str_replace( $patch['search'], $patch['replace'], $content );
+	file_put_contents( $patch['file'], $patched );
+	echo "OK:   {$name} — patch applied\n";
+}
+
+if ( $failed ) {
+	echo "\nSome patches failed. Please check the output above.\n";
+	exit( 1 );
+}
+
+echo "\nAll patches applied successfully.\n";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The email editor's vendored CSS inlining packages (`pelago/emogrifier` and `symfony/css-selector`) have unbounded static caches that cause memory exhaustion in long-running processes (e.g. newsletter digests).

This PR adds a **post-install composer patch script** (`patches/patch-memory-leaks.php`) that applies upstream memory leak fixes to the vendor-prefixed packages, following the [MailPoet pattern](https://github.com/mailpoet/mailpoet/blob/935df8a7d7429fc1d72139fe0d28ce5655f6a25c/mailpoet/composer.json#L67-L81) so patches survive dependency regeneration via Mozart.

**Three patches applied:**

1. **`DeclarationBlockParser`** — adds `clearCache()` static method to reset the unbounded `$cache` array ([emogrifier#1567](https://github.com/MyIntervals/emogrifier/pull/1567))
2. **`CssInliner`** — calls `DeclarationBlockParser::clearCache()` inside `clearAllCaches()` so the static cache is cleared between documents ([emogrifier#1567](https://github.com/MyIntervals/emogrifier/pull/1567))
3. **`CssSelectorConverter`** — replaces unbounded `toXPath()` cache with an LRU-capped version (max 200 entries per prefix), evicting least-recently-used entries ([symfony#63400](https://github.com/symfony/symfony/pull/63400))

The patch script is **idempotent** — running it multiple times safely skips already-applied patches.

Supersedes #63354.

### How to test the changes in this Pull Request:

1. Verify the patch script works correctly:
   ```bash
   cd packages/php/email-editor/vendor-prefixed
   php patches/patch-memory-leaks.php
   ```
   Expected output: all four patches report "SKIP" (already applied).

2. Verify patched files contain the expected changes:
   - `DeclarationBlockParser.php` has a `clearCache()` method
   - `CssInliner.php` calls `DeclarationBlockParser::clearCache()` in `clearAllCaches()`
   - `CssSelectorConverter.php` has `$maxCachedItems = 200` and LRU logic in `toXPath()`

3. Simulate dependency regeneration to verify patches survive:
   ```bash
   cd packages/php/email-editor/vendor-prefixed
   composer install
   ```
   The post-install hook should apply (or skip) patches automatically.

4. Test email editor functionality still works:
   - Create a WooCommerce email template with various CSS styles
   - Verify CSS inlining produces correct results

### Testing that has already taken place:

- Verified patch script applies all patches correctly
- Verified patch script is idempotent (second run skips all)
- Linting passes (`pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`)
- Visually confirmed patched files match upstream fix implementations

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually in `packages/php/email-editor/changelog/fix-memory-leak-css-caches`.

</details>