### PR TITLE
[Backport 10.6.0]Add action hooks for cart item add, update, and remove events

### DIFF
--- a/plugins/woocommerce/changelog/dev-WOOSUBS-1439-cart-hooks-trunk
+++ b/plugins/woocommerce/changelog/dev-WOOSUBS-1439-cart-hooks-trunk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added hooks for user triggered cart updates.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -538,7 +538,7 @@ class WC_AJAX {
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $quantity );
+			do_action( 'woocommerce_cart_item_added_from_user_request', $variation_id ? $variation_id : $product_id, (int) $quantity );
 
 			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				wc_add_to_cart_message( array( $product_id => $quantity ), true );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -536,7 +536,7 @@ class WC_AJAX {
 			 * @param int $product_id Product ID.
 			 * @param int $quantity   Quantity added to the cart.
 			 *
-			 * @since 10.7.0
+			 * @since 10.6.0
 			 */
 			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $quantity );
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -571,6 +571,15 @@ class WC_AJAX {
 		$cart_item_key = wc_clean( isset( $_POST['cart_item_key'] ) ? wp_unslash( $_POST['cart_item_key'] ) : '' );
 
 		if ( $cart_item_key && false !== WC()->cart->remove_cart_item( $cart_item_key ) ) {
+			/**
+			 * Fires when an item is removed from the cart from a user request.
+			 *
+			 * @param string|array $cart_item_key Cart item key.
+			 * @param \WC_Cart     $cart          Cart object.
+			 *
+			 * @since 10.6.0
+			 */
+			do_action( 'internal_woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
 			self::get_refreshed_fragments();
 		} else {
 			wp_send_json_error();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -538,7 +538,7 @@ class WC_AJAX {
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_added_from_user_request', $variation_id ? $variation_id : $product_id, $quantity );
+			do_action( 'internal_woocommerce_cart_item_added_from_user_request', $variation_id ? $variation_id : $product_id, $quantity );
 
 			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				wc_add_to_cart_message( array( $product_id => $quantity ), true );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -570,12 +570,12 @@ class WC_AJAX {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$cart_item_key = wc_clean( isset( $_POST['cart_item_key'] ) ? wp_unslash( $_POST['cart_item_key'] ) : '' );
 
-		if ( $cart_item_key && false !== WC()->cart->remove_cart_item( $cart_item_key ) ) {
+		if ( $cart_item_key && is_string( $cart_item_key ) && false !== WC()->cart->remove_cart_item( $cart_item_key ) ) {
 			/**
 			 * Fires when an item is removed from the cart from a user request.
 			 *
-			 * @param string|array $cart_item_key Cart item key.
-			 * @param \WC_Cart     $cart          Cart object.
+			 * @param string   $cart_item_key Cart item key.
+			 * @param \WC_Cart $cart          Cart object.
 			 *
 			 * @since 10.6.0
 			 */

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -533,12 +533,12 @@ class WC_AJAX {
 			/**
 			 * Fires when an item is added to the cart from a user request.
 			 *
-			 * @param int $product_id Product ID.
-			 * @param int $quantity   Quantity added to the cart.
+			 * @param int       $product_id Product ID.
+			 * @param int|float $quantity   Quantity added to the cart.
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_added_from_user_request', $variation_id ? $variation_id : $product_id, (int) $quantity );
+			do_action( 'woocommerce_cart_item_added_from_user_request', $variation_id ? $variation_id : $product_id, $quantity );
 
 			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				wc_add_to_cart_message( array( $product_id => $quantity ), true );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -530,6 +530,16 @@ class WC_AJAX {
 
 			do_action( 'woocommerce_ajax_added_to_cart', $product_id );
 
+			/**
+			 * Fires when an item is added to the cart from a user request.
+			 *
+			 * @param int $product_id Product ID.
+			 * @param int $quantity   Quantity added to the cart.
+			 *
+			 * @since 10.7.0
+			 */
+			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $quantity );
+
 			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				wc_add_to_cart_message( array( $product_id => $quantity ), true );
 			}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -665,7 +665,7 @@ class WC_Form_Handler {
 					 *
 					 * @since 10.6.0
 					 */
-					do_action( 'woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
+					do_action( 'internal_woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
 				}
 
 				$product = wc_get_product( $cart_item['product_id'] );
@@ -751,7 +751,7 @@ class WC_Form_Handler {
 						 *
 						 * @since 10.6.0
 						 */
-						do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
+						do_action( 'internal_woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 					}
 				}
 			}
@@ -884,7 +884,7 @@ class WC_Form_Handler {
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+			do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
 
 			$url = apply_filters( 'woocommerce_add_to_cart_redirect', $url, $adding_to_cart );
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -657,13 +657,12 @@ class WC_Form_Handler {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
 				/**
-				 * Action hook to track cart item removed event.
+				 * Fires when a cart item is removed via the shortcode cart form.
+				 *
+				 * @param string   $cart_item_key Cart item key.
+				 * @param \WC_Cart $cart          Cart object.
 				 *
 				 * @since 10.7.0
-				 *
-				 * @param string $cart_item_key Cart item key.
-				 * @param object $cart          Cart object.
-				 * @return void
 				 */
 				do_action( 'woocommerce_shortcode_cart_item_removed', $cart_item_key, WC()->cart );
 
@@ -736,7 +735,7 @@ class WC_Form_Handler {
 					}
 
 					if ( $passed_validation ) {
-						$old_quantity = WC()->cart->get_cart()[ $cart_item_key ]['quantity'];
+						$old_quantity = $values['quantity'];
 						WC()->cart->set_quantity( $cart_item_key, $quantity, false );
 						/**
 						 * Fires when a cart item quantity is updated via the shortcode cart form.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -657,7 +657,7 @@ class WC_Form_Handler {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
 				/**
-				 * Fires when a cart item is removed from a user request (shortcode or Store API).
+				 * Fires when a cart item is removed from a user request.
 				 *
 				 * @param string   $cart_item_key Cart item key.
 				 * @param \WC_Cart $cart          Cart object.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -654,17 +654,19 @@ class WC_Form_Handler {
 			$cart_item     = WC()->cart->get_cart_item( $cart_item_key );
 
 			if ( $cart_item ) {
-				WC()->cart->remove_cart_item( $cart_item_key );
+				$removed = WC()->cart->remove_cart_item( $cart_item_key );
 
-				/**
-				 * Fires when a cart item is removed from a user request.
-				 *
-				 * @param string   $cart_item_key Cart item key.
-				 * @param \WC_Cart $cart          Cart object.
-				 *
-				 * @since 10.6.0
-				 */
-				do_action( 'woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
+				if ( $removed ) {
+					/**
+					 * Fires when a cart item is removed from a user request.
+					 *
+					 * @param string   $cart_item_key Cart item key.
+					 * @param \WC_Cart $cart          Cart object.
+					 *
+					 * @since 10.6.0
+					 */
+					do_action( 'woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
+				}
 
 				$product = wc_get_product( $cart_item['product_id'] );
 
@@ -744,8 +746,8 @@ class WC_Form_Handler {
 							 * Fires when a cart item quantity is updated from a user request.
 							 *
 							 * @param string   $cart_item_key Cart item key.
-							 * @param int      $quantity      New quantity.
-							 * @param int      $old_quantity  Old quantity.
+							 * @param int|float $quantity     New quantity.
+							 * @param int|float $old_quantity Old quantity.
 							 * @param \WC_Cart $cart          Cart object.
 							 *
 							 * @since 10.6.0
@@ -874,13 +876,13 @@ class WC_Form_Handler {
 
 		// If we added the product to the cart we can now optionally do a redirect.
 		if ( $was_added_to_cart && 0 === wc_notice_count( 'error' ) ) {
-			$quantity = isset( $_POST['quantity'] ) ? absint( wp_unslash( $_POST['quantity'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$quantity = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			/**
 			 * Fires when an item is added to the cart from a user request.
 			 *
-			 * @param int $product_id Product ID.
-			 * @param int $quantity   Quantity added to the cart.
+			 * @param int       $product_id Product ID.
+			 * @param int|float $quantity   Quantity added to the cart.
 			 *
 			 * @since 10.6.0
 			 */

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -660,8 +660,8 @@ class WC_Form_Handler {
 					/**
 					 * Fires when a cart item is removed from a user request.
 					 *
-					 * @param string   $cart_item_key Cart item key.
-					 * @param \WC_Cart $cart          Cart object.
+					 * @param string|array $cart_item_key Cart item key.
+					 * @param \WC_Cart     $cart          Cart object.
 					 *
 					 * @since 10.6.0
 					 */

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -656,6 +656,17 @@ class WC_Form_Handler {
 			if ( $cart_item ) {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
+				/**
+				 * Action hook to track cart item removed event.
+				 *
+				 * @since 10.7.0
+				 *
+				 * @param string $cart_item_key Cart item key.
+				 * @param object $cart          Cart object.
+				 * @return void
+				 */
+				do_action( 'woocommerce_shortcode_cart_item_removed', $cart_item_key, WC()->cart );
+
 				$product = wc_get_product( $cart_item['product_id'] );
 
 				/* translators: %s: Item name. */

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -860,6 +860,7 @@ class WC_Form_Handler {
 
 		if ( ProductType::VARIABLE === $add_to_cart_handler || ProductType::VARIATION === $add_to_cart_handler ) {
 			$was_added_to_cart = self::add_to_cart_handler_variable( $product_id );
+			$product_id        = ! empty( $_REQUEST['variation_id'] ) ? absint( wp_unslash( $_REQUEST['variation_id'] ) ) : $product_id; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		} elseif ( ProductType::GROUPED === $add_to_cart_handler ) {
 			$was_added_to_cart = self::add_to_cart_handler_grouped( $product_id );
 		} elseif ( has_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler ) ) {

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -737,18 +737,21 @@ class WC_Form_Handler {
 					if ( $passed_validation ) {
 						$old_quantity = $values['quantity'];
 						WC()->cart->set_quantity( $cart_item_key, $quantity, false );
-						/**
-						 * Fires when a cart item quantity is updated from a user request.
-						 *
-						 * @param string   $cart_item_key Cart item key.
-						 * @param int      $quantity      New quantity.
-						 * @param int      $old_quantity  Old quantity.
-						 * @param \WC_Cart $cart          Cart object.
-						 *
-						 * @since 10.6.0
-						 */
-						do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 						$cart_updated = true;
+
+						if ( $old_quantity !== $quantity ) {
+							/**
+							 * Fires when a cart item quantity is updated from a user request.
+							 *
+							 * @param string   $cart_item_key Cart item key.
+							 * @param int      $quantity      New quantity.
+							 * @param int      $old_quantity  Old quantity.
+							 * @param \WC_Cart $cart          Cart object.
+							 *
+							 * @since 10.6.0
+							 */
+							do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
+						}
 					}
 				}
 			}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -662,7 +662,7 @@ class WC_Form_Handler {
 				 * @param string   $cart_item_key Cart item key.
 				 * @param \WC_Cart $cart          Cart object.
 				 *
-				 * @since 10.7.0
+				 * @since 10.6.0
 				 */
 				do_action( 'woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
 
@@ -745,7 +745,7 @@ class WC_Form_Handler {
 						 * @param int      $old_quantity  Old quantity.
 						 * @param \WC_Cart $cart          Cart object.
 						 *
-						 * @since 10.7.0
+						 * @since 10.6.0
 						 */
 						do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 						$cart_updated = true;
@@ -879,7 +879,7 @@ class WC_Form_Handler {
 			 * @param int $product_id Product ID.
 			 * @param int $quantity   Quantity added to the cart.
 			 *
-			 * @since 10.7.0
+			 * @since 10.6.0
 			 */
 			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -660,8 +660,8 @@ class WC_Form_Handler {
 					/**
 					 * Fires when a cart item is removed from a user request.
 					 *
-					 * @param string|array $cart_item_key Cart item key.
-					 * @param \WC_Cart     $cart          Cart object.
+					 * @param string   $cart_item_key Cart item key.
+					 * @param \WC_Cart $cart          Cart object.
 					 *
 					 * @since 10.6.0
 					 */

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -725,7 +725,19 @@ class WC_Form_Handler {
 					}
 
 					if ( $passed_validation ) {
+						$old_quantity = WC()->cart->get_cart()[ $cart_item_key ]['quantity'];
 						WC()->cart->set_quantity( $cart_item_key, $quantity, false );
+						/**
+						 * Fires when a cart item quantity is updated via the shortcode cart form.
+						 *
+						 * @param string   $cart_item_key Cart item key.
+						 * @param int      $quantity      New quantity.
+						 * @param int      $old_quantity  Old quantity.
+						 * @param \WC_Cart $cart          Cart object.
+						 *
+						 * @since 10.7.0
+						 */
+						do_action( 'woocommerce_shortcode_cart_item_update_quantity', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 						$cart_updated = true;
 					}
 				}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -657,14 +657,14 @@ class WC_Form_Handler {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
 				/**
-				 * Fires when a cart item is removed via the shortcode cart form.
+				 * Fires when a cart item is removed from a user request (shortcode or Store API).
 				 *
 				 * @param string   $cart_item_key Cart item key.
 				 * @param \WC_Cart $cart          Cart object.
 				 *
 				 * @since 10.7.0
 				 */
-				do_action( 'woocommerce_shortcode_cart_item_removed', $cart_item_key, WC()->cart );
+				do_action( 'woocommerce_cart_item_removed_from_user_request', $cart_item_key, WC()->cart );
 
 				$product = wc_get_product( $cart_item['product_id'] );
 

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -870,6 +870,18 @@ class WC_Form_Handler {
 
 		// If we added the product to the cart we can now optionally do a redirect.
 		if ( $was_added_to_cart && 0 === wc_notice_count( 'error' ) ) {
+			$quantity = isset( $_POST['quantity'] ) ? absint( wp_unslash( $_POST['quantity'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+			/**
+			 * Fires when an item is added to the cart from a user request.
+			 *
+			 * @param int $product_id Product ID.
+			 * @param int $quantity   Quantity added to the cart.
+			 *
+			 * @since 10.7.0
+			 */
+			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+
 			$url = apply_filters( 'woocommerce_add_to_cart_redirect', $url, $adding_to_cart );
 
 			if ( $url ) {

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -738,7 +738,7 @@ class WC_Form_Handler {
 						$old_quantity = $values['quantity'];
 						WC()->cart->set_quantity( $cart_item_key, $quantity, false );
 						/**
-						 * Fires when a cart item quantity is updated via the shortcode cart form.
+						 * Fires when a cart item quantity is updated from a user request.
 						 *
 						 * @param string   $cart_item_key Cart item key.
 						 * @param int      $quantity      New quantity.
@@ -747,7 +747,7 @@ class WC_Form_Handler {
 						 *
 						 * @since 10.7.0
 						 */
-						do_action( 'woocommerce_shortcode_cart_item_update_quantity', $cart_item_key, $quantity, $old_quantity, WC()->cart );
+						do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 						$cart_updated = true;
 					}
 				}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -741,19 +741,17 @@ class WC_Form_Handler {
 						WC()->cart->set_quantity( $cart_item_key, $quantity, false );
 						$cart_updated = true;
 
-						if ( $old_quantity !== $quantity ) {
-							/**
-							 * Fires when a cart item quantity is updated from a user request.
-							 *
-							 * @param string   $cart_item_key Cart item key.
-							 * @param int|float $quantity     New quantity.
-							 * @param int|float $old_quantity Old quantity.
-							 * @param \WC_Cart $cart          Cart object.
-							 *
-							 * @since 10.6.0
-							 */
-							do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
-						}
+						/**
+						 * Fires when a cart item quantity is updated from a user request.
+						 *
+						 * @param string   $cart_item_key Cart item key.
+						 * @param int|float $quantity     New quantity.
+						 * @param int|float $old_quantity Old quantity.
+						 * @param \WC_Cart $cart          Cart object.
+						 *
+						 * @since 10.6.0
+						 */
+						do_action( 'woocommerce_cart_item_updated_from_user_request', $cart_item_key, $quantity, $old_quantity, WC()->cart );
 					}
 				}
 			}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -8935,12 +8935,6 @@ parameters:
 			path: includes/class-wc-ajax.php
 
 		-
-			message: '#^Parameter \#1 \$cart_item_key of method WC_Cart\:\:remove_cart_item\(\) expects string, array\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-ajax.php
-
-		-
 			message: '#^Parameter \#1 \$coupon_code of method WC_Cart\:\:remove_coupon\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -140,7 +140,7 @@ class CartAddItem extends AbstractCartRoute {
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+			do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
 		}
 
 		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -124,20 +124,24 @@ class CartAddItem extends AbstractCartRoute {
 			$request
 		);
 
-		$item_id    = $this->cart_controller->add_to_cart( $add_to_cart_data );
-		$cart       = $this->cart_controller->get_cart_instance();
-		$cart_item  = $cart->get_cart_item( $item_id );
-		$product_id = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
+		$item_id   = $this->cart_controller->add_to_cart( $add_to_cart_data );
+		$cart      = $this->cart_controller->get_cart_instance();
+		$cart_item = $cart->get_cart_item( $item_id );
 
-		/**
-		 * Fires when an item is added to the cart from a user request.
-		 *
-		 * @param int $product_id Product ID.
-		 * @param int $quantity   Quantity added to the cart.
-		 *
-		 * @since 10.6.0
-		 */
-		do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $cart_item['quantity'] );
+		if ( ! empty( $cart_item ) ) {
+			$product_id = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
+			$quantity   = $add_to_cart_data['quantity'] ?? $cart_item['quantity'];
+
+			/**
+			 * Fires when an item is added to the cart from a user request.
+			 *
+			 * @param int       $product_id Product ID (variation ID for variable products).
+			 * @param int|float $quantity   Quantity added to the cart.
+			 *
+			 * @since 10.6.0
+			 */
+			do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+		}
 
 		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 		$response->set_status( 201 );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -131,11 +131,11 @@ class CartAddItem extends AbstractCartRoute {
 		/**
 		 * Fires when an item is added to the cart via the Store API.
 		 *
-		 * @since 10.7.0
+		 * @param string   $item_id  Cart item id.
+		 * @param int      $quantity Quantity added to the cart.
+		 * @param \WC_Cart $cart     Cart object.
 		 *
-		 * @param string    $item_id  Cart item id.
-		 * @param float $quantity Quantity added to the cart.
-		 * @param \WC_Cart  $cart     Cart object.
+		 * @since 10.7.0
 		 */
 		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $cart_item['quantity'] ?? 1, $cart );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -124,20 +124,20 @@ class CartAddItem extends AbstractCartRoute {
 			$request
 		);
 
-		$item_id   = $this->cart_controller->add_to_cart( $add_to_cart_data );
-		$cart      = $this->cart_controller->get_cart_instance();
-		$cart_item = $cart->get_cart_item( $item_id );
+		$item_id    = $this->cart_controller->add_to_cart( $add_to_cart_data );
+		$cart       = $this->cart_controller->get_cart_instance();
+		$cart_item  = $cart->get_cart_item( $item_id );
+		$product_id = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
 
 		/**
-		 * Fires when an item is added to the cart via the Store API.
+		 * Fires when an item is added to the cart from a user request.
 		 *
-		 * @param string   $item_id  Cart item id.
-		 * @param int      $quantity Quantity added to the cart.
-		 * @param \WC_Cart $cart     Cart object.
+		 * @param int $product_id Product ID.
+		 * @param int $quantity   Quantity added to the cart.
 		 *
 		 * @since 10.7.0
 		 */
-		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $cart_item['quantity'] ?? 1, $cart );
+		do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $cart_item['quantity'] );
 
 		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 		$response->set_status( 201 );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -135,7 +135,7 @@ class CartAddItem extends AbstractCartRoute {
 		 * @param int $product_id Product ID.
 		 * @param int $quantity   Quantity added to the cart.
 		 *
-		 * @since 10.7.0
+		 * @since 10.6.0
 		 */
 		do_action( 'woocommerce_cart_item_added_from_user_request', $product_id, (int) $cart_item['quantity'] );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -124,7 +124,18 @@ class CartAddItem extends AbstractCartRoute {
 			$request
 		);
 
-		$this->cart_controller->add_to_cart( $add_to_cart_data );
+		$item_id = $this->cart_controller->add_to_cart( $add_to_cart_data );
+		$cart = $this->cart_controller->get_cart_instance();
+
+		/**
+		 * Fires when a cart item is updated from the Store API.
+		 *
+		 * @param string $item_id Cart item id.
+		 * @param int $quantity Quantity.
+		 * @param int $old_quantity Old quantity.
+		 * @param \WC_Cart $cart Cart object.
+		 */
+		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $request['quantity'], $cart );
 
 		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 		$response->set_status( 201 );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -124,19 +124,20 @@ class CartAddItem extends AbstractCartRoute {
 			$request
 		);
 
-		$item_id = $this->cart_controller->add_to_cart( $add_to_cart_data );
-		$cart    = $this->cart_controller->get_cart_instance();
+		$item_id   = $this->cart_controller->add_to_cart( $add_to_cart_data );
+		$cart      = $this->cart_controller->get_cart_instance();
+		$cart_item = $cart->get_cart_item( $item_id );
 
 		/**
 		 * Fires when an item is added to the cart via the Store API.
 		 *
 		 * @since 10.7.0
 		 *
-		 * @param string   $item_id  Cart item id.
-		 * @param int      $quantity Quantity.
-		 * @param \WC_Cart $cart     Cart object.
+		 * @param string    $item_id  Cart item id.
+		 * @param float $quantity Quantity added to the cart.
+		 * @param \WC_Cart  $cart     Cart object.
 		 */
-		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $request['quantity'], $cart );
+		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $cart_item['quantity'] ?? 1, $cart );
 
 		$response = rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_for_response() ) );
 		$response->set_status( 201 );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -125,15 +125,16 @@ class CartAddItem extends AbstractCartRoute {
 		);
 
 		$item_id = $this->cart_controller->add_to_cart( $add_to_cart_data );
-		$cart = $this->cart_controller->get_cart_instance();
+		$cart    = $this->cart_controller->get_cart_instance();
 
 		/**
-		 * Fires when a cart item is updated from the Store API.
+		 * Fires when an item is added to the cart via the Store API.
 		 *
-		 * @param string $item_id Cart item id.
-		 * @param int $quantity Quantity.
-		 * @param int $old_quantity Old quantity.
-		 * @param \WC_Cart $cart Cart object.
+		 * @since 10.7.0
+		 *
+		 * @param string   $item_id  Cart item id.
+		 * @param int      $quantity Quantity.
+		 * @param \WC_Cart $cart     Cart object.
 		 */
 		do_action( 'woocommerce_store_api_cart_item_add_from_request', $item_id, $request['quantity'], $cart );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -79,8 +79,8 @@ class CartRemoveItem extends AbstractCartRoute {
 			/**
 			 * Fires when a cart item is removed from a user request.
 			 *
-			 * @param string|array $cart_item_key Cart item key.
-			 * @param \WC_Cart     $cart          Cart object.
+			 * @param string   $cart_item_key Cart item key.
+			 * @param \WC_Cart $cart          Cart object.
 			 *
 			 * @since 10.6.0
 			 */

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -81,7 +81,7 @@ class CartRemoveItem extends AbstractCartRoute {
 		 * @param string   $cart_item_key Cart item key.
 		 * @param \WC_Cart $cart          Cart object.
 		 *
-		 * @since 10.7.0
+		 * @since 10.6.0
 		 */
 		do_action( 'woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -74,6 +74,18 @@ class CartRemoveItem extends AbstractCartRoute {
 		}
 
 		$cart->remove_cart_item( $request['key'] );
+
+		/**
+		 * Action hook to track cart item removed event.
+		 *
+		 * @since 10.7.0
+		 *
+		 * @param string $cart_item_key Cart item key.
+		 * @param object $cart          Cart object.
+		 * @return void
+		 */
+		do_action( 'woocommerce_store_api_cart_item_removed_from_request', $request['key'], $cart );
+
 		$this->maybe_release_stock();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -76,14 +76,14 @@ class CartRemoveItem extends AbstractCartRoute {
 		$cart->remove_cart_item( $request['key'] );
 
 		/**
-		 * Fires when a cart item is removed via the Store API.
+		 * Fires when a cart item is removed from a user request (shortcode or Store API).
 		 *
 		 * @param string   $cart_item_key Cart item key.
 		 * @param \WC_Cart $cart          Cart object.
 		 *
 		 * @since 10.7.0
 		 */
-		do_action( 'woocommerce_store_api_cart_item_removed_from_request', $request['key'], $cart );
+		do_action( 'woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
 
 		$this->maybe_release_stock();
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -73,17 +73,19 @@ class CartRemoveItem extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woocommerce' ), 409 );
 		}
 
-		$cart->remove_cart_item( $request['key'] );
+		$removed = $cart->remove_cart_item( $request['key'] );
 
-		/**
-		 * Fires when a cart item is removed from a user request.
-		 *
-		 * @param string   $cart_item_key Cart item key.
-		 * @param \WC_Cart $cart          Cart object.
-		 *
-		 * @since 10.6.0
-		 */
-		do_action( 'woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
+		if ( $removed ) {
+			/**
+			 * Fires when a cart item is removed from a user request.
+			 *
+			 * @param string   $cart_item_key Cart item key.
+			 * @param \WC_Cart $cart          Cart object.
+			 *
+			 * @since 10.6.0
+			 */
+			do_action( 'woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
+		}
 
 		$this->maybe_release_stock();
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -79,8 +79,8 @@ class CartRemoveItem extends AbstractCartRoute {
 			/**
 			 * Fires when a cart item is removed from a user request.
 			 *
-			 * @param string   $cart_item_key Cart item key.
-			 * @param \WC_Cart $cart          Cart object.
+			 * @param string|array $cart_item_key Cart item key.
+			 * @param \WC_Cart     $cart          Cart object.
 			 *
 			 * @since 10.6.0
 			 */

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -84,7 +84,7 @@ class CartRemoveItem extends AbstractCartRoute {
 			 *
 			 * @since 10.6.0
 			 */
-			do_action( 'woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
+			do_action( 'internal_woocommerce_cart_item_removed_from_user_request', $request['key'], $cart );
 		}
 
 		$this->maybe_release_stock();

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -76,7 +76,7 @@ class CartRemoveItem extends AbstractCartRoute {
 		$cart->remove_cart_item( $request['key'] );
 
 		/**
-		 * Fires when a cart item is removed from a user request (shortcode or Store API).
+		 * Fires when a cart item is removed from a user request.
 		 *
 		 * @param string   $cart_item_key Cart item key.
 		 * @param \WC_Cart $cart          Cart object.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -76,13 +76,12 @@ class CartRemoveItem extends AbstractCartRoute {
 		$cart->remove_cart_item( $request['key'] );
 
 		/**
-		 * Action hook to track cart item removed event.
+		 * Fires when a cart item is removed via the Store API.
+		 *
+		 * @param string   $cart_item_key Cart item key.
+		 * @param \WC_Cart $cart          Cart object.
 		 *
 		 * @since 10.7.0
-		 *
-		 * @param string $cart_item_key Cart item key.
-		 * @param object $cart          Cart object.
-		 * @return void
 		 */
 		do_action( 'woocommerce_store_api_cart_item_removed_from_request', $request['key'], $cart );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -74,17 +74,20 @@ class CartUpdateItem extends AbstractCartRoute {
 			$cart_item    = $cart->get_cart_item( $request['key'] );
 			$old_quantity = $cart_item['quantity'] ?? 0;
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
-			/**
-			 * Fires when a cart item quantity is updated from a user request.
-			 *
-			 * @param string   $cart_item_key Cart item key.
-			 * @param int      $quantity      Quantity.
-			 * @param int      $old_quantity  Old quantity.
-			 * @param \WC_Cart $cart          Cart object.
-			 *
-			 * @since 10.6.0
-			 */
-			do_action( 'woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
+			
+			if ( $old_quantity !== $request['quantity'] ) {
+				/**
+				 * Fires when a cart item quantity is updated from a user request.
+				 *
+				 * @param string   $cart_item_key Cart item key.
+				 * @param int      $quantity      Quantity.
+				 * @param int      $old_quantity  Old quantity.
+				 * @param \WC_Cart $cart          Cart object.
+				 *
+				 * @since 10.6.0
+				 */
+				do_action( 'woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
+			}
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -82,7 +82,7 @@ class CartUpdateItem extends AbstractCartRoute {
 			 * @param int      $old_quantity Old quantity.
 			 * @param \WC_Cart $cart         Cart object.
 			 *
-			 * @since 10.7.0
+			 * @since 10.6.0
 			 */
 			do_action( 'woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -86,7 +86,7 @@ class CartUpdateItem extends AbstractCartRoute {
 				 *
 				 * @since 10.6.0
 				 */
-				do_action( 'woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
+				do_action( 'internal_woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
 			}
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -68,18 +68,20 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$cart = $this->cart_controller->get_cart_instance();
+		$cart         = $this->cart_controller->get_cart_instance();
 		$old_quantity = $cart->get_cart_item( $request['key'] )['quantity'];
 
 		if ( isset( $request['quantity'] ) ) {
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 			/**
-			 * Fires when a cart item is updated from the Store API.
+			 * Fires when a cart item quantity is updated via the Store API.
 			 *
-			 * @param string $item_id Cart item id.
-			 * @param int $quantity Quantity.
-			 * @param int $old_quantity Old quantity.
-			 * @param \WC_Cart $cart Cart object.
+			 * @since 10.7.0
+			 *
+			 * @param string   $item_id      Cart item id.
+			 * @param int      $quantity     Quantity.
+			 * @param int      $old_quantity Old quantity.
+			 * @param \WC_Cart $cart         Cart object.
 			 */
 			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], $request['quantity'], $old_quantity, $cart );
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -74,15 +74,15 @@ class CartUpdateItem extends AbstractCartRoute {
 			$cart_item    = $cart->get_cart_item( $request['key'] );
 			$old_quantity = $cart_item['quantity'] ?? 0;
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
-			
-			if ( $old_quantity !== $request['quantity'] ) {
+
+			if ( $old_quantity !== (int) $request['quantity'] ) {
 				/**
 				 * Fires when a cart item quantity is updated from a user request.
 				 *
-				 * @param string   $cart_item_key Cart item key.
-				 * @param int      $quantity      Quantity.
-				 * @param int      $old_quantity  Old quantity.
-				 * @param \WC_Cart $cart          Cart object.
+				 * @param string    $cart_item_key Cart item key.
+				 * @param int       $quantity      New quantity.
+				 * @param int|float $old_quantity  Old quantity.
+				 * @param \WC_Cart  $cart          Cart object.
 				 *
 				 * @since 10.6.0
 				 */

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -72,17 +72,17 @@ class CartUpdateItem extends AbstractCartRoute {
 
 		if ( isset( $request['quantity'] ) ) {
 			$cart_item    = $cart->get_cart_item( $request['key'] );
-			$old_quantity = ! empty( $cart_item ) && isset( $cart_item['quantity'] ) ? $cart_item['quantity'] : 0;
+			$old_quantity = $cart_item['quantity'] ?? 0;
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 			/**
 			 * Fires when a cart item quantity is updated via the Store API.
-			 *
-			 * @since 10.7.0
 			 *
 			 * @param string   $item_key     Cart item key.
 			 * @param int      $quantity     Quantity.
 			 * @param int      $old_quantity Old quantity.
 			 * @param \WC_Cart $cart         Cart object.
+			 *
+			 * @since 10.7.0
 			 */
 			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -77,10 +77,10 @@ class CartUpdateItem extends AbstractCartRoute {
 			/**
 			 * Fires when a cart item quantity is updated from a user request.
 			 *
-			 * @param string   $item_key     Cart item key.
-			 * @param int      $quantity     Quantity.
-			 * @param int      $old_quantity Old quantity.
-			 * @param \WC_Cart $cart         Cart object.
+			 * @param string   $cart_item_key Cart item key.
+			 * @param int      $quantity      Quantity.
+			 * @param int      $old_quantity  Old quantity.
+			 * @param \WC_Cart $cart          Cart object.
 			 *
 			 * @since 10.6.0
 			 */

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -75,7 +75,7 @@ class CartUpdateItem extends AbstractCartRoute {
 			$old_quantity = $cart_item['quantity'] ?? 0;
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 			/**
-			 * Fires when a cart item quantity is updated via the Store API.
+			 * Fires when a cart item quantity is updated from a user request.
 			 *
 			 * @param string   $item_key     Cart item key.
 			 * @param int      $quantity     Quantity.
@@ -84,7 +84,7 @@ class CartUpdateItem extends AbstractCartRoute {
 			 *
 			 * @since 10.7.0
 			 */
-			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
+			do_action( 'woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -69,9 +69,19 @@ class CartUpdateItem extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		$cart = $this->cart_controller->get_cart_instance();
+		$old_quantity = $cart->get_cart_item( $request['key'] )['quantity'];
 
 		if ( isset( $request['quantity'] ) ) {
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
+			/**
+			 * Fires when a cart item is updated from the Store API.
+			 *
+			 * @param string $item_id Cart item id.
+			 * @param int $quantity Quantity.
+			 * @param int $old_quantity Old quantity.
+			 * @param \WC_Cart $cart Cart object.
+			 */
+			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], $request['quantity'], $old_quantity, $cart );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -68,22 +68,23 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$cart         = $this->cart_controller->get_cart_instance();
-		$old_quantity = $cart->get_cart_item( $request['key'] )['quantity'];
+		$cart = $this->cart_controller->get_cart_instance();
 
 		if ( isset( $request['quantity'] ) ) {
+			$cart_item    = $cart->get_cart_item( $request['key'] );
+			$old_quantity = ! empty( $cart_item ) && isset( $cart_item['quantity'] ) ? $cart_item['quantity'] : 0;
 			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 			/**
 			 * Fires when a cart item quantity is updated via the Store API.
 			 *
 			 * @since 10.7.0
 			 *
-			 * @param string   $item_id      Cart item id.
+			 * @param string   $item_key     Cart item key.
 			 * @param int      $quantity     Quantity.
 			 * @param int      $old_quantity Old quantity.
 			 * @param \WC_Cart $cart         Cart object.
 			 */
-			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], $request['quantity'], $old_quantity, $cart );
+			do_action( 'woocommerce_store_api_cart_item_update_from_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -315,7 +315,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when adding an item via AJAX.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request when adding an item via AJAX.
 	 */
 	public function test_add_to_cart_fires_cart_item_added_from_user_request(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -331,7 +331,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$this->do_ajax( 'woocommerce_add_to_cart' );
 
@@ -339,7 +339,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
 		$this->assertEquals( 3, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 
 		WC()->cart->empty_cart();
 		unset( $_POST['product_id'], $_POST['quantity'] );
@@ -347,7 +347,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with variation ID when adding a variation via AJAX.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request with variation ID when adding a variation via AJAX.
 	 */
 	public function test_add_to_cart_fires_cart_item_added_from_user_request_for_variation(): void {
 		$product = new \WC_Product_Variable();
@@ -373,7 +373,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$this->do_ajax( 'woocommerce_add_to_cart' );
 
@@ -381,7 +381,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
 		$this->assertEquals( 2, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 
 		WC()->cart->empty_cart();
 		unset( $_POST['product_id'], $_POST['quantity'] );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -315,6 +315,37 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when adding an item via AJAX.
+	 */
+	public function test_add_to_cart_fires_cart_item_added_from_user_request(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$_POST['product_id'] = $product->get_id();
+		$_POST['quantity']   = 3;
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		$this->do_ajax( 'woocommerce_add_to_cart' );
+
+		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
+		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
+		$this->assertSame( 3, $captured_args['quantity'] );
+
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+
+		unset( $_POST['product_id'], $_POST['quantity'] );
+		$product->delete( true );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -337,11 +337,55 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 
 		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
 		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
-		$this->assertSame( 3, $captured_args['quantity'] );
+		$this->assertEquals( 3, $captured_args['quantity'] );
 
 		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 
+		WC()->cart->empty_cart();
 		unset( $_POST['product_id'], $_POST['quantity'] );
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with variation ID when adding a variation via AJAX.
+	 */
+	public function test_add_to_cart_fires_cart_item_added_from_user_request_for_variation(): void {
+		$product = new \WC_Product_Variable();
+		$product->set_name( 'Test Variable Product' );
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'color', array( 'blue' ) );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes( array( 'pa_color' => 'blue' ) );
+		$variation->set_regular_price( 10 );
+		$variation->save();
+
+		$_POST['product_id'] = $variation->get_id();
+		$_POST['quantity']   = 2;
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		$this->do_ajax( 'woocommerce_add_to_cart' );
+
+		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
+		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
+		$this->assertEquals( 2, $captured_args['quantity'] );
+
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+
+		WC()->cart->empty_cart();
+		unset( $_POST['product_id'], $_POST['quantity'] );
+		$variation->delete( true );
 		$product->delete( true );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -390,6 +390,40 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Should fire internal_woocommerce_cart_item_removed_from_user_request when removing an item via AJAX.
+	 */
+	public function test_remove_from_cart_fires_cart_item_removed_from_user_request(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		WC()->cart->empty_cart();
+		$cart_item_key = WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$_POST['cart_item_key'] = $cart_item_key;
+
+		$captured_args = array();
+		$callback      = function ( $key, $cart ) use ( &$captured_args ) {
+			$captured_args = array(
+				'cart_item_key' => $key,
+				'cart'          => $cart,
+			);
+		};
+
+		add_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
+
+		$this->do_ajax( 'woocommerce_remove_from_cart' );
+
+		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
+		$this->assertSame( $cart_item_key, $captured_args['cart_item_key'] );
+		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback );
+
+		WC()->cart->empty_cart();
+		unset( $_POST['cart_item_key'] );
+		$product->delete( true );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1237,11 +1237,11 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$nonce = wp_create_nonce( 'woocommerce-cart' );
 
-		$_POST['_wpnonce']   = $nonce;
-		$_REQUEST['_wpnonce'] = $nonce;
-		$_POST['update_cart'] = 'Update Cart';
+		$_POST['_wpnonce']       = $nonce;
+		$_REQUEST['_wpnonce']    = $nonce;
+		$_POST['update_cart']    = 'Update Cart';
 		$_REQUEST['update_cart'] = 'Update Cart';
-		$_POST['cart']        = array(
+		$_POST['cart']           = array(
 			$cart_item_key => array( 'qty' => 5 ),
 		);
 
@@ -1264,6 +1264,42 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		remove_action( 'woocommerce_shortcode_cart_item_update_quantity', $callback );
 
 		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox Should fire woocommerce_shortcode_cart_item_removed when cart item is removed via form.
+	 */
+	public function test_update_cart_action_fires_remove_item_action(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$cart_items    = WC()->cart->get_cart();
+		$cart_item_key = array_key_first( $cart_items );
+
+		$nonce = wp_create_nonce( 'woocommerce-cart' );
+
+		$_REQUEST['_wpnonce']    = $nonce;
+		$_GET['remove_item']     = $cart_item_key;
+		$_REQUEST['remove_item'] = $cart_item_key;
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_key, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'cart' );
+		};
+
+		add_action( 'woocommerce_shortcode_cart_item_removed', $callback, 10, 2 );
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertNotEmpty( $captured_args, 'The remove item action should have been fired' );
+		$this->assertSame( $cart_item_key, $captured_args['item_key'] );
+		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_shortcode_cart_item_removed', $callback );
+
+		unset( $_REQUEST['_wpnonce'], $_GET['remove_item'], $_REQUEST['remove_item'] );
 		$product->delete( true );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1226,7 +1226,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_updated_from_user_request when cart item quantity is updated via form.
+	 * @testdox Should fire internal_woocommerce_cart_item_updated_from_user_request when cart item quantity is updated via form.
 	 */
 	public function test_update_cart_action_fires_update_quantity_action(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1251,7 +1251,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
-		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		WC_Form_Handler::update_cart_action();
 
@@ -1261,14 +1261,14 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 
 		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
 		$product->delete( true );
 	}
 
 	/**
-	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
+	 * @testdox Should not fire internal_woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
 	 */
 	public function test_update_cart_action_does_not_fire_update_quantity_action_when_unchanged(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1292,20 +1292,20 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			$hook_fired = true;
 		};
 
-		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		WC_Form_Handler::update_cart_action();
 
 		$this->assertFalse( $hook_fired, 'The update quantity action should not fire when the quantity is unchanged' );
 
-		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 
 		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
 		$product->delete( true );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_removed_from_user_request when cart item is removed via form.
+	 * @testdox Should fire internal_woocommerce_cart_item_removed_from_user_request when cart item is removed via form.
 	 */
 	public function test_update_cart_action_fires_remove_item_action(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1326,7 +1326,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			$captured_args = compact( 'cart_item_key', 'cart' );
 		};
 
-		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
 
 		WC_Form_Handler::update_cart_action();
 
@@ -1334,14 +1334,14 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( $cart_item_key, $captured_args['cart_item_key'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback );
 
 		unset( $_REQUEST['_wpnonce'], $_GET['remove_item'], $_REQUEST['remove_item'] );
 		$product->delete( true );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when a simple product is added via the shortcode form.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request when a simple product is added via the shortcode form.
 	 */
 	public function test_add_to_cart_action_fires_cart_item_added_from_user_request(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1358,7 +1358,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		WC_Form_Handler::add_to_cart_action( false );
 
@@ -1366,14 +1366,14 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
 		$this->assertEquals( 3, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 
 		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
 		$product->delete( true );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with the variation ID when a variable product is added via the shortcode form.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request with the variation ID when a variable product is added via the shortcode form.
 	 */
 	public function test_add_to_cart_action_fires_cart_item_added_from_user_request_for_variable_product(): void {
 		$product = new WC_Product_Variable();
@@ -1402,7 +1402,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		WC_Form_Handler::add_to_cart_action( false );
 
@@ -1410,7 +1410,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
 		$this->assertEquals( 2, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 
 		unset( $_REQUEST['add-to-cart'], $_REQUEST['variation_id'], $_REQUEST['quantity'], $_POST['quantity'], $_REQUEST['attribute_pa_color'] );
 		$variation->delete( true );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1247,8 +1247,8 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
+		$callback = function ( $cart_item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
 		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
@@ -1256,7 +1256,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC_Form_Handler::update_cart_action();
 
 		$this->assertNotEmpty( $captured_args, 'The update quantity action should have been fired' );
-		$this->assertSame( $cart_item_key, $captured_args['item_key'] );
+		$this->assertSame( $cart_item_key, $captured_args['cart_item_key'] );
 		$this->assertSame( 5, $captured_args['quantity'] );
 		$this->assertSame( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
@@ -1285,8 +1285,8 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'cart' );
+		$callback = function ( $cart_item_key, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'cart' );
 		};
 
 		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
@@ -1294,7 +1294,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC_Form_Handler::update_cart_action();
 
 		$this->assertNotEmpty( $captured_args, 'The remove item action should have been fired' );
-		$this->assertSame( $cart_item_key, $captured_args['item_key'] );
+		$this->assertSame( $cart_item_key, $captured_args['cart_item_key'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1257,8 +1257,8 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$this->assertNotEmpty( $captured_args, 'The update quantity action should have been fired' );
 		$this->assertSame( $cart_item_key, $captured_args['cart_item_key'] );
-		$this->assertSame( 5, $captured_args['quantity'] );
-		$this->assertSame( 2, $captured_args['old_quantity'] );
+		$this->assertEquals( 5, $captured_args['quantity'] );
+		$this->assertEquals( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
@@ -1364,7 +1364,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
 		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
-		$this->assertSame( 3, $captured_args['quantity'] );
+		$this->assertEquals( 3, $captured_args['quantity'] );
 
 		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 
@@ -1408,7 +1408,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
 		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
-		$this->assertSame( 2, $captured_args['quantity'] );
+		$this->assertEquals( 2, $captured_args['quantity'] );
 
 		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1268,7 +1268,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_shortcode_cart_item_removed when cart item is removed via form.
+	 * @testdox Should fire woocommerce_cart_item_removed_from_user_request when cart item is removed via form.
 	 */
 	public function test_update_cart_action_fires_remove_item_action(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1289,7 +1289,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			$captured_args = compact( 'item_key', 'cart' );
 		};
 
-		add_action( 'woocommerce_shortcode_cart_item_removed', $callback, 10, 2 );
+		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
 
 		WC_Form_Handler::update_cart_action();
 
@@ -1297,7 +1297,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( $cart_item_key, $captured_args['item_key'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_shortcode_cart_item_removed', $callback );
+		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );
 
 		unset( $_REQUEST['_wpnonce'], $_GET['remove_item'], $_REQUEST['remove_item'] );
 		$product->delete( true );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1226,7 +1226,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_shortcode_cart_item_update_quantity when cart item quantity is updated via form.
+	 * @testdox Should fire woocommerce_cart_item_updated_from_user_request when cart item quantity is updated via form.
 	 */
 	public function test_update_cart_action_fires_update_quantity_action(): void {
 		$product = WC_Helper_Product::create_simple_product();
@@ -1251,7 +1251,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
-		add_action( 'woocommerce_shortcode_cart_item_update_quantity', $callback, 10, 4 );
+		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		WC_Form_Handler::update_cart_action();
 
@@ -1261,7 +1261,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertSame( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_shortcode_cart_item_update_quantity', $callback );
+		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
 
 		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
 		$product->delete( true );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1268,6 +1268,43 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
+	 */
+	public function test_update_cart_action_does_not_fire_update_quantity_action_when_unchanged(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+
+		$cart_items    = WC()->cart->get_cart();
+		$cart_item_key = array_key_first( $cart_items );
+
+		$nonce = wp_create_nonce( 'woocommerce-cart' );
+
+		$_POST['_wpnonce']       = $nonce;
+		$_REQUEST['_wpnonce']    = $nonce;
+		$_POST['update_cart']    = 'Update Cart';
+		$_REQUEST['update_cart'] = 'Update Cart';
+		$_POST['cart']           = array(
+			$cart_item_key => array( 'qty' => 2 ),
+		);
+
+		$hook_fired = false;
+		$callback   = function () use ( &$hook_fired ) {
+			$hook_fired = true;
+		};
+
+		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertFalse( $hook_fired, 'The update quantity action should not fire when the quantity is unchanged' );
+
+		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+
+		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox Should fire woocommerce_cart_item_removed_from_user_request when cart item is removed via form.
 	 */
 	public function test_update_cart_action_fires_remove_item_action(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1224,4 +1224,46 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product->delete( true );
 		wp_delete_user( $user_id );
 	}
+
+	/**
+	 * @testdox Should fire woocommerce_shortcode_cart_item_update_quantity when cart item quantity is updated via form.
+	 */
+	public function test_update_cart_action_fires_update_quantity_action(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+
+		$cart_items    = WC()->cart->get_cart();
+		$cart_item_key = array_key_first( $cart_items );
+
+		$nonce = wp_create_nonce( 'woocommerce-cart' );
+
+		$_POST['_wpnonce']   = $nonce;
+		$_REQUEST['_wpnonce'] = $nonce;
+		$_POST['update_cart'] = 'Update Cart';
+		$_REQUEST['update_cart'] = 'Update Cart';
+		$_POST['cart']        = array(
+			$cart_item_key => array( 'qty' => 5 ),
+		);
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
+		};
+
+		add_action( 'woocommerce_shortcode_cart_item_update_quantity', $callback, 10, 4 );
+
+		WC_Form_Handler::update_cart_action();
+
+		$this->assertNotEmpty( $captured_args, 'The update quantity action should have been fired' );
+		$this->assertSame( $cart_item_key, $captured_args['item_key'] );
+		$this->assertSame( 5, $captured_args['quantity'] );
+		$this->assertSame( 2, $captured_args['old_quantity'] );
+		$this->assertInstanceOf( WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_shortcode_cart_item_update_quantity', $callback );
+
+		unset( $_POST['_wpnonce'], $_REQUEST['_wpnonce'], $_POST['update_cart'], $_REQUEST['update_cart'], $_POST['cart'] );
+		$product->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1302,4 +1302,36 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		unset( $_REQUEST['_wpnonce'], $_GET['remove_item'], $_REQUEST['remove_item'] );
 		$product->delete( true );
 	}
+
+	/**
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when a simple product is added via the shortcode form.
+	 */
+	public function test_add_to_cart_action_fires_cart_item_added_from_user_request(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$_REQUEST['add-to-cart'] = $product->get_id();
+		$_REQUEST['quantity']    = 3;
+		$_POST['quantity']       = 3;
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		WC_Form_Handler::add_to_cart_action( false );
+
+		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
+		$this->assertSame( $product->get_id(), $captured_args['product_id'] );
+		$this->assertSame( 3, $captured_args['quantity'] );
+
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+
+		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
+		$product->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -1334,4 +1334,49 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
 		$product->delete( true );
 	}
+
+	/**
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with the variation ID when a variable product is added via the shortcode form.
+	 */
+	public function test_add_to_cart_action_fires_cart_item_added_from_user_request_for_variable_product(): void {
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Variable Product' );
+		$attribute = WC_Helper_Product::create_product_attribute_object( 'color', array( 'blue' ) );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes( array( 'pa_color' => 'blue' ) );
+		$variation->set_regular_price( 10 );
+		$variation->save();
+
+		$_REQUEST['add-to-cart']        = $product->get_id();
+		$_REQUEST['variation_id']       = $variation->get_id();
+		$_REQUEST['quantity']           = 2;
+		$_POST['quantity']              = 2;
+		$_REQUEST['attribute_pa_color'] = 'blue';
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		WC_Form_Handler::add_to_cart_action( false );
+
+		$this->assertNotEmpty( $captured_args, 'The action should have been fired' );
+		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
+		$this->assertSame( 2, $captured_args['quantity'] );
+
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+
+		unset( $_REQUEST['add-to-cart'], $_REQUEST['variation_id'], $_REQUEST['quantity'], $_POST['quantity'], $_REQUEST['attribute_pa_color'] );
+		$variation->delete( true );
+		$product->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1087,9 +1087,9 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that adding an item to cart fires the cart item add action.
+	 * @testdox Should fire woocommerce_store_api_cart_item_add_from_request when adding an item.
 	 */
-	public function test_add_item_fires_add_action() {
+	public function test_add_item_fires_add_action(): void {
 		wc_empty_cart();
 
 		$captured_args = array();
@@ -1120,9 +1120,9 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that adding an item without specifying quantity fires the add action with default quantity of 1.
+	 * @testdox Should fire woocommerce_store_api_cart_item_add_from_request with default quantity of 1 when quantity is omitted.
 	 */
-	public function test_add_item_fires_add_action_when_quantity_omitted() {
+	public function test_add_item_fires_add_action_when_quantity_omitted(): void {
 		wc_empty_cart();
 
 		$captured_args = array();
@@ -1152,9 +1152,9 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that updating a cart item quantity fires the cart item update action.
+	 * @testdox Should fire woocommerce_store_api_cart_item_update_from_request when updating item quantity.
 	 */
-	public function test_update_item_fires_update_action() {
+	public function test_update_item_fires_update_action(): void {
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$callback = function ( $item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
@@ -1186,7 +1186,7 @@ class Cart extends ControllerTestCase {
 	/**
 	 * @testdox Should fire woocommerce_store_api_cart_item_removed_from_request when removing a cart item.
 	 */
-	public function test_remove_item_fires_remove_action() {
+	public function test_remove_item_fires_remove_action(): void {
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$callback = function ( $item_key, $cart ) use ( &$captured_args ) {
@@ -1213,9 +1213,9 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * Test that updating a cart item without changing quantity does not fire the update action.
+	 * @testdox Should not fire woocommerce_store_api_cart_item_update_from_request when quantity is not set.
 	 */
-	public function test_update_item_without_quantity_does_not_fire_update_action() {
+	public function test_update_item_without_quantity_does_not_fire_update_action(): void {
 		$action_fired = false;
 		$callback     = function () use ( &$action_fired ) {
 			$action_fired = true;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1085,4 +1085,95 @@ class Cart extends ControllerTestCase {
 			)
 		);
 	}
+
+	/**
+	 * Test that adding an item to cart fires the cart item add action.
+	 */
+	public function test_add_item_fires_add_action() {
+		wc_empty_cart();
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_id, $quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_id', 'quantity', 'cart' );
+		};
+
+		add_action( 'woocommerce_store_api_cart_item_add_from_request', $callback, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => 2,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 201 );
+
+		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
+		$this->assertIsString( $captured_args['item_id'] );
+		$this->assertEquals( 2, $captured_args['quantity'] );
+		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_store_api_cart_item_add_from_request', $callback );
+	}
+
+	/**
+	 * Test that updating a cart item quantity fires the cart item update action.
+	 */
+	public function test_update_item_fires_update_action() {
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
+		};
+
+		add_action( 'woocommerce_store_api_cart_item_update_from_request', $callback, 10, 4 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key'      => $this->keys[0],
+				'quantity' => 5,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
+		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
+		$this->assertEquals( 5, $captured_args['quantity'] );
+		$this->assertEquals( 2, $captured_args['old_quantity'] );
+		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_store_api_cart_item_update_from_request', $callback );
+	}
+
+	/**
+	 * Test that updating a cart item without changing quantity does not fire the update action.
+	 */
+	public function test_update_item_without_quantity_does_not_fire_update_action() {
+		$action_fired = false;
+		$callback     = function () use ( &$action_fired ) {
+			$action_fired = true;
+		};
+
+		add_action( 'woocommerce_store_api_cart_item_update_from_request', $callback, 10, 4 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key' => $this->keys[0],
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertFalse( $action_fired, 'The update action should not fire when quantity is not set' );
+
+		remove_action( 'woocommerce_store_api_cart_item_update_from_request', $callback );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1094,8 +1094,8 @@ class Cart extends ControllerTestCase {
 
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_id, $quantity, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_id', 'quantity', 'cart' );
+		$callback = function ( $item_key, $quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'quantity', 'cart' );
 		};
 
 		add_action( 'woocommerce_store_api_cart_item_add_from_request', $callback, 10, 3 );
@@ -1112,8 +1112,40 @@ class Cart extends ControllerTestCase {
 		$this->assertAPIResponse( $request, 201 );
 
 		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
-		$this->assertIsString( $captured_args['item_id'] );
-		$this->assertEquals( 2, $captured_args['quantity'] );
+		$this->assertIsString( $captured_args['item_key'] );
+		$this->assertSame( 2, $captured_args['quantity'] );
+		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_store_api_cart_item_add_from_request', $callback );
+	}
+
+	/**
+	 * Test that adding an item without specifying quantity fires the add action with default quantity of 1.
+	 */
+	public function test_add_item_fires_add_action_when_quantity_omitted() {
+		wc_empty_cart();
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_key, $quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'quantity', 'cart' );
+		};
+
+		add_action( 'woocommerce_store_api_cart_item_add_from_request', $callback, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id' => $this->products[0]->get_id(),
+			)
+		);
+
+		$this->assertAPIResponse( $request, 201 );
+
+		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
+		$this->assertIsString( $captured_args['item_key'] );
+		$this->assertSame( 1, $captured_args['quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_store_api_cart_item_add_from_request', $callback );
@@ -1144,8 +1176,8 @@ class Cart extends ControllerTestCase {
 
 		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
 		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
-		$this->assertEquals( 5, $captured_args['quantity'] );
-		$this->assertEquals( 2, $captured_args['old_quantity'] );
+		$this->assertSame( 5, $captured_args['quantity'] );
+		$this->assertSame( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_store_api_cart_item_update_from_request', $callback );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1115,7 +1115,7 @@ class Cart extends ControllerTestCase {
 
 		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
 		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
-		$this->assertSame( 2, $captured_args['quantity'] );
+		$this->assertEquals( 2, $captured_args['quantity'] );
 
 		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 	}
@@ -1148,7 +1148,7 @@ class Cart extends ControllerTestCase {
 
 		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
 		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
-		$this->assertSame( 1, $captured_args['quantity'] );
+		$this->assertEquals( 1, $captured_args['quantity'] );
 
 		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 	}
@@ -1178,8 +1178,8 @@ class Cart extends ControllerTestCase {
 
 		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
 		$this->assertSame( $this->keys[0], $captured_args['cart_item_key'] );
-		$this->assertSame( 5, $captured_args['quantity'] );
-		$this->assertSame( 2, $captured_args['old_quantity'] );
+		$this->assertEquals( 5, $captured_args['quantity'] );
+		$this->assertEquals( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
@@ -1212,6 +1212,82 @@ class Cart extends ControllerTestCase {
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );
+	}
+
+	/**
+	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
+	 */
+	public function test_update_item_with_same_quantity_does_not_fire_update_action(): void {
+		$action_fired = false;
+		$callback     = function () use ( &$action_fired ) {
+			$action_fired = true;
+		};
+
+		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key'      => $this->keys[0],
+				'quantity' => 2,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertFalse( $action_fired, 'The update action should not fire when quantity is unchanged' );
+
+		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+	}
+
+	/**
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with the variation ID when adding a variable product.
+	 */
+	public function test_add_item_fires_add_action_with_variation_id(): void {
+		wc_empty_cart();
+
+		$fixtures  = new FixtureData();
+		$attribute = $fixtures->get_product_attribute( 'color', array( 'blue' ) );
+		$product   = $fixtures->get_variable_product(
+			array(
+				'name' => 'Test Variable Product',
+			),
+			array( $attribute )
+		);
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes( array( 'pa_color' => 'blue' ) );
+		$variation->set_regular_price( 10 );
+		$variation->save();
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $variation->get_id(),
+				'quantity' => 1,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 201 );
+
+		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
+		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
+		$this->assertEquals( 1, $captured_args['quantity'] );
+
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1087,7 +1087,7 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when adding an item.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request when adding an item.
 	 */
 	public function test_add_item_fires_add_action(): void {
 		wc_empty_cart();
@@ -1100,7 +1100,7 @@ class Cart extends ControllerTestCase {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1117,11 +1117,11 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
 		$this->assertEquals( 2, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with default quantity of 1 when quantity is omitted.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request with default quantity of 1 when quantity is omitted.
 	 */
 	public function test_add_item_fires_add_action_when_quantity_omitted(): void {
 		wc_empty_cart();
@@ -1134,7 +1134,7 @@ class Cart extends ControllerTestCase {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1150,11 +1150,11 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
 		$this->assertEquals( 1, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_updated_from_user_request when updating item quantity.
+	 * @testdox Should fire internal_woocommerce_cart_item_updated_from_user_request when updating item quantity.
 	 */
 	public function test_update_item_fires_update_action(): void {
 		$captured_args = array();
@@ -1163,7 +1163,7 @@ class Cart extends ControllerTestCase {
 			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
-		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1182,11 +1182,11 @@ class Cart extends ControllerTestCase {
 		$this->assertEquals( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_removed_from_user_request when removing a cart item.
+	 * @testdox Should fire internal_woocommerce_cart_item_removed_from_user_request when removing a cart item.
 	 */
 	public function test_remove_item_fires_remove_action(): void {
 		$captured_args = array();
@@ -1195,7 +1195,7 @@ class Cart extends ControllerTestCase {
 			$captured_args = compact( 'cart_item_key', 'cart' );
 		};
 
-		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1211,11 +1211,11 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( $this->keys[0], $captured_args['cart_item_key'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_removed_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
+	 * @testdox Should not fire internal_woocommerce_cart_item_updated_from_user_request when quantity is unchanged.
 	 */
 	public function test_update_item_with_same_quantity_does_not_fire_update_action(): void {
 		$action_fired = false;
@@ -1223,7 +1223,7 @@ class Cart extends ControllerTestCase {
 			$action_fired = true;
 		};
 
-		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1238,11 +1238,11 @@ class Cart extends ControllerTestCase {
 
 		$this->assertFalse( $action_fired, 'The update action should not fire when quantity is unchanged' );
 
-		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with the variation ID when adding a variable product.
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request with the variation ID when adding a variable product.
 	 */
 	public function test_add_item_fires_add_action_with_variation_id(): void {
 		wc_empty_cart();
@@ -1270,7 +1270,7 @@ class Cart extends ControllerTestCase {
 			);
 		};
 
-		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1287,11 +1287,11 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( $variation->get_id(), $captured_args['product_id'], 'The product_id should be the variation ID, not the parent product ID' );
 		$this->assertEquals( 1, $captured_args['quantity'] );
 
-		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is not set.
+	 * @testdox Should not fire internal_woocommerce_cart_item_updated_from_user_request when quantity is not set.
 	 */
 	public function test_update_item_without_quantity_does_not_fire_update_action(): void {
 		$action_fired = false;
@@ -1299,7 +1299,7 @@ class Cart extends ControllerTestCase {
 			$action_fired = true;
 		};
 
-		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1313,6 +1313,6 @@ class Cart extends ControllerTestCase {
 
 		$this->assertFalse( $action_fired, 'The update action should not fire when quantity is not set' );
 
-		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1186,7 +1186,7 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_store_api_cart_item_removed_from_request when removing a cart item.
+	 * @testdox Should fire woocommerce_cart_item_removed_from_user_request when removing a cart item.
 	 */
 	public function test_remove_item_fires_remove_action(): void {
 		$captured_args = array();
@@ -1195,7 +1195,7 @@ class Cart extends ControllerTestCase {
 			$captured_args = compact( 'item_key', 'cart' );
 		};
 
-		add_action( 'woocommerce_store_api_cart_item_removed_from_request', $callback, 10, 2 );
+		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1211,7 +1211,7 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_store_api_cart_item_removed_from_request', $callback );
+		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1154,7 +1154,7 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_store_api_cart_item_update_from_request when updating item quantity.
+	 * @testdox Should fire woocommerce_cart_item_updated_from_user_request when updating item quantity.
 	 */
 	public function test_update_item_fires_update_action(): void {
 		$captured_args = array();
@@ -1163,7 +1163,7 @@ class Cart extends ControllerTestCase {
 			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
-		add_action( 'woocommerce_store_api_cart_item_update_from_request', $callback, 10, 4 );
+		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1182,7 +1182,7 @@ class Cart extends ControllerTestCase {
 		$this->assertSame( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_store_api_cart_item_update_from_request', $callback );
+		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
 	}
 
 	/**
@@ -1215,7 +1215,7 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Should not fire woocommerce_store_api_cart_item_update_from_request when quantity is not set.
+	 * @testdox Should not fire woocommerce_cart_item_updated_from_user_request when quantity is not set.
 	 */
 	public function test_update_item_without_quantity_does_not_fire_update_action(): void {
 		$action_fired = false;
@@ -1223,7 +1223,7 @@ class Cart extends ControllerTestCase {
 			$action_fired = true;
 		};
 
-		add_action( 'woocommerce_store_api_cart_item_update_from_request', $callback, 10, 4 );
+		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1237,6 +1237,6 @@ class Cart extends ControllerTestCase {
 
 		$this->assertFalse( $action_fired, 'The update action should not fire when quantity is not set' );
 
-		remove_action( 'woocommerce_store_api_cart_item_update_from_request', $callback );
+		remove_action( 'woocommerce_cart_item_updated_from_user_request', $callback );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1184,6 +1184,35 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
+	 * @testdox Should fire woocommerce_store_api_cart_item_removed_from_request when removing a cart item.
+	 */
+	public function test_remove_item_fires_remove_action() {
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $item_key, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'item_key', 'cart' );
+		};
+
+		add_action( 'woocommerce_store_api_cart_item_removed_from_request', $callback, 10, 2 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key' => $this->keys[0],
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertNotEmpty( $captured_args, 'The remove action should have been fired' );
+		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
+		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
+
+		remove_action( 'woocommerce_store_api_cart_item_removed_from_request', $callback );
+	}
+
+	/**
 	 * Test that updating a cart item without changing quantity does not fire the update action.
 	 */
 	public function test_update_item_without_quantity_does_not_fire_update_action() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1087,18 +1087,20 @@ class Cart extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_store_api_cart_item_add_from_request when adding an item.
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request when adding an item.
 	 */
 	public function test_add_item_fires_add_action(): void {
 		wc_empty_cart();
 
 		$captured_args = array();
-		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $quantity, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'quantity', 'cart' );
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
 		};
 
-		add_action( 'woocommerce_store_api_cart_item_add_from_request', $callback, 10, 3 );
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1112,26 +1114,27 @@ class Cart extends ControllerTestCase {
 		$this->assertAPIResponse( $request, 201 );
 
 		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
-		$this->assertIsString( $captured_args['item_key'] );
+		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
 		$this->assertSame( 2, $captured_args['quantity'] );
-		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_store_api_cart_item_add_from_request', $callback );
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**
-	 * @testdox Should fire woocommerce_store_api_cart_item_add_from_request with default quantity of 1 when quantity is omitted.
+	 * @testdox Should fire woocommerce_cart_item_added_from_user_request with default quantity of 1 when quantity is omitted.
 	 */
 	public function test_add_item_fires_add_action_when_quantity_omitted(): void {
 		wc_empty_cart();
 
 		$captured_args = array();
-		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $quantity, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'quantity', 'cart' );
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
 		};
 
-		add_action( 'woocommerce_store_api_cart_item_add_from_request', $callback, 10, 3 );
+		add_action( 'woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
@@ -1144,11 +1147,10 @@ class Cart extends ControllerTestCase {
 		$this->assertAPIResponse( $request, 201 );
 
 		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
-		$this->assertIsString( $captured_args['item_key'] );
+		$this->assertSame( $this->products[0]->get_id(), $captured_args['product_id'] );
 		$this->assertSame( 1, $captured_args['quantity'] );
-		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
-		remove_action( 'woocommerce_store_api_cart_item_add_from_request', $callback );
+		remove_action( 'woocommerce_cart_item_added_from_user_request', $callback );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1159,8 +1159,8 @@ class Cart extends ControllerTestCase {
 	public function test_update_item_fires_update_action(): void {
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'quantity', 'old_quantity', 'cart' );
+		$callback = function ( $cart_item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
 		};
 
 		add_action( 'woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
@@ -1177,7 +1177,7 @@ class Cart extends ControllerTestCase {
 		$this->assertAPIResponse( $request, 200 );
 
 		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
-		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
+		$this->assertSame( $this->keys[0], $captured_args['cart_item_key'] );
 		$this->assertSame( 5, $captured_args['quantity'] );
 		$this->assertSame( 2, $captured_args['old_quantity'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
@@ -1191,8 +1191,8 @@ class Cart extends ControllerTestCase {
 	public function test_remove_item_fires_remove_action(): void {
 		$captured_args = array();
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$callback = function ( $item_key, $cart ) use ( &$captured_args ) {
-			$captured_args = compact( 'item_key', 'cart' );
+		$callback = function ( $cart_item_key, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'cart' );
 		};
 
 		add_action( 'woocommerce_cart_item_removed_from_user_request', $callback, 10, 2 );
@@ -1208,7 +1208,7 @@ class Cart extends ControllerTestCase {
 		$this->assertAPIResponse( $request, 200 );
 
 		$this->assertNotEmpty( $captured_args, 'The remove action should have been fired' );
-		$this->assertSame( $this->keys[0], $captured_args['item_key'] );
+		$this->assertSame( $this->keys[0], $captured_args['cart_item_key'] );
 		$this->assertInstanceOf( \WC_Cart::class, $captured_args['cart'] );
 
 		remove_action( 'woocommerce_cart_item_removed_from_user_request', $callback );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds new WordPress action hooks that fire when cart items are added, updated, or removed **from a user request**. The hooks use a unified naming convention — `internal_woocommerce_cart_item_{action}_from_user_request` — and fire in both the Store API (Cart/Checkout blocks) and the shortcode/AJAX cart paths.

### Rationale

The hooks are placed as close as possible to the controller/request layer. This ensures they only fire for real customer interactions (e.g. adding to cart from a product page, updating quantity in the cart, clicking remove) and **not** from programmatic cart manipulation by 3rd-party code. This reduces duplicate events and avoids logging pseudo-cart activity.

#### Hooks

| Hook | Fires when | Parameters |
|---|---|---|
| `internal_woocommerce_cart_item_added_from_user_request` | Item added to cart | `$product_id`, `$quantity` |
| `internal_woocommerce_cart_item_updated_from_user_request` | Cart item quantity changed | `$cart_item_key`, `$quantity`, `$old_quantity`, `$cart` |
| `internal_woocommerce_cart_item_removed_from_user_request` | Cart item removed | `$cart_item_key`, `$cart` |

Each hook fires from **both** code paths:
- **Store API** — `CartAddItem`, `CartUpdateItem`, `CartRemoveItem` routes
- **Shortcode / AJAX** — `WC_Form_Handler` (update cart, remove item, add to cart) and `WC_AJAX` (add to cart)

The `_updated_` hook only fires when a `quantity` parameter is explicitly provided and differs from the current quantity.

The `_added_` hook includes variation ID handling for variable products.

Part of WOOSUBS-1439

### How to test the changes in this Pull Request:

#### Prerequisites
- A WooCommerce store with `WP_DEBUG` and `WP_DEBUG_LOG` enabled in `wp-config.php`.
- At least one simple product published. Note its product ID (referred to as `<PRODUCT_ID>` below).
- A page with the Cart block (for Store API tests) and a page with the `[woocommerce_cart]` shortcode (for shortcode tests).

---

#### Test 1 — Add item hook fires (Store API)

1. Add the following snippet to a custom plugin or theme's `functions.php`:
   ```php
   add_action( 'internal_woocommerce_cart_item_added_from_user_request', function ( $product_id, $quantity ) {
       error_log( sprintf( 'Cart Add — product: %d, qty: %d', $product_id, $quantity ) );
   }, 10, 2 );
   ```
2. Visit a page with the Cart block to get a nonce, then run in the browser console:
   ```js
   fetch( '/wp-json/wc/store/v1/cart/add-item', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Nonce': wcSettings.storeApiNonce },
       body: JSON.stringify( { id: <PRODUCT_ID>, quantity: 2 } ),
   } ).then( r => r.json() ).then( console.log );
   ```
3. Check `debug.log`.
4. **Expected:** A log entry: `Cart Add — product: <ID>, qty: 2`.

#### Test 2 — Update item hook fires (Store API)

1. Add the following snippet:
   ```php
   add_action( 'internal_woocommerce_cart_item_updated_from_user_request', function ( $item_key, $quantity, $old_quantity, $cart ) {
       error_log( sprintf( 'Cart Update — key: %s, qty: %d → %d', $item_key, $old_quantity, $quantity ) );
   }, 10, 4 );
   ```
2. From the Test 1 response, copy the `key` of the cart item (found in the `items` array).
3. Run in the browser console:
   ```js
   fetch( '/wp-json/wc/store/v1/cart/update-item', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Nonce': wcSettings.storeApiNonce },
       body: JSON.stringify( { key: '<ITEM_KEY>', quantity: 5 } ),
   } ).then( r => r.json() ).then( console.log );
   ```
4. **Expected:** A log entry: `Cart Update — key: <hash>, qty: 2 → 5`.

#### Test 3 — Update item hook does NOT fire without quantity (Store API)

1. With the same logging from Test 2 active, run:
   ```js
   fetch( '/wp-json/wc/store/v1/cart/update-item', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Nonce': wcSettings.storeApiNonce },
       body: JSON.stringify( { key: '<ITEM_KEY>' } ),
   } ).then( r => r.json() ).then( console.log );
   ```
2. **Expected:** No new log entry from the update action.

#### Test 4 — Remove item hook fires (Store API)

1. Add the following snippet:
   ```php
   add_action( 'internal_woocommerce_cart_item_removed_from_user_request', function ( $item_key, $cart ) {
       error_log( sprintf( 'Cart Remove — key: %s, remaining items: %d', $item_key, count( $cart->get_cart() ) ) );
   }, 10, 2 );
   ```
2. Run in the browser console:
   ```js
   fetch( '/wp-json/wc/store/v1/cart/remove-item', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Nonce': wcSettings.storeApiNonce },
       body: JSON.stringify( { key: '<ITEM_KEY>' } ),
   } ).then( r => r.json() ).then( console.log );
   ```
3. **Expected:** A log entry: `Cart Remove — key: <hash>, remaining items: 0`.

#### Test 5 — Add item hook fires (Shortcode / AJAX)

1. With the same logging from Test 1 active, add a product to cart from the shop page (classic add-to-cart button or AJAX).
2. **Expected:** A log entry: `Cart Add — product: <ID>, qty: 1`.

#### Test 6 — Update quantity hook fires (Shortcode cart)

1. With the same logging from Test 2 active, visit the page with the `[woocommerce_cart]` shortcode.
2. Change the quantity of a cart item and click "Update cart".
3. **Expected:** A log entry: `Cart Update — key: <hash>, qty: <old> → <new>`.

#### Test 7 — Remove item hook fires (Shortcode cart)

1. With the same logging from Test 4 active, on the shortcode cart page, click the "×" remove link next to a cart item.
2. **Expected:** A log entry: `Cart Remove — key: <hash>, remaining items: <count>`.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
