### PR TITLE
Export EditTemplateModal and SelectTemplateModal from email editor package

### DIFF
--- a/packages/js/email-editor/changelog/add-export-template-modals
+++ b/packages/js/email-editor/changelog/add-export-template-modals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Export EditTemplateModal and SelectTemplateModal from the email editor package for extensibility.

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -404,3 +404,36 @@ export { EmailActionsFill } from './components/sidebar/settings-panel';
  * @since 1.0.0
  */
 export { TemplateSelection } from './components/sidebar/template-selection';
+
+/**
+ * A confirmation modal shown before navigating to the template editor.
+ *
+ * Warns the user that editing a template affects all emails using it,
+ * then navigates to the template editor on confirmation. Used internally
+ * by `TemplateSelection` and exported for consumers building custom
+ * template selection UIs.
+ *
+ * @param props       - Component properties
+ * @param props.close - Callback to close the modal without navigating
+ *
+ * @since 1.7.0
+ */
+export { EditTemplateModal } from './components/sidebar/edit-template-modal';
+
+/**
+ * A full-screen modal for browsing and selecting email templates.
+ *
+ * Displays available templates in a categorized grid with previews.
+ * Handles template selection by applying the chosen template to the
+ * current post. Used internally by `TemplateSelection` and exported
+ * for consumers building custom template selection UIs.
+ *
+ * @param props                  - Component properties
+ * @param props.onSelectCallback - Called after a template is selected
+ * @param props.closeCallback    - Called when the modal is closed without selection
+ * @param props.previewContent   - Custom email content for template previews
+ * @param props.postType         - The post type of the current email
+ *
+ * @since 1.7.0
+ */
+export { SelectTemplateModal } from './components/template-select';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Exports `EditTemplateModal` and `SelectTemplateModal` from `@woocommerce/email-editor`, enabling consumers to build custom template selection UIs while reusing upstream modal components.

Follows the same extensibility pattern established in #63277 for `TemplateSelection` and `EmailActionsFill`.

Related to https://linear.app/a8c/issue/STOMAIL-7601/align-the-template-control-with-the-design-and-current-editor-behavior

### How to test the changes in this Pull Request:

1. Check out this branch and build the email editor package: `pnpm --filter=@woocommerce/email-editor build`
2. Verify that `EditTemplateModal` and `SelectTemplateModal` can be imported from `@woocommerce/email-editor` (e.g. confirm they appear in the built output).
3. Open the email editor in WP Admin (**WooCommerce > Settings > Email**) and verify the existing template selection behavior is unchanged — swapping and editing templates should work as before.

### Testing that has already taken place:

- Verified the package builds successfully with the new exports.
- Confirmed existing `TemplateSelection` behavior is unchanged in the editor.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Add - Adds functionality

#### Message
Export EditTemplateModal and SelectTemplateModal from the email editor package for extensibility.

</details>