### PR TITLE
Support non-optimistic item count property

### DIFF
--- a/plugins/woocommerce/changelog/63378-minicart-support-non-optimistic-items-count
+++ b/plugins/woocommerce/changelog/63378-minicart-support-non-optimistic-items-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini-Cart: use server-computed item count when third-party filters modify `woocommerce_cart_contents_count`.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -35,6 +35,7 @@ export type WooCommerceConfig = {
 	};
 	placeholderImgSrc?: string;
 	currency?: Currency;
+	nonOptimisticProperties?: string[];
 };
 
 export type SelectedAttributes = Omit< CartVariationItem, 'raw_attribute' >;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -31,9 +31,11 @@ import { translateJQueryEventToNative } from '../../base/stores/woocommerce/lega
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
-const { currency, placeholderImgSrc } = getConfig(
-	'woocommerce'
-) as WooCommerceConfig;
+const {
+	currency,
+	placeholderImgSrc,
+	nonOptimisticProperties = [],
+} = getConfig( 'woocommerce' ) as WooCommerceConfig;
 const {
 	onCartClickBehaviour,
 	checkoutUrl,
@@ -171,6 +173,9 @@ store< MiniCart >(
 	{
 		state: {
 			get totalItemsInCart() {
+				if ( nonOptimisticProperties.includes( 'cart.items_count' ) ) {
+					return woocommerceState.cart.items_count as number;
+				}
 				return woocommerceState.cart.items.reduce< number >(
 					( total, { quantity } ) => total + quantity,
 					0

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/cart-contents-count-filter.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/cart-contents-count-filter.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Blocks Test Cart Contents Count Filter
+ * Description: Overrides the cart contents count to always return 999 for e2e testing.
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ *
+ * @package woocommerce-blocks-test-cart-contents-count-filter
+ */
+
+add_filter(
+	'woocommerce_cart_contents_count',
+	function () {
+		return 999;
+	}
+);

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/cart-contents-count-filter.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/cart-contents-count-filter.php
@@ -8,6 +8,8 @@
  * @package woocommerce-blocks-test-cart-contents-count-filter
  */
 
+declare( strict_types = 1 );
+
 add_filter(
 	'woocommerce_cart_contents_count',
 	function () {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -300,4 +300,35 @@ test.describe( `${ blockData.name } Block`, () => {
 		await page.getByRole( 'link', { name: 'Go to checkout' } ).click();
 		await expect( page ).toHaveURL( /\/checkout\/?$/ );
 	} );
+
+	test.describe( 'optimistic updates', () => {
+		test( 'should show the server filtered item count in the mini-cart title', async ( {
+			page,
+			frontendUtils,
+			miniCartUtils,
+			requestUtils,
+		} ) => {
+			await requestUtils.activatePlugin(
+				'woocommerce-blocks-test-cart-contents-count-filter'
+			);
+
+			await frontendUtils.goToShop();
+			await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+			await miniCartUtils.openMiniCart();
+
+			// The filter overrides the count to 999. The mini-cart title should
+			// display this filtered value rather than the actual number of items.
+			const miniCartTitleItemsCounterBlock = page.locator(
+				'[data-block-name="woocommerce/mini-cart-title-items-counter-block"]'
+			);
+			await expect( miniCartTitleItemsCounterBlock ).toBeVisible();
+			await expect( miniCartTitleItemsCounterBlock ).toContainText(
+				'999'
+			);
+
+			await requestUtils.deactivatePlugin(
+				'woocommerce-blocks-test-cart-contents-count-filter'
+			);
+		} );
+	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -302,6 +302,12 @@ test.describe( `${ blockData.name } Block`, () => {
 	} );
 
 	test.describe( 'optimistic updates', () => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! config.features[ 'experimental-iapi-mini-cart' ],
+			'These tests are only relevant for the iAPI mini cart.'
+		);
+
 		test( 'should show the server filtered item count in the mini-cart title', async ( {
 			page,
 			frontendUtils,
@@ -312,23 +318,25 @@ test.describe( `${ blockData.name } Block`, () => {
 				'woocommerce-blocks-test-cart-contents-count-filter'
 			);
 
-			await frontendUtils.goToShop();
-			await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-			await miniCartUtils.openMiniCart();
+			try {
+				await frontendUtils.goToShop();
+				await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+				await miniCartUtils.openMiniCart();
 
-			// The filter overrides the count to 999. The mini-cart title should
-			// display this filtered value rather than the actual number of items.
-			const miniCartTitleItemsCounterBlock = page.locator(
-				'[data-block-name="woocommerce/mini-cart-title-items-counter-block"]'
-			);
-			await expect( miniCartTitleItemsCounterBlock ).toBeVisible();
-			await expect( miniCartTitleItemsCounterBlock ).toContainText(
-				'999'
-			);
-
-			await requestUtils.deactivatePlugin(
-				'woocommerce-blocks-test-cart-contents-count-filter'
-			);
+				// The filter overrides the count to 999. The mini-cart title should
+				// display this filtered value rather than the actual number of items.
+				const miniCartTitleItemsCounterBlock = page.locator(
+					'[data-block-name="woocommerce/mini-cart-title-items-counter-block"]'
+				);
+				await expect( miniCartTitleItemsCounterBlock ).toBeVisible();
+				await expect( miniCartTitleItemsCounterBlock ).toContainText(
+					'999'
+				);
+			} finally {
+				await requestUtils.deactivatePlugin(
+					'woocommerce-blocks-test-cart-contents-count-filter'
+				);
+			}
 		} );
 	} );
 } );

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -176,7 +176,7 @@ class BlocksSharedState {
 	 * property must use the server-computed value instead of a client-side
 	 * optimistic computation.
 	 *
-	 * @since 10.7.0
+	 * `@return` string[] List of cart property paths (dot-delimited) that cannot be optimistic.
 	 *
 	 * @return string[] List of cart property paths (dot-delimited) that cannot be optimistic.
 	 */

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -24,7 +24,7 @@ class BlocksSharedState {
 	private static string $consent_statement = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
 
 	/**
-	 * The namespace for the config.
+	 * The namespace for interactivity config and state.
 	 *
 	 * @var string
 	 */
@@ -113,8 +113,13 @@ class BlocksSharedState {
 				self::prevent_cache();
 			}
 
+			wp_interactivity_config(
+				self::$settings_namespace,
+				array( 'nonOptimisticProperties' => self::get_non_optimistic_properties() )
+			);
+
 			wp_interactivity_state(
-				'woocommerce',
+				self::$settings_namespace,
 				array(
 					'cart'     => self::$blocks_shared_cart_state,
 					'nonce'    => wp_create_nonce( 'wc_store_api' ),
@@ -161,6 +166,28 @@ class BlocksSharedState {
 				'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 			),
 		);
+	}
+
+	/**
+	 * Get cart properties that cannot use optimistic UI on the frontend.
+	 *
+	 * Detects whether third-party code has registered callbacks on filters that
+	 * modify cart property values. When callbacks are present, the corresponding
+	 * property must use the server-computed value instead of a client-side
+	 * optimistic computation.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @return string[] List of cart property paths (dot-delimited) that cannot be optimistic.
+	 */
+	private static function get_non_optimistic_properties(): array {
+		$properties = array();
+
+		if ( has_filter( 'woocommerce_cart_contents_count' ) ) {
+			$properties[] = 'cart.items_count';
+		}
+
+		return $properties;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
@@ -49,11 +49,12 @@ class BlocksSharedStateTest extends \WP_UnitTestCase {
 		$cart_state->setAccessible( true );
 		$cart_state->setValue( null, null );
 
-		$interactivity       = wp_interactivity();
-		$interactivity_ref   = new \ReflectionClass( $interactivity );
-		$config_data         = $interactivity_ref->getProperty( 'config_data' );
+		$interactivity     = wp_interactivity();
+		$interactivity_ref = new \ReflectionClass( $interactivity );
+		$config_data       = $interactivity_ref->getProperty( 'config_data' );
+
 		$config_data->setAccessible( true );
-		$data                = $config_data->getValue( $interactivity );
+		$data = $config_data->getValue( $interactivity );
 		unset( $data['woocommerce'] );
 		$config_data->setValue( $interactivity, $data );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Utils;
+
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+
+/**
+ * Tests for the BlocksSharedState class.
+ */
+class BlocksSharedStateTest extends \WP_UnitTestCase {
+
+	/**
+	 * The consent statement required by the private API.
+	 *
+	 * @var string
+	 */
+	private string $consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->reset_shared_state();
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_cart_contents_count' );
+		$this->reset_shared_state();
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset the static flags and interactivity config so load_store_config()
+	 * and load_cart_state() can run again with a clean slate.
+	 */
+	private function reset_shared_state(): void {
+		$reflection = new \ReflectionClass( BlocksSharedState::class );
+
+		$prop = $reflection->getProperty( 'core_config_registered' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, false );
+
+		$cart_state = $reflection->getProperty( 'blocks_shared_cart_state' );
+		$cart_state->setAccessible( true );
+		$cart_state->setValue( null, null );
+
+		$interactivity       = wp_interactivity();
+		$interactivity_ref   = new \ReflectionClass( $interactivity );
+		$config_data         = $interactivity_ref->getProperty( 'config_data' );
+		$config_data->setAccessible( true );
+		$data                = $config_data->getValue( $interactivity );
+		unset( $data['woocommerce'] );
+		$config_data->setValue( $interactivity, $data );
+	}
+
+	/**
+	 * @testdox nonOptimisticProperties is empty when no filter is registered.
+	 */
+	public function test_no_filter_returns_empty_non_optimistic_properties(): void {
+		BlocksSharedState::load_cart_state( $this->consent );
+
+		$config = wp_interactivity_config( 'woocommerce' );
+
+		$this->assertArrayHasKey( 'nonOptimisticProperties', $config );
+		$this->assertSame( array(), $config['nonOptimisticProperties'] );
+	}
+
+	/**
+	 * @testdox nonOptimisticProperties contains items_count when a third-party filter is registered.
+	 */
+	public function test_third_party_filter_detected(): void {
+		add_filter( 'woocommerce_cart_contents_count', fn( $count ) => $count + 1 );
+
+		BlocksSharedState::load_cart_state( $this->consent );
+
+		$config = wp_interactivity_config( 'woocommerce' );
+
+		$this->assertArrayHasKey( 'nonOptimisticProperties', $config );
+		$this->assertContains( 'cart.items_count', $config['nonOptimisticProperties'] );
+	}
+
+	/**
+	 * @testdox nonOptimisticProperties is empty when a filter is added and then removed.
+	 */
+	public function test_filter_added_then_removed_returns_empty(): void {
+		$callback = fn( $count ) => $count + 1;
+
+		add_filter( 'woocommerce_cart_contents_count', $callback );
+		remove_filter( 'woocommerce_cart_contents_count', $callback );
+
+		BlocksSharedState::load_cart_state( $this->consent );
+
+		$config = wp_interactivity_config( 'woocommerce' );
+
+		$this->assertArrayHasKey( 'nonOptimisticProperties', $config );
+		$this->assertSame( array(), $config['nonOptimisticProperties'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 /**
  * Tests for the BlocksSharedState class.
  */
-class BlocksSharedStateTest extends \WP_UnitTestCase {
+class BlocksSharedStateTest extends \WC_Unit_Test_Case {
 
 	/**
 	 * The consent statement required by the private API.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/62479.

The Mini-Cart block computes the total items count optimistically on the client side by summing item quantities. This works well in general, but breaks when third-party plugins use the `woocommerce_cart_contents_count` filter to modify the count (e.g., counting unique line items instead of total quantities, or applying custom business logic).

This PR introduces a mechanism to detect when server-side filters are registered on cart properties, and automatically falls back to the server-computed value instead of the optimistic client-side calculation.

**How it works:**

- A new `get_non_optimistic_properties()` method in `BlocksSharedState` checks whether callbacks are registered on the `woocommerce_cart_contents_count` filter.
- When callbacks are detected, `cart.items_count` is added to a `nonOptimisticProperties` list that is passed to the frontend via `wp_interactivity_config`.
- On the frontend, the Mini-Cart's `totalItemsInCart` getter checks this list and uses the server-provided `items_count` instead of the optimistic sum of quantities.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. **Without filter (default behavior):** Add products to the cart from the shop page and verify that the Mini-Cart badge shows the correct total quantity (e.g., adding 2 of product A and 1 of product B shows "3").
2. **With a third-party filter:** Create a simple plugin or use the test plugin at `client/blocks/tests/e2e/plugins/cart-contents-count-filter.php` that hooks into `woocommerce_cart_contents_count` and returns a custom value (e.g., 999). Add a product to the cart and verify the Mini-Cart badge displays the filtered value (999) instead of the actual item quantity.
3. **Filter removal:** Deactivate the plugin from step 2, reload the page, and verify the Mini-Cart returns to calculating the count optimistically from item quantities.

### Testing that has already taken place:

- PHP unit tests added for `BlocksSharedState::get_non_optimistic_properties()` covering: no filter registered, third-party filter detected, and filter added then removed.
- E2E test added that activates a test plugin overriding `woocommerce_cart_contents_count` to 999, adds a product, and verifies the Mini-Cart title displays the filtered count.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Mini-Cart: use server-computed item count when third-party filters modify `woocommerce_cart_contents_count`.

</details>
