### PR TITLE
Fix: WC_Blocks_Utils::has_block_in_page() fails to detect blocks nested inside container blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-has-block-in-page-recursive-search
+++ b/plugins/woocommerce/changelog/fix-has-block-in-page-recursive-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - Make WC_Blocks_Utils::has_block_in_page() search nested blocks recursively.

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -75,7 +75,7 @@ class WC_Blocks_Utils {
 		$blocks = parse_blocks( $page_to_check->post_content );
 		return self::has_block_in_blocks( $blocks, $block_name );
 	}
-	
+
 	/**
 	 * Recursively searches an array of blocks (and their innerBlocks).
 	 *

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -60,38 +60,15 @@ class WC_Blocks_Utils {
 	}
 
 	/**
-	 * Check if a given page contains a particular block.
+	 * Determine if a page has a block in its content.
 	 *
-	 * @param int|WP_Post $page Page post ID or post object.
+	 * @param int|WP_Post $page       Page post ID or post object.
 	 * @param string      $block_name The name (id) of a block, e.g. `woocommerce/cart`.
-	 * @return bool Boolean value if the page contains the block or not. Null in case the page does not exist.
-	 */
-	public static function has_block_in_page( $page, $block_name ) {
-		$page_to_check = get_post( $page );
-		if ( null === $page_to_check ) {
-			return false;
-		}
-
-		$blocks = parse_blocks( $page_to_check->post_content );
-		return self::has_block_in_blocks( $blocks, $block_name );
-	}
-
-	/**
-	 * Recursively searches an array of blocks (and their innerBlocks).
+	 * @return bool True if the page contains the block, false otherwise.
 	 *
-	 * @param array  $blocks     Array of parsed blocks.
-	 * @param string $block_name The block name to search for.
-	 * @return bool True if the block is found, false otherwise.
+	 * @see has_block()
 	 */
-	private static function has_block_in_blocks( array $blocks, string $block_name ): bool {
-		foreach ( $blocks as $block ) {
-			if ( $block_name === $block['blockName'] ) {
-				return true;
-			}
-			if ( ! empty( $block['innerBlocks'] ) && self::has_block_in_blocks( $block['innerBlocks'], $block_name ) ) {
-				return true;
-			}
-		}
-		return false;
+	public static function has_block_in_page( $page, $block_name ): bool {
+		return has_block( $block_name, $page );
 	}
 }

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -73,12 +73,25 @@ class WC_Blocks_Utils {
 		}
 
 		$blocks = parse_blocks( $page_to_check->post_content );
+		return self::has_block_in_blocks( $blocks, $block_name );
+	}
+	
+	/**
+	 * Recursively searches an array of blocks (and their innerBlocks).
+	 *
+	 * @param array  $blocks     Array of parsed blocks.
+	 * @param string $block_name The block name to search for.
+	 * @return bool True if the block is found, false otherwise.
+	 */
+	private static function has_block_in_blocks( array $blocks, string $block_name ): bool {
 		foreach ( $blocks as $block ) {
 			if ( $block_name === $block['blockName'] ) {
 				return true;
 			}
+			if ( ! empty( $block['innerBlocks'] ) && self::has_block_in_blocks( $block['innerBlocks'], $block_name ) ) {
+				return true;
+			}
 		}
-
 		return false;
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
@@ -73,6 +73,51 @@ class WC_Test_Blocks_Utils extends WC_Unit_Test_Case {
 
 	/**
 	 * @group block-utils
+	 * Test: has_block_in_page detects block nested multiple levels deep.
+	 */
+	public function test_has_block_in_page_detects_block_nested_multiple_levels_deep() {
+		$page = array(
+			'name'    => 'checkout-page-deep',
+			'title'   => 'Checkout Deep',
+			'content' => '<!-- wp:group -->
+				<!-- wp:columns -->
+					<!-- wp:column -->
+						<!-- wp:woocommerce/checkout -->
+						<!-- /wp:woocommerce/checkout -->
+					<!-- /wp:column -->
+				<!-- /wp:columns -->
+			<!-- /wp:group -->',
+		);
+
+		$page_id = wc_create_page( $page['name'], '', $page['title'], $page['content'] );
+
+		$this->assertTrue( WC_Blocks_Utils::has_block_in_page( $page_id, 'woocommerce/checkout' ) );
+	}
+
+	/**
+	 * @group block-utils
+	 * Test: has_block_in_page returns false when nested block is not present.
+	 */
+	public function test_has_block_in_page_returns_false_when_nested_block_not_present() {
+		$page = array(
+			'name'    => 'checkout-page-no-block',
+			'title'   => 'Checkout No Block',
+			'content' => '<!-- wp:columns -->
+				<!-- wp:column -->
+					<!-- wp:paragraph -->
+					<p>Some text</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:column -->
+			<!-- /wp:columns -->',
+		);
+
+		$page_id = wc_create_page( $page['name'], '', $page['title'], $page['content'] );
+
+		$this->assertFalse( WC_Blocks_Utils::has_block_in_page( $page_id, 'woocommerce/checkout' ) );
+	}
+
+	/**
+	 * @group block-utils
 	 * Test: get_all_blocks_from_page.
 	 *
 	 */
@@ -87,19 +132,19 @@ class WC_Test_Blocks_Utils extends WC_Unit_Test_Case {
 
 		$expected = array(
 			0 => array(
-				'blockName' => 'core/heading',
-				'attrs' => array(),
-				'innerBlocks' => array(),
-				'innerHTML' => '<h2>test1</h2>',
+				'blockName'    => 'core/heading',
+				'attrs'        => array(),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<h2>test1</h2>',
 				'innerContent' => array(
 					0 => '<h2>test1</h2>',
 				),
 			),
 			1 => array(
-				'blockName' => 'core/heading',
-				'attrs' => array(),
-				'innerBlocks' => array(),
-				'innerHTML' => '<h1>test2</h1>',
+				'blockName'    => 'core/heading',
+				'attrs'        => array(),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '<h1>test2</h1>',
 				'innerContent' => array(
 					0 => '<h1>test2</h1>',
 				),

--- a/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
@@ -1,6 +1,4 @@
 <?php
-declare( strict_types = 1 );
-
 /**
  * Tests for the WC_Data class.
  *

--- a/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/blocks/class-wc-tests-blocks-utils.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 /**
  * Tests for the WC_Data class.
  *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Extracted the search logic into a private recursive helper method `has_block_in_blocks()` that traverses `innerBlocks` at every level of nesting.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

### Describe the changes made to this Pull Request and the reason for such changes.
 
- `WC_Blocks_Utils::has_block_in_page()` only checked top-level blocks in a page's parsed block tree, causing it to return `false` when a block (e.g. `woocommerce/checkout`) was nested inside container blocks like `wp:columns`.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #63364

### Screenshots or screen recordings:


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Add this code to check debug logs:
```
add_action( "woocommerce_init", function() {
    if ( ! class_exists( 'WC_Blocks_Utils' ) ) {
        return;
    }

    $checkout_page_id = wc_get_page_id( 'checkout' );

    $result = WC_Blocks_Utils::has_block_in_page( $checkout_page_id, 'woocommerce/checkout' );

    error_log( 'has_block_in_page result: ' . ( $result ? 'true' : 'false' ) );
} );
```

- Go to Pages → Checkout in WordPress admin
- Edit the checkout page using the block editor
- Add a Columns block to the page
- Inside one of the columns, add the WooCommerce Checkout block
- Save the page

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
