### PR TITLE
[Performance] - Remove unnecessary calculate_totals() call in CartCoupons DELETE handler

### DIFF
--- a/plugins/woocommerce/changelog/63404-fix-delete-cart-coupons-performance
+++ b/plugins/woocommerce/changelog/63404-fix-delete-cart-coupons-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Remove unnecessary `calculate_totals()` call from `DELETE /wc/store/v1/cart/coupons`. The result was never used since the endpoint returns an empty response body.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartCoupons.php
@@ -129,7 +129,6 @@ class CartCoupons extends AbstractCartRoute {
 		$cart = $this->cart_controller->get_cart_instance();
 
 		$cart->remove_coupons();
-		$cart->calculate_totals();
 
 		return new \WP_REST_Response( [], 200 );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

`DELETE /wc/store/v1/cart/coupons` called `$cart->calculate_totals()` after removing all coupons, but the result was never used, the endpoint immediately returns an empty `[]`response body with no cart totals. 

- This PR removes the unnecessary `calculate_totals()` call from `CartCoupons::get_route_delete_response()`.
- The next consumer request (`GET /cart`) will trigger recalculation via `CartController::get_cart_for_response()` as designed.
- `AbstractCartRoute::cart_updated()` documents this explicitly: *"This does not trigger a recalculation of the cart, endpoints should have already done so before returning the cart response."*

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — logic change, no visual output.

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a coupon in WooCommerce admin (e.g. `SAVE10`).
2. Add a product to the cart and apply the coupon via `POST /wc/store/v1/cart/coupons` with body `{"code": "SAVE10"}`.
3. Call `GET /wc/store/v1/cart` and note the discounted totals, confirm `SAVE10` appears in the coupon list.
4. Call `DELETE /wc/store/v1/cart/coupons` and confirm the response is `200 []`.
5. Call `GET /wc/store/v1/cart` again and confirm the coupon list is empty and totals reflect full price with no discount.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove unnecessary `calculate_totals()` call from `DELETE /wc/store/v1/cart/coupons`. The result was never used since the endpoint returns an empty response body.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
