### PR TITLE
chore(tracks): loosen Node.js engine constraint to support v22+

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -21,6 +21,19 @@
 			"isBanned": true
 		},
 		{
+			"label": "Allow @woocommerce/tracks to support Node.js v22+",
+			"dependencies": [
+				"node"
+			],
+			"dependencyTypes": [
+				"engines"
+			],
+			"pinVersion": ">=20.11.1",
+			"packages": [
+				"@woocommerce/tracks"
+			]
+		},
+		{
 			"dependencies": [
 				"node"
 			],

--- a/packages/js/tracks/changelog/update-tracks-node-engines
+++ b/packages/js/tracks/changelog/update-tracks-node-engines
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Loosens the Node.js engine constraint.

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -5,7 +5,7 @@
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"engines": {
-		"node": "^20.11.1"
+		"node": ">=20.11.1"
 	},
 	"keywords": [
 		"wordpress",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `@woocommerce/tracks` package currently pins its Node.js engine to `^20.11.1`, which prevents usage with Node.js v22 and later. This blocks integration with CIAB Admin, which requires Node 22+.

Since this is a browser-only package (uses `window`, `document`, `localStorage` — no Node-specific APIs), the engine constraint only affects the build toolchain, which is fully compatible with Node 22.

This PR:
- Changes `engines.node` from `^20.11.1` to `>=20.11.1` in `packages/js/tracks/package.json`
- Adds a syncpack version group override in `.syncpackrc` specifically for `@woocommerce/tracks`, so the monorepo-wide `^20.11.1` pin remains unaffected for all other packages

### How to test the changes in this Pull Request:

1. Verify syncpack passes: `pnpm syncpack list-mismatches` — should return no errors.
2. Verify the tracks package builds successfully: `pnpm --filter=@woocommerce/tracks build`.
3. Verify other packages still have `"node": "^20.11.1"` in their `package.json` engines field.

### Testing that has already taken place:

- Confirmed `pnpm syncpack list-mismatches` passes with no errors.
- Reviewed all source files in the tracks package — no Node.js-specific APIs used (browser-only: `window`, `document`, `localStorage`, `Image`).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Loosens the Node.js engine constraint.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>