### PR TITLE
Update locale validation to reflect that there are valid 2 and 3 letter locales.

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
@@ -41,10 +41,15 @@ class PushTokenValidator {
 	/**
 	 * Validates device locale format:
 	 * - language code (2–3 lowercase letters)
-	 * - underscore
-	 * - region code (2 uppercase letters).
+	 * - optionally followed by underscore and region code (2 uppercase letters)
+	 *
+	 * We don't have access to a locale dictionary to check valid locales, but
+	 * it's important to note that we do not support country codes here, ONLY
+	 * valid locales. Some countries have valid 2 and 3 character locales (like
+	 * Japanese - ja, Arabic - ar, Asturian - ast), which is what this regex
+	 * reflects.
 	 */
-	const DEVICE_LOCALE_FORMAT = '/^(?<language>[a-z]{2,3})_(?<region>[A-Z]{2})$/';
+	const DEVICE_LOCALE_FORMAT = '/^(?<language>[a-z]{2,3})(_(?<region>[A-Z]{2}))?$/';
 
 	/**
 	 * The regex to use when validating device UUID format.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Validators/PushTokenValidator.php
@@ -45,11 +45,11 @@ class PushTokenValidator {
 	 *
 	 * We don't have access to a locale dictionary to check valid locales, but
 	 * it's important to note that we do not support country codes here, ONLY
-	 * valid locales. Some countries have valid 2 and 3 character locales (like
+	 * valid locales. Some languages have valid 2 and 3 character locales (like
 	 * Japanese - ja, Arabic - ar, Asturian - ast), which is what this regex
 	 * reflects.
 	 */
-	const DEVICE_LOCALE_FORMAT = '/^(?<language>[a-z]{2,3})(_(?<region>[A-Z]{2}))?$/';
+	const DEVICE_LOCALE_FORMAT = '/^(?<language>[a-z]{2,3})(?:_(?<region>[A-Z]{2}))?$/';
 
 	/**
 	 * The regex to use when validating device UUID format.

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
@@ -924,12 +924,13 @@ class PushTokenValidatorTest extends WC_Unit_Test_Case {
 	 */
 	public function invalid_locales_provider(): array {
 		return array(
-			'no underscore'    => array( 'enUS' ),
-			'lowercase region' => array( 'en_gb' ),
-			'uppercase lang'   => array( 'EN_US' ),
-			'single char'      => array( 'e' ),
-			'with hyphen'      => array( 'en-US' ),
-			'too long lang'    => array( 'engl_US' ),
+			'no underscore'       => array( 'enUS' ),
+			'lowercase region'    => array( 'en_gb' ),
+			'uppercase lang'      => array( 'EN_US' ),
+			'single char'         => array( 'e' ),
+			'with hyphen'         => array( 'en-US' ),
+			'too long lang'       => array( 'engl_US' ),
+			'trailing underscore' => array( 'en_US_' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
@@ -907,13 +907,13 @@ class PushTokenValidatorTest extends WC_Unit_Test_Case {
 	 */
 	public function valid_locales_provider(): array {
 		return array(
-			'English US'          => array( 'en_US' ),
-			'French'              => array( 'fr_FR' ),
-			'Chinese'             => array( 'zh_CN' ),
-			'Portuguese'          => array( 'pt_BR' ),
-			'Three-letter'        => array( 'ast_ES' ),
-			'Two-letter locale'   => array( 'ja' ),
-			'Three-letter locale' => array( 'ast' ),
+			'English US'                  => array( 'en_US' ),
+			'French'                      => array( 'fr_FR' ),
+			'Chinese'                     => array( 'zh_CN' ),
+			'Portuguese'                  => array( 'pt_BR' ),
+			'Three-letter with region'    => array( 'rup_MK' ),
+			'Two-letter without region'   => array( 'ja' ),
+			'Three-letter without region' => array( 'ast' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
@@ -907,11 +907,13 @@ class PushTokenValidatorTest extends WC_Unit_Test_Case {
 	 */
 	public function valid_locales_provider(): array {
 		return array(
-			'English US'   => array( 'en_US' ),
-			'French'       => array( 'fr_FR' ),
-			'Chinese'      => array( 'zh_CN' ),
-			'Portuguese'   => array( 'pt_BR' ),
-			'Three-letter' => array( 'ast_ES' ),
+			'English US'          => array( 'en_US' ),
+			'French'              => array( 'fr_FR' ),
+			'Chinese'             => array( 'zh_CN' ),
+			'Portuguese'          => array( 'pt_BR' ),
+			'Three-letter'        => array( 'ast_ES' ),
+			'Two-letter locale'   => array( 'ja' ),
+			'Three-letter locale' => array( 'ast' ),
 		);
 	}
 
@@ -925,7 +927,7 @@ class PushTokenValidatorTest extends WC_Unit_Test_Case {
 			'no underscore'    => array( 'enUS' ),
 			'lowercase region' => array( 'en_gb' ),
 			'uppercase lang'   => array( 'EN_US' ),
-			'just language'    => array( 'en' ),
+			'single char'      => array( 'e' ),
 			'with hyphen'      => array( 'en-US' ),
 			'too long lang'    => array( 'engl_US' ),
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Validators/PushTokenValidatorTest.php
@@ -930,7 +930,7 @@ class PushTokenValidatorTest extends WC_Unit_Test_Case {
 			'single char'         => array( 'e' ),
 			'with hyphen'         => array( 'en-US' ),
 			'too long lang'       => array( 'engl_US' ),
-			'trailing underscore' => array( 'en_US_' ),
+			'trailing underscore' => array( 'en_' ),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-2051
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change updates the device locale validation to reflect that there are valid 2 and 3 letter locales.

**Key requirements:**
* Allow all valid locale formats:
    * 2 char country and 2 char region: e.g. `en_US`
    * 3 char country and 2 char region: e.g. `rup_MK`
    * 2 char country: e.g. `ja`
    * 3 char country: e.g. `ast`


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
These new files are not yet used so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack installed and connected
- You have at least 2 test users with `shop_manager` or `administrator` roles
- You have a tool to make HTTP requests (e.g. Postman, curl, or browser REST client)
- You are authenticated as one of your test users when making requests

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

#### 1. Valid locales

##### 1.1 2 char country and 2 char region
Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "en_US",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID

##### 1.2 3 char country and 2 char region

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "rup_MK",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID

##### 1.3 2 char country

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "ja",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID

##### 1.4 2 char country

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "ast",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID


#### 2. Invalid locales

##### 1.1 1 char country and 2 char region
Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "e_US",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 400 Bad Request

##### 1.2 All uppercase

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "RUP_MK",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 400 Bad Request

##### 1.3 With hyphen

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "en-US",
  "metadata": { "app_version": "1.0.0" }
}
```

**Expected result:**
* Status: 400 Bad Request


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
