### PR TITLE
Fix PHP unit test failures on WP 7.0-beta1

### DIFF
--- a/plugins/woocommerce/changelog/63425-fix-wp70-beta-php-unit-test-flakiness
+++ b/plugins/woocommerce/changelog/63425-fix-wp70-beta-php-unit-test-flakiness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Adjust tests for WP 7.0-beta.1 compatibility

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -143,18 +143,12 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Returns an object mocking what we need from `\WP_Screen`.
+	 * Returns a WP_Screen instance for use in tests.
 	 *
-	 * @return object
+	 * @return \WP_Screen
 	 */
 	private function get_screen_mock() {
-		$screen_mock = $this->getMockBuilder( stdClass::class )->setMethods( array( 'in_admin', 'add_option' ) )->getMock();
-		$screen_mock->method( 'in_admin' )->willReturn( true );
-		foreach ( array( 'id', 'base', 'action', 'post_type' ) as $key ) {
-			$screen_mock->{$key} = '';
-		}
-
-		return $screen_mock;
+		return \WP_Screen::get( '' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -53,10 +53,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	public function test_display_notices( string $current_screen_base, bool $should_display_notices ) : void {
 		global $current_screen;
 
-		$screen = new \stdClass();
-		$screen->base = $current_screen_base;
-
-		$current_screen = $screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$current_screen = \WP_Screen::get( $current_screen_base ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// phpcs:disable Squiz.Commenting
 		$instance = new class() extends ReviewsCommentsOverrides {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The `PHP 7.4 WP: pre-release [WP 7.0-beta1]` CI job is failing with 3 test failures across trunk and all branches. The root cause is that both `WC_Orders_Tracking_Test` and `ReviewsCommentsOverridesTest` use `stdClass` mocks for `$current_screen`, but WordPress's `get_current_screen()` function performs an `instanceof WP_Screen` check and returns `null` when the global is not a real `WP_Screen` instance. This causes the tested methods to exit early, resulting in no tracks events being recorded or notices being displayed.

This PR replaces the `stdClass` mocks with proper `WP_Screen::get()` instances, which pass the `instanceof` check correctly across all WP versions.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch.
2. Run `pnpm test:php:env -- --filter WC_Orders_Tracking_Test` and verify all 6 tests pass.
3. Run `pnpm test:php:env -- --filter ReviewsCommentsOverridesTest` and verify all 12 tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Both test classes were run locally via Docker (PHP 8.1, WP 6.9.1) and all tests pass (6/6 for `WC_Orders_Tracking_Test` and 12/12 for `ReviewsCommentsOverridesTest`).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Adjust tests for WP 7.0-beta.1 compatibility
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
</details>
