### PR TITLE
Fix email editor E2E test strict mode violation with MailPoet

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/email-editor/email-editor-loads.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email-editor/email-editor-loads.spec.ts
@@ -24,7 +24,10 @@ test.describe( 'WooCommerce Email Editor Core', () => {
 			.getByRole( 'checkbox', { name: 'Enable the block-based email' } )
 			.check();
 		await page.getByRole( 'button', { name: 'Save changes' } ).click();
-		await page.getByRole( 'link', { name: 'Emails' } ).click();
+		await page
+			.locator( '#mainform' )
+			.getByRole( 'link', { name: 'Emails' } )
+			.click();
 		await expect(
 			page.locator( '#email_notification_settings-description' )
 		).toContainText(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Scopes the `getByRole('link', { name: 'Emails' })` locator in the email editor E2E test to `#mainform` to avoid a Playwright strict mode violation when plugins like MailPoet are active.

When MailPoet is installed, it adds an "Emails" link to the WordPress admin sidebar. The unscoped locator then resolves to 2 elements, causing the test to fail with:

```
Error: strict mode violation: getByRole('link', { name: 'Emails' }) resolved to 2 elements
```

The fix scopes the locator to `page.locator('#mainform').getByRole('link', { name: 'Emails' })` so it only matches the WooCommerce Settings tab.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Install and activate the MailPoet plugin on the test site
2. Run the email editor E2E test: `npx playwright test --config=tests/e2e-pw/envs/default/playwright.config.js --project=e2e --grep "Can enable the email editor"`
3. Verify the test passes

### Testing that has already taken place:

- Verified the test fails without the fix when MailPoet is active
- Verified the test passes with the fix when MailPoet is active
- Verified the test passes with the fix without MailPoet

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is a test-only change with no impact on production code.

</details>