### PR TITLE
Email Editor: use file templates until content is edited

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
@@ -257,7 +257,9 @@ export const useTransactionalEmails = (
 	);
 
 	const recreateEmailPost = useCallback(
-		async ( emailId: string ) => {
+		async (
+			emailId: string
+		): Promise< EmailListingRecreateEmailPostResponse | null > => {
 			try {
 				const response: EmailListingRecreateEmailPostResponse =
 					await apiFetch( {
@@ -266,6 +268,7 @@ export const useTransactionalEmails = (
 						data: { email_id: emailId },
 					} );
 				updateEmailPostIdInState( emailId, response?.post_id || '' );
+				return response;
 			} catch ( e ) {
 				const wpError = e as WPError;
 				// eslint-disable-next-line no-console
@@ -273,6 +276,7 @@ export const useTransactionalEmails = (
 					'[WooCommerce Admin] Error recreating email post: ',
 					wpError
 				);
+				return null;
 			}
 		},
 		[ updateEmailPostIdInState ]

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -114,7 +114,7 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				label: __( 'Edit', 'woocommerce' ),
 				icon: <Icon icon={ edit } />,
 				supportsBulk: false,
-				callback: ( items: EmailType[] ) => {
+				callback: async ( items: EmailType[] ) => {
 					const email = items[ 0 ];
 					if ( email.post_id ) {
 						window.location.href = getAdminLink(
@@ -123,11 +123,17 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 							) }&action=edit`
 						);
 					} else {
-						window.location.href = getAdminLink(
-							`admin.php?page=wc-settings&tab=email&section=${ encodeURIComponent(
-								email.email_key
-							) }`
+						// Lazily create an auto-draft post for this email type.
+						const response = await recreateEmailPost(
+							email.id
 						);
+						if ( response?.post_id ) {
+							window.location.href = getAdminLink(
+								`post.php?post=${ encodeURIComponent(
+									response.post_id
+								) }&action=edit`
+							);
+						}
 					}
 				},
 			},
@@ -165,17 +171,6 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 						items[ 0 ].id,
 						! items[ 0 ].enabled
 					);
-				},
-			},
-			{
-				id: 'recreate-email-post',
-				label: __( 'Recreate email post', 'woocommerce' ),
-				disabled: false,
-				supportsBulk: false,
-				isEligible: ( item: EmailType ) => ! item?.post_id,
-				callback: ( items: EmailType[] ) => {
-					void recreateEmailPost( items[ 0 ].id );
-					return true;
 				},
 			},
 		],

--- a/plugins/woocommerce/src/Internal/Admin/Emails/EmailListingRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Emails/EmailListingRestController.php
@@ -4,8 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\Emails;
 
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
 use WP_Error;
 use WP_REST_Request;
 
@@ -168,16 +171,50 @@ class EmailListingRestController extends RestApiControllerBase {
 	/**
 	 * Handle the POST /settings/email/listing/recreate-email-post.
 	 *
+	 * Creates an auto-draft email post for the given email type, or returns an existing
+	 * published/auto-draft post if one already exists. This follows the WordPress Site Editor
+	 * pattern where posts are only created when the user opens the editor.
+	 *
 	 * @param WP_REST_Request $request The received request.
 	 * @return array|WP_Error Request response or an error.
 	 */
 	public function recreate_email_post( WP_REST_Request $request ) {
 		$email_id = $request->get_param( 'email_id' );
 
-		$generated_post_id = '';
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
 
+		// Check for existing published post first.
+		$existing_post_id = $post_manager->get_email_template_post_id( $email_id );
+		if ( $existing_post_id ) {
+			$post = get_post( $existing_post_id );
+			if ( $post instanceof \WP_Post ) {
+				return array(
+					'message' => sprintf(
+						// translators: %s: WooCommerce transactional email ID.
+						__( 'Email post already exists for %s.', 'woocommerce' ),
+						$email_id
+					),
+					'post_id' => (string) $existing_post_id,
+				);
+			}
+		}
+
+		// Check for existing auto-draft.
+		$existing_auto_draft = $this->find_auto_draft_for_email_type( $email_id );
+		if ( $existing_auto_draft ) {
+			return array(
+				'message' => sprintf(
+					// translators: %s: WooCommerce transactional email ID.
+					__( 'Email auto-draft exists for %s.', 'woocommerce' ),
+					$email_id
+				),
+				'post_id' => (string) $existing_auto_draft->ID,
+			);
+		}
+
+		// Create a new auto-draft with file template content.
 		try {
-			$generated_post_id = $this->email_template_generator->generate_email_template_if_not_exists( $email_id );
+			$post_id = $this->create_auto_draft( $email_id );
 		} catch ( \Exception $e ) {
 			return new WP_Error(
 				'woocommerce_rest_email_post_generation_failed',
@@ -187,17 +224,90 @@ class EmailListingRestController extends RestApiControllerBase {
 			);
 		}
 
-		if ( $generated_post_id ) {
+		if ( $post_id ) {
 			return array(
 				// translators: %s: WooCommerce transactional email ID.
-				'message' => sprintf( __( 'Email post generated for %s.', 'woocommerce' ), $email_id ),
-				'post_id' => (string) $generated_post_id,
+				'message' => sprintf( __( 'Email auto-draft created for %s.', 'woocommerce' ), $email_id ),
+				'post_id' => (string) $post_id,
 			);
 		}
+
 		return new WP_Error(
 			'woocommerce_rest_email_post_generation_error',
 			__( 'Error unable to generate email post.', 'woocommerce' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	/**
+	 * Find an existing auto-draft post for the given email type.
+	 *
+	 * @param string $email_id The email type identifier.
+	 * @return \WP_Post|null The auto-draft post if found, null otherwise.
+	 */
+	private function find_auto_draft_for_email_type( string $email_id ): ?\WP_Post {
+		$posts = get_posts(
+			array(
+				'post_type'   => Integration::EMAIL_POST_TYPE,
+				'post_status' => 'auto-draft',
+				'meta_key'    => '_wc_email_type', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'  => $email_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'numberposts' => 1,
+			)
+		);
+
+		return ! empty( $posts ) ? $posts[0] : null;
+	}
+
+	/**
+	 * Create an auto-draft email post with file template content.
+	 *
+	 * @param string $email_id The email type identifier.
+	 * @return int The post ID of the created auto-draft.
+	 * @throws \Exception When the email type is not found or post creation fails.
+	 */
+	private function create_auto_draft( string $email_id ): int {
+		$file_content = WCTransactionalEmailPostsGenerator::get_file_template_content( $email_id );
+		if ( null === $file_content ) {
+			throw new \Exception(
+				esc_html( sprintf( 'Could not load file template for email type: %s', $email_id ) )
+			);
+		}
+
+		$emails = \WC()->mailer()->get_emails();
+		$email  = null;
+		foreach ( $emails as $e ) {
+			if ( $e->id === $email_id ) {
+				$email = $e;
+				break;
+			}
+		}
+
+		if ( ! $email ) {
+			throw new \Exception(
+				esc_html( sprintf( 'Email type not found: %s', $email_id ) )
+			);
+		}
+
+		$post_data = array(
+			'post_type'    => Integration::EMAIL_POST_TYPE,
+			'post_status'  => 'auto-draft',
+			'post_name'    => $email_id,
+			'post_title'   => $email->get_title(),
+			'post_excerpt' => $email->get_description(),
+			'post_content' => $file_content,
+			'meta_input'   => array(
+				'_wp_page_template' => ( new WooEmailTemplate() )->get_slug(),
+				'_wc_email_type'    => $email_id,
+			),
+		);
+
+		$post_id = wp_insert_post( $post_data, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			throw new \Exception( esc_html( $post_id->get_error_message() ) );
+		}
+
+		return $post_id;
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\Internal\EmailEditor;
 use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
 use Automattic\WooCommerce\EmailEditor\Engine\Personalizer;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer as EmailRenderer;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 
 /**
@@ -72,8 +74,14 @@ class BlockEmailRenderer {
 	 */
 	public function maybe_render_block_email( \WC_Email $wc_email ): ?string {
 		$email_post = $this->get_email_post_by_wc_email( $wc_email );
+
+		// If no published post exists, build a synthetic WP_Post from the file template.
+		// This follows the WP Site Editor pattern: file templates are used until the user edits and saves.
 		if ( ! $email_post ) {
-			return null;
+			$email_post = $this->build_post_from_file_template( $wc_email );
+			if ( ! $email_post ) {
+				return null;
+			}
 		}
 
 		$woo_content = $this->woo_content_processor->get_woo_content( $wc_email );
@@ -96,9 +104,11 @@ class BlockEmailRenderer {
 			};
 			add_filter( 'woocommerce_email_editor_rendering_email_context', $filter_callback, 10, 1 );
 
-			$subject             = $wc_email->get_subject(); // We will get subject from $email_post after we add it to the editor.
-			$preheader           = $wc_email->get_preheader();
-			$rendered_email_data = $this->renderer->render( $email_post, $subject, $preheader, 'en' );
+			$subject       = $wc_email->get_subject(); // We will get subject from $email_post after we add it to the editor.
+			$preheader     = $wc_email->get_preheader();
+			$template_slug = 0 === $email_post->ID ? ( new WooEmailTemplate() )->get_slug() : '';
+
+			$rendered_email_data = $this->renderer->render( $email_post, $subject, $preheader, 'en', '', $template_slug );
 			$personalized_email  = $this->personalizer->personalize_content( $rendered_email_data['html'] );
 			$rendered_email      = str_replace( self::WOO_EMAIL_CONTENT_PLACEHOLDER, $woo_content, $personalized_email );
 
@@ -139,6 +149,33 @@ class BlockEmailRenderer {
 	 * @param \WC_Email $wc_email WooCommerce email object.
 	 * @return array Email context data.
 	 */
+	/**
+	 * Build a synthetic WP_Post from the file-based template for an email type.
+	 *
+	 * Used when no published post exists in the database, allowing rendering
+	 * directly from file templates without requiring a DB record.
+	 *
+	 * @param \WC_Email $wc_email WooCommerce email object.
+	 * @return \WP_Post|null Synthetic post or null if file template not found.
+	 */
+	private function build_post_from_file_template( \WC_Email $wc_email ): ?\WP_Post {
+		$file_content = WCTransactionalEmailPostsGenerator::get_file_template_content( $wc_email->id );
+		if ( null === $file_content ) {
+			return null;
+		}
+
+		return new \WP_Post(
+			(object) array(
+				'ID'           => 0,
+				'post_type'    => Integration::EMAIL_POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => $file_content,
+				'post_title'   => $wc_email->get_title(),
+				'post_name'    => $wc_email->id,
+			)
+		);
+	}
+
 	private function build_email_context( \WC_Email $wc_email ): array {
 		$recipient_raw = $wc_email->get_recipient();
 		$emails        = array_values( array_filter( array_map( 'sanitize_email', array_map( 'trim', explode( ',', $recipient_raw ) ) ) ) );

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -139,6 +139,7 @@ class Integration {
 		add_filter( 'woocommerce_email_editor_preview_post_template_html', array( $this, 'update_preview_post_template_html_data' ), 100, 1 );
 		add_action( 'woocommerce_email_editor_send_preview_email_before_wp_mail', array( $this, 'send_preview_email_before_wp_mail' ), 10 );
 		add_action( 'woocommerce_email_editor_send_preview_email_after_wp_mail', array( $this, 'send_preview_email_after_wp_mail' ), 10 );
+		add_action( 'transition_post_status', array( $this, 'save_email_mapping_on_publish' ), 10, 3 );
 	}
 
 	/**
@@ -414,5 +415,33 @@ class Integration {
 	public function send_preview_email_after_wp_mail() {
 		remove_filter( 'wp_mail_from', array( $this->wc_email_instance, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this->wc_email_instance, 'get_from_name' ) );
+	}
+
+	/**
+	 * Save the email type → post ID mapping when a woo_email auto-draft is published.
+	 *
+	 * This follows the WordPress Site Editor pattern: the post only becomes "permanent"
+	 * when the user actually saves in the editor (auto-draft → publish).
+	 *
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post object.
+	 */
+	public function save_email_mapping_on_publish( $new_status, $old_status, $post ): void {
+		if ( self::EMAIL_POST_TYPE !== $post->post_type ) {
+			return;
+		}
+
+		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+			return;
+		}
+
+		$email_type = get_post_meta( $post->ID, '_wc_email_type', true );
+		if ( empty( $email_type ) ) {
+			return;
+		}
+
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$post_manager->save_email_template_post_id( $email_type, $post->ID );
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -152,6 +152,26 @@ class WCTransactionalEmailPostsGenerator {
 	}
 
 	/**
+	 * Get the file-based template content for a given email type.
+	 *
+	 * Looks up the \WC_Email object from the mailer and loads
+	 * the template HTML from the file system.
+	 *
+	 * @param string $email_type The email type identifier (e.g., 'customer_processing_order').
+	 * @return string|null The template HTML content, or null if the email type is not found.
+	 */
+	public static function get_file_template_content( $email_type ) {
+		$emails = \WC()->mailer()->get_emails();
+		foreach ( $emails as $email ) {
+			if ( $email->id === $email_type ) {
+				$generator = new self();
+				return $generator->get_email_template( $email );
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Generate initial email templates.
 	 *
 	 * This function generates the initial email templates for the core transactional emails.

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManager.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManager.php
@@ -129,7 +129,17 @@ class WCTransactionalEmailPostsManager {
 		);
 
 		if ( empty( $option_name ) ) {
-			return null;
+			// Fallback: check post meta for auto-draft posts that don't have an options mapping yet.
+			$email_type = get_post_meta( $post_id, '_wc_email_type', true );
+			if ( empty( $email_type ) ) {
+				return null;
+			}
+
+			// Store in both caches.
+			$this->post_id_to_email_type_cache[ $post_id ] = $email_type;
+			wp_cache_set( $cache_key, $email_type, self::CACHE_GROUP, self::CACHE_EXPIRATION );
+
+			return $email_type;
 		}
 
 		$email_type = $this->get_email_type_from_option_name( $option_name );

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -58,7 +58,10 @@ class WCTransactionalEmails {
 	 * @internal
 	 */
 	final public function init() {
-		add_action( 'current_screen', array( $this, 'init_email_templates' ), 50 );
+		// Email posts are no longer created on initialization.
+		// They are created lazily when a user opens the email editor for a specific email type.
+		// This aligns with the WordPress Site Editor pattern where wp_template posts
+		// are only created when the user edits and saves a template.
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR aligns the WooCommerce block email editor with the WordPress Site Editor pattern: file-based templates are the source of truth until the user explicitly edits and saves an email.

**Problem:** Previously, `woo_email` posts were bulk-generated in the database on initialization (when visiting any WC admin page). Once stored, the DB content was frozen — WC version updates to template files didn't propagate, and content was generated in the locale active at initialization time rather than at render time.

**Solution:** Follow the WordPress Site Editor pattern for `wp_template` posts:
- **No posts created on initialization** — removed bulk generation from `WCTransactionalEmails::init()`
- **File templates used for rendering** when no published post exists — `BlockEmailRenderer` builds a synthetic `WP_Post` from the file template
- **Auto-draft created lazily** when user clicks "Edit" in the email listing — via the existing `recreate-email-post` REST endpoint
- **Auto-draft promoted to published on save** — a `transition_post_status` hook persists the email_type → post_id mapping
- **Auto-draft cleanup** handled automatically by WordPress cron (`wp_delete_auto_drafts`)

**Key changes across 8 files:**
- `WCTransactionalEmails.php` — Removed `current_screen` hook that triggered bulk post generation
- `WCTransactionalEmailPostsGenerator.php` — Added `get_file_template_content()` static method
- `EmailListingRestController.php` — Rewrote endpoint to create auto-drafts with `_wc_email_type` post meta
- `WCTransactionalEmailPostsManager.php` — Added post meta fallback for email type lookup on auto-drafts
- `Integration.php` — Added `transition_post_status` hook to save mapping when auto-draft → published
- `BlockEmailRenderer.php` — Renders from file templates when no published post exists
- `settings-email-listing-data.ts` — `recreateEmailPost` now returns the API response
- `settings-email-listing-listview.tsx` — Edit action creates auto-draft on demand; removed redundant "Recreate email post" action

Closes WOOPLUG-6171.

### How to test the changes in this Pull Request:

1. Set up the email editor dev environment (see `woocommerce-email-editor` skill)
2. **Fresh install (no existing posts):**
   - Verify no `woo_email` posts exist after visiting WC admin pages
   - Go to WC Settings > Email — verify the email listing loads correctly
   - Trigger an email (e.g., create a new order) — verify it renders correctly using the file template
3. **Lazy creation:**
   - Click "Edit" on an email in the listing — verify an auto-draft is created and the editor opens with file template content
   - Close the editor without saving — verify the auto-draft remains (will be cleaned by WP cron)
4. **Save creates published post:**
   - Edit an email and save — verify the post status changes to `publish` and the options mapping is saved
   - Trigger that email again — verify it uses the saved DB content
5. **Existing installations:**
   - On an install with previously created `woo_email` posts, verify all emails still work correctly

### Testing that has already taken place:

- PHPStan analysis passes on all changed files
- Code review of existing test files confirms compatibility (tests create posts directly, not via initialization)

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Update - Update existing functionality

#### Message
Email Editor: use file-based templates for rendering until the user edits and saves an email, aligning with the WordPress Site Editor pattern.

</details>