### PR TITLE
[WOOPLUG-6273] Shipping partner updates: add tracks events

### DIFF
--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
@@ -1,0 +1,381 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import tracksActions from '../tracks';
+import type { CoreProfilerStateMachineContext } from '../../index';
+import type { PluginInstallError } from '../../services/installAndActivatePlugins';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getSetting: jest.fn( () => '9.8.0' ),
+} ) );
+
+const makeContext = (
+	overrides: Partial< CoreProfilerStateMachineContext > = {}
+): CoreProfilerStateMachineContext =>
+	( {
+		optInDataSharing: false,
+		userProfile: {},
+		pluginsAvailable: [],
+		pluginsSelected: [],
+		pluginsInstallationErrors: [],
+		geolocatedLocation: undefined,
+		businessInfo: { location: 'US:CA' },
+		countries: [],
+		loader: {},
+		coreProfilerCompletedSteps: {},
+		onboardingProfile: {},
+		currentUserEmail: undefined,
+		...overrides,
+	} as CoreProfilerStateMachineContext );
+
+const shippingPlugins = [
+	{
+		key: 'woocommerce-shipping',
+		slug: 'woocommerce-shipping',
+		name: 'WooCommerce Shipping',
+		label: 'WooCommerce Shipping',
+		is_activated: false,
+		description: '',
+		image_url: '',
+		manage_url: '',
+		is_built_by_wc: true,
+		is_visible: true,
+	},
+	{
+		key: 'woocommerce-shipstation-integration',
+		slug: 'woocommerce-shipstation-integration',
+		name: 'ShipStation',
+		label: 'ShipStation',
+		is_activated: false,
+		description: '',
+		image_url: '',
+		manage_url: '',
+		is_built_by_wc: false,
+		is_visible: true,
+	},
+];
+
+const nonShippingPlugin = {
+	key: 'woocommerce-payments',
+	slug: 'woocommerce-payments',
+	name: 'WooPayments',
+	label: 'WooPayments',
+	is_activated: false,
+	description: '',
+	image_url: '',
+	manage_url: '',
+	is_built_by_wc: true,
+	is_visible: true,
+};
+
+describe( 'Core Profiler shipping partner tracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'recordShippingPartnerImpression', () => {
+		it( 'should fire shipping_partner_impression when shipping plugins are available', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_impression when no shipping plugins are available', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ nonShippingPlugin ],
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordTracksPluginsInstallationRequest (shipping_partner_click)', () => {
+		it( 'should fire shipping_partner_click for each selected shipping plugin', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordTracksPluginsInstallationRequest( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_REQUESTED',
+					payload: {
+						pluginsShown: [
+							'woocommerce-shipping',
+							'woocommerce-shipstation-integration',
+							'woocommerce-payments',
+						],
+						pluginsSelected: [
+							'woocommerce-shipping',
+							'woocommerce-shipstation-integration',
+							'woocommerce-payments',
+						],
+						pluginsUnselected: [],
+					},
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_click',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_click',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipstation-integration',
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_click when no shipping plugins are selected', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordTracksPluginsInstallationRequest( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_REQUESTED',
+					payload: {
+						pluginsShown: [
+							'woocommerce-shipping',
+							'woocommerce-payments',
+						],
+						pluginsSelected: [ 'woocommerce-payments' ],
+						pluginsUnselected: [ 'woocommerce-shipping' ],
+					},
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_click',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordSuccessfulPluginInstallation (shipping_partner_install + shipping_partner_activate)', () => {
+		it( 'should fire install and activate success for each shipping plugin', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordSuccessfulPluginInstallation( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED',
+					payload: {
+						installationCompletedResult: {
+							installedPlugins: [
+								{
+									plugin: 'woocommerce-shipping',
+									installTime: 1000,
+								},
+								{
+									plugin: 'woocommerce-payments',
+									installTime: 2000,
+								},
+							],
+							totalTime: 3000,
+						},
+					},
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+
+		it( 'should not fire shipping events for non-shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ nonShippingPlugin ],
+			} );
+
+			tracksActions.recordSuccessfulPluginInstallation( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED',
+					payload: {
+						installationCompletedResult: {
+							installedPlugins: [
+								{
+									plugin: 'woocommerce-payments',
+									installTime: 2000,
+								},
+							],
+							totalTime: 2000,
+						},
+					},
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_install',
+				expect.anything()
+			);
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordFailedPluginInstallations (shipping_partner_install failure)', () => {
+		it( 'should fire shipping_partner_install with failure for failed shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			const errors: PluginInstallError[] = [
+				{
+					plugin: 'woocommerce-shipping',
+					error: 'Install failed',
+					errorDetails: {
+						data: {
+							code: 'install_error',
+							data: { status: 500 },
+						},
+					},
+				},
+			];
+
+			tracksActions.recordFailedPluginInstallations( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED_WITH_ERRORS',
+					payload: { errors },
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_install for failed non-shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			const errors: PluginInstallError[] = [
+				{
+					plugin: 'woocommerce-payments',
+					error: 'Install failed',
+					errorDetails: {
+						data: {
+							code: 'install_error',
+							data: { status: 500 },
+						},
+					},
+				},
+			];
+
+			tracksActions.recordFailedPluginInstallations( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED_WITH_ERRORS',
+					payload: { errors },
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_install',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'country code extraction', () => {
+		it( 'should extract country code from location with state', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ shippingPlugins[ 0 ] ],
+				businessInfo: { location: 'DE:BE' },
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.objectContaining( { country: 'DE' } )
+			);
+		} );
+
+		it( 'should handle missing location gracefully', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ shippingPlugins[ 0 ] ],
+				businessInfo: {},
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.objectContaining( { country: '' } )
+			);
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -22,6 +22,32 @@ import {
 	PluginInstallError,
 } from '../services/installAndActivatePlugins';
 import { getPluginTrackKey, getTimeFrame } from '~/utils';
+import { getPluginSlug } from '~/utils/plugins';
+import { getCountryCode } from '~/dashboard/utils';
+
+const SHIPPING_PLUGIN_SLUGS = new Set( [
+	'woocommerce-shipping',
+	'woocommerce-shipstation-integration',
+	'packlink-pro-shipping',
+] );
+
+const isShippingPlugin = ( pluginKey: string ) =>
+	SHIPPING_PLUGIN_SLUGS.has( getPluginSlug( pluginKey ) );
+
+const getShippingPartnerTrackingBase = (
+	context: CoreProfilerStateMachineContext
+) => {
+	const shippingPlugins = context.pluginsAvailable
+		.filter( ( plugin ) => isShippingPlugin( plugin.key ) )
+		.map( ( plugin ) => getPluginSlug( plugin.key ) )
+		.join( ',' );
+
+	return {
+		context: 'core-profiler' as const,
+		country: getCountryCode( context.businessInfo.location ) ?? '',
+		plugins: shippingPlugins,
+	};
+};
 
 const recordTracksStepViewed = ( _: unknown, params: { step: string } ) => {
 	recordEvent( 'coreprofiler_step_view', {
@@ -138,9 +164,23 @@ const recordTracksBusinessInfoCompleted = ( {
 	} );
 };
 
+const recordShippingPartnerImpression = ( {
+	context,
+}: {
+	context: CoreProfilerStateMachineContext;
+} ) => {
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
+	if ( trackingBase.plugins.length > 0 ) {
+		recordEvent( 'shipping_partner_impression', trackingBase );
+	}
+};
+
 const recordTracksPluginsInstallationRequest = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: Extract<
 		PluginsInstallationRequestedEvent,
 		{ type: 'PLUGINS_INSTALLATION_REQUESTED' }
@@ -150,6 +190,18 @@ const recordTracksPluginsInstallationRequest = ( {
 		shown: event.payload.pluginsShown || [],
 		selected: event.payload.pluginsSelected || [],
 		unselected: event.payload.pluginsUnselected || [],
+	} );
+
+	const trackingBase = getShippingPartnerTrackingBase( context );
+	const selectedShippingPlugins = (
+		event.payload.pluginsSelected || []
+	).filter( ( slug ) => SHIPPING_PLUGIN_SLUGS.has( getPluginSlug( slug ) ) );
+
+	selectedShippingPlugins.forEach( ( pluginSlug ) => {
+		recordEvent( 'shipping_partner_click', {
+			...trackingBase,
+			selected_plugin: getPluginSlug( pluginSlug ),
+		} );
 	} );
 };
 
@@ -167,8 +219,10 @@ const recordTracksPluginsInstallationNoPermissionError = () =>
 	recordEvent( 'coreprofiler_store_extensions_no_permission_error' );
 
 const recordFailedPluginInstallations = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: PluginsInstallationCompletedWithErrorsEvent;
 } ) => {
 	const failedExtensions = event.payload.errors.map(
@@ -180,18 +234,30 @@ const recordFailedPluginInstallations = ( {
 		failed_extensions: failedExtensions,
 	} );
 
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
 	event.payload.errors.forEach( ( error: PluginInstallError ) => {
 		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
 			success: false,
 			extension: getPluginTrackKey( error.plugin ),
 			error_message: error.error,
 		} );
+
+		if ( isShippingPlugin( error.plugin ) ) {
+			recordEvent( 'shipping_partner_install', {
+				...trackingBase,
+				selected_plugin: getPluginSlug( error.plugin ),
+				success: false,
+			} );
+		}
 	} );
 };
 
 const recordSuccessfulPluginInstallation = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: PluginsInstallationCompletedEvent;
 } ) => {
 	const installationCompletedResult =
@@ -211,6 +277,8 @@ const recordSuccessfulPluginInstallation = ( {
 		total_time: getTimeFrame( installationCompletedResult.totalTime ),
 	};
 
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
 	for ( const installedPlugin of installationCompletedResult.installedPlugins ) {
 		const pluginKey = getPluginTrackKey( installedPlugin.plugin );
 		const installTime = getTimeFrame( installedPlugin.installTime );
@@ -221,6 +289,20 @@ const recordSuccessfulPluginInstallation = ( {
 			extension: pluginKey,
 			install_time: installTime,
 		} );
+
+		if ( isShippingPlugin( installedPlugin.plugin ) ) {
+			const slug = getPluginSlug( installedPlugin.plugin );
+			recordEvent( 'shipping_partner_install', {
+				...trackingBase,
+				selected_plugin: slug,
+				success: true,
+			} );
+			recordEvent( 'shipping_partner_activate', {
+				...trackingBase,
+				selected_plugin: slug,
+				success: true,
+			} );
+		}
 	}
 
 	recordEvent(
@@ -243,4 +325,5 @@ export default {
 	recordSuccessfulPluginInstallation,
 	recordTracksPluginsInstallationRequest,
 	recordTracksIsEmailChanged,
+	recordShippingPartnerImpression,
 };

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1504,6 +1504,9 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							params: { step: 'plugins' },
 						},
 						{
+							type: 'recordShippingPartnerImpression',
+						},
+						{
 							type: 'updateQueryStep',
 							params: { step: 'plugins' },
 						},

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	pluginsStore,
 	settingsStore,
 	onboardingStore,
 } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -74,16 +76,35 @@ const ShippingRecommendations = () => {
 		};
 	}, [] );
 
-	if ( isSellingDigitalProductsOnly ) {
-		return <ShippingTour showShippingRecommendationsStep={ false } />;
-	}
-
 	const extensionsForCountry =
 		COUNTRY_EXTENSIONS_MAP[ countryCode ?? '' ] ?? [];
 
-	const visibleExtensions = extensionsForCountry.filter(
-		( ext ) => ! activePlugins.includes( EXTENSION_PLUGIN_SLUGS[ ext ] )
-	);
+	const visibleExtensions = isSellingDigitalProductsOnly
+		? []
+		: extensionsForCountry.filter(
+				( ext ) =>
+					! activePlugins.includes( EXTENSION_PLUGIN_SLUGS[ ext ] )
+		  );
+
+	const visiblePluginSlugs = visibleExtensions
+		.map( ( ext ) => EXTENSION_PLUGIN_SLUGS[ ext ] )
+		.join( ',' );
+
+	const impressionFired = useRef( false );
+	useEffect( () => {
+		if ( visibleExtensions.length > 0 && ! impressionFired.current ) {
+			recordEvent( 'shipping_partner_impression', {
+				context: 'settings',
+				country: countryCode,
+				plugins: visiblePluginSlugs,
+			} );
+			impressionFired.current = true;
+		}
+	}, [ visibleExtensions.length, countryCode, visiblePluginSlugs ] );
+
+	if ( isSellingDigitalProductsOnly ) {
+		return <ShippingTour showShippingRecommendationsStep={ false } />;
+	}
 
 	if ( visibleExtensions.length === 0 ) {
 		return <ShippingTour showShippingRecommendationsStep={ false } />;
@@ -97,6 +118,11 @@ const ShippingRecommendations = () => {
 					const isPluginInstalled = installedPlugins.includes(
 						EXTENSION_PLUGIN_SLUGS[ ext ]
 					);
+					const trackingProps = {
+						context: 'settings' as const,
+						country: countryCode ?? '',
+						plugins: visiblePluginSlugs,
+					};
 					switch ( ext ) {
 						case 'woocommerce-shipping':
 							return (
@@ -106,6 +132,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						case 'shipstation':
@@ -116,6 +143,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						case 'packlink':
@@ -126,6 +154,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						default:

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
@@ -15,27 +15,46 @@ import WooIcon from './woo-icon.svg';
 
 const WOOCOMMERCE_SHIPPING_PLUGIN_SLUG = 'woocommerce-shipping';
 
+export type ShippingPartnerTrackingProps = {
+	context: 'settings' | 'tasklist';
+	country: string;
+	plugins: string;
+};
+
 const WooCommerceShippingItem = ( {
 	isPluginInstalled,
 	onInstallClick,
 	onActivateClick,
 	pluginsBeingSetup,
+	tracking,
 }: {
 	isPluginInstalled: boolean;
 	pluginsBeingSetup: Array< string >;
 	onInstallClick: ( slugs: string[] ) => PromiseLike< void >;
 	onActivateClick: ( slugs: string[] ) => PromiseLike< void >;
+	tracking?: ShippingPartnerTrackingProps;
 } ) => {
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const handleClick = () => {
-		recordEvent( 'settings_shipping_recommendation_setup_click', {
-			plugin: WOOCOMMERCE_SHIPPING_PLUGIN_SLUG,
-			action: isPluginInstalled ? 'activate' : 'install',
-		} );
+		const trackingBase = {
+			...( tracking ?? {} ),
+			selected_plugin: WOOCOMMERCE_SHIPPING_PLUGIN_SLUG,
+		};
+
+		recordEvent( 'shipping_partner_click', trackingBase );
+
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
+		const eventName = isPluginInstalled
+			? 'shipping_partner_activate'
+			: 'shipping_partner_install';
+
 		action( [ WOOCOMMERCE_SHIPPING_PLUGIN_SLUG ] ).then(
 			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: true,
+				} );
 				createSuccessNotice(
 					isPluginInstalled
 						? __( 'WooCommerce Shipping activated!', 'woocommerce' )
@@ -46,7 +65,12 @@ const WooCommerceShippingItem = ( {
 					{}
 				);
 			},
-			() => {}
+			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: false,
+				} );
+			}
 		);
 	};
 

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
@@ -16,7 +16,7 @@ import WooIcon from './woo-icon.svg';
 const WOOCOMMERCE_SHIPPING_PLUGIN_SLUG = 'woocommerce-shipping';
 
 export type ShippingPartnerTrackingProps = {
-	context: 'settings' | 'tasklist';
+	context: 'settings' | 'tasklist' | 'core-profiler';
 	country: string;
 	plugins: string;
 };

--- a/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import './woocommerce-shipping-item.scss';
+import type { ShippingPartnerTrackingProps } from './experimental-woocommerce-shipping-item';
 
 const PACKLINK_PLUGIN_SLUG = 'packlink-pro-shipping';
 
@@ -18,22 +19,35 @@ const PacklinkItem = ( {
 	onInstallClick,
 	onActivateClick,
 	pluginsBeingSetup,
+	tracking,
 }: {
 	isPluginInstalled: boolean;
 	pluginsBeingSetup: Array< string >;
 	onInstallClick: ( slugs: string[] ) => PromiseLike< void >;
 	onActivateClick: ( slugs: string[] ) => PromiseLike< void >;
+	tracking?: ShippingPartnerTrackingProps;
 } ) => {
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const handleClick = () => {
-		recordEvent( 'settings_shipping_recommendation_setup_click', {
-			plugin: PACKLINK_PLUGIN_SLUG,
-			action: isPluginInstalled ? 'activate' : 'install',
-		} );
+		const trackingBase = {
+			...( tracking ?? {} ),
+			selected_plugin: PACKLINK_PLUGIN_SLUG,
+		};
+
+		recordEvent( 'shipping_partner_click', trackingBase );
+
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
+		const eventName = isPluginInstalled
+			? 'shipping_partner_activate'
+			: 'shipping_partner_install';
+
 		action( [ PACKLINK_PLUGIN_SLUG ] ).then(
 			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: true,
+				} );
 				createSuccessNotice(
 					isPluginInstalled
 						? __( 'Packlink PRO activated!', 'woocommerce' )
@@ -41,7 +55,12 @@ const PacklinkItem = ( {
 					{}
 				);
 			},
-			() => {}
+			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: false,
+				} );
+			}
 		);
 	};
 

--- a/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -96,38 +96,52 @@ describe( 'WooCommerceShippingItem', () => {
 		] );
 	} );
 
-	it( 'should record track when clicking Install button', () => {
+	it( 'should record shipping_partner_click when clicking Install button', () => {
 		render(
 			<WooCommerceShippingItem
 				isPluginInstalled={ false }
 				{ ...defaultProps }
+				tracking={ {
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+				} }
 			/>
 		);
 
 		screen.queryByRole( 'button', { name: 'Install' } )?.click();
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'settings_shipping_recommendation_setup_click',
+			'shipping_partner_click',
 			{
-				plugin: 'woocommerce-shipping',
-				action: 'install',
+				context: 'settings',
+				country: 'US',
+				plugins: 'woocommerce-shipping',
+				selected_plugin: 'woocommerce-shipping',
 			}
 		);
 	} );
 
-	it( 'should record track when clicking Activate button', () => {
+	it( 'should record shipping_partner_click when clicking Activate button', () => {
 		render(
 			<WooCommerceShippingItem
 				isPluginInstalled={ true }
 				{ ...defaultProps }
+				tracking={ {
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+				} }
 			/>
 		);
 
 		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'settings_shipping_recommendation_setup_click',
+			'shipping_partner_click',
 			{
-				plugin: 'woocommerce-shipping',
-				action: 'activate',
+				context: 'settings',
+				country: 'US',
+				plugins: 'woocommerce-shipping',
+				selected_plugin: 'woocommerce-shipping',
 			}
 		);
 	} );
@@ -147,5 +161,129 @@ describe( 'WooCommerceShippingItem', () => {
 		expect( onActivateClick ).toHaveBeenCalledWith( [
 			'woocommerce-shipping',
 		] );
+	} );
+
+	it( 'should record shipping_partner_install with success on successful install', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ false }
+				{ ...defaultProps }
+				onInstallClick={ jest.fn( () => Promise.resolve() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Install' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_install with failure on failed install', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ false }
+				{ ...defaultProps }
+				onInstallClick={ jest.fn( () => Promise.reject() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Install' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_activate with success on successful activation', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ true }
+				{ ...defaultProps }
+				onActivateClick={ jest.fn( () => Promise.resolve() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_activate with failure on failed activation', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ true }
+				{ ...defaultProps }
+				onActivateClick={ jest.fn( () => Promise.reject() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
@@ -110,15 +110,12 @@ describe( 'WooCommerceShippingItem', () => {
 		);
 
 		screen.queryByRole( 'button', { name: 'Install' } )?.click();
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_partner_click',
-			{
-				context: 'settings',
-				country: 'US',
-				plugins: 'woocommerce-shipping',
-				selected_plugin: 'woocommerce-shipping',
-			}
-		);
+		expect( recordEvent ).toHaveBeenCalledWith( 'shipping_partner_click', {
+			context: 'settings',
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+			selected_plugin: 'woocommerce-shipping',
+		} );
 	} );
 
 	it( 'should record shipping_partner_click when clicking Activate button', () => {
@@ -135,15 +132,12 @@ describe( 'WooCommerceShippingItem', () => {
 		);
 
 		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_partner_click',
-			{
-				context: 'settings',
-				country: 'US',
-				plugins: 'woocommerce-shipping',
-				selected_plugin: 'woocommerce-shipping',
-			}
-		);
+		expect( recordEvent ).toHaveBeenCalledWith( 'shipping_partner_click', {
+			context: 'settings',
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+			selected_plugin: 'woocommerce-shipping',
+		} );
 	} );
 
 	it( 'should call onActivateClick when clicking Activate button', () => {

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -152,6 +152,43 @@ export class Shipping extends Component {
 		};
 	}
 
+	recordInstallAndActivateEvents( selectedPlugin, success ) {
+		const trackingBase = {
+			...this.getShippingPartnerTrackingProps(),
+			selected_plugin: selectedPlugin,
+		};
+
+		if ( success ) {
+			recordEvent( 'shipping_partner_install', {
+				...trackingBase,
+				success: true,
+			} );
+			recordEvent( 'shipping_partner_activate', {
+				...trackingBase,
+				success: true,
+			} );
+		} else {
+			const { installedPlugins } = this.props;
+			const wasInstalled = installedPlugins.includes( selectedPlugin );
+
+			if ( wasInstalled ) {
+				recordEvent( 'shipping_partner_install', {
+					...trackingBase,
+					success: true,
+				} );
+				recordEvent( 'shipping_partner_activate', {
+					...trackingBase,
+					success: false,
+				} );
+			} else {
+				recordEvent( 'shipping_partner_install', {
+					...trackingBase,
+					success: false,
+				} );
+			}
+		}
+	}
+
 	componentDidUpdate( prevProps, prevState ) {
 		const { countryCode, countryName, settings } = this.props;
 		const {
@@ -381,20 +418,18 @@ export class Shipping extends Component {
 						<Plugins
 							onComplete={ ( _plugins, response ) => {
 								createNoticesFromResponse( response );
-								recordEvent( 'shipping_partner_install', {
-									...this.getShippingPartnerTrackingProps(),
-									selected_plugin: pluginsToActivate[ 0 ],
-									success: true,
-								} );
+								this.recordInstallAndActivateEvents(
+									pluginsToActivate[ 0 ],
+									true
+								);
 								this.completeStep();
 							} }
 							onError={ ( errors, response ) => {
 								createNoticesFromResponse( response );
-								recordEvent( 'shipping_partner_install', {
-									...this.getShippingPartnerTrackingProps(),
-									selected_plugin: pluginsToActivate[ 0 ],
-									success: false,
-								} );
+								this.recordInstallAndActivateEvents(
+									pluginsToActivate[ 0 ],
+									false
+								);
 							} }
 							onClick={ () => {
 								recordEvent( 'shipping_partner_click', {
@@ -516,14 +551,9 @@ export class Shipping extends Component {
 																createNoticesFromResponse(
 																	response
 																);
-																recordEvent(
-																	'shipping_partner_install',
-																	{
-																		...this.getShippingPartnerTrackingProps(),
-																		selected_plugin:
-																			shippingMethod.slug,
-																		success: true,
-																	}
+																this.recordInstallAndActivateEvents(
+																	shippingMethod.slug,
+																	true
 																);
 																invalidateResolutionForStoreSelector();
 																this.completeStep();
@@ -535,14 +565,9 @@ export class Shipping extends Component {
 																createNoticesFromResponse(
 																	response
 																);
-																recordEvent(
-																	'shipping_partner_install',
-																	{
-																		...this.getShippingPartnerTrackingProps(),
-																		selected_plugin:
-																			shippingMethod.slug,
-																		success: false,
-																	}
+																this.recordInstallAndActivateEvents(
+																	shippingMethod.slug,
+																	false
 																);
 															} }
 															onClick={ () => {
@@ -619,15 +644,9 @@ export class Shipping extends Component {
 											createNoticesFromResponse(
 												response
 											);
-											recordEvent(
-												'shipping_partner_install',
-												{
-													...this.getShippingPartnerTrackingProps(),
-													selected_plugin:
-														pluginsToPromote[ 0 ]
-															?.slug,
-													success: true,
-												}
+											this.recordInstallAndActivateEvents(
+												pluginsToPromote[ 0 ]?.slug,
+												true
 											);
 											invalidateResolutionForStoreSelector();
 											this.completeStep();
@@ -636,15 +655,9 @@ export class Shipping extends Component {
 											createNoticesFromResponse(
 												response
 											);
-											recordEvent(
-												'shipping_partner_install',
-												{
-													...this.getShippingPartnerTrackingProps(),
-													selected_plugin:
-														pluginsToPromote[ 0 ]
-															?.slug,
-													success: false,
-												}
+											this.recordInstallAndActivateEvents(
+												pluginsToPromote[ 0 ]?.slug,
+												false
 											);
 										} }
 										onClick={ () => {
@@ -763,7 +776,8 @@ const ShippingWrapper = compose(
 	withSelect( ( select ) => {
 		const { getSettings, isUpdateSettingsRequesting } =
 			select( settingsStore );
-		const { getActivePlugins, isJetpackConnected } = select( pluginsStore );
+		const { getActivePlugins, getInstalledPlugins, isJetpackConnected } =
+			select( pluginsStore );
 		const { getCountry } = select( COUNTRIES_STORE_NAME );
 
 		const { general: settings = {} } = getSettings( 'general' );
@@ -777,6 +791,7 @@ const ShippingWrapper = compose(
 		const country = countryCode ? getCountry( countryCode ) : null;
 		const countryName = country ? country.name : null;
 		const activePlugins = getActivePlugins();
+		const installedPlugins = getInstalledPlugins();
 
 		return {
 			countryCode,
@@ -784,6 +799,7 @@ const ShippingWrapper = compose(
 			isUpdateSettingsRequesting: isUpdateSettingsRequesting( 'general' ),
 			settings,
 			activePlugins,
+			installedPlugins,
 			isJetpackConnected: isJetpackConnected(),
 			shippingPartners,
 		};

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -65,6 +65,7 @@ export class Shipping extends Component {
 
 		this.storeLocationCompleted = false;
 		this.shippingPartners = props.shippingPartners;
+		this.impressionFired = false;
 
 		this.jetpackAuthRedirectUrl = getAdminLink( 'admin.php?page=wc-admin' );
 	}
@@ -136,6 +137,21 @@ export class Shipping extends Component {
 		this.setState( { isPending: false, shippingZones } );
 	}
 
+	getShippingPartnerTrackingProps() {
+		const { countryCode, shippingPartners } = this.props;
+		const pluginSlugs = shippingPartners
+			.map( ( partner ) => partner.slug )
+			.filter(
+				( slug ) => typeof slug === 'string' && slug.trim().length > 0
+			)
+			.join( ',' );
+		return {
+			context: 'tasklist',
+			country: countryCode,
+			plugins: pluginSlugs,
+		};
+	}
+
 	componentDidUpdate( prevProps, prevState ) {
 		const { countryCode, countryName, settings } = this.props;
 		const {
@@ -154,6 +170,21 @@ export class Shipping extends Component {
 			this.setState( { isPending: true } );
 			if ( countryName ) {
 				this.fetchShippingZones();
+			}
+		}
+
+		if (
+			step === 'label_printing' &&
+			prevState.step !== 'label_printing' &&
+			! this.impressionFired
+		) {
+			const { shippingPartners } = this.props;
+			if ( shippingPartners.length > 0 ) {
+				recordEvent(
+					'shipping_partner_impression',
+					this.getShippingPartnerTrackingProps()
+				);
+				this.impressionFired = true;
 			}
 		}
 
@@ -350,26 +381,28 @@ export class Shipping extends Component {
 						<Plugins
 							onComplete={ ( _plugins, response ) => {
 								createNoticesFromResponse( response );
-								recordEvent(
-									'tasklist_shipping_label_printing',
-									{
-										install: true,
-										plugins_to_activate: pluginsToActivate,
-									}
-								);
+								recordEvent( 'shipping_partner_install', {
+									...this.getShippingPartnerTrackingProps(),
+									selected_plugin: pluginsToActivate[ 0 ],
+									success: true,
+								} );
 								this.completeStep();
 							} }
-							onError={ ( errors, response ) =>
-								createNoticesFromResponse( response )
-							}
+							onError={ ( errors, response ) => {
+								createNoticesFromResponse( response );
+								recordEvent( 'shipping_partner_install', {
+									...this.getShippingPartnerTrackingProps(),
+									selected_plugin: pluginsToActivate[ 0 ],
+									success: false,
+								} );
+							} }
+							onClick={ () => {
+								recordEvent( 'shipping_partner_click', {
+									...this.getShippingPartnerTrackingProps(),
+									selected_plugin: pluginsToActivate[ 0 ],
+								} );
+							} }
 							onSkip={ () => {
-								recordEvent(
-									'tasklist_shipping_label_printing',
-									{
-										install: false,
-										plugins_to_activate: pluginsToActivate,
-									}
-								);
 								invalidateResolutionForStoreSelector();
 								getHistory().push( getNewPath( {}, '/', {} ) );
 								onComplete();
@@ -484,11 +517,12 @@ export class Shipping extends Component {
 																	response
 																);
 																recordEvent(
-																	'tasklist_shipping_label_printing',
+																	'shipping_partner_install',
 																	{
-																		install: true,
-																		plugins_to_activate:
-																			pluginsForPartner,
+																		...this.getShippingPartnerTrackingProps(),
+																		selected_plugin:
+																			shippingMethod.slug,
+																		success: true,
 																	}
 																);
 																invalidateResolutionForStoreSelector();
@@ -497,11 +531,30 @@ export class Shipping extends Component {
 															onError={ (
 																errors,
 																response
-															) =>
+															) => {
 																createNoticesFromResponse(
 																	response
-																)
-															}
+																);
+																recordEvent(
+																	'shipping_partner_install',
+																	{
+																		...this.getShippingPartnerTrackingProps(),
+																		selected_plugin:
+																			shippingMethod.slug,
+																		success: false,
+																	}
+																);
+															} }
+															onClick={ () => {
+																recordEvent(
+																	'shipping_partner_click',
+																	{
+																		...this.getShippingPartnerTrackingProps(),
+																		selected_plugin:
+																			shippingMethod.slug,
+																	}
+																);
+															} }
 															installText={ __(
 																'Install and enable',
 																'woocommerce'
@@ -567,21 +620,44 @@ export class Shipping extends Component {
 												response
 											);
 											recordEvent(
-												'tasklist_shipping_label_printing',
+												'shipping_partner_install',
 												{
-													install: true,
-													plugins_to_activate:
-														pluginsToActivate,
+													...this.getShippingPartnerTrackingProps(),
+													selected_plugin:
+														pluginsToPromote[ 0 ]
+															?.slug,
+													success: true,
 												}
 											);
 											invalidateResolutionForStoreSelector();
 											this.completeStep();
 										} }
-										onError={ ( errors, response ) =>
+										onError={ ( errors, response ) => {
 											createNoticesFromResponse(
 												response
-											)
-										}
+											);
+											recordEvent(
+												'shipping_partner_install',
+												{
+													...this.getShippingPartnerTrackingProps(),
+													selected_plugin:
+														pluginsToPromote[ 0 ]
+															?.slug,
+													success: false,
+												}
+											);
+										} }
+										onClick={ () => {
+											recordEvent(
+												'shipping_partner_click',
+												{
+													...this.getShippingPartnerTrackingProps(),
+													selected_plugin:
+														pluginsToPromote[ 0 ]
+															?.slug,
+												}
+											);
+										} }
 										onSkip={
 											onShippingPluginInstalltionSkip
 										}

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
@@ -214,6 +214,118 @@ describe( 'Shipping', () => {
 		} );
 	} );
 
+	describe( 'recordInstallAndActivateEvents', () => {
+		const shippingPartners = [
+			{
+				id: 'woocommerce-shipping',
+				name: 'WooCommerce Shipping',
+				slug: 'woocommerce-shipping',
+			},
+		];
+
+		it( 'should fire both install and activate success events on success', () => {
+			( recordEvent as jest.Mock ).mockClear();
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+				installedPlugins: [],
+			} );
+
+			component.recordInstallAndActivateEvents(
+				'woocommerce-shipping',
+				true
+			);
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+
+		it( 'should fire install failure only when plugin was not installed', () => {
+			( recordEvent as jest.Mock ).mockClear();
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+				installedPlugins: [],
+			} );
+
+			component.recordInstallAndActivateEvents(
+				'woocommerce-shipping',
+				false
+			);
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				expect.anything()
+			);
+		} );
+
+		it( 'should fire install success and activate failure when plugin was installed but activation failed', () => {
+			( recordEvent as jest.Mock ).mockClear();
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+				installedPlugins: [ 'woocommerce-shipping' ],
+			} );
+
+			component.recordInstallAndActivateEvents(
+				'woocommerce-shipping',
+				false
+			);
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
+	} );
+
 	describe( 'getShippingPartnerTrackingProps', () => {
 		it( 'should return correct tracking props', () => {
 			const shippingPartners = [

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
@@ -205,7 +205,9 @@ describe( 'Shipping', () => {
 				{ step: 'rates' }
 			);
 
-			const impressionCalls = ( recordEvent as jest.Mock ).mock.calls.filter(
+			const impressionCalls = (
+				recordEvent as jest.Mock
+			 ).mock.calls.filter(
 				( call ) => call[ 0 ] === 'shipping_partner_impression'
 			);
 			expect( impressionCalls ).toHaveLength( 1 );

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/test/index.tsx
@@ -97,4 +97,175 @@ describe( 'Shipping', () => {
 	it( 'treats missing slugs as non-installable partners', () => {
 		expect( hasInstallableSlug( {} ) ).toBe( false );
 	} );
+
+	describe( 'shipping partner impression tracking', () => {
+		it( 'should fire shipping_partner_impression when entering label_printing step with partners', () => {
+			const shippingPartners = [
+				{
+					id: 'woocommerce-shipping',
+					name: 'WooCommerce Shipping',
+					slug: 'woocommerce-shipping',
+				},
+				{
+					id: 'shipstation',
+					name: 'ShipStation',
+					slug: 'woocommerce-shipstation-integration',
+				},
+			];
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+			} );
+
+			// Simulate componentDidMount
+			component.setState = jest.fn();
+			component.state = { ...component.state, step: 'store_location' };
+
+			// Simulate stepping to label_printing
+			component.componentDidUpdate(
+				{ ...props, shippingPartners },
+				{ step: 'rates' }
+			);
+
+			// Should not fire yet because step is store_location, not label_printing
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.anything()
+			);
+
+			// Now simulate the step being label_printing
+			component.state = { ...component.state, step: 'label_printing' };
+			component.componentDidUpdate(
+				{ ...props, shippingPartners },
+				{ step: 'rates' }
+			);
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				{
+					context: 'tasklist',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_impression when there are no shipping partners', () => {
+			( recordEvent as jest.Mock ).mockClear();
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners: [],
+			} );
+
+			component.setState = jest.fn();
+			component.state = { ...component.state, step: 'label_printing' };
+
+			component.componentDidUpdate(
+				{ ...props, shippingPartners: [] },
+				{ step: 'rates' }
+			);
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.anything()
+			);
+		} );
+
+		it( 'should only fire shipping_partner_impression once', () => {
+			( recordEvent as jest.Mock ).mockClear();
+
+			const shippingPartners = [
+				{
+					id: 'woocommerce-shipping',
+					name: 'WooCommerce Shipping',
+					slug: 'woocommerce-shipping',
+				},
+			];
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+			} );
+
+			component.setState = jest.fn();
+			component.state = { ...component.state, step: 'label_printing' };
+
+			// First transition into label_printing
+			component.componentDidUpdate(
+				{ ...props, shippingPartners },
+				{ step: 'rates' }
+			);
+
+			// Second transition (e.g., re-entering)
+			component.componentDidUpdate(
+				{ ...props, shippingPartners },
+				{ step: 'rates' }
+			);
+
+			const impressionCalls = ( recordEvent as jest.Mock ).mock.calls.filter(
+				( call ) => call[ 0 ] === 'shipping_partner_impression'
+			);
+			expect( impressionCalls ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'getShippingPartnerTrackingProps', () => {
+		it( 'should return correct tracking props', () => {
+			const shippingPartners = [
+				{
+					id: 'woocommerce-shipping',
+					name: 'WooCommerce Shipping',
+					slug: 'woocommerce-shipping',
+				},
+				{
+					id: 'shipstation',
+					name: 'ShipStation',
+					slug: 'woocommerce-shipstation-integration',
+				},
+			];
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+			} );
+
+			const trackingProps = component.getShippingPartnerTrackingProps();
+			expect( trackingProps ).toEqual( {
+				context: 'tasklist',
+				country: 'US',
+				plugins:
+					'woocommerce-shipping,woocommerce-shipstation-integration',
+			} );
+		} );
+
+		it( 'should filter out partners without slugs', () => {
+			const shippingPartners = [
+				{
+					id: 'woocommerce-shipping',
+					name: 'WooCommerce Shipping',
+					slug: 'woocommerce-shipping',
+				},
+				{
+					id: 'envia',
+					name: 'Envia',
+					slug: '',
+				},
+			];
+
+			const component = new Shipping( {
+				...props,
+				shippingPartners,
+			} );
+
+			const trackingProps = component.getShippingPartnerTrackingProps();
+			expect( trackingProps ).toEqual( {
+				context: 'tasklist',
+				country: 'US',
+				plugins: 'woocommerce-shipping',
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Related Linear issue: [WOOPLUG-6273](https://linear.app/a8c/issue/WOOPLUG-6273/shipping-category-placement-updates-confirm-tracks-tracking)

This PR implements unified Tracks tracking events for shipping partner placements across the Task List and Shipping settings page. The goal is to enable funnel analysis (impressions, clicks, installs, activations) for each featured shipping integration.

**What changed:**

- Introduced four new unified Tracks events to replace the previously fragmented tracking:
  - `shipping_partner_impression` - fires when shipping partner suggestions are displayed
  - `shipping_partner_click` - fires when a user clicks Install/Activate on a shipping partner
  - `shipping_partner_install` - fires on install success or failure
  - `shipping_partner_activate` - fires on activation success or failure
- All events include a `context` property (`settings` or `tasklist`) to distinguish which surface the event originated from, along with `country`, `plugins` (all visible plugin slugs), and `selected_plugin` (the specific plugin acted upon).
- Settings page: Added impression tracking via `useEffect` on mount in `experimental-shipping-recommendations.tsx`, and updated all three item components (`experimental-woocommerce-shipping-item.tsx`, `shipstation-item.tsx`, `packlink-item.tsx`) to fire click/install/activate events with success/failure tracking.
- Task list: Added impression tracking in `componentDidUpdate` when entering the `label_printing` step. Updated all `<Plugins>` callback handlers to fire click events, and both `shipping_partner_install` and `shipping_partner_activate` events on completion. On failure, the code checks `installedPlugins` from the store to determine whether install or activation failed, logging the correct events accordingly.

**Replaced events:**

- `settings_shipping_recommendation_setup_click` replaced by `shipping_partner_click` + `shipping_partner_install` or `shipping_partner_activate`
- `tasklist_shipping_label_printing` (install: true) replaced by `shipping_partner_click` + `shipping_partner_install` + `shipping_partner_activate`
- `tasklist_shipping_label_printing` (install: false/skip) removed (skip no longer fires a shipping partner event)

Closes WOOPLUG-6273.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Prerequisites

To test install/activate failure scenarios, create the following mu-plugin and toggle the relevant section:

**`wp-content/mu-plugins/fake-plugin-failure.php`**
```php
<?php
add_filter( 'rest_pre_dispatch', function( $result, $server, $request ) {
    // Uncomment to simulate install failure:
    // if ( str_contains( $request->get_route(), '/wc-admin/plugins/install' ) ) {
    //     return new WP_Error( 'install_failed', 'Simulated install failure' );
    // }

    // Uncomment to simulate activate failure (install succeeds, activate fails):
    // if ( str_contains( $request->get_route(), '/wc-admin/plugins/activate' ) ) {
    //     return new WP_Error( 'activate_failed', 'Simulated activation failure' );
    // }

    return $result;
}, 10, 3 );
```

#### Settings page tests

**Test 1: `shipping_partner_impression`**

1. Navigate to WooCommerce > Settings > Shipping.
2. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_impression`.
3. Verify the event fired with `context: 'settings'`, the correct `country` code, and a comma-separated `plugins` list matching the visible partner suggestions.

**Test 2: `shipping_partner_click`**

1. Navigate to WooCommerce > Settings > Shipping.
2. Click "Install" (or "Activate") on any visible shipping partner.
3. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_click`.
4. Verify the event fired with `context: 'settings'`, the correct `country`, `plugins`, and `selected_plugin`.

**Test 3: `shipping_partner_install` with success**

1. Make sure the mu-plugin filter is disabled (both lines commented out).
2. Navigate to WooCommerce > Settings > Shipping.
3. Click "Install" on a shipping partner that is not yet installed.
4. Wait for the install to complete successfully.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_install`.
6. Verify the event fired with `context: 'settings'`, the correct `selected_plugin`, and `success: true`.

**Test 4: `shipping_partner_install` with failure**

1. Enable the install failure filter in the mu-plugin (uncomment the install block).
2. Navigate to WooCommerce > Settings > Shipping.
3. Click "Install" on a shipping partner.
4. Wait for the error response.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_install`.
6. Verify the event fired with `context: 'settings'`, the correct `selected_plugin`, and `success: false`.
7. Disable the filter when done.

**Test 5: `shipping_partner_activate` with success**

1. Make sure a shipping plugin is installed but not active (deactivate it from the Plugins page if needed).
2. Make sure the mu-plugin filter is disabled.
3. Navigate to WooCommerce > Settings > Shipping and click "Activate" on that partner.
4. Wait for activation to complete.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_activate`.
6. Verify the event fired with `context: 'settings'`, the correct `selected_plugin`, and `success: true`.

**Test 6: `shipping_partner_activate` with failure**

1. Make sure a shipping plugin is installed but not active.
2. Enable the activate failure filter in the mu-plugin (uncomment the activate block).
3. Navigate to WooCommerce > Settings > Shipping and click "Activate" on that partner.
4. Wait for the error response.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_activate`.
6. Verify the event fired with `context: 'settings'`, the correct `selected_plugin`, and `success: false`.
7. Disable the filter when done.

**Test 7: Country-specific plugins**

1. Change the store country (e.g., US, DE, FR, AU) from WooCommerce > Settings > General.
2. Navigate to WooCommerce > Settings > Shipping.
3. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_impression`.
4. Verify the `plugins` property matches the expected partners for the selected country.

#### Task list tests

**Test 8: `shipping_partner_impression`**

1. Start the shipping onboarding task and progress to the "Enable shipping label printing" step.
2. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_impression`.
3. Verify the event fired with `context: 'tasklist'` and the correct `plugins` list.

**Test 9: `shipping_partner_click`**

1. Start the shipping onboarding task and progress to the "Enable shipping label printing" step.
2. Click "Install and enable" on a shipping partner.
3. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_click`.
4. Verify the event fired with `context: 'tasklist'`, the correct `country`, `plugins`, and `selected_plugin`.

**Test 10: `shipping_partner_install` + `shipping_partner_activate` with success**

1. Make sure the mu-plugin filter is disabled.
2. Start the shipping onboarding task and progress to the "Enable shipping label printing" step.
3. Click "Install and enable" on a shipping partner.
4. Wait for the operation to complete successfully.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_install` and `shipping_partner_activate`.
6. Verify both events fired with `context: 'tasklist'`, the correct `selected_plugin`, and `success: true`.

**Test 11: `shipping_partner_install` with failure**

1. Enable the install failure filter in the mu-plugin.
2. Start the shipping onboarding task and progress to the "Enable shipping label printing" step.
3. Click "Install and enable" on a shipping partner.
4. Wait for the error response.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_install`.
6. Verify the event fired with `context: 'tasklist'`, the correct `selected_plugin`, and `success: false`.
7. Verify that **no** `shipping_partner_activate` event was fired.
8. Disable the filter when done.

**Test 12: `shipping_partner_activate` with failure (install succeeded)**

1. Enable the activate failure filter in the mu-plugin (uncomment only the activate block).
2. Start the shipping onboarding task and progress to the "Enable shipping label printing" step.
3. Click "Install and enable" on a shipping partner.
4. Wait for the error response.
5. Open [Tracks UI](https://mc.a8c.com/tracks/live/) and search for `shipping_partner_install` and `shipping_partner_activate`.
6. Verify `shipping_partner_install` fired with `success: true` and `shipping_partner_activate` fired with `success: false`.
7. Disable the filter when done.

#### Cleanup

Delete `wp-content/mu-plugins/fake-plugin-failure.php` when done testing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- All 70 unit tests pass across 5 test suites:
  - `experimental-shipping-recommendations` (38 tests): impression tracking, country-based filtering, click/install/activate events with success/failure
  - `experimental-woocommerce-shipping-item` (10 tests): click, install success/failure, activate success/failure
  - `shipping-recommendations` (4 tests): legacy component unchanged
  - `shipping-recommendations-wrapper` (5 tests): wrapper component unchanged
  - `task-lists/fills/shipping` (13 tests): impression tracking, `getShippingPartnerTrackingProps`, `recordInstallAndActivateEvents` (success, install failure, activate failure), deduplication
- TypeScript type checking passes (`pnpm run ts:check`)
- ESLint passes on all modified files

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

<blockquote>

#### Significance
<!-- Choose only one -->
-   [x] Patch
-   [ ] Minor
-   [ ] Major

</blockquote>

<blockquote>

#### Type
<!-- Choose only one -->
-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

</blockquote>

<blockquote>

#### Message
<!-- Add a changelog message here -->
Add tracks events to shipping partner recommendations

</blockquote>

<blockquote>

#### Comment
<!-- If the checkbox "This Pull Request does not require a changelog entry" is checked, add a comment here explaining why -->


</blockquote>

</details>
