### PR TITLE
[WOOPLUG-6345] Add unified shipping partner Tracks events on settings page

### DIFF
--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	pluginsStore,
 	settingsStore,
 	onboardingStore,
 } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -74,16 +76,35 @@ const ShippingRecommendations = () => {
 		};
 	}, [] );
 
-	if ( isSellingDigitalProductsOnly ) {
-		return <ShippingTour showShippingRecommendationsStep={ false } />;
-	}
-
 	const extensionsForCountry =
 		COUNTRY_EXTENSIONS_MAP[ countryCode ?? '' ] ?? [];
 
-	const visibleExtensions = extensionsForCountry.filter(
-		( ext ) => ! activePlugins.includes( EXTENSION_PLUGIN_SLUGS[ ext ] )
-	);
+	const visibleExtensions = isSellingDigitalProductsOnly
+		? []
+		: extensionsForCountry.filter(
+				( ext ) =>
+					! activePlugins.includes( EXTENSION_PLUGIN_SLUGS[ ext ] )
+		  );
+
+	const visiblePluginSlugs = visibleExtensions
+		.map( ( ext ) => EXTENSION_PLUGIN_SLUGS[ ext ] )
+		.join( ',' );
+
+	const impressionFired = useRef( false );
+	useEffect( () => {
+		if ( visibleExtensions.length > 0 && ! impressionFired.current ) {
+			recordEvent( 'shipping_partner_impression', {
+				context: 'settings',
+				country: countryCode,
+				plugins: visiblePluginSlugs,
+			} );
+			impressionFired.current = true;
+		}
+	}, [ visibleExtensions.length, countryCode, visiblePluginSlugs ] );
+
+	if ( isSellingDigitalProductsOnly ) {
+		return <ShippingTour showShippingRecommendationsStep={ false } />;
+	}
 
 	if ( visibleExtensions.length === 0 ) {
 		return <ShippingTour showShippingRecommendationsStep={ false } />;
@@ -97,6 +118,11 @@ const ShippingRecommendations = () => {
 					const isPluginInstalled = installedPlugins.includes(
 						EXTENSION_PLUGIN_SLUGS[ ext ]
 					);
+					const trackingProps = {
+						context: 'settings' as const,
+						country: countryCode ?? '',
+						plugins: visiblePluginSlugs,
+					};
 					switch ( ext ) {
 						case 'woocommerce-shipping':
 							return (
@@ -106,6 +132,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						case 'shipstation':
@@ -116,6 +143,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						case 'packlink':
@@ -126,6 +154,7 @@ const ShippingRecommendations = () => {
 									pluginsBeingSetup={ pluginsBeingSetup }
 									onInstallClick={ handleInstall }
 									onActivateClick={ handleActivate }
+									tracking={ trackingProps }
 								/>
 							);
 						default:

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -76,8 +76,10 @@ const ShippingRecommendations = () => {
 		};
 	}, [] );
 
+	const normalizedCountry = countryCode ?? '';
+
 	const extensionsForCountry =
-		COUNTRY_EXTENSIONS_MAP[ countryCode ?? '' ] ?? [];
+		COUNTRY_EXTENSIONS_MAP[ normalizedCountry ] ?? [];
 
 	const visibleExtensions = isSellingDigitalProductsOnly
 		? []
@@ -95,12 +97,12 @@ const ShippingRecommendations = () => {
 		if ( visibleExtensions.length > 0 && ! impressionFired.current ) {
 			recordEvent( 'shipping_partner_impression', {
 				context: 'settings',
-				country: countryCode,
+				country: normalizedCountry,
 				plugins: visiblePluginSlugs,
 			} );
 			impressionFired.current = true;
 		}
-	}, [ visibleExtensions.length, countryCode, visiblePluginSlugs ] );
+	}, [ visibleExtensions.length, normalizedCountry, visiblePluginSlugs ] );
 
 	if ( isSellingDigitalProductsOnly ) {
 		return <ShippingTour showShippingRecommendationsStep={ false } />;
@@ -120,7 +122,7 @@ const ShippingRecommendations = () => {
 					);
 					const trackingProps = {
 						context: 'settings' as const,
-						country: countryCode ?? '',
+						country: normalizedCountry,
 						plugins: visiblePluginSlugs,
 					};
 					switch ( ext ) {

--- a/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import './woocommerce-shipping-item.scss';
+import type { ShippingPartnerTrackingProps } from './experimental-woocommerce-shipping-item';
 
 const PACKLINK_PLUGIN_SLUG = 'packlink-pro-shipping';
 
@@ -18,22 +19,35 @@ const PacklinkItem = ( {
 	onInstallClick,
 	onActivateClick,
 	pluginsBeingSetup,
+	tracking,
 }: {
 	isPluginInstalled: boolean;
 	pluginsBeingSetup: Array< string >;
 	onInstallClick: ( slugs: string[] ) => PromiseLike< void >;
 	onActivateClick: ( slugs: string[] ) => PromiseLike< void >;
+	tracking?: ShippingPartnerTrackingProps;
 } ) => {
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const handleClick = () => {
-		recordEvent( 'settings_shipping_recommendation_setup_click', {
-			plugin: PACKLINK_PLUGIN_SLUG,
-			action: isPluginInstalled ? 'activate' : 'install',
-		} );
+		const trackingBase = {
+			...( tracking ?? {} ),
+			selected_plugin: PACKLINK_PLUGIN_SLUG,
+		};
+
+		recordEvent( 'shipping_partner_click', trackingBase );
+
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
+		const eventName = isPluginInstalled
+			? 'shipping_partner_activate'
+			: 'shipping_partner_install';
+
 		action( [ PACKLINK_PLUGIN_SLUG ] ).then(
 			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: true,
+				} );
 				createSuccessNotice(
 					isPluginInstalled
 						? __( 'Packlink PRO activated!', 'woocommerce' )
@@ -41,7 +55,12 @@ const PacklinkItem = ( {
 					{}
 				);
 			},
-			() => {}
+			() => {
+				recordEvent( eventName, {
+					...trackingBase,
+					success: false,
+				} );
+			}
 		);
 	};
 

--- a/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -96,40 +96,48 @@ describe( 'WooCommerceShippingItem', () => {
 		] );
 	} );
 
-	it( 'should record track when clicking Install button', () => {
+	it( 'should record shipping_partner_click when clicking Install button', () => {
 		render(
 			<WooCommerceShippingItem
 				isPluginInstalled={ false }
 				{ ...defaultProps }
+				tracking={ {
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+				} }
 			/>
 		);
 
 		screen.queryByRole( 'button', { name: 'Install' } )?.click();
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'settings_shipping_recommendation_setup_click',
-			{
-				plugin: 'woocommerce-shipping',
-				action: 'install',
-			}
-		);
+		expect( recordEvent ).toHaveBeenCalledWith( 'shipping_partner_click', {
+			context: 'settings',
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+			selected_plugin: 'woocommerce-shipping',
+		} );
 	} );
 
-	it( 'should record track when clicking Activate button', () => {
+	it( 'should record shipping_partner_click when clicking Activate button', () => {
 		render(
 			<WooCommerceShippingItem
 				isPluginInstalled={ true }
 				{ ...defaultProps }
+				tracking={ {
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+				} }
 			/>
 		);
 
 		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'settings_shipping_recommendation_setup_click',
-			{
-				plugin: 'woocommerce-shipping',
-				action: 'activate',
-			}
-		);
+		expect( recordEvent ).toHaveBeenCalledWith( 'shipping_partner_click', {
+			context: 'settings',
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+			selected_plugin: 'woocommerce-shipping',
+		} );
 	} );
 
 	it( 'should call onActivateClick when clicking Activate button', () => {
@@ -147,5 +155,129 @@ describe( 'WooCommerceShippingItem', () => {
 		expect( onActivateClick ).toHaveBeenCalledWith( [
 			'woocommerce-shipping',
 		] );
+	} );
+
+	it( 'should record shipping_partner_install with success on successful install', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ false }
+				{ ...defaultProps }
+				onInstallClick={ jest.fn( () => Promise.resolve() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Install' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_install with failure on failed install', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ false }
+				{ ...defaultProps }
+				onInstallClick={ jest.fn( () => Promise.reject() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Install' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_activate with success on successful activation', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ true }
+				{ ...defaultProps }
+				onActivateClick={ jest.fn( () => Promise.resolve() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+	} );
+
+	it( 'should record shipping_partner_activate with failure on failed activation', async () => {
+		const tracking = {
+			context: 'settings' as const,
+			country: 'US',
+			plugins: 'woocommerce-shipping',
+		};
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ true }
+				{ ...defaultProps }
+				onActivateClick={ jest.fn( () => Promise.reject() ) }
+				tracking={ tracking }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
+
+		await waitFor( () => {
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'settings',
+					country: 'US',
+					plugins: 'woocommerce-shipping',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of [WOOPLUG-6273](https://linear.app/wooplugins/issue/WOOPLUG-6273) (sub-issue: [WOOPLUG-6345](https://linear.app/wooplugins/issue/WOOPLUG-6345)).

Adds unified `shipping_partner_*` Tracks events to the **WooCommerce > Settings > Shipping** page. These events enable consistent analytics across all shipping partner placement surfaces.

**Events added:**
- `shipping_partner_impression` - fired when a shipping partner recommendation is displayed
- `shipping_partner_click` - fired when the user clicks the CTA button on a recommendation
- `shipping_partner_install` - fired when plugin installation completes (success or failure)
- `shipping_partner_activate` - fired when plugin activation completes (success or failure)

**Event properties:**
- `context`: `'settings'`
- `country`: store country code (e.g. `'US'`)
- `plugins`: comma-separated list of all visible shipping partner plugin slugs
- `selected_plugin`: the specific plugin slug for click/install/activate events
- `success`: boolean for install/activate events

**Files changed:**
- `experimental-shipping-recommendations.tsx` - impression event on mount, tracking props passed to children
- `experimental-woocommerce-shipping-item.tsx` - click/install/activate events, shared type definition
- `packlink-item.tsx` - click/install/activate events
- `shipstation-item.tsx` - click/install/activate events
- Tests updated for all components

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Prerequisites

To test install/activate failures, add this mu-plugin to `wp-content/mu-plugins/simulate-shipping-failures.php`:

```php
<?php
add_filter( 'rest_request_before_callbacks', function ( $response, $handler, $request ) {
    if ( $request->get_route() !== '/wp/v2/plugins' ) {
        return $response;
    }
    $slug = $request->get_param( 'slug' );
    if ( ! in_array( $slug, [ 'woocommerce-shipping', 'woocommerce-shipstation-integration', 'packlink-pro-shipping' ], true ) ) {
        return $response;
    }
    if ( $request->get_method() === 'POST' ) {
        return new WP_Error( 'simulated_install_failure', 'Simulated install failure for ' . $slug, [ 'status' => 500 ] );
    }
    return $response;
}, 10, 3 );
```

#### Test 1: `shipping_partner_impression`

1. Go to **WooCommerce > Settings > Shipping**.
2. Scroll to the shipping partner recommendations section.
3. Verify a `shipping_partner_impression` event fires with:
   - `context: 'settings'`
   - `country`: your store's country code
   - `plugins`: comma-separated slugs of visible shipping recommendations

#### Test 2: `shipping_partner_click`

1. On the same page, click the CTA button (e.g. "Get started") on any shipping partner recommendation.
2. Verify a `shipping_partner_click` event fires with:
   - `context: 'settings'`
   - `country`: your store's country code
   - `plugins`: same as above
   - `selected_plugin`: the slug of the clicked partner

#### Test 3: `shipping_partner_install` and `shipping_partner_activate` (success)

1. Ensure no mu-plugin filter is active.
2. Click the CTA on a shipping partner that is not yet installed.
3. Verify two events fire:
   - `shipping_partner_install` with `success: true`, `selected_plugin: '<slug>'`
   - `shipping_partner_activate` with `success: true`, `selected_plugin: '<slug>'`

#### Test 4: `shipping_partner_install` (failure)

1. Enable the mu-plugin filter above.
2. Click the CTA on a shipping partner.
3. Verify a `shipping_partner_install` event fires with `success: false`.
4. Verify no `shipping_partner_activate` event fires.

#### Test 5: `shipping_partner_activate` (failure)

1. Modify the mu-plugin to only block PUT requests (activation) instead of POST (install).
2. Click the CTA on an uninstalled shipping partner.
3. Verify:
   - `shipping_partner_install` fires with `success: true`
   - `shipping_partner_activate` fires with `success: false`

#### Test 6: Unit tests

1. Run `pnpm run test:js -- client/shipping/test/experimental-shipping-recommendations.tsx`
2. Run `pnpm run test:js -- client/shipping/test/experimental-woocommerce-shipping-item.tsx`
3. All tests should pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- All unit tests pass (Jest)
- Manual verification of event firing on settings page

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Add unified shipping partner Tracks events (impression, click, install, activate) on the Settings > Shipping page.

</details>