### PR TITLE
[WOOPLUG-6347] Add unified shipping partner Tracks events on Core Profiler

### DIFF
--- a/plugins/woocommerce/changelog/63439-add-wooplug-6347-core-profiler-shipping-tracks
+++ b/plugins/woocommerce/changelog/63439-add-wooplug-6347-core-profiler-shipping-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add unified shipping partner Tracks events (impression, click, install, activate) in the Core Profiler onboarding flow.

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
@@ -340,6 +340,10 @@ describe( 'Core Profiler shipping partner tracking', () => {
 					success: false,
 				}
 			);
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				expect.anything()
+			);
 		} );
 
 		it( 'should not fire shipping_partner_install for failed non-shipping plugins', () => {

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
@@ -1,0 +1,381 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import tracksActions from '../tracks';
+import type { CoreProfilerStateMachineContext } from '../../index';
+import type { PluginInstallError } from '../../services/installAndActivatePlugins';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getSetting: jest.fn( () => '9.8.0' ),
+} ) );
+
+const makeContext = (
+	overrides: Partial< CoreProfilerStateMachineContext > = {}
+): CoreProfilerStateMachineContext =>
+	( {
+		optInDataSharing: false,
+		userProfile: {},
+		pluginsAvailable: [],
+		pluginsSelected: [],
+		pluginsInstallationErrors: [],
+		geolocatedLocation: undefined,
+		businessInfo: { location: 'US:CA' },
+		countries: [],
+		loader: {},
+		coreProfilerCompletedSteps: {},
+		onboardingProfile: {},
+		currentUserEmail: undefined,
+		...overrides,
+	} as CoreProfilerStateMachineContext );
+
+const shippingPlugins = [
+	{
+		key: 'woocommerce-shipping',
+		slug: 'woocommerce-shipping',
+		name: 'WooCommerce Shipping',
+		label: 'WooCommerce Shipping',
+		is_activated: false,
+		description: '',
+		image_url: '',
+		manage_url: '',
+		is_built_by_wc: true,
+		is_visible: true,
+	},
+	{
+		key: 'woocommerce-shipstation-integration',
+		slug: 'woocommerce-shipstation-integration',
+		name: 'ShipStation',
+		label: 'ShipStation',
+		is_activated: false,
+		description: '',
+		image_url: '',
+		manage_url: '',
+		is_built_by_wc: false,
+		is_visible: true,
+	},
+];
+
+const nonShippingPlugin = {
+	key: 'woocommerce-payments',
+	slug: 'woocommerce-payments',
+	name: 'WooPayments',
+	label: 'WooPayments',
+	is_activated: false,
+	description: '',
+	image_url: '',
+	manage_url: '',
+	is_built_by_wc: true,
+	is_visible: true,
+};
+
+describe( 'Core Profiler shipping partner tracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'recordShippingPartnerImpression', () => {
+		it( 'should fire shipping_partner_impression when shipping plugins are available', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_impression when no shipping plugins are available', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ nonShippingPlugin ],
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordTracksPluginsInstallationRequest (shipping_partner_click)', () => {
+		it( 'should fire shipping_partner_click for each selected shipping plugin', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordTracksPluginsInstallationRequest( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_REQUESTED',
+					payload: {
+						pluginsShown: [
+							'woocommerce-shipping',
+							'woocommerce-shipstation-integration',
+							'woocommerce-payments',
+						],
+						pluginsSelected: [
+							'woocommerce-shipping',
+							'woocommerce-shipstation-integration',
+							'woocommerce-payments',
+						],
+						pluginsUnselected: [],
+					},
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_click',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_click',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipstation-integration',
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_click when no shipping plugins are selected', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordTracksPluginsInstallationRequest( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_REQUESTED',
+					payload: {
+						pluginsShown: [
+							'woocommerce-shipping',
+							'woocommerce-payments',
+						],
+						pluginsSelected: [ 'woocommerce-payments' ],
+						pluginsUnselected: [ 'woocommerce-shipping' ],
+					},
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_click',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordSuccessfulPluginInstallation (shipping_partner_install + shipping_partner_activate)', () => {
+		it( 'should fire install and activate success for each shipping plugin', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordSuccessfulPluginInstallation( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED',
+					payload: {
+						installationCompletedResult: {
+							installedPlugins: [
+								{
+									plugin: 'woocommerce-shipping',
+									installTime: 1000,
+								},
+								{
+									plugin: 'woocommerce-payments',
+									installTime: 2000,
+								},
+							],
+							totalTime: 3000,
+						},
+					},
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: true,
+				}
+			);
+		} );
+
+		it( 'should not fire shipping events for non-shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ nonShippingPlugin ],
+			} );
+
+			tracksActions.recordSuccessfulPluginInstallation( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED',
+					payload: {
+						installationCompletedResult: {
+							installedPlugins: [
+								{
+									plugin: 'woocommerce-payments',
+									installTime: 2000,
+								},
+							],
+							totalTime: 2000,
+						},
+					},
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_install',
+				expect.anything()
+			);
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_activate',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'recordFailedPluginInstallations (shipping_partner_install failure)', () => {
+		it( 'should fire shipping_partner_install with failure for failed shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			const errors: PluginInstallError[] = [
+				{
+					plugin: 'woocommerce-shipping',
+					error: 'Install failed',
+					errorDetails: {
+						data: {
+							code: 'install_error',
+							data: { status: 500 },
+						},
+					},
+				},
+			];
+
+			tracksActions.recordFailedPluginInstallations( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED_WITH_ERRORS',
+					payload: { errors },
+				},
+			} );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_install',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+					selected_plugin: 'woocommerce-shipping',
+					success: false,
+				}
+			);
+		} );
+
+		it( 'should not fire shipping_partner_install for failed non-shipping plugins', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			const errors: PluginInstallError[] = [
+				{
+					plugin: 'woocommerce-payments',
+					error: 'Install failed',
+					errorDetails: {
+						data: {
+							code: 'install_error',
+							data: { status: 500 },
+						},
+					},
+				},
+			];
+
+			tracksActions.recordFailedPluginInstallations( {
+				context,
+				event: {
+					type: 'PLUGINS_INSTALLATION_COMPLETED_WITH_ERRORS',
+					payload: { errors },
+				},
+			} );
+
+			expect( recordEvent ).not.toHaveBeenCalledWith(
+				'shipping_partner_install',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'country code extraction', () => {
+		it( 'should extract country code from location with state', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ shippingPlugins[ 0 ] ],
+				businessInfo: { location: 'DE:BE' },
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.objectContaining( { country: 'DE' } )
+			);
+		} );
+
+		it( 'should handle missing location gracefully', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ shippingPlugins[ 0 ] ],
+				businessInfo: {},
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				expect.objectContaining( { country: '' } )
+			);
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/test/tracks.test.ts
@@ -6,7 +6,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import tracksActions from '../tracks';
+import tracksActions, { resetShippingPartnerImpressionFlag } from '../tracks';
 import type { CoreProfilerStateMachineContext } from '../../index';
 import type { PluginInstallError } from '../../services/installAndActivatePlugins';
 
@@ -80,6 +80,7 @@ const nonShippingPlugin = {
 describe( 'Core Profiler shipping partner tracking', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		resetShippingPartnerImpressionFlag();
 	} );
 
 	describe( 'recordShippingPartnerImpression', () => {
@@ -112,6 +113,31 @@ describe( 'Core Profiler shipping partner tracking', () => {
 				'shipping_partner_impression',
 				expect.anything()
 			);
+		} );
+
+		it( 'should only fire shipping_partner_impression once even if called multiple times', () => {
+			const context = makeContext( {
+				pluginsAvailable: [ ...shippingPlugins, nonShippingPlugin ],
+			} );
+
+			tracksActions.recordShippingPartnerImpression( { context } );
+			tracksActions.recordShippingPartnerImpression( { context } );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_partner_impression',
+				{
+					context: 'core-profiler',
+					country: 'US',
+					plugins:
+						'woocommerce-shipping,woocommerce-shipstation-integration',
+				}
+			);
+			expect(
+				( recordEvent as jest.Mock ).mock.calls.filter(
+					( [ eventName ] ) =>
+						eventName === 'shipping_partner_impression'
+				)
+			).toHaveLength( 1 );
 		} );
 	} );
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -164,14 +164,21 @@ const recordTracksBusinessInfoCompleted = ( {
 	} );
 };
 
+let shippingPartnerImpressionRecorded = false;
+
 const recordShippingPartnerImpression = ( {
 	context,
 }: {
 	context: CoreProfilerStateMachineContext;
 } ) => {
+	if ( shippingPartnerImpressionRecorded ) {
+		return;
+	}
+
 	const trackingBase = getShippingPartnerTrackingBase( context );
 
 	if ( trackingBase.plugins.length > 0 ) {
+		shippingPartnerImpressionRecorded = true;
 		recordEvent( 'shipping_partner_impression', trackingBase );
 	}
 };
@@ -309,6 +316,10 @@ const recordSuccessfulPluginInstallation = ( {
 		'coreprofiler_store_extensions_installed_and_activated',
 		trackData
 	);
+};
+
+export const resetShippingPartnerImpressionFlag = () => {
+	shippingPartnerImpressionRecorded = false;
 };
 
 export default {

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -22,6 +22,32 @@ import {
 	PluginInstallError,
 } from '../services/installAndActivatePlugins';
 import { getPluginTrackKey, getTimeFrame } from '~/utils';
+import { getPluginSlug } from '~/utils/plugins';
+import { getCountryCode } from '~/dashboard/utils';
+
+const SHIPPING_PLUGIN_SLUGS = new Set( [
+	'woocommerce-shipping',
+	'woocommerce-shipstation-integration',
+	'packlink-pro-shipping',
+] );
+
+const isShippingPlugin = ( pluginKey: string ) =>
+	SHIPPING_PLUGIN_SLUGS.has( getPluginSlug( pluginKey ) );
+
+const getShippingPartnerTrackingBase = (
+	context: CoreProfilerStateMachineContext
+) => {
+	const shippingPlugins = context.pluginsAvailable
+		.filter( ( plugin ) => isShippingPlugin( plugin.key ) )
+		.map( ( plugin ) => getPluginSlug( plugin.key ) )
+		.join( ',' );
+
+	return {
+		context: 'core-profiler' as const,
+		country: getCountryCode( context.businessInfo.location ) ?? '',
+		plugins: shippingPlugins,
+	};
+};
 
 const recordTracksStepViewed = ( _: unknown, params: { step: string } ) => {
 	recordEvent( 'coreprofiler_step_view', {
@@ -138,9 +164,23 @@ const recordTracksBusinessInfoCompleted = ( {
 	} );
 };
 
+const recordShippingPartnerImpression = ( {
+	context,
+}: {
+	context: CoreProfilerStateMachineContext;
+} ) => {
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
+	if ( trackingBase.plugins.length > 0 ) {
+		recordEvent( 'shipping_partner_impression', trackingBase );
+	}
+};
+
 const recordTracksPluginsInstallationRequest = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: Extract<
 		PluginsInstallationRequestedEvent,
 		{ type: 'PLUGINS_INSTALLATION_REQUESTED' }
@@ -150,6 +190,18 @@ const recordTracksPluginsInstallationRequest = ( {
 		shown: event.payload.pluginsShown || [],
 		selected: event.payload.pluginsSelected || [],
 		unselected: event.payload.pluginsUnselected || [],
+	} );
+
+	const trackingBase = getShippingPartnerTrackingBase( context );
+	const selectedShippingPlugins = (
+		event.payload.pluginsSelected || []
+	).filter( ( slug ) => SHIPPING_PLUGIN_SLUGS.has( getPluginSlug( slug ) ) );
+
+	selectedShippingPlugins.forEach( ( pluginSlug ) => {
+		recordEvent( 'shipping_partner_click', {
+			...trackingBase,
+			selected_plugin: getPluginSlug( pluginSlug ),
+		} );
 	} );
 };
 
@@ -167,8 +219,10 @@ const recordTracksPluginsInstallationNoPermissionError = () =>
 	recordEvent( 'coreprofiler_store_extensions_no_permission_error' );
 
 const recordFailedPluginInstallations = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: PluginsInstallationCompletedWithErrorsEvent;
 } ) => {
 	const failedExtensions = event.payload.errors.map(
@@ -180,18 +234,30 @@ const recordFailedPluginInstallations = ( {
 		failed_extensions: failedExtensions,
 	} );
 
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
 	event.payload.errors.forEach( ( error: PluginInstallError ) => {
 		recordEvent( 'coreprofiler_store_extension_installed_and_activated', {
 			success: false,
 			extension: getPluginTrackKey( error.plugin ),
 			error_message: error.error,
 		} );
+
+		if ( isShippingPlugin( error.plugin ) ) {
+			recordEvent( 'shipping_partner_install', {
+				...trackingBase,
+				selected_plugin: getPluginSlug( error.plugin ),
+				success: false,
+			} );
+		}
 	} );
 };
 
 const recordSuccessfulPluginInstallation = ( {
+	context,
 	event,
 }: {
+	context: CoreProfilerStateMachineContext;
 	event: PluginsInstallationCompletedEvent;
 } ) => {
 	const installationCompletedResult =
@@ -211,6 +277,8 @@ const recordSuccessfulPluginInstallation = ( {
 		total_time: getTimeFrame( installationCompletedResult.totalTime ),
 	};
 
+	const trackingBase = getShippingPartnerTrackingBase( context );
+
 	for ( const installedPlugin of installationCompletedResult.installedPlugins ) {
 		const pluginKey = getPluginTrackKey( installedPlugin.plugin );
 		const installTime = getTimeFrame( installedPlugin.installTime );
@@ -221,6 +289,20 @@ const recordSuccessfulPluginInstallation = ( {
 			extension: pluginKey,
 			install_time: installTime,
 		} );
+
+		if ( isShippingPlugin( installedPlugin.plugin ) ) {
+			const slug = getPluginSlug( installedPlugin.plugin );
+			recordEvent( 'shipping_partner_install', {
+				...trackingBase,
+				selected_plugin: slug,
+				success: true,
+			} );
+			recordEvent( 'shipping_partner_activate', {
+				...trackingBase,
+				selected_plugin: slug,
+				success: true,
+			} );
+		}
 	}
 
 	recordEvent(
@@ -243,4 +325,5 @@ export default {
 	recordSuccessfulPluginInstallation,
 	recordTracksPluginsInstallationRequest,
 	recordTracksIsEmailChanged,
+	recordShippingPartnerImpression,
 };

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1504,6 +1504,9 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							params: { step: 'plugins' },
 						},
 						{
+							type: 'recordShippingPartnerImpression',
+						},
+						{
 							type: 'updateQueryStep',
 							params: { step: 'plugins' },
 						},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of [WOOPLUG-6273](https://linear.app/wooplugins/issue/WOOPLUG-6273) (sub-issue: [WOOPLUG-6347](https://linear.app/wooplugins/issue/WOOPLUG-6347)).

Adds unified `shipping_partner_*` Tracks events to the **Core Profiler** onboarding flow. These events enable consistent analytics across all shipping partner placement surfaces.

**Events added:**
- `shipping_partner_impression` - fired when the plugins page loads and shipping plugins are among the available recommendations
- `shipping_partner_click` - fired when the user selects a shipping plugin and proceeds with installation
- `shipping_partner_install` - fired when plugin installation completes (success or failure)
- `shipping_partner_activate` - fired when plugin activation completes (success or failure)

**Event properties:**
- `context`: `'core-profiler'`
- `country`: store country code from business info (e.g. `'US'`)
- `plugins`: comma-separated list of all available shipping partner plugin slugs
- `selected_plugin`: the specific plugin slug for click/install/activate events
- `success`: boolean for install/activate events

**Key implementation details:**
- Added `SHIPPING_PLUGIN_SLUGS` set and `isShippingPlugin` helper for filtering
- Added `getShippingPartnerTrackingBase` to build shared tracking properties from context
- `recordShippingPartnerImpression` is a new action fired on plugins page entry
- Existing `recordTracksPluginsInstallationRequest`, `recordSuccessfulPluginInstallation`, and `recordFailedPluginInstallations` now also fire shipping-specific events for shipping plugins
- Core Profiler installs all selected plugins together, so shipping events are filtered from the full plugin list

**Files changed:**
- `core-profiler/actions/tracks.tsx` - shipping partner tracking helpers and events
- `core-profiler/index.tsx` - impression action on plugins page entry
- `core-profiler/actions/test/tracks.test.ts` - 10 new tests

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Prerequisites

- Reset your store so the Core Profiler onboarding flow is shown (delete the `woocommerce_onboarding_profile` option or use a fresh install).
- Set your store country to one that shows shipping partner recommendations (e.g. US).
- To test install failures (Test 4), add this mu-plugin to `wp-content/mu-plugins/simulate-shipping-failures.php`:

```php
<?php
add_filter( 'rest_request_before_callbacks', function ( $response, $handler, $request ) {
    if ( $request->get_route() !== '/wp/v2/plugins' ) {
        return $response;
    }
    $slug = $request->get_param( 'slug' );
    if ( ! in_array( $slug, [ 'woocommerce-shipping', 'woocommerce-shipstation-integration', 'packlink-pro-shipping' ], true ) ) {
        return $response;
    }
    if ( $request->get_method() === 'POST' ) {
        return new WP_Error( 'simulated_install_failure', 'Simulated install failure for ' . $slug, [ 'status' => 500 ] );
    }
    return $response;
}, 10, 3 );
```

#### Test 1: `shipping_partner_impression`

1. Start the Core Profiler onboarding flow.
2. Proceed through steps until you reach the **Extensions** (plugins) page.
3. Verify a `shipping_partner_impression` event fires with:
   - `context: 'core-profiler'`
   - `country`: your store's country code
   - `plugins`: comma-separated slugs of available shipping plugins (e.g. `'woocommerce-shipping'`)

#### Test 2: `shipping_partner_click`

1. On the Extensions page, ensure a shipping plugin is checked (e.g. WooCommerce Shipping).
2. Click "Continue" to proceed with installation.
3. Verify a `shipping_partner_click` event fires for each selected shipping plugin with:
   - `context: 'core-profiler'`
   - `selected_plugin`: the slug of the shipping plugin

#### Test 3: `shipping_partner_install` and `shipping_partner_activate` (success)

1. Allow the Core Profiler to install the selected plugins (no failure simulation).
2. Verify two events fire per shipping plugin:
   - `shipping_partner_install` with `success: true`, `selected_plugin: '<slug>'`
   - `shipping_partner_activate` with `success: true`, `selected_plugin: '<slug>'`

#### Test 4: `shipping_partner_install` (failure)

1. Enable the mu-plugin from the Prerequisites section above.
2. Proceed through the Core Profiler with a shipping plugin selected.
3. Verify a `shipping_partner_install` event fires with `success: false`.
4. Verify no `shipping_partner_activate` event fires for that plugin.

#### Test 5: No shipping plugins available

1. Set your store country to one with no shipping partner recommendations.
2. Proceed through the Core Profiler.
3. Verify no `shipping_partner_impression` event fires.
4. Verify no `shipping_partner_click` / `shipping_partner_install` / `shipping_partner_activate` events fire.

#### Test 6: Unit tests

1. Run `pnpm run test:js -- client/core-profiler/actions/test/tracks.test.ts`
2. All 10 tests should pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- All 10 unit tests pass (Jest)
- Code review of XState action integration

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add unified shipping partner Tracks events (impression, click, install, activate) in the Core Profiler onboarding flow.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
