### PR TITLE
Fix _load_textdomain_just_in_time warning from PointOfSaleEmailHandler

### DIFF
--- a/plugins/woocommerce/src/Internal/Orders/PointOfSaleEmailHandler.php
+++ b/plugins/woocommerce/src/Internal/Orders/PointOfSaleEmailHandler.php
@@ -8,7 +8,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\Orders;
 
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Abstract_Order;
 
 /**
@@ -41,10 +40,6 @@ class PointOfSaleEmailHandler implements RegisterHooksInterface {
 	 * Register hooks and filters.
 	 */
 	public function register(): void {
-		if ( ! FeaturesUtil::feature_is_enabled( 'point_of_sale' ) ) {
-			return;
-		}
-
 		foreach ( self::SUPPRESSED_EMAIL_IDS as $email_id ) {
 			add_filter( 'woocommerce_email_enabled_' . $email_id, array( $this, 'maybe_suppress_email' ), 10, 2 );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/PointOfSaleEmailHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/PointOfSaleEmailHandlerTest.php
@@ -101,11 +101,9 @@ class PointOfSaleEmailHandlerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox register adds filters only when POS feature is enabled.
+	 * @testdox register adds email suppression filters for all standard email IDs.
 	 */
-	public function test_register_adds_filters_when_pos_enabled(): void {
-		update_option( 'woocommerce_feature_point_of_sale_enabled', 'yes' );
-
+	public function test_register_adds_filters(): void {
 		$handler = new PointOfSaleEmailHandler();
 		$handler->register();
 
@@ -134,22 +132,5 @@ class PointOfSaleEmailHandlerTest extends WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_email_enabled_customer_refunded_order' );
 		remove_all_filters( 'woocommerce_email_enabled_customer_partially_refunded_order' );
 		remove_all_filters( 'woocommerce_email_enabled_new_order' );
-	}
-
-	/**
-	 * @testdox register does not add filters when POS feature is disabled.
-	 */
-	public function test_register_does_not_add_filters_when_pos_disabled(): void {
-		remove_all_filters( 'woocommerce_email_enabled_customer_completed_order' );
-		update_option( 'woocommerce_feature_point_of_sale_enabled', 'no' );
-
-		$handler = new PointOfSaleEmailHandler();
-		$handler->register();
-
-		$this->assertFalse(
-			has_filter( 'woocommerce_email_enabled_customer_completed_order', array( $handler, 'maybe_suppress_email' ) )
-		);
-
-		delete_option( 'woocommerce_feature_point_of_sale_enabled' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/63433.

Bug introduced in PR #63322.

**Problem:**

PR #63322 added `PointOfSaleEmailHandler::register()` to `init_hooks()` in `class-woocommerce.php`. This `register()` method calls `FeaturesUtil::feature_is_enabled('point_of_sale')`, which is the first synchronous `feature_is_enabled()` call during `init_hooks()`. All other `register()` calls either skip feature checks or defer them to later hooks like `init`.

This triggers `FeaturesController::init_feature_definitions()`, which calls `__('...', 'woocommerce')` for every feature name and description. Since `init_hooks()` runs in the WooCommerce constructor (before the `init` action), these translation calls happen too early, producing the `_load_textdomain_just_in_time` warning on WordPress 6.7+.

**Fix:**

Remove the `FeaturesUtil::feature_is_enabled('point_of_sale')` guard from `register()` entirely. The feature flag check is redundant here because the suppression filters are naturally no-ops when POS is disabled: if POS is not in use, no orders will have POS payment metadata (`created_via = 'pos-rest-api'`, `_wcpay_ipp_channel = mobile_pos`, or `_cash_change_amount`), so `PointOfSaleOrderUtil::is_order_paid_at_pos()` in the callback will always return false and no emails will be suppressed.

Otherwise, this flag is enabled by default and the checks are happening either way.

After this change, `register()` only calls `add_filter()`, which is safe to call at any point in the WordPress lifecycle.

### How to test the changes in this Pull Request:

From `plugins/woocommerce`, start wp-env and enable debug logging:

```bash
pnpm wp-env start
pnpm wp-env run cli wp config set WP_DEBUG true --raw
pnpm wp-env run cli wp config set WP_DEBUG_LOG true --raw
```

Clear the log, hit the site, and check for the warning:

```bash
pnpm wp-env run cli bash -c 'rm -f /var/www/html/wp-content/debug.log'
curl -s -o /dev/null http://localhost:8888/
curl -s -o /dev/null http://localhost:8888/wp-admin/
pnpm wp-env run cli bash -c 'grep -i "load_textdomain_just_in_time" /var/www/html/wp-content/debug.log 2>/dev/null || echo "NO TEXTDOMAIN WARNING"'
```

**Expected result:** `NO TEXTDOMAIN WARNING`

To verify the bug existed before the fix, revert `PointOfSaleEmailHandler.php` to the previous version on trunk, restart wp-env (`pnpm wp-env stop && pnpm wp-env start`), re-enable WP_DEBUG/WP_DEBUG_LOG, and repeat the steps above. The `_load_textdomain_just_in_time` warning will appear in the log.

### Testing that has already taken place:

- PHPCS lint passes with no errors.
- Verified locally with wp-env: warning appears without the fix, disappears with the fix.
- Code path analysis confirms `register()` no longer triggers any translation loading.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Fixes a notice introduced in the same release cycle. No user-facing behavior change.

</details>