### PR TITLE
Add blocks-specific JS lint instructions to dev-cycle skill

### DIFF
--- a/.ai/skills/woocommerce-dev-cycle/code-quality.md
+++ b/.ai/skills/woocommerce-dev-cycle/code-quality.md
@@ -80,6 +80,16 @@ This command:
 - Identifies code style and potential issues
 - Does not modify files
 
+**Important:** The plugin-level `.eslintignore` excludes `client/blocks/`, so `lint:changes:branch:js` will not catch eslint or prettier issues in blocks code. For blocks changes, also run the blocks package lint:
+
+```bash
+# Check blocks JS/TS (includes prettier via eslint plugin)
+pnpm --filter=@woocommerce/block-library lint:js
+
+# Auto-fix blocks JS/TS issues
+pnpm --filter=@woocommerce/block-library lint:js-fix
+```
+
 For detailed JavaScript/TypeScript linting configuration and patterns, see `client/admin/CLAUDE.md`.
 
 ## Markdown Linting
@@ -198,6 +208,7 @@ Before committing your changes:
 - [ ] Run `pnpm run lint:changes:branch:php`
 - [ ] Run `pnpm run lint:php:fix` if issues found
 - [ ] Run `pnpm run lint:changes:branch:js` if you modified JS files
+- [ ] Run `pnpm --filter=@woocommerce/block-library lint:js-fix` if you modified blocks JS/TS files
 - [ ] Review all automatic fixes with `git diff`
 - [ ] Address any remaining issues that can't be auto-fixed
 - [ ] Run tests to ensure fixes didn't break functionality


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The plugin-level .eslintignore excludes client/blocks/, so lint:changes:branch:js silently skips blocks files. Document that blocks changes need the blocks package lint command to catch eslint and prettier issues before CI.

### Screenshots or screen recordings:

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

N/A we don't have a way right now to validate skills.

<!-- End testing instructions -->

### Testing that has already taken place:

N/A

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
This is just an addition to Claude skills for the monorepo and has no impact on WooCommerce runtime.

</details>
