### PR TITLE
fix: allow math expressions in flat rate shipping cost field.

### DIFF
--- a/plugins/woocommerce/changelog/fix-flat-rate-shipping-math-expression-validation
+++ b/plugins/woocommerce/changelog/fix-flat-rate-shipping-math-expression-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix math expressions being rejected in the flat rate shipping cost field

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -285,16 +285,20 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$decimal_separator  = wc_get_price_decimal_separator();
 		$thousand_separator = wc_get_price_thousand_separator();
 
-		/*
-		* Breakdown:
-		*   [\d{dec}{thou}\s]+           - First operand: digits, decimal/thousand separators, or spaces.
-		*   (                            - Begin repeating group:
-		*     [+\-*\/]                   -   An arithmetic operator (+, -, *, /).
-		*     [\d{dec}{thou}\s]+         -   Next operand: digits, decimal/thousand separators, or spaces.
-		*   )+                           - One or more operator+operand pairs (ensures no trailing operator).
-		* */
+		// Use preg_quote() to safely escaping separators.
+		$separators = preg_quote( $decimal_separator, '/' );
+		if ( '' !== $thousand_separator ) {
+			$separators .= preg_quote( $thousand_separator, '/' );
+		}
+
+		// Breakdown:
+		// [\d{sep}\s]+             - First operand: digits, separators, or spaces.
+		// (                        - Begin repeating group:
+		// [+\-*\/]               -   An arithmetic operator (+, -, *, /).
+		// [\d{sep}\s]+           -   Next operand: digits, separators, or spaces.
+		// )+                       - One or more operator+operand pairs (ensures no trailing operator).
 		return (bool) preg_match(
-			'/^[\d\\' . $decimal_separator . '\\' . $thousand_separator . '\s]+([+\-*\/][\d\\' . $decimal_separator . '\\' . $thousand_separator . '\s]+)+$/',
+			'/^[\d' . $separators . '\s]+([+\-*\/][\d' . $separators . '\s]+)+$/',
 			trim( $value )
 		);
 	}

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -287,7 +287,9 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$value = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $value );
 
 		$contains_shortcodes = false !== strpos( $value, '[' ) || false !== strpos( $value, ']' );
-		if ( ! $contains_shortcodes ) {
+		$is_math_expression = (bool) preg_match( '/^[\d\.\s]+([+\-*\/][\d\.\s]+)+$/', trim( $value ) );
+
+		if ( ! $contains_shortcodes && ! $is_math_expression ) {
 			$value = \Automattic\WooCommerce\Utilities\NumberUtil::sanitize_cost_in_current_locale( $value );
 		}
 

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -274,6 +274,32 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	}
 
 	/**
+	 * Check if a value is a math expression.
+	 *
+	 * Matches two or more numeric operands separated by arithmetic operators.
+	 *
+	 * @param string $value Value to test.
+	 * @return bool True if value is a well-formed math expression.
+	 */
+	protected function is_math_expression( string $value ): bool {
+		$decimal_separator  = wc_get_price_decimal_separator();
+		$thousand_separator = wc_get_price_thousand_separator();
+
+		/*
+		* Breakdown:
+		*   [\d{dec}{thou}\s]+           - First operand: digits, decimal/thousand separators, or spaces.
+		*   (                            - Begin repeating group:
+		*     [+\-*\/]                   -   An arithmetic operator (+, -, *, /).
+		*     [\d{dec}{thou}\s]+         -   Next operand: digits, decimal/thousand separators, or spaces.
+		*   )+                           - One or more operator+operand pairs (ensures no trailing operator).
+		* */
+		return (bool) preg_match(
+			'/^[\d\\' . $decimal_separator . '\\' . $thousand_separator . '\s]+([+\-*\/][\d\\' . $decimal_separator . '\\' . $thousand_separator . '\s]+)+$/',
+			trim( $value )
+		);
+	}
+
+	/**
 	 * Sanitize the cost field.
 	 *
 	 * @since 3.4.0
@@ -287,9 +313,8 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$value = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $value );
 
 		$contains_shortcodes = false !== strpos( $value, '[' ) || false !== strpos( $value, ']' );
-		$is_math_expression = (bool) preg_match( '/^[\d\.\s]+([+\-*\/][\d\.\s]+)+$/', trim( $value ) );
 
-		if ( ! $contains_shortcodes && ! $is_math_expression ) {
+		if ( ! $contains_shortcodes && ! $this->is_math_expression( $value ) ) {
 			$value = \Automattic\WooCommerce\Utilities\NumberUtil::sanitize_cost_in_current_locale( $value );
 		}
 

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -282,23 +282,19 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	 * @return bool True if value is a well-formed math expression.
 	 */
 	protected function is_math_expression( string $value ): bool {
-		$decimal_separator  = wc_get_price_decimal_separator();
-		$thousand_separator = wc_get_price_thousand_separator();
+		$decimal_separator = wc_get_price_decimal_separator();
 
-		// Use preg_quote() to safely escaping separators.
-		$separators = preg_quote( $decimal_separator, '/' );
-		if ( '' !== $thousand_separator ) {
-			$separators .= preg_quote( $thousand_separator, '/' );
-		}
+		// Use preg_quote() to safely escaping separator.
+		$separator = preg_quote( $decimal_separator, '/' );
 
 		// Breakdown:
-		// [\d{sep}\s]+             - First operand: digits, separators, or spaces.
+		// [\d{sep}\s]+             - First operand: digits, separator, or spaces.
 		// (                        - Begin repeating group:
 		// [+\-*\/]               -   An arithmetic operator (+, -, *, /).
-		// [\d{sep}\s]+           -   Next operand: digits, separators, or spaces.
+		// [\d{sep}\s]+           -   Next operand: digits, separator, or spaces.
 		// )+                       - One or more operator+operand pairs (ensures no trailing operator).
 		return (bool) preg_match(
-			'/^[\d' . $separators . '\s]+([+\-*\/][\d' . $separators . '\s]+)+$/',
+			'/^[\d' . $separator . '\s]+([+\-*\/][\d' . $separator . '\s]+)+$/',
 			trim( $value )
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- backcompat nomenclature.
 

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -19,9 +19,9 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	private $call_evaluate_cost;
 
 	/**
-	 * @var Closure Function to call protected method is_math_expression.
+	 * @var Closure Function to call public method sanitize_cost.
 	 */
-	private $call_is_math_expression;
+	private $call_sanitize_cost;
 
 	/**
 	 * Set up test case.
@@ -30,12 +30,12 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->sut                     = new WC_Shipping_Flat_Rate();
-		$this->call_evaluate_cost      = function ( $sum, $args ) {
+		$this->sut                = new WC_Shipping_Flat_Rate();
+		$this->call_evaluate_cost = function ( $sum, $args ) {
 			return $this->evaluate_cost( $sum, $args );
 		};
-		$this->call_is_math_expression = function ( $value ) {
-			return $this->is_math_expression( $value );
+		$this->call_sanitize_cost = function ( $value ) {
+			return $this->sanitize_cost( $value );
 		};
 		update_option( 'woocommerce_price_decimal_sep', ',' );
 		update_option( 'woocommerce_price_thousand_sep', '.' );
@@ -162,82 +162,65 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox is_math_expression() returns true for valid math expressions.
+	 * @testDox sanitize_cost() accepts and preserves valid math expressions.
+	 *
 	 * @dataProvider provider_valid_math_expressions
 	 *
 	 * @param string $value           Value to test.
 	 * @param string $decimal_sep     Decimal separator to use.
 	 * @param string $thousand_sep    Thousand separator to use.
-	 * @param float  $expected_result Expected result of evaluating the expression.
 	 */
-	public function test_is_math_expression_returns_true( string $value, string $decimal_sep, string $thousand_sep, float $expected_result ): void {
+	public function test_sanitize_cost_accepts_math_expressions( string $value, string $decimal_sep, string $thousand_sep ): void {
 		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
 		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
 
-		$this->assertTrue(
-			$this->call_is_math_expression->call( $this->sut, $value ),
-			"Expected '{$value}' to be recognised as a math expression."
-		);
-
-		$result = $this->call_evaluate_cost->call(
-			$this->sut,
-			$value,
-			array(
-				'qty'  => 1,
-				'cost' => 1,
-			)
-		);
-		$this->assertEquals(
-			$expected_result,
-			$result,
-			"Expected '{$value}' to evaluate to {$expected_result}."
-		);
+		$result = $this->call_sanitize_cost->call( $this->sut, $value );
+		$this->assertEquals( $value, trim( $result ) );
 	}
 
 	/**
-	 * @testDox is_math_expression() returns false for non-math-expression values.
+	 * @testDox sanitize_cost() rejects invalid math expressions.
 	 *
 	 * @dataProvider provider_invalid_math_expressions
 	 *
-	 * @param string $value       Value to test.
-	 * @param string $decimal_sep  Decimal separator to use.
+	 * @param string $value       Value to sanitize.
+	 * @param string $decimal_sep Decimal separator to use.
 	 * @param string $thousand_sep Thousand separator to use.
 	 */
-	public function test_is_math_expression_returns_false( string $value, string $decimal_sep, string $thousand_sep ): void {
+	public function test_sanitize_cost_rejects_invalid_expressions( string $value, string $decimal_sep, string $thousand_sep ): void {
 		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
 		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
 
-		$this->assertFalse(
-			$this->call_is_math_expression->call( $this->sut, $value ),
-			"Expected '{$value}' to NOT be recognised as a math expression."
-		);
+		$this->expectException( Exception::class );
+		$this->call_sanitize_cost->call( $this->sut, $value );
 	}
 
 	/**
 	 * Valid math expression cases.
 	 *
-	 * Format: [ value, decimal_separator, thousand_separator, expected_result ]
+	 * Format: [ value, decimal_separator, thousand_separator ]
 	 */
 	public function provider_valid_math_expressions(): array {
 		return array(
+			'plain number'                  => array( '10.00', '.', ',' ),
+			'empty string'                  => array( '', '.', ',' ),
+			'shortcode qty'                 => array( '[qty]', '.', ',' ),
+			'shortcode expression'          => array( '10.00 * [qty]', '.', ',' ),
+
 			// period decimal, comma thousand.
-			'simple division'                   => array( '3.50 / 1.21', '.', ',', 3.50 / 1.21 ),
-			'simple multiplication'             => array( '10.00 * 1.21', '.', ',', 10.00 * 1.21 ),
-			'simple addition'                   => array( '10 + 5', '.', ',', 15.0 ),
-			'simple subtraction'                => array( '20 - 3.50', '.', ',', 16.50 ),
-			'chained operators'                 => array( '10 * 2 + 5', '.', ',', 25.0 ),
+			'simple division'               => array( '3.50 / 1.21', '.', ',' ),
+			'simple multiplication'         => array( '10.00 * 1.21', '.', ',' ),
+			'simple addition'               => array( '10 + 5', '.', ',' ),
+			'simple subtraction'            => array( '20 - 3.50', '.', ',' ),
+			'chained operators'             => array( '10 * 2 + 5', '.', ',' ),
 
 			// comma decimal, period thousand.
-			'EU locale division'                => array( '3,50 / 1,21', ',', '.', 3.50 / 1.21 ),
-			'EU locale multiplication'          => array( '10,00 * 1,21', ',', '.', 10.00 * 1.21 ),
+			'EU locale division'            => array( '3,50 / 1,21', ',', '.' ),
+			'EU locale multiplication'      => array( '10,00 * 1,21', ',', '.' ),
 
 			// No thousand separator locale.
-			'no thousand separator simple'      => array( '3.50 / 1.21', '.', '', 3.50 / 1.21 ),
-			'no thousand separator chained'     => array( '10 * 2 + 5', '.', '', 25.0 ),
-
-			// Whitespace variations.
-			'extra whitespace between operands' => array( '3.50  /  1.21', '.', ',', 3.50 / 1.21 ),
-			'leading and trailing whitespace'   => array( '  3.50 / 1.21  ', '.', ',', 3.50 / 1.21 ),
+			'no thousand separator simple'  => array( '3.50 / 1.21', '.', '' ),
+			'no thousand separator chained' => array( '10 * 2 + 5', '.', '' ),
 		);
 	}
 
@@ -248,11 +231,6 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	 */
 	public function provider_invalid_math_expressions(): array {
 		return array(
-			// Plain numbers.
-			'plain integer'                 => array( '10', '.', ',' ),
-			'plain decimal'                 => array( '10.00', '.', ',' ),
-			'plain EU decimal'              => array( '10,00', ',', '.' ),
-
 			// Thousand-separated operands must not be used in math expressions
 			// as evaluate_cost() normalises all separators to ".", causing
 			// "10,000" to be evaluated as "10.0" instead of "10000".
@@ -268,11 +246,6 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 			// Invalid characters.
 			'alphabetic string'             => array( 'abc', '.', ',' ),
 			'alphanumeric'                  => array( '10abc', '.', ',' ),
-			'empty string'                  => array( '', '.', ',' ),
-
-			// Shortcodes — handled separately by $contains_shortcodes check.
-			'shortcode qty'                 => array( '[qty]', '.', ',' ),
-			'expression with shortcode'     => array( '10 * [qty]', '.', ',' ),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -18,15 +18,23 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	private $call_evaluate_cost;
 
 	/**
+	 * @var Closure Function to call protected method is_math_expression.
+	 */
+	private $call_is_math_expression;
+
+	/**
 	 * Set up test case.
 	 *
 	 * @return void
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->sut                = new WC_Shipping_Flat_Rate();
-		$this->call_evaluate_cost = function ( $sum, $args ) {
+		$this->sut                     = new WC_Shipping_Flat_Rate();
+		$this->call_evaluate_cost      = function ( $sum, $args ) {
 			return $this->evaluate_cost( $sum, $args );
+		};
+		$this->call_is_math_expression = function ( $value ) {
+			return $this->is_math_expression( $value );
 		};
 		update_option( 'woocommerce_price_decimal_sep', ',' );
 		update_option( 'woocommerce_price_thousand_sep', '.' );
@@ -150,5 +158,102 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 			)
 		);
 		$this->assertEquals( 10, $val );
+	}
+
+	/**
+	 * @testDox is_math_expression() returns true for valid math expressions.
+	 *
+	 * @dataProvider provider_valid_math_expressions
+	 *
+	 * @param string $value       Value to test.
+	 * @param string $decimal_sep  Decimal separator to use.
+	 * @param string $thousand_sep Thousand separator to use.
+	 */
+	public function test_is_math_expression_returns_true( string $value, string $decimal_sep, string $thousand_sep ): void {
+		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
+		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
+
+		$this->assertTrue(
+			$this->call_is_math_expression->call( $this->sut, $value ),
+			"Expected '{$value}' to be recognised as a math expression."
+		);
+	}
+
+	/**
+	 * @testDox is_math_expression() returns false for non-math-expression values.
+	 *
+	 * @dataProvider provider_invalid_math_expressions
+	 *
+	 * @param string $value       Value to test.
+	 * @param string $decimal_sep  Decimal separator to use.
+	 * @param string $thousand_sep Thousand separator to use.
+	 */
+	public function test_is_math_expression_returns_false( string $value, string $decimal_sep, string $thousand_sep ): void {
+		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
+		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
+
+		$this->assertFalse(
+			$this->call_is_math_expression->call( $this->sut, $value ),
+			"Expected '{$value}' to NOT be recognised as a math expression."
+		);
+	}
+
+	/**
+	 * Valid math expression cases.
+	 *
+	 * Format: [ value, decimal_separator, thousand_separator ]
+	 */
+	public function provider_valid_math_expressions(): array {
+		return array(
+			// period decimal, comma thousand.
+			'simple division'                   => array( '3.50 / 1.21', '.', ',' ),
+			'simple multiplication'             => array( '10.00 * 1.21', '.', ',' ),
+			'simple addition'                   => array( '10 + 5', '.', ',' ),
+			'simple subtraction'                => array( '20 - 3.50', '.', ',' ),
+			'chained operators'                 => array( '10 * 2 + 5', '.', ',' ),
+			'thousand separated operand'        => array( '10,500 * 3000', '.', ',' ),
+
+			// comma decimal, period thousand.
+			'EU locale division'                => array( '10,350 / 11,121', ',', '.' ),
+			'EU locale multiplication'          => array( '10,000 * 1,218', ',', '.' ),
+			'EU locale thousand separated'      => array( '10.500 * 30000', ',', '.' ),
+
+			// No thousand separator locale.
+			'no thousand separator simple'      => array( '3.50 / 1.21', '.', '' ),
+			'no thousand separator chained'     => array( '10 * 2 + 5', '.', '' ),
+
+			// Whitespace variations.
+			'extra whitespace between operands' => array( '3.50  /  1.21', '.', ',' ),
+			'leading and trailing whitespace'   => array( '  3.50 / 1.21  ', '.', ',' ),
+		);
+	}
+
+	/**
+	 * Invalid math expression cases.
+	 *
+	 * Format: [ value, decimal_separator, thousand_separator ]
+	 */
+	public function provider_invalid_math_expressions(): array {
+		return array(
+			// Plain numbers.
+			'plain integer'             => array( '10', '.', ',' ),
+			'plain decimal'             => array( '10.00', '.', ',' ),
+			'plain EU decimal'          => array( '10,000', ',', '.' ),
+
+			// Trailing operator — incomplete expressions.
+			'trailing plus'             => array( '20 +', '.', ',' ),
+			'trailing minus'            => array( '20 -', '.', ',' ),
+			'trailing multiply'         => array( '20 *', '.', ',' ),
+			'trailing divide'           => array( '3.50 /', '.', ',' ),
+
+			// Invalid characters.
+			'alphabetic string'         => array( 'abc', '.', ',' ),
+			'alphanumeric'              => array( '10abc', '.', ',' ),
+			'empty string'              => array( '', '.', ',' ),
+
+			// Shortcodes — handled separately by $contains_shortcodes check.
+			'shortcode qty'             => array( '[qty]', '.', ',' ),
+			'expression with shortcode' => array( '10 * [qty]', '.', ',' ),
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -162,20 +162,34 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 
 	/**
 	 * @testDox is_math_expression() returns true for valid math expressions.
-	 *
 	 * @dataProvider provider_valid_math_expressions
 	 *
-	 * @param string $value       Value to test.
-	 * @param string $decimal_sep  Decimal separator to use.
-	 * @param string $thousand_sep Thousand separator to use.
+	 * @param string $value           Value to test.
+	 * @param string $decimal_sep     Decimal separator to use.
+	 * @param string $thousand_sep    Thousand separator to use.
+	 * @param float  $expected_result Expected result of evaluating the expression.
 	 */
-	public function test_is_math_expression_returns_true( string $value, string $decimal_sep, string $thousand_sep ): void {
+	public function test_is_math_expression_returns_true( string $value, string $decimal_sep, string $thousand_sep, float $expected_result ): void {
 		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
 		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
 
 		$this->assertTrue(
 			$this->call_is_math_expression->call( $this->sut, $value ),
 			"Expected '{$value}' to be recognised as a math expression."
+		);
+
+		$result = $this->call_evaluate_cost->call(
+			$this->sut,
+			$value,
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals(
+			$expected_result,
+			$result,
+			"Expected '{$value}' to evaluate to {$expected_result}."
 		);
 	}
 
@@ -201,30 +215,28 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	/**
 	 * Valid math expression cases.
 	 *
-	 * Format: [ value, decimal_separator, thousand_separator ]
+	 * Format: [ value, decimal_separator, thousand_separator, expected_result ]
 	 */
 	public function provider_valid_math_expressions(): array {
 		return array(
 			// period decimal, comma thousand.
-			'simple division'                   => array( '3.50 / 1.21', '.', ',' ),
-			'simple multiplication'             => array( '10.00 * 1.21', '.', ',' ),
-			'simple addition'                   => array( '10 + 5', '.', ',' ),
-			'simple subtraction'                => array( '20 - 3.50', '.', ',' ),
-			'chained operators'                 => array( '10 * 2 + 5', '.', ',' ),
-			'thousand separated operand'        => array( '10,500 * 3000', '.', ',' ),
+			'simple division'                   => array( '3.50 / 1.21', '.', ',', 3.50 / 1.21 ),
+			'simple multiplication'             => array( '10.00 * 1.21', '.', ',', 10.00 * 1.21 ),
+			'simple addition'                   => array( '10 + 5', '.', ',', 15.0 ),
+			'simple subtraction'                => array( '20 - 3.50', '.', ',', 16.50 ),
+			'chained operators'                 => array( '10 * 2 + 5', '.', ',', 25.0 ),
 
 			// comma decimal, period thousand.
-			'EU locale division'                => array( '10,350 / 11,121', ',', '.' ),
-			'EU locale multiplication'          => array( '10,000 * 1,218', ',', '.' ),
-			'EU locale thousand separated'      => array( '10.500 * 30000', ',', '.' ),
+			'EU locale division'                => array( '3,50 / 1,21', ',', '.', 3.50 / 1.21 ),
+			'EU locale multiplication'          => array( '10,00 * 1,21', ',', '.', 10.00 * 1.21 ),
 
 			// No thousand separator locale.
-			'no thousand separator simple'      => array( '3.50 / 1.21', '.', '' ),
-			'no thousand separator chained'     => array( '10 * 2 + 5', '.', '' ),
+			'no thousand separator simple'      => array( '3.50 / 1.21', '.', '', 3.50 / 1.21 ),
+			'no thousand separator chained'     => array( '10 * 2 + 5', '.', '', 25.0 ),
 
 			// Whitespace variations.
-			'extra whitespace between operands' => array( '3.50  /  1.21', '.', ',' ),
-			'leading and trailing whitespace'   => array( '  3.50 / 1.21  ', '.', ',' ),
+			'extra whitespace between operands' => array( '3.50  /  1.21', '.', ',', 3.50 / 1.21 ),
+			'leading and trailing whitespace'   => array( '  3.50 / 1.21  ', '.', ',', 3.50 / 1.21 ),
 		);
 	}
 
@@ -236,24 +248,30 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 	public function provider_invalid_math_expressions(): array {
 		return array(
 			// Plain numbers.
-			'plain integer'             => array( '10', '.', ',' ),
-			'plain decimal'             => array( '10.00', '.', ',' ),
-			'plain EU decimal'          => array( '10,000', ',', '.' ),
+			'plain integer'                 => array( '10', '.', ',' ),
+			'plain decimal'                 => array( '10.00', '.', ',' ),
+			'plain EU decimal'              => array( '10,00', ',', '.' ),
+
+			// Thousand-separated operands must not be used in math expressions
+			// as evaluate_cost() normalises all separators to ".", causing
+			// "10,000" to be evaluated as "10.0" instead of "10000".
+			'thousand separated operand'    => array( '10,500 * 3000', '.', ',' ),
+			'EU thousand separated operand' => array( '10.500 * 3000', ',', '.' ),
 
 			// Trailing operator — incomplete expressions.
-			'trailing plus'             => array( '20 +', '.', ',' ),
-			'trailing minus'            => array( '20 -', '.', ',' ),
-			'trailing multiply'         => array( '20 *', '.', ',' ),
-			'trailing divide'           => array( '3.50 /', '.', ',' ),
+			'trailing plus'                 => array( '20 +', '.', ',' ),
+			'trailing minus'                => array( '20 -', '.', ',' ),
+			'trailing multiply'             => array( '20 *', '.', ',' ),
+			'trailing divide'               => array( '3.50 /', '.', ',' ),
 
 			// Invalid characters.
-			'alphabetic string'         => array( 'abc', '.', ',' ),
-			'alphanumeric'              => array( '10abc', '.', ',' ),
-			'empty string'              => array( '', '.', ',' ),
+			'alphabetic string'             => array( 'abc', '.', ',' ),
+			'alphanumeric'                  => array( '10abc', '.', ',' ),
+			'empty string'                  => array( '', '.', ',' ),
 
 			// Shortcodes — handled separately by $contains_shortcodes check.
-			'shortcode qty'             => array( '[qty]', '.', ',' ),
-			'expression with shortcode' => array( '10 * [qty]', '.', ',' ),
+			'shortcode qty'                 => array( '[qty]', '.', ',' ),
+			'expression with shortcode'     => array( '10 * [qty]', '.', ',' ),
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Adds a check for valid math expression.

### Why This Is a Bug
When entering a math expression (e.g. `3.50 / 1.21`) as a flat rate  shipping cost, a validation error is thrown:

```
3.50 / 1.21 is not a valid numeric value. Allowed characters are numbers, the thousand (,), and decimal (.) separators.
```
The help tip explicitly documents math expressions as supported syntax:

> Enter a cost (excl. tax) or sum, e.g. `10.00 * [qty]`
<img width="776" height="542" alt="Screenshot 2026-02-26 at 4 24 05 PM" src="https://github.com/user-attachments/assets/147890e0-239b-492b-9ffd-ddd7d604fad2" />

Additionally, `evaluate_cost()` already handles pure math expressions  like `3.50 / 1.21` correctly via `WC_Eval_Math`. The validation was inconsistent with both the documented behavior and the runtime behavior.


Closes #63389 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Go to WooCommerce > Settings > Shipping > Shipping zones.
- Click the Edit button on the shipping zone where you want to offer this method
- Enter math expressions 

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**Preconditions**

- Go to WooCommerce > Settings > General
- Set Decimal separator to . and Thousand separator to ,
- Save changes
- Go to WooCommerce > Settings > Shipping
- Open an existing shipping zone or create one
- Add a Flat rate shipping method

**Action**

- Click the flat rate method to edit it
- In the Cost field, enter 3.50 / 1.21
- Click Save changes

**Validation**

Confirm no validation error is shown



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
