### PR TITLE
Adds notification trigger classes and tests.

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -73,9 +73,12 @@ class PushNotifications {
 		$this->register_post_types();
 
 		wc_get_container()->get( PushTokenRestController::class )->register();
-		wc_get_container()->get( PendingNotificationStore::class )->register();
-		wc_get_container()->get( NewOrderNotificationTrigger::class )->register();
-		wc_get_container()->get( NewReviewNotificationTrigger::class )->register();
+
+		$store = wc_get_container()->get( PendingNotificationStore::class );
+		$store->register();
+
+		( new NewOrderNotificationTrigger( $store ) )->register();
+		( new NewReviewNotificationTrigger( $store ) )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -10,6 +10,8 @@ use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Logger;
@@ -72,6 +74,8 @@ class PushNotifications {
 
 		wc_get_container()->get( PushTokenRestController::class )->register();
 		wc_get_container()->get( PendingNotificationStore::class )->register();
+		wc_get_container()->get( NewOrderNotificationTrigger::class )->register();
+		wc_get_container()->get( NewReviewNotificationTrigger::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -76,7 +76,7 @@ class NewOrderNotificationTrigger {
 		}
 
 		$this->pending_notification_store->add(
-			new NewOrderNotification( $order_id, get_current_blog_id() )
+			new NewOrderNotification( $order_id )
 		);
 	}
 
@@ -104,7 +104,7 @@ class NewOrderNotificationTrigger {
 		}
 
 		$this->pending_notification_store->add(
-			new NewOrderNotification( $order_id, get_current_blog_id() )
+			new NewOrderNotification( $order_id )
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -111,7 +111,10 @@ class NewOrderNotificationTrigger {
 		WC_Order $order
 	): void {
 		// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		if ( ! in_array( $next_status, self::NOTIFIABLE_STATUSES, true ) ) {
+		if (
+			in_array( $previous_status, self::NOTIFIABLE_STATUSES, true )
+			|| ! in_array( $next_status, self::NOTIFIABLE_STATUSES, true )
+		) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -49,6 +49,8 @@ class NewOrderNotificationTrigger {
 	private PendingNotificationStore $pending_notification_store;
 
 	/**
+	 * Constructs the trigger.
+	 *
 	 * @param PendingNotificationStore $pending_notification_store The notification store.
 	 *
 	 * @since 10.7.0

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -21,11 +21,23 @@ class NewOrderNotificationTrigger {
 	 * Order statuses that should trigger a notification.
 	 */
 	const NOTIFIABLE_STATUSES = array(
+		/**
+		 * Source: WooCommerce plugin.
+		 */
 		'processing',
 		'on-hold',
 		'completed',
+		/**
+		 * Source: WooCommerce Pre-Orders plugin.
+		 */
 		'pre-order',
+		/**
+		 *  Source: WPCOM - "commonly used custom pre-order status".
+		 */
 		'pre-ordered',
+		/**
+		 *  Source: WooCommerce Deposits plugin.
+		 */
 		'partial-payment',
 	);
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -49,16 +49,12 @@ class NewOrderNotificationTrigger {
 	private PendingNotificationStore $pending_notification_store;
 
 	/**
-	 * Receives dependencies from the DI container.
+	 * @param PendingNotificationStore $pending_notification_store The notification store.
 	 *
-	 * @param PendingNotificationStore $store The notification store.
-	 * @return void
-	 *
-	 * @internal
 	 * @since 10.7.0
 	 */
-	final public function init( PendingNotificationStore $store ): void {
-		$this->pending_notification_store = $store;
+	public function __construct( PendingNotificationStore $pending_notification_store ) {
+		$this->pending_notification_store = $pending_notification_store;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use WC_Order;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Listens for new and status-changed orders and feeds notifications into
+ * the PendingNotificationStore.
+ *
+ * @since 10.7.0
+ */
+class NewOrderNotificationTrigger {
+	/**
+	 * Order statuses that should trigger a notification.
+	 */
+	const NOTIFIABLE_STATUSES = array(
+		'processing',
+		'on-hold',
+		'completed',
+		'pre-order',
+		'pre-ordered',
+		'partial-payment',
+	);
+
+	/**
+	 * The pending notification store.
+	 *
+	 * @var PendingNotificationStore
+	 */
+	private PendingNotificationStore $pending_notification_store;
+
+	/**
+	 * Receives dependencies from the DI container.
+	 *
+	 * @param PendingNotificationStore $store The notification store.
+	 * @return void
+	 *
+	 * @internal
+	 * @since 10.7.0
+	 */
+	final public function init( PendingNotificationStore $store ): void {
+		$this->pending_notification_store = $store;
+	}
+
+	/**
+	 * Registers WordPress hooks for order events.
+	 *
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function register(): void {
+		add_action( 'woocommerce_new_order', array( $this, 'on_new_order' ), 10, 2 );
+		add_action( 'woocommerce_order_status_changed', array( $this, 'on_order_status_changed' ), 10, 4 );
+	}
+
+	/**
+	 * Handles the woocommerce_new_order hook.
+	 *
+	 * @param int      $order_id The order ID.
+	 * @param WC_Order $order    The order object.
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function on_new_order( int $order_id, WC_Order $order ): void {
+		if ( ! in_array( $order->get_status(), self::NOTIFIABLE_STATUSES, true ) ) {
+			return;
+		}
+
+		$this->pending_notification_store->add(
+			new NewOrderNotification( $order_id, get_current_blog_id() )
+		);
+	}
+
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	/**
+	 * Handles the woocommerce_order_status_changed hook.
+	 *
+	 * @param int      $order_id        The order ID.
+	 * @param string   $previous_status The previous order status.
+	 * @param string   $next_status     The new order status.
+	 * @param WC_Order $order           The order object.
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function on_order_status_changed(
+		int $order_id,
+		string $previous_status,
+		string $next_status,
+		WC_Order $order
+	): void {
+		// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( ! in_array( $next_status, self::NOTIFIABLE_STATUSES, true ) ) {
+			return;
+		}
+
+		$this->pending_notification_store->add(
+			new NewOrderNotification( $order_id, get_current_blog_id() )
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -1,0 +1,80 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Listens for new approved product reviews and feeds notifications into
+ * the PendingNotificationStore.
+ *
+ * @since 10.7.0
+ */
+class NewReviewNotificationTrigger {
+	/**
+	 * The pending notification store.
+	 *
+	 * @var PendingNotificationStore
+	 */
+	private PendingNotificationStore $store;
+
+	/**
+	 * Receives dependencies from the DI container.
+	 *
+	 * @param PendingNotificationStore $store The notification store.
+	 * @return void
+	 *
+	 * @internal
+	 * @since 10.7.0
+	 */
+	final public function init( PendingNotificationStore $store ): void {
+		$this->store = $store;
+	}
+
+	/**
+	 * Registers WordPress hooks for review events.
+	 *
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function register(): void {
+		add_action( 'comment_post', array( $this, 'on_comment_post' ), 10, 3 );
+	}
+
+	/**
+	 * Handles the comment_post hook.
+	 *
+	 * Only creates a notification for approved reviews on products.
+	 *
+	 * @param int        $comment_id       The comment ID.
+	 * @param int|string $comment_approved 1 if approved, 0 if not, 'spam' if spam.
+	 * @param array      $commentdata      The comment data.
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function on_comment_post( int $comment_id, $comment_approved, array $commentdata ): void {
+		if (
+			'spam' === $comment_approved
+			|| 'review' !== ( $commentdata['comment_type'] ?? '' )
+		) {
+			return;
+		}
+
+		$commented_on = get_post_type( (int) ( $commentdata['comment_post_ID'] ?? 0 ) );
+
+		if ( 'product' !== $commented_on ) {
+			return;
+		}
+
+		$this->store->add(
+			new NewReviewNotification( $comment_id, get_current_blog_id() )
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -24,15 +24,11 @@ class NewReviewNotificationTrigger {
 	private PendingNotificationStore $store;
 
 	/**
-	 * Receives dependencies from the DI container.
-	 *
 	 * @param PendingNotificationStore $store The notification store.
-	 * @return void
 	 *
-	 * @internal
 	 * @since 10.7.0
 	 */
-	final public function init( PendingNotificationStore $store ): void {
+	public function __construct( PendingNotificationStore $store ) {
 		$this->store = $store;
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -50,7 +50,7 @@ class NewReviewNotificationTrigger {
 	/**
 	 * Handles the comment_post hook.
 	 *
-	 * Only creates a notification for approved reviews on products.
+	 * Only creates a notification for non-spam reviews on products.
 	 *
 	 * @param int        $comment_id       The comment ID.
 	 * @param int|string $comment_approved 1 if approved, 0 if not, 'spam' if spam.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -74,7 +74,7 @@ class NewReviewNotificationTrigger {
 		}
 
 		$this->store->add(
-			new NewReviewNotification( $comment_id, get_current_blog_id() )
+			new NewReviewNotification( $comment_id )
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -24,6 +24,8 @@ class NewReviewNotificationTrigger {
 	private PendingNotificationStore $store;
 
 	/**
+	 * Constructs the trigger.
+	 *
 	 * @param PendingNotificationStore $store The notification store.
 	 *
 	 * @since 10.7.0

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -39,8 +39,7 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
 		wc_get_container()->reset_all_resolved();
 
-		$this->trigger = new NewOrderNotificationTrigger();
-		$this->trigger->init( $this->store );
+		$this->trigger = new NewOrderNotificationTrigger( $this->store );
 		$this->trigger->register();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
+use WC_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the NewOrderNotificationTrigger class.
+ */
+class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
+	/**
+	 * An instance of NewOrderNotificationTrigger.
+	 *
+	 * @var NewOrderNotificationTrigger
+	 */
+	private $trigger;
+
+	/**
+	 * The notification store used by the trigger.
+	 *
+	 * @var PendingNotificationStore
+	 */
+	private $store;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->store = new PendingNotificationStore();
+		$this->store->register();
+
+		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
+		wc_get_container()->reset_all_resolved();
+
+		$this->trigger = new NewOrderNotificationTrigger();
+		$this->trigger->init( $this->store );
+		$this->trigger->register();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_action( 'woocommerce_new_order', array( $this->trigger, 'on_new_order' ) );
+		remove_action( 'woocommerce_order_status_changed', array( $this->trigger, 'on_order_status_changed' ) );
+		remove_action( 'shutdown', array( $this->store, 'dispatch_all' ) );
+
+		$this->reset_container_replacements();
+		wc_get_container()->reset_all_resolved();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should register the woocommerce_new_order hook.
+	 */
+	public function test_register_adds_new_order_hook(): void {
+		$this->assertNotFalse(
+			has_action(
+				'woocommerce_new_order',
+				array( $this->trigger, 'on_new_order' )
+			),
+			'woocommerce_new_order hook should be registered'
+		);
+	}
+
+	/**
+	 * @testdox Should register the woocommerce_order_status_changed hook.
+	 */
+	public function test_register_adds_status_changed_hook(): void {
+		$this->assertNotFalse(
+			has_action(
+				'woocommerce_order_status_changed',
+				array( $this->trigger, 'on_order_status_changed' )
+			),
+			'woocommerce_order_status_changed hook should be registered'
+		);
+	}
+
+	/**
+	 * @testdox Should add a notification when a new order has a notifiable status.
+	 */
+	public function test_on_new_order_adds_notification_for_notifiable_status(): void {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_status' )->willReturn( 'processing' );
+
+		$this->trigger->on_new_order( 1, $order );
+
+		$this->assertSame( 1, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should not add a notification when a new order has a non-notifiable status.
+	 */
+	public function test_on_new_order_ignores_non_notifiable_status(): void {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_status' )->willReturn( 'pending' );
+
+		$this->trigger->on_new_order( 1, $order );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should add a notification when order status changes to a notifiable status.
+	 */
+	public function test_on_order_status_changed_adds_notification_for_notifiable_status(): void {
+		$order = $this->createMock( WC_Order::class );
+
+		$this->trigger->on_order_status_changed( 1, 'pending', 'processing', $order );
+
+		$this->assertSame( 1, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should not add a notification when order status changes to a non-notifiable status.
+	 */
+	public function test_on_order_status_changed_ignores_non_notifiable_status(): void {
+		$order = $this->createMock( WC_Order::class );
+
+		$this->trigger->on_order_status_changed( 1, 'pending', 'cancelled', $order );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should deduplicate notifications for the same order across hooks.
+	 */
+	public function test_same_order_deduplicated_across_hooks(): void {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_status' )->willReturn( 'processing' );
+
+		$this->trigger->on_new_order( 1, $order );
+		$this->trigger->on_order_status_changed( 1, 'pending', 'processing', $order );
+
+		$this->assertSame( 1, $this->store->count(), 'Same order should be deduplicated' );
+	}
+
+	/**
+	 * @testdox Should accept all notifiable statuses.
+	 * @dataProvider notifiable_statuses_provider
+	 *
+	 * @param string $status The order status.
+	 */
+	public function test_all_notifiable_statuses_accepted( string $status ): void {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_status' )->willReturn( $status );
+
+		$this->trigger->on_new_order( 1, $order );
+
+		$this->assertSame( 1, $this->store->count(), "Status '$status' should be notifiable" );
+	}
+
+	/**
+	 * Data provider for all notifiable statuses.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function notifiable_statuses_provider(): array {
+		return array(
+			'processing'      => array( 'processing' ),
+			'on-hold'         => array( 'on-hold' ),
+			'completed'       => array( 'completed' ),
+			'pre-order'       => array( 'pre-order' ),
+			'pre-ordered'     => array( 'pre-ordered' ),
+			'partial-payment' => array( 'partial-payment' ),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -105,6 +105,17 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not add a notification when order status changes between two notifiable statuses.
+	 */
+	public function test_status_change_between_notifiable_statuses_is_ignored(): void {
+		$order = $this->createMock( WC_Order::class );
+
+		$this->trigger->on_order_status_changed( 1, 'processing', 'completed', $order );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
 	 * @testdox Should not add a notification when order status changes to a non-notifiable status.
 	 */
 	public function test_on_order_status_changed_ignores_non_notifiable_status(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -59,88 +59,34 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should register the woocommerce_new_order hook.
+	 * @testdox Should add a notification when a new order is created with a notifiable status.
 	 */
-	public function test_register_adds_new_order_hook(): void {
-		$this->assertNotFalse(
-			has_action(
-				'woocommerce_new_order',
-				array( $this->trigger, 'on_new_order' )
-			),
-			'woocommerce_new_order hook should be registered'
-		);
+	public function test_new_order_with_notifiable_status_adds_notification(): void {
+		wc_create_order( array( 'status' => 'processing' ) );
+
+		$this->assertSame( 1, $this->store->count(), 'Exactly one notification should be stored even though both hooks fire' );
 	}
 
 	/**
-	 * @testdox Should register the woocommerce_order_status_changed hook.
+	 * @testdox Should not add a notification when a new order is created with a non-notifiable status.
 	 */
-	public function test_register_adds_status_changed_hook(): void {
-		$this->assertNotFalse(
-			has_action(
-				'woocommerce_order_status_changed',
-				array( $this->trigger, 'on_order_status_changed' )
-			),
-			'woocommerce_order_status_changed hook should be registered'
-		);
-	}
-
-	/**
-	 * @testdox Should add a notification when a new order has a notifiable status.
-	 */
-	public function test_on_new_order_adds_notification_for_notifiable_status(): void {
-		$order = $this->createMock( WC_Order::class );
-		$order->method( 'get_status' )->willReturn( 'processing' );
-
-		$this->trigger->on_new_order( 1, $order );
-
-		$this->assertSame( 1, $this->store->count() );
-	}
-
-	/**
-	 * @testdox Should not add a notification when a new order has a non-notifiable status.
-	 */
-	public function test_on_new_order_ignores_non_notifiable_status(): void {
-		$order = $this->createMock( WC_Order::class );
-		$order->method( 'get_status' )->willReturn( 'pending' );
-
-		$this->trigger->on_new_order( 1, $order );
+	public function test_new_order_with_non_notifiable_status_is_ignored(): void {
+		wc_create_order( array( 'status' => 'pending' ) );
 
 		$this->assertSame( 0, $this->store->count() );
 	}
 
 	/**
-	 * @testdox Should add a notification when order status changes to a notifiable status.
+	 * @testdox Should add a notification when an order status changes to a notifiable status.
 	 */
-	public function test_on_order_status_changed_adds_notification_for_notifiable_status(): void {
-		$order = $this->createMock( WC_Order::class );
+	public function test_status_change_to_notifiable_adds_notification(): void {
+		$order = wc_create_order( array( 'status' => 'pending' ) );
+		$this->assertSame( 0, $this->store->count() );
 
-		$this->trigger->on_order_status_changed( 1, 'pending', 'processing', $order );
+		$order->set_status( 'processing' );
+		$order->save();
 
 		$this->assertSame( 1, $this->store->count() );
-	}
-
-	/**
-	 * @testdox Should not add a notification when order status changes to a non-notifiable status.
-	 */
-	public function test_on_order_status_changed_ignores_non_notifiable_status(): void {
-		$order = $this->createMock( WC_Order::class );
-
-		$this->trigger->on_order_status_changed( 1, 'pending', 'cancelled', $order );
-
-		$this->assertSame( 0, $this->store->count() );
-	}
-
-	/**
-	 * @testdox Should deduplicate notifications for the same order across hooks.
-	 */
-	public function test_same_order_deduplicated_across_hooks(): void {
-		$order = $this->createMock( WC_Order::class );
-		$order->method( 'get_status' )->willReturn( 'processing' );
-
-		$this->trigger->on_new_order( 1, $order );
-		$this->trigger->on_order_status_changed( 1, 'pending', 'processing', $order );
-
-		$this->assertSame( 1, $this->store->count(), 'Same order should be deduplicated' );
 	}
 
 	/**
@@ -156,6 +102,17 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 		$this->trigger->on_new_order( 1, $order );
 
 		$this->assertSame( 1, $this->store->count(), "Status '$status' should be notifiable" );
+	}
+
+	/**
+	 * @testdox Should not add a notification when order status changes to a non-notifiable status.
+	 */
+	public function test_on_order_status_changed_ignores_non_notifiable_status(): void {
+		$order = $this->createMock( WC_Order::class );
+
+		$this->trigger->on_order_status_changed( 1, 'pending', 'cancelled', $order );
+
+		$this->assertSame( 0, $this->store->count() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the NewReviewNotificationTrigger class.
+ */
+class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
+	/**
+	 * An instance of NewReviewNotificationTrigger.
+	 *
+	 * @var NewReviewNotificationTrigger
+	 */
+	private $trigger;
+
+	/**
+	 * The notification store used by the trigger.
+	 *
+	 * @var PendingNotificationStore
+	 */
+	private $store;
+
+	/**
+	 * A test product ID.
+	 *
+	 * @var int
+	 */
+	private int $product_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->store = new PendingNotificationStore();
+		$this->store->register();
+
+		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
+		wc_get_container()->reset_all_resolved();
+
+		$this->trigger = new NewReviewNotificationTrigger();
+		$this->trigger->init( $this->store );
+		$this->trigger->register();
+
+		$product          = WC_Helper_Product::create_simple_product();
+		$this->product_id = $product->get_id();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_action( 'comment_post', array( $this->trigger, 'on_comment_post' ) );
+		remove_action( 'shutdown', array( $this->store, 'dispatch_all' ) );
+
+		$this->reset_container_replacements();
+		wc_get_container()->reset_all_resolved();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should register the comment_post hook.
+	 */
+	public function test_register_adds_comment_post_hook(): void {
+		$this->assertNotFalse(
+			has_action(
+				'comment_post',
+				array( $this->trigger, 'on_comment_post' )
+			),
+			'comment_post hook should be registered'
+		);
+	}
+
+	/**
+	 * @testdox Should add a notification for an approved product review.
+	 */
+	public function test_adds_notification_for_approved_review(): void {
+		$commentdata = $this->build_review_data( $this->product_id );
+		$comment_id  = wp_insert_comment( $commentdata );
+
+		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+
+		$this->assertSame( 1, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should add a notification for an unapproved product review.
+	 */
+	public function test_adds_notification_for_unapproved_review(): void {
+		$commentdata = $this->build_review_data( $this->product_id );
+		$comment_id  = wp_insert_comment( $commentdata );
+
+		$this->trigger->on_comment_post( $comment_id, 0, $commentdata );
+
+		$this->assertSame( 1, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should not add a notification for a spam review.
+	 */
+	public function test_ignores_spam_review(): void {
+		$commentdata = $this->build_review_data( $this->product_id );
+		$comment_id  = wp_insert_comment( $commentdata );
+
+		$this->trigger->on_comment_post( $comment_id, 'spam', $commentdata );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should not add a notification for a regular comment that is not a review.
+	 */
+	public function test_ignores_non_review_comment(): void {
+		$commentdata = array(
+			'comment_post_ID'  => $this->product_id,
+			'comment_author'   => 'test',
+			'comment_content'  => 'A regular comment.',
+			'comment_approved' => 1,
+			'comment_type'     => '',
+		);
+		$comment_id  = wp_insert_comment( $commentdata );
+
+		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @testdox Should not add a notification for a review on a non-product post.
+	 */
+	public function test_ignores_review_on_non_product(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'A blog post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$commentdata = array(
+			'comment_post_ID'  => $post_id,
+			'comment_author'   => 'test',
+			'comment_content'  => 'A review on a blog post.',
+			'comment_approved' => 1,
+			'comment_type'     => 'review',
+		);
+		$comment_id  = wp_insert_comment( $commentdata );
+
+		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+
+		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * Builds the comment data array for a product review.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return array The comment data.
+	 */
+	private function build_review_data( int $product_id ): array {
+		return array(
+			'comment_post_ID'  => $product_id,
+			'comment_author'   => 'Test Reviewer',
+			'comment_content'  => 'Great product!',
+			'comment_approved' => 1,
+			'comment_type'     => 'review',
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
@@ -48,7 +48,6 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 
 		$this->trigger = new NewReviewNotificationTrigger();
 		$this->trigger->init( $this->store );
-		$this->trigger->register();
 
 		$product          = WC_Helper_Product::create_simple_product();
 		$this->product_id = $product->get_id();
@@ -71,6 +70,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 	 * @testdox Should register the comment_post hook.
 	 */
 	public function test_register_adds_comment_post_hook(): void {
+		$this->trigger->register();
+
 		$this->assertNotFalse(
 			has_action(
 				'comment_post',
@@ -85,9 +86,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 	 */
 	public function test_adds_notification_for_approved_review(): void {
 		$commentdata = $this->build_review_data( $this->product_id );
-		$comment_id  = wp_insert_comment( $commentdata );
 
-		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+		$this->trigger->on_comment_post( 1, 1, $commentdata );
 
 		$this->assertSame( 1, $this->store->count() );
 	}
@@ -97,9 +97,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 	 */
 	public function test_adds_notification_for_unapproved_review(): void {
 		$commentdata = $this->build_review_data( $this->product_id );
-		$comment_id  = wp_insert_comment( $commentdata );
 
-		$this->trigger->on_comment_post( $comment_id, 0, $commentdata );
+		$this->trigger->on_comment_post( 1, 0, $commentdata );
 
 		$this->assertSame( 1, $this->store->count() );
 	}
@@ -109,9 +108,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 	 */
 	public function test_ignores_spam_review(): void {
 		$commentdata = $this->build_review_data( $this->product_id );
-		$comment_id  = wp_insert_comment( $commentdata );
 
-		$this->trigger->on_comment_post( $comment_id, 'spam', $commentdata );
+		$this->trigger->on_comment_post( 1, 'spam', $commentdata );
 
 		$this->assertSame( 0, $this->store->count() );
 	}
@@ -127,9 +125,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 			'comment_approved' => 1,
 			'comment_type'     => '',
 		);
-		$comment_id  = wp_insert_comment( $commentdata );
 
-		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+		$this->trigger->on_comment_post( 1, 1, $commentdata );
 
 		$this->assertSame( 0, $this->store->count() );
 	}
@@ -153,9 +150,8 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 			'comment_approved' => 1,
 			'comment_type'     => 'review',
 		);
-		$comment_id  = wp_insert_comment( $commentdata );
 
-		$this->trigger->on_comment_post( $comment_id, 1, $commentdata );
+		$this->trigger->on_comment_post( 1, 1, $commentdata );
 
 		$this->assertSame( 0, $this->store->count() );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
@@ -46,8 +46,7 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
 		wc_get_container()->reset_all_resolved();
 
-		$this->trigger = new NewReviewNotificationTrigger();
-		$this->trigger->init( $this->store );
+		$this->trigger = new NewReviewNotificationTrigger( $this->store );
 
 		$product          = WC_Helper_Product::create_simple_product();
 		$this->product_id = $product->get_id();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-1795
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change adds the notification triggers that will be used to push notifications to the `PendingNotificationStore`.

**Key requirements:**
* Add `NewReviewNotificationTrigger` which will be used to generate a review notification payload
* Add `NewOrderNotificationTrigger` which will be used to generate an order notification payload
* Register the triggers in `PushNotifications` to add the hooks

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
These new files are not yet used so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack installed and connected
- You have at least 2 test users with `shop_manager` or `administrator` roles
- You have a tool to make HTTP requests (e.g. Postman, curl, or browser REST client)
- You are authenticated as one of your test users when making requests

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

#### 1. Create token

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "en_US"
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID
* Note this ID for later scenarios

#### 2. Update token

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Use the same device_uuid from scenario 1 but with a different token value:

Request body:
```
{
  "token": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
  "platform": "apple",
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce",
  "device_locale": "en_US"
}
```

**Expected result:**
- Status: 201 Created
- Response contains an id field with the updated token ID

#### 3. Delete tokens

Endpoint: `DELETE /wp-json/wc-push-notifications/push-tokens/{id}`

Use the token ID from scenario 1

**Expected result:**
- Status: 204 No Content
- No response body

Try to delete the same token ID again

**Expected result:**
- Status: 404 Not Found
- Error message: "Push token could not be found."

#### 4. Other

- Ensure your WooCommerce install functions as expected, e.g.:
  - Add a product to cart
  - View WooCommerce settings in WP Admin
  - View WooCommerce orders in WP Admin
- Make an authenticated request to the API to ensure this works as expected, e.g.:
  - https://YOUR_URL/wp-json/wc-admin/features
  - https://YOUR_URL/wp-json/wc/v3/settings
  - https://YOUR_URL/wp-json/wc/v3/customers


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
