### PR TITLE
Fix free shipping min amount when stored with comma decimal

### DIFF
--- a/plugins/woocommerce/changelog/63458-fix-56852-free-shipping-min-amount-locale
+++ b/plugins/woocommerce/changelog/63458-fix-56852-free-shipping-min-amount-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix free shipping minimum order amount when stored with comma decimal separator.

--- a/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -186,7 +186,9 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 
 			$total = NumberUtil::round( $total, wc_get_price_decimals() );
 
-			if ( $total >= $this->min_amount ) {
+			// Convert to number for comparison (value may be locale-formatted in DB).
+			$min_amount = '' !== $this->min_amount ? (float) wc_format_decimal( $this->min_amount ) : 0.0;
+			if ( $total >= $min_amount ) {
 				$has_met_min_amount = true;
 			}
 		}

--- a/plugins/woocommerce/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
@@ -200,7 +200,9 @@ class WC_Shipping_Legacy_Free_Shipping extends WC_Shipping_Method {
 				$total = NumberUtil::round( $total - WC()->cart->get_discount_total(), wc_get_price_decimals() );
 			}
 
-			if ( $total >= $this->min_amount ) {
+			// Convert to number for comparison (value may be locale-formatted in DB).
+			$min_amount = '' !== $this->min_amount ? (float) wc_format_decimal( $this->min_amount ) : 0.0;
+			if ( $total >= $min_amount ) {
 				$has_met_min_amount = true;
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -208,4 +208,42 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * @testdox Free shipping min_amount works when stored with comma decimal (e.g. "100,00").
+	 */
+	public function test_free_shipping_min_amount_compared_numerically_with_locale_formatted_value(): void {
+		$saved_decimal_sep = get_option( 'woocommerce_price_decimal_sep' );
+		update_option( 'woocommerce_price_decimal_sep', ',' );
+
+		$method = new WC_Shipping_Free_Shipping( 1 );
+		$method->requires   = 'min_amount';
+		$method->min_amount = '100,00';
+
+		$package = array(
+			'contents'    => array(),
+			'destination' => array(
+				'country'  => 'US',
+				'state'    => '',
+				'postcode' => '',
+				'city'     => '',
+			),
+		);
+
+		WC()->cart->empty_cart();
+		$product = WC_Helper_Product::create_simple_product( true, array( 'price' => 100, 'regular_price' => 100 ) );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$this->assertTrue( $method->is_available( $package ) );
+
+		WC()->cart->empty_cart();
+		$cheap_product = WC_Helper_Product::create_simple_product( true, array( 'price' => 99, 'regular_price' => 99 ) );
+		WC()->cart->add_to_cart( $cheap_product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$this->assertFalse( $method->is_available( $package ) );
+
+		update_option( 'woocommerce_price_decimal_sep', $saved_decimal_sep );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes the free shipping minimum order check when the threshold is stored with a comma as decimal separator (e.g. "100,00"). In that case the code was comparing a number to a string, so PHP did string comparison and free shipping could show or hide incorrectly.

We now convert `min_amount` to a number with `wc_format_decimal()` before comparing to the cart total. Same change in both the main free shipping class and the legacy one. Existing data in the DB is handled correctly either way.

Closes #56852.

### Screenshots or screen recordings:

No UI change. N/A.

### How to test the changes in this Pull Request:

1. In WooCommerce settings, set the decimal separator to comma.
2. Add a free shipping method with "A minimum order amount" and minimum order amount 100 (any currency).
3. Confirm checkout shows free shipping when cart total is 100.
4. In Shipping zones, edit that free shipping method. The field will show "100,00". Save without changing anything.
5. Reload checkout with cart total 100. Free shipping should still be offered. With cart total 99 it should not be offered.

### Testing that has already taken place:

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix free shipping minimum order amount when stored with comma decimal separator.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>