### PR TITLE
Fix customer note email preview text and newline support

### DIFF
--- a/plugins/woocommerce/changelog/stomail-7827-fix-customer-note-email-preview-and-newlines
+++ b/plugins/woocommerce/changelog/stomail-7827-fix-customer-note-email-preview-and-newlines
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix customer note email preview using wrong note text and missing newline support in admin order note personalization tag.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -216,7 +216,7 @@ class EmailPreview {
 		} else {
 			$object = $this->get_dummy_order();
 			if ( 'WC_Email_Customer_Note' === $email_type ) {
-				$this->email->customer_note = $object->get_customer_note();
+				$this->email->customer_note = __( "This is an order note sent from the Admin to the customer during fulfillment when you add a new Order Note and choose to send it to the customer.\n\nIt can be multiple lines.", 'woocommerce' );
 			}
 			if ( 'WC_Email_Customer_Refunded_Order' === $email_type ) {
 				$this->email->partial_refund = false;

--- a/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
@@ -105,7 +105,7 @@ class StoreTagsProvider extends AbstractTagProvider {
 				__( 'Store', 'woocommerce' ),
 				function ( array $context ): string {
 					if ( isset( $context['wc_email'], $context['wc_email']->customer_note ) ) {
-						return wptexturize( $context['wc_email']->customer_note );
+						return nl2br( wptexturize( $context['wc_email']->customer_note ) );
 					}
 					return '';
 				},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes two issues with the "Customer note added" block email (STOMAIL-7827):

1. **Newline support in admin order note personalization tag**: The `woocommerce/admin-order-note` personalization tag callback in `StoreTagsProvider` now wraps the output with `nl2br()` so that multi-line customer notes render with proper `<br>` line breaks in the email instead of collapsing into a single paragraph.

2. **Correct preview text for customer note email**: There are two different "customer notes" on an order that are easy to confuse:
   - **`$order->get_customer_note()`** — the checkout note a *shopper* writes to the *store* (e.g., "Please gift wrap this"). This lives on the `WC_Order` object.
   - **`$email->customer_note`** — the admin fulfillment note a *store manager* writes to the *customer* (e.g., "Your package shipped via FedEx"). This is passed as an argument to `WC_Email_Customer_Note::trigger()` at send time and stored on the email object, **not** on the order.

   In preview mode, `trigger()` is never called — there's no real order event — so `$email->customer_note` would be empty. The dummy order's `get_customer_note()` contains the *shopper's* checkout note, which is the wrong context entirely for this email. We set `$email->customer_note` directly with a descriptive admin-to-customer text so the preview accurately represents what the email will look like when a store manager sends a customer note.

Closes https://linear.app/a8c/issue/STOMAIL-7827

Before | After
---- | ----
<img width="658" height="570" alt="Screenshot 2026-02-26 at 2 26 58 PM" src="https://github.com/user-attachments/assets/ecc71937-3b45-4f4d-a049-6f32d3c3ee72" /> | <img width="758" height="631" alt="Screenshot 2026-02-26 at 2 23 37 PM" src="https://github.com/user-attachments/assets/4aea1d1b-f35c-4543-8396-155acc6613a2" />
<img width="1022" height="711" alt="Screenshot 2026-02-26 at 2 27 18 PM" src="https://github.com/user-attachments/assets/d59562d9-716b-450e-8baa-38e718bda770" /> | <img width="1002" height="800" alt="Screenshot 2026-02-26 at 2 25 32 PM" src="https://github.com/user-attachments/assets/646e4749-9674-439f-9cb6-aa5fd30e9c28" />



### How to test the changes in this Pull Request:

1. Enable the block email editor feature at WP Admin → WooCommerce → Settings → Advanced → Features.
2. Go to WooCommerce → Settings → Email and open the "Customer note" email template in the block editor.
3. Click "Send preview email" or use the preview panel.
4. **Verify the preview note text** — it should say something like "This is an order note sent from the Admin to the customer during fulfillment..." (not the checkout customer note).
5. Create a test order, then add a customer note with multiple lines (e.g. "Line one\nLine two\nLine three") and check "Send to customer".
6. **Verify the received email** renders the note with proper line breaks (each line on its own line, not collapsed into one paragraph).

### Testing that has already taken place:

- Manual testing in local wp-env environment with Mailpit
- Verified rendered email HTML shows `<br />` tags for newlines in the customer note
- Verified preview email shows the corrected admin→customer note text
- PHP linting passed (`pnpm lint:php:changes`)
- PHPStan analysis passed on both modified files

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry was created manually via `plugins/woocommerce/changelog/stomail-7827-fix-customer-note-email-preview-and-newlines`.