### PR TITLE
Render template overrides as individual rows in system status report

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/system-status.js
+++ b/plugins/woocommerce/client/legacy/js/admin/system-status.js
@@ -36,7 +36,7 @@ jQuery( function ( $ ) {
 		generateReport: function() {
 			var report = '';
 
-			$( '.wc_status_table thead, .wc_status_table tbody' ).each( function() {
+			$( '.wc_status_table thead, .wc_status_table tbody, .wc_status_table tfoot' ).each( function() {
 				if ( $( this ).is( 'thead' ) ) {
 					var label = $( this ).find( 'th:eq(0)' ).data( 'exportLabel' ) || $( this ).text();
 					report = report + '\n### ' + label.trim() + ' ###\n\n';
@@ -66,7 +66,11 @@ jQuery( function ( $ ) {
 							the_value = temp_line;
 						}
 
-						report = report + '' + the_name + ': ' + the_value + '\n';
+						if ( the_name || the_value ) {
+							report = report + '' + the_name + ': ' + the_value + '\n';
+						} else {
+							report = report + '\n';
+						}
 					});
 				}
 			});

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -1048,41 +1048,39 @@ if ( 0 < $mu_plugins_count ) :
 		</tr>
 		<?php endif ?>
 		<?php if ( ! empty( $theme['overrides'] ) ) : ?>
+			<?php foreach ( $theme['overrides'] as $i => $override ) : ?>
 			<tr>
-				<td data-export-label="Overrides"><?php esc_html_e( 'Overrides', 'woocommerce' ); ?></td>
-				<td class="help">&nbsp;</td>
-				<td>
-					<?php
-					$total_overrides = is_countable( $theme['overrides'] ) ? count( $theme['overrides'] ) : 0;
-					for ( $i = 0; $i < $total_overrides; $i++ ) {
-						$override = $theme['overrides'][ $i ];
-						if ( $override['core_version'] && '' === $override['version'] ) {
-							printf(
-								/* Translators: %1$s: Template name, %2$s: Core version. */
-								esc_html__( '%1$s - version header is missing. The core version is %2$s', 'woocommerce' ),
-								'<code>' . esc_html( $override['file'] ) . '</code>',
-								esc_html( $override['core_version'] )
-							);
-						} elseif ( $override['core_version'] && version_compare( $override['version'], $override['core_version'], '<' ) ) {
-							printf(
-								/* Translators: %1$s: Template name, %2$s: Template version, %3$s: Core version. */
-								esc_html__( '%1$s version %2$s is out of date. The core version is %3$s', 'woocommerce' ),
-								'<code>' . esc_html( $override['file'] ) . '</code>',
-								'<strong style="color:red">' . esc_html( $override['version'] ) . '</strong>',
-								esc_html( $override['core_version'] )
-							);
-						} else {
-							echo '<code>' . esc_html( $override['file'] ) . '</code>';
-						}
-
-						if ( ( $total_overrides - 1 ) !== $i ) {
-							echo ', ';
-						}
-						echo '<br />';
-					}
-					?>
+				<td data-export-label="Override">
+					<?php if ( 0 === $i ) : ?>
+						<?php esc_html_e( 'Overrides', 'woocommerce' ); ?>:
+					<?php endif; ?>
 				</td>
+				<td class="help">&nbsp;</td>
+				<?php
+				echo '<td>';
+				echo '<code>' . esc_html( $override['file'] ) . '</code>';
+				if ( $override['core_version'] && '' === $override['version'] ) {
+					echo ' <br><mark class="error"><span class="dashicons dashicons-warning"></span> ';
+					printf(
+						/* Translators: %s: Core version. */
+						esc_html__( 'Version header is missing. The core version is %s', 'woocommerce' ),
+						'<strong>' . esc_html( $override['core_version'] ) . '</strong>'
+					);
+					echo '</mark>';
+				} elseif ( $override['core_version'] && version_compare( $override['version'], $override['core_version'], '<' ) ) {
+					echo ' <br><mark class="error"><span class="dashicons dashicons-warning"></span> ';
+					printf(
+						/* Translators: %1$s: Template version, %2$s: Core version. */
+						esc_html__( 'Version %1$s is out of date. The core version is %2$s', 'woocommerce' ),
+						'<strong>' . esc_html( $override['version'] ) . '</strong>',
+						'<strong>' . esc_html( $override['core_version'] ) . '</strong>'
+					);
+					echo '</mark>';
+				}
+				echo '</td>';
+				?>
 			</tr>
+			<?php endforeach; ?>
 		<?php else : ?>
 			<tr>
 				<td data-export-label="Overrides"><?php esc_html_e( 'Overrides', 'woocommerce' ); ?>:</td>
@@ -1090,30 +1088,31 @@ if ( 0 < $mu_plugins_count ) :
 				<td>&ndash;</td>
 			</tr>
 		<?php endif; ?>
-
-		<?php if ( true === $theme['has_outdated_templates'] ) : ?>
-			<tr>
-				<td data-export-label="Outdated Templates"><?php esc_html_e( 'Outdated templates', 'woocommerce' ); ?>:</td>
-				<td class="help">&nbsp;</td>
-				<td>
-					<mark class="error">
-						<span class="dashicons dashicons-warning"></span>
-					</mark>
-					<span class="private">
-						<a href="https://developer.woocommerce.com/docs/theming/theme-development/fixing-outdated-woocommerce-templates/" target="_blank">
-							<?php esc_html_e( 'Learn how to update', 'woocommerce' ); ?>
-						</a> |
-						<mark class="info">
-							<span class="dashicons dashicons-info"></span>
-						</mark>
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=tools' ) ); ?>">
-							<?php esc_html_e( 'Clear system status theme info cache', 'woocommerce' ); ?>
-						</a>
-					</span>
-				</td>
-			</tr>
-		<?php endif; ?>
 	</tbody>
+	<?php if ( true === $theme['has_outdated_templates'] ) : ?>
+	<tfoot>
+		<tr>
+			<td data-export-label="Outdated Templates"><?php esc_html_e( 'Outdated templates', 'woocommerce' ); ?>:</td>
+			<td class="help">&nbsp;</td>
+			<td>
+				<mark class="error">
+					<span class="dashicons dashicons-warning"></span>
+				</mark>
+				<span class="private">
+					<a href="https://developer.woocommerce.com/docs/theming/theme-development/fixing-outdated-woocommerce-templates/" target="_blank">
+						<?php esc_html_e( 'Learn how to update', 'woocommerce' ); ?>
+					</a> |
+					<mark class="info">
+						<span class="dashicons dashicons-info"></span>
+					</mark>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=tools' ) ); ?>">
+						<?php esc_html_e( 'Clear system status theme info cache', 'woocommerce' ); ?>
+					</a>
+				</span>
+			</td>
+		</tr>
+	</tfoot>
+	<?php endif; ?>
 </table>
 
 <?php


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Replaces the comma-separated list of template overrides in WooCommerce > Status with individual table rows for improved readability and scannability.

**Overrides layout:**
- Each override gets its own `<tr>` with the "Overrides:" label on the first row
- File path displayed in `<code>` in the wide value column (no more wrapping in the narrow label column)
- Error states (missing version header, outdated) show a `<mark class="error">` + dashicon warning on a second line within the same cell, matching existing patterns elsewhere on the page
- Up-to-date overrides show just the file path with no icon
- Version numbers are bold for easy comparison

**"Templates up to date" row:**
- Moved from `<tbody>` into `<tfoot>` for visual border separation from the override list

**Text export (system-status.js):**
- Added `tfoot` to the export selector so the "Templates up to date" row is included
- Empty rows now output a blank line instead of an orphaned `: `
- Each override exports cleanly as `Override: path/to/file.php` with inline status text

Depends on #63460.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Comma-separated list crammed into a single cell | Individual rows with status icons per override |

### How to test the changes in this Pull Request:

1. Create template overrides in three states:
   - **Up to date**: Copy a WooCommerce template and keep the `@version` matching core
   - **Missing version header**: Copy a template and remove the `@version` line
   - **Outdated**: Copy a template and set `@version` to a lower value than core
2. Navigate to **WooCommerce > Status**
3. Verify each override appears on its own row with:
   - Up-to-date: just the file path, no icon
   - Missing version: file path + warning icon with "Version header is missing" text
   - Outdated: file path + warning icon with "Version X is out of date" text, both versions bold
4. Verify "Templates up to date" row appears in `<tfoot>` with a visible border separating it from the overrides
5. Click **Get system report** → **Copy for support** and verify the text export:
   - Each override on its own line: `Override: path/to/file.php`
   - Error overrides include status text inline: `Override: path/to/file.php ❌ Version...`
   - "Templates up to date" row is present
6. Verify the no-overrides state still shows `Overrides: –`

### Testing that has already taken place:

Manually tested all three override states (up to date, missing version header, outdated) in both the visual rendering and text export. Verified the no-overrides fallback. Confirmed PHP syntax check and PHPCS linting pass clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Update - Update existing functionality

#### Message
Render template overrides as individual rows in the System Status report for improved readability.

</details>