### PR TITLE
Standardize support text in block email templates

### DIFF
--- a/plugins/woocommerce/changelog/63463-fix-standardize-block-email-support-text
+++ b/plugins/woocommerce/changelog/63463-fix-standardize-block-email-support-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Standardize closing support text across all customer-facing block email templates.

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -6,7 +6,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -45,6 +45,6 @@ printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-printf( esc_html__( 'We hope to see you again soon.', 'woocommerce' ) );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-failed-order.php
@@ -56,6 +56,6 @@ defined( 'ABSPATH' ) || exit;
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-printf( esc_html__( 'If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-created.php
@@ -39,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
-echo esc_html__( 'Please note that couriers may need some time to provide the latest shipping information.', 'woocommerce' );
+/* translators: %s: Store admin email */
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-deleted.php
@@ -39,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
-echo esc_html__( 'If you have any questions or notice anything unexpected, feel free to reach out to our support team through your account or reply to this email.', 'woocommerce' );
+/* translators: %s: Store admin email */
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
@@ -45,6 +45,7 @@ defined( 'ABSPATH' ) || exit;
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
-echo esc_html__( 'If anything looks off or you have questions, feel free to contact our support team.', 'woocommerce' );
+/* translators: %s: Store admin email */
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/block/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-note.php
+++ b/plugins/woocommerce/templates/emails/block/customer-note.php
@@ -57,6 +57,6 @@ defined( 'ABSPATH' ) || exit;
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-partially-refunded-order.php
@@ -55,6 +55,6 @@ printf( esc_html__( 'Your order from %s has been partially refunded.', 'woocomme
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-printf( esc_html__( 'If you need any help with your order, please contact us at %s', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -49,6 +49,6 @@ defined( 'ABSPATH' ) || exit;
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -55,6 +55,6 @@ printf( esc_html__( 'Your order from %s has been refunded.', 'woocommerce' ), '<
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php
 /* translators: %s: Store admin email */
-printf( esc_html__( 'If you need any help with your order, please contact us at %s', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Standardize the closing support text across all customer-facing block email templates to a consistent message:

> "Thanks again! If you need any help with your order, please contact us at {store email}."

Previously, each template had different closing text (e.g. "We hope to see you again soon", "If anything looks off…", "Please note that couriers may need some time…"). This unifies them per the design spec.

Closes https://linear.app/a8c/issue/WOOPRD-2478

### How to test the changes in this Pull Request:

Enable the **block email editor** feature flag at:
   `WP Admin → WooCommerce → Settings → Advanced → Features`
   (check "Block email editor" and save).


Reset existing email templates: Reset templates first:

```sh
pnpm --filter=@woocommerce/plugin-woocommerce -- wp-env run cli bash -c "wp post delete \$(wp post list --post_type=woo_email --format=ids) --force && wp transient delete wc_email_editor_initial_templates_generated"
```

Then visit any WooCommerce admin page — the templates will be regenerated from the updated PHP files.

Create a test order (WP Admin → WooCommerce → Orders → Add new) with a customer that has an email address, then trigger email and verify the closing paragraph in Mailpit.

- The closing paragraph reads exactly: **"Thanks again! If you need any help with your order, please contact us at {store admin email}."** (ending with a period, not a comma)
- The `{store admin email}` placeholder is replaced with the actual store admin email address
- No leftover old copy (e.g. "We hope to see you again soon", "If anything looks off…", etc.)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Update - Update existing functionality

#### Message
Standardize closing support text across all customer-facing block email templates.

</details>
