### PR TITLE
In-App Marketplace: improve Discover page events

### DIFF
--- a/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
@@ -78,10 +78,11 @@ export default function Discover(): JSX.Element | null {
 			.finally( () => {
 				setIsLoading( false );
 			} );
-	}, [] );
+	}, [ setIsLoading ] );
 
 	useEffect( () => {
 		if (
+			isLoading ||
 			! productGroups.length ||
 			! ( 'IntersectionObserver' in window )
 		) {
@@ -135,7 +136,7 @@ export default function Discover(): JSX.Element | null {
 		return () => {
 			observer.disconnect();
 		};
-	}, [ productGroups ] );
+	}, [ isLoading, productGroups ] );
 
 	if ( isLoading ) {
 		return (

--- a/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
@@ -25,14 +25,19 @@ export default function Discover(): JSX.Element | null {
 	function recordTracksEvent( products: ProductGroup[] ) {
 		const product_ids = products
 			.flatMap( ( group ) => group.items )
-			.map( ( product ) => {
-				return product.id;
-			} );
+			.map( ( product ) => product.id );
+		const utm_groups = Object.fromEntries(
+			products.map( ( group ) => [
+				group.id,
+				group.items.map( ( product ) => product.id ),
+			] )
+		);
 
 		// This is a new event specific to the Discover tab, added with Woo 8.4.
 		recordEvent( 'marketplace_discover_viewed', {
 			view: 'discover',
 			product_ids,
+			utm_groups,
 		} );
 
 		// This is the new page view event added with Woo 8.3. It's improved with the marketplace_discover_viewed event

--- a/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
@@ -19,7 +19,6 @@ export default function Discover(): JSX.Element | null {
 	const [ productGroups, setProductGroups ] = useState<
 		Array< ProductGroup >
 	>( [] );
-	const seenGroups = useRef( new Set< string >() );
 	const groupElements = useRef< Record< string, HTMLDivElement | null > >(
 		{}
 	);
@@ -95,6 +94,7 @@ export default function Discover(): JSX.Element | null {
 				productGroup,
 			] )
 		);
+		const seenGroups = new Set< string >();
 
 		const observer = new IntersectionObserver(
 			( entries ) => {
@@ -106,7 +106,7 @@ export default function Discover(): JSX.Element | null {
 					const groupId = ( entry.target as HTMLDivElement ).dataset
 						.groupId;
 
-					if ( ! groupId || seenGroups.current.has( groupId ) ) {
+					if ( ! groupId || seenGroups.has( groupId ) ) {
 						return;
 					}
 
@@ -117,7 +117,7 @@ export default function Discover(): JSX.Element | null {
 					}
 
 					recordGroupViewedTrackEvent( group );
-					seenGroups.current.add( groupId );
+					seenGroups.add( groupId );
 					observer.unobserve( entry.target );
 				} );
 			},

--- a/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
@@ -19,7 +19,7 @@ export default function Discover(): JSX.Element | null {
 	const [ productGroups, setProductGroups ] = useState<
 		Array< ProductGroup >
 	>( [] );
-	const seenUtmGroups = useRef( new Set< string >() );
+	const seenGroups = useRef( new Set< string >() );
 	const groupElements = useRef< Record< string, HTMLDivElement | null > >(
 		{}
 	);
@@ -30,7 +30,7 @@ export default function Discover(): JSX.Element | null {
 		const product_ids = products
 			.flatMap( ( group ) => group.items )
 			.map( ( product ) => product.id );
-		const utm_groups = Object.fromEntries(
+		const groups = Object.fromEntries(
 			products.map( ( group ) => [
 				group.id,
 				group.items.map( ( product ) => product.id ),
@@ -41,7 +41,7 @@ export default function Discover(): JSX.Element | null {
 		recordEvent( 'marketplace_discover_viewed', {
 			view: 'discover',
 			product_ids,
-			utm_groups,
+			groups,
 		} );
 
 		// This is the new page view event added with Woo 8.3. It's improved with the marketplace_discover_viewed event
@@ -54,7 +54,7 @@ export default function Discover(): JSX.Element | null {
 	function recordGroupViewedTrackEvent( group: ProductGroup ) {
 		recordEvent( 'marketplace_discover_group_viewed', {
 			view: 'discover',
-			utm_group: group.id,
+			group_id: group.id,
 			product_ids: group.items.map( ( product ) => product.id ),
 		} );
 	}
@@ -103,21 +103,21 @@ export default function Discover(): JSX.Element | null {
 						return;
 					}
 
-					const utmGroup = ( entry.target as HTMLDivElement ).dataset
-						.utmGroup;
+					const groupId = ( entry.target as HTMLDivElement ).dataset
+						.groupId;
 
-					if ( ! utmGroup || seenUtmGroups.current.has( utmGroup ) ) {
+					if ( ! groupId || seenGroups.current.has( groupId ) ) {
 						return;
 					}
 
-					const group = productGroupsById.get( utmGroup );
+					const group = productGroupsById.get( groupId );
 
 					if ( ! group ) {
 						return;
 					}
 
 					recordGroupViewedTrackEvent( group );
-					seenUtmGroups.current.add( utmGroup );
+					seenGroups.current.add( groupId );
 					observer.unobserve( entry.target );
 				} );
 			},
@@ -163,7 +163,7 @@ export default function Discover(): JSX.Element | null {
 					groupURLType={ groups.url_type }
 					type={ groups.itemType }
 					cardType={ groups.cardType ?? ProductCardType.regular }
-					utmGroup={ groups.id }
+					groupId={ groups.id }
 					containerRef={ ( element ) => {
 						groupElements.current[ groups.id ] = element;
 					} }

--- a/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/discover/discover.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useContext, useEffect, useState } from '@wordpress/element';
+import { useContext, useEffect, useRef, useState } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -19,6 +19,10 @@ export default function Discover(): JSX.Element | null {
 	const [ productGroups, setProductGroups ] = useState<
 		Array< ProductGroup >
 	>( [] );
+	const seenUtmGroups = useRef( new Set< string >() );
+	const groupElements = useRef< Record< string, HTMLDivElement | null > >(
+		{}
+	);
 	const marketplaceContextValue = useContext( MarketplaceContext );
 	const { isLoading, setIsLoading } = marketplaceContextValue;
 
@@ -47,6 +51,14 @@ export default function Discover(): JSX.Element | null {
 		} );
 	}
 
+	function recordGroupViewedTrackEvent( group: ProductGroup ) {
+		recordEvent( 'marketplace_discover_group_viewed', {
+			view: 'discover',
+			utm_group: group.id,
+			product_ids: group.items.map( ( product ) => product.id ),
+		} );
+	}
+
 	// Get the content for this screen
 	useEffect( () => {
 		setIsLoading( true );
@@ -68,6 +80,62 @@ export default function Discover(): JSX.Element | null {
 				setIsLoading( false );
 			} );
 	}, [] );
+
+	useEffect( () => {
+		if (
+			! productGroups.length ||
+			! ( 'IntersectionObserver' in window )
+		) {
+			return;
+		}
+
+		const productGroupsById = new Map(
+			productGroups.map( ( productGroup ) => [
+				productGroup.id,
+				productGroup,
+			] )
+		);
+
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				entries.forEach( ( entry ) => {
+					if ( ! entry.isIntersecting ) {
+						return;
+					}
+
+					const utmGroup = ( entry.target as HTMLDivElement ).dataset
+						.utmGroup;
+
+					if ( ! utmGroup || seenUtmGroups.current.has( utmGroup ) ) {
+						return;
+					}
+
+					const group = productGroupsById.get( utmGroup );
+
+					if ( ! group ) {
+						return;
+					}
+
+					recordGroupViewedTrackEvent( group );
+					seenUtmGroups.current.add( utmGroup );
+					observer.unobserve( entry.target );
+				} );
+			},
+			{ threshold: 0.25 }
+		);
+
+		productGroups.forEach( ( group ) => {
+			const groupElement = groupElements.current[ group.id ];
+
+			if ( groupElement ) {
+				observer.observe( groupElement );
+			}
+		} );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ productGroups ] );
 
 	if ( isLoading ) {
 		return (
@@ -95,6 +163,10 @@ export default function Discover(): JSX.Element | null {
 					groupURLType={ groups.url_type }
 					type={ groups.itemType }
 					cardType={ groups.cardType ?? ProductCardType.regular }
+					utmGroup={ groups.id }
+					containerRef={ ( element ) => {
+						groupElements.current[ groups.id ] = element;
+					} }
 				/>
 			) ) }
 		</div>

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-list/product-list.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-list/product-list.tsx
@@ -15,7 +15,7 @@ interface ProductListProps {
 	cardType?: ProductCardType;
 	groupURLText: string | null;
 	groupURLType: 'wc-admin' | 'wp-admin' | 'external' | undefined; // types defined by Link component
-	utmGroup?: string;
+	groupId?: string;
 	containerRef?: ( element: HTMLDivElement | null ) => void;
 }
 
@@ -30,14 +30,14 @@ export default function ProductList( props: ProductListProps ): JSX.Element {
 		groupURLText,
 		groupURLType,
 		cardType,
-		utmGroup,
+		groupId,
 		containerRef,
 	} = props;
 
 	return (
 		<div
 			className="woocommerce-marketplace__product-list"
-			data-utm-group={ utmGroup }
+			data-group-id={ groupId }
 			ref={ containerRef }
 		>
 			<ProductListHeader

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-list/product-list.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-list/product-list.tsx
@@ -15,6 +15,8 @@ interface ProductListProps {
 	cardType?: ProductCardType;
 	groupURLText: string | null;
 	groupURLType: 'wc-admin' | 'wp-admin' | 'external' | undefined; // types defined by Link component
+	utmGroup?: string;
+	containerRef?: ( element: HTMLDivElement | null ) => void;
 }
 
 export default function ProductList( props: ProductListProps ): JSX.Element {
@@ -28,10 +30,16 @@ export default function ProductList( props: ProductListProps ): JSX.Element {
 		groupURLText,
 		groupURLType,
 		cardType,
+		utmGroup,
+		containerRef,
 	} = props;
 
 	return (
-		<div className="woocommerce-marketplace__product-list">
+		<div
+			className="woocommerce-marketplace__product-list"
+			data-utm-group={ utmGroup }
+			ref={ containerRef }
+		>
 			<ProductListHeader
 				title={ title }
 				groupURL={ groupURL }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- Add new prop for groups to `wcadmin_marketplace_discover_viewed`
- Add new event `wcadmin_marketplace_discover_group_viewed`

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WCCOM-2306

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<!-- Begin testing instructions -->
<img width="1915" height="1633" alt="image" src="https://github.com/user-attachments/assets/b4b626c7-6f2c-4593-9711-b7681d826fb7" />


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Checkout this branch and get a new build
2. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions, but turn on the JS console in dev tools and paste in `localStorage.setItem('debug', 'wc-admin:*')`
3. Refresh the page
4. Please note the `marketplace_discover_viewed` event. Confirm it now has `group` array as a prop. In this array, keys are the group id, and values are the products ids belonging to that group.
5. Also note the `wcadmin_marketplace_discover_group_viewed`. This firs whenever a group becomes visible on the page. Scroll down in the Discover page to fire this event for groups below the fold.
6. Please test around this issue.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Update Tracks events in the In-App Marketplace

</details>
