### PR TITLE
Fix prettier lint errors from E2E WP 7.0 compat PR

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/onboarding/onboarding-wizard.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/onboarding/onboarding-wizard.spec.ts
@@ -422,9 +422,13 @@ test.describe(
 			} );
 
 			await test.step( 'Clean up installed extensions', async () => {
-				const deactivateAndDeletePlugin = async ( slug: string ) => {
+				const deactivateAndDeletePlugin = async (
+					slug: string
+				) => {
 					await page.goto( 'wp-admin/plugins.php' );
-					const pluginRow = page.locator( `tr[data-slug="${ slug }"]` );
+					const pluginRow = page.locator(
+						`tr[data-slug="${ slug }"]`
+					);
 
 					// Skip if plugin is not present
 					if ( ! ( await pluginRow.isVisible() ) ) {
@@ -432,7 +436,10 @@ test.describe(
 					}
 
 					// Deactivate if active
-					const deactivateLink = pluginRow.getByRole( 'link', { name: 'Deactivate', exact: true } );
+					const deactivateLink = pluginRow.getByRole(
+						'link',
+						{ name: 'Deactivate', exact: true }
+					);
 					if ( await deactivateLink.isVisible() ) {
 						await deactivateLink.click();
 						await expect(
@@ -441,19 +448,28 @@ test.describe(
 					}
 
 					// Delete plugin
-					const deleteLink = pluginRow.getByRole( 'link', { name: 'Delete', exact: true } );
+					const deleteLink = pluginRow.getByRole(
+						'link',
+						{ name: 'Delete', exact: true }
+					);
 					if ( await deleteLink.isVisible() ) {
 						try {
 							await deleteLink.click();
 							await expect(
-								page.getByText( 'was successfully deleted.' )
+								page.getByText(
+									'was successfully deleted.'
+								)
 							).toBeVisible( { timeout: 5000 } );
 						} catch ( e ) {
 							await page
-								.getByText( 'Yes, delete these files and data' )
+								.getByText(
+									'Yes, delete these files and data'
+								)
 								.click();
 							await page
-								.getByText( 'The selected plugin has been deleted.' )
+								.getByText(
+									'The selected plugin has been deleted.'
+								)
 								.waitFor();
 						}
 					}

--- a/plugins/woocommerce/tests/e2e-pw/tests/onboarding/onboarding-wizard.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/onboarding/onboarding-wizard.spec.ts
@@ -422,9 +422,7 @@ test.describe(
 			} );
 
 			await test.step( 'Clean up installed extensions', async () => {
-				const deactivateAndDeletePlugin = async (
-					slug: string
-				) => {
+				const deactivateAndDeletePlugin = async ( slug: string ) => {
 					await page.goto( 'wp-admin/plugins.php' );
 					const pluginRow = page.locator(
 						`tr[data-slug="${ slug }"]`
@@ -436,10 +434,10 @@ test.describe(
 					}
 
 					// Deactivate if active
-					const deactivateLink = pluginRow.getByRole(
-						'link',
-						{ name: 'Deactivate', exact: true }
-					);
+					const deactivateLink = pluginRow.getByRole( 'link', {
+						name: 'Deactivate',
+						exact: true,
+					} );
 					if ( await deactivateLink.isVisible() ) {
 						await deactivateLink.click();
 						await expect(
@@ -448,23 +446,19 @@ test.describe(
 					}
 
 					// Delete plugin
-					const deleteLink = pluginRow.getByRole(
-						'link',
-						{ name: 'Delete', exact: true }
-					);
+					const deleteLink = pluginRow.getByRole( 'link', {
+						name: 'Delete',
+						exact: true,
+					} );
 					if ( await deleteLink.isVisible() ) {
 						try {
 							await deleteLink.click();
 							await expect(
-								page.getByText(
-									'was successfully deleted.'
-								)
+								page.getByText( 'was successfully deleted.' )
 							).toBeVisible( { timeout: 5000 } );
 						} catch ( e ) {
 							await page
-								.getByText(
-									'Yes, delete these files and data'
-								)
+								.getByText( 'Yes, delete these files and data' )
 								.click();
 							await page
 								.getByText(

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.ts
@@ -321,7 +321,7 @@ test.describe( 'Product Reviews', () => {
 			const trashNoticeText = await trashNotice.textContent();
 			expect(
 				trashNoticeText?.includes( trashMessage ) ||
-				trashNoticeText?.includes( trashMessageSmart )
+					trashNoticeText?.includes( trashMessageSmart )
 			).toBeTruthy();
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
 
@@ -335,7 +335,7 @@ test.describe( 'Product Reviews', () => {
 			const trashNoticeText2 = await trashNotice2.textContent();
 			expect(
 				trashNoticeText2?.includes( trashMessage ) ||
-				trashNoticeText2?.includes( trashMessageSmart )
+					trashNoticeText2?.includes( trashMessageSmart )
 			).toBeTruthy();
 
 			await page.click( 'a[href*="comment_status=trash"]' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes prettier formatting errors introduced in #63484:

- **`onboarding-wizard.spec.ts`:** Line length violations in the `deactivateAndDeletePlugin` helper (long `locator()`, `getByRole()`, and `getByText()` calls).
- **`product-reviews.spec.ts`:** Indentation errors in the `||` continuation lines inside `expect()` calls.

Closes # .

Bug introduced in PR #63484.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Verify the lint check passes: `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch:js`
2. Verify E2E tests still pass (no behavioral changes, formatting only).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

Formatting-only changes. No behavioral impact.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Formatting-only fix for E2E test files. No user-facing or behavioral changes.

</details>