### PR TITLE
Update "on hold" email copy for block email editor

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-2432-on-hold-emails-for-services
+++ b/plugins/woocommerce/changelog/wooprd-2432-on-hold-emails-for-services
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update 'on hold' email copy in block email editor to be more neutral for services and virtual products.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 
 			if ( $this->block_email_editor_enabled ) {
 				$this->title       = __( 'Order on hold', 'woocommerce' );
-				$this->description = __( 'Notifies customers when their order has been placed on hold.', 'woocommerce' );
+				$this->description = __( 'Notifies customers when their order is pending payment confirmation.', 'woocommerce' );
 			}
 		}
 
@@ -64,6 +64,9 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
+			if ( $this->block_email_editor_enabled ) {
+				return __( 'Your order from {site_title} is on hold', 'woocommerce' );
+			}
 			return __( 'Your {site_title} order has been received!', 'woocommerce' );
 		}
 
@@ -74,6 +77,9 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
+			if ( $this->block_email_editor_enabled ) {
+				return __( 'Payment confirmation pending', 'woocommerce' );
+			}
 			return __( 'Thank you for your order', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.6.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading"> <?php echo esc_html__( 'Thank you for your order', 'woocommerce' ); ?> </h2>
+<h2 class="wp-block-heading"> <?php echo esc_html__( 'Payment confirmation pending', 'woocommerce' ); ?> </h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -35,11 +35,14 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'We’ve received your order and it’s currently on hold until we can confirm your payment has been processed.', 'woocommerce' ); ?> </p>
+<p><?php
+	/* translators: %s: Payment method (bold, personalization tag) */
+	printf( esc_html__( 'Thanks for your order. It’s currently on hold while we confirm your payment via %s.', 'woocommerce' ), '<strong><!--[woocommerce/order-payment-method]--></strong>' );
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?> </p>
+<p> <?php echo esc_html__( 'We’ll update you once payment has been confirmed. Here’s a summary of your order:', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woocommerce/email-content {"lock":{"move":false,"remove":true}} -->


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Updates the "on hold" email copy to be more neutral and product-type agnostic when the block email editor feature flag is enabled. This addresses the issue where the existing copy used shipping-oriented language that didn't make sense for services, virtual products, and other non-physical product types.

Changes gated behind the `block_email_editor_enabled` flag:

- **Email description (merchant-facing)**: "Notifies customers when their order is pending payment confirmation."
- **Email subject (shopper-facing)**: "Your order from {site_title} is on hold"
- **Email heading (shopper-facing)**: "Payment confirmation pending"
- **Block template body text**: Updated to include the payment method via the `woocommerce/order-payment-method` personalization tag and a confirmation-pending message

Closes https://linear.app/a8c/issue/WOOPRD-2432/on-hold-emails-for-services

### How to test the changes in this Pull Request:

1. Enable the block email editor feature flag at **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Email** and locate the "Order on hold" email.
3. Verify the description reads: "Notifies customers when their order is pending payment confirmation."
4. Preview the email and verify:
   - The subject reads: "Your order from [site title] is on hold"
   - The heading reads: "Payment confirmation pending"
   - The body text reads: "Thanks for your order. It's currently on hold while we confirm your payment via **[payment method]**."
   - The second paragraph reads: "We'll update you once payment has been confirmed. Here's a summary of your order:"
5. Disable the block email editor feature flag.
6. Verify the "Order on hold" email reverts to the original copy (subject: "Your {site_title} order has been received!", heading: "Thank you for your order").

### Testing that has already taken place:

- Verified PHPCS linting passes with no new violations on all modified files.
- Confirmed existing E2E and unit tests are unaffected (they test the processing order email, not the on-hold email).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Update 'on hold' email copy in block email editor to be more neutral for services and virtual products.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>
