### PR TITLE
Prevent "Order again" button showing on order confirmation page

### DIFF
--- a/plugins/woocommerce/changelog/woothme-277-order-again-button-appears-on-confirmation
+++ b/plugins/woocommerce/changelog/woothme-277-order-again-button-appears-on-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent "Order again" button showing on order confirmation page

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3107,7 +3107,7 @@ if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 		 * @param array $statuses_for_reordering Array of valid order statuses for reordering.
 		 */
 		$statuses_for_reordering = apply_filters( 'woocommerce_valid_order_statuses_for_order_again', array( OrderStatus::COMPLETED ) );
-		if ( ! $order || ! $order->has_status( $statuses_for_reordering ) || ! is_user_logged_in() ) {
+		if ( ! $order || ! $order->has_status( $statuses_for_reordering ) || ! is_user_logged_in() || is_order_received_page() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hide the "Order again" button on the order confirmation (thank you) page.

When a product type auto-completes orders on payment (e.g. virtual bookable products), the order reaches `completed` status immediately. This causes the "Order again" button to render on the order confirmation page right after checkout, which is confusing — the customer just placed the order.

The fix adds an `is_order_received_page()` check to `woocommerce_order_again_button()` so the button is suppressed on the order confirmation page. It continues to display on My Account > Orders > View Order, where it's useful.

Closes WOOTHME-277

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a virtual bookable product (or any product type that auto-completes orders on payment, e.g. a simple virtual + downloadable product).
2. Log in as a customer and place an order for that product using a payment method that completes immediately (e.g. WooPayments)
3. On the order confirmation page, verify that the "Order again" button is **not** displayed.
4. Navigate to My Account > Orders, find the order, and click "View". Verify that the "Order again" button **is** displayed on the order detail page.
5. Repeat steps 2-3 with a non-virtual product (order will be `processing` status). Confirm the button does not appear on the confirmation page (same as before — no regression).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
