### PR TITLE
Fix woo_email post deletion not cleaning up email template options in WP-CLI

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-2809-woo_email-posts-deleted-via-wp-cli-dont-clean-up
+++ b/plugins/woocommerce/changelog/wooprd-2809-woo_email-posts-deleted-via-wp-cli-dont-clean-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure that woocommerce_email_templates_*_post_id options are properly deleted when woo_email posts are removed in non-admin environments, such as WP-CLI.

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -78,6 +78,11 @@ class Integration {
 		}
 
 		add_action( 'woocommerce_init', array( $this, 'initialize' ) );
+
+		// Register the post deletion cleanup hook early and unconditionally so it works in
+		// both admin and non-admin contexts (e.g. WP-CLI). This only needs $wpdb and the
+		// posts manager singleton — it must not depend on the full editor init chain.
+		add_action( 'before_delete_post', array( $this, 'delete_email_template_associated_with_email_editor_post' ), 10, 2 );
 	}
 
 	/**
@@ -133,7 +138,6 @@ class Integration {
 		add_filter( 'woocommerce_email_editor_post_types', array( $this, 'add_email_post_type' ) );
 		add_filter( 'woocommerce_is_email_editor_page', array( $this, 'is_editor_page' ), 10, 1 );
 		add_filter( 'replace_editor', array( $this, 'replace_editor' ), 10, 2 );
-		add_action( 'before_delete_post', array( $this, 'delete_email_template_associated_with_email_editor_post' ), 10, 2 );
 		add_filter( 'woocommerce_email_editor_send_preview_email_rendered_data', array( $this, 'update_send_preview_email_rendered_data' ), 10, 2 );
 		add_filter( 'woocommerce_email_editor_send_preview_email_personalizer_context', array( $this, 'update_send_preview_email_personalizer_context' ) );
 		add_filter( 'woocommerce_email_editor_preview_post_template_html', array( $this, 'update_preview_post_template_html_data' ), 100, 1 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When `woo_email` posts are permanently deleted via WP-CLI (e.g. `wp post delete <id> --force`), the associated `woocommerce_email_templates_*_post_id` options were not being cleaned up. This happened because the `before_delete_post` hook was only registered inside `register_hooks()`, which is called from `initialize()` via the `woocommerce_init` action — a chain that requires the full editor init and only runs in admin contexts.

This PR moves the `before_delete_post` hook registration from `register_hooks()` to `init()`, so it fires early and unconditionally (in both admin and non-admin contexts like WP-CLI). The cleanup handler only needs `$wpdb` and the posts manager singleton, so it does not depend on the full editor initialization chain.

Closes https://linear.app/a8c/issue/WOOPRD-2809

### How to test the changes in this Pull Request:

1. Set up a WooCommerce development environment with WP-CLI available.
2. Enable the email editor feature (ensure `woo_email` posts exist, e.g. by visiting WooCommerce → Settings → Emails and enabling the block email editor).
3. Identify a `woo_email` post ID — run: `wp post list --post_type=woo_email --fields=ID,post_title`.
4. Confirm the associated option exists: `wp option list --search='woocommerce_email_templates_*_post_id'`.
5. Delete the `woo_email` post via WP-CLI: `wp post delete <ID> --force`.
6. Verify the associated `woocommerce_email_templates_*_post_id` option has been removed: `wp option list --search='woocommerce_email_templates_*_post_id'`.
7. The option corresponding to the deleted post should no longer exist.

### Testing that has already taken place:

Manual testing via WP-CLI confirming that `woocommerce_email_templates_*_post_id` options are properly cleaned up when `woo_email` posts are deleted outside of admin context.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Make sure that woocommerce_email_templates_*_post_id options are properly deleted when woo_email posts are removed in non-admin environments, such as WP-CLI.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
