### PR TITLE
Fix POS emails showing "My WordPress Site" as store name

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooprd-2567-pos-store-name-skip-initial-save
+++ b/plugins/woocommerce/changelog/fix-wooprd-2567-pos-store-name-skip-initial-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip initial save of POS store name setting so emails use the current site name instead of the stale "My WordPress Site" default.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
@@ -72,12 +72,13 @@ class WC_Settings_Point_Of_Sale extends WC_Settings_Page {
 			),
 
 			array(
-				'title'   => __( 'Store name', 'woocommerce' ),
-				'desc'    => __( 'The name of your physical store.', 'woocommerce' ),
-				'id'      => 'woocommerce_pos_store_name',
-				'default' => PointOfSaleDefaultSettings::get_default_store_name(),
-				'type'    => 'text',
-				'css'     => 'min-width:300px;',
+				'title'              => __( 'Store name', 'woocommerce' ),
+				'desc'               => __( 'The name of your physical store.', 'woocommerce' ),
+				'id'                 => 'woocommerce_pos_store_name',
+				'default'            => PointOfSaleDefaultSettings::get_default_store_name(),
+				'type'               => 'text',
+				'css'                => 'min-width:300px;',
+				'skip_initial_save'  => true,
 			),
 
 			array(

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-point-of-sale.php
@@ -72,13 +72,13 @@ class WC_Settings_Point_Of_Sale extends WC_Settings_Page {
 			),
 
 			array(
-				'title'              => __( 'Store name', 'woocommerce' ),
-				'desc'               => __( 'The name of your physical store.', 'woocommerce' ),
-				'id'                 => 'woocommerce_pos_store_name',
-				'default'            => PointOfSaleDefaultSettings::get_default_store_name(),
-				'type'               => 'text',
-				'css'                => 'min-width:300px;',
-				'skip_initial_save'  => true,
+				'title'             => __( 'Store name', 'woocommerce' ),
+				'desc'              => __( 'The name of your physical store.', 'woocommerce' ),
+				'id'                => 'woocommerce_pos_store_name',
+				'default'           => PointOfSaleDefaultSettings::get_default_store_name(),
+				'type'              => 'text',
+				'css'               => 'min-width:300px;',
+				'skip_initial_save' => true,
 			),
 
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

During WooCommerce initial setup, the `woocommerce_pos_store_name` option is saved to the database with its default value from `get_bloginfo('name')`, which is typically "My WordPress Site". In some cases, want the flexibility to continue using the default value until the merchant manually sets a new POS store name.

This PR adds `'skip_initial_save' => true` to the POS store name setting, preventing the default value from being written to the database during setup. Instead, `get_option()` dynamically falls back to `get_bloginfo('name')` — picking up the current site name. The option is only persisted when the merchant explicitly edits it in POS settings.

This follows the same pattern already used for the email "From" name setting (`class-wc-settings-emails.php`).

Closes https://linear.app/a8c/issue/WOOPRD-2567/customer-notifs-pos-emails-shouldnt-have-my-wordpress-site-appear-at 

### How to test the changes in this Pull Request:

1. Set up a fresh WooCommerce installation with the POS feature enabled.
2. Do **not** manually edit the POS store name in **WooCommerce > Settings > Point of Sale**.
3. Change the site title in **Settings > General** to something other than "My WordPress Site" (e.g., "My Cool Store").
4. Create a POS order and trigger the order complete or order refunded email.
5. Verify the email displays the updated site title ("My Cool Store") in the store information section, not "My WordPress Site".
6. Now go to **WooCommerce > Settings > Point of Sale**, manually set a store name (e.g., "Downtown Shop"), and save.
7. Trigger another POS email and verify it uses "Downtown Shop" as the store name.

### Testing that has already taken place:

- Code review confirming the `skip_initial_save` flag is handled in `WC_Install::create_options()` and prevents `add_option()` from being called for this setting during setup.
- Verified consistency with the existing pattern in `class-wc-settings-emails.php`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Skip initial save of POS store name setting so emails use the current site name instead of the stale "My WordPress Site" default.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
