### PR TITLE
Apply patch 439 to trunk

### DIFF
--- a/plugins/woocommerce/changelog/fix-sirt-store-api-batch-nonce-bypass
+++ b/plugins/woocommerce/changelog/fix-sirt-store-api-batch-nonce-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Store API batch endpoint path validation to prevent routing requests to non-Store-API endpoints.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -117,7 +117,8 @@ class Batch extends AbstractRoute implements RouteInterface {
 	public function get_response( WP_REST_Request $request ) {
 		try {
 			foreach ( $request['requests'] as $args ) {
-				if ( ! stristr( $args['path'], 'wc/store' ) ) {
+				$parsed_path = wp_parse_url( $args['path'], PHP_URL_PATH );
+				if ( ! $parsed_path || strpos( $parsed_path, '/wc/store' ) !== 0 ) {
 					throw new RouteException( 'woocommerce_rest_invalid_path', __( 'Invalid path provided.', 'woocommerce' ), 400 );
 				}
 			}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -161,6 +161,7 @@ class Batch extends ControllerTestCase {
 	/**
 	 * @testdox Should reject batch sub-request with path outside Store API namespace.
 	 * @dataProvider invalid_batch_paths_data
+	 * @param string $path The path to test.
 	 */
 	public function test_batch_rejects_invalid_path( string $path ): void {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
@@ -201,6 +202,7 @@ class Batch extends ControllerTestCase {
 	/**
 	 * @testdox Should accept batch sub-request with valid Store API path.
 	 * @dataProvider valid_batch_paths_data
+	 * @param string $path The path to test.
 	 */
 	public function test_batch_accepts_valid_store_api_path( string $path ): void {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -157,4 +157,112 @@ class Batch extends ControllerTestCase {
 		$this->assertEquals( 2, count( $response_data['responses'] ) );
 		$this->assertEquals( 200, $response_data['responses'][0]['status'] );
 	}
+
+	/**
+	 * @testdox Should reject batch sub-request with path outside Store API namespace.
+	 * @dataProvider invalid_batch_paths_data
+	 */
+	public function test_batch_rejects_invalid_path( string $path ): void {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array(
+						'method' => 'POST',
+						'path'   => $path,
+						'body'   => array(),
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status(), "Path '$path' should be rejected" );
+		$this->assertEquals( 'woocommerce_rest_invalid_path', $response->get_data()['code'], "Path '$path' should return woocommerce_rest_invalid_path error code" );
+	}
+
+	/**
+	 * Data provider for paths that should be rejected by batch path validation.
+	 *
+	 * @return array
+	 */
+	public function invalid_batch_paths_data(): array {
+		return array(
+			'non-store-api path'                         => array( '/wp/v2/users' ),
+			'query string containing wc/store'           => array( '/wp/v2/users?query=wc/store' ),
+			'fragment containing wc/store'               => array( '/wp/v2/users#wc/store' ),
+			'wc/store appears in middle of non-api path' => array( '/other/wc/store/endpoint' ),
+			'empty path'                                 => array( '' ),
+		);
+	}
+
+	/**
+	 * @testdox Should accept batch sub-request with valid Store API path.
+	 * @dataProvider valid_batch_paths_data
+	 */
+	public function test_batch_accepts_valid_store_api_path( string $path ): void {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array(
+						'method' => 'GET',
+						'path'   => $path,
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertNotEquals( 'woocommerce_rest_invalid_path', $response->get_data()['code'] ?? '', "Path '$path' should not be rejected by path validation" );
+	}
+
+	/**
+	 * Data provider for paths that should pass batch path validation.
+	 *
+	 * @return array
+	 */
+	public function valid_batch_paths_data(): array {
+		return array(
+			'store api cart'             => array( '/wc/store/v1/cart' ),
+			'store api products'         => array( '/wc/store/v1/products' ),
+			'store api with query param' => array( '/wc/store/v1/products?per_page=5' ),
+		);
+	}
+
+	/**
+	 * @testdox Should reject batch when one sub-request has a valid path and another has an invalid path.
+	 */
+	public function test_batch_rejects_if_any_path_is_invalid(): void {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array(
+						'method' => 'GET',
+						'path'   => '/wc/store/v1/cart',
+					),
+					array(
+						'method' => 'POST',
+						'path'   => '/wp/v2/users?query=wc/store',
+						'body'   => array(
+							'username' => 'newuser',
+							'email'    => 'newuser@example.com',
+							'password' => 'password123',
+						),
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status(), 'Batch should be rejected when any sub-request path is invalid' );
+		$this->assertEquals( 'woocommerce_rest_invalid_path', $response->get_data()['code'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
