### PR TITLE
fix: Reset letter-spacing on email order detail heading span

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-font-family-consistency
+++ b/plugins/woocommerce/changelog/fix-email-font-family-consistency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add explicit font-family to email CSS selectors (.td, .address, h2.email-order-detail-heading span, .wc-bacs-bank-details) to prevent inconsistent fonts in email clients that don't inherit font-family through table elements.
+Reset letter-spacing on order detail heading span to prevent tight text caused by inherited negative letter-spacing from heading typography in block email editor.

--- a/plugins/woocommerce/changelog/fix-email-font-family-consistency
+++ b/plugins/woocommerce/changelog/fix-email-font-family-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add explicit font-family to email CSS selectors (.td, .address, h2.email-order-detail-heading span, .wc-bacs-bank-details) to prevent inconsistent fonts in email clients that don't inherit font-family through table elements.

--- a/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
@@ -87,8 +87,30 @@ class WooContentProcessor {
 		if ( empty( $woo_content ) ) {
 			return '';
 		}
-		$css = $this->theme_controller->get_stylesheet_for_rendering();
+		$css  = $this->theme_controller->get_stylesheet_for_rendering();
+		$css .= $this->get_woo_content_css();
 		return $this->css_inliner->from_html( $woo_content )->inline_css( $css )->render();
+	}
+
+	/**
+	 * Get CSS rules for WooCommerce-specific selectors in block emails.
+	 *
+	 * Email clients like Outlook don't reliably inherit font-family through table elements,
+	 * so we need to explicitly set it on WooCommerce content selectors.
+	 *
+	 * @since 10.7.0
+	 * @return string
+	 */
+	private function get_woo_content_css(): string {
+		$email_styles = $this->theme_controller->get_styles();
+		$font_family  = $email_styles['typography']['fontFamily'] ?? 'inherit';
+
+		return "
+			.td { font-family: {$font_family}; }
+			.address { font-family: {$font_family}; }
+			h2.email-order-detail-heading span { font-family: {$font_family}; }
+			.wc-bacs-bank-details, .wc-bacs-bank-details li { font-family: {$font_family}; }
+		";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
@@ -95,22 +95,15 @@ class WooContentProcessor {
 	/**
 	 * Get CSS rules for WooCommerce-specific selectors in block emails.
 	 *
-	 * Email clients like Outlook don't reliably inherit font-family through table elements,
-	 * so we need to explicitly set it on WooCommerce content selectors.
+	 * The block email editor theme applies letter-spacing: -.1px to headings. When the
+	 * order detail heading span is rendered at body-text size (14px) it inherits that
+	 * negative value, making the text look noticeably tight. This resets it.
 	 *
 	 * @since 10.7.0
 	 * @return string
 	 */
 	private function get_woo_content_css(): string {
-		$email_styles = $this->theme_controller->get_styles();
-		$font_family  = $email_styles['typography']['fontFamily'] ?? 'inherit';
-
-		return "
-			.td { font-family: {$font_family}; }
-			.address { font-family: {$font_family}; }
-			h2.email-order-detail-heading span { font-family: {$font_family}; }
-			.wc-bacs-bank-details, .wc-bacs-bank-details li { font-family: {$font_family}; }
-		";
+		return 'h2.email-order-detail-heading span { letter-spacing: normal; }';
 	}
 
 	/**

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -346,14 +346,12 @@ body {
 .td {
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 	border: <?php echo $email_improvements_enabled ? '0' : '1px solid ' . esc_attr( $body_darker_10 ); ?>;
-	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	vertical-align: middle;
 }
 
 .address {
 	<?php if ( $email_improvements_enabled ) { ?>
 		color: <?php echo esc_attr( $text ); ?>;
-		font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 		font-style: normal;
 		line-height: 120%;
 		padding: 8px 0;
@@ -370,11 +368,6 @@ body {
 	padding-<?php echo is_rtl() ? 'right' : 'left'; ?>: 10px !important;
 }
 <?php endif; ?>
-
-.wc-bacs-bank-details,
-.wc-bacs-bank-details li {
-	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-}
 
 .additional-fields {
 	padding: 12px 12px 0;
@@ -475,9 +468,9 @@ img {
 h2.email-order-detail-heading span {
 	color: <?php echo esc_attr( $footer_text ); ?>;
 	display: block;
-	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: 14px;
 	font-weight: normal;
+	letter-spacing: normal;
 }
 
 h2.email-order-detail-heading span a {

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -346,12 +346,14 @@ body {
 .td {
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 	border: <?php echo $email_improvements_enabled ? '0' : '1px solid ' . esc_attr( $body_darker_10 ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	vertical-align: middle;
 }
 
 .address {
 	<?php if ( $email_improvements_enabled ) { ?>
 		color: <?php echo esc_attr( $text ); ?>;
+		font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 		font-style: normal;
 		line-height: 120%;
 		padding: 8px 0;
@@ -368,6 +370,11 @@ body {
 	padding-<?php echo is_rtl() ? 'right' : 'left'; ?>: 10px !important;
 }
 <?php endif; ?>
+
+.wc-bacs-bank-details,
+.wc-bacs-bank-details li {
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+}
 
 .additional-fields {
 	padding: 12px 12px 0;
@@ -468,6 +475,7 @@ img {
 h2.email-order-detail-heading span {
 	color: <?php echo esc_attr( $footer_text ); ?>;
 	display: block;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: 14px;
 	font-weight: normal;
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -4,8 +4,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
 
-use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
-use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
 use Automattic\WooCommerce\Internal\EmailEditor\WooContentProcessor;
 
 /**
@@ -68,24 +66,16 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that get_woo_content_css returns font-family rules for WooCommerce-specific selectors.
+	 * Test that get_woo_content_css resets letter-spacing on order detail heading span.
 	 */
-	public function testGetWooContentCssIncludesFontFamilyForWooSelectors(): void {
+	public function testGetWooContentCssResetsLetterSpacingOnOrderDetailHeadingSpan(): void {
 		$reflection = new \ReflectionClass( $this->woo_content_processor );
 		$method     = $reflection->getMethod( 'get_woo_content_css' );
 		$method->setAccessible( true );
 
 		$css = $method->invoke( $this->woo_content_processor );
 
-		// Get the expected font-family from the theme controller.
-		$theme_controller = Email_Editor_Container::container()->get( Theme_Controller::class );
-		$email_styles     = $theme_controller->get_styles();
-		$font_family      = $email_styles['typography']['fontFamily'] ?? 'inherit';
-
-		$this->assertStringContainsString( '.td', $css );
-		$this->assertStringContainsString( '.address', $css );
 		$this->assertStringContainsString( 'h2.email-order-detail-heading span', $css );
-		$this->assertStringContainsString( '.wc-bacs-bank-details', $css );
-		$this->assertStringContainsString( "font-family: {$font_family}", $css );
+		$this->assertStringContainsString( 'letter-spacing: normal', $css );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -4,10 +4,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
 use Automattic\WooCommerce\Internal\EmailEditor\WooContentProcessor;
 
 /**
- * Tests for the BlockEmailRenderer class.
+ * Tests for the WooContentProcessor class.
  */
 class WooContentProcessorTest extends \WC_Unit_Test_Case {
 	/**
@@ -63,5 +65,27 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'testuser', $original_content );
 		$this->assertStringContainsString( 'Test email header', $original_content );
 		$this->assertStringContainsString( 'Test email footer', $original_content );
+	}
+
+	/**
+	 * Test that get_woo_content_css returns font-family rules for WooCommerce-specific selectors.
+	 */
+	public function testGetWooContentCssIncludesFontFamilyForWooSelectors(): void {
+		$reflection = new \ReflectionClass( $this->woo_content_processor );
+		$method     = $reflection->getMethod( 'get_woo_content_css' );
+		$method->setAccessible( true );
+
+		$css = $method->invoke( $this->woo_content_processor );
+
+		// Get the expected font-family from the theme controller.
+		$theme_controller = Email_Editor_Container::container()->get( Theme_Controller::class );
+		$email_styles     = $theme_controller->get_styles();
+		$font_family      = $email_styles['typography']['fontFamily'] ?? 'inherit';
+
+		$this->assertStringContainsString( '.td', $css );
+		$this->assertStringContainsString( '.address', $css );
+		$this->assertStringContainsString( 'h2.email-order-detail-heading span', $css );
+		$this->assertStringContainsString( '.wc-bacs-bank-details', $css );
+		$this->assertStringContainsString( "font-family: {$font_family}", $css );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the block email editor, `<h2>` headings receive `letter-spacing: -.1px` from the theme's heading typography. The "Order #98 (February 25, 2026)" text is rendered as a `<span>` inside `<h2 class="email-order-detail-heading">` at `font-size: 14px`. It inherits the heading's negative letter-spacing, which looks noticeably tight at body-text size compared to the rest of the email.

This PR resets `letter-spacing: normal` on `h2.email-order-detail-heading span` in both email paths:

- **Block email editor** (`WooContentProcessor.php`): Added `get_woo_content_css()` method that returns a CSS rule resetting letter-spacing on the order detail heading span. This CSS is appended to the theme stylesheet before Emogrifier inlines it.
- **Classic email templates** (`email-styles.php`): Added `letter-spacing: normal` to the existing `h2.email-order-detail-heading span` selector.

Closes https://linear.app/a8c/issue/STOMAIL-7851

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Enable the **Email Improvements** feature and the **Block Email Editor** feature at WooCommerce > Settings > Advanced > Features.
2. Place a test order to trigger a notification email.
3. Inspect the resulting email HTML (via Mailpit or email client "View Source").
4. Find the `<h2 class="email-order-detail-heading">` element and verify its inner `<span>` has `letter-spacing: normal` inlined in its `style` attribute.
5. Repeat with the block email editor **disabled** to verify the classic email template also includes `letter-spacing: normal` on the same selector.

### Testing that has already taken place:

- PHPUnit tests pass (including new test for `get_woo_content_css()`)
- PHP linting clean
- PHPStan clean

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog was created manually via `pnpm changelog add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)