### PR TITLE
Improve locator in E2E test to make test more robust and prevent issues when running on QIT

### DIFF
--- a/plugins/woocommerce/changelog/update-tests-delete-users
+++ b/plugins/woocommerce/changelog/update-tests-delete-users
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This PR makes an E2E locator more robust so tests don't break when running in combination with other WooCommerce extensions.
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/user/users-manage.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/user/users-manage.spec.ts
@@ -76,7 +76,8 @@ async function userDeletionTest( page: Page, username: string ) {
 
 		await expect(
 			page
-				.getByText( 'Delete Users You have' )
+				.locator( 'div', { hasText: 'Delete Users' } )
+				.filter( { hasText: 'You have' } )
 				.getByText( `${ username }` )
 		).toBeVisible();
 		await page.getByRole( 'button', { name: 'Confirm Deletion' } ).click();


### PR DESCRIPTION
The tests `can delete a customer` and `can delete a shop manager` from `users-manage.spec.ts` failed when running WooCommerce E2E through QIT for the ShipStation extension.

After debugging the issue, we realized it was caused by a warning shown by ShipStation in the WooCommerce Admin pages. The previous version of the locator updated searched the element by the text `Delete Users You have`, i.e. it chained 2 different elements (title and paragraph) inside the `getByText` Playwright method. However, the ShipStation warning was rendered exactly between the title and the paragraph, so it was breaking the element search somehow.

However, this is not an issue caused by ShipStation, but a lack of robustness in the locator used in the WooCommerce E2E tests. This PR aims to solve that by making the locator more robust, no matter if a new element is added in the Delete Users page, no matter if added by ShipStation or any other extension.

Linking the failed test report that triggered this investigation for reference:
https://qit.woo.com/?qit_results=4995934.Hp22mzu1n3l3yIDdyf9pHl8Xwiv68L7Ode8agEubqPbtPMr2b7PHSJoxkAkx1T1X

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Updated locator in `users-manage.spec.ts`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

This change only updates an E2E tests, so no manual testing needed. Just ensure E2E tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>
Improve locator in e2e test to fix QIT issues when running WooCommerce E2E tests in combination with other extensions.
#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
