### PR TITLE
Add to Cart + Options: Fix adding variable products to cart with 'any' as an attribute

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-variation-with-any
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-variation-with-any
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add to Cart + Options: Fix adding variable products to cart with 'any' as an attribute
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -243,7 +243,7 @@ const doesCartItemMatchAttributes = (
 				return (
 					item.attribute === raw_attribute &&
 					( item.value.toLowerCase() === value.toLowerCase() ||
-						( item.value && value === '' ) ) // Handle "any" attribute type
+						( item.value && value === null ) ) // Handle "any" attribute type
 				);
 			} )
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -242,8 +242,7 @@ const doesCartItemMatchAttributes = (
 			selectedAttributes.some( ( item: SelectedAttributes ) => {
 				return (
 					item.attribute === raw_attribute &&
-					( item.value.toLowerCase() === value.toLowerCase() ||
-						( item.value && value === null ) ) // Handle "any" attribute type
+					item.value.toLowerCase() === value?.toLowerCase()
 				);
 			} )
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
@@ -91,9 +91,10 @@ export const findMatchingVariation = (
 				);
 
 				// If variation attribute has empty value, it accepts "Any" value.
-				if ( attr.value === '' ) {
+				if ( attr.value === null ) {
 					return (
-						selectedAttr !== undefined && selectedAttr.value !== ''
+						selectedAttr !== undefined &&
+						selectedAttr.value !== null
 					);
 				}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
@@ -90,7 +90,7 @@ export const findMatchingVariation = (
 						).toLowerCase() === attrNameLower
 				);
 
-				// If variation attribute has empty value, it accepts "Any" value.
+				// If variation attribute is null, it accepts "Any" value.
 				if ( attr.value === null ) {
 					return (
 						selectedAttr !== undefined &&

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
@@ -38,8 +38,7 @@ export const doesCartItemMatchAttributes = (
 			selectedAttributes.some( ( item: SelectedAttributes ) => {
 				return (
 					attributeNamesMatch( item.attribute, raw_attribute ) &&
-					( item.value.toLowerCase() === value.toLowerCase() ||
-						( item.value && value === '' ) ) // Handle "any" attribute type
+					item.value.toLowerCase() === value?.toLowerCase()
 				);
 			} )
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
@@ -157,7 +157,7 @@ describe( 'findMatchingVariation', () => {
 				{
 					id: 201,
 					attributes: [
-						{ name: 'Color', value: '' }, // "Any" color
+						{ name: 'Color', value: null }, // "Any" color
 						{ name: 'Size', value: 'Small' },
 					],
 				},
@@ -165,7 +165,7 @@ describe( 'findMatchingVariation', () => {
 					id: 202,
 					attributes: [
 						{ name: 'Color', value: 'Blue' },
-						{ name: 'Size', value: '' }, // "Any" size
+						{ name: 'Size', value: null }, // "Any" size
 					],
 				},
 			],
@@ -183,9 +183,9 @@ describe( 'findMatchingVariation', () => {
 			expect( result?.id ).toBe( 201 );
 		} );
 
-		it( 'does not match "Any" attribute when selected value is empty', () => {
+		it( 'does not match "Any" attribute when selected value is null', () => {
 			const selectedAttributes = [
-				{ attribute: 'Color', value: '' },
+				{ attribute: 'Color', value: null },
 				{ attribute: 'Size', value: 'Small' },
 			];
 			expect(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -118,7 +118,7 @@ const isAttributeValueValid = ( {
 		// Skip variations that don't match the current attribute value.
 		if (
 			variationAttrValue !== attributeValue &&
-			variationAttrValue !== '' // "" is used for "any".
+			variationAttrValue !== null // null is used for "any".
 		) {
 			return false;
 		}
@@ -138,11 +138,11 @@ const isAttributeValueValid = ( {
 				) {
 					return true;
 				}
-				// If the current available variation has an empty value
+				// If the current available variation has a null value
 				// (matching any), count it if it refers to a different
 				// attribute or the attribute it refers matches the current
 				// selection.
-				if ( availableVariationAttributeValue === '' ) {
+				if ( availableVariationAttributeValue === null ) {
 					if (
 						! attributeNamesMatch(
 							selectedAttribute.attribute,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -329,6 +329,48 @@ test.describe( 'Add to Cart + Options Block', () => {
 		} );
 	} );
 
+	test( 'allows adding variable products that have "any" as a variation attribute', async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/v-neck-t-shirt/' );
+
+		// The radio input is visually hidden and, thus, not clickable. That's
+		// why we need to select the <label> instead.
+		const colorBlueOption = page.locator( 'label:has-text("Blue")' );
+		const colorRedOption = page.locator( 'label:has-text("Red")' );
+		const sizeLargeOption = page.locator( 'label:has-text("Large")' );
+
+		await colorBlueOption.click();
+		await sizeLargeOption.click();
+
+		// We use the Add to Cart + Options class to make sure we don't select
+		// the Add to Cart button from the Related Products block.
+		const addToCartButton = page
+			.locator( '.wp-block-add-to-cart-with-options' )
+			.getByRole( 'button', { name: 'Add to cart' } );
+
+		// Note: The button is always enabled for accessibility reasons.
+		// Instead, we check directly for the "disabled" class, which grays
+		// out the button.
+		await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
+
+		await addToCartButton.click();
+
+		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+
+		await colorRedOption.click();
+
+		await expect( page.getByText( '1 in cart' ) ).toBeHidden();
+	} );
+
 	test( 'allows adding grouped products to cart', async ( {
 		page,
 		pageObject,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It wasn't possible to add variable products to cart when the variation had 'any' as one of their attributes. That was because until now, we were assuming 'any' was represented as an empty string. But recently, that changed to `null`. This PR fixes that.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/62880.

### How to test the changes in this Pull Request:

1. Create a variable product making sure at least one of the variations has one of the attributes set to 'any'. (Alternatively, use the `V-Neck T-Shirt` product from the sample data)

<img width="1897" height="608" alt="imatge" src="https://github.com/user-attachments/assets/1e90ed24-97f5-4b1c-a298-19c76f8cc8f9" />

2. In the frontend, using the blockified Add to Cart + Options block, try adding that product to cart.
3. Verify the options are enabled and you can successfully add the product to cart.

Before | After
--- | ---
<img width="1080" height="750" alt="imatge" src="https://github.com/user-attachments/assets/1fef374b-5070-4fc5-acb5-69e92f3dee43" /> | <img width="1080" height="750" alt="imatge" src="https://github.com/user-attachments/assets/e3348348-ea48-4ae6-8fd8-04a156bd8936" />