### PR TITLE
Fix V4 Customers API requiring username/password based on store settings

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1726-customer-creation-issue-depending-on-password-settings
+++ b/plugins/woocommerce/changelog/wooprd-1726-customer-creation-issue-depending-on-password-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make username and password optional in V4 Customers REST API regardless of store registration settings.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
@@ -117,6 +117,14 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		}
 
 		$customer->set_id( $id );
+
+		// Sync back the user data from the created WP user in case it was auto-generated.
+		$wp_user = new WP_User( $id );
+		if ( $wp_user->exists() ) {
+			$customer->set_username( $wp_user->user_login );
+			$customer->set_date_created( $wp_user->user_registered );
+		}
+
 		$this->update_user_meta( $customer );
 
 		// Prevent wp_update_user calls in the same request and customer trigger the 'Notice of Password Changed' email.
@@ -133,8 +141,6 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 				$customer
 			)
 		);
-		$wp_user = new WP_User( $customer->get_id() );
-		$customer->set_date_created( $wp_user->user_registered );
 		$customer->set_date_modified( get_user_meta( $customer->get_id(), 'last_update', true ) );
 		$customer->save_meta_data();
 		$customer->apply_changes();

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Customers/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Customers/Controller.php
@@ -116,13 +116,13 @@ class Controller extends AbstractController {
 								'description' => __( 'New user email address.', 'woocommerce' ),
 							),
 							'username' => array(
-								'required'    => 'no' === get_option( 'woocommerce_registration_generate_username', 'yes' ),
-								'description' => __( 'New user username.', 'woocommerce' ),
+								'required'    => false,
+								'description' => __( 'New user username. Generated from email if not provided.', 'woocommerce' ),
 								'type'        => 'string',
 							),
 							'password' => array(
-								'required'    => 'no' === get_option( 'woocommerce_registration_generate_password', 'no' ),
-								'description' => __( 'New user password.', 'woocommerce' ),
+								'required'    => false,
+								'description' => __( 'New user password. Generated automatically if not provided.', 'woocommerce' ),
 								'type'        => 'string',
 							),
 						)

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Customers/class-wc-rest-customers-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Customers/class-wc-rest-customers-v4-controller-tests.php
@@ -926,6 +926,37 @@ class WC_REST_Customers_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test creating customer without username or password succeeds regardless of store settings.
+	 *
+	 * Store settings like woocommerce_registration_generate_username and
+	 * woocommerce_registration_generate_password should not affect this admin API.
+	 * Username and password should always be optional and auto-generated when not provided.
+	 */
+	public function test_create_customer_without_username_or_password(): void {
+		// Disable auto-generation in store settings (simulates the problematic configuration).
+		update_option( 'woocommerce_registration_generate_username', 'no' );
+		update_option( 'woocommerce_registration_generate_password', 'no' );
+
+		$customer_data = array(
+			'email'      => 'nousernameorpassword@example.com',
+			'first_name' => 'Test',
+			'last_name'  => 'User',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/customers' );
+		$request->set_body_params( $customer_data );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertNotEmpty( $response_data['username'] );
+		$this->assertEquals( 'nousernameorpassword@example.com', $response_data['email'] );
+
+		$this->created_customers[] = $response_data['id'];
+	}
+
+	/**
 	 * Test comprehensive value validation for all customer fields.
 	 */
 	public function test_comprehensive_value_validation(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The V4 Customers REST API endpoint incorrectly ties the `required` status of `username` and `password` parameters to frontend store registration settings (`woocommerce_registration_generate_username` and `woocommerce_registration_generate_password`). This means that when these settings disable auto-generation (intended for frontend registration forms), the admin API also rejects requests without username/password, which is unexpected.

This is an admin-facing API — store registration settings should only affect frontend user registration forms, not API consumers.

**Changes:**

1. **Controller** (`src/Internal/RestApi/Routes/V4/Customers/Controller.php`): Make `username` and `password` always optional (`required: false`) by removing the `get_option()` checks from route registration.

2. **Data Store** (`includes/data-stores/class-wc-customer-data-store.php`): After `wc_create_new_customer()` creates the WP user (auto-generating username/password when empty), sync the generated username back to the `WC_Customer` object. Previously only the ID was set back, leaving the customer object with an empty username in the response.

3. **Test**: Added `test_create_customer_without_username_or_password` verifying that customer creation succeeds with only an email, even when store settings have auto-generation disabled.

Closes #WOOPRD-1726.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > Accounts & Privacy**.
2. Uncheck both "Allow customers to create an account during checkout" auto-generation options, or set `woocommerce_registration_generate_username` to `no` and `woocommerce_registration_generate_password` to `no` via the database/WP CLI.
3. Send a POST request to `/wp-json/wc/v4/customers` with only `{ "email": "test@example.com" }` (no username or password) using admin authentication.
4. Verify the customer is created successfully (HTTP 201) with an auto-generated username.
5. Verify existing behavior still works: sending username and password explicitly should use those values.

### Testing that has already taken place:

- All 33 existing V4 Customer Controller tests pass.
- New test `test_create_customer_without_username_or_password` passes.
- PHPStan analysis passes with no errors.
- PHP linting passes with no violations.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Make username and password optional in V4 Customers REST API regardless of store registration settings.

</details>