### PR TITLE
Update checkout textarea to use global text colour for placeholder

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-1577-checkout-textarea-fields-do-not-inherit-global-text-color
+++ b/plugins/woocommerce/changelog/wooprd-1577-checkout-textarea-fields-do-not-inherit-global-text-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Textarea inputs on Checkout will now have the correct placeholder colour on light themes

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -15,7 +15,6 @@
 
 	&::placeholder {
 		color: currentColor;
-		opacity: 0.7;
 	}
 
 	// When the user has typed text, use the standard input text color.
@@ -38,7 +37,6 @@
 
 		&::placeholder {
 			color: currentColor;
-			opacity: 0.6;
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -2,7 +2,7 @@
 	@include reset-typography();
 	@include font-small-locked;
 	background-color: $input-background-light;
-	border: 1px solid $universal-border-strong;
+	border: 1px solid color-mix(in srgb, $input-text-light 80%, transparent);
 	border-radius: $universal-border-radius;
 	// Use inherit so the placeholder picks up the global text color.
 	// Typed text color is reset below via :not(:placeholder-shown).
@@ -26,8 +26,8 @@
 		background-color: $input-background-light;
 		// Keep border at 1px to prevent layout shift, use box-shadow for the extra
 		// 0.5px thickness
-		border: 1px solid currentColor;
-		box-shadow: inset 0 0 0 0.5px currentColor;
+		border: 1px solid $input-text-light;
+		box-shadow: inset 0 0 0 0.5px $input-text-light;
 	}
 
 	.has-dark-controls & {

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -4,7 +4,9 @@
 	background-color: $input-background-light;
 	border: 1px solid $universal-border-strong;
 	border-radius: $universal-border-radius;
-	color: $input-text-light;
+	// Use inherit so the placeholder picks up the global text color.
+	// Typed text color is reset below via :not(:placeholder-shown).
+	color: inherit;
 	font-family: inherit;
 	margin: 0;
 	padding: $gap-small;
@@ -12,12 +14,17 @@
 	box-sizing: border-box;
 
 	&::placeholder {
-		color: $universal-body-low-emphasis;
+		color: currentColor;
+		opacity: 0.7;
+	}
+
+	// When the user has typed text, use the standard input text color.
+	&:not(:placeholder-shown) {
+		color: $input-text-light;
 	}
 
 	&:focus {
 		background-color: $input-background-light;
-		color: $input-text-light;
 		// Keep border at 1px to prevent layout shift, use box-shadow for the extra
 		// 0.5px thickness
 		border: 1px solid currentColor;
@@ -30,7 +37,8 @@
 		color: $input-text-dark;
 
 		&::placeholder {
-			color: $input-placeholder-dark;
+			color: currentColor;
+			opacity: 0.6;
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Checkout textarea placeholder text does not inherit the global text color from WordPress theme styles. Regular input placeholders were updated in PR #46362 to pull in global styles, but textarea placeholders were missed.

The textarea component hardcoded its `color` to `$input-text-light`, preventing `::placeholder` from inheriting the theme's text color. This fix changes the textarea to use `color: inherit` so the placeholder picks up the global color, then resets typed text back to `$input-text-light` via `:not(:placeholder-shown)`.

Closes WOOPRD-1577

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="636" height="142" alt="image" src="https://github.com/user-attachments/assets/c31fec64-51a7-4689-939c-88e0568bc8ed" /> | <img width="620" height="137" alt="image" src="https://github.com/user-attachments/assets/070df86d-28c2-4f50-a19e-ada021a8d02e" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Using a block theme, apply a style variation with a non-default text color
2. Edit the checkout page and ensure the checkout block does not have "Dark mode inputs" enabled.
3. Go to the Checkout block on the front end and check "Add a note to your order" to reveal the textarea.
4. Verify the "placeholder" text inherits the theme's text color
5. Type some text into the textarea and verify the typed text uses the standard dark input color (`#2b2d2f`), matching other input fields.
6. Enable "Dark mode inputs" on the checkout block and confirm the textarea still works correctly with white text and placeholder.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
