### PR TITLE
Address console warnings in cart & checkout blocks in editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-62340
+++ b/plugins/woocommerce/changelog/fix-62340
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix console warnings in the editor when using cart and checkout blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -15,8 +15,10 @@ import { ProductQueryContext as Context } from '@woocommerce/blocks/product-quer
 import { useProduct } from '@woocommerce/entities';
 import {
 	Disabled,
-	Button,
-	ButtonGroup,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanel as ToolsPanel,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -40,14 +42,6 @@ function WidthPanel( {
 	selectedWidth: number | undefined;
 	setAttributes: ( attributes: BlockAttributes ) => void;
 } ) {
-	function handleChange( newWidth: number ) {
-		// Check if we are toggling the width off
-		const width = selectedWidth === newWidth ? undefined : newWidth;
-
-		// Update attributes.
-		setAttributes( { width } );
-	}
-
 	return (
 		<ToolsPanel
 			label={ __( 'Width settings', 'woocommerce' ) }
@@ -63,24 +57,24 @@ function WidthPanel( {
 				}
 				isShownByDefault
 			>
-				<ButtonGroup aria-label={ __( 'Button width', 'woocommerce' ) }>
-					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-						return (
-							<Button
-								key={ widthValue }
-								isSmall
-								variant={
-									widthValue === selectedWidth
-										? 'primary'
-										: undefined
-								}
-								onClick={ () => handleChange( widthValue ) }
-							>
-								{ widthValue }%
-							</Button>
-						);
-					} ) }
-				</ButtonGroup>
+				<ToggleGroupControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Button width', 'woocommerce' ) }
+					value={ selectedWidth }
+					isDeselectable
+					onChange={ ( value?: number ) =>
+						setAttributes( { width: value } )
+					}
+				>
+					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => (
+						<ToggleGroupControlOption
+							key={ widthValue }
+							value={ widthValue }
+							label={ `${ widthValue }%` }
+						/>
+					) ) }
+				</ToggleGroupControl>
 			</ToolsPanelItem>
 		</ToolsPanel>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -60,6 +60,7 @@ function WidthPanel( {
 				<ToggleGroupControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
+					hideLabelFromVision
 					label={ __( 'Button width', 'woocommerce' ) }
 					value={ selectedWidth }
 					isDeselectable

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
@@ -173,6 +173,7 @@ const Edit = ( {
 							isShownByDefault
 						>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								label={ __(
 									'Link to Product Page',
 									'woocommerce'
@@ -203,6 +204,7 @@ const Edit = ( {
 						>
 							<ToggleGroupControl
 								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 								label={ __( 'Resolution', 'woocommerce' ) }
 								isBlock
 								help={

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/edit.tsx
@@ -202,6 +202,7 @@ const Edit = ( {
 							isShownByDefault
 						>
 							<ToggleGroupControl
+								__next40pxDefaultSize
 								label={ __( 'Resolution', 'woocommerce' ) }
 								isBlock
 								help={

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
@@ -82,6 +82,7 @@ export const ImageSizeSettings = ( {
 			label={ __( 'Image size', 'woocommerce' ) }
 		>
 			<UnitControl
+				__next40pxDefaultSize
 				label={ __( 'Height', 'woocommerce' ) }
 				onChange={ ( value: string ) => {
 					setAttributes( { height: value } );
@@ -90,6 +91,7 @@ export const ImageSizeSettings = ( {
 				units={ sizeUnits }
 			/>
 			<UnitControl
+				__next40pxDefaultSize
 				label={ __( 'Width', 'woocommerce' ) }
 				onChange={ ( value: string ) => {
 					setAttributes( { width: value } );
@@ -103,6 +105,7 @@ export const ImageSizeSettings = ( {
 					label={ __( 'Scale', 'woocommerce' ) }
 				>
 					<ToggleGroupControl
+						__next40pxDefaultSize
 						label={ __( 'Scale', 'woocommerce' ) }
 						value={ scale }
 						help={ scaleHelp[ scale ] }

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/image-size-settings.tsx
@@ -106,6 +106,7 @@ export const ImageSizeSettings = ( {
 				>
 					<ToggleGroupControl
 						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						label={ __( 'Scale', 'woocommerce' ) }
 						value={ scale }
 						help={ scaleHelp[ scale ] }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
@@ -32,6 +32,7 @@ export const Edit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __(
 							'Cross-Sells products to show',
 							'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
@@ -33,6 +33,7 @@ export const Edit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 					<RangeControl
 						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						label={ __(
 							'Cross-Sells products to show',
 							'woocommerce'

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/form-step/form-step-heading.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/form-step/form-step-heading.tsx
@@ -15,7 +15,6 @@ const FormStepHeading = ( {
 } ): JSX.Element => (
 	<div className="wc-block-components-checkout-step__heading">
 		<Title
-			aria-hidden="true"
 			className="wc-block-components-checkout-step__title"
 			headingLevel="2"
 		>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/width-options-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/inspector-controls/width-options-control.tsx
@@ -73,6 +73,7 @@ const WidthOptionsControl = ( {
 			</ToggleGroupControl>
 			{ widthType === WidthOptions.FIXED && (
 				<UnitControl
+					__next40pxDefaultSize
 					onChange={ ( value: string ) => {
 						setAttributes( {
 							dimensions: {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes several console warnings that appear in the block editor when working with cart and checkout blocks. In particular:

- An `aria-hidden` accessibility warning in the Checkout block.
- Some deprecation warnings from WordPress due to our use of deprecated componente `ButtonGroup` and lack of `__next40pxDefaultSize` and `__nextHasNoMarginBottom` opt-in props.

While testing, I noticed the block also triggers a `useSelect()` warning due to its use of the `CesFeedbackButton` component in the settings. I split this fix into #63554.

Closes #62340.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### `aria-hidden` fix (Checkout block)
1. Open the _Checkout_ page for editing in the admin.
2. Click on a checkout step title (e.g. "Contact information").
3. Confirm in the browser dev tools console that no `Blocked aria-hidden on an element because its descendant retained focus.` warning appears.
4. Visit the checkout page on the frontend and resize the window to a mobile size (or select one of the presets from the dev tools).
5. Inspect the "Order summary" heading at the bottom of the page and confirm it doesn't have attribute `aria-hidden="true"`.

#### Deprecation warnings (Cart block)
1. Open the _Cart_ page for editing in the admin.
2. Select the _Product Image_ block inside _Cross-Sells_ and open the settings panel. Confirm no deprecation warnings appear for `ToggleControl`, `ToggleGroupControl` or `UnitControl`.
1. Now select the _Add to Cart button_ block.
   1. Verify no `ButtonGroup` deprecation warning appears.
   2. Confirm the new component (`ToggleGroupControl` / `ToggleGroupControlOption`) works correctly (clicking the same value twice should deselect it)

      |Before|After|
      |------|-----|
      |<img width="297" height="111" alt="Screenshot 2026-03-05 at 09 50 12" src="https://github.com/user-attachments/assets/2be00fe3-0fbc-4faa-ad5a-47d867c2409b" />|<img width="267" height="94" alt="Screenshot 2026-03-05 at 10 25 59" src="https://github.com/user-attachments/assets/36e03f11-f7a7-4e97-a58f-179dde53b1ae" />|

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.