### PR TITLE
Email Editor: Add rich cards for WordPress embeds with performance cap

### DIFF
--- a/packages/php/email-editor/changelog/add-email-embed-rich-card-excerpt
+++ b/packages/php/email-editor/changelog/add-email-embed-rich-card-excerpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Fetch excerpt and site icon from WordPress embed page for rich embed cards in email rendering.

--- a/packages/php/email-editor/changelog/add-email-embed-rich-card-excerpt
+++ b/packages/php/email-editor/changelog/add-email-embed-rich-card-excerpt
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Fetch excerpt and site icon from WordPress embed page for rich embed cards in email rendering.
+Add rich cards for WordPress embeds in emails with excerpt, site icon, and a performance cap of 5 per email.

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
@@ -173,6 +173,7 @@ class Content_Renderer {
 	public function render_without_css_inline( WP_Post $post, WP_Block_Template $template ): array {
 		$this->set_template_globals( $post, $template );
 		$this->initialize();
+		do_action( 'woocommerce_email_editor_render_start' );
 		$rendered_html = get_the_block_template_html();
 		$this->reset();
 

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
@@ -173,9 +173,12 @@ class Content_Renderer {
 	public function render_without_css_inline( WP_Post $post, WP_Block_Template $template ): array {
 		$this->set_template_globals( $post, $template );
 		$this->initialize();
-		do_action( 'woocommerce_email_editor_render_start' );
-		$rendered_html = get_the_block_template_html();
-		$this->reset();
+		try {
+			do_action( 'woocommerce_email_editor_render_start' );
+			$rendered_html = get_the_block_template_html();
+		} finally {
+			$this->reset();
+		}
 
 		return array(
 			'html'   => $rendered_html,

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -24,6 +24,19 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
  */
 class Embed extends Abstract_Block_Renderer {
 	/**
+	 * Maximum number of rich card embeds per email render.
+	 * Beyond this limit, embeds render as compact link cards (no HTTP fetch).
+	 */
+	private const MAX_RICH_CARDS = 5;
+
+	/**
+	 * Number of rich cards rendered so far by this instance.
+	 *
+	 * @var int
+	 */
+	private int $rich_card_count = 0;
+
+	/**
 	 * Supported audio providers with their configuration.
 	 *
 	 * @var array
@@ -150,12 +163,21 @@ class Embed extends Abstract_Block_Renderer {
 		$provider = $this->get_supported_provider( $attr, $block_content );
 		if ( empty( $provider ) ) {
 			// For non-supported embeds, try to render as a rich card using oEmbed data.
-			$url = $this->extract_provider_url( $attr, $block_content );
-			if ( ! empty( $url ) ) {
+			// Only attempt the embed page fetch for WordPress embeds (type "wp-embed")
+			// to avoid wasted HTTP requests to non-WordPress sites.
+			$url         = $this->extract_provider_url( $attr, $block_content );
+			$is_wp_embed = isset( $attr['type'] ) && 'wp-embed' === $attr['type'];
+			if ( ! empty( $url ) && $is_wp_embed ) {
+				if ( $this->rich_card_count >= self::MAX_RICH_CARDS ) {
+					return $this->render_compact_link_card( $url, $parsed_block, $rendering_context );
+				}
+				++$this->rich_card_count;
 				$card_result = $this->render_link_embed_card( $url, $parsed_block, $rendering_context );
 				if ( ! empty( $card_result ) ) {
 					return $card_result;
 				}
+				// Fetch failed — render as compact link card instead of plain link.
+				return $this->render_compact_link_card( $url, $parsed_block, $rendering_context );
 			}
 			return $this->render_link_fallback( $attr, $block_content, $parsed_block, $rendering_context );
 		}
@@ -649,54 +671,21 @@ class Embed extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Fetch oEmbed data for a URL with transient caching.
-	 *
-	 * @param string $url URL to fetch oEmbed data for.
-	 * @return object|null oEmbed data object or null on failure.
-	 */
-	private function fetch_oembed_data( string $url ) {
-		if ( ! $this->is_valid_url( $url ) ) {
-			return null;
-		}
-
-		$cache_key = 'wc_email_oembed_' . md5( $url );
-		$cached    = get_transient( $cache_key );
-
-		if ( false !== $cached ) {
-			if ( is_object( $cached ) ) {
-				return $cached;
-			}
-			// Empty string means previous lookup failed.
-			return null;
-		}
-
-		$oembed      = new \WP_oEmbed();
-		$oembed_data = $oembed->get_data( $url );
-
-		/** This filter is documented in packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php */
-		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );
-
-		if ( false === $oembed_data || ! is_object( $oembed_data ) ) {
-			set_transient( $cache_key, '', $cache_ttl );
-			return null;
-		}
-
-		set_transient( $cache_key, $oembed_data, $cache_ttl );
-		return $oembed_data;
-	}
-
-	/**
 	 * Fetch metadata from a WordPress embed page.
 	 *
 	 * WordPress sites expose a {url}/embed/ endpoint that renders a post preview
-	 * containing the excerpt inside a <div class="wp-embed-excerpt"> element and
-	 * a site icon inside an <img class="wp-embed-site-icon"> element.
+	 * containing the title, excerpt, featured image, provider name, and site icon.
+	 * This single fetch provides all the data needed for the rich embed card.
 	 *
 	 * @param string $url URL of the post to fetch metadata for.
-	 * @return array{ excerpt: string, site_icon_url: string } Embed page metadata.
+	 * @return array{ title: string, thumbnail_url: string, provider_name: string, provider_url: string, excerpt: string, site_icon_url: string } Embed page metadata.
 	 */
 	private function fetch_embed_page_data( string $url ): array {
 		$empty_result = array(
+			'title'         => '',
+			'thumbnail_url' => '',
+			'provider_name' => '',
+			'provider_url'  => '',
 			'excerpt'       => '',
 			'site_icon_url' => '',
 		);
@@ -710,10 +699,17 @@ class Embed extends Abstract_Block_Renderer {
 		$cache_key = 'wc_email_embed_pg_' . md5( $url );
 		$cached    = get_transient( $cache_key );
 
-		if ( false !== $cached && is_array( $cached ) && isset( $cached['excerpt'], $cached['site_icon_url'] )
+		if ( false !== $cached && is_array( $cached )
+			&& isset( $cached['title'], $cached['thumbnail_url'], $cached['provider_name'], $cached['provider_url'], $cached['excerpt'], $cached['site_icon_url'] )
+			&& is_string( $cached['title'] ) && is_string( $cached['thumbnail_url'] )
+			&& is_string( $cached['provider_name'] ) && is_string( $cached['provider_url'] )
 			&& is_string( $cached['excerpt'] ) && is_string( $cached['site_icon_url'] )
 		) {
 			return array(
+				'title'         => $cached['title'],
+				'thumbnail_url' => $cached['thumbnail_url'],
+				'provider_name' => $cached['provider_name'],
+				'provider_url'  => $cached['provider_url'],
 				'excerpt'       => $cached['excerpt'],
 				'site_icon_url' => $cached['site_icon_url'],
 			);
@@ -742,13 +738,51 @@ class Embed extends Abstract_Block_Renderer {
 			return $empty_result;
 		}
 
-		// Parse HTML and extract excerpt and site icon using XPath.
+		// Parse HTML and extract metadata using XPath.
 		libxml_use_internal_errors( true );
 		$dom = new \DOMDocument();
 		$dom->loadHTML( '<?xml encoding="UTF-8">' . $body, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		libxml_clear_errors();
 
 		$xpath = new \DOMXPath( $dom );
+
+		// Extract title from wp-embed-heading.
+		$title         = '';
+		$heading_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-heading ')]" );
+		$heading_node  = ( false !== $heading_nodes && $heading_nodes->length > 0 ) ? $heading_nodes->item( 0 ) : null;
+		if ( $heading_node instanceof \DOMElement ) {
+			$title = trim( $heading_node->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		// Extract thumbnail from featured image.
+		$thumbnail_url  = '';
+		$featured_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-featured-image ')]//img" );
+		$featured_node  = ( false !== $featured_nodes && $featured_nodes->length > 0 ) ? $featured_nodes->item( 0 ) : null;
+		if ( $featured_node instanceof \DOMElement ) {
+			$img_src = $featured_node->getAttribute( 'src' );
+			if ( $this->is_valid_url( $img_src ) ) {
+				$thumbnail_url = $img_src;
+			}
+		}
+
+		// Extract provider name from site title.
+		$provider_name    = '';
+		$site_title_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-site-title ')]//span" );
+		$site_title_node  = ( false !== $site_title_nodes && $site_title_nodes->length > 0 ) ? $site_title_nodes->item( 0 ) : null;
+		if ( $site_title_node instanceof \DOMElement ) {
+			$provider_name = trim( $site_title_node->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		// Extract provider URL from site title link.
+		$provider_url    = '';
+		$site_link_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-site-title ')]//a" );
+		$site_link_node  = ( false !== $site_link_nodes && $site_link_nodes->length > 0 ) ? $site_link_nodes->item( 0 ) : null;
+		if ( $site_link_node instanceof \DOMElement ) {
+			$href = $site_link_node->getAttribute( 'href' );
+			if ( $this->is_valid_url( $href ) ) {
+				$provider_url = $href;
+			}
+		}
 
 		// Extract excerpt.
 		$excerpt       = '';
@@ -776,6 +810,10 @@ class Embed extends Abstract_Block_Renderer {
 		}
 
 		$result = array(
+			'title'         => $title,
+			'thumbnail_url' => $thumbnail_url,
+			'provider_name' => $provider_name,
+			'provider_url'  => $provider_url,
 			'excerpt'       => $excerpt,
 			'site_icon_url' => $site_icon_url,
 		);
@@ -785,38 +823,28 @@ class Embed extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Render a link embed as a rich card using oEmbed data.
+	 * Render a link embed as a rich card using data from the WordPress embed page.
 	 *
 	 * @param string            $url URL to render as a card.
 	 * @param array             $parsed_block Parsed block.
 	 * @param Rendering_Context $rendering_context Rendering context.
-	 * @return string Rendered card HTML or empty string if oEmbed data is insufficient.
+	 * @return string Rendered card HTML or empty string if embed page data is insufficient.
 	 */
 	private function render_link_embed_card( string $url, array $parsed_block, Rendering_Context $rendering_context ): string {
-		$oembed_data = $this->fetch_oembed_data( $url );
+		$embed_data = $this->fetch_embed_page_data( $url );
 
-		if ( null === $oembed_data || empty( $oembed_data->title ) ) {
+		if ( empty( $embed_data['title'] ) ) {
 			return '';
 		}
 
-		$title = $oembed_data->title;
-
-		// Only use thumbnail if it's valid and wide enough to not look blurry at full width.
-		$min_thumbnail_width = 300;
-		$thumbnail_width     = isset( $oembed_data->thumbnail_width ) ? (int) $oembed_data->thumbnail_width : 0;
-		$thumbnail_url       = isset( $oembed_data->thumbnail_url ) && $this->is_valid_url( $oembed_data->thumbnail_url )
-			&& ( 0 === $thumbnail_width || $thumbnail_width >= $min_thumbnail_width )
-			? $oembed_data->thumbnail_url
-			: '';
-		$provider_name       = ! empty( $oembed_data->provider_name )
-			? $oembed_data->provider_name
-			: wp_parse_url( $url, PHP_URL_HOST );
-		$provider_url        = ! empty( $oembed_data->provider_url ) && $this->is_valid_url( $oembed_data->provider_url )
-			? $oembed_data->provider_url
-			: '';
-		$embed_page_data     = $this->fetch_embed_page_data( $url );
-		$excerpt             = $embed_page_data['excerpt'];
-		$site_icon_url       = $embed_page_data['site_icon_url'];
+		$title         = $embed_data['title'];
+		$thumbnail_url = $embed_data['thumbnail_url'];
+		$provider_name = ! empty( $embed_data['provider_name'] )
+			? $embed_data['provider_name']
+			: (string) wp_parse_url( $url, PHP_URL_HOST );
+		$provider_url  = $embed_data['provider_url'];
+		$excerpt       = $embed_data['excerpt'];
+		$site_icon_url = $embed_data['site_icon_url'];
 
 		$email_styles = $rendering_context->get_theme_styles();
 		$text_color   = $email_styles['color']['text'] ?? '#1e1e1e';
@@ -855,7 +883,7 @@ class Embed extends Abstract_Block_Renderer {
 				esc_html( $excerpt )
 			);
 			$content_parts .= sprintf(
-				' <a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 14px; color: %s; text-decoration: none;">%s</a>',
+				' <a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 14px; color: %s; text-decoration: underline;">%s</a>',
 				esc_url( $url ),
 				esc_attr( $link_color ),
 				esc_html__( 'Continue reading', 'woocommerce' )
@@ -900,6 +928,54 @@ class Embed extends Abstract_Block_Renderer {
 			'<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border: 1px solid #ddd; border-radius: 4px; width: 100%%;">'
 		);
 		$card_html .= '<tbody>' . $rows_html . '</tbody></table>';
+
+		$outlook_wrapped = Table_Wrapper_Helper::render_outlook_table_wrapper(
+			$card_html,
+			array(
+				'align' => 'left',
+				'width' => '100%',
+			)
+		);
+
+		return $this->add_spacer(
+			$outlook_wrapped,
+			$parsed_block['email_attrs'] ?? array()
+		);
+	}
+
+	/**
+	 * Render a compact link card for embeds that exceed the rich card cap.
+	 * Displays the URL in a bordered card without making any HTTP requests.
+	 *
+	 * @param string            $url URL to render.
+	 * @param array             $parsed_block Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string Rendered compact link card HTML.
+	 */
+	private function render_compact_link_card( string $url, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$email_styles = $rendering_context->get_theme_styles();
+		$link_color   = $email_styles['elements']['link']['color']['text'] ?? '#0073aa';
+		$link_color   = Html_Processing_Helper::sanitize_color( $link_color );
+
+		// Build display text: strip scheme from URL.
+		$display_host = (string) wp_parse_url( $url, PHP_URL_HOST );
+		$display_path = (string) wp_parse_url( $url, PHP_URL_PATH );
+		$display_text = $display_host . $display_path;
+
+		$link_html = sprintf(
+			'<a href="%s" target="_blank" rel="noopener nofollow" style="color: %s; text-decoration: none;">%s</a>',
+			esc_url( $url ),
+			esc_attr( $link_color ),
+			esc_html( $display_text )
+		);
+
+		$content_cell = Table_Wrapper_Helper::render_table_cell(
+			$link_html,
+			array( 'style' => 'padding: 12px;' )
+		);
+
+		$card_html  = '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border: 1px solid #ddd; border-radius: 4px; width: 100%;">';
+		$card_html .= '<tbody><tr>' . $content_cell . '</tr></tbody></table>';
 
 		$outlook_wrapped = Table_Wrapper_Helper::render_outlook_table_wrapper(
 			$card_html,

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Html_Processing_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 
 /**
  * Embed block renderer.
@@ -148,7 +149,14 @@ class Embed extends Abstract_Block_Renderer {
 		// Check if this is a supported audio or video provider embed and has a valid URL.
 		$provider = $this->get_supported_provider( $attr, $block_content );
 		if ( empty( $provider ) ) {
-			// For non-supported embeds, try to render as a simple link fallback.
+			// For non-supported embeds, try to render as a rich card using oEmbed data.
+			$url = $this->extract_provider_url( $attr, $block_content );
+			if ( ! empty( $url ) ) {
+				$card_result = $this->render_link_embed_card( $url, $parsed_block, $rendering_context );
+				if ( ! empty( $card_result ) ) {
+					return $card_result;
+				}
+			}
 			return $this->render_link_fallback( $attr, $block_content, $parsed_block, $rendering_context );
 		}
 
@@ -638,5 +646,270 @@ class Embed extends Abstract_Block_Renderer {
 		// Cache empty result for invalid URLs.
 		set_transient( $cache_key, '', $cache_ttl );
 		return '';
+	}
+
+	/**
+	 * Fetch oEmbed data for a URL with transient caching.
+	 *
+	 * @param string $url URL to fetch oEmbed data for.
+	 * @return object|null oEmbed data object or null on failure.
+	 */
+	private function fetch_oembed_data( string $url ) {
+		if ( ! $this->is_valid_url( $url ) ) {
+			return null;
+		}
+
+		$cache_key = 'wc_email_oembed_' . md5( $url );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			if ( is_object( $cached ) ) {
+				return $cached;
+			}
+			// Empty string means previous lookup failed.
+			return null;
+		}
+
+		$oembed      = new \WP_oEmbed();
+		$oembed_data = $oembed->get_data( $url );
+
+		/** This filter is documented in packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php */
+		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );
+
+		if ( false === $oembed_data || ! is_object( $oembed_data ) ) {
+			set_transient( $cache_key, '', $cache_ttl );
+			return null;
+		}
+
+		set_transient( $cache_key, $oembed_data, $cache_ttl );
+		return $oembed_data;
+	}
+
+	/**
+	 * Fetch metadata from a WordPress embed page.
+	 *
+	 * WordPress sites expose a {url}/embed/ endpoint that renders a post preview
+	 * containing the excerpt inside a <div class="wp-embed-excerpt"> element and
+	 * a site icon inside an <img class="wp-embed-site-icon"> element.
+	 *
+	 * @param string $url URL of the post to fetch metadata for.
+	 * @return array{ excerpt: string, site_icon_url: string } Embed page metadata.
+	 */
+	private function fetch_embed_page_data( string $url ): array {
+		$empty_result = array(
+			'excerpt'       => '',
+			'site_icon_url' => '',
+		);
+
+		$embed_url = trailingslashit( $url ) . 'embed/';
+
+		if ( ! $this->is_valid_url( $embed_url ) ) {
+			return $empty_result;
+		}
+
+		$cache_key = 'wc_email_embed_pg_' . md5( $url );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached && is_array( $cached ) && isset( $cached['excerpt'], $cached['site_icon_url'] ) ) {
+			return array(
+				'excerpt'       => (string) $cached['excerpt'],
+				'site_icon_url' => (string) $cached['site_icon_url'],
+			);
+		}
+		if ( false !== $cached ) {
+			// Negative cache (empty string from previous failure).
+			return $empty_result;
+		}
+
+		/** This filter is documented in packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php */
+		$cache_ttl = (int) apply_filters( 'oembed_ttl', DAY_IN_SECONDS, $url, array(), '' );
+
+		$response = wp_safe_remote_get(
+			$embed_url,
+			array( 'timeout' => 5 )
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			set_transient( $cache_key, '', $cache_ttl );
+			return $empty_result;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( empty( $body ) ) {
+			set_transient( $cache_key, '', $cache_ttl );
+			return $empty_result;
+		}
+
+		// Parse HTML and extract excerpt and site icon using XPath.
+		libxml_use_internal_errors( true );
+		$dom = new \DOMDocument();
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $body, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+
+		$xpath = new \DOMXPath( $dom );
+
+		// Extract excerpt.
+		$excerpt       = '';
+		$excerpt_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-excerpt ')]" );
+		$excerpt_node  = ( false !== $excerpt_nodes && $excerpt_nodes->length > 0 ) ? $excerpt_nodes->item( 0 ) : null;
+		if ( $excerpt_node instanceof \DOMElement ) {
+			$excerpt = trim( $excerpt_node->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		// Cap at 200 characters as a safety limit.
+		if ( mb_strlen( $excerpt ) > 200 ) {
+			$excerpt = mb_substr( $excerpt, 0, 200 );
+			$excerpt = rtrim( $excerpt ) . '…';
+		}
+
+		// Extract site icon URL.
+		$site_icon_url = '';
+		$icon_nodes    = $xpath->query( "//img[contains(concat(' ', normalize-space(@class), ' '), ' wp-embed-site-icon ')]" );
+		$icon_node     = ( false !== $icon_nodes && $icon_nodes->length > 0 ) ? $icon_nodes->item( 0 ) : null;
+		if ( $icon_node instanceof \DOMElement ) {
+			$icon_src = $icon_node->getAttribute( 'src' );
+			if ( $this->is_valid_url( $icon_src ) ) {
+				$site_icon_url = $icon_src;
+			}
+		}
+
+		$result = array(
+			'excerpt'       => $excerpt,
+			'site_icon_url' => $site_icon_url,
+		);
+
+		set_transient( $cache_key, $result, $cache_ttl );
+		return $result;
+	}
+
+	/**
+	 * Render a link embed as a rich card using oEmbed data.
+	 *
+	 * @param string            $url URL to render as a card.
+	 * @param array             $parsed_block Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string Rendered card HTML or empty string if oEmbed data is insufficient.
+	 */
+	private function render_link_embed_card( string $url, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$oembed_data = $this->fetch_oembed_data( $url );
+
+		if ( null === $oembed_data || empty( $oembed_data->title ) ) {
+			return '';
+		}
+
+		$title = $oembed_data->title;
+
+		// Only use thumbnail if it's valid and wide enough to not look blurry at full width.
+		$min_thumbnail_width = 300;
+		$thumbnail_width     = isset( $oembed_data->thumbnail_width ) ? (int) $oembed_data->thumbnail_width : 0;
+		$thumbnail_url       = isset( $oembed_data->thumbnail_url ) && $this->is_valid_url( $oembed_data->thumbnail_url )
+			&& ( 0 === $thumbnail_width || $thumbnail_width >= $min_thumbnail_width )
+			? $oembed_data->thumbnail_url
+			: '';
+		$provider_name       = ! empty( $oembed_data->provider_name )
+			? $oembed_data->provider_name
+			: wp_parse_url( $url, PHP_URL_HOST );
+		$provider_url        = ! empty( $oembed_data->provider_url ) && $this->is_valid_url( $oembed_data->provider_url )
+			? $oembed_data->provider_url
+			: '';
+		$embed_page_data     = $this->fetch_embed_page_data( $url );
+		$excerpt             = $embed_page_data['excerpt'];
+		$site_icon_url       = $embed_page_data['site_icon_url'];
+
+		$email_styles = $rendering_context->get_theme_styles();
+		$text_color   = $email_styles['color']['text'] ?? '#1e1e1e';
+		$text_color   = Html_Processing_Helper::sanitize_color( $text_color );
+		$link_color   = $email_styles['elements']['link']['color']['text'] ?? '#0073aa';
+		$link_color   = Html_Processing_Helper::sanitize_color( $link_color );
+
+		// Build card rows.
+		$rows_html = '';
+
+		// Optional thumbnail row.
+		if ( ! empty( $thumbnail_url ) ) {
+			$thumbnail_cell = Table_Wrapper_Helper::render_table_cell(
+				sprintf(
+					'<a href="%s" target="_blank" rel="noopener nofollow"><img src="%s" alt="%s" style="display: block; width: 100%%; border-radius: 4px 4px 0 0;" /></a>',
+					esc_url( $url ),
+					esc_url( $thumbnail_url ),
+					esc_attr( $title )
+				),
+				array( 'style' => 'padding: 0;' )
+			);
+			$rows_html     .= '<tr>' . $thumbnail_cell . '</tr>';
+		}
+
+		// Build content: title, optional excerpt, provider.
+		$content_parts = sprintf(
+			'<a href="%s" target="_blank" rel="noopener nofollow" style="color: %s; text-decoration: none; font-weight: bold;">%s</a>',
+			esc_url( $url ),
+			esc_attr( $text_color ),
+			esc_html( $title )
+		);
+
+		if ( ! empty( $excerpt ) ) {
+			$content_parts .= sprintf(
+				'<br /><span style="font-size: 14px; color: #555; line-height: 1.4;">%s</span>',
+				esc_html( $excerpt )
+			);
+			$content_parts .= sprintf(
+				' <a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 14px; color: %s; text-decoration: none;">%s</a>',
+				esc_url( $url ),
+				esc_attr( $link_color ),
+				esc_html__( 'Continue reading', 'woocommerce' )
+			);
+		}
+
+		// Provider row with optional site icon.
+		$provider_text = ! empty( $provider_url )
+			? sprintf(
+				'<a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 13px; color: #757575; text-decoration: none;">%s</a>',
+				esc_url( $provider_url ),
+				esc_html( $provider_name )
+			)
+			: sprintf(
+				'<span style="font-size: 13px; color: #757575;">%s</span>',
+				esc_html( $provider_name )
+			);
+
+		if ( ! empty( $site_icon_url ) ) {
+			$content_parts .= sprintf(
+				'<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top: 16px;">'
+				. '<tr>'
+				. '<td style="vertical-align: middle; padding-right: 6px;">'
+				. '<img src="%s" width="16" height="16" alt="" style="display: block; border-radius: 2px;" />'
+				. '</td>'
+				. '<td style="vertical-align: middle;">%s</td>'
+				. '</tr></table>',
+				esc_url( $site_icon_url ),
+				$provider_text
+			);
+		} else {
+			$content_parts .= '<br />' . $provider_text;
+		}
+
+		$content_cell = Table_Wrapper_Helper::render_table_cell(
+			$content_parts,
+			array( 'style' => 'padding: 12px;' )
+		);
+		$rows_html   .= '<tr>' . $content_cell . '</tr>';
+
+		$card_html  = sprintf(
+			'<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border: 1px solid #ddd; border-radius: 4px; width: 100%%;">'
+		);
+		$card_html .= '<tbody>' . $rows_html . '</tbody></table>';
+
+		$outlook_wrapped = Table_Wrapper_Helper::render_outlook_table_wrapper(
+			$card_html,
+			array(
+				'align' => 'left',
+				'width' => '100%',
+			)
+		);
+
+		return $this->add_spacer(
+			$outlook_wrapped,
+			$parsed_block['email_attrs'] ?? array()
+		);
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -690,7 +690,13 @@ class Embed extends Abstract_Block_Renderer {
 			'site_icon_url' => '',
 		);
 
-		$embed_url = trailingslashit( $url ) . 'embed/';
+		$parsed = wp_parse_url( $url );
+		if ( empty( $parsed['scheme'] ) || empty( $parsed['host'] ) ) {
+			return $empty_result;
+		}
+		$embed_url = $parsed['scheme'] . '://' . $parsed['host']
+			. ( isset( $parsed['port'] ) ? ':' . $parsed['port'] : '' )
+			. trailingslashit( $parsed['path'] ?? '/' ) . 'embed/';
 
 		if ( ! $this->is_valid_url( $embed_url ) ) {
 			return $empty_result;
@@ -739,10 +745,14 @@ class Embed extends Abstract_Block_Renderer {
 		}
 
 		// Parse HTML and extract metadata using XPath.
-		libxml_use_internal_errors( true );
-		$dom = new \DOMDocument();
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $body, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
+		$previous_libxml_errors = libxml_use_internal_errors( true );
+		try {
+			$dom = new \DOMDocument();
+			$dom->loadHTML( '<?xml encoding="UTF-8">' . $body, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+			libxml_clear_errors();
+		} finally {
+			libxml_use_internal_errors( $previous_libxml_errors );
+		}
 
 		$xpath = new \DOMXPath( $dom );
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -24,17 +24,18 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
  */
 class Embed extends Abstract_Block_Renderer {
 	/**
-	 * Maximum number of rich card embeds per email render.
+	 * Maximum number of embed page fetch attempts per email render.
 	 * Beyond this limit, embeds render as compact link cards (no HTTP fetch).
+	 * Counts attempts, not successes, to cap outbound HTTP requests.
 	 */
-	private const MAX_RICH_CARDS = 5;
+	private const MAX_EMBED_FETCHES = 5;
 
 	/**
-	 * Number of rich cards rendered so far by this instance.
+	 * Number of embed page fetch attempts so far by this instance.
 	 *
 	 * @var int
 	 */
-	private int $rich_card_count = 0;
+	private int $embed_fetch_count = 0;
 
 	/**
 	 * Supported audio providers with their configuration.
@@ -168,10 +169,10 @@ class Embed extends Abstract_Block_Renderer {
 			$url         = $this->extract_provider_url( $attr, $block_content );
 			$is_wp_embed = isset( $attr['type'] ) && 'wp-embed' === $attr['type'];
 			if ( ! empty( $url ) && $is_wp_embed ) {
-				if ( $this->rich_card_count >= self::MAX_RICH_CARDS ) {
+				if ( $this->embed_fetch_count >= self::MAX_EMBED_FETCHES ) {
 					return $this->render_compact_link_card( $url, $parsed_block, $rendering_context );
 				}
-				++$this->rich_card_count;
+				++$this->embed_fetch_count;
 				$card_result = $this->render_link_embed_card( $url, $parsed_block, $rendering_context );
 				if ( ! empty( $card_result ) ) {
 					return $card_result;

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -890,7 +890,8 @@ class Embed extends Abstract_Block_Renderer {
 
 		if ( ! empty( $excerpt ) ) {
 			$content_parts .= sprintf(
-				'<br /><span style="font-size: 14px; color: #555; line-height: 1.4;">%s</span>',
+				'<br /><span style="font-size: 14px; color: %s; line-height: 1.4;">%s</span>',
+				esc_attr( $text_color ),
 				esc_html( $excerpt )
 			);
 			$content_parts .= sprintf(
@@ -904,12 +905,14 @@ class Embed extends Abstract_Block_Renderer {
 		// Provider row with optional site icon.
 		$provider_text = ! empty( $provider_url )
 			? sprintf(
-				'<a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 13px; color: #757575; text-decoration: none;">%s</a>',
+				'<a href="%s" target="_blank" rel="noopener nofollow" style="font-size: 13px; color: %s; text-decoration: none;">%s</a>',
 				esc_url( $provider_url ),
+				esc_attr( $text_color ),
 				esc_html( $provider_name )
 			)
 			: sprintf(
-				'<span style="font-size: 13px; color: #757575;">%s</span>',
+				'<span style="font-size: 13px; color: %s;">%s</span>',
+				esc_attr( $text_color ),
 				esc_html( $provider_name )
 			);
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -731,7 +731,10 @@ class Embed extends Abstract_Block_Renderer {
 
 		$response = wp_safe_remote_get(
 			$embed_url,
-			array( 'timeout' => 5 )
+			array(
+				'timeout'             => 5,
+				'limit_response_size' => 150 * KB_IN_BYTES,
+			)
 		);
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -710,10 +710,12 @@ class Embed extends Abstract_Block_Renderer {
 		$cache_key = 'wc_email_embed_pg_' . md5( $url );
 		$cached    = get_transient( $cache_key );
 
-		if ( false !== $cached && is_array( $cached ) && isset( $cached['excerpt'], $cached['site_icon_url'] ) ) {
+		if ( false !== $cached && is_array( $cached ) && isset( $cached['excerpt'], $cached['site_icon_url'] )
+			&& is_string( $cached['excerpt'] ) && is_string( $cached['site_icon_url'] )
+		) {
 			return array(
-				'excerpt'       => (string) $cached['excerpt'],
-				'site_icon_url' => (string) $cached['site_icon_url'],
+				'excerpt'       => $cached['excerpt'],
+				'site_icon_url' => $cached['site_icon_url'],
 			);
 		}
 		if ( false !== $cached ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-embed.php
@@ -714,7 +714,7 @@ class Embed extends Abstract_Block_Renderer {
 				'site_icon_url' => $cached['site_icon_url'],
 			);
 		}
-		if ( false !== $cached ) {
+		if ( is_string( $cached ) ) {
 			// Negative cache (empty string from previous failure).
 			return $empty_result;
 		}

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -91,6 +91,14 @@ class Initializer {
 	public function initialize(): void {
 		add_filter( 'woocommerce_email_editor_theme_json', array( $this, 'adjust_theme_json' ), 10, 1 );
 		add_filter( 'safe_style_css', array( $this, 'allow_styles' ) );
+		add_action( 'woocommerce_email_editor_render_start', array( $this, 'reset_renderers' ) );
+	}
+
+	/**
+	 * Clear cached renderer instances so stateful renderers reset between emails.
+	 */
+	public function reset_renderers(): void {
+		$this->renderers = array();
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -726,36 +726,15 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Callback for oembed_providers filter.
+	 * Helper to mock the embed page HTTP response for example.com URLs.
 	 *
-	 * @var callable|null
-	 */
-	private $oembed_provider_callback;
-
-	/**
-	 * Helper to register example.com as an oEmbed provider and mock HTTP responses.
-	 *
-	 * @param string|false $mock_body      JSON-encoded oEmbed response body (from wp_json_encode).
-	 * @param string       $embed_page_html Optional HTML for the embed page response. Empty string disables.
+	 * @param string $embed_page_html HTML for the embed page response.
 	 * @return callable The HTTP filter callback (for removal in cleanup).
 	 */
-	private function mock_oembed_for_example_com( $mock_body, string $embed_page_html = '' ): callable {
-		$mock_body                      = (string) $mock_body;
-		$this->oembed_provider_callback = function ( $providers ) {
-			$providers['https://example.com/*'] = array( 'https://example.com/wp-json/oembed/1.0/embed', false );
-			return $providers;
-		};
-		add_filter( 'oembed_providers', $this->oembed_provider_callback );
-
-		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_body, $embed_page_html ) {
-			if ( strpos( $url, 'example.com/wp-json/oembed' ) !== false ) {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => $mock_body,
-				);
-			}
+	private function mock_embed_page_for_example_com( string $embed_page_html ): callable {
+		$filter_callback = function ( $preempt, $args, $url ) use ( $embed_page_html ) {
 			// Intercept embed page requests (URLs ending with /embed/).
-			if ( ! empty( $embed_page_html ) && preg_match( '#example\.com/.*/embed/?$#', $url ) ) {
+			if ( preg_match( '#example\.com/.*/embed/?$#', $url ) ) {
 				return array(
 					'response' => array( 'code' => 200 ),
 					'body'     => $embed_page_html,
@@ -769,67 +748,30 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Helper to register example.com as an oEmbed provider that returns errors.
-	 *
-	 * @return callable The HTTP filter callback (for removal in cleanup).
-	 */
-	private function mock_oembed_failure_for_example_com(): callable {
-		$this->oembed_provider_callback = function ( $providers ) {
-			$providers['https://example.com/*'] = array( 'https://example.com/wp-json/oembed/1.0/embed', false );
-			return $providers;
-		};
-		add_filter( 'oembed_providers', $this->oembed_provider_callback );
-
-		$filter_callback = function ( $preempt, $args, $url ) {
-			if ( strpos( $url, 'example.com/wp-json/oembed' ) !== false ) {
-				return new \WP_Error( 'http_request_failed', 'Connection refused' );
-			}
-			return $preempt;
-		};
-
-		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
-		return $filter_callback;
-	}
-
-	/**
-	 * Helper to clean up oEmbed mocks.
+	 * Helper to clean up embed page mocks.
 	 *
 	 * @param callable $filter_callback The HTTP filter callback to remove.
 	 * @param string   $url The URL whose transient should be deleted.
 	 */
-	private function cleanup_oembed_mock( callable $filter_callback, string $url ): void {
+	private function cleanup_embed_mock( callable $filter_callback, string $url ): void {
 		remove_filter( 'pre_http_request', $filter_callback, 10 );
-		delete_transient( 'wc_email_oembed_' . md5( $url ) );
 		delete_transient( 'wc_email_embed_pg_' . md5( $url ) );
-		if ( null !== $this->oembed_provider_callback ) {
-			remove_filter( 'oembed_providers', $this->oembed_provider_callback );
-			$this->oembed_provider_callback = null;
-		}
 	}
 
 	/**
-	 * Test that wp-embed link renders as rich card when oEmbed returns title and thumbnail
+	 * Test that wp-embed link renders as rich card from embed page data
 	 */
 	public function test_renders_wp_embed_as_rich_card(): void {
 		$url             = 'https://example.com/my-blog-post';
 		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">My Blog Post Title</a></p>'
 			. '<div class="wp-embed-excerpt"><p>A short excerpt about garlic roasted potatoes and other delicious things.</p></div>'
+			. '<div class="wp-embed-featured-image square"><a href="' . $url . '" target="_top"><img src="https://example.com/image.jpg" alt="" /></a></div>'
 			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
 			. '<img src="https://example.com/icon-32.png" width="32" height="32" alt="" class="wp-embed-site-icon" />'
 			. '<span>Example Blog</span></a></div>'
 			. '</div></body></html>';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'My Blog Post Title',
-					'thumbnail_url' => 'https://example.com/image.jpg',
-					'provider_name' => 'Example Blog',
-					'provider_url'  => 'https://example.com',
-					'type'          => 'link',
-				)
-			),
-			$embed_page_html
-		);
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -844,10 +786,10 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
-		$this->assertStringContainsString( 'My Blog Post Title', $rendered, 'Card should contain the oEmbed title' );
+		$this->assertStringContainsString( 'My Blog Post Title', $rendered, 'Card should contain the title' );
 		$this->assertStringContainsString( 'https://example.com/image.jpg', $rendered, 'Card should contain the thumbnail image' );
 		$this->assertStringContainsString( 'garlic roasted potatoes', $rendered, 'Card should contain the excerpt from embed page' );
 		$this->assertStringContainsString( 'Continue reading', $rendered, 'Card should contain a Continue reading link' );
@@ -860,19 +802,16 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that card renders without thumbnail when oEmbed has title but no thumbnail_url
+	 * Test that card renders without thumbnail when embed page has no featured image
 	 */
 	public function test_renders_card_without_thumbnail(): void {
 		$url             = 'https://example.com/no-image-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'A Post Without Image',
-					'provider_name' => 'No Image Blog',
-					'type'          => 'link',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">A Post Without Image</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>No Image Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -887,7 +826,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
 		$this->assertStringContainsString( 'A Post Without Image', $rendered, 'Card should contain the title' );
@@ -896,18 +835,14 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that card uses domain as provider name when oEmbed does not include provider_name
+	 * Test that card uses domain as provider name when embed page has no site title
 	 */
 	public function test_renders_card_with_domain_fallback_for_provider(): void {
 		$url             = 'https://example.com/domain-fallback';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title' => 'Domain Fallback Post',
-					'type'  => 'link',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">Domain Fallback Post</a></p>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -922,7 +857,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
 		$this->assertStringContainsString( 'Domain Fallback Post', $rendered, 'Card should contain the title' );
@@ -930,12 +865,12 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that embed falls back to bare link when oEmbed HTTP request fails
+	 * Test that embed falls back to compact link card when embed page HTTP request fails
 	 */
-	public function test_falls_back_to_link_when_oembed_fails(): void {
-		$url             = 'https://example.com/failing-post';
-		$filter_callback = $this->mock_oembed_failure_for_example_com();
+	public function test_falls_back_to_compact_card_when_embed_page_fails(): void {
+		$url = 'https://example.com/failing-post';
 
+		// No mock registered — wp_safe_remote_get will fail in the test environment.
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
@@ -949,26 +884,24 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			delete_transient( 'wc_email_embed_pg_' . md5( $url ) );
 		}
 
-		$this->assertStringContainsString( '<a href="https://example.com/failing-post"', $rendered, 'Should fall back to bare link' );
-		$this->assertStringNotContainsString( 'border: 1px solid #ddd', $rendered, 'Should not render as card' );
+		$this->assertStringContainsString( '<a href="https://example.com/failing-post"', $rendered, 'Should contain link to URL' );
+		$this->assertStringContainsString( 'border: 1px solid #ddd', $rendered, 'Should render as compact link card' );
+		$this->assertStringContainsString( 'example.com/failing-post', $rendered, 'Should display URL without scheme' );
 	}
 
 	/**
-	 * Test that embed falls back to bare link when oEmbed response has no title
+	 * Test that embed falls back to compact link card when embed page has no title
 	 */
-	public function test_falls_back_to_link_when_oembed_has_no_title(): void {
+	public function test_falls_back_to_compact_card_when_embed_page_has_no_title(): void {
 		$url             = 'https://example.com/no-title';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'type'          => 'link',
-					'provider_name' => 'Example',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Example</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -983,28 +916,26 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
-		$this->assertStringContainsString( '<a href="https://example.com/no-title"', $rendered, 'Should fall back to bare link' );
-		$this->assertStringNotContainsString( 'border: 1px solid #ddd', $rendered, 'Should not render as card' );
+		$this->assertStringContainsString( '<a href="https://example.com/no-title"', $rendered, 'Should contain link to URL' );
+		$this->assertStringContainsString( 'border: 1px solid #ddd', $rendered, 'Should render as compact link card' );
+		$this->assertStringContainsString( 'example.com/no-title', $rendered, 'Should display URL without scheme' );
 	}
 
 	/**
-	 * Test that card renders without thumbnail when thumbnail_url is invalid
+	 * Test that card renders without thumbnail when featured image URL is invalid
 	 */
 	public function test_renders_card_without_thumbnail_when_thumbnail_url_invalid(): void {
 		$url             = 'https://example.com/bad-thumbnail';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Post With Bad Thumbnail',
-					'thumbnail_url' => 'javascript:alert(1)',
-					'provider_name' => 'Sketchy Blog',
-					'type'          => 'link',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">Post With Bad Thumbnail</a></p>'
+			. '<div class="wp-embed-featured-image square"><a href="' . $url . '" target="_top"><img src="javascript:alert(1)" alt="" /></a></div>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Sketchy Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -1019,7 +950,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
 		$this->assertStringContainsString( 'Post With Bad Thumbnail', $rendered, 'Card should still render with title' );
@@ -1028,19 +959,16 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that oEmbed response is cached and reused on subsequent renders
+	 * Test that embed page response is cached and reused on subsequent renders
 	 */
-	public function test_oembed_response_is_cached(): void {
+	public function test_embed_page_response_is_cached(): void {
 		$url             = 'https://example.com/cached-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Cached Post',
-					'provider_name' => 'Cache Blog',
-					'type'          => 'link',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">Cached Post</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Cache Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -1059,7 +987,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 			$second_render = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
 		$this->assertStringContainsString( 'Cached Post', $first_render, 'First render should contain the title' );
@@ -1071,15 +999,12 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	 */
 	public function test_link_embed_card_respects_email_attrs_spacing(): void {
 		$url             = 'https://example.com/spaced-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Spaced Post',
-					'provider_name' => 'Space Blog',
-					'type'          => 'link',
-				)
-			)
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">Spaced Post</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Space Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName'   => 'core/embed',
@@ -1097,7 +1022,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
 		$this->assertStringContainsString( 'Spaced Post', $rendered, 'Card should render' );
@@ -1105,28 +1030,24 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test that card skips thumbnail when thumbnail_width is below minimum
+	 * Test that card shows thumbnail when embed page has a featured image
 	 */
-	public function test_renders_card_without_thumbnail_when_too_small(): void {
-		$url             = 'https://example.com/small-thumb-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'           => 'Small Thumbnail Post',
-					'thumbnail_url'   => 'https://example.com/tiny.jpg',
-					'thumbnail_width' => 150,
-					'provider_name'   => 'Tiny Blog',
-					'type'            => 'link',
-				)
-			)
-		);
+	public function test_renders_card_with_thumbnail(): void {
+		$url             = 'https://example.com/thumb-post';
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '" target="_top">Post With Thumbnail</a></p>'
+			. '<div class="wp-embed-featured-image square"><a href="' . $url . '" target="_top"><img src="https://example.com/featured.jpg" alt="" /></a></div>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Image Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
 			'attrs'     => array(
 				'url'              => $url,
 				'type'             => 'wp-embed',
-				'providerNameSlug' => 'tiny-blog',
+				'providerNameSlug' => 'image-blog',
 			),
 			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
 		);
@@ -1134,128 +1055,12 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
-		$this->assertStringContainsString( 'Small Thumbnail Post', $rendered, 'Card should still render with title' );
-		$this->assertStringContainsString( 'Tiny Blog', $rendered, 'Card should contain provider name' );
-		$this->assertStringNotContainsString( '<img', $rendered, 'Card should not show small thumbnail' );
-		$this->assertStringNotContainsString( 'tiny.jpg', $rendered, 'Small thumbnail URL should not appear' );
-	}
-
-	/**
-	 * Test that card shows thumbnail when thumbnail_width meets minimum
-	 */
-	public function test_renders_card_with_thumbnail_when_large_enough(): void {
-		$url             = 'https://example.com/large-thumb-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'           => 'Large Thumbnail Post',
-					'thumbnail_url'   => 'https://example.com/big.jpg',
-					'thumbnail_width' => 600,
-					'provider_name'   => 'Big Blog',
-					'type'            => 'link',
-				)
-			)
-		);
-
-		$parsed_wp_embed = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => $url,
-				'type'             => 'wp-embed',
-				'providerNameSlug' => 'big-blog',
-			),
-			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
-		);
-
-		try {
-			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
-		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
-		}
-
-		$this->assertStringContainsString( 'Large Thumbnail Post', $rendered, 'Card should render with title' );
-		$this->assertStringContainsString( 'https://example.com/big.jpg', $rendered, 'Card should show large thumbnail' );
-		$this->assertStringContainsString( '<img', $rendered, 'Card should contain an image tag' );
-	}
-
-	/**
-	 * Test that card shows thumbnail when thumbnail_width is not provided by oEmbed
-	 */
-	public function test_renders_card_with_thumbnail_when_width_unknown(): void {
-		$url             = 'https://example.com/unknown-width-post';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Unknown Width Post',
-					'thumbnail_url' => 'https://example.com/mystery.jpg',
-					'provider_name' => 'Mystery Blog',
-					'type'          => 'link',
-				)
-			)
-		);
-
-		$parsed_wp_embed = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => $url,
-				'type'             => 'wp-embed',
-				'providerNameSlug' => 'mystery-blog',
-			),
-			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
-		);
-
-		try {
-			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
-		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
-		}
-
-		$this->assertStringContainsString( 'Unknown Width Post', $rendered, 'Card should render with title' );
-		$this->assertStringContainsString( 'https://example.com/mystery.jpg', $rendered, 'Card should show thumbnail when width is unknown' );
-		$this->assertStringContainsString( '<img', $rendered, 'Card should contain an image tag' );
-	}
-
-	/**
-	 * Test that card renders without excerpt when embed page fetch fails
-	 */
-	public function test_renders_card_without_excerpt_when_embed_page_fails(): void {
-		$url = 'https://example.com/no-embed-page';
-
-		// Register oEmbed provider but do NOT provide embed page HTML — the default
-		// pre_http_request will not intercept the /embed/ URL, so wp_safe_remote_get
-		// will return an error in the test environment.
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Post Without Embed Page',
-					'provider_name' => 'Example Blog',
-					'type'          => 'link',
-				)
-			)
-		);
-
-		$parsed_wp_embed = array(
-			'blockName' => 'core/embed',
-			'attrs'     => array(
-				'url'              => $url,
-				'type'             => 'wp-embed',
-				'providerNameSlug' => 'example-blog',
-			),
-			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
-		);
-
-		try {
-			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
-		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
-		}
-
-		$this->assertStringContainsString( 'Post Without Embed Page', $rendered, 'Card should still render title' );
-		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain provider name' );
-		$this->assertStringNotContainsString( 'font-size: 14px; color: #555', $rendered, 'Card should not contain excerpt styling' );
+		$this->assertStringContainsString( 'Post With Thumbnail', $rendered, 'Card should render with title' );
+		$this->assertStringContainsString( 'https://example.com/featured.jpg', $rendered, 'Card should show featured image as thumbnail' );
+		$this->assertStringContainsString( 'Image Blog', $rendered, 'Card should contain provider name' );
 	}
 
 	/**
@@ -1263,17 +1068,12 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	 */
 	public function test_renders_card_without_excerpt_when_no_excerpt_element(): void {
 		$url             = 'https://example.com/no-excerpt-element';
-		$embed_page_html = '<html><body><div class="wp-embed"><p class="wp-embed-heading"><a href="' . $url . '">Post Title</a></p></div></body></html>';
-		$filter_callback = $this->mock_oembed_for_example_com(
-			wp_json_encode(
-				array(
-					'title'         => 'Post Without Excerpt Element',
-					'provider_name' => 'Example Blog',
-					'type'          => 'link',
-				)
-			),
-			$embed_page_html
-		);
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="' . $url . '">Post Title</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Example Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
 
 		$parsed_wp_embed = array(
 			'blockName' => 'core/embed',
@@ -1288,11 +1088,114 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		try {
 			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
 		} finally {
-			$this->cleanup_oembed_mock( $filter_callback, $url );
+			$this->cleanup_embed_mock( $filter_callback, $url );
 		}
 
-		$this->assertStringContainsString( 'Post Without Excerpt Element', $rendered, 'Card should still render title' );
+		$this->assertStringContainsString( 'Post Title', $rendered, 'Card should still render title' );
 		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain provider name' );
 		$this->assertStringNotContainsString( 'font-size: 14px; color: #555', $rendered, 'Card should not contain excerpt styling' );
+	}
+
+	/**
+	 * Test that rich cards are capped at five per render instance
+	 */
+	public function test_caps_rich_cards_at_five_per_render(): void {
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="https://example.com/post" target="_top">Rich Card Title</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Example Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
+
+		$urls = array();
+		try {
+			for ( $i = 1; $i <= 6; $i++ ) {
+				$url    = 'https://example.com/post-' . $i;
+				$urls[] = $url;
+
+				$parsed_block = array(
+					'blockName' => 'core/embed',
+					'attrs'     => array(
+						'url'              => $url,
+						'type'             => 'wp-embed',
+						'providerNameSlug' => 'example-blog',
+					),
+					'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+				);
+
+				$rendered = $this->embed_renderer->render( $parsed_block['innerHTML'], $parsed_block, $this->rendering_context );
+
+				if ( $i <= 5 ) {
+					$this->assertStringContainsString( 'Rich Card Title', $rendered, "Embed #{$i} should render as a rich card" );
+				} else {
+					$this->assertStringNotContainsString( 'Rich Card Title', $rendered, 'Embed #6 should NOT render as a rich card' );
+					$this->assertStringContainsString( 'border: 1px solid #ddd', $rendered, 'Embed #6 should render as a compact link card' );
+					$this->assertStringContainsString( 'example.com/post-6', $rendered, 'Compact card should display the URL' );
+				}
+			}
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+			foreach ( $urls as $url ) {
+				delete_transient( 'wc_email_embed_pg_' . md5( $url ) );
+			}
+		}
+	}
+
+	/**
+	 * Test that compact link card shows URL in a styled card with theme link color
+	 */
+	public function test_compact_link_card_shows_url_in_card(): void {
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<p class="wp-embed-heading"><a href="https://example.com/post" target="_top">Title</a></p>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<span>Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_embed_page_for_example_com( $embed_page_html );
+
+		$urls = array();
+		try {
+			// Exhaust the 5 rich card slots.
+			for ( $i = 1; $i <= 5; $i++ ) {
+				$url    = 'https://example.com/filler-' . $i;
+				$urls[] = $url;
+
+				$parsed_block = array(
+					'blockName' => 'core/embed',
+					'attrs'     => array(
+						'url'              => $url,
+						'type'             => 'wp-embed',
+						'providerNameSlug' => 'example-blog',
+					),
+					'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+				);
+				$this->embed_renderer->render( $parsed_block['innerHTML'], $parsed_block, $this->rendering_context );
+			}
+
+			// The 6th should be a compact link card.
+			$target_url   = 'https://example.com/the-target-post';
+			$urls[]       = $target_url;
+			$parsed_block = array(
+				'blockName' => 'core/embed',
+				'attrs'     => array(
+					'url'              => $target_url,
+					'type'             => 'wp-embed',
+					'providerNameSlug' => 'example-blog',
+				),
+				'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $target_url . '</div></figure>',
+			);
+			$rendered     = $this->embed_renderer->render( $parsed_block['innerHTML'], $parsed_block, $this->rendering_context );
+
+			$this->assertStringContainsString( 'border: 1px solid #ddd', $rendered, 'Compact card should have a card border' );
+			$this->assertStringContainsString( 'border-radius: 4px', $rendered, 'Compact card should have rounded corners' );
+			$this->assertStringContainsString( 'example.com/the-target-post', $rendered, 'Compact card should display the URL without scheme' );
+			$this->assertStringContainsString( 'href="https://example.com/the-target-post"', $rendered, 'Compact card URL should link to the original URL' );
+			// Verify the link uses theme link color (default for test context).
+			$this->assertStringContainsString( 'text-decoration: none', $rendered, 'Compact card link should have no underline' );
+		} finally {
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+			foreach ( $urls as $url ) {
+				delete_transient( 'wc_email_embed_pg_' . md5( $url ) );
+			}
+		}
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -1093,7 +1093,7 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 
 		$this->assertStringContainsString( 'Post Title', $rendered, 'Card should still render title' );
 		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain provider name' );
-		$this->assertStringNotContainsString( 'font-size: 14px; color: #555', $rendered, 'Card should not contain excerpt styling' );
+		$this->assertStringNotContainsString( 'line-height: 1.4;', $rendered, 'Card should not contain excerpt styling' );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -735,11 +735,12 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 	/**
 	 * Helper to register example.com as an oEmbed provider and mock HTTP responses.
 	 *
-	 * @param string $mock_body      JSON-encoded oEmbed response body.
-	 * @param string $embed_page_html Optional HTML for the embed page response. Empty string disables.
+	 * @param string|false $mock_body      JSON-encoded oEmbed response body (from wp_json_encode).
+	 * @param string       $embed_page_html Optional HTML for the embed page response. Empty string disables.
 	 * @return callable The HTTP filter callback (for removal in cleanup).
 	 */
-	private function mock_oembed_for_example_com( string $mock_body, string $embed_page_html = '' ): callable {
+	private function mock_oembed_for_example_com( $mock_body, string $embed_page_html = '' ): callable {
+		$mock_body                      = (string) $mock_body;
 		$this->oembed_provider_callback = function ( $providers ) {
 			$providers['https://example.com/*'] = array( 'https://example.com/wp-json/oembed/1.0/embed', false );
 			return $providers;

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Embed_Test.php
@@ -724,4 +724,574 @@ class Embed_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertNotEmpty( $rendered );
 		$this->assertStringContainsString( 'background-image', $rendered, 'VideoPress embed should have background image' );
 	}
+
+	/**
+	 * Callback for oembed_providers filter.
+	 *
+	 * @var callable|null
+	 */
+	private $oembed_provider_callback;
+
+	/**
+	 * Helper to register example.com as an oEmbed provider and mock HTTP responses.
+	 *
+	 * @param string $mock_body      JSON-encoded oEmbed response body.
+	 * @param string $embed_page_html Optional HTML for the embed page response. Empty string disables.
+	 * @return callable The HTTP filter callback (for removal in cleanup).
+	 */
+	private function mock_oembed_for_example_com( string $mock_body, string $embed_page_html = '' ): callable {
+		$this->oembed_provider_callback = function ( $providers ) {
+			$providers['https://example.com/*'] = array( 'https://example.com/wp-json/oembed/1.0/embed', false );
+			return $providers;
+		};
+		add_filter( 'oembed_providers', $this->oembed_provider_callback );
+
+		$filter_callback = function ( $preempt, $args, $url ) use ( $mock_body, $embed_page_html ) {
+			if ( strpos( $url, 'example.com/wp-json/oembed' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $mock_body,
+				);
+			}
+			// Intercept embed page requests (URLs ending with /embed/).
+			if ( ! empty( $embed_page_html ) && preg_match( '#example\.com/.*/embed/?$#', $url ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $embed_page_html,
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+		return $filter_callback;
+	}
+
+	/**
+	 * Helper to register example.com as an oEmbed provider that returns errors.
+	 *
+	 * @return callable The HTTP filter callback (for removal in cleanup).
+	 */
+	private function mock_oembed_failure_for_example_com(): callable {
+		$this->oembed_provider_callback = function ( $providers ) {
+			$providers['https://example.com/*'] = array( 'https://example.com/wp-json/oembed/1.0/embed', false );
+			return $providers;
+		};
+		add_filter( 'oembed_providers', $this->oembed_provider_callback );
+
+		$filter_callback = function ( $preempt, $args, $url ) {
+			if ( strpos( $url, 'example.com/wp-json/oembed' ) !== false ) {
+				return new \WP_Error( 'http_request_failed', 'Connection refused' );
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter_callback, 10, 3 );
+		return $filter_callback;
+	}
+
+	/**
+	 * Helper to clean up oEmbed mocks.
+	 *
+	 * @param callable $filter_callback The HTTP filter callback to remove.
+	 * @param string   $url The URL whose transient should be deleted.
+	 */
+	private function cleanup_oembed_mock( callable $filter_callback, string $url ): void {
+		remove_filter( 'pre_http_request', $filter_callback, 10 );
+		delete_transient( 'wc_email_oembed_' . md5( $url ) );
+		delete_transient( 'wc_email_embed_pg_' . md5( $url ) );
+		if ( null !== $this->oembed_provider_callback ) {
+			remove_filter( 'oembed_providers', $this->oembed_provider_callback );
+			$this->oembed_provider_callback = null;
+		}
+	}
+
+	/**
+	 * Test that wp-embed link renders as rich card when oEmbed returns title and thumbnail
+	 */
+	public function test_renders_wp_embed_as_rich_card(): void {
+		$url             = 'https://example.com/my-blog-post';
+		$embed_page_html = '<html><body><div class="wp-embed">'
+			. '<div class="wp-embed-excerpt"><p>A short excerpt about garlic roasted potatoes and other delicious things.</p></div>'
+			. '<div class="wp-embed-site-title"><a href="https://example.com" target="_top">'
+			. '<img src="https://example.com/icon-32.png" width="32" height="32" alt="" class="wp-embed-site-icon" />'
+			. '<span>Example Blog</span></a></div>'
+			. '</div></body></html>';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'My Blog Post Title',
+					'thumbnail_url' => 'https://example.com/image.jpg',
+					'provider_name' => 'Example Blog',
+					'provider_url'  => 'https://example.com',
+					'type'          => 'link',
+				)
+			),
+			$embed_page_html
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'my-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed is-provider-my-blog"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'My Blog Post Title', $rendered, 'Card should contain the oEmbed title' );
+		$this->assertStringContainsString( 'https://example.com/image.jpg', $rendered, 'Card should contain the thumbnail image' );
+		$this->assertStringContainsString( 'garlic roasted potatoes', $rendered, 'Card should contain the excerpt from embed page' );
+		$this->assertStringContainsString( 'Continue reading', $rendered, 'Card should contain a Continue reading link' );
+		$this->assertStringContainsString( 'https://example.com/icon-32.png', $rendered, 'Card should contain the site icon' );
+		$this->assertStringContainsString( 'width="16" height="16"', $rendered, 'Site icon should be scaled to 16px' );
+		$this->assertStringContainsString( '<a href="https://example.com"', $rendered, 'Provider name should be linked' );
+		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain the provider name' );
+		$this->assertStringContainsString( '<table', $rendered, 'Card should use table-based layout' );
+		$this->assertStringContainsString( 'border: 1px solid #ddd', $rendered, 'Card should have a border' );
+	}
+
+	/**
+	 * Test that card renders without thumbnail when oEmbed has title but no thumbnail_url
+	 */
+	public function test_renders_card_without_thumbnail(): void {
+		$url             = 'https://example.com/no-image-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'A Post Without Image',
+					'provider_name' => 'No Image Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'no-image-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'A Post Without Image', $rendered, 'Card should contain the title' );
+		$this->assertStringContainsString( 'No Image Blog', $rendered, 'Card should contain the provider name' );
+		$this->assertStringNotContainsString( '<img', $rendered, 'Card should not contain an image tag' );
+	}
+
+	/**
+	 * Test that card uses domain as provider name when oEmbed does not include provider_name
+	 */
+	public function test_renders_card_with_domain_fallback_for_provider(): void {
+		$url             = 'https://example.com/domain-fallback';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title' => 'Domain Fallback Post',
+					'type'  => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'example-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Domain Fallback Post', $rendered, 'Card should contain the title' );
+		$this->assertStringContainsString( 'example.com', $rendered, 'Card should fall back to domain as provider' );
+	}
+
+	/**
+	 * Test that embed falls back to bare link when oEmbed HTTP request fails
+	 */
+	public function test_falls_back_to_link_when_oembed_fails(): void {
+		$url             = 'https://example.com/failing-post';
+		$filter_callback = $this->mock_oembed_failure_for_example_com();
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'failing-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( '<a href="https://example.com/failing-post"', $rendered, 'Should fall back to bare link' );
+		$this->assertStringNotContainsString( 'border: 1px solid #ddd', $rendered, 'Should not render as card' );
+	}
+
+	/**
+	 * Test that embed falls back to bare link when oEmbed response has no title
+	 */
+	public function test_falls_back_to_link_when_oembed_has_no_title(): void {
+		$url             = 'https://example.com/no-title';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'type'          => 'link',
+					'provider_name' => 'Example',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'no-title-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( '<a href="https://example.com/no-title"', $rendered, 'Should fall back to bare link' );
+		$this->assertStringNotContainsString( 'border: 1px solid #ddd', $rendered, 'Should not render as card' );
+	}
+
+	/**
+	 * Test that card renders without thumbnail when thumbnail_url is invalid
+	 */
+	public function test_renders_card_without_thumbnail_when_thumbnail_url_invalid(): void {
+		$url             = 'https://example.com/bad-thumbnail';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Post With Bad Thumbnail',
+					'thumbnail_url' => 'javascript:alert(1)',
+					'provider_name' => 'Sketchy Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'sketchy-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Post With Bad Thumbnail', $rendered, 'Card should still render with title' );
+		$this->assertStringNotContainsString( '<img', $rendered, 'Card should not contain an image tag' );
+		$this->assertStringNotContainsString( 'javascript:', $rendered, 'Card should not contain javascript URL' );
+	}
+
+	/**
+	 * Test that oEmbed response is cached and reused on subsequent renders
+	 */
+	public function test_oembed_response_is_cached(): void {
+		$url             = 'https://example.com/cached-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Cached Post',
+					'provider_name' => 'Cache Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'cache-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$first_render = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+
+			remove_filter( 'pre_http_request', $filter_callback, 10 );
+
+			$second_render = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Cached Post', $first_render, 'First render should contain the title' );
+		$this->assertStringContainsString( 'Cached Post', $second_render, 'Second render should also contain the title from cache' );
+	}
+
+	/**
+	 * Test that link embed card respects email_attrs spacing
+	 */
+	public function test_link_embed_card_respects_email_attrs_spacing(): void {
+		$url             = 'https://example.com/spaced-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Spaced Post',
+					'provider_name' => 'Space Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName'   => 'core/embed',
+			'attrs'       => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'space-blog',
+			),
+			'innerHTML'   => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+			'email_attrs' => array(
+				'margin-top' => '30px',
+			),
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Spaced Post', $rendered, 'Card should render' );
+		$this->assertStringContainsString( 'margin-top:30px', $rendered, 'Card should respect email_attrs spacing' );
+	}
+
+	/**
+	 * Test that card skips thumbnail when thumbnail_width is below minimum
+	 */
+	public function test_renders_card_without_thumbnail_when_too_small(): void {
+		$url             = 'https://example.com/small-thumb-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'           => 'Small Thumbnail Post',
+					'thumbnail_url'   => 'https://example.com/tiny.jpg',
+					'thumbnail_width' => 150,
+					'provider_name'   => 'Tiny Blog',
+					'type'            => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'tiny-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Small Thumbnail Post', $rendered, 'Card should still render with title' );
+		$this->assertStringContainsString( 'Tiny Blog', $rendered, 'Card should contain provider name' );
+		$this->assertStringNotContainsString( '<img', $rendered, 'Card should not show small thumbnail' );
+		$this->assertStringNotContainsString( 'tiny.jpg', $rendered, 'Small thumbnail URL should not appear' );
+	}
+
+	/**
+	 * Test that card shows thumbnail when thumbnail_width meets minimum
+	 */
+	public function test_renders_card_with_thumbnail_when_large_enough(): void {
+		$url             = 'https://example.com/large-thumb-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'           => 'Large Thumbnail Post',
+					'thumbnail_url'   => 'https://example.com/big.jpg',
+					'thumbnail_width' => 600,
+					'provider_name'   => 'Big Blog',
+					'type'            => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'big-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Large Thumbnail Post', $rendered, 'Card should render with title' );
+		$this->assertStringContainsString( 'https://example.com/big.jpg', $rendered, 'Card should show large thumbnail' );
+		$this->assertStringContainsString( '<img', $rendered, 'Card should contain an image tag' );
+	}
+
+	/**
+	 * Test that card shows thumbnail when thumbnail_width is not provided by oEmbed
+	 */
+	public function test_renders_card_with_thumbnail_when_width_unknown(): void {
+		$url             = 'https://example.com/unknown-width-post';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Unknown Width Post',
+					'thumbnail_url' => 'https://example.com/mystery.jpg',
+					'provider_name' => 'Mystery Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'mystery-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Unknown Width Post', $rendered, 'Card should render with title' );
+		$this->assertStringContainsString( 'https://example.com/mystery.jpg', $rendered, 'Card should show thumbnail when width is unknown' );
+		$this->assertStringContainsString( '<img', $rendered, 'Card should contain an image tag' );
+	}
+
+	/**
+	 * Test that card renders without excerpt when embed page fetch fails
+	 */
+	public function test_renders_card_without_excerpt_when_embed_page_fails(): void {
+		$url = 'https://example.com/no-embed-page';
+
+		// Register oEmbed provider but do NOT provide embed page HTML — the default
+		// pre_http_request will not intercept the /embed/ URL, so wp_safe_remote_get
+		// will return an error in the test environment.
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Post Without Embed Page',
+					'provider_name' => 'Example Blog',
+					'type'          => 'link',
+				)
+			)
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'example-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Post Without Embed Page', $rendered, 'Card should still render title' );
+		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain provider name' );
+		$this->assertStringNotContainsString( 'font-size: 14px; color: #555', $rendered, 'Card should not contain excerpt styling' );
+	}
+
+	/**
+	 * Test that card renders without excerpt when embed page has no wp-embed-excerpt element
+	 */
+	public function test_renders_card_without_excerpt_when_no_excerpt_element(): void {
+		$url             = 'https://example.com/no-excerpt-element';
+		$embed_page_html = '<html><body><div class="wp-embed"><p class="wp-embed-heading"><a href="' . $url . '">Post Title</a></p></div></body></html>';
+		$filter_callback = $this->mock_oembed_for_example_com(
+			wp_json_encode(
+				array(
+					'title'         => 'Post Without Excerpt Element',
+					'provider_name' => 'Example Blog',
+					'type'          => 'link',
+				)
+			),
+			$embed_page_html
+		);
+
+		$parsed_wp_embed = array(
+			'blockName' => 'core/embed',
+			'attrs'     => array(
+				'url'              => $url,
+				'type'             => 'wp-embed',
+				'providerNameSlug' => 'example-blog',
+			),
+			'innerHTML' => '<figure class="wp-block-embed is-type-wp-embed"><div class="wp-block-embed__wrapper">' . $url . '</div></figure>',
+		);
+
+		try {
+			$rendered = $this->embed_renderer->render( $parsed_wp_embed['innerHTML'], $parsed_wp_embed, $this->rendering_context );
+		} finally {
+			$this->cleanup_oembed_mock( $filter_callback, $url );
+		}
+
+		$this->assertStringContainsString( 'Post Without Excerpt Element', $rendered, 'Card should still render title' );
+		$this->assertStringContainsString( 'Example Blog', $rendered, 'Card should contain provider name' );
+		$this->assertStringNotContainsString( 'font-size: 14px; color: #555', $rendered, 'Card should not contain excerpt styling' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes NL-190

When the email editor renders a `core/embed` block for a WordPress post (type `wp-embed`), we now fetch the WordPress embed page (`{url}/embed/`) to build a rich card containing:

- **Featured image** as a full-width thumbnail
- **Post title** as a linked heading
- **Post excerpt** with a "Continue reading" link using the theme link color
- **Site icon** (16×16) next to the provider name using an email-safe inline table layout

Previously, rich card data came from the oEmbed API (which often returned low-quality thumbnails and no excerpt). Now all data comes from a single embed page fetch, which is the same endpoint WordPress uses for its own embed previews.

**Performance safeguards:**
- **WordPress-only fetches** — Only `type: "wp-embed"` blocks trigger the embed page fetch. Non-WordPress URLs (NYTimes, Twitter, etc.) skip the HTTP request entirely and render as a plain link fallback.
- **5-card cap per email** — Rich card renders are capped at 5 per email. Beyond the limit, WordPress embeds render as compact bordered link cards (URL displayed in a styled card, no HTTP fetch).
- **Compact card for failed fetches** — If the embed page fetch fails or returns no title, the embed renders as a compact link card instead of a bare link, keeping the visual style consistent.
- **Transient caching** — Embed page results are cached for 1 day (matching WordPress oEmbed TTL) to avoid repeated fetches across email sends.
- **Renderer state reset** — The `CoreInitializer` is a singleton in the DI container, so its cached block renderers persist across email renders. A new `woocommerce_email_editor_render_start` action fires at the start of each email render, and the Initializer hooks it to clear its renderer cache. This ensures the Embed renderer's 5-card counter resets between emails. Other renderers are stateless, so re-instantiating them has no functional impact.

Before | After
---- | ----
<img width="684" height="559" alt="Screenshot 2026-03-04 at 3 18 11 PM" src="https://github.com/user-attachments/assets/c03db499-733e-499d-9fb5-a7ee2542e7ac" /> | <img width="610" height="623" alt="Screenshot 2026-03-09 at 3 01 18 PM" src="https://github.com/user-attachments/assets/9fd90481-01a3-4f0e-bd06-b6293b36e2ed" />

Fetch failed / too many requests:
<img width="605" height="94" alt="Screenshot 2026-03-09 at 3 01 53 PM" src="https://github.com/user-attachments/assets/df3954a1-af12-473b-86ff-fe1094f7f5b4" />



### How to test the changes in this Pull Request:

1. Set up the email editor development environment
2. In the email editor, add an Embed block with a WordPress blog post URL (e.g., any WordPress.com or self-hosted WordPress blog post). It can't be inserted in the editor because core/embed isn't yet a supported block type.
3. Send a preview email
4. Verify the rich card shows:
   - Thumbnail image (if the post has a featured image)
   - Post title as a link
   - Excerpt text with underlined "Continue reading" link
   - Site icon (16×16) next to the provider name
5. Add 6+ WordPress embed blocks — verify the first 5 render as rich cards and the 6th renders as a compact bordered link card showing just the URL
6. Test with a non-WordPress URL — verify it renders as a plain link with no HTTP fetch delay
7. Test with a WordPress URL whose embed page is unreachable — verify it renders as a compact link card

### Testing that has already taken place:

- All 352 integration tests pass including new tests for:
  - Rich card cap at 5 per render instance
  - Compact link card styling and content
  - Failed fetch fallback to compact card
  - No-title fallback to compact card
- PHPCS passes clean
- PHPStan passes with no errors (PHP 8.4 config)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Changelog entry was created manually in `packages/php/email-editor/changelog/add-email-embed-rich-card-excerpt`.
</details>