### PR TITLE
Prevent race conditions between checkout form updates and shipping rates calculation

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -179,8 +179,6 @@ const updateCheckoutData = (): void => {
 			localState.doingPush = false;
 			processErrorResponse( response );
 		} );
-
-	localState.doingPush = false;
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -19,6 +19,7 @@ import {
 	hasValidationError,
 	validateAdditionalFields,
 } from './utils';
+import { flushChanges as flushCartChanges } from '../cart/push-changes';
 
 // This is used to track and cache the local state of push changes.
 const localState = {
@@ -163,6 +164,10 @@ const updateCheckoutData = (): void => {
 
 	// Update local cache
 	localState.checkoutData = newCheckoutData;
+
+	// Flush any pending cart address updates so the server session has the
+	// latest address before recalculating totals in the checkout PUT.
+	flushCartChanges();
 
 	dispatch( CHECKOUT_STORE_KEY )
 		.updateDraftOrder( requestData )

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
@@ -39,6 +39,7 @@ import type {
 import { apiFetchWithHeaders } from '../shared-controls';
 import { CheckoutPutAbortController } from '../utils/clear-put-requests';
 import { CART_STORE_KEY } from '../cart';
+import { getIsCustomerDataDirty } from '../cart/utils';
 
 export interface CheckoutThunkArgs {
 	select: CurriedSelectorsOf< CheckoutStoreDescriptor >;
@@ -165,6 +166,7 @@ export const __internalEmitAfterProcessingEvents: emitAfterProcessingEventsType 
 export const updateDraftOrder = ( data: CheckoutPutData ) => {
 	return async ( { registry } ) => {
 		const { receiveCartContents } = registry.dispatch( CART_STORE_KEY );
+		const customerDataDirtyBeforeRequest = getIsCustomerDataDirty();
 		try {
 			const response = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/checkout?__experimental_calc_totals=true',
@@ -173,7 +175,26 @@ export const updateDraftOrder = ( data: CheckoutPutData ) => {
 				signal: CheckoutPutAbortController.signal,
 			} );
 			if ( response?.response?.__experimentalCart ) {
-				receiveCartContents( response.response.__experimentalCart );
+				const cart = response.response.__experimentalCart;
+				// The checkout PUT does not send address data; shipping is
+				// recalculated from the server session. When the customer's
+				// address hasn't been pushed yet, the session is stale and the
+				// returned shipping rates would be wrong. Preserve the
+				// existing rates in that case to avoid a momentary "no
+				// shipping available" flash.
+				if (
+					customerDataDirtyBeforeRequest ||
+					getIsCustomerDataDirty()
+				) {
+					const {
+						shipping_rates: _,
+						has_calculated_shipping: __,
+						...cartWithoutShipping
+					} = cart;
+					receiveCartContents( cartWithoutShipping );
+				} else {
+					receiveCartContents( cart );
+				}
 			}
 			return response;
 		} catch ( error ) {


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

I traced a similar issue to [https://github.com/woocommerce/woocommerce/issues/60414](<https://github.com/woocommerce/woocommerce/issues/60414>).

I'm submitting this PR, but as I'm new to this project and don't own the e-commerce website (I'm simply helping its owner) nor operate other WordPress websites myself, I have no idea how to test the PR before submitting it, so please bear with me, and if necessary, tell me how to test.

The issue we had was the following:

1. Fill the shipping address form
2. You should see the available shipping method based on this address
3. Change some form fields on the page (in this shop's case, either an email address or a payment method)
4. You should **sometimes** see that there is no shipping option available  <br>***Workaround fix***
5. Redo step 3 one or two more times (eg. change the payment method)
6. You should now see that the shipping options are back

The site is running WooCommerce version 10.5.3 and WordPress version 6.9.1

What bothered me was the '**sometimes**' of step 4. This hinted at a race condition in state management, either on the frontend or the backend. So after playing with it for a while, I noticed it happened the most when I managed to do steps 3 to 5 very quickly (in about 1 or 2 seconds).

After digging into the code, I think I found the race conditions. There are 2 push-changes.ts files in the cart and checkout sections, which submit independently to the cart store state (using a debounce with a 1.5-second delay, matching the behavior of the issue, which only happens if I run the test steps fast enough) and could cause corruption if one has stale data. On top of that, there was a concurrency guard (`doingPush`) that was incorrectly positioned and thus didn't block concurrent updates to the checkout form, increasing the likelihood of the race condition.

As you'll see in the PR, both race conditions are prevented, and as a precaution, I also made sure the 'empty' shipping rates due to stale data in the checkout update process don't overwrite the frontend's state.

Closes woocommerce/woocommerce#60414

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Fill the shipping address form
2. You should see the available shipping method based on this address
3. Change some form fields on the page (in this shop's case, either an email address or a payment method)
4. You should keep seeing the shipping options

### Testing that has already taken place:

### Milestone

- [ ] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>