### PR TITLE
Exclude test orders from analytics data

### DIFF
--- a/plugins/woocommerce/changelog/63550-wooa7s-1069-remove-test-orders-from-analytics-data
+++ b/plugins/woocommerce/changelog/63550-wooa7s-1069-remove-test-orders-from-analytics-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Exclude WCPay test orders from analytics data to prevent test transactions from polluting reports.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -19152,7 +19152,6 @@ parameters:
 			count: 1
 			path: includes/emails/class-wc-email-customer-pos-refunded-order.php
 
-
 		-
 			message: '#^Method WC_Email_Customer_Processing_Order\:\:trigger\(\) has no return type specified\.$#'
 			identifier: missingType.return
@@ -43739,6 +43738,12 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
+			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\.$#'
+			identifier: class.notFound
+			count: 3
+			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
+
+		-
 			message: '#^Binary operation "\*" between \-1 and string results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -43769,7 +43774,7 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\WP_Error but returns Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|\(object\{totals\: null, intervals\: array, total\: int, pages\: int, page_no\: int\}&stdClass\)\.$#'
+			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\WP_Error but returns Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -43781,15 +43786,15 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass but returns WP_Error\.$#'
-			identifier: return.type
-			count: 2
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass but returns Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\.$#'
 			identifier: return.type
 			count: 1
+			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
+
+		-
+			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass but returns WP_Error\.$#'
+			identifier: return.type
+			count: 2
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -43739,24 +43739,6 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
-			identifier: class.notFound
-			count: 7
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Access to property \$totals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
 			message: '#^Binary operation "\*" between \-1 and string results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -43799,21 +43781,15 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error but returns Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error but returns WP_Error\.$#'
+			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass but returns WP_Error\.$#'
 			identifier: return.type
 			count: 2
+			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
+
+		-
+			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) should return Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\|stdClass but returns Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\.$#'
+			identifier: return.type
+			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
@@ -43859,7 +43835,7 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Parameter \#1 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Segmenter\:\:add_intervals_segments\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass, Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\|Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass given\.$#'
+			message: '#^Parameter \#1 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Segmenter\:\:add_intervals_segments\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass, Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass\|stdClass given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -43871,20 +43847,8 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Parameter \#3 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass, object\{totals\: null, intervals\: array, total\: int, pages\: int, page_no\: int\}&stdClass given\.$#'
+			message: '#^Parameter \#5 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\DataStore\:\:fill_in_missing_intervals\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass, stdClass given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \#5 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\DataStore\:\:fill_in_missing_intervals\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\stdClass, Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -43753,7 +43753,7 @@ parameters:
 		-
 			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
 			identifier: class.notFound
-			count: 7
+			count: 4
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
@@ -43963,7 +43963,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_net_total\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
@@ -43975,7 +43975,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_num_items_sold\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -43739,12 +43739,6 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^@param WC_Order \$order does not accept actual type of parameter\: Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\|WC_Order\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
 			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WP_Error\.$#'
 			identifier: class.notFound
 			count: 3
@@ -43753,7 +43747,7 @@ parameters:
 		-
 			message: '#^Access to property \$intervals on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
 			identifier: class.notFound
-			count: 4
+			count: 7
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
@@ -43765,84 +43759,6 @@ parameters:
 		-
 			message: '#^Binary operation "\*" between \-1 and string results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_date_completed\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_date_created\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_date_paid\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_id\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_meta\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_parent_id\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_report_customer_id\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_shipping_total\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_status\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_total\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_total_tax\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method get_type\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Call to method is_returning_customer\(\) on an unknown class Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
@@ -43955,36 +43871,6 @@ parameters:
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_net_total\(\) expects WC_Order, Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\|WC_Order given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_net_total\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_num_items_sold\(\) expects WC_Order, Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\|WC_Order given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_num_items_sold\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:update\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\|WC_Order, WC_Order\|WC_Order_Refund given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
 			message: '#^Parameter \#3 \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) expects Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass, object\{totals\: null, intervals\: array, total\: int, pages\: int, page_no\: int\}&stdClass given\.$#'
 			identifier: argument.type
 			count: 1
@@ -43998,12 +43884,6 @@ parameters:
 
 		-
 			message: '#^Parameter \$data of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_noncached_stats_data\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\stdClass\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
-
-		-
-			message: '#^Parameter \$order of method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:update\(\) has invalid type Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\WC_Order_Refund\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -43963,7 +43963,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_net_total\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-
@@ -43975,7 +43975,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$order of static method Automattic\\WooCommerce\\Admin\\API\\Reports\\Orders\\Stats\\DataStore\:\:get_num_items_sold\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Admin/API/Reports/Orders/Stats/DataStore.php
 
 		-

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Admin\API\Reports\StatsDataStoreTrait;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use stdClass;
 use WC_Order;
 use WC_Order_Refund;
 use Automattic\WooCommerce\Admin\Overrides\Order;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -14,10 +14,14 @@ use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
 use Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
+use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Admin\API\Reports\StatsDataStoreTrait;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Order;
+use WC_Order_Refund;
+use Automattic\WooCommerce\Admin\Overrides\Order;
+use Automattic\WooCommerce\Admin\Overrides\OrderRefund;
 
 /**
  * API\Reports\Orders\Stats\DataStore.
@@ -501,6 +505,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
+		/** @var false|Order|OrderRefund $order  */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;
@@ -512,7 +517,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Update the database with stats data.
 	 *
-	 * @param WC_Order|WC_Order_Refund $order Order or refund to update row for.
+	 * @param Order|OrderRefund $order Order or refund to update row for.
 	 * @return int|bool Returns -1 if order won't be processed, or a boolean indicating processing success.
 	 */
 	public static function update( $order ) {
@@ -520,6 +525,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$table_name = self::get_db_table_name();
 
 		if ( ! $order->get_id() || ! $order->get_date_created() ) {
+			return -1;
+		}
+
+		// Skip test orders.
+		if ( OrdersScheduler::is_test_order( $order ) ) {
 			return -1;
 		}
 
@@ -568,7 +578,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * Filters order stats data.
 		 *
 		 * @param array $data Data written to order stats lookup table.
-		 * @param WC_Order $order  Order object.
+		 * @param Order|OrderRefund $order  Order object.
 		 *
 		 * @since 4.0.0
 		 */
@@ -653,7 +663,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get number of items sold among all orders.
 	 *
-	 * @param WC_Order $order WC_Order object.
+	 * @param WC_Order|WC_Order_Refund $order WC_Order object.
 	 * @return int
 	 */
 	protected static function get_num_items_sold( $order ) {
@@ -670,7 +680,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get the net amount from an order without shipping, tax, or refunds.
 	 *
-	 * @param WC_Order $order WC_Order object.
+	 * @param WC_Order|WC_Order_Refund $order WC_Order object.
 	 * @return float
 	 */
 	protected static function get_net_total( $order ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -505,8 +505,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		// phpcs:ignore Generic.Commenting.DocComment.MissingShort -- PHPStan type hint.
-		/** @var false|Order|OrderRefund $order */
+		/**
+		 * Get the order object for syncing.
+		 *
+		 * @var false|Order|OrderRefund $order
+		 */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -506,7 +506,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		/** @var false|Order|OrderRefund $order (Override classes registered via OrdersScheduler::init()) */
+		/** @var false|Order|OrderRefund $order Order instance (Override classes registered via OrdersScheduler::init()). */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -505,7 +505,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		/** @var false|Order|OrderRefund $order  */
+		// phpcs:ignore Generic.Commenting.DocComment.MissingShort -- PHPStan type hint.
+		/** @var false|Order|OrderRefund $order */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -506,7 +506,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		/** @var false|Order|OrderRefund $order Order instance (Override classes registered via OrdersScheduler::init()). */
+		/**
+		 * The order instance to be synchronized.
+		 *
+		 * @var false|Order|OrderRefund $order Order instance (Override classes registered via OrdersScheduler::init()).
+		 */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -506,11 +506,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		/**
-		 * Get the order object for syncing.
-		 *
-		 * @var false|Order|OrderRefund $order
-		 */
+		/** @var false|Order|OrderRefund $order (Override classes registered via OrdersScheduler::init()) */
 		$order = wc_get_order( $post_id );
 		if ( ! $order ) {
 			return -1;
@@ -533,7 +529,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		// Skip test orders.
+		// Exclude test orders (e.g., WCPay test mode) from analytics stats.
+		// Defense-in-depth: also checked in OrdersScheduler::import(), but
+		// update() can be called directly outside of the import flow.
 		if ( OrdersScheduler::is_test_order( $order ) ) {
 			return -1;
 		}
@@ -668,7 +666,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get number of items sold among all orders.
 	 *
-	 * @param WC_Order|WC_Order_Refund $order Order or refund object.
+	 * @param WC_Order|WC_Order_Refund $order WC_Order or WC_Order_Refund object.
 	 * @return int
 	 */
 	protected static function get_num_items_sold( $order ) {
@@ -685,7 +683,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get the net amount from an order without shipping, tax, or refunds.
 	 *
-	 * @param WC_Order|WC_Order_Refund $order Order or refund object.
+	 * @param WC_Order|WC_Order_Refund $order WC_Order or WC_Order_Refund object.
 	 * @return float
 	 */
 	protected static function get_net_total( $order ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -663,7 +663,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get number of items sold among all orders.
 	 *
-	 * @param WC_Order|WC_Order_Refund $order WC_Order object.
+	 * @param WC_Order|WC_Order_Refund $order Order or refund object.
 	 * @return int
 	 */
 	protected static function get_num_items_sold( $order ) {
@@ -680,7 +680,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Get the net amount from an order without shipping, tax, or refunds.
 	 *
-	 * @param WC_Order|WC_Order_Refund $order WC_Order object.
+	 * @param WC_Order|WC_Order_Refund $order Order or refund object.
 	 * @return float
 	 */
 	protected static function get_net_total( $order ) {

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -705,11 +705,15 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 * @since 10.7.0
 	 */
 	public static function is_test_order( $order ) {
+		if ( ! $order instanceof \WC_Abstract_Order ) {
+			return false;
+		}
+
 		// For refunds, check the parent order.
 		$check_order = $order;
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			$check_order = wc_get_order( $order->get_parent_id() );
-			if ( ! $check_order ) {
+			if ( ! $check_order instanceof \WC_Abstract_Order ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -346,8 +346,12 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 			return;
 		}
 
-		// Skip test orders from analytics.
+		// Skip test orders (e.g., WCPay test mode) from analytics.
 		if ( self::is_test_order( $order ) ) {
+			wc_get_logger()->debug(
+				sprintf( 'Skipping test order #%d from analytics import.', $order_id ),
+				array( 'source' => 'wc-analytics-order-import' )
+			);
 			return;
 		}
 
@@ -692,8 +696,13 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	/**
 	 * Check if an order is a test order that should be excluded from analytics.
 	 *
+	 * For refunds, the parent order is checked instead, since refunds do not
+	 * carry the test mode metadata directly.
+	 *
 	 * @param \WC_Abstract_Order $order Order object.
 	 * @return bool
+	 *
+	 * @since 10.7.0
 	 */
 	public static function is_test_order( $order ) {
 		// For refunds, check the parent order.
@@ -710,9 +719,14 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 		/**
 		 * Filter whether an order is a test order excluded from analytics.
 		 *
-		 * @since 10.7.0
+		 * Use this filter to customize test order detection beyond the default
+		 * WCPay test mode check, e.g., to exclude orders from other payment
+		 * gateways' test/sandbox modes.
+		 *
 		 * @param bool               $is_test Whether the order is a test order.
-		 * @param \WC_Abstract_Order $order   The order being checked.
+		 * @param \WC_Abstract_Order $order   The order being checked (for refunds, this is the parent order).
+		 *
+		 * @since 10.7.0
 		 */
 		return apply_filters( 'woocommerce_analytics_is_test_order', $is_test, $check_order );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -346,6 +346,11 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 			return;
 		}
 
+		// Skip test orders from analytics.
+		if ( self::is_test_order( $order ) ) {
+			return;
+		}
+
 		$results = array(
 			OrdersStatsDataStore::sync_order( $order_id ),
 			ProductsDataStore::sync_order_products( $order_id ),
@@ -682,6 +687,34 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 				$limit
 			)
 		);
+	}
+
+	/**
+	 * Check if an order is a test order that should be excluded from analytics.
+	 *
+	 * @param \WC_Abstract_Order $order Order object.
+	 * @return bool
+	 */
+	public static function is_test_order( $order ) {
+		// For refunds, check the parent order.
+		$check_order = $order;
+		if ( 'shop_order_refund' === $order->get_type() ) {
+			$check_order = wc_get_order( $order->get_parent_id() );
+			if ( ! $check_order ) {
+				return false;
+			}
+		}
+
+		$is_test = 'test' === $check_order->get_meta( '_wcpay_mode' );
+
+		/**
+		 * Filter whether an order is a test order excluded from analytics.
+		 *
+		 * @since 10.7.0
+		 * @param bool               $is_test Whether the order is a test order.
+		 * @param \WC_Abstract_Order $order   The order being checked.
+		 */
+		return apply_filters( 'woocommerce_analytics_is_test_order', $is_test, $check_order );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Schedulers;
 
 use Automattic\WooCommerce\Internal\Admin\Schedulers\OrdersScheduler;
+use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use WC_Unit_Test_Case;
 use Automattic\WooCommerce\Admin\Features\Features;
 
@@ -206,9 +207,9 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that an order with _wcpay_mode = 'test' is identified as a test order.
+	 * @testdox Should identify order with _wcpay_mode test as a test order.
 	 */
-	public function test_is_test_order_with_wcpay_test_mode() {
+	public function test_is_test_order_with_wcpay_test_mode(): void {
 		$order = \WC_Helper_Order::create_order();
 		$order->update_meta_data( '_wcpay_mode', 'test' );
 		$order->save();
@@ -217,18 +218,18 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a normal order is not identified as a test order.
+	 * @testdox Should not identify a normal order as a test order.
 	 */
-	public function test_is_test_order_with_normal_order() {
+	public function test_is_test_order_with_normal_order(): void {
 		$order = \WC_Helper_Order::create_order();
 
 		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
 	}
 
 	/**
-	 * Test that an order with _wcpay_mode = 'live' is not a test order.
+	 * @testdox Should not identify an order with _wcpay_mode live as a test order.
 	 */
-	public function test_is_test_order_with_wcpay_live_mode() {
+	public function test_is_test_order_with_wcpay_live_mode(): void {
 		$order = \WC_Helper_Order::create_order();
 		$order->update_meta_data( '_wcpay_mode', 'live' );
 		$order->save();
@@ -237,9 +238,9 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a refund of a test order is also identified as a test order.
+	 * @testdox Should identify a refund of a test order as a test order.
 	 */
-	public function test_is_test_order_with_refund_of_test_order() {
+	public function test_is_test_order_with_refund_of_test_order(): void {
 		$order = \WC_Helper_Order::create_order();
 		$order->update_meta_data( '_wcpay_mode', 'test' );
 		$order->save();
@@ -256,9 +257,9 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a refund of a normal order is not a test order.
+	 * @testdox Should not identify a refund of a normal order as a test order.
 	 */
-	public function test_is_test_order_with_refund_of_normal_order() {
+	public function test_is_test_order_with_refund_of_normal_order(): void {
 		$order = \WC_Helper_Order::create_order();
 
 		$refund = wc_create_refund(
@@ -273,9 +274,9 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the woocommerce_analytics_is_test_order filter can override the default check.
+	 * @testdox Should allow the woocommerce_analytics_is_test_order filter to mark a normal order as a test order.
 	 */
-	public function test_is_test_order_filter_can_override() {
+	public function test_is_test_order_filter_can_override(): void {
 		$order = \WC_Helper_Order::create_order();
 
 		// Order has no _wcpay_mode meta, so default is false.
@@ -290,9 +291,9 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the woocommerce_analytics_is_test_order filter can allow a test order.
+	 * @testdox Should allow the woocommerce_analytics_is_test_order filter to include a test order in analytics.
 	 */
-	public function test_is_test_order_filter_can_allow_test_order() {
+	public function test_is_test_order_filter_can_allow_test_order(): void {
 		$order = \WC_Helper_Order::create_order();
 		$order->update_meta_data( '_wcpay_mode', 'test' );
 		$order->save();
@@ -306,6 +307,84 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
 
 		remove_filter( 'woocommerce_analytics_is_test_order', '__return_false' );
+	}
+
+	/**
+	 * @testdox Should return false for a refund whose parent order has been deleted.
+	 */
+	public function test_is_test_order_with_orphaned_refund(): void {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		// Delete the parent order to create an orphaned refund.
+		$order->delete( true );
+
+		$this->assertFalse( OrdersScheduler::is_test_order( $refund ) );
+	}
+
+	/**
+	 * @testdox Should pass the parent order to the filter when checking a refund.
+	 */
+	public function test_is_test_order_filter_receives_parent_order_for_refund(): void {
+		$order = \WC_Helper_Order::create_order();
+		$order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$received_order = null;
+		$filter_callback = function ( $is_test, $filter_order ) use ( &$received_order ) {
+			$received_order = $filter_order;
+			return $is_test;
+		};
+		add_filter( 'woocommerce_analytics_is_test_order', $filter_callback, 10, 2 );
+
+		OrdersScheduler::is_test_order( $refund );
+
+		$this->assertNotNull( $received_order );
+		$this->assertEquals( $order->get_id(), $received_order->get_id() );
+
+		remove_filter( 'woocommerce_analytics_is_test_order', $filter_callback );
+	}
+
+	/**
+	 * @testdox Should return -1 from DataStore update when given a test order.
+	 */
+	public function test_datastore_update_skips_test_order(): void {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		$result = OrdersStatsDataStore::update( $order );
+
+		$this->assertSame( -1, $result );
+	}
+
+	/**
+	 * @testdox Should return -1 from DataStore sync_order when given a test order ID.
+	 */
+	public function test_datastore_sync_order_skips_test_order(): void {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		$result = OrdersStatsDataStore::sync_order( $order->get_id() );
+
+		$this->assertSame( -1, $result );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -346,7 +346,7 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$received_order = null;
+		$received_order  = null;
 		$filter_callback = function ( $is_test, $filter_order ) use ( &$received_order ) {
 			$received_order = $filter_order;
 			return $is_test;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -206,6 +206,109 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that an order with _wcpay_mode = 'test' is identified as a test order.
+	 */
+	public function test_is_test_order_with_wcpay_test_mode() {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		$this->assertTrue( OrdersScheduler::is_test_order( $order ) );
+	}
+
+	/**
+	 * Test that a normal order is not identified as a test order.
+	 */
+	public function test_is_test_order_with_normal_order() {
+		$order = \WC_Helper_Order::create_order();
+
+		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
+	}
+
+	/**
+	 * Test that an order with _wcpay_mode = 'live' is not a test order.
+	 */
+	public function test_is_test_order_with_wcpay_live_mode() {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'live' );
+		$order->save();
+
+		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
+	}
+
+	/**
+	 * Test that a refund of a test order is also identified as a test order.
+	 */
+	public function test_is_test_order_with_refund_of_test_order() {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$this->assertTrue( OrdersScheduler::is_test_order( $refund ) );
+	}
+
+	/**
+	 * Test that a refund of a normal order is not a test order.
+	 */
+	public function test_is_test_order_with_refund_of_normal_order() {
+		$order = \WC_Helper_Order::create_order();
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+				'reason'   => 'Test refund',
+			)
+		);
+
+		$this->assertFalse( OrdersScheduler::is_test_order( $refund ) );
+	}
+
+	/**
+	 * Test that the woocommerce_analytics_is_test_order filter can override the default check.
+	 */
+	public function test_is_test_order_filter_can_override() {
+		$order = \WC_Helper_Order::create_order();
+
+		// Order has no _wcpay_mode meta, so default is false.
+		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
+
+		// Override via filter to mark it as test.
+		add_filter( 'woocommerce_analytics_is_test_order', '__return_true' );
+
+		$this->assertTrue( OrdersScheduler::is_test_order( $order ) );
+
+		remove_filter( 'woocommerce_analytics_is_test_order', '__return_true' );
+	}
+
+	/**
+	 * Test that the woocommerce_analytics_is_test_order filter can allow a test order.
+	 */
+	public function test_is_test_order_filter_can_allow_test_order() {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		// Default is true because _wcpay_mode is 'test'.
+		$this->assertTrue( OrdersScheduler::is_test_order( $order ) );
+
+		// Override via filter to allow it.
+		add_filter( 'woocommerce_analytics_is_test_order', '__return_false' );
+
+		$this->assertFalse( OrdersScheduler::is_test_order( $order ) );
+
+		remove_filter( 'woocommerce_analytics_is_test_order', '__return_false' );
+	}
+
+	/**
 	 * Clear any scheduled batch processor actions.
 	 *
 	 * @return void


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WCPay test orders (with meta `_wcpay_mode = 'test'`) were being included in WooCommerce Analytics reports, polluting real data in the `wc_order_stats` and all related lookup tables.

This PR prevents test orders from entering analytics at two levels:

1. **`OrdersScheduler::import()`** — intercepts before any of the 5 DataStore sync calls (stats, products, coupons, taxes, customers), preventing test data from entering ALL lookup tables.
2. **`OrdersStatsDataStore::update()`** — guards against direct callers that bypass the scheduler flow.

A new public `OrdersScheduler::is_test_order()` method checks `_wcpay_mode === 'test'` on the order (or parent order for refunds), and is extensible via the `woocommerce_analytics_is_test_order` filter so other plugins can define their own test order criteria.

Also fixes pre-existing PHPStan type issues in `DataStore.php` by properly importing `WC_Order_Refund` and using the correct `Order`/`OrderRefund` override types.

Closes WOOA7S-1069

### How to test the changes in this Pull Request:

1. Set up WCPay in test mode and create a test order.
2. Trigger the import if your site is using scheduled imports or wait forschedule import job to be finished.
3. Verify the test order does NOT appear in `wc_order_stats`:
   ```sql
   SELECT * FROM wp_wc_order_stats WHERE order_id = <test_order_id>;
   ```
4. Create a normal order (without `_wcpay_mode = 'test'` meta).
5. Verify the normal order IS synced to `wc_order_stats`.
6. Create a refund on a test order and verify it is also excluded.
7. Verify the `woocommerce_analytics_is_test_order` filter works:
   ```php
   add_filter( 'woocommerce_analytics_is_test_order', '__return_true' );
   ```
   This should exclude all orders from analytics.

### Testing that has already taken place:

- All 13 `OrdersSchedulerTest` tests pass (7 existing + 6 new).
- PHPStan analysis passes with no errors.
- PHP linting passes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Add - Adds functionality

#### Message <!-- Add a changelog message here -->
Exclude WCPay test orders from analytics data to prevent test transactions from polluting reports.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>