### PR TITLE
Add FAQ sections for QIT test results and resubmissions

### DIFF
--- a/docs/woo-marketplace/managing-your-account.mdx
+++ b/docs/woo-marketplace/managing-your-account.mdx
@@ -80,3 +80,18 @@ Test your `changelog.txt` file to ensure that it meets [Woo Marketplace standard
 - To request another admin, [contact us via the link in your dashboard](https://woocommerce.com/wp-admin/admin.php?page=wcpv-vendor-support) or email [partners@woocommerce.com](mailto:partners@woocommerce.com) using your current partner account email. Please first ensure that they have [created a WooCommerce.com account](https://woocommerce.com/sso?new=1&next=%2Fwoocommerce%2F) with [two-step authentication enabled](https://wordpress.com/support/security/two-step-authentication/).
 
 </details>
+
+<details>
+<summary>Why does my QIT test result link show "Invalid URL" or say it has expired?</summary>
+
+- QIT test result links are temporary signed URLs. They expire after a short period of time. This is expected and not an error.
+- To get fresh results, re-run the test from your [Vendor Dashboard](https://woocommerce.com/wp-admin/). New links will be generated with the updated results.
+
+</details>
+
+<details>
+<summary>How do I resubmit after making changes?</summary>
+
+- When your submission is in **Changes required** status, you can upload a corrected zip file directly from your [Vendor Dashboard](https://woocommerce.com/wp-admin/) and resubmit.
+
+</details>


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Added two new FAQ entries to the "Managing your account" Marketplace docs page:

- **QIT test result link expiration** — Explains that QIT test result links are temporary signed URLs and guides vendors to re-run tests from their Vendor Dashboard for fresh links.
- **How to resubmit after making changes** — Explains that vendors can upload a corrected zip when their submission is in "Changes required" status.

These are common vendor questions handled by the Happiness team that had no public-facing documentation.

### How to test the changes in this Pull Request:

1. Navigate to `developer.woocommerce.com/docs/woo-marketplace/managing-your-account/#faqs`
2. Verify the two new FAQ entries render correctly as expandable `<details>` sections.
3. Click each FAQ to confirm it expands and collapses properly.
4. Verify the Vendor Dashboard link points to `https://woocommerce.com/wp-admin/`.

### Testing that has already taken place:

Reviewed content locally. Documentation-only change — no code or functionality impact.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation-only change. No code, functionality, or user-facing product changes.

</details>