### PR TITLE
Fix unstable `useSelect()` return value in `useCustomerEffortScoreModal`

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-62340-ces
+++ b/packages/js/customer-effort-score/changelog/fix-62340-ces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unstable `useSelect()` return value in feedback button.

--- a/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
+++ b/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
@@ -10,28 +10,33 @@ import { optionsStore } from '@woocommerce/data';
 import { SHOWN_FOR_ACTIONS_OPTION_NAME } from '../../constants';
 import { STORE_KEY } from '../../store';
 
+const EMPTY_SHOWN_ACTIONS: string[] = [];
+
 export const useCustomerEffortScoreModal = () => {
 	const { showCesModal: _showCesModal, showProductMVPFeedbackModal } =
 		useDispatch( STORE_KEY );
 	const { updateOptions } = useDispatch( optionsStore );
 
-	const { wasPreviouslyShown, isLoading } = useSelect( ( select ) => {
+	const { shownForActions, isLoading } = useSelect( ( select ) => {
 		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const shownForActionsOption =
-			( getOption( SHOWN_FOR_ACTIONS_OPTION_NAME ) as string[] ) || [];
+			( getOption( SHOWN_FOR_ACTIONS_OPTION_NAME ) as string[] ) ||
+			EMPTY_SHOWN_ACTIONS;
 
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			SHOWN_FOR_ACTIONS_OPTION_NAME,
 		] );
 
 		return {
-			wasPreviouslyShown: ( action: string ) => {
-				return shownForActionsOption.includes( action );
-			},
+			shownForActions: shownForActionsOption,
 			isLoading: resolving,
 		};
 	}, [] );
+
+	const wasPreviouslyShown = ( action: string ) => {
+		return shownForActions.includes( action );
+	};
 
 	const markCesAsShown = async ( action: string ) => {
 		const { getOption } = resolveSelect( optionsStore );

--- a/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
+++ b/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
@@ -20,9 +20,10 @@ export const useCustomerEffortScoreModal = () => {
 	const { shownForActions, isLoading } = useSelect( ( select ) => {
 		const { getOption, hasFinishedResolution } = select( optionsStore );
 
-		const shownForActionsOption =
-			( getOption( SHOWN_FOR_ACTIONS_OPTION_NAME ) as string[] ) ||
-			EMPTY_SHOWN_ACTIONS;
+		const rawShownForActions = getOption( SHOWN_FOR_ACTIONS_OPTION_NAME );
+		const shownForActionsOption = Array.isArray( rawShownForActions )
+			? rawShownForActions
+			: EMPTY_SHOWN_ACTIONS;
 
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			SHOWN_FOR_ACTIONS_OPTION_NAME,
@@ -41,10 +42,12 @@ export const useCustomerEffortScoreModal = () => {
 	const markCesAsShown = async ( action: string ) => {
 		const { getOption } = resolveSelect( optionsStore );
 
-		const shownForActionsOption =
-			( ( await getOption(
-				SHOWN_FOR_ACTIONS_OPTION_NAME
-			) ) as string[] ) || [];
+		const rawShownForActions = await getOption(
+			SHOWN_FOR_ACTIONS_OPTION_NAME
+		);
+		const shownForActionsOption = Array.isArray( rawShownForActions )
+			? rawShownForActions
+			: [];
 
 		updateOptions( {
 			[ SHOWN_FOR_ACTIONS_OPTION_NAME ]: [

--- a/plugins/woocommerce/changelog/fix-62340-ces
+++ b/plugins/woocommerce/changelog/fix-62340-ces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unstable `useSelect()` return value in feedback button.

--- a/plugins/woocommerce/changelog/fix-62340-ces
+++ b/plugins/woocommerce/changelog/fix-62340-ces
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix unstable `useSelect()` return value in feedback button.
+Address deprecation warnings in feedback button.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/ces-feedback-button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/ces-feedback-button/index.tsx
@@ -95,6 +95,7 @@ export const CesFeedbackButton = ( {
 					return (
 						<div>
 							<TextareaControl
+								__nextHasNoMarginBottom
 								label={ feedbackLabel }
 								value={
 									extraFieldsValues.feedback_comment || ''
@@ -108,6 +109,8 @@ export const CesFeedbackButton = ( {
 								placeholder={ feedbackPlaceholder }
 							/>
 							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 								label={ emailLabel }
 								type="email"
 								value={ extraFieldsValues.email || '' }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The `useCustomerEffortScoreModal` hook was triggering a `useSelect` warning in the console because the inline `wasPreviouslyShown` function as well as the hardcoded fallback value of `[` ] resulted in a new reference on every call.

I noticed the warning while testing #63541 as the product collection block renders a feedback button in the settings.

This PR makes the `useSelect()` return a consistent value and keeps the public API the same. It also addresses a few deprecation notices being triggered by the modal itself.

Related to #62340.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Ensure WooCommerce usage tracking is enabled in **WC > Settings > Advanced > WooCommerce.com**.
1. Open the _Cart_ page on the admin for editing.
1. Select the Cross-Sells block.
1. Confirm there's no `useSelect` warning mentioning `wasPreviouslyShown`.
1. Click the _Help us improve_ button in the inspector and confirm the modal opens correctly.
   <img width="284" height="91" alt="Screenshot 2026-03-05 at 14 54 35" src="https://github.com/user-attachments/assets/1af3f1ad-3103-44fd-b073-e360b9355d05" />

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.