### PR TITLE
Ensures container use is justified and consistent

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -72,13 +72,11 @@ class PushNotifications {
 
 		$this->register_post_types();
 
-		wc_get_container()->get( PushTokenRestController::class )->register();
+		wc_get_container()->get( PendingNotificationStore::class )->register();
 
-		$store = wc_get_container()->get( PendingNotificationStore::class );
-		$store->register();
-
-		( new NewOrderNotificationTrigger( $store ) )->register();
-		( new NewReviewNotificationTrigger( $store ) )->register();
+		( new PushTokenRestController() )->register();
+		( new NewOrderNotificationTrigger() )->register();
+		( new NewReviewNotificationTrigger() )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewOrderNotificationTrigger.php
@@ -42,24 +42,6 @@ class NewOrderNotificationTrigger {
 	);
 
 	/**
-	 * The pending notification store.
-	 *
-	 * @var PendingNotificationStore
-	 */
-	private PendingNotificationStore $pending_notification_store;
-
-	/**
-	 * Constructs the trigger.
-	 *
-	 * @param PendingNotificationStore $pending_notification_store The notification store.
-	 *
-	 * @since 10.7.0
-	 */
-	public function __construct( PendingNotificationStore $pending_notification_store ) {
-		$this->pending_notification_store = $pending_notification_store;
-	}
-
-	/**
 	 * Registers WordPress hooks for order events.
 	 *
 	 * @return void
@@ -85,7 +67,7 @@ class NewOrderNotificationTrigger {
 			return;
 		}
 
-		$this->pending_notification_store->add(
+		wc_get_container()->get( PendingNotificationStore::class )->add(
 			new NewOrderNotification( $order_id )
 		);
 	}
@@ -116,7 +98,7 @@ class NewOrderNotificationTrigger {
 			return;
 		}
 
-		$this->pending_notification_store->add(
+		wc_get_container()->get( PendingNotificationStore::class )->add(
 			new NewOrderNotification( $order_id )
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Triggers/NewReviewNotificationTrigger.php
@@ -17,24 +17,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class NewReviewNotificationTrigger {
 	/**
-	 * The pending notification store.
-	 *
-	 * @var PendingNotificationStore
-	 */
-	private PendingNotificationStore $store;
-
-	/**
-	 * Constructs the trigger.
-	 *
-	 * @param PendingNotificationStore $store The notification store.
-	 *
-	 * @since 10.7.0
-	 */
-	public function __construct( PendingNotificationStore $store ) {
-		$this->store = $store;
-	}
-
-	/**
 	 * Registers WordPress hooks for review events.
 	 *
 	 * @return void
@@ -71,7 +53,7 @@ class NewReviewNotificationTrigger {
 			return;
 		}
 
-		$this->store->add(
+		wc_get_container()->get( PendingNotificationStore::class )->add(
 			new NewReviewNotification( $comment_id )
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
 
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use WC_Order;
@@ -39,7 +40,7 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
 		wc_get_container()->reset_all_resolved();
 
-		$this->trigger = new NewOrderNotificationTrigger( $this->store );
+		$this->trigger = new NewOrderNotificationTrigger();
 		$this->trigger->register();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
 
-use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use WC_Order;

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
@@ -46,7 +46,7 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );
 		wc_get_container()->reset_all_resolved();
 
-		$this->trigger = new NewReviewNotificationTrigger( $this->store );
+		$this->trigger = new NewReviewNotificationTrigger();
 
 		$product          = WC_Helper_Product::create_simple_product();
 		$this->product_id = $product->get_id();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-1795
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

This change removes unnecessary use of the container from the library, and ensures that the `PendingNotificationStore` is always used from the container to ensure all notifications are pushed to the same store.

**Key requirements:**
* Remove `PushTokenRestController` from the container
* Use the `PendingNotificationStore` in the triggers directly from the container - they were using this via injection previously, but hopefully (in addition to the PHPDoc documentation) this reinforces that the store instance used should always be the one from the container

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
This is a small refactor so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

- Ensure your WooCommerce install functions as expected, e.g.:
  - Add a product to cart
  - View WooCommerce settings in WP Admin
  - View WooCommerce orders in WP Admin
- Make an authenticated request to the API to ensure this works as expected, e.g.:
  - https://YOUR_URL/wp-json/wc-admin/features
  - https://YOUR_URL/wp-json/wc/v3/settings
  - https://YOUR_URL/wp-json/wc/v3/customers


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
