### PR TITLE
Add reset notification email content

### DIFF
--- a/packages/js/email-editor/changelog/wooprd-1019-export-register-entity-action
+++ b/packages/js/email-editor/changelog/wooprd-1019-export-register-entity-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Export registerEntityAction, unregisterEntityAction and PostWithPermissions from the email editor package public API.

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -170,7 +170,14 @@ export type {
 	PostWithPermissions,
 } from './store/types';
 
-export { registerEntityAction } from './private-apis';
+/**
+ * The registerEntityAction and unregisterEntityAction are used to register and unregister entity actions.
+ * These use Gutenberg's private APIs and are highly unstable.
+ * DO NOT USE OUTSIDE WooCommerce.
+ *
+ * If necessary, import the unlock module and access the private APIs for your use case.
+ */
+export { registerEntityAction, unregisterEntityAction } from './private-apis';
 
 /**
  * A modal component for sending test emails from the email editor.

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -167,7 +167,10 @@ export type {
 	EmailEditorSettings,
 	EmailTheme,
 	EmailEditorUrls,
+	PostWithPermissions,
 } from './store/types';
+
+export { registerEntityAction } from './private-apis';
 
 /**
  * A modal component for sending test emails from the email editor.

--- a/plugins/woocommerce/changelog/wooprd-1019-add-reset-notification-email-content
+++ b/plugins/woocommerce/changelog/wooprd-1019-add-reset-notification-email-content
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add reset notification email content action to the email editor, allowing users to reset email content to the original plugin-distributed state.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -3,9 +3,12 @@
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, addAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { initializeEditor } from '@woocommerce/email-editor';
+import {
+	initializeEditor,
+	registerEntityAction,
+} from '@woocommerce/email-editor';
 
 /**
  * Internal dependencies
@@ -14,6 +17,7 @@ import { NAME_SPACE } from './constants';
 import { modifyTemplateSidebar } from './templates';
 import { modifySidebar } from './sidebar_settings';
 import { registerEmailValidationRules } from './email-validation';
+import getResetNotificationEmailContentAction from './reset-notification-email-content';
 
 import './style.scss';
 
@@ -68,4 +72,34 @@ addFilter( 'woocommerce_email_editor_create_coupon_handler', NAME_SPACE, () => {
 modifySidebar();
 modifyTemplateSidebar();
 registerEmailValidationRules();
+
+/**
+ * Register the reset notification email content entity action for the woo_email post type.
+ * This action allows users to reset the email content to the original state as distributed by the plugin.
+ */
+const registerResetNotificationEmailContentAction = ( postType: string ) => {
+	if ( postType !== 'woo_email' ) {
+		return;
+	}
+	registerEntityAction(
+		'postType',
+		postType,
+		getResetNotificationEmailContentAction()
+	);
+};
+
+// Available in WordPress 6.8+
+addAction(
+	'core.registerPostTypeSchema',
+	`${ NAME_SPACE }/reset-notification-email-content`,
+	registerResetNotificationEmailContentAction
+);
+
+// Support for WordPress 6.7+
+addAction(
+	'core.registerPostTypeActions',
+	`${ NAME_SPACE }/reset-notification-email-content`,
+	registerResetNotificationEmailContentAction
+);
+
 initializeEditor( 'woocommerce-email-editor' );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -88,16 +88,8 @@ const registerResetNotificationEmailContentAction = ( postType: string ) => {
 	);
 };
 
-// Available in WordPress 6.8+
 addAction(
 	'core.registerPostTypeSchema',
-	`${ NAME_SPACE }/reset-notification-email-content`,
-	registerResetNotificationEmailContentAction
-);
-
-// Support for WordPress 6.7+
-addAction(
-	'core.registerPostTypeActions',
 	`${ NAME_SPACE }/reset-notification-email-content`,
 	registerResetNotificationEmailContentAction
 );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { backup } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
+import { parse, serialize } from '@wordpress/blocks';
+import apiFetch from '@wordpress/api-fetch';
+
+// eslint-disable-next-line @woocommerce/dependency-group
+import type { PostWithPermissions } from '@woocommerce/email-editor';
+
+function getItemTitle( item: {
+	title: string | { rendered: string } | { raw: string };
+} ) {
+	if ( typeof item.title === 'string' ) {
+		return decodeEntities( item.title );
+	}
+	if ( item.title && 'rendered' in item.title ) {
+		return decodeEntities( item.title.rendered );
+	}
+	if ( item.title && 'raw' in item.title ) {
+		return decodeEntities( item.title.raw );
+	}
+	return '';
+}
+
+const getResetNotificationEmailContentAction = () => {
+	/**
+	 * Reset notification email content action.
+	 * Resets a woo_email post content to the original state as distributed by the plugin.
+	 */
+	const resetNotificationEmailContent = {
+		id: 'reset-notification-email-content',
+		label: __( 'Reset content to default', 'woocommerce' ),
+		supportsBulk: false,
+		icon: backup,
+		isEligible( item: PostWithPermissions ) {
+			if (
+				item.type === 'wp_template' ||
+				item.type === 'wp_template_part' ||
+				item.type === 'wp_block'
+			) {
+				return false;
+			}
+			const { permissions } = item;
+			return permissions?.update;
+		},
+		hideModalHeader: true,
+		modalFocusOnMount: 'firstContentElement',
+		RenderModal: ( {
+			items,
+			closeModal,
+			onActionPerformed,
+		}: {
+			items: PostWithPermissions[];
+			closeModal?: () => void;
+			onActionPerformed?: ( items: PostWithPermissions[] ) => void;
+		} ) => {
+			const [ isBusy, setIsBusy ] = useState( false );
+			const { createSuccessNotice, createErrorNotice } =
+				useDispatch( noticesStore );
+			const { editEntityRecord, saveEditedEntityRecord } =
+				useDispatch( coreStore );
+
+			const item = items[ 0 ];
+			const modalTitle = sprintf(
+				// translators: %s: The email's title
+				__(
+					'Are you sure you want to reset "%s" content to the default?',
+					'woocommerce'
+				),
+				getItemTitle( item )
+			);
+
+			return (
+				<VStack spacing="5">
+					<Text>{ modalTitle }</Text>
+					<HStack justify="right">
+						<Button
+							variant="tertiary"
+							onClick={ () => {
+								closeModal?.();
+							} }
+							disabled={ isBusy }
+							__next40pxDefaultSize
+						>
+							{ __( 'Cancel', 'woocommerce' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ async () => {
+								setIsBusy( true );
+
+								try {
+									const response = ( await apiFetch( {
+										path: `/woocommerce-email-editor/v1/emails/${ item.id }/default-content`,
+									} ) ) as { content: string };
+
+									const blocks = parse(
+										response.content || ''
+									);
+
+									await editEntityRecord(
+										'postType',
+										item.type,
+										item.id,
+										{
+											blocks,
+											content: serialize( blocks ),
+										}
+									);
+
+									await saveEditedEntityRecord(
+										'postType',
+										item.type,
+										item.id,
+										{}
+									);
+
+									const successMessage = sprintf(
+										/* translators: The email's title. */
+										__(
+											'"%s" content reset to default.',
+											'woocommerce'
+										),
+										getItemTitle( item )
+									);
+
+									createSuccessNotice( successMessage, {
+										type: 'snackbar',
+										id: 'reset-notification-email-content-action',
+									} );
+
+									onActionPerformed?.( items );
+								} catch ( error ) {
+									let errorMessage = __(
+										'An error occurred while resetting the email content.',
+										'woocommerce'
+									);
+
+									if (
+										error &&
+										typeof error === 'object' &&
+										'message' in error
+									) {
+										errorMessage = String( error.message );
+									}
+
+									createErrorNotice( errorMessage, {
+										type: 'snackbar',
+									} );
+								} finally {
+									setIsBusy( false );
+									closeModal?.();
+								}
+							} }
+							isBusy={ isBusy }
+							disabled={ isBusy }
+							__next40pxDefaultSize
+						>
+							{ __( 'Reset to default', 'woocommerce' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			);
+		},
+	};
+
+	return resetNotificationEmailContent;
+};
+
+export default getResetNotificationEmailContentAction;

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -279,7 +279,8 @@ class EmailApiController {
 	/**
 	 * Return the default (plugin-distributed) block content for a woo_email post.
 	 *
-	 * @param WP_REST_Request<array<string, mixed>> $request The REST request.
+	 * @param WP_REST_Request $request The REST request.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_default_content_response( WP_REST_Request $request ) {

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -6,8 +6,11 @@ namespace Automattic\WooCommerce\Internal\EmailEditor;
 
 use Automattic\WooCommerce\EmailEditor\Validator\Builder;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use WC_Email;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -246,5 +249,56 @@ class EmailApiController {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Register REST API routes for the email API controller.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			'woocommerce-email-editor/v1',
+			'/emails/(?P<id>\d+)/default-content',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_default_content_response' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_woocommerce' );
+				},
+				'args'                => array(
+					'id' => array(
+						'description'       => __( 'The ID of the woo_email post.', 'woocommerce' ),
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the default (plugin-distributed) block content for a woo_email post.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_default_content_response( WP_REST_Request $request ) {
+		$post_id    = (int) $request->get_param( 'id' );
+		$email_type = $this->post_manager->get_email_type_from_post_id( $post_id );
+		$email      = $this->get_email_by_type( $email_type ?? '' );
+
+		if ( ! $email ) {
+			return new WP_Error(
+				'woocommerce_email_not_found',
+				__( 'No email found for the given post ID.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$generator = new WCTransactionalEmailPostsGenerator();
+		return new WP_REST_Response(
+			array( 'content' => $generator->get_email_template( $email ) ),
+			200
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -29,12 +29,20 @@ class EmailApiController {
 	private ?WCTransactionalEmailPostsManager $post_manager;
 
 	/**
+	 * The WooCommerce transactional email posts generator.
+	 *
+	 * @var WCTransactionalEmailPostsGenerator|null
+	 */
+	private ?WCTransactionalEmailPostsGenerator $posts_generator = null;
+
+	/**
 	 * Initialize the controller.
 	 *
 	 * @internal
 	 */
 	final public function init(): void {
-		$this->post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$this->post_manager    = WCTransactionalEmailPostsManager::get_instance();
+		$this->posts_generator = new WCTransactionalEmailPostsGenerator();
 	}
 
 	/**
@@ -272,7 +280,28 @@ class EmailApiController {
 						'sanitize_callback' => 'absint',
 					),
 				),
+				'schema'              => array( $this, 'get_default_content_schema' ),
 			)
+		);
+	}
+
+	/**
+	 * Get the schema for the default content endpoint response.
+	 *
+	 * @return array
+	 */
+	public function get_default_content_schema(): array {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'woo_email_default_content',
+			'type'       => 'object',
+			'properties' => array(
+				'content' => array(
+					'description' => __( 'The default block content for the email.', 'woocommerce' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+			),
 		);
 	}
 
@@ -284,7 +313,7 @@ class EmailApiController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_default_content_response( WP_REST_Request $request ) {
-		if ( ! $this->post_manager ) {
+		if ( ! ( $this->post_manager && $this->posts_generator ) ) {
 			return new WP_Error(
 				'woocommerce_email_editor_not_initialized',
 				__( 'Email editor is not initialized.', 'woocommerce' ),
@@ -304,9 +333,8 @@ class EmailApiController {
 			);
 		}
 
-		$generator = new WCTransactionalEmailPostsGenerator();
 		return new WP_REST_Response(
-			array( 'content' => $generator->get_email_template( $email ) ),
+			array( 'content' => $this->posts_generator->get_email_template( $email ) ),
 			200
 		);
 	}

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -279,10 +279,18 @@ class EmailApiController {
 	/**
 	 * Return the default (plugin-distributed) block content for a woo_email post.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param WP_REST_Request<array<string, mixed>> $request The REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_default_content_response( WP_REST_Request $request ) {
+		if ( ! $this->post_manager ) {
+			return new WP_Error(
+				'woocommerce_email_editor_not_initialized',
+				__( 'Email editor is not initialized.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+
 		$post_id    = (int) $request->get_param( 'id' );
 		$email_type = $this->post_manager->get_email_type_from_post_id( $post_id );
 		$email      = $this->get_email_by_type( $email_type ?? '' );

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -11,9 +11,13 @@ use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplateApiController;
 use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger;
 use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -140,6 +144,7 @@ class Integration {
 		add_action( 'woocommerce_email_editor_send_preview_email_before_wp_mail', array( $this, 'send_preview_email_before_wp_mail' ), 10 );
 		add_action( 'woocommerce_email_editor_send_preview_email_after_wp_mail', array( $this, 'send_preview_email_after_wp_mail' ), 10 );
 		add_filter( 'woocommerce_email_editor_send_preview_email_subject', array( $this, 'update_email_subject_for_send_preview_email' ), 10, 2 );
+		add_action( 'rest_api_init', array( $this, 'register_email_content_api_routes' ) );
 	}
 
 	/**
@@ -452,5 +457,84 @@ class Integration {
 		} catch ( \Throwable $e ) {
 			return $subject;
 		}
+	}
+
+	/**
+	 * Register REST API routes for email content management.
+	 */
+	public function register_email_content_api_routes(): void {
+		register_rest_route(
+			'woocommerce-email-editor/v1',
+			'/emails/(?P<id>\d+)/default-content',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_default_email_content' ),
+				'permission_callback' => function ( WP_REST_Request $request ) {
+					return current_user_can( 'edit_post', (int) $request->get_param( 'id' ) );
+				},
+				'args'                => array(
+					'id' => array(
+						'description'       => __( 'The email post ID.', 'woocommerce' ),
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get the default (plugin-distributed) content for a woo_email post.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_default_email_content( WP_REST_Request $request ) {
+		$post_id = (int) $request->get_param( 'id' );
+		$post    = get_post( $post_id );
+
+		if ( ! $post || self::EMAIL_POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'invalid_post',
+				__( 'Invalid email post.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$email_type   = $post_manager->get_email_type_from_post_id( $post_id );
+
+		if ( empty( $email_type ) ) {
+			return new WP_Error(
+				'email_type_not_found',
+				__( 'Email type not found for this post.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$email = null;
+		foreach ( WC()->mailer()->get_emails() as $wc_email ) {
+			if ( $wc_email->id === $email_type ) {
+				$email = $wc_email;
+				break;
+			}
+		}
+
+		if ( ! $email ) {
+			return new WP_Error(
+				'email_not_found',
+				__( 'Email configuration not found.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$generator       = new WCTransactionalEmailPostsGenerator();
+		$default_content = $generator->get_email_template( $email );
+
+		return new WP_REST_Response(
+			array( 'content' => $default_content ),
+			200
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -394,7 +394,6 @@ class Integration {
 				'schema'          => $this->email_api_controller->get_email_data_schema(),
 			)
 		);
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -11,13 +11,9 @@ use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
-use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplateApiController;
 use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger;
 use WP_Post;
-use WP_REST_Request;
-use WP_REST_Response;
-use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -144,7 +140,7 @@ class Integration {
 		add_action( 'woocommerce_email_editor_send_preview_email_before_wp_mail', array( $this, 'send_preview_email_before_wp_mail' ), 10 );
 		add_action( 'woocommerce_email_editor_send_preview_email_after_wp_mail', array( $this, 'send_preview_email_after_wp_mail' ), 10 );
 		add_filter( 'woocommerce_email_editor_send_preview_email_subject', array( $this, 'update_email_subject_for_send_preview_email' ), 10, 2 );
-		add_action( 'rest_api_init', array( $this, 'register_email_content_api_routes' ) );
+		add_action( 'rest_api_init', array( $this->email_api_controller, 'register_routes' ) );
 	}
 
 	/**
@@ -398,6 +394,7 @@ class Integration {
 				'schema'          => $this->email_api_controller->get_email_data_schema(),
 			)
 		);
+
 	}
 
 	/**
@@ -457,84 +454,5 @@ class Integration {
 		} catch ( \Throwable $e ) {
 			return $subject;
 		}
-	}
-
-	/**
-	 * Register REST API routes for email content management.
-	 */
-	public function register_email_content_api_routes(): void {
-		register_rest_route(
-			'woocommerce-email-editor/v1',
-			'/emails/(?P<id>\d+)/default-content',
-			array(
-				'methods'             => 'GET',
-				'callback'            => array( $this, 'get_default_email_content' ),
-				'permission_callback' => function ( WP_REST_Request $request ) {
-					return current_user_can( 'edit_post', (int) $request->get_param( 'id' ) );
-				},
-				'args'                => array(
-					'id' => array(
-						'description'       => __( 'The email post ID.', 'woocommerce' ),
-						'type'              => 'integer',
-						'required'          => true,
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Get the default (plugin-distributed) content for a woo_email post.
-	 *
-	 * @param WP_REST_Request $request The REST request.
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function get_default_email_content( WP_REST_Request $request ) {
-		$post_id = (int) $request->get_param( 'id' );
-		$post    = get_post( $post_id );
-
-		if ( ! $post || self::EMAIL_POST_TYPE !== $post->post_type ) {
-			return new WP_Error(
-				'invalid_post',
-				__( 'Invalid email post.', 'woocommerce' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$post_manager = WCTransactionalEmailPostsManager::get_instance();
-		$email_type   = $post_manager->get_email_type_from_post_id( $post_id );
-
-		if ( empty( $email_type ) ) {
-			return new WP_Error(
-				'email_type_not_found',
-				__( 'Email type not found for this post.', 'woocommerce' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$email = null;
-		foreach ( WC()->mailer()->get_emails() as $wc_email ) {
-			if ( $wc_email->id === $email_type ) {
-				$email = $wc_email;
-				break;
-			}
-		}
-
-		if ( ! $email ) {
-			return new WP_Error(
-				'email_not_found',
-				__( 'Email configuration not found.', 'woocommerce' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$generator       = new WCTransactionalEmailPostsGenerator();
-		$default_content = $generator->get_email_template( $email );
-
-		return new WP_REST_Response(
-			array( 'content' => $default_content ),
-			200
-		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
 
 use Automattic\WooCommerce\Internal\EmailEditor\EmailApiController;
 use Automattic\WooCommerce\Internal\EmailEditor\Integration;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 
 require_once 'EmailStub.php';
@@ -279,5 +280,62 @@ class EmailApiControllerTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'immediate-bcc@example.com', $result['bcc'] );
 		$this->assertEquals( $this->email_type, $result['email_type'] );
 		$this->assertEquals( 'Default Subject', $result['default_subject'] );
+	}
+
+	/**
+	 * @testdox Should return 404 when post ID has no associated email type.
+	 */
+	public function test_get_default_content_response_returns_404_for_unknown_post(): void {
+		$unassociated_post = $this->factory()->post->create_and_get(
+			array(
+				'post_title'  => 'Unknown Email',
+				'post_name'   => 'unknown_email',
+				'post_type'   => Integration::EMAIL_POST_TYPE,
+				'post_status' => 'draft',
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/woocommerce-email-editor/v1/emails/' . $unassociated_post->ID . '/default-content' );
+		$request->set_param( 'id', $unassociated_post->ID );
+
+		$result = $this->email_api_controller->get_default_content_response( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'woocommerce_email_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @testdox Should return default content for a valid email post.
+	 */
+	public function test_get_default_content_response_returns_content_for_valid_post(): void {
+		$mock_email     = $this->createMock( \WC_Email::class );
+		$mock_email->id = $this->email_type;
+
+		$mock_generator = $this->createMock( WCTransactionalEmailPostsGenerator::class );
+		$mock_generator->method( 'get_email_template' )
+			->willReturn( '<!-- wp:paragraph --><p>Default content</p><!-- /wp:paragraph -->' );
+
+		$controller = $this->getMockBuilder( EmailApiController::class )
+			->onlyMethods( array( 'get_emails' ) )
+			->getMock();
+		$controller->method( 'get_emails' )
+			->willReturn( array( $mock_email ) );
+		$controller->init();
+
+		$reflection = new \ReflectionClass( EmailApiController::class );
+		$property   = $reflection->getProperty( 'posts_generator' );
+		$property->setAccessible( true );
+		$property->setValue( $controller, $mock_generator );
+
+		$request = new \WP_REST_Request( 'GET', '/woocommerce-email-editor/v1/emails/' . $this->email_post->ID . '/default-content' );
+		$request->set_param( 'id', $this->email_post->ID );
+
+		$result = $controller->get_default_content_response( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertArrayHasKey( 'content', $result->get_data() );
+		$this->assertSame( '<!-- wp:paragraph --><p>Default content</p><!-- /wp:paragraph -->', $result->get_data()['content'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #WOOPRD-1019.

Adds a "Reset content to default" action to the WooCommerce email editor, allowing users to reset a notification email's block content to the original plugin-distributed state.

  **What changed:**

  - **New entity action** (`reset-notification-email-content.tsx`): Registers a `woo_email`-specific action via `registerEntityAction`. Shows a confirmation modal, fetches the original template content from the API, then calls `editEntityRecord` + `saveEditedEntityRecord` to reset and persist the content.
  - **New REST endpoint** (`EmailApiController::register_routes()`): `GET` `/woocommerce-email-editor/v1/emails/{id}/default-content` — returns the plugin-distributed block template for a given woo_email post. Registered on-demand (not as a REST field) to avoid an expensive filesystem read on every post fetch.
  - **Email editor package exports** (`packages/js/email-editor/src/index.ts`): Exports `registerEntityAction` and `PostWithPermissions` from the package's public API so WooCommerce (and other integrators) can consume them without accessing private APIs directly.

Note: We used the `woocommerce-email-editor/v1` namespace because it is always available (registered unconditionally by the email editor PHP package), unlike `wc/v4`, which is feature-flagged.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="278" height="212" alt="Screenshot 2026-03-05 at 3 56 59 PM" src="https://github.com/user-attachments/assets/f6d572f1-9568-4860-a689-027e7bede8df" />   |    <img width="287" height="225" alt="Screenshot 2026-03-05 at 3 35 37 PM" src="https://github.com/user-attachments/assets/ccc7a32d-794a-47b4-80e4-9c6cc9ecc031" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

  1. Enable the block email editor at **WooCommerce → Settings → Advanced → Features**.
  2. Go to **WooCommerce → Settings → Emails** and click "Edit" on any notification email (e.g. New Order).
  3. Make some edits to the email content and save.
  4. Open the three-dot (⋮) menu in the top-right of the editor toolbar.
  5. Confirm the **"Reset content to default"** action is present in the list.
  6. Click it — a confirmation modal should appear with the email's title.
  7. Click **"Reset to default"** — the editor content should update to the original plugin template and a success snackbar should appear.
  8. Verify the network tab shows a `GET` `/wp-json/woocommerce-email-editor/v1/emails/{id}/default-content` request fired only when confirming the reset (not on page load).
  9. Click "Cancel" in the modal — no changes should be made.
  10. Repeat for an email where you do **not** have `manage_woocommerce` capability — the action should not appear.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
