### PR TITLE
Make email header image clickable in classic email templates

### DIFF
--- a/plugins/woocommerce/changelog/63559-add-WOOPLUG-6239-clickable-email-header-image
+++ b/plugins/woocommerce/changelog/63559-add-WOOPLUG-6239-clickable-email-header-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Make email header image/logo clickable with a link to the store homepage in classic email templates. Adds `woocommerce_email_header_image_url` filter for customization.

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 10.7.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -23,6 +23,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
+
+/**
+ * Filter the URL used for the email header image/logo link.
+ *
+ * Return an empty string to disable the link.
+ *
+ * @since 10.7.0
+ * @param string $url The URL to link to. Defaults to the site home URL.
+ */
+$header_image_url = apply_filters( 'woocommerce_email_header_image_url', home_url() );
 
 ?>
 <!DOCTYPE html>
@@ -60,7 +70,16 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 												<td id="template_header_image">
 													<?php
 													if ( $img ) {
-														echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $store_name ) . '" /></p>';
+														$image_html = '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $store_name ) . '" />';
+														if ( $header_image_url ) {
+															// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $image_html is built from esc_url() and esc_attr().
+															echo '<p style="margin-top:0;"><a href="' . esc_url( $header_image_url ) . '" style="display: inline-block; text-decoration: none;" target="_blank">' . $image_html . '</a></p>';
+														} else {
+															// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+															echo '<p style="margin-top:0;">' . $image_html . '</p>';
+														}
+													} elseif ( $header_image_url ) {
+														echo '<p class="email-logo-text"><a href="' . esc_url( $header_image_url ) . '" style="color: inherit; text-decoration: none;" target="_blank">' . esc_html( $store_name ) . '</a></p>';
 													} else {
 														echo '<p class="email-logo-text">' . esc_html( $store_name ) . '</p>';
 													}
@@ -72,7 +91,14 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 										<div id="template_header_image">
 											<?php
 											if ( $img ) {
-												echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $store_name ) . '" /></p>';
+												$image_html = '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $store_name ) . '" />';
+												if ( $header_image_url ) {
+													// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $image_html is built from esc_url() and esc_attr().
+													echo '<p style="margin-top:0;"><a href="' . esc_url( $header_image_url ) . '" style="display: inline-block; text-decoration: none;" target="_blank">' . $image_html . '</a></p>';
+												} else {
+													// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+													echo '<p style="margin-top:0;">' . $image_html . '</p>';
+												}
 											}
 											?>
 										</div>

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-header-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-header-template-test.php
@@ -7,6 +7,17 @@ declare( strict_types = 1 );
  * @covers `email-header.php` template
  */
 class WC_Email_Header_Template_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'woocommerce_email_header_image' );
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'no' );
+		remove_all_filters( 'woocommerce_email_header_image_url' );
+	}
+
 	/**
 	 * @testdox Email header template includes blog name when store name is not set.
 	 */
@@ -40,5 +51,130 @@ class WC_Email_Header_Template_Test extends \WC_Unit_Test_Case {
 		// Then email header should include blog name.
 		$this->assertStringContainsString( '<title>Another store</title>', $content );
 		$this->assertStringNotContainsString( '<title>Online Store</title>', $content );
+	}
+
+	/**
+	 * @testdox Header image is wrapped in a link to home_url() when improvements are disabled.
+	 */
+	public function test_header_image_wrapped_in_link() {
+		update_option( 'woocommerce_email_header_image', 'https://example.com/logo.png' );
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertMatchesRegularExpression( '/<a href="[^"]*"[^>]*target="_blank"[^>]*><img src="https:\/\/example\.com\/logo\.png"/', $content );
+	}
+
+	/**
+	 * @testdox Header image is wrapped in a link to home_url() when improvements are enabled.
+	 */
+	public function test_header_image_wrapped_in_link_with_improvements_enabled() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+		update_option( 'woocommerce_email_header_image', 'https://example.com/logo.png' );
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertMatchesRegularExpression( '/<a href="[^"]*"[^>]*target="_blank"[^>]*><img src="https:\/\/example\.com\/logo\.png"/', $content );
+	}
+
+	/**
+	 * @testdox Text fallback is wrapped in a link when improvements are enabled and no image is set.
+	 */
+	public function test_text_fallback_wrapped_in_link_with_improvements_enabled() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+		update_option( 'blogname', 'My Store' );
+		delete_option( 'woocommerce_email_header_image' );
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringContainsString( 'email-logo-text', $content );
+		$this->assertStringContainsString( '<a href="' . esc_url( home_url() ) . '"', $content );
+		$this->assertStringContainsString( 'My Store</a>', $content );
+	}
+
+	/**
+	 * @testdox No text fallback or link is rendered when improvements are disabled and no image is set.
+	 */
+	public function test_no_text_fallback_without_improvements() {
+		delete_option( 'woocommerce_email_header_image' );
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringNotContainsString( 'email-logo-text', $content );
+		$this->assertStringNotContainsString( '<a href="' . esc_url( home_url() ) . '" style="color: inherit', $content );
+	}
+
+	/**
+	 * @testdox Header image URL is filterable via woocommerce_email_header_image_url.
+	 */
+	public function test_header_image_url_is_filterable() {
+		update_option( 'woocommerce_email_header_image', 'https://example.com/logo.png' );
+		add_filter(
+			'woocommerce_email_header_image_url',
+			function () {
+				return 'https://custom-url.com/shop';
+			}
+		);
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringContainsString( '<a href="https://custom-url.com/shop"', $content );
+	}
+
+	/**
+	 * @testdox No link wraps image when filter returns empty string and improvements are enabled.
+	 */
+	public function test_no_link_when_filter_returns_empty_with_improvements_enabled() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+		update_option( 'woocommerce_email_header_image', 'https://example.com/logo.png' );
+		add_filter(
+			'woocommerce_email_header_image_url',
+			function () {
+				return '';
+			}
+		);
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringContainsString( '<img src="https://example.com/logo.png"', $content );
+		$this->assertStringNotContainsString( '<a href=', $content );
+	}
+
+	/**
+	 * @testdox Text fallback has no link when filter returns empty string and improvements are enabled.
+	 */
+	public function test_text_fallback_no_link_when_filter_returns_empty_with_improvements_enabled() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+		update_option( 'blogname', 'My Store' );
+		delete_option( 'woocommerce_email_header_image' );
+		add_filter(
+			'woocommerce_email_header_image_url',
+			function () {
+				return '';
+			}
+		);
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringContainsString( 'email-logo-text', $content );
+		$this->assertStringContainsString( 'My Store', $content );
+		$this->assertStringNotContainsString( '<a href=', $content );
+	}
+
+	/**
+	 * @testdox No link is rendered when filter returns empty string.
+	 */
+	public function test_no_link_when_filter_returns_empty() {
+		update_option( 'woocommerce_email_header_image', 'https://example.com/logo.png' );
+		add_filter(
+			'woocommerce_email_header_image_url',
+			function () {
+				return '';
+			}
+		);
+
+		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
+
+		$this->assertStringContainsString( '<img src="https://example.com/logo.png"', $content );
+		$this->assertStringNotContainsString( '<a href=', $content );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-header-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-header-template-test.php
@@ -61,7 +61,9 @@ class WC_Email_Header_Template_Test extends \WC_Unit_Test_Case {
 
 		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
 
-		$this->assertMatchesRegularExpression( '/<a href="[^"]*"[^>]*target="_blank"[^>]*><img src="https:\/\/example\.com\/logo\.png"/', $content );
+		$this->assertStringContainsString( '<a ', $content );
+		$this->assertStringContainsString( 'target="_blank"', $content );
+		$this->assertStringContainsString( 'src="https://example.com/logo.png"', $content );
 	}
 
 	/**
@@ -73,7 +75,9 @@ class WC_Email_Header_Template_Test extends \WC_Unit_Test_Case {
 
 		$content = wc_get_template_html( 'emails/email-header.php', array( 'email_heading' => 'Test' ) );
 
-		$this->assertMatchesRegularExpression( '/<a href="[^"]*"[^>]*target="_blank"[^>]*><img src="https:\/\/example\.com\/logo\.png"/', $content );
+		$this->assertStringContainsString( '<a ', $content );
+		$this->assertStringContainsString( 'target="_blank"', $content );
+		$this->assertStringContainsString( 'src="https://example.com/logo.png"', $content );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Wraps the email header image/logo in a clickable `<a>` link pointing to the store homepage in classic (non-block) email templates. This follows the standard UX pattern where clicking a logo navigates to the main site.

**What's included:**

- **Both code paths covered:** Works with the `email_improvements` feature flag ON and OFF
- **Text fallback:** When improvements are enabled and no header image is set, the store name text is also wrapped in a link
- **Customizable via filter:** New `woocommerce_email_header_image_url` filter allows merchants to change the link URL or disable it entirely by returning an empty string
- **Inline styles:** Uses inline styles on `<a>` tags (`text-decoration: none`, `display: inline-block`) for reliable rendering across email clients
- **Template version bumped** from 10.4.0 to 10.7.0

Closes https://github.com/woocommerce/woocommerce/issues/63101 WOOPLUG-6239

### Screenshots or screen recordings:

N/A — no visual change other than the image/logo becoming clickable.

### How to test the changes in this Pull Request:

#### Prerequisites

- Ensure there is **no theme template override** for `email-header.php` (check `yourtheme/woocommerce/emails/email-header.php` — if it exists, remove or rename it for testing).
- These changes apply to **classic email templates only**. The block email editor already supports clickable images natively.

#### Test 1: Header image link with `email_improvements` OFF (default)

1. Go to **WooCommerce > Settings > Emails** and ensure a header image URL is set (upload one if not already configured).
2. Ensure the `email_improvements` feature flag is **disabled** (default state).
3. Trigger a WooCommerce email (e.g., go to **WooCommerce > Orders**, open an order, and use **Order actions > Email invoice / order details to customer**).
4. Open the received email and verify:
   - The header image is clickable and links to the store homepage.
   - The link opens in a new tab (`target="_blank"`).
   - No underline or visual artifact appears on the image link.

#### Test 2: Header image link with `email_improvements` ON

1. Enable the feature flag: add `add_filter( 'woocommerce_feature_email_improvements_enabled', '__return_true' );` to your theme's `functions.php`, or enable via **WooCommerce > Settings > Advanced > Features**.
2. With a header image set, trigger another email.
3. Verify the same behavior as Test 1 — image is clickable, links to homepage.

#### Test 3: Text fallback link (`email_improvements` ON, no header image)

1. Keep `email_improvements` enabled.
2. Go to **WooCommerce > Settings > Emails** and **remove** the header image URL (clear the field and save).
3. Trigger an email.
4. Verify the store name text appears in the header and is clickable, linking to the homepage.

#### Test 4: No text fallback (`email_improvements` OFF, no header image)

1. Disable the `email_improvements` feature flag.
2. Ensure no header image is set.
3. Trigger an email.
4. Verify no logo image or text link appears in the header area (existing behavior, unchanged).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message
Make email header image/logo clickable with a link to the store homepage in classic email templates. Adds `woocommerce_email_header_image_url` filter for customization.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>
