### PR TITLE
[WOOPLUG-6376] update: add IE, PT with Packlink and move DE to Packlink

### DIFF
--- a/plugins/woocommerce/changelog/63567-update-wooplug-6376-add-ie-pt-with-packlink-and-move-de-to-packlink
+++ b/plugins/woocommerce/changelog/63567-update-wooplug-6376-add-ie-pt-with-packlink-and-move-de-to-packlink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Update shipping partner suggestions to add Ireland and Portugal with Packlink, and move Germany to Packlink.
+

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -32,13 +32,15 @@ const COUNTRY_EXTENSIONS_MAP: Record< string, ExtensionId[] > = {
 	FR: [ 'packlink' ],
 	ES: [ 'packlink' ],
 	IT: [ 'packlink' ],
-	DE: [ 'shipstation', 'packlink' ],
-	GB: [ 'shipstation', 'packlink' ],
+	DE: [ 'packlink' ],
+	GB: [ 'shipstation' ],
 	NL: [ 'packlink' ],
 	AT: [ 'packlink' ],
 	BE: [ 'packlink' ],
 	AU: [ 'shipstation' ],
 	NZ: [ 'shipstation' ],
+	IE: [ 'packlink' ],
+	PT: [ 'packlink' ],
 };
 
 const EXTENSION_PLUGIN_SLUGS: Record< ExtensionId, string > = {

--- a/plugins/woocommerce/client/admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -122,23 +122,27 @@ describe( 'ShippingRecommendations', () => {
 			expect( screen.queryByText( 'Packlink PRO' ) ).toBeInTheDocument();
 		} );
 
-		it( 'should show ShipStation and Packlink PRO for DE', () => {
+		it( 'should show only Packlink PRO for DE', () => {
 			mockSelectForCountry( 'DE' );
 			render( <ShippingRecommendations /> );
 
 			expect(
 				screen.queryByText( 'WooCommerce Shipping' )
 			).not.toBeInTheDocument();
-			expect( screen.queryByText( 'ShipStation' ) ).toBeInTheDocument();
+			expect(
+				screen.queryByText( 'ShipStation' )
+			).not.toBeInTheDocument();
 			expect( screen.queryByText( 'Packlink PRO' ) ).toBeInTheDocument();
 		} );
 
-		it( 'should show ShipStation and Packlink PRO for GB', () => {
+		it( 'should show only ShipStation for GB', () => {
 			mockSelectForCountry( 'GB' );
 			render( <ShippingRecommendations /> );
 
 			expect( screen.queryByText( 'ShipStation' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Packlink PRO' ) ).toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Packlink PRO' )
+			).not.toBeInTheDocument();
 		} );
 
 		it( 'should show only ShipStation for AU', () => {
@@ -158,7 +162,7 @@ describe( 'ShippingRecommendations', () => {
 			expect( screen.queryByText( 'ShipStation' ) ).toBeInTheDocument();
 		} );
 
-		it.each( [ 'ES', 'IT', 'NL', 'AT', 'BE' ] )(
+		it.each( [ 'ES', 'IT', 'NL', 'AT', 'BE', 'IE', 'PT' ] )(
 			'should show only Packlink PRO for %s',
 			( country ) => {
 				mockSelectForCountry( country );
@@ -218,10 +222,9 @@ describe( 'ShippingRecommendations', () => {
 		} );
 
 		it( 'should not show Packlink PRO when it is already active', () => {
-			mockSelectForCountry( 'DE', [ 'packlink-pro-shipping' ] );
+			mockSelectForCountry( 'FR', [ 'packlink-pro-shipping' ] );
 			render( <ShippingRecommendations /> );
 
-			expect( screen.queryByText( 'ShipStation' ) ).toBeInTheDocument();
 			expect(
 				screen.queryByText( 'Packlink PRO' )
 			).not.toBeInTheDocument();
@@ -287,8 +290,7 @@ describe( 'ShippingRecommendations', () => {
 				{
 					context: 'settings',
 					country: 'DE',
-					plugins:
-						'woocommerce-shipstation-integration,packlink-pro-shipping',
+					plugins: 'packlink-pro-shipping',
 				}
 			);
 		} );

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -116,7 +116,7 @@ class Shipping extends Task {
 				return true;
 			}
 
-			return in_array( $store_country, array( 'US', 'CA', 'AU', 'NZ', 'SG', 'HK', 'GB', 'ES', 'IT', 'DE', 'FR', 'MX', 'CO', 'CL', 'AR', 'PE', 'BR', 'UY', 'GT', 'NL', 'AT', 'BE' ), true );
+			return in_array( $store_country, array( 'US', 'CA', 'AU', 'NZ', 'SG', 'HK', 'GB', 'ES', 'IT', 'DE', 'FR', 'MX', 'CO', 'CL', 'AR', 'PE', 'BR', 'UY', 'GT', 'NL', 'AT', 'BE', 'IE', 'PT' ), true );
 		}
 
 		return self::has_physical_products();

--- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
+++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/DefaultShippingPartners.php
@@ -212,10 +212,10 @@ class DefaultShippingPartners {
 				),
 				'learn_more_link'         => 'https://wordpress.org/plugins/packlink-pro-shipping/',
 				'is_visible'              => array(
-					self::get_rules_for_countries( array( 'FR', 'DE', 'ES', 'IT', 'NL', 'AT', 'BE' ) ),
+					self::get_rules_for_countries( array( 'FR', 'DE', 'ES', 'IT', 'NL', 'AT', 'BE', 'IE', 'PT' ) ),
 				),
 				'available_layouts'       => array( 'row', 'column' ),
-				'countries_where_primary' => array( 'FR', 'DE', 'ES', 'IT', 'NL', 'AT', 'BE' ),
+				'countries_where_primary' => array( 'FR', 'DE', 'ES', 'IT', 'NL', 'AT', 'BE', 'IE', 'PT' ),
 			),
 			array(
 				'id'                      => 'woocommerce-shipping',

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -482,7 +482,7 @@ class DefaultFreeExtensions {
 				'is_visible'     => array(
 					array(
 						'type'      => 'base_location_country',
-						'value'     => array( 'CA', 'DE', 'GB', 'AU', 'NZ' ),
+						'value'     => array( 'CA', 'GB', 'AU', 'NZ' ),
 						'operation' => 'in',
 					),
 				),
@@ -495,7 +495,7 @@ class DefaultFreeExtensions {
 				'is_visible'     => array(
 					array(
 						'type'      => 'base_location_country',
-						'value'     => array( 'FR', 'ES', 'IT', 'NL', 'AT', 'BE' ),
+						'value'     => array( 'FR', 'ES', 'IT', 'DE', 'NL', 'AT', 'BE', 'IE', 'PT' ),
 						'operation' => 'in',
 					),
 				),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
@@ -150,13 +150,19 @@ class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
 	 */
 	public function data_provider_can_view_eligible_countries() {
 		return array(
-			array( 'AU' ),
+			array( 'US' ),
 			array( 'CA' ),
+			array( 'AU' ),
+			array( 'NZ' ),
+			array( 'SG' ),
+			array( 'HK' ),
 			array( 'GB' ),
 			array( 'ES' ),
 			array( 'IT' ),
 			array( 'DE' ),
 			array( 'FR' ),
+			array( 'MX' ),
+			array( 'CO' ),
 			array( 'CL' ),
 			array( 'AR' ),
 			array( 'PE' ),
@@ -166,6 +172,8 @@ class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
 			array( 'NL' ),
 			array( 'AT' ),
 			array( 'BE' ),
+			array( 'IE' ),
+			array( 'PT' ),
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related Linear Issue: [WOOPLUG-6376](https://linear.app/a8c/issue/WOOPLUG-6376/add-ie-pt-with-packlink-and-move-de-to-packlink)
Related GitHub Issue: https://github.com/woocommerce/woocommerce/issues/63528

Update shipping plugin recommendations to:
- Add Ireland (IE) with Packlink as the recommended shipping extension
- Add Portugal (PT) with Packlink as the recommended shipping extension
- Move Germany (DE) from ShipStation to Packlink
- Update UK (GB) shipping settings to show only ShipStation (remove Packlink)

These changes apply to all three shipping recommendation surfaces:
- OBW / Core Profiler (onboarding wizard): DE moved to Packlink, IE/PT added with Packlink
- WC Core Tasks list (shipping task recommended plugins): IE/PT added with Packlink
- Shipping settings (recommendations under shipping zones table): DE changed to Packlink only, GB changed to ShipStation only, IE/PT added with Packlink

Closes #63528.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Prerequisites

To test the Core Profiler and Task List shipping recommendations using the local/fallback specs (instead of remote specs from WooCommerce.com), disable marketplace suggestions:
```
wp option update woocommerce_show_marketplace_suggestions no
```
This forces `ShippingPartnerSuggestions::get_specs()` to use `DefaultShippingPartners::get_all()` directly, bypassing the remote data source.

To revert this change after testing:
```
wp option update woocommerce_show_marketplace_suggestions yes
```

#### Testing Steps

For each country (Ireland - IE, Portugal - PT, Germany - DE), repeat the following:

**1. Set the store country:**
```
wp option update woocommerce_default_country <COUNTRY_CODE>
```

**2. Test the Core Profiler (OBW):**
- Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard` to open the onboarding wizard.
- Proceed through the steps until you reach the shipping extension recommendation.
- Verify that Packlink is shown as the recommended shipping extension.

**3. Test the Task List (shipping task):**
- Delete all existing shipping zones (the shipping task only appears when no zones are configured).
- Remove `shipping` and `review-shipping` from the completed tasks list to make the task visible again:
```
wp eval "
\$completed = get_option('woocommerce_task_list_tracked_completed_tasks', []);
\$completed = array_values(array_diff(\$completed, ['shipping', 'review-shipping']));
update_option('woocommerce_task_list_tracked_completed_tasks', \$completed);
"
```
- Delete the shipping zone count transient:
```
wp transient delete woocommerce_shipping_task_zone_count_transient
```
- Navigate to `/wp-admin/admin.php?page=wc-admin` and click the "Set up shipping" task.
- Verify that Packlink is shown as the recommended shipping extension.

**4. Test the Shipping Settings:**
- Navigate to **WooCommerce > Settings > Shipping**.
- Verify that Packlink appears in the shipping partner suggestions below the shipping zones table.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Update shipping partner suggestions to add Ireland and Portugal with Packlink, and move Germany to Packlink.

</details>
