### PR TITLE
[WOOPLUG-6377] fix: shipping category placement updates: restore old tracks events

### DIFF
--- a/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-woocommerce-shipping-item.tsx
@@ -43,6 +43,10 @@ const WooCommerceShippingItem = ( {
 		};
 
 		recordEvent( 'shipping_partner_click', trackingBase );
+		recordEvent( 'settings_shipping_recommendation_setup_click', {
+			plugin: WOOCOMMERCE_SHIPPING_PLUGIN_SLUG,
+			action: isPluginInstalled ? 'activate' : 'install',
+		} );
 
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
 		const eventName = isPluginInstalled

--- a/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/packlink-item.tsx
@@ -36,6 +36,10 @@ const PacklinkItem = ( {
 		};
 
 		recordEvent( 'shipping_partner_click', trackingBase );
+		recordEvent( 'settings_shipping_recommendation_setup_click', {
+			plugin: PACKLINK_PLUGIN_SLUG,
+			action: isPluginInstalled ? 'activate' : 'install',
+		} );
 
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
 		const eventName = isPluginInstalled

--- a/plugins/woocommerce/client/admin/client/shipping/shipstation-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/shipstation-item.tsx
@@ -36,6 +36,10 @@ const ShipStationItem = ( {
 		};
 
 		recordEvent( 'shipping_partner_click', trackingBase );
+		recordEvent( 'settings_shipping_recommendation_setup_click', {
+			plugin: SHIPSTATION_PLUGIN_SLUG,
+			action: isPluginInstalled ? 'activate' : 'install',
+		} );
 
 		const action = isPluginInstalled ? onActivateClick : onInstallClick;
 		const eventName = isPluginInstalled

--- a/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/experimental-woocommerce-shipping-item.tsx
@@ -140,6 +140,42 @@ describe( 'WooCommerceShippingItem', () => {
 		} );
 	} );
 
+	it( 'should record settings_shipping_recommendation_setup_click with action=install when clicking Install button', () => {
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ false }
+				{ ...defaultProps }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Install' } )?.click();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_shipping_recommendation_setup_click',
+			{
+				plugin: 'woocommerce-shipping',
+				action: 'install',
+			}
+		);
+	} );
+
+	it( 'should record settings_shipping_recommendation_setup_click with action=activate when clicking Activate button', () => {
+		render(
+			<WooCommerceShippingItem
+				isPluginInstalled={ true }
+				{ ...defaultProps }
+			/>
+		);
+
+		screen.queryByRole( 'button', { name: 'Activate' } )?.click();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_shipping_recommendation_setup_click',
+			{
+				plugin: 'woocommerce-shipping',
+				action: 'activate',
+			}
+		);
+	} );
+
 	it( 'should call onActivateClick when clicking Activate button', () => {
 		const onActivateClick = jest.fn( () => Promise.resolve() );
 		render(

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -418,6 +418,13 @@ export class Shipping extends Component {
 						<Plugins
 							onComplete={ ( _plugins, response ) => {
 								createNoticesFromResponse( response );
+								recordEvent(
+									'tasklist_shipping_label_printing',
+									{
+										install: true,
+										plugins_to_activate: pluginsToActivate,
+									}
+								);
 								this.recordInstallAndActivateEvents(
 									pluginsToActivate[ 0 ],
 									true
@@ -432,13 +439,6 @@ export class Shipping extends Component {
 								);
 							} }
 							onClick={ () => {
-								recordEvent(
-									'tasklist_shipping_label_printing',
-									{
-										install: true,
-										plugins_to_activate: pluginsToActivate,
-									}
-								);
 								recordEvent( 'shipping_partner_click', {
 									...this.getShippingPartnerTrackingProps(),
 									selected_plugin: pluginsToActivate[ 0 ],
@@ -558,6 +558,14 @@ export class Shipping extends Component {
 																createNoticesFromResponse(
 																	response
 																);
+																recordEvent(
+																	'tasklist_shipping_label_printing',
+																	{
+																		install: true,
+																		plugins_to_activate:
+																			pluginsForPartner,
+																	}
+																);
 																this.recordInstallAndActivateEvents(
 																	shippingMethod.slug,
 																	true
@@ -578,14 +586,6 @@ export class Shipping extends Component {
 																);
 															} }
 															onClick={ () => {
-																recordEvent(
-																	'tasklist_shipping_label_printing',
-																	{
-																		install: true,
-																		plugins_to_activate:
-																			pluginsToActivate,
-																	}
-																);
 																recordEvent(
 																	'shipping_partner_click',
 																	{
@@ -659,6 +659,14 @@ export class Shipping extends Component {
 											createNoticesFromResponse(
 												response
 											);
+											recordEvent(
+												'tasklist_shipping_label_printing',
+												{
+													install: true,
+													plugins_to_activate:
+														pluginsToActivate,
+												}
+											);
 											this.recordInstallAndActivateEvents(
 												pluginsToPromote[ 0 ]?.slug,
 												true
@@ -676,14 +684,6 @@ export class Shipping extends Component {
 											);
 										} }
 										onClick={ () => {
-											recordEvent(
-												'tasklist_shipping_label_printing',
-												{
-													install: true,
-													plugins_to_activate:
-														pluginsToActivate,
-												}
-											);
 											recordEvent(
 												'shipping_partner_click',
 												{

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -445,6 +445,13 @@ export class Shipping extends Component {
 								} );
 							} }
 							onSkip={ () => {
+								recordEvent(
+									'tasklist_shipping_label_printing',
+									{
+										install: false,
+										plugins_to_activate: pluginsToActivate,
+									}
+								);
 								invalidateResolutionForStoreSelector();
 								getHistory().push( getNewPath( {}, '/', {} ) );
 								onComplete();

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -432,6 +432,13 @@ export class Shipping extends Component {
 								);
 							} }
 							onClick={ () => {
+								recordEvent(
+									'tasklist_shipping_label_printing',
+									{
+										install: true,
+										plugins_to_activate: pluginsToActivate,
+									}
+								);
 								recordEvent( 'shipping_partner_click', {
 									...this.getShippingPartnerTrackingProps(),
 									selected_plugin: pluginsToActivate[ 0 ],
@@ -572,6 +579,14 @@ export class Shipping extends Component {
 															} }
 															onClick={ () => {
 																recordEvent(
+																	'tasklist_shipping_label_printing',
+																	{
+																		install: true,
+																		plugins_to_activate:
+																			pluginsToActivate,
+																	}
+																);
+																recordEvent(
 																	'shipping_partner_click',
 																	{
 																		...this.getShippingPartnerTrackingProps(),
@@ -661,6 +676,14 @@ export class Shipping extends Component {
 											);
 										} }
 										onClick={ () => {
+											recordEvent(
+												'tasklist_shipping_label_printing',
+												{
+													install: true,
+													plugins_to_activate:
+														pluginsToActivate,
+												}
+											);
 											recordEvent(
 												'shipping_partner_click',
 												{


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During the shipping category placement updates ([WOOPLUG-6273](https://linear.app/a8c/issue/WOOPLUG-6273)), two legacy tracks events were removed and replaced with new unified events. This PR restores those legacy events alongside the new ones so that existing reports are not broken.

**Restored events:**

1. **`settings_shipping_recommendation_setup_click`** (removed in PR #63437)
   - Restored in the settings page shipping partner components: `experimental-woocommerce-shipping-item.tsx`, `packlink-item.tsx`, `shipstation-item.tsx`
   - Fires alongside the new `shipping_partner_click` event when a user clicks Install or Activate
   - Properties: `{ plugin: '<slug>', action: 'install' | 'activate' }`

2. **`tasklist_shipping_label_printing`** with `install: true` (removed in PR #63438)
   - Restored in 3 onClick handlers in the task list shipping flow (`task-lists/fills/shipping/index.js`)
   - Fires alongside the new `shipping_partner_click` event when a user clicks to install/enable a shipping partner
   - Properties: `{ install: true, plugins_to_activate: [...] }`
   - Note: the `install: false` variant (fired on skip) was already present and was not removed

Tests added for `settings_shipping_recommendation_setup_click` in the existing test file.

Related Linear issue: [WOOPLUG-6377](https://linear.app/a8c/issue/WOOPLUG-6377/shipping-category-placement-updates-restore-old-tracks-events)
Related GitHub issue: https://github.com/woocommerce/woocommerce/issues/63529

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #63529.

(For Bug Fixes) Bug introduced in PR #63437 and PR #63438.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Testing `settings_shipping_recommendation_setup_click` on Settings page

1. Go to **WooCommerce > Settings > Shipping**.
2. Open the browser developer console and run: `wp.hooks.addAction('wcTracks.recordEvent', 'test', (name, props) => console.log('Track:', name, props));`
3. If a shipping partner recommendation is shown (e.g., WooCommerce Shipping, Packlink, ShipStation), click the **Install** or **Activate** button.
4. Verify in the console that **both** of the following events are fired:
   - `shipping_partner_click` (new event, with `context`, `country`, `plugins`, `selected_plugin`)
   - `settings_shipping_recommendation_setup_click` (restored event, with `plugin` and `action: 'install'` or `action: 'activate'`)

#### Testing `tasklist_shipping_label_printing` on Task List

1. Navigate to the **Home** screen task list and open the **Shipping** task (or reset shipping task completion to make it available).
2. Open the browser developer console and run: `wp.hooks.addAction('wcTracks.recordEvent', 'test', (name, props) => console.log('Track:', name, props));`
3. Proceed through the shipping task steps until you reach the **label printing** step.
4. Click the **Install and enable** button for one of the shipping partners.
5. Verify in the console that **both** of the following events are fired:
   - `shipping_partner_click` (new event)
   - `tasklist_shipping_label_printing` (restored event, with `install: true` and `plugins_to_activate: [...]`)
6. Optionally, click **No Thanks** / skip and verify `tasklist_shipping_label_printing` fires with `install: false`.

#### Unit tests

Run the related unit tests to confirm they pass:
```bash
npx jest --config client/jest.config.js --testPathPattern="experimental-woocommerce-shipping-item"
npx jest --config client/jest.config.js --testPathPattern="task-lists/fills/shipping/test"
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

- Unit tests pass for `experimental-woocommerce-shipping-item.tsx` (12 tests, including 2 new ones for the restored event)
- Unit tests pass for `task-lists/fills/shipping/test/index.tsx` (13 tests)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Restore legacy tracks events (settings_shipping_recommendation_setup_click and tasklist_shipping_label_printing) alongside new unified shipping partner events to preserve existing analytics reports.

</details>