### PR TITLE
Fix undefined variable in robots_txt method

### DIFF
--- a/plugins/woocommerce/changelog/pr-63589
+++ b/plugins/woocommerce/changelog/pr-63589
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix undefined site_url variable in robots_txt

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1180,6 +1180,7 @@ final class WooCommerce {
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function robots_txt( $output ) {
+		$site_url = parse_url( site_url() );
 		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
 		$lines       = preg_split( '/\r\n|\r|\n/', $output );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1180,8 +1180,8 @@ final class WooCommerce {
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function robots_txt( $output ) {
-		$site_url = parse_url( site_url() );
-		$path = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+		$site_url = wp_parse_url( site_url() );
+		$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
 		$lines       = preg_split( '/\r\n|\r|\n/', $output );
 		$agent_index = array_search( 'User-agent: *', $lines, true );

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -16597,18 +16597,6 @@ parameters:
 			path: includes/class-woocommerce.php
 
 		-
-			message: '#^Undefined variable\: \$site_url$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/class-woocommerce.php
-
-		-
-			message: '#^Variable \$site_url in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: includes/class-woocommerce.php
-
-		-
 			message: '#^Call to method display_items\(\) on an unknown class WP_CLI\\Formatter\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Define the undefined `$site_url` variable in the function that customizes `robots.txt`. Without this, the "Disallow" entries that WooCommerce adds will have an incorrect root when WordPress is not in the root of the site (e.g. for multisite).

### Testing instructions

1. Create a WordPress site that's not in the root of the domain. An easy way to do that is to create a multisite using [Jurassic Ninja](https://jurassic.ninja/), then creating a second site e.g. `/site2` and activating WooCommerce on that site.
2. Run the following in the command line: `wp --url="<domain root>/site2" eval "do_robots();"`

Without this fix you'll see the lines that WooCommerce adds with the wrong root (e.g. `Disallow: /wp-content/uploads/wc-logs/`). With this fix you'll see the correct root (e.g. `Disallow: /site2/wp-content/uploads/wc-logs/`).

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Define the undefined `$site_url`

</details>
