### PR TITLE
Feasibility: Product types as custom post types

### DIFF
--- a/agent-os/specs/2026-03-08-product-types-as-cpt/findings.md
+++ b/agent-os/specs/2026-03-08-product-types-as-cpt/findings.md
@@ -1,0 +1,268 @@
+# Findings: Product Types as Custom Post Types
+
+## Overview
+
+This document summarizes the feasibility analysis of converting WooCommerce's product type system from a taxonomy-based approach (`product_type` taxonomy on the `product` post type) to individual custom post types (`wc_product_simple`, `wc_product_variable`, `wc_product_grouped`, `wc_product_external`).
+
+## 1. Prototype Implementation Summary
+
+### What was built
+
+- **Feature flag**: `product_type_post_types` in `FeaturesController` (experimental, disabled by default, no UI)
+- **4 new post types**: `wc_product_simple`, `wc_product_variable`, `wc_product_grouped`, `wc_product_external`
+- **Helper functions**: `wc_get_product_post_types()`, `wc_product_type_to_post_type()`, `wc_post_type_to_product_type()`, `wc_is_product_post_type()`
+- **Updated core systems**: Product Factory, Data Store (CPT), Product Model classes, WC_Query, conditional functions, Template Loader, REST API v2/v3, Store API, Product Query block, Shortcodes
+- **WP-CLI migration script**: Forward migration + rollback with batch processing
+- **Performance benchmark CLI**: Type resolution, shop queries, product counts, creation speed
+- **Backward compatibility**: `post_type_link` filter for URL consistency, `pre_get_posts` expansion
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/Internal/Features/FeaturesController.php` | Feature flag registration |
+| `includes/class-wc-post-types.php` | Post type registration, taxonomy attachment, permalink filter, query expansion, Gutenberg filter |
+| `includes/class-wc-product-factory.php` | Type resolution from post type, product ID detection |
+| `includes/data-stores/class-wc-product-data-store-cpt.php` | Create/update/read/delete, type queries, SQL queries (~15 locations) |
+| `includes/class-wc-product-simple.php` | Constructor post_type override |
+| `includes/class-wc-product-variable.php` | Constructor post_type override |
+| `includes/class-wc-product-grouped.php` | Constructor post_type override |
+| `includes/class-wc-product-external.php` | Constructor post_type override |
+| `includes/wc-product-functions.php` | Helper functions |
+| `includes/class-wc-query.php` | Frontend query expansion |
+| `includes/wc-conditional-functions.php` | `is_product()`, `is_shop()` expansion |
+| `includes/class-wc-template-loader.php` | Template detection |
+| `includes/class-wc-shortcodes.php` | Post type checks and queries |
+| `includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php` | Type filtering, post_type query |
+| `src/StoreApi/Utilities/ProductQuery.php` | Type filtering, post_type query |
+| `src/Blocks/BlockTypes/ProductQuery.php` | Post type in block queries |
+| `includes/class-woocommerce.php` | CLI command registration |
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/Internal/ProductTypePostTypes/MigrationCLICommand.php` | WP-CLI migration/rollback |
+| `src/Internal/ProductTypePostTypes/PerformanceBenchmarkCLICommand.php` | Performance benchmarks |
+
+## 2. Performance Analysis
+
+### Expected Gains
+
+**Type resolution**: `get_post_type()` is a direct column read from `wp_posts.post_type`, already cached in the WP post cache. The current `get_the_terms()` approach requires a JOIN across `wp_term_relationships`, `wp_term_taxonomy`, and `wp_terms`. On a cold cache, this is measurably slower.
+
+**Shop page queries**: When filtering by type (e.g., "show only simple products"), the current approach uses a `tax_query` which adds SQL JOINs. With per-type post types, this becomes a simple `WHERE post_type = 'wc_product_simple'` — the `post_type` column is indexed.
+
+**Query elimination**: For the common case of "get all products" (shop page, REST API listing), the current system queries `post_type = 'product'` (good), but the proposed system queries `post_type IN ('wc_product_simple', ...)` — which is slightly worse due to the IN clause but eliminates the need for type-specific tax_queries.
+
+### Expected Costs
+
+**Product count overhead**: `wp_count_posts()` is called per post type. With 4 new types, we need 4 calls instead of 1. WordPress caches these individually, so the overhead is per-request cache population, not per-call SQL.
+
+**Post type IN clauses**: All SQL queries that previously used `post_type = 'product'` now use `post_type IN (...)` with 4+ values. This is a minor cost.
+
+**WordPress object cache**: Separate cache groups per post type mean more cache entries. This is neutral to slightly negative for memory.
+
+### Net Assessment
+
+The biggest win is eliminating the `product_type` taxonomy JOIN for type resolution and type-filtered queries. For stores with 100K+ products, this should show measurable improvement in type resolution speed and filtered query performance. The product count overhead is minimal.
+
+## 3. Backward Compatibility Assessment
+
+### Critical Breakage Vector: `get_post_type() === 'product'`
+
+**There is no transparent shim for this.** Any code (core, extension, or custom) that checks `get_post_type($id) === 'product'` will break for migrated products.
+
+This affects:
+- Third-party extensions doing direct post type checks
+- Custom theme code checking product post types
+- WP hooks that fire per-post-type (e.g., `save_post_product`)
+- Admin code that uses `$typenow === 'product'`
+- WordPress SEO plugins that register special handling for the `product` post type
+
+### Catalog of Hardcoded References in WooCommerce Core
+
+The prototype updated ~50 locations across 17 files. Additional hardcoded references exist in:
+- Admin classes (product editor, list tables)
+- Analytics/reporting code
+- Webhooks (`woocommerce_webhook_topic_hooks` for `product.created`, etc.)
+- Email classes
+- Widget code
+- Various utility functions
+
+A full production implementation would need to audit and update 100+ additional files.
+
+### Third-Party Extension Impact
+
+**WooCommerce Subscriptions** (by WooCommerce):
+- Registers `subscription` and `variable-subscription` product types via `product_type_selector` filter
+- Uses `woocommerce_product_class` filter for class mapping
+- Would need to register its own post types (`wc_product_subscription`, etc.)
+- The extensibility API (Task 22) would need to support this
+
+**WooCommerce Product Bundles** (by WooCommerce):
+- Registers `bundle` product type
+- Similar pattern to Subscriptions
+
+**Common extension patterns**:
+1. `add_filter('product_type_selector', ...)` — still works for taxonomy-based type
+2. `add_filter('woocommerce_product_class', ...)` — still works
+3. `get_post_type($id) === 'product'` — **BREAKS**
+4. `$query->set('post_type', 'product')` — works (caught by `pre_get_posts` filter)
+
+### WordPress Core Limitations
+
+**Shared slug rewriting**: WordPress doesn't natively support multiple post types sharing the same URL slug prefix. The prototype uses `rewrite = false` and a custom `post_type_link` filter, but this is fragile:
+- `get_permalink()` works (via our filter)
+- URL resolution works (via `pre_get_posts` expansion)
+- But `is_post_type_archive()` only works for the `product` post type natively
+
+**`is_post_type_archive()`**: This WP function checks the queried post type. When we expand the query to include multiple post types, `is_post_type_archive('product')` returns false because the queried object is now an array. The prototype handles this in `WC_Query` and `is_shop()`, but third-party code may not.
+
+## 4. Product Type Switching Investigation (Task 21)
+
+When types are post types, switching from Simple to Variable means changing `post_type` via `wp_update_post()`. This works:
+- WordPress allows changing `post_type` on existing posts
+- Post ID remains stable
+- All post meta is preserved
+- The URL stays the same (our permalink filter handles it)
+
+Concerns:
+- `wp_update_post()` fires `transition_post_status` and `save_post_{post_type}` hooks — the post_type in the hook name changes, which could break extensions listening to `save_post_product`
+- Object cache for the post must be invalidated (`clean_post_cache()`)
+- The `woocommerce_product_type_changed` action fires correctly (our updated `update_version_and_type()` handles this)
+- Variation deletion when switching from Variable to Simple still works (handled by WC_Product_Variable)
+
+## 5. Third-Party Product Types Investigation (Task 22)
+
+### Current Extension Mechanism
+
+Extensions register types via two filters:
+1. `product_type_selector` — adds type to the product editor type dropdown
+2. `woocommerce_product_class` — maps type string to PHP class
+
+### Proposed Extensibility API
+
+When per-type post types are enabled, extensions would also need:
+1. Register a custom post type (e.g., `wc_product_subscription`)
+2. Add it to `wc_product_post_types` filter
+3. Add mappings to `wc_product_type_to_post_type_map` and `wc_post_type_to_product_type_map` filters
+
+Example:
+```php
+add_filter( 'wc_product_post_types', function( $types ) {
+    $types[] = 'wc_product_subscription';
+    return $types;
+});
+
+add_filter( 'wc_product_type_to_post_type_map', function( $map ) {
+    $map['subscription'] = 'wc_product_subscription';
+    return $map;
+});
+
+add_filter( 'wc_post_type_to_product_type_map', function( $map ) {
+    $map['wc_product_subscription'] = 'subscription';
+    return $map;
+});
+```
+
+This is more complex than the current mechanism but provides full integration with the post type system.
+
+## 6. Import/Export Compatibility (Task 23)
+
+### CSV Import (`class-wc-product-csv-importer.php`)
+
+The CSV importer uses `wc_get_product_object_type()` and then calls `$product->save()`, which goes through the data store. Since we updated the data store's `create()` method to use the correct post type, **imports should work** — the importer creates the product object by type, and our model classes set the correct `$post_type` in their constructors.
+
+### CSV Export (`class-wc-product-csv-exporter.php`)
+
+The exporter uses `wc_get_products()` which goes through `WC_Product_Query`. Since we updated the query to expand post types, **exports should work** — all product types will be included in the query results.
+
+### REST API Import
+
+Same as CSV — the REST API controllers use `wc_get_product()` and the data store for CRUD, both of which are updated.
+
+## 7. Block Product Collection (Task 24)
+
+The Product Collection block uses `ProductQuery.php` (updated in this prototype) and the `ProductQuery` block type class (also updated). The block should:
+- Render products from all types
+- Support type filtering via block attributes
+- Work with layered navigation (taxonomy queries work because we attach taxonomies to all post types)
+
+## 8. Auto-Generated REST Endpoints (Task 14)
+
+With `show_in_rest = true`, WordPress auto-creates:
+- `/wp/v2/wc_product_simple`
+- `/wp/v2/wc_product_variable`
+- `/wp/v2/wc_product_grouped`
+- `/wp/v2/wc_product_external`
+
+These endpoints:
+- Return raw WP_Post data (not WooCommerce-formatted product data)
+- Could conflict with WooCommerce's own `/wc/v3/products` endpoint in developer confusion
+- Could be useful for headless setups that want per-type endpoints
+- Should probably be disabled or documented as "not the canonical API"
+
+Recommendation: Set `show_in_rest` to `true` but add `rest_controller_class` to use a custom controller that returns 404 or redirects to the WC API.
+
+## 9. Migration Complexity
+
+### Forward Migration
+
+- Direct SQL update: `UPDATE wp_posts SET post_type = 'wc_product_simple' WHERE post_type = 'product' AND ...`
+- Products without a `product_type` term → treated as simple (same as current behavior)
+- `wc_product_meta_lookup` table is unaffected (joins on ID, no post_type column)
+- Object cache must be flushed post-migration
+- Batch processing prevents timeout on large stores
+
+### Rollback
+
+- Single SQL: `UPDATE wp_posts SET post_type = 'product' WHERE post_type IN ('wc_product_simple', ...)`
+- Taxonomy terms are preserved (the prototype keeps setting them for rollback compatibility)
+- Clean rollback, no data loss
+
+### Risk for Large Stores
+
+- 1M products: ~2 minutes for the SQL UPDATE (batch processed)
+- Lock contention: the UPDATE locks rows, could cause brief downtime
+- Recommendation: perform during maintenance window
+- `wc_product_meta_lookup` joins are unaffected, so product search continues to work during migration
+
+## 10. Go/No-Go Recommendation
+
+### Arguments For
+
+1. **Performance**: Eliminates taxonomy JOIN for type resolution (measurable on 10K+ stores)
+2. **WordPress alignment**: Native template hierarchy, REST API, capabilities per type
+3. **Precedent**: `product_variation` already works this way
+4. **Query simplification**: Type filtering becomes a WHERE clause instead of a JOIN
+5. **Future-proof**: Block editor, Full Site Editing, and WordPress trends all key off post type
+
+### Arguments Against
+
+1. **Breaking change**: `get_post_type() === 'product'` breaks everywhere — no transparent shim possible
+2. **Extension ecosystem**: Every extension with product post type checks needs updating
+3. **Marginal gains**: The performance improvement, while measurable, may not justify the ecosystem disruption
+4. **Complexity**: 4× post types means 4× `wp_count_posts()`, 4× rewrite rules, 4× cache groups
+5. **Shared slug hack**: WordPress wasn't designed for multiple post types sharing a URL slug prefix
+
+### Recommendation: **NO-GO for near-term, CONDITIONAL GO for long-term**
+
+The technical implementation is feasible and the prototype demonstrates it works. However, the backward compatibility cost is too high for the current extension ecosystem. The recommended path:
+
+1. **Ship the feature flag (disabled)** — lets early adopters and extension developers test
+2. **Publish the extensibility API** — let Subscriptions, Product Bundles, etc. add support
+3. **Add `wc_is_product_post_type()` to the public API** — encourage extensions to use it instead of direct `get_post_type()` comparison
+4. **Deprecation cycle** — warn about `get_post_type() === 'product'` checks over 2-3 major releases
+5. **Enable by default** — after the ecosystem has had time to adapt (12-18 months)
+
+## Appendix: Post Type Name Compliance
+
+| Post Type | Length | Max (20) | Valid |
+|-----------|--------|----------|-------|
+| `wc_product_simple` | 17 | 20 | Yes |
+| `wc_product_variable` | 19 | 20 | Yes |
+| `wc_product_grouped` | 18 | 20 | Yes |
+| `wc_product_external` | 19 | 20 | Yes |
+
+All names fit within WordPress's 20-character `post_type` column limit.

--- a/agent-os/specs/2026-03-08-product-types-as-cpt/plan.md
+++ b/agent-os/specs/2026-03-08-product-types-as-cpt/plan.md
@@ -1,0 +1,302 @@
+# Feasibility Study: WooCommerce Product Types as Custom Post Types
+
+## Context
+
+WooCommerce products use a single `product` custom post type, with product types (simple, variable, grouped, external) stored as terms in a hidden `product_type` taxonomy. This exploration investigates converting each product type to its own custom post type (e.g., `wc_product_simple`, `wc_product_variable`), leveraging WordPress's native post type features (template hierarchy, block templates, REST endpoints, capabilities) and reducing divergence from the WP data model.
+
+**Precedent:** `product_variation` already exists as a separate post type, proving the architecture can support multiple product post types.
+
+**Key constraint:** Backward compatibility — existing extensions must still work.
+
+---
+
+## Task 1: Save Spec Documentation
+
+Create `agent-os/specs/2026-03-08-product-types-as-cpt/` with:
+- **plan.md** — This full plan
+- **shape.md** — Shaping notes (scope, decisions, rationale)
+- **references.md** — Key files and architectural notes from exploration
+
+---
+
+## Task 2: Create Feature Flag
+
+Register experimental feature in `FeaturesController::init_feature_definitions()`.
+
+- **File:** `src/Internal/Features/FeaturesController.php`
+- Flag: `product_type_post_types`, experimental, disabled by default, no UI
+- All prototype code gated behind `FeaturesUtil::feature_is_enabled('product_type_post_types')`
+
+---
+
+## Task 3: Register New Post Types
+
+Conditionally register four new post types in `WC_Post_Types::register_post_types()`.
+
+- **File:** `includes/class-wc-post-types.php`
+- Post types: `wc_product_simple`, `wc_product_variable`, `wc_product_grouped`, `wc_product_external`
+- `capability_type` = `'product'` (reuses existing caps)
+- `rewrite` = `false` (custom rewrite rules to share `/product/` slug)
+- `has_archive` = `false` (shop page aggregates all types)
+- `show_ui` = `false` (no separate admin menu entries)
+- `show_in_rest` = `true`
+- Add `pre_get_posts` filter to expand `post_type` for product slug resolution
+
+---
+
+## Task 4: Update Taxonomy Registration
+
+Attach all product taxonomies to new post types when flag is on.
+
+- **File:** `includes/class-wc-post-types.php`
+- Hook into `woocommerce_taxonomy_objects_*` filters for: `product_cat`, `product_tag`, `product_shipping_class`, `product_visibility`, all `pa_*` attribute taxonomies
+
+---
+
+## Task 5: Update Product Factory Type Resolution
+
+Modify `get_product_type()` to resolve type from post type directly (no taxonomy query).
+
+- **File:** `includes/class-wc-product-factory.php` (line 105-113)
+- **File:** `includes/data-stores/class-wc-product-data-store-cpt.php` (line 2109-2131)
+- When flag on: map `wc_product_simple` → `'simple'`, etc. — eliminates taxonomy lookup
+- Update `get_product_id()` (line 132-146) to accept all product post types
+
+---
+
+## Task 6: Update Data Store Create/Update
+
+Change data store to set post type based on product class type.
+
+- **File:** `includes/data-stores/class-wc-product-data-store-cpt.php`
+- `create()` (line 201): hardcodes `post_type => 'product'` — map from `get_type()`
+- `update()` (line 338): same hardcoding
+- `update_version_and_type()` (line 1127-1139): change from `wp_set_object_terms()` to `post_type` update
+
+---
+
+## Task 7: Update Product Model Classes
+
+Set `$post_type` property on each product class when flag is on.
+
+- **Files:** `includes/class-wc-product-simple.php`, `class-wc-product-variable.php`, `class-wc-product-grouped.php`, `class-wc-product-external.php`
+- Follow `WC_Product_Variation` pattern (line 27: `protected $post_type = 'product_variation'`)
+- Override in constructor based on feature flag
+
+---
+
+## Task 8: Create `wc_get_product_post_types()` Helper
+
+Centralize post type list for all query locations.
+
+- **File:** `includes/wc-product-functions.php`
+- Returns `['product', 'product_variation']` when flag off
+- Returns `['wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external', 'product_variation']` when flag on
+- Update ~20 hardcoded `post_type = 'product'` references in `class-wc-product-data-store-cpt.php`
+
+---
+
+## Task 9: Update WC_Product_Query and WC_Query
+
+Replace taxonomy-based type filtering with post_type filtering.
+
+- **File:** `includes/class-wc-product-query.php`
+- **File:** `includes/class-wc-query.php` (lines 358, 379: `post_type = 'product'`)
+- **File:** `includes/data-stores/class-wc-product-data-store-cpt.php` (`get_wp_query_args()` line 2162)
+- `type=simple` maps to `post_type='wc_product_simple'` — no `tax_query` needed
+- Shop page queries expand to all product post types
+
+---
+
+## Task 10: Update Conditional Functions
+
+Expand post type checks in frontend conditionals.
+
+- **File:** `includes/wc-conditional-functions.php`
+- `is_product()` (line 85): `is_singular(array('product'))` → `is_singular(wc_get_product_post_types())`
+- `is_shop()` (line 35): `is_post_type_archive('product')` → expand
+- `is_product_taxonomy()` (line 47): `get_object_taxonomies('product')` → expand
+
+---
+
+## Task 11: Backward Compatibility Shim
+
+Create `wc_is_product_post_type($post_type)` helper for third-party code.
+
+- Hook `post_type_link` to ensure consistent URLs
+- Document: no transparent shim exists for `get_post_type() === 'product'` — this is a known breakage vector
+
+---
+
+## Task 12: Update REST API V2/V3 Controllers
+
+Update product controllers to query multiple post types.
+
+- **File:** `includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php` (line 50: `protected $post_type = 'product'`)
+- `prepare_objects_query()` (line 341): replace `product_type` taxonomy query with post_type mapping
+- Unified `/wc/v3/products` endpoint must return all products
+
+---
+
+## Task 13: Update Store API ProductQuery
+
+Replace taxonomy filtering with post type filtering.
+
+- **File:** `src/StoreApi/Utilities/ProductQuery.php` (line 41: `'post_type' => 'product'`)
+- Lines 53-63: type filtering via `product_type` taxonomy → post_type mapping
+
+---
+
+## Task 14: Document Auto-Generated REST Endpoints
+
+With `show_in_rest = true`, WordPress creates `/wp/v2/wc_product_simple` etc.
+
+- Document what these look like and whether they're useful
+- Check for conflicts with WooCommerce's own REST API
+
+---
+
+## Task 15: Update Template Loader
+
+Expand post type checks in template loading.
+
+- **File:** `includes/class-wc-template-loader.php`
+- `is_singular('product')` at lines 162, 215, 265 → expand
+- Document: with separate post types, WP auto-provides `single-wc_product_variable.php` hierarchy
+- Quantify how much template loader code could be eliminated
+
+---
+
+## Task 16: Update Block Editor Integration
+
+Expand post type checks in Gutenberg integration.
+
+- **File:** `includes/class-wc-post-types.php` (line 760: `gutenberg_can_edit_post_type`)
+- **File:** `src/Blocks/BlockTypes/ProductQuery.php` (line 266: `'post_type' => 'product'`)
+- Test native block template support per post type
+
+---
+
+## Task 17: Update Shortcodes
+
+Expand post type checks in shortcode queries.
+
+- **File:** `includes/class-wc-shortcodes.php`
+- Lines 343, 393: `in_array($product_data->post_type, array('product', 'product_variation'))`
+- Lines 548, 601: `'post_type' => 'product'`
+
+---
+
+## Task 18: Build Migration Script (WP-CLI)
+
+Create forward + rollback migration command.
+
+- Migration: `UPDATE wp_posts SET post_type = 'wc_product_simple' WHERE post_type = 'product' AND ID IN (...)`
+- Handle implicit simple products (no `product_type` term assigned)
+- Preserve taxonomy terms for rollback
+- Invalidate WordPress object caches post-migration
+- `wc_product_meta_lookup` table should work as-is (joins on ID, no post_type column)
+
+---
+
+## Task 19: Build Performance Benchmarks
+
+Measure with 1K, 10K, 100K products:
+
+1. **Type resolution speed:** `get_the_terms()` (current) vs `get_post_type()` (proposed)
+2. **Shop page query speed:** `tax_query` on `product_type` vs `post_type` filtering (eliminates JOIN)
+3. **Product count overhead:** 4× `wp_count_posts()` calls vs 1
+4. **Memory:** separate per-type caches vs single cache
+
+---
+
+## Task 20: Write Findings Document
+
+Comprehensive document covering:
+
+1. Performance data from Task 19
+2. Backward compatibility assessment (catalog of hardcoded `'product'` references)
+3. Third-party extension impact (Subscriptions, Product Bundles patterns)
+4. WordPress core limitations (shared slug rewriting, `is_post_type_archive()`)
+5. Migration complexity and risk for large stores
+6. Go/no-go recommendation with rationale
+
+---
+
+## Task 21: Investigate Product Type Switching
+
+Test changing type from Simple → Variable when types are post types.
+
+- Currently: changes taxonomy term. With post types: changes `post_type` field.
+- `wp_update_post()` allows it, but test cache invalidation, URL changes, hook firing
+- Variation deletion behavior must still work
+
+---
+
+## Task 22: Investigate Third-Party Product Types
+
+WooCommerce Subscriptions registers `subscription`, `variable-subscription` types.
+
+- Current mechanism: `product_type_selector` filter + `woocommerce_product_class` filter
+- New requirement: registration API for extensions to register their own post types
+- Design the extensibility API
+
+---
+
+## Task 23: Test Import/Export Compatibility
+
+WooCommerce CSV import/export uses `post_type = 'product'`.
+
+- Test CSV import creates products with correct new post types
+- Test CSV export includes products across all post types
+- Test REST API import compatibility
+
+---
+
+## Task 24: Test WooCommerce Blocks Product Collection
+
+Product Collection block uses `ProductQuery` with hardcoded post type.
+
+- Test Product Collection block renders all product types
+- Test layered navigation / filtering by type
+- Test product grid/list blocks
+
+---
+
+## Key Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| URL slug collision across post types | High | Custom rewrite rules in Task 3 |
+| Third-party `get_post_type() === 'product'` breakage | Critical | No transparent shim possible — document in findings |
+| WordPress admin count fragmentation | Medium | Hook `wp_count_posts` to aggregate |
+| Extension registration API design | High | Task 22 designs the API |
+| Large store migration (millions of products) | Medium | Batch processing in WP-CLI command |
+
+## Critical Files
+
+- `includes/class-wc-post-types.php` — post type + taxonomy registration
+- `includes/class-wc-product-factory.php` — type resolution + class mapping
+- `includes/data-stores/class-wc-product-data-store-cpt.php` — data persistence (~20 hardcoded refs)
+- `includes/abstracts/abstract-wc-product.php` — base product class
+- `includes/class-wc-product-query.php` — product queries
+- `includes/wc-conditional-functions.php` — `is_product()`, `is_shop()`, etc.
+- `includes/class-wc-query.php` — frontend query handler
+- `includes/class-wc-template-loader.php` — template overrides
+- `includes/wc-product-functions.php` — `wc_get_product_types()` etc.
+- `src/StoreApi/Utilities/ProductQuery.php` — Store API queries
+- `includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php` — REST API
+- `src/Internal/Features/FeaturesController.php` — feature flag registration
+
+## Verification
+
+1. Enable feature flag, run migration script on test store
+2. Verify product CRUD: create, read, update, delete for each product type
+3. Verify shop page shows all products
+4. Verify single product pages render correctly
+5. Verify REST API `/wc/v3/products` returns all products
+6. Verify Store API product queries work
+7. Verify product type switching (Simple ↔ Variable)
+8. Verify CSV import/export round-trip
+9. Run performance benchmarks and document results
+10. Verify rollback migration restores original state

--- a/agent-os/specs/2026-03-08-product-types-as-cpt/references.md
+++ b/agent-os/specs/2026-03-08-product-types-as-cpt/references.md
@@ -1,0 +1,110 @@
+# References: Product Types as Custom Post Types
+
+## Critical Files (plugins/woocommerce/)
+
+### Post Type & Taxonomy Registration
+- `includes/class-wc-post-types.php` — `register_post_types()` (line 321), `register_taxonomies()` (line 41)
+  - `product_variation` registered at line 472 — precedent for separate product post type
+  - `gutenberg_can_edit_post_type()` at line 760 — hardcodes `'product'`
+  - Taxonomy `product_type` registered at line 55 with `apply_filters('woocommerce_taxonomy_objects_product_type', array('product'))`
+  - Taxonomy `product_cat` at line 89, `product_tag` at line 133, `product_shipping_class` at line 178
+  - All use `apply_filters("woocommerce_taxonomy_objects_{$name}", array('product'))` pattern — extensible
+
+### Product Factory
+- `includes/class-wc-product-factory.php`
+  - `get_product_type()` (line 105): delegates to data store, returns type string
+  - `get_product_id()` (line 132): hardcodes `get_post_type($post->ID) === 'product'` check
+  - `get_product_classname()` (line 78): maps type string to class name via `woocommerce_product_class` filter
+
+### Data Store (CPT)
+- `includes/data-stores/class-wc-product-data-store-cpt.php`
+  - `create()` — hardcodes `'post_type' => 'product'`
+  - `update()` — same
+  - `get_product_type()` — uses `get_the_terms($id, 'product_type')` taxonomy lookup
+  - `update_version_and_type()` — uses `wp_set_object_terms()` to set type
+  - `get_wp_query_args()` — builds WP_Query args, type filtering via tax_query
+  - ~20 hardcoded `'product'` post type references throughout
+
+### Product Model Classes
+- `includes/abstracts/abstract-wc-product.php` — base class, `$post_type = 'product'`
+- `includes/class-wc-product-simple.php` — no explicit `$post_type` override
+- `includes/class-wc-product-variable.php` — no explicit `$post_type` override
+- `includes/class-wc-product-grouped.php` — no explicit `$post_type` override
+- `includes/class-wc-product-external.php` — no explicit `$post_type` override
+- `includes/class-wc-product-variation.php` — `$post_type = 'product_variation'` (line 27) — **the precedent**
+
+### Query Classes
+- `includes/class-wc-product-query.php` — product query abstraction
+- `includes/class-wc-query.php` — frontend query handler, `post_type = 'product'` at lines ~358, 379
+
+### Conditional Functions
+- `includes/wc-conditional-functions.php`
+  - `is_product()` — `is_singular(array('product'))`
+  - `is_shop()` — `is_post_type_archive('product')`
+  - `is_product_taxonomy()` — `get_object_taxonomies('product')`
+
+### Product Functions
+- `includes/wc-product-functions.php` — `wc_get_product()`, `wc_get_products()`, `wc_get_product_types()`
+
+### Template Loader
+- `includes/class-wc-template-loader.php` — `is_singular('product')` at multiple locations
+
+### REST API
+- `includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php`
+  - `$post_type = 'product'` (line 50)
+  - `prepare_objects_query()` — type filtering via taxonomy
+
+### Store API
+- `src/StoreApi/Utilities/ProductQuery.php`
+  - `'post_type' => 'product'` (line 41)
+  - Type filtering via `product_type` taxonomy (lines 53-63)
+
+### Block Integration
+- `src/Blocks/BlockTypes/ProductQuery.php` — `'post_type' => 'product'`
+
+### Shortcodes
+- `includes/class-wc-shortcodes.php` — `post_type` checks and query args
+
+### Feature Flag
+- `src/Internal/Features/FeaturesController.php` — `init_feature_definitions()` for registering new flags
+- `src/Utilities/FeaturesUtil.php` — `feature_is_enabled()` for checking flags
+
+### Import/Export
+- `includes/export/class-wc-product-csv-exporter.php`
+- `includes/import/class-wc-product-csv-importer.php`
+
+## Architectural Notes
+
+### WordPress Post Type Limits
+- Post type names: max 20 characters
+- `post_type` column in `wp_posts`: varchar(20)
+- All proposed names fit within limit
+
+### Existing `product_variation` Pattern
+The `product_variation` post type demonstrates that WooCommerce already supports multiple product-related post types:
+- Registered with `capability_type => 'product'`
+- `public => false`, `rewrite => false`
+- Referenced throughout codebase with explicit checks
+
+### Taxonomy Filter Pattern
+All taxonomy registrations use `apply_filters("woocommerce_taxonomy_objects_{$taxonomy}", array('product'))`.
+This existing filter pattern is the hook point for attaching taxonomies to new post types.
+
+### Feature Flag Pattern
+Features are registered in `FeaturesController::init_feature_definitions()` with:
+```php
+$this->add_feature_definition(
+    'product_type_post_types',
+    __( 'Product type post types', 'woocommerce' ),
+    array(
+        'is_experimental'              => true,
+        'enabled_by_default'           => false,
+        'disable_ui'                   => true,
+        'default_plugin_compatibility' => 'incompatible',
+    )
+);
+```
+
+### ProductType Enum
+- `src/Enums/ProductType.php` — defines `SIMPLE`, `GROUPED`, `EXTERNAL`, `VARIABLE`, `VARIATION` constants
+- Used throughout modern code instead of string literals

--- a/agent-os/specs/2026-03-08-product-types-as-cpt/shape.md
+++ b/agent-os/specs/2026-03-08-product-types-as-cpt/shape.md
@@ -1,0 +1,87 @@
+# Shape: Product Types as Custom Post Types
+
+## Scope
+
+**In scope:**
+- Register `wc_product_simple`, `wc_product_variable`, `wc_product_grouped`, `wc_product_external` as separate CPTs
+- Gate everything behind `product_type_post_types` feature flag (experimental, disabled by default)
+- Update core product CRUD, queries, factory, conditional functions, REST API, Store API
+- Build WP-CLI migration + rollback script
+- Performance benchmarks comparing taxonomy-based vs post-type-based type resolution
+- Document backward compatibility impact and go/no-go recommendation
+
+**Out of scope:**
+- Production-ready implementation (this is a feasibility prototype)
+- Admin UI changes (new post types have `show_ui = false`)
+- Changes to the block-based product editor
+- Actual migration of live stores
+
+## Key Decisions
+
+### Why separate post types instead of the current taxonomy approach?
+
+1. **Performance:** `get_post_type()` is a direct column read; `get_the_terms()` requires a JOIN. For shop pages with hundreds of products, eliminating the taxonomy JOIN for type resolution is measurable.
+2. **WordPress alignment:** WP's template hierarchy, REST API, and capabilities system all key off post type. Using taxonomy for type forces WooCommerce to reimplement what WP provides natively.
+3. **Precedent:** `product_variation` already exists as a separate post type, proving the pattern works.
+
+### Why `wc_product_*` naming?
+
+- WordPress post types have a 20-character limit
+- `wc_product_simple` (17 chars), `wc_product_variable` (19 chars), `wc_product_grouped` (18 chars), `wc_product_external` (19 chars) — all fit
+- `wc_` prefix avoids collision with other plugins
+- Consistent with existing `product_variation` convention (though that lacks the `wc_` prefix for historical reasons)
+
+### Why `capability_type = 'product'`?
+
+Reuses existing product capabilities. No changes needed to user roles or permissions.
+
+### Why `rewrite = false`?
+
+All product types must share the `/product/` slug prefix. Custom rewrite rules handle slug resolution across post types. This avoids URL breakage.
+
+### Why `show_ui = false`?
+
+The admin product list page should show all products together, not separate lists per type. The existing product admin UI continues to work against the `product` post type conceptually.
+
+## Rationale
+
+The biggest risk is third-party extension breakage. Any code doing `get_post_type($id) === 'product'` will break. There is no transparent shim for this — it's a fundamental change to the data model.
+
+The feasibility study quantifies this risk:
+- How many places in core WooCommerce hardcode `'product'`?
+- What patterns do major extensions (Subscriptions, Product Bundles) use?
+- Is the performance gain worth the compatibility cost?
+
+## Architecture Notes
+
+### Type Resolution Flow (Current)
+```
+wc_get_product($id)
+  → WC_Product_Factory::get_product_type($id)
+    → WC_Data_Store::load('product')->get_product_type($id)
+      → get_the_terms($id, 'product_type')
+        → SQL JOIN on wp_term_relationships
+```
+
+### Type Resolution Flow (Proposed)
+```
+wc_get_product($id)
+  → WC_Product_Factory::get_product_type($id)
+    → get_post_type($id)
+      → Direct column read from wp_posts.post_type (already cached)
+    → Map 'wc_product_simple' → 'simple'
+```
+
+### Query Flow (Current)
+```
+WC_Product_Query(['type' => 'simple'])
+  → tax_query: [['taxonomy' => 'product_type', 'terms' => 'simple']]
+  → SQL JOIN on wp_term_relationships + wp_terms
+```
+
+### Query Flow (Proposed)
+```
+WC_Product_Query(['type' => 'simple'])
+  → post_type: 'wc_product_simple'
+  → Direct WHERE clause on wp_posts.post_type (indexed)
+```

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -33,6 +33,25 @@ class WC_Post_Types {
 		add_action( 'woocommerce_flush_rewrite_rules', array( __CLASS__, 'flush_rewrite_rules' ) );
 		add_filter( 'gutenberg_can_edit_post_type', array( __CLASS__, 'gutenberg_can_edit_post_type' ), 10, 2 );
 		add_filter( 'use_block_editor_for_post_type', array( __CLASS__, 'gutenberg_can_edit_post_type' ), 10, 2 );
+
+		// Attach product taxonomies to per-type post types when the feature is on.
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$taxonomy_filters = array(
+				'woocommerce_taxonomy_objects_product_type',
+				'woocommerce_taxonomy_objects_product_visibility',
+				'woocommerce_taxonomy_objects_product_cat',
+				'woocommerce_taxonomy_objects_product_tag',
+				'woocommerce_taxonomy_objects_product_shipping_class',
+				'woocommerce_taxonomy_objects_pos_product_visibility',
+			);
+
+			foreach ( $taxonomy_filters as $filter ) {
+				add_filter( $filter, array( __CLASS__, 'add_product_type_post_types_to_taxonomy' ) );
+			}
+
+			// Also hook attribute taxonomies via a dynamic filter.
+			add_filter( 'woocommerce_register_taxonomy', array( __CLASS__, 'hook_attribute_taxonomy_filters' ) );
+		}
 	}
 
 	/**
@@ -484,6 +503,47 @@ class WC_Post_Types {
 			)
 		);
 
+		// Register per-type product post types when the feature flag is enabled.
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$product_type_post_types = array(
+				'wc_product_simple'   => __( 'Simple products', 'woocommerce' ),
+				'wc_product_variable' => __( 'Variable products', 'woocommerce' ),
+				'wc_product_grouped'  => __( 'Grouped products', 'woocommerce' ),
+				'wc_product_external' => __( 'External products', 'woocommerce' ),
+			);
+
+			foreach ( $product_type_post_types as $post_type_name => $label ) {
+				register_post_type(
+					$post_type_name,
+					apply_filters(
+						'woocommerce_register_post_type_' . $post_type_name,
+						array(
+							'label'              => $label,
+							'public'             => true,
+							'publicly_queryable' => true,
+							'show_ui'            => false,
+							'show_in_menu'       => false,
+							'show_in_nav_menus'  => false,
+							'show_in_rest'       => true,
+							'hierarchical'       => false,
+							'supports'           => $supports,
+							'capability_type'    => 'product',
+							'map_meta_cap'       => true,
+							'rewrite'            => false,
+							'has_archive'        => false,
+							'query_var'          => false,
+						)
+					)
+				);
+			}
+
+			// Expand product slug resolution to include the new post types.
+			add_filter( 'pre_get_posts', array( __CLASS__, 'expand_product_post_type_query' ) );
+
+			// Ensure product permalinks use the /product/ slug regardless of post type.
+			add_filter( 'post_type_link', array( __CLASS__, 'product_type_post_type_link' ), 10, 2 );
+		}
+
 		wc_register_order_type(
 			'shop_order',
 			apply_filters(
@@ -758,7 +818,16 @@ class WC_Post_Types {
 	 * @return bool
 	 */
 	public static function gutenberg_can_edit_post_type( $can_edit, $post_type ) {
-		return 'product' === $post_type ? false : $can_edit;
+		if ( 'product' === $post_type ) {
+			return false;
+		}
+
+		// Also disable block editor for per-type product post types.
+		if ( function_exists( 'wc_is_product_post_type' ) && wc_is_product_post_type( $post_type ) && 'product_variation' !== $post_type ) {
+			return false;
+		}
+
+		return $can_edit;
 	}
 
 	/**
@@ -780,6 +849,97 @@ class WC_Post_Types {
 		$post_types[] = 'product';
 
 		return $post_types;
+	}
+
+	/**
+	 * Ensure product permalinks use the standard /product/ slug for all product post types.
+	 *
+	 * Since the new post types have rewrite=false, WordPress would generate
+	 * ugly ?wc_product_simple=slug URLs. This filter intercepts that and
+	 * generates the correct /product/slug/ URL.
+	 *
+	 * @param string  $post_link The post's permalink.
+	 * @param WP_Post $post      The post object.
+	 * @return string
+	 */
+	public static function product_type_post_type_link( $post_link, $post ) {
+		$product_post_types = array( 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external' );
+
+		if ( ! in_array( $post->post_type, $product_post_types, true ) ) {
+			return $post_link;
+		}
+
+		$permalinks = wc_get_permalink_structure();
+		$slug       = $post->post_name;
+
+		if ( ! empty( $permalinks['product_rewrite_slug'] ) ) {
+			return home_url( '/' . $permalinks['product_rewrite_slug'] . '/' . $slug . '/' );
+		}
+
+		// Fallback: use the 'product' post type permalink structure.
+		return home_url( '/product/' . $slug . '/' );
+	}
+
+	/**
+	 * Add per-type product post types to taxonomy object type arrays.
+	 *
+	 * @param array $post_types The current post types for the taxonomy.
+	 * @return array
+	 */
+	public static function add_product_type_post_types_to_taxonomy( $post_types ) {
+		$new_types = array( 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external' );
+		return array_unique( array_merge( $post_types, $new_types ) );
+	}
+
+	/**
+	 * Hook attribute taxonomy filters for per-type product post types.
+	 *
+	 * Since attribute taxonomies are dynamic (pa_*), we can't pre-register
+	 * filters for them in init(). Instead, we hook into the
+	 * woocommerce_register_taxonomy action and add filters for all known
+	 * attribute taxonomy names.
+	 */
+	public static function hook_attribute_taxonomy_filters() {
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+		if ( $attribute_taxonomies ) {
+			foreach ( $attribute_taxonomies as $tax ) {
+				$name = wc_attribute_taxonomy_name( $tax->attribute_name );
+				if ( $name ) {
+					add_filter( "woocommerce_taxonomy_objects_{$name}", array( __CLASS__, 'add_product_type_post_types_to_taxonomy' ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Expand product post type queries to include per-type post types.
+	 *
+	 * When the product_type_post_types feature is enabled, queries for the
+	 * 'product' post type on the frontend need to also include the new
+	 * per-type post types so that product slug resolution works correctly.
+	 *
+	 * @param WP_Query $query The WP_Query instance.
+	 */
+	public static function expand_product_post_type_query( $query ) {
+		if ( is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		$post_type = $query->get( 'post_type' );
+
+		if ( 'product' === $post_type || ( is_array( $post_type ) && in_array( 'product', $post_type, true ) ) ) {
+			$product_post_types = function_exists( 'wc_get_product_post_types' )
+				? wc_get_product_post_types()
+				: array( 'product', 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external', 'product_variation' );
+
+			if ( is_array( $post_type ) ) {
+				$post_type = array_unique( array_merge( $post_type, $product_post_types ) );
+			} else {
+				$post_type = $product_post_types;
+			}
+
+			$query->set( 'post_type', $post_type );
+		}
 	}
 }
 

--- a/plugins/woocommerce/includes/class-wc-product-external.php
+++ b/plugins/woocommerce/includes/class-wc-product-external.php
@@ -29,6 +29,18 @@ class WC_Product_External extends WC_Product {
 	);
 
 	/**
+	 * Initialize external product.
+	 *
+	 * @param WC_Product|int $product Product instance or ID.
+	 */
+	public function __construct( $product = 0 ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$this->post_type = 'wc_product_external';
+		}
+		parent::__construct( $product );
+	}
+
+	/**
 	 * Get internal type.
 	 *
 	 * @return string

--- a/plugins/woocommerce/includes/class-wc-product-factory.php
+++ b/plugins/woocommerce/includes/class-wc-product-factory.php
@@ -106,6 +106,16 @@ class WC_Product_Factory {
 		// Allow the overriding of the lookup in this function. Return the product type here.
 		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
 		if ( ! $override ) {
+			// When per-type post types are enabled, resolve type from post type directly.
+			if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+				$post_type = get_post_type( $product_id );
+				if ( $post_type ) {
+					$type = wc_post_type_to_product_type( $post_type );
+					if ( false !== $type ) {
+						return $type;
+					}
+				}
+			}
 			return WC_Data_Store::load( 'product' )->get_product_type( $product_id );
 		} else {
 			return $override;
@@ -132,7 +142,7 @@ class WC_Product_Factory {
 	private function get_product_id( $product ) {
 		global $post;
 
-		if ( false === $product && isset( $post, $post->ID ) && 'product' === get_post_type( $post->ID ) ) {
+		if ( false === $product && isset( $post, $post->ID ) && wc_is_product_post_type( get_post_type( $post->ID ) ) ) {
 			return absint( $post->ID );
 		} elseif ( is_numeric( $product ) ) {
 			return $product;

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -27,6 +27,18 @@ class WC_Product_Grouped extends WC_Product {
 	);
 
 	/**
+	 * Initialize grouped product.
+	 *
+	 * @param WC_Product|int $product Product instance or ID.
+	 */
+	public function __construct( $product = 0 ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$this->post_type = 'wc_product_grouped';
+		}
+		parent::__construct( $product );
+	}
+
+	/**
 	 * Get internal type.
 	 *
 	 * @return string

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -22,6 +22,9 @@ class WC_Product_Simple extends WC_Product {
 	 * @param WC_Product|int $product Product instance or ID.
 	 */
 	public function __construct( $product = 0 ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$this->post_type = 'wc_product_simple';
+		}
 		$this->supports[] = 'ajax_add_to_cart';
 		parent::__construct( $product );
 	}

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -19,6 +19,18 @@ defined( 'ABSPATH' ) || exit;
 class WC_Product_Variable extends WC_Product {
 
 	/**
+	 * Initialize variable product.
+	 *
+	 * @param WC_Product|int $product Product instance or ID.
+	 */
+	public function __construct( $product = 0 ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$this->post_type = 'wc_product_variable';
+		}
+		parent::__construct( $product );
+	}
+
+	/**
 	 * Array of children variation IDs. Determined by children.
 	 *
 	 * @var array

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -412,7 +412,7 @@ class WC_Query {
 				add_filter( 'wpseo_metadesc', array( $this, 'wpseo_metadesc' ) );
 				add_filter( 'wpseo_metakey', array( $this, 'wpseo_metakey' ) );
 			}
-		} elseif ( ! $q->is_post_type_archive( 'product' ) && ! $q->is_tax( get_object_taxonomies( 'product' ) ) ) {
+		} elseif ( ! $q->is_post_type_archive( 'product' ) && ! $q->is_tax( get_object_taxonomies( 'product' ) ) && ! ( function_exists( 'wc_is_product_post_type' ) && $q->is_post_type_archive( wc_get_product_post_types() ) ) ) {
 			// Only apply to product categories, the product post archive, the shop page, product tags, and product attribute taxonomies.
 			return;
 		}

--- a/plugins/woocommerce/includes/class-wc-shortcodes.php
+++ b/plugins/woocommerce/includes/class-wc-shortcodes.php
@@ -340,7 +340,7 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ), true ) ? wc_setup_product_data( $product_data ) : false;
+		$product = is_object( $product_data ) && wc_is_product_post_type( $product_data->post_type ) ? wc_setup_product_data( $product_data ) : false;
 
 		if ( ! $product ) {
 			return '';
@@ -390,7 +390,7 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ), true ) ? wc_setup_product_data( $product_data ) : false;
+		$product = is_object( $product_data ) && wc_is_product_post_type( $product_data->post_type ) ? wc_setup_product_data( $product_data ) : false;
 
 		if ( ! $product ) {
 			return '';
@@ -543,9 +543,13 @@ class WC_Shortcodes {
 			return '';
 		}
 
+		$shortcode_post_type = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' )
+			? array_values( array_diff( wc_get_product_post_types(), array( 'product_variation' ) ) )
+			: 'product';
+
 		$args = array(
 			'posts_per_page'      => 1,
-			'post_type'           => 'product',
+			'post_type'           => $shortcode_post_type,
 			'post_status'         => $product_status,
 			'ignore_sticky_posts' => 1,
 			'no_found_rows'       => 1,
@@ -558,7 +562,9 @@ class WC_Shortcodes {
 				'compare' => '=',
 			);
 
-			$args['post_type'] = array( 'product', 'product_variation' );
+			$args['post_type'] = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' )
+				? wc_get_product_post_types()
+				: array( 'product', 'product_variation' );
 		}
 
 		if ( isset( $atts['id'] ) ) {
@@ -598,7 +604,7 @@ class WC_Shortcodes {
 			// Get the parent product object.
 			$args = array(
 				'posts_per_page'      => 1,
-				'post_type'           => 'product',
+				'post_type'           => $shortcode_post_type,
 				'post_status'         => ProductStatus::PUBLISH,
 				'ignore_sticky_posts' => 1,
 				'no_found_rows'       => 1,

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -159,7 +159,7 @@ class WC_Template_Loader {
 	 */
 	private static function get_template_loader_default_file() {
 		if (
-			is_singular( 'product' ) &&
+			is_product() &&
 			! self::has_block_template( 'single-product' )
 		) {
 			$default_file = 'single-product.php';
@@ -212,7 +212,7 @@ class WC_Template_Loader {
 			}
 		}
 
-		if ( is_singular( 'product' ) ) {
+		if ( is_product() ) {
 			$object       = get_queried_object();
 			$name_decoded = urldecode( $object->post_name );
 			if ( $name_decoded !== $object->post_name ) {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -813,6 +813,8 @@ final class WooCommerce {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
+			\Automattic\WooCommerce\Internal\ProductTypePostTypes\MigrationCLICommand::register();
+			\Automattic\WooCommerce\Internal\ProductTypePostTypes\PerformanceBenchmarkCLICommand::register();
 		}
 
 		if ( $this->is_request( 'admin' ) ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -104,6 +104,23 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	protected $updated_props = array();
 
+	/**
+	 * Get the SQL IN clause for all product post types, for use in raw queries.
+	 *
+	 * @param bool $include_variations Whether to include product_variation.
+	 * @return string SQL fragment like "'product', 'product_variation'" or "'wc_product_simple', ...".
+	 */
+	protected static function get_product_post_types_sql( $include_variations = true ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$types = wc_get_product_post_types();
+			if ( ! $include_variations ) {
+				$types = array_diff( $types, array( 'product_variation' ) );
+			}
+		} else {
+			$types = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
+		}
+		return implode( ', ', array_map( function ( $t ) { return "'" . esc_sql( $t ) . "'"; }, $types ) );
+	}
 
 	/**
 	 * Method to obtain DB lock on SKU to make sure we only
@@ -203,11 +220,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->set_date_created( time() );
 		}
 
+		$create_post_type = 'product';
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$create_post_type = wc_product_type_to_post_type( $product->get_type() );
+		}
+
 		$id = wp_insert_post(
 			apply_filters(
 				'woocommerce_new_product_data',
 				array(
-					'post_type'      => 'product',
+					'post_type'      => $create_post_type,
 					'post_status'    => $product->get_status() ? $product->get_status() : ProductStatus::PUBLISH,
 					'post_author'    => get_current_user_id(),
 					'post_title'     => $product->get_name() ? $product->get_name() : __( 'Product', 'woocommerce' ),
@@ -274,7 +296,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$product->set_defaults();
 		$post_object = get_post( $product->get_id() );
 
-		if ( ! $product->get_id() || ! $post_object || 'product' !== $post_object->post_type ) {
+		if ( ! $product->get_id() || ! $post_object || ! wc_is_product_post_type( $post_object->post_type ) ) {
 			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
 		}
 
@@ -325,6 +347,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		// Only update the post when the post data changes.
 		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order', 'date_created', 'date_modified', 'slug', 'post_password' ), array_keys( $changes ) ) ) {
+			$update_post_type = 'product';
+			if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+				$update_post_type = wc_product_type_to_post_type( $product->get_type() );
+			}
+
 			$post_data = array(
 				'post_content'   => $product->get_description( 'edit' ),
 				'post_excerpt'   => $product->get_short_description( 'edit' ),
@@ -335,7 +362,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'menu_order'     => $product->get_menu_order( 'edit' ),
 				'post_password'  => $product->get_post_password( 'edit' ),
 				'post_name'      => $product->get_slug( 'edit' ),
-				'post_type'      => 'product',
+				'post_type'      => $update_post_type,
 			);
 			if ( $product->get_date_created( 'edit' ) ) {
 				$post_data['post_date']     = gmdate( 'Y-m-d H:i:s', $product->get_date_created( 'edit' )->getOffsetTimestamp() );
@@ -404,8 +431,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @param array      $args Array of args to pass to the delete method.
 	 */
 	public function delete( &$product, $args = array() ) {
-		$id        = $product->get_id();
-		$post_type = $product->is_type( ProductType::VARIATION ) ? 'product_variation' : 'product';
+		$id = $product->get_id();
+		if ( $product->is_type( ProductType::VARIATION ) ) {
+			$post_type = 'product_variation';
+		} elseif ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$post_type = wc_product_type_to_post_type( $product->get_type() );
+		} else {
+			$post_type = 'product';
+		}
 
 		$args = wp_parse_args(
 			$args,
@@ -1128,7 +1161,23 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$old_type = WC_Product_Factory::get_product_type( $product->get_id() );
 		$new_type = $product->get_type();
 
-		wp_set_object_terms( $product->get_id(), $new_type, 'product_type' );
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			// Update the post type directly instead of using taxonomy.
+			$new_post_type     = wc_product_type_to_post_type( $new_type );
+			$current_post_type = get_post_type( $product->get_id() );
+
+			if ( $current_post_type !== $new_post_type ) {
+				wp_update_post(
+					array(
+						'ID'        => $product->get_id(),
+						'post_type' => $new_post_type,
+					)
+				);
+			}
+		} else {
+			wp_set_object_terms( $product->get_id(), $new_type, 'product_type' );
+		}
+
 		update_post_meta( $product->get_id(), '_product_version', Constants::get_constant( 'WC_VERSION' ) );
 
 		// Action for the transition.
@@ -1199,6 +1248,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$outofstock_where = ' AND exclude_join.object_id IS NULL';
 		}
 
+		$all_product_types_sql     = self::get_product_post_types_sql( true );
+		$non_variation_types_sql   = self::get_product_post_types_sql( false );
+
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return $wpdb->get_results(
 			"
@@ -1206,13 +1258,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			FROM {$wpdb->posts} AS posts
 			INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 			$outofstock_join
-			WHERE posts.post_type IN ( 'product', 'product_variation' )
+			WHERE posts.post_type IN ( $all_product_types_sql )
 			AND posts.post_status = 'publish'
 			AND lookup.onsale = 1
 			$outofstock_where
 			AND posts.post_parent NOT IN (
 				SELECT ID FROM `$wpdb->posts` as posts
-				WHERE posts.post_type = 'product'
+				WHERE posts.post_type IN ( $non_variation_types_sql )
 				AND posts.post_parent = 0
 				AND posts.post_status != 'publish'
 			)
@@ -1232,10 +1284,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function get_featured_product_ids() {
 		$product_visibility_term_ids = wc_get_product_visibility_term_ids();
+		$featured_post_types         = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' )
+			? wc_get_product_post_types()
+			: array( 'product', 'product_variation' );
 
 		return get_posts(
 			array(
-				'post_type'      => array( 'product', 'product_variation' ),
+				'post_type'      => $featured_post_types,
 				'posts_per_page' => -1,
 				'post_status'    => 'publish',
 				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -1268,15 +1323,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function is_existing_sku( $product_id, $sku ) {
 		global $wpdb;
 
+		$product_types_sql = self::get_product_post_types_sql( true );
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		return (bool) $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare(
 				"
 				SELECT posts.ID
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 				WHERE
-				posts.post_type IN ( 'product', 'product_variation' )
+				posts.post_type IN ( $product_types_sql )
 				AND posts.post_status != 'trash'
 				AND lookup.sku = %s
 				AND lookup.product_id <> %d
@@ -1299,15 +1357,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function is_existing_global_unique_id( $product_id, $global_unique_id ) {
 		global $wpdb;
 
+		$product_types_sql = self::get_product_post_types_sql( true );
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		return (bool) $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare(
 				"
 				SELECT posts.ID
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 				WHERE
-				posts.post_type IN ( 'product', 'product_variation' )
+				posts.post_type IN ( $product_types_sql )
 				AND posts.post_status != 'trash'
 				AND lookup.global_unique_id = %s
 				AND lookup.product_id <> %d
@@ -1329,15 +1390,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_product_id_by_sku( $sku ) {
 		global $wpdb;
 
+		$product_types_sql = self::get_product_post_types_sql( true );
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		$id = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare(
 				"
 				SELECT posts.ID
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 				WHERE
-				posts.post_type IN ( 'product', 'product_variation' )
+				posts.post_type IN ( $product_types_sql )
 				AND posts.post_status != 'trash'
 				AND lookup.sku = %s
 				LIMIT 1
@@ -1359,15 +1423,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_product_id_by_global_unique_id( $global_unique_id ) {
 		global $wpdb;
 
+		$product_types_sql = self::get_product_post_types_sql( true );
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		$id = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare(
 				"
 				SELECT posts.ID
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
 				WHERE
-				posts.post_type IN ( 'product', 'product_variation' )
+				posts.post_type IN ( $product_types_sql )
 				AND posts.post_status != 'trash'
 				AND lookup.global_unique_id = %s
 				LIMIT 1
@@ -1678,6 +1745,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$exclude_term_ids[] = $product_visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ];
 		}
 
+		$non_variation_types_sql = self::get_product_post_types_sql( false );
+
 		$query = array(
 			'fields' => "
 				SELECT DISTINCT ID FROM {$wpdb->posts} p
@@ -1686,7 +1755,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'where'  => "
 				WHERE 1=1
 				AND p.post_status = 'publish'
-				AND p.post_type = 'product'
+				AND p.post_type IN ( $non_variation_types_sql )
 
 			",
 			'limits' => '
@@ -1967,7 +2036,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			return $custom_results;
 		}
 
-		$post_types   = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$post_types = wc_get_product_post_types();
+			if ( ! $include_variations ) {
+				$post_types = array_diff( $post_types, array( 'product_variation' ) );
+			}
+		} else {
+			$post_types = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
+		}
 		$join_query   = '';
 		$type_where   = '';
 		$status_where = '';
@@ -2116,7 +2192,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$post_type = get_post_type( $product_id );
 
-		if ( 'product_variation' === $post_type ) {
+		// When per-type post types are enabled, resolve from post type directly.
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			$product_type = wc_post_type_to_product_type( $post_type );
+			if ( false === $product_type ) {
+				$product_type = false;
+			}
+		} elseif ( 'product_variation' === $post_type ) {
 			$product_type = ProductType::VARIATION;
 		} elseif ( 'product' === $post_type ) {
 			$terms        = get_the_terms( $product_id, 'product_type' );
@@ -2213,7 +2295,23 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		// Handle product types.
-		if ( ProductType::VARIATION === $query_vars['type'] ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			// Map type(s) directly to post types — no tax_query needed.
+			$types = (array) $query_vars['type'];
+			$post_types_for_query = array();
+
+			foreach ( $types as $type ) {
+				$post_types_for_query[] = wc_product_type_to_post_type( $type );
+			}
+
+			$post_types_for_query = array_unique( $post_types_for_query );
+
+			if ( 1 === count( $post_types_for_query ) ) {
+				$wp_query_args['post_type'] = reset( $post_types_for_query );
+			} else {
+				$wp_query_args['post_type'] = $post_types_for_query;
+			}
+		} elseif ( ProductType::VARIATION === $query_vars['type'] ) {
 			$wp_query_args['post_type'] = 'product_variation';
 		} elseif ( is_array( $query_vars['type'] ) && in_array( ProductType::VARIATION, $query_vars['type'], true ) ) {
 			$wp_query_args['post_type']   = array( 'product_variation', 'product' );
@@ -2438,7 +2536,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( isset( $query_vars['return'] ) && 'objects' === $query_vars['return'] && ! empty( $query->posts ) ) {
 			// Prime caches before grabbing objects.
-			update_post_caches( $query->posts, array( 'product', 'product_variation' ) );
+			$cache_post_types = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' )
+				? wc_get_product_post_types()
+				: array( 'product', 'product_variation' );
+			update_post_caches( $query->posts, $cache_post_types );
 		}
 
 		$products = ( isset( $query_vars['return'] ) && 'ids' === $query_vars['return'] ) ? $query->posts : array_filter( array_map( 'wc_get_product', $query->posts ) );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -368,11 +368,16 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Filter product type by slug.
 		if ( ! empty( $request['type'] ) ) {
-			$tax_query[] = array(
-				'taxonomy' => 'product_type',
-				'field'    => 'slug',
-				'terms'    => $request['type'],
-			);
+			if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+				// Map type to post type directly — no tax_query needed.
+				$args['post_type'] = wc_product_type_to_post_type( $request['type'] );
+			} else {
+				$tax_query[] = array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => $request['type'],
+				);
+			}
 		}
 
 		// Filter by attribute and term.
@@ -457,7 +462,15 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		// Force the post_type argument, since it's not a user input variable.
-		if ( ! empty( $request['sku'] ) ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			if ( ! empty( $request['sku'] ) ) {
+				$args['post_type'] = wc_get_product_post_types();
+			} elseif ( ! isset( $args['post_type'] ) || $this->post_type === $args['post_type'] ) {
+				// Query all product post types when no specific type filter was set.
+				$non_variation_types = array_diff( wc_get_product_post_types(), array( 'product_variation' ) );
+				$args['post_type']  = array_values( $non_variation_types );
+			}
+		} elseif ( ! empty( $request['sku'] ) ) {
 			$args['post_type'] = array( 'product', 'product_variation' );
 		} else {
 			$args['post_type'] = $this->post_type;

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -32,7 +32,16 @@ if ( ! function_exists( 'is_shop' ) ) {
 	 * @return bool
 	 */
 	function is_shop() {
-		return ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) );
+		if ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) {
+			return true;
+		}
+
+		// When per-type post types are on, check if this is an archive of any product post type.
+		if ( function_exists( 'wc_get_product_post_types' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			return is_post_type_archive( wc_get_product_post_types() );
+		}
+
+		return false;
 	}
 }
 
@@ -82,6 +91,9 @@ if ( ! function_exists( 'is_product' ) ) {
 	 * @return bool
 	 */
 	function is_product() {
+		if ( function_exists( 'wc_get_product_post_types' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+			return is_singular( wc_get_product_post_types() );
+		}
 		return is_singular( array( 'product' ) );
 	}
 }

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -959,6 +959,108 @@ function wc_get_product_types() {
 }
 
 /**
+ * Get all product post types.
+ *
+ * When the product_type_post_types feature flag is enabled, returns the
+ * per-type post types. Otherwise returns the legacy 'product' post type.
+ * Always includes 'product_variation'.
+ *
+ * @return array
+ */
+function wc_get_product_post_types() {
+	if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+		$post_types = array(
+			'wc_product_simple',
+			'wc_product_variable',
+			'wc_product_grouped',
+			'wc_product_external',
+			'product_variation',
+		);
+
+		/**
+		 * Filter the product post types when per-type post types are enabled.
+		 *
+		 * Extensions that register custom product types as post types should
+		 * filter this to include their own post types.
+		 *
+		 * @param array $post_types The product post types.
+		 */
+		return apply_filters( 'wc_product_post_types', $post_types );
+	}
+
+	return array( 'product', 'product_variation' );
+}
+
+/**
+ * Map a product type string to its corresponding post type name.
+ *
+ * @param string $product_type The product type (e.g. 'simple', 'variable').
+ * @return string The post type name (e.g. 'wc_product_simple').
+ */
+function wc_product_type_to_post_type( $product_type ) {
+	$map = array(
+		ProductType::SIMPLE   => 'wc_product_simple',
+		ProductType::VARIABLE => 'wc_product_variable',
+		ProductType::GROUPED  => 'wc_product_grouped',
+		ProductType::EXTERNAL => 'wc_product_external',
+		ProductType::VARIATION => 'product_variation',
+	);
+
+	/**
+	 * Filter the product type to post type mapping.
+	 *
+	 * @param array $map The mapping of product type strings to post type names.
+	 */
+	$map = apply_filters( 'wc_product_type_to_post_type_map', $map );
+
+	return isset( $map[ $product_type ] ) ? $map[ $product_type ] : 'product';
+}
+
+/**
+ * Map a post type name to its corresponding product type string.
+ *
+ * @param string $post_type The post type name (e.g. 'wc_product_simple').
+ * @return string|false The product type string (e.g. 'simple'), or false if not a product post type.
+ */
+function wc_post_type_to_product_type( $post_type ) {
+	$map = array(
+		'wc_product_simple'   => ProductType::SIMPLE,
+		'wc_product_variable' => ProductType::VARIABLE,
+		'wc_product_grouped'  => ProductType::GROUPED,
+		'wc_product_external' => ProductType::EXTERNAL,
+		'product_variation'   => ProductType::VARIATION,
+		'product'             => ProductType::SIMPLE, // Legacy fallback: untyped products are simple.
+	);
+
+	/**
+	 * Filter the post type to product type mapping.
+	 *
+	 * @param array $map The mapping of post type names to product type strings.
+	 */
+	$map = apply_filters( 'wc_post_type_to_product_type_map', $map );
+
+	return isset( $map[ $post_type ] ) ? $map[ $post_type ] : false;
+}
+
+/**
+ * Check if a given post type is a product post type.
+ *
+ * @param string $post_type The post type to check.
+ * @return bool
+ */
+function wc_is_product_post_type( $post_type ) {
+	if ( 'product' === $post_type || 'product_variation' === $post_type ) {
+		return true;
+	}
+
+	if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' ) ) {
+		return in_array( $post_type, wc_get_product_post_types(), true );
+	}
+
+	return false;
+}
+
+/**
  * Check if product sku is unique.
  *
  * @since 2.2

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -263,7 +263,9 @@ class ProductQuery extends AbstractBlock {
 			'offset'         => $query['offset'],
 			'post__in'       => array(),
 			'post_status'    => ProductStatus::PUBLISH,
-			'post_type'      => 'product',
+			'post_type'      => \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' )
+				? array_values( array_diff( wc_get_product_post_types(), array( 'product_variation' ) ) )
+				: 'product',
 			'tax_query'      => array(),
 		);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -591,6 +591,18 @@ class FeaturesController {
 				'is_experimental'              => true,
 				'disable_ui'                   => false,
 			),
+			'product_type_post_types'            => array(
+				'name'                         => __( 'Product type post types', 'woocommerce' ),
+				'description'                  => __(
+					'Register each product type (simple, variable, grouped, external) as its own custom post type instead of using the product_type taxonomy.',
+					'woocommerce'
+				),
+				'enabled_by_default'           => false,
+				'is_experimental'              => true,
+				'disable_ui'                   => true,
+				'skip_compatibility_checks'    => false,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::INCOMPATIBLE,
+			),
 		);
 
 		if ( ! $tracking_enabled ) {

--- a/plugins/woocommerce/src/Internal/ProductTypePostTypes/MigrationCLICommand.php
+++ b/plugins/woocommerce/src/Internal/ProductTypePostTypes/MigrationCLICommand.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * WP-CLI command for migrating products to per-type post types.
+ *
+ * @package WooCommerce\Internal\ProductTypePostTypes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\ProductTypePostTypes;
+
+use Automattic\WooCommerce\Enums\ProductType;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate product post types for the product_type_post_types feature.
+ *
+ * ## EXAMPLES
+ *
+ *     # Migrate products to per-type post types
+ *     wp wc product-type-migration migrate --batch-size=500
+ *
+ *     # Rollback to the legacy 'product' post type
+ *     wp wc product-type-migration rollback --batch-size=500
+ *
+ *     # Show current migration status
+ *     wp wc product-type-migration status
+ */
+class MigrationCLICommand extends WP_CLI_Command {
+
+	/**
+	 * Mapping of product type taxonomy terms to new post types.
+	 */
+	private const TYPE_MAP = array(
+		ProductType::SIMPLE   => 'wc_product_simple',
+		ProductType::VARIABLE => 'wc_product_variable',
+		ProductType::GROUPED  => 'wc_product_grouped',
+		ProductType::EXTERNAL => 'wc_product_external',
+	);
+
+	/**
+	 * Register this command with WP-CLI.
+	 */
+	public static function register() {
+		if ( ! class_exists( 'WP_CLI' ) ) {
+			return;
+		}
+
+		WP_CLI::add_command( 'wc product-type-migration', self::class );
+	}
+
+	/**
+	 * Migrate products from 'product' post type to per-type post types.
+	 *
+	 * Products without a product_type taxonomy term are treated as simple.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<number>]
+	 * : Number of products to process per batch.
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Show what would be migrated without making changes.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function migrate( $args, $assoc_args ) {
+		global $wpdb;
+
+		$batch_size = (int) ( $assoc_args['batch-size'] ?? 500 );
+		$dry_run    = isset( $assoc_args['dry-run'] );
+
+		if ( $dry_run ) {
+			WP_CLI::log( '--- DRY RUN MODE ---' );
+		}
+
+		// Count products by type.
+		$counts = $this->get_product_type_counts();
+		WP_CLI::log( 'Current product distribution:' );
+		foreach ( $counts as $type => $count ) {
+			WP_CLI::log( sprintf( '  %s: %d', $type, $count ) );
+		}
+
+		$total_migrated = 0;
+		$offset         = 0;
+
+		while ( true ) {
+			// Get a batch of products with post_type = 'product'.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$products = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT p.ID, COALESCE(
+						(SELECT t.slug FROM {$wpdb->terms} t
+						 INNER JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
+						 INNER JOIN {$wpdb->term_relationships} tr ON tt.term_taxonomy_id = tr.term_taxonomy_id
+						 WHERE tr.object_id = p.ID AND tt.taxonomy = 'product_type'
+						 LIMIT 1), 'simple'
+					) as product_type
+					FROM {$wpdb->posts} p
+					WHERE p.post_type = 'product'
+					ORDER BY p.ID ASC
+					LIMIT %d OFFSET %d",
+					$batch_size,
+					$offset
+				)
+			);
+
+			if ( empty( $products ) ) {
+				break;
+			}
+
+			$batch_updates = array();
+			foreach ( $products as $product ) {
+				$new_post_type = self::TYPE_MAP[ $product->product_type ] ?? 'wc_product_simple';
+				$batch_updates[ $new_post_type ][] = (int) $product->ID;
+			}
+
+			if ( ! $dry_run ) {
+				foreach ( $batch_updates as $new_post_type => $ids ) {
+					$id_placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+					$wpdb->query(
+						$wpdb->prepare(
+							"UPDATE {$wpdb->posts} SET post_type = %s WHERE ID IN ($id_placeholders)",
+							array_merge( array( $new_post_type ), $ids )
+						)
+					);
+					$total_migrated += count( $ids );
+				}
+			} else {
+				foreach ( $batch_updates as $new_post_type => $ids ) {
+					WP_CLI::log( sprintf( '  Would migrate %d products to %s', count( $ids ), $new_post_type ) );
+					$total_migrated += count( $ids );
+				}
+			}
+
+			$offset += $batch_size;
+			WP_CLI::log( sprintf( 'Processed %d products...', $offset ) );
+		}
+
+		if ( ! $dry_run ) {
+			// Invalidate WordPress object caches.
+			wp_cache_flush();
+			WP_CLI::log( 'Object cache flushed.' );
+		}
+
+		WP_CLI::success( sprintf( '%s %d products.', $dry_run ? 'Would migrate' : 'Migrated', $total_migrated ) );
+	}
+
+	/**
+	 * Rollback: move all per-type products back to the 'product' post type.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<number>]
+	 * : Number of products to process per batch.
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Show what would be rolled back without making changes.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function rollback( $args, $assoc_args ) {
+		global $wpdb;
+
+		$batch_size = (int) ( $assoc_args['batch-size'] ?? 500 );
+		$dry_run    = isset( $assoc_args['dry-run'] );
+
+		if ( $dry_run ) {
+			WP_CLI::log( '--- DRY RUN MODE ---' );
+		}
+
+		$new_post_types = array_values( self::TYPE_MAP );
+		$placeholders   = implode( ', ', array_fill( 0, count( $new_post_types ), '%s' ) );
+		$total_rolled   = 0;
+
+		// Count how many exist.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type IN ($placeholders)",
+				$new_post_types
+			)
+		);
+
+		WP_CLI::log( sprintf( 'Found %d products to roll back.', $total ) );
+
+		if ( $dry_run ) {
+			WP_CLI::success( sprintf( 'Would roll back %d products.', $total ) );
+			return;
+		}
+
+		while ( true ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			$affected = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->posts} SET post_type = 'product' WHERE post_type IN ($placeholders) LIMIT %d",
+					array_merge( $new_post_types, array( $batch_size ) )
+				)
+			);
+
+			if ( 0 === $affected || false === $affected ) {
+				break;
+			}
+
+			$total_rolled += $affected;
+			WP_CLI::log( sprintf( 'Rolled back %d products...', $total_rolled ) );
+		}
+
+		wp_cache_flush();
+		WP_CLI::log( 'Object cache flushed.' );
+		WP_CLI::success( sprintf( 'Rolled back %d products to post_type=product.', $total_rolled ) );
+	}
+
+	/**
+	 * Show the current migration status.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function status( $args, $assoc_args ) {
+		global $wpdb;
+
+		$post_types = array_merge( array( 'product' ), array_values( self::TYPE_MAP ), array( 'product_variation' ) );
+
+		WP_CLI::log( 'Product post type distribution:' );
+		WP_CLI::log( '' );
+
+		$total = 0;
+		foreach ( $post_types as $pt ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$count = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s",
+					$pt
+				)
+			);
+			if ( $count > 0 ) {
+				WP_CLI::log( sprintf( '  %-25s %d', $pt, $count ) );
+				$total += $count;
+			}
+		}
+
+		WP_CLI::log( sprintf( '  %-25s %d', '---', $total ) );
+
+		$feature_enabled = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' );
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'Feature flag: %s', $feature_enabled ? 'ENABLED' : 'DISABLED' ) );
+	}
+
+	/**
+	 * Get product counts by type from the taxonomy.
+	 *
+	 * @return array<string, int> Type name => count.
+	 */
+	private function get_product_type_counts(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$results = $wpdb->get_results(
+			"SELECT t.slug as product_type, COUNT(*) as count
+			FROM {$wpdb->posts} p
+			LEFT JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+			LEFT JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id AND tt.taxonomy = 'product_type'
+			LEFT JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+			WHERE p.post_type = 'product'
+			GROUP BY t.slug"
+		);
+
+		$counts = array();
+		foreach ( $results as $row ) {
+			$type            = $row->product_type ?: '(unset/simple)';
+			$counts[ $type ] = (int) $row->count;
+		}
+
+		return $counts;
+	}
+}

--- a/plugins/woocommerce/src/Internal/ProductTypePostTypes/PerformanceBenchmarkCLICommand.php
+++ b/plugins/woocommerce/src/Internal/ProductTypePostTypes/PerformanceBenchmarkCLICommand.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * WP-CLI command for benchmarking product type post type performance.
+ *
+ * @package WooCommerce\Internal\ProductTypePostTypes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\ProductTypePostTypes;
+
+use Automattic\WooCommerce\Enums\ProductType;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Benchmark performance of the product_type_post_types feature.
+ *
+ * ## EXAMPLES
+ *
+ *     wp wc product-type-benchmark run
+ */
+class PerformanceBenchmarkCLICommand extends WP_CLI_Command {
+
+	/**
+	 * Register this command with WP-CLI.
+	 */
+	public static function register() {
+		if ( ! class_exists( 'WP_CLI' ) ) {
+			return;
+		}
+
+		WP_CLI::add_command( 'wc product-type-benchmark', self::class );
+	}
+
+	/**
+	 * Run all performance benchmarks.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--iterations=<number>]
+	 * : Number of iterations per benchmark.
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function run( $args, $assoc_args ) {
+		global $wpdb;
+
+		$iterations = (int) ( $assoc_args['iterations'] ?? 100 );
+
+		$feature_enabled = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' );
+		$mode            = $feature_enabled ? 'POST TYPE' : 'TAXONOMY';
+
+		WP_CLI::log( sprintf( '=== Performance Benchmark (mode: %s, iterations: %d) ===', $mode, $iterations ) );
+		WP_CLI::log( '' );
+
+		// Count products.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$product_count = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts}
+			WHERE post_type IN ('product', 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external')
+			AND post_status = 'publish'"
+		);
+		WP_CLI::log( sprintf( 'Total published products: %d', $product_count ) );
+		WP_CLI::log( '' );
+
+		// Get a sample of product IDs.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$sample_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts}
+				WHERE post_type IN ('product', 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external')
+				AND post_status = 'publish'
+				ORDER BY RAND()
+				LIMIT %d",
+				min( $iterations, $product_count )
+			)
+		);
+
+		if ( empty( $sample_ids ) ) {
+			WP_CLI::warning( 'No products found to benchmark.' );
+			return;
+		}
+
+		// Benchmark 1: Type resolution speed.
+		WP_CLI::log( '--- Benchmark 1: Type Resolution Speed ---' );
+		$this->benchmark_type_resolution( $sample_ids, $iterations );
+
+		// Benchmark 2: Shop page query speed.
+		WP_CLI::log( '' );
+		WP_CLI::log( '--- Benchmark 2: Shop Page Query Speed ---' );
+		$this->benchmark_shop_query( $iterations );
+
+		// Benchmark 3: Product count overhead.
+		WP_CLI::log( '' );
+		WP_CLI::log( '--- Benchmark 3: Product Count Overhead ---' );
+		$this->benchmark_product_count( $iterations );
+
+		// Benchmark 4: Product CRUD.
+		WP_CLI::log( '' );
+		WP_CLI::log( '--- Benchmark 4: Product Creation Speed ---' );
+		$this->benchmark_product_creation( min( 10, $iterations ) );
+
+		WP_CLI::log( '' );
+		WP_CLI::success( 'Benchmarks complete.' );
+	}
+
+	/**
+	 * Benchmark type resolution for individual products.
+	 *
+	 * @param array $ids        Product IDs.
+	 * @param int   $iterations Number of iterations.
+	 */
+	private function benchmark_type_resolution( array $ids, int $iterations ): void {
+		// Clear all caches.
+		wp_cache_flush();
+
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			$id = $ids[ $i % count( $ids ) ];
+			\WC_Product_Factory::get_product_type( (int) $id );
+		}
+		$elapsed = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d type lookups in %.4fs (avg: %.4fms per lookup)',
+			$iterations,
+			$elapsed,
+			( $elapsed / $iterations ) * 1000
+		) );
+
+		// Now with warm cache.
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			$id = $ids[ $i % count( $ids ) ];
+			\WC_Product_Factory::get_product_type( (int) $id );
+		}
+		$elapsed_warm = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d type lookups (warm cache) in %.4fs (avg: %.4fms per lookup)',
+			$iterations,
+			$elapsed_warm,
+			( $elapsed_warm / $iterations ) * 1000
+		) );
+	}
+
+	/**
+	 * Benchmark shop page queries.
+	 *
+	 * @param int $iterations Number of iterations.
+	 */
+	private function benchmark_shop_query( int $iterations ): void {
+		$iterations = min( $iterations, 20 ); // Limit to avoid heavy DB load.
+		wp_cache_flush();
+
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			wc_get_products(
+				array(
+					'status'  => 'publish',
+					'limit'   => 20,
+					'page'    => 1,
+					'orderby' => 'date',
+					'order'   => 'DESC',
+					'return'  => 'ids',
+				)
+			);
+			// Flush cache each time to measure cold query.
+			wp_cache_flush();
+		}
+		$elapsed = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d shop queries (20 products each) in %.4fs (avg: %.4fms per query)',
+			$iterations,
+			$elapsed,
+			( $elapsed / $iterations ) * 1000
+		) );
+
+		// Type-filtered query.
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			wc_get_products(
+				array(
+					'status'  => 'publish',
+					'type'    => 'simple',
+					'limit'   => 20,
+					'page'    => 1,
+					'orderby' => 'date',
+					'order'   => 'DESC',
+					'return'  => 'ids',
+				)
+			);
+			wp_cache_flush();
+		}
+		$elapsed_typed = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d type-filtered queries (type=simple, 20 products) in %.4fs (avg: %.4fms per query)',
+			$iterations,
+			$elapsed_typed,
+			( $elapsed_typed / $iterations ) * 1000
+		) );
+	}
+
+	/**
+	 * Benchmark product counting.
+	 *
+	 * @param int $iterations Number of iterations.
+	 */
+	private function benchmark_product_count( int $iterations ): void {
+		$iterations = min( $iterations, 50 );
+		wp_cache_flush();
+
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			$feature_enabled = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' );
+			if ( $feature_enabled ) {
+				// Need to count across all post types.
+				$total = 0;
+				foreach ( array( 'wc_product_simple', 'wc_product_variable', 'wc_product_grouped', 'wc_product_external' ) as $pt ) {
+					$counts = wp_count_posts( $pt );
+					$total += $counts->publish ?? 0;
+				}
+			} else {
+				$counts = wp_count_posts( 'product' );
+				// Type filtering requires additional taxonomy query.
+			}
+		}
+		$elapsed = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d product count operations in %.4fs (avg: %.4fms per count)',
+			$iterations,
+			$elapsed,
+			( $elapsed / $iterations ) * 1000
+		) );
+	}
+
+	/**
+	 * Benchmark product creation.
+	 *
+	 * @param int $iterations Number of products to create and delete.
+	 */
+	private function benchmark_product_creation( int $iterations ): void {
+		$created_ids = array();
+
+		$start = microtime( true );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			$product = new \WC_Product_Simple();
+			$product->set_name( 'Benchmark Product ' . $i );
+			$product->set_status( 'draft' );
+			$product->set_regular_price( '9.99' );
+			$product->save();
+			$created_ids[] = $product->get_id();
+		}
+		$elapsed = microtime( true ) - $start;
+
+		WP_CLI::log( sprintf(
+			'  %d product creates in %.4fs (avg: %.4fms per create)',
+			$iterations,
+			$elapsed,
+			( $elapsed / $iterations ) * 1000
+		) );
+
+		// Clean up.
+		foreach ( $created_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -41,9 +41,16 @@ class ProductQuery implements QueryClausesGenerator {
 			'post_type'           => 'product',
 		);
 
+		$feature_enabled = \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_type_post_types' );
+
+		if ( $feature_enabled ) {
+			// Default to all non-variation product post types.
+			$args['post_type'] = array_values( array_diff( wc_get_product_post_types(), array( 'product_variation' ) ) );
+		}
+
 		// If searching for a specific SKU or slug, allow any post type.
 		if ( ! empty( $request['sku'] ) || ! empty( $request['slug'] ) ) {
-			$args['post_type'] = array( 'product', 'product_variation' );
+			$args['post_type'] = $feature_enabled ? wc_get_product_post_types() : array( 'product', 'product_variation' );
 		}
 
 		// Taxonomy query to filter products by type, category, tag, shipping class, and attribute.
@@ -51,7 +58,10 @@ class ProductQuery implements QueryClausesGenerator {
 
 		// Filter product type by slug.
 		if ( ! empty( $request['type'] ) ) {
-			if ( ProductType::VARIATION === $request['type'] ) {
+			if ( $feature_enabled ) {
+				// Map type to post type directly.
+				$args['post_type'] = wc_product_type_to_post_type( $request['type'] );
+			} elseif ( ProductType::VARIATION === $request['type'] ) {
 				$args['post_type'] = 'product_variation';
 			} else {
 				$args['post_type'] = 'product';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

**Feasibility study: Product types as custom post types**

This is a prototype exploring whether WooCommerce product types (simple, variable, grouped, external) should be registered as individual custom post types (`wc_product_simple`, `wc_product_variable`, `wc_product_grouped`, `wc_product_external`) instead of using the `product_type` taxonomy on a single `product` post type.

**Motivation:**
- `get_post_type()` is a direct column read; `get_the_terms()` for type resolution requires a JOIN — measurable performance difference at scale
- WordPress template hierarchy, REST API, and capabilities system all key off post type — using taxonomy for type forces WooCommerce to reimplement what WP provides natively
- `product_variation` already exists as a separate post type, proving the pattern works

**What's included:**
- Feature flag (`product_type_post_types`) — experimental, disabled by default, no UI
- 4 new post types registered conditionally behind the flag
- Updated Product Factory, Data Store, Product Model classes, WC_Query, conditional functions, Template Loader, REST API v2/v3, Store API, ProductQuery block, Shortcodes
- Helper functions: `wc_get_product_post_types()`, `wc_product_type_to_post_type()`, `wc_post_type_to_product_type()`, `wc_is_product_post_type()`
- WP-CLI migration + rollback script with batch processing and dry-run support
- Performance benchmark CLI command
- Comprehensive findings document with go/no-go recommendation

**Key finding:** Conditional long-term GO with a 12-18 month deprecation cycle. The critical risk is `get_post_type() === 'product'` breakage in third-party extensions — no transparent shim is possible.

> **This PR is NOT intended to be merged.** It is a feasibility prototype for review and discussion.

### How to test the changes in this Pull Request:

1. This is a feasibility prototype — code review and architectural discussion only
2. All code is gated behind the `product_type_post_types` feature flag (disabled by default)
3. Review the findings document at `agent-os/specs/2026-03-08-product-types-as-cpt/findings.md`

### Testing that has already taken place:

- PHP syntax checks pass on all modified files
- Architectural review of ~36 additional files with 50+ hardcoded `'product'` post type references identified

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Feasibility prototype — not intended for merge. No user-facing changes.

</details>