### PR TITLE
Add the dispatcher classes that will call the internal loopback endpoint and the WPCOM send endpoint

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Dispatchers;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
 
 /**
@@ -44,7 +45,15 @@ class InternalNotificationDispatcher {
 		}
 
 		$encoded = array_map( fn ( Notification $notification ) => $notification->to_array(), $notifications );
-		$body    = (string) wp_json_encode( array( 'notifications' => $encoded ) );
+		$body    = wp_json_encode( array( 'notifications' => $encoded ) );
+
+		if ( false === $body ) {
+			wc_get_logger()->error(
+				'Failed to JSON-encode push notification payload.',
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
 
 		$token = JsonWebToken::create(
 			array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
 
 /**
  * Fires a non-blocking POST to the internal REST endpoint with JSON-encoded
- * notification metadata and a signed JWT.
+ * notification data and a signed JWT.
  *
  * Called directly by PendingNotificationStore::dispatch_all() on shutdown.
  *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
@@ -1,0 +1,71 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Dispatchers;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
+
+/**
+ * Fires a non-blocking POST to the internal REST endpoint with JSON-encoded
+ * notification metadata and a signed JWT.
+ *
+ * Called directly by PendingNotificationStore::dispatch_all() on shutdown.
+ *
+ * @since 10.7.0
+ */
+class InternalNotificationDispatcher {
+
+	/**
+	 * REST route for the send endpoint.
+	 */
+	const SEND_ENDPOINT = 'wc-push-notifications/send';
+
+	/**
+	 * JWT expiry in seconds.
+	 */
+	const JWT_EXPIRY_SECONDS = 30;
+
+	/**
+	 * JSON-encodes notifications and fires a non-blocking POST to the internal
+	 * REST endpoint.
+	 *
+	 * @param Notification[] $notifications The notifications to dispatch.
+	 * @return void
+	 *
+	 * @since 10.7.0
+	 */
+	public function dispatch( array $notifications ): void {
+		if ( empty( $notifications ) ) {
+			return;
+		}
+
+		$encoded = array_map( fn ( Notification $notification ) => $notification->to_array(), $notifications );
+		$body    = (string) wp_json_encode( array( 'notifications' => $encoded ) );
+
+		$token = JsonWebToken::create(
+			array(
+				'iss'       => get_site_url(),
+				'exp'       => time() + self::JWT_EXPIRY_SECONDS,
+				'body_hash' => hash( 'sha256', $body ),
+			),
+			wp_salt( 'auth' )
+		);
+
+		wp_remote_post(
+			rest_url( self::SEND_ENDPOINT ),
+			array(
+				'blocking' => false,
+				'timeout'  => 1,
+				'headers'  => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $token,
+				),
+				'body'     => $body,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcher.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
  *
  * Called directly by PendingNotificationStore::dispatch_all() on shutdown.
  *
+ * @internal
  * @since 10.7.0
  */
 class InternalNotificationDispatcher {
@@ -64,7 +65,7 @@ class InternalNotificationDispatcher {
 			wp_salt( 'auth' )
 		);
 
-		wp_remote_post(
+		$response = wp_remote_post(
 			rest_url( self::SEND_ENDPOINT ),
 			array(
 				'blocking' => false,
@@ -76,5 +77,12 @@ class InternalNotificationDispatcher {
 				'body'     => $body,
 			)
 		);
+
+		if ( is_wp_error( $response ) ) {
+			wc_get_logger()->error(
+				sprintf( 'Loopback dispatch failed: %s', $response->get_error_message() ),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
@@ -17,10 +17,10 @@ use WP_Http;
 /**
  * Sends a notification to WPCOM via the Jetpack connection.
  *
- * Called by the NotificationProcessor (not wired to any hook). Combines the
- * notification payload with formatted push tokens and sends to the WPCOM
- * push endpoint. Returns a result array indicating success/failure and an
- * optional retry-after value.
+ * Called directly by the NotificationProcessor. Combines the notification
+ * payload with formatted push tokens and sends to the WPCOM push endpoint.
+ * Returns a result array indicating success/failure and an optional retry-after
+ * value.
  *
  * @since 10.7.0
  */
@@ -34,7 +34,7 @@ class WpcomNotificationDispatcher {
 	/**
 	 * WPCOM endpoint path (appended after /sites/{id}/).
 	 */
-	const SEND_ENDPOINT = 'push-notifications/send';
+	const SEND_ENDPOINT = 'push-notifications';
 
 	/**
 	 * HTTP request timeout in seconds.
@@ -134,15 +134,19 @@ class WpcomNotificationDispatcher {
 	 * @return array|WP_Error
 	 *
 	 * @since 10.7.0
+	 *
+	 * @phpstan-ignore return.unusedType
 	 */
 	private function make_request( int $site_id, array $payload, array $tokens ) {
 		$body = (string) wp_json_encode(
-			array(
-				'payload' => $payload,
-				'tokens'  => array_map(
-					fn ( PushToken $token ) => $token->to_wpcom_format(),
-					$tokens
-				),
+			array_merge(
+				$payload,
+				array(
+					'tokens' => array_map(
+						fn ( PushToken $token ) => $token->to_wpcom_format(),
+						$tokens
+					),
+				)
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
@@ -135,10 +135,10 @@ class WpcomNotificationDispatcher {
 	 *
 	 * @since 10.7.0
 	 *
-	 * @phpstan-ignore return.unusedType
+	 * @phpstan-ignore return.unusedType (Jetpack stubs lack array return type.)
 	 */
 	private function make_request( int $site_id, array $payload, array $tokens ) {
-		$body = (string) wp_json_encode(
+		$body = wp_json_encode(
 			array_merge(
 				$payload,
 				array(
@@ -149,6 +149,10 @@ class WpcomNotificationDispatcher {
 				)
 			)
 		);
+
+		if ( false === $body ) {
+			return new WP_Error( 'json_encode_failed', 'Failed to encode push notification payload.' );
+		}
 
 		// @phpstan-ignore return.type
 		return Jetpack_Connection_Client::wpcom_json_api_request_as_blog(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
@@ -22,6 +22,7 @@ use WP_Http;
  * Returns a result array indicating success/failure and an optional retry-after
  * value.
  *
+ * @internal
  * @since 10.7.0
  */
 class WpcomNotificationDispatcher {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcher.php
@@ -1,0 +1,162 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Dispatchers;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Jetpack_Options;
+use WP_Error;
+use WP_Http;
+
+/**
+ * Sends a notification to WPCOM via the Jetpack connection.
+ *
+ * Called by the NotificationProcessor (not wired to any hook). Combines the
+ * notification payload with formatted push tokens and sends to the WPCOM
+ * push endpoint. Returns a result array indicating success/failure and an
+ * optional retry-after value.
+ *
+ * @since 10.7.0
+ */
+class WpcomNotificationDispatcher {
+
+	/**
+	 * WPCOM API version.
+	 */
+	const WPCOM_API_VERSION = '2';
+
+	/**
+	 * WPCOM endpoint path (appended after /sites/{id}/).
+	 */
+	const SEND_ENDPOINT = 'push-notifications/send';
+
+	/**
+	 * HTTP request timeout in seconds.
+	 */
+	const REQUEST_TIMEOUT = 15;
+
+	/**
+	 * Dispatches a notification with push tokens to WPCOM.
+	 *
+	 * @param Notification $notification The notification to send.
+	 * @param PushToken[]  $tokens       The push tokens to send to.
+	 * @return array{success: bool, retry_after: int|null}
+	 *
+	 * @since 10.7.0
+	 */
+	public function dispatch( Notification $notification, array $tokens ): array {
+		$site_id = class_exists( Jetpack_Options::class ) ? Jetpack_Options::get_option( 'id' ) : null;
+
+		if ( empty( $site_id ) ) {
+			wc_get_logger()->error(
+				'Cannot send push notifications: Jetpack site ID unavailable.',
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+
+			return array(
+				'success'     => false,
+				'retry_after' => null,
+			);
+		}
+
+		$payload = $notification->to_payload();
+
+		if ( null === $payload ) {
+			wc_get_logger()->error(
+				sprintf(
+					'Cannot send push notification: resource no longer exists (type=%s, resource_id=%d).',
+					$notification->get_type(),
+					$notification->get_resource_id()
+				),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+
+			return array(
+				'success'     => false,
+				'retry_after' => null,
+			);
+		}
+
+		$response = $this->make_request( $site_id, $payload, $tokens );
+
+		if ( is_wp_error( $response ) ) {
+			wc_get_logger()->error(
+				sprintf(
+					'Push notification request failed: %s',
+					$response->get_error_message()
+				),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+
+			return array(
+				'success'     => false,
+				'retry_after' => null,
+			);
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( WP_Http::OK === $status_code ) {
+			return array(
+				'success'     => true,
+				'retry_after' => null,
+			);
+		}
+
+		$retry_after = wp_remote_retrieve_header( $response, 'retry-after' );
+
+		wc_get_logger()->error(
+			sprintf(
+				'Push notification request returned HTTP %d.',
+				$status_code
+			),
+			array( 'source' => PushNotifications::FEATURE_NAME )
+		);
+
+		return array(
+			'success'     => false,
+			'retry_after' => '' !== $retry_after ? (int) $retry_after : null,
+		);
+	}
+
+	/**
+	 * Makes the WPCOM API request via the Jetpack connection.
+	 *
+	 * @param int         $site_id The Jetpack site ID.
+	 * @param array       $payload The notification payload.
+	 * @param PushToken[] $tokens  The push tokens.
+	 * @return array|WP_Error
+	 *
+	 * @since 10.7.0
+	 */
+	private function make_request( int $site_id, array $payload, array $tokens ) {
+		$body = (string) wp_json_encode(
+			array(
+				'payload' => $payload,
+				'tokens'  => array_map(
+					fn ( PushToken $token ) => $token->to_wpcom_format(),
+					$tokens
+				),
+			)
+		);
+
+		// @phpstan-ignore return.type
+		return Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/%s', $site_id, self::SEND_ENDPOINT ),
+			self::WPCOM_API_VERSION,
+			array(
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'method'  => 'POST',
+				'timeout' => self::REQUEST_TIMEOUT,
+			),
+			$body,
+			'wpcom'
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -450,6 +450,22 @@ class PushToken {
 	}
 
 	/**
+	 * Returns this token formatted for the WPCOM push notifications endpoint.
+	 *
+	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null}
+	 *
+	 * @since 10.7.0
+	 */
+	public function to_wpcom_format(): array {
+		return array(
+			'user_id'       => $this->user_id,
+			'token'         => $this->token,
+			'origin'        => $this->origin,
+			'device_locale' => $this->device_locale,
+		);
+	}
+
+	/**
 	 * Determines whether this token can be created.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -461,7 +461,7 @@ class PushToken {
 			'user_id'       => $this->user_id,
 			'token'         => $this->token,
 			'origin'        => $this->origin,
-			'device_locale' => $this->device_locale,
+			'device_locale' => $this->device_locale ?? self::DEFAULT_DEVICE_LOCALE,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -60,10 +60,7 @@ class NewOrderNotification extends Notification {
 		return array(
 			'type'        => self::TYPE,
 			'icon'        => self::ICON,
-			/**
-			 * This represents the time the notification was triggered, so we
-			 * can monitor age of notification at delivery.
-			 */
+			// This represents the time the notification was triggered, so we can monitor age of notification at  delivery.
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -60,7 +60,7 @@ class NewOrderNotification extends Notification {
 		return array(
 			'type'        => self::TYPE,
 			'icon'        => self::ICON,
-			'blog_id'     => get_current_blog_id(),
+			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(
 				/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -60,7 +60,7 @@ class NewOrderNotification extends Notification {
 		return array(
 			'type'        => self::TYPE,
 			'icon'        => self::ICON,
-			// This represents the time the notification was triggered, so we can monitor age of notification at  delivery.
+			// This represents the time the notification was triggered, so we can monitor age of notification at delivery.
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewOrderNotification.php
@@ -60,6 +60,10 @@ class NewOrderNotification extends Notification {
 		return array(
 			'type'        => self::TYPE,
 			'icon'        => self::ICON,
+			/**
+			 * This represents the time the notification was triggered, so we
+			 * can monitor age of notification at delivery.
+			 */
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -48,10 +48,7 @@ class NewReviewNotification extends Notification {
 
 		return array(
 			'type'        => self::TYPE,
-			/**
-			 * This represents the time the notification was triggered, so we
-			 * can monitor age of notification at delivery.
-			 */
+			// This represents the time the notification was triggered, so we can monitor age of notification at  delivery.
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -48,6 +48,10 @@ class NewReviewNotification extends Notification {
 
 		return array(
 			'type'        => self::TYPE,
+			/**
+			 * This represents the time the notification was triggered, so we
+			 * can monitor age of notification at delivery.
+			 */
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -48,7 +48,7 @@ class NewReviewNotification extends Notification {
 
 		return array(
 			'type'        => self::TYPE,
-			// This represents the time the notification was triggered, so we can monitor age of notification at  delivery.
+			// This represents the time the notification was triggered, so we can monitor age of notification at delivery.
 			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Notifications/NewReviewNotification.php
@@ -48,7 +48,7 @@ class NewReviewNotification extends Notification {
 
 		return array(
 			'type'        => self::TYPE,
-			'blog_id'     => get_current_blog_id(),
+			'timestamp'   => gmdate( 'c' ),
 			'resource_id' => $this->get_resource_id(),
 			'title'       => array(
 				'format' => 'You have a new review! ⭐️',

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -8,6 +8,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -8,7 +8,6 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
-use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -31,6 +31,9 @@ class PendingNotificationStore {
 	 * The dispatcher used to send notifications on shutdown.
 	 *
 	 * @var InternalNotificationDispatcher
+	 *
+	 * @phpstan-ignore property.onlyWritten (this will be read when the loopback
+	 * controller is added)
 	 */
 	private InternalNotificationDispatcher $dispatcher;
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -28,7 +28,7 @@ class PendingNotificationStore {
 	private bool $enabled = false;
 
 	/**
-	 * The dispatcher used to send notifications on shutdown.
+	 * The dispatcher that will be used to send notifications on shutdown.
 	 *
 	 * @var InternalNotificationDispatcher
 	 *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -106,10 +106,10 @@ class PendingNotificationStore {
 	}
 
 	/**
-	 * Dispatches all pending notifications by firing an action hook.
+	 * Dispatches all pending notifications via the loopback endpoint.
 	 *
-	 * Called on shutdown. Fires the `wc_push_notifications_dispatch` action
-	 * with the array of pending notifications, then clears the store.
+	 * Called on shutdown. Sends all pending notifications through the
+	 * InternalNotificationDispatcher, then clears the store.
 	 *
 	 * @return void
 	 *

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -6,12 +6,13 @@ namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 
 /**
  * Store that collects notifications during a request and dispatches them all on
- * on shutdown. Should be accessed from the container (`wc_get_container`) to
- * ensure store is shared by all usage.
+ * shutdown via the InternalNotificationDispatcher. Should be accessed from the
+ * container (`wc_get_container`) to ensure store is shared by all usage.
  *
  * Notifications are keyed by `{type}_{resource_id}` (with blog ID from
  * `get_current_blog_id()`) to prevent duplicates within a single request.
@@ -27,6 +28,13 @@ class PendingNotificationStore {
 	private bool $enabled = false;
 
 	/**
+	 * The dispatcher used to send notifications on shutdown.
+	 *
+	 * @var InternalNotificationDispatcher
+	 */
+	private InternalNotificationDispatcher $dispatcher;
+
+	/**
 	 * Pending notifications keyed by identifier.
 	 *
 	 * @var array<string, Notification>
@@ -39,6 +47,19 @@ class PendingNotificationStore {
 	 * @var bool
 	 */
 	private bool $shutdown_registered = false;
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @internal
+	 *
+	 * @param InternalNotificationDispatcher $dispatcher The dispatcher to use on shutdown.
+	 *
+	 * @since 10.7.0
+	 */
+	final public function init( InternalNotificationDispatcher $dispatcher ): void {
+		$this->dispatcher = $dispatcher;
+	}
 
 	/**
 	 * Enables the store so it accepts notifications.
@@ -99,17 +120,7 @@ class PendingNotificationStore {
 			return;
 		}
 
-		$notifications = array_values( $this->pending );
-
-		/**
-		 * Fires when pending push notifications are ready to be dispatched.
-		 *
-		 * @param Notification[] $notifications The notifications to dispatch.
-		 *
-		 * @since 10.7.0
-		 *
-		 * The call to dispatch the notifications will go here.
-		 */
+		$this->dispatcher->dispatch( array_values( $this->pending ) );
 
 		/**
 		 * Store is single-use per request lifecycle, so disable it and clear

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -120,7 +120,16 @@ class PendingNotificationStore {
 			return;
 		}
 
-		$this->dispatcher->dispatch( array_values( $this->pending ) );
+		/**
+		 * Fires when pending push notifications are ready to be dispatched.
+		 *
+		 * @param Notification[] $notifications The notifications to dispatch.
+		 *
+		 * @since 10.7.0
+		 *
+		 * The call to dispatch the notifications will go here when the
+		 * receiving controller has been added.
+		 */
 
 		/**
 		 * Store is single-use per request lifecycle, so disable it and clear

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcherTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Dispatchers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the InternalNotificationDispatcher class.
+ */
+class InternalNotificationDispatcherTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var InternalNotificationDispatcher
+	 */
+	private $sut;
+
+	/**
+	 * Captured HTTP request arguments from the last wp_remote_post call.
+	 *
+	 * @var array|null
+	 */
+	private $captured_request;
+
+	/**
+	 * Captured URL from the last wp_remote_post call.
+	 *
+	 * @var string|null
+	 */
+	private $captured_url;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut              = new InternalNotificationDispatcher();
+		$this->captured_request = null;
+		$this->captured_url     = null;
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Intercepts wp_remote_post calls and captures request data.
+	 *
+	 * @param false|array $preempt   Whether to preempt the request.
+	 * @param array       $args      Request arguments.
+	 * @param string      $url       Request URL.
+	 * @return array Fake successful response.
+	 */
+	public function intercept_http_request( $preempt, $args, $url ) {
+		unset( $preempt );
+		$this->captured_request = $args;
+		$this->captured_url     = $url;
+
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => '',
+		);
+	}
+
+	/**
+	 * @testdox Should fire POST to the send endpoint URL.
+	 */
+	public function test_dispatch_fires_post_to_send_endpoint(): void {
+		$notifications = array( $this->create_notification( 'store_order', 1 ) );
+
+		$this->sut->dispatch( $notifications );
+
+		$this->assertStringContainsString(
+			InternalNotificationDispatcher::SEND_ENDPOINT,
+			$this->captured_url,
+			'Request URL should contain the send endpoint'
+		);
+	}
+
+	/**
+	 * @testdox Should send a non-blocking request.
+	 */
+	public function test_dispatch_sends_non_blocking_request(): void {
+		$notifications = array( $this->create_notification( 'store_order', 1 ) );
+
+		$this->sut->dispatch( $notifications );
+
+		$this->assertFalse(
+			$this->captured_request['blocking'],
+			'Request should be non-blocking'
+		);
+	}
+
+	/**
+	 * @testdox Should include a valid JWT in the Authorization header.
+	 */
+	public function test_dispatch_includes_valid_jwt(): void {
+		$notifications = array( $this->create_notification( 'store_order', 1 ) );
+
+		$this->sut->dispatch( $notifications );
+
+		$auth_header = $this->captured_request['headers']['Authorization'];
+		$token       = str_replace( 'Bearer ', '', $auth_header );
+
+		$this->assertTrue(
+			JsonWebToken::validate( $token, wp_salt( 'auth' ) ),
+			'JWT should be valid when verified with the auth salt'
+		);
+	}
+
+	/**
+	 * @testdox Should include correct claims in the JWT.
+	 */
+	public function test_dispatch_jwt_contains_correct_claims(): void {
+		$notifications = array( $this->create_notification( 'store_order', 1 ) );
+
+		$this->sut->dispatch( $notifications );
+
+		$auth_header = $this->captured_request['headers']['Authorization'];
+		$token       = str_replace( 'Bearer ', '', $auth_header );
+		$parts       = JsonWebToken::get_parts( $token );
+
+		$this->assertSame( get_site_url(), $parts->payload->iss, 'JWT issuer should be the site URL' );
+		$this->assertGreaterThan( time(), (int) $parts->payload->exp, 'JWT should not be expired' );
+	}
+
+	/**
+	 * @testdox Should include a body hash in the JWT claims.
+	 */
+	public function test_dispatch_jwt_contains_body_hash(): void {
+		$notifications = array( $this->create_notification( 'store_order', 1 ) );
+
+		$this->sut->dispatch( $notifications );
+
+		$auth_header = $this->captured_request['headers']['Authorization'];
+		$token       = str_replace( 'Bearer ', '', $auth_header );
+		$parts       = JsonWebToken::get_parts( $token );
+		$body_hash   = hash( 'sha256', $this->captured_request['body'] );
+
+		$this->assertSame(
+			$body_hash,
+			$parts->payload->body_hash,
+			'JWT body_hash should match SHA-256 hash of the request body'
+		);
+	}
+
+	/**
+	 * @testdox Should include encoded notifications in the request body.
+	 */
+	public function test_dispatch_body_contains_encoded_notifications(): void {
+		$notifications = array(
+			$this->create_notification( 'store_order', 10 ),
+			$this->create_notification( 'store_review', 20 ),
+		);
+
+		$this->sut->dispatch( $notifications );
+
+		$body = json_decode( $this->captured_request['body'], true );
+
+		$this->assertArrayHasKey( 'notifications', $body );
+		$this->assertCount( 2, $body['notifications'] );
+		$this->assertSame( 'store_order', $body['notifications'][0]['type'] );
+		$this->assertSame( 10, $body['notifications'][0]['resource_id'] );
+		$this->assertSame( 'store_review', $body['notifications'][1]['type'] );
+		$this->assertSame( 20, $body['notifications'][1]['resource_id'] );
+	}
+
+	/**
+	 * @testdox Should skip dispatch when notifications array is empty.
+	 */
+	public function test_dispatch_skips_when_empty(): void {
+		$this->sut->dispatch( array() );
+
+		$this->assertNull( $this->captured_url, 'No HTTP request should be made for empty notifications' );
+	}
+
+	/**
+	 * Creates a concrete Notification instance for testing.
+	 *
+	 * @param string $type        The notification type.
+	 * @param int    $resource_id The resource ID.
+	 * @return Notification
+	 */
+	private function create_notification( string $type, int $resource_id ): Notification {
+		return new class( $type, $resource_id ) extends Notification {
+			/**
+			 * {@inheritDoc}
+			 */
+			public function to_payload(): ?array {
+				return array( 'test' => true );
+			}
+		};
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/InternalNotificationDispatcherTest.php
@@ -79,9 +79,9 @@ class InternalNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fire POST to the send endpoint URL.
+	 * @testdox Should fire a non-blocking POST to the send endpoint URL.
 	 */
-	public function test_dispatch_fires_post_to_send_endpoint(): void {
+	public function test_dispatch_fires_non_blocking_post_to_send_endpoint(): void {
 		$notifications = array( $this->create_notification( 'store_order', 1 ) );
 
 		$this->sut->dispatch( $notifications );
@@ -91,16 +91,6 @@ class InternalNotificationDispatcherTest extends WC_Unit_Test_Case {
 			$this->captured_url,
 			'Request URL should contain the send endpoint'
 		);
-	}
-
-	/**
-	 * @testdox Should send a non-blocking request.
-	 */
-	public function test_dispatch_sends_non_blocking_request(): void {
-		$notifications = array( $this->create_notification( 'store_order', 1 ) );
-
-		$this->sut->dispatch( $notifications );
-
 		$this->assertFalse(
 			$this->captured_request['blocking'],
 			'Request should be non-blocking'
@@ -108,9 +98,9 @@ class InternalNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include a valid JWT in the Authorization header.
+	 * @testdox Should include a valid JWT with correct claims and body hash.
 	 */
-	public function test_dispatch_includes_valid_jwt(): void {
+	public function test_dispatch_includes_valid_jwt_with_correct_claims(): void {
 		$notifications = array( $this->create_notification( 'store_order', 1 ) );
 
 		$this->sut->dispatch( $notifications );
@@ -122,37 +112,12 @@ class InternalNotificationDispatcherTest extends WC_Unit_Test_Case {
 			JsonWebToken::validate( $token, wp_salt( 'auth' ) ),
 			'JWT should be valid when verified with the auth salt'
 		);
-	}
 
-	/**
-	 * @testdox Should include correct claims in the JWT.
-	 */
-	public function test_dispatch_jwt_contains_correct_claims(): void {
-		$notifications = array( $this->create_notification( 'store_order', 1 ) );
-
-		$this->sut->dispatch( $notifications );
-
-		$auth_header = $this->captured_request['headers']['Authorization'];
-		$token       = str_replace( 'Bearer ', '', $auth_header );
-		$parts       = JsonWebToken::get_parts( $token );
+		$parts     = JsonWebToken::get_parts( $token );
+		$body_hash = hash( 'sha256', $this->captured_request['body'] );
 
 		$this->assertSame( get_site_url(), $parts->payload->iss, 'JWT issuer should be the site URL' );
 		$this->assertGreaterThan( time(), (int) $parts->payload->exp, 'JWT should not be expired' );
-	}
-
-	/**
-	 * @testdox Should include a body hash in the JWT claims.
-	 */
-	public function test_dispatch_jwt_contains_body_hash(): void {
-		$notifications = array( $this->create_notification( 'store_order', 1 ) );
-
-		$this->sut->dispatch( $notifications );
-
-		$auth_header = $this->captured_request['headers']['Authorization'];
-		$token       = str_replace( 'Bearer ', '', $auth_header );
-		$parts       = JsonWebToken::get_parts( $token );
-		$body_hash   = hash( 'sha256', $this->captured_request['body'] );
-
 		$this->assertSame(
 			$body_hash,
 			$parts->payload->body_hash,

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Dispatchers;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificationDispatcher;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use WC_Unit_Test_Case;
+use WP_Error;
+
+/**
+ * Tests for the WpcomNotificationDispatcher class.
+ */
+class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WpcomNotificationDispatcher
+	 */
+	private WpcomNotificationDispatcher $sut;
+
+	/**
+	 * The response to return from intercepted HTTP requests.
+	 *
+	 * @var array|WP_Error
+	 */
+	private $mock_response;
+
+	/**
+	 * Captured HTTP request arguments from the last intercepted call.
+	 *
+	 * @var array|null
+	 */
+	private ?array $captured_request;
+
+	/**
+	 * Captured URL from the last intercepted call.
+	 *
+	 * @var string|null
+	 */
+	private ?string $captured_url;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut              = new WpcomNotificationDispatcher();
+		$this->mock_response    = $this->make_response( 200 );
+		$this->captured_request = null;
+		$this->captured_url     = null;
+
+		add_filter( 'pre_option_jetpack_options', array( $this, 'filter_jetpack_options' ) );
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'filter_jetpack_private_options' ) );
+		add_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_option_jetpack_options', array( $this, 'filter_jetpack_options' ) );
+		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'filter_jetpack_private_options' ) );
+		remove_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns fake Jetpack options with a site ID.
+	 *
+	 * @return array
+	 */
+	public function filter_jetpack_options(): array {
+		return array( 'id' => 12345 );
+	}
+
+	/**
+	 * Returns fake Jetpack private options with a blog token.
+	 *
+	 * @return array
+	 */
+	public function filter_jetpack_private_options(): array {
+		return array( 'blog_token' => 'test.blogtokenvalue' );
+	}
+
+	/**
+	 * Intercepts HTTP requests and captures request data.
+	 *
+	 * @param false|array $preempt Whether to preempt the request.
+	 * @param array       $args    Request arguments.
+	 * @param string      $url     Request URL.
+	 * @return array|WP_Error The mock response.
+	 */
+	public function intercept_http_request( $preempt, $args, $url ) {
+		unset( $preempt );
+		$this->captured_request = $args;
+		$this->captured_url     = $url;
+		return $this->mock_response;
+	}
+
+	/**
+	 * @testdox Should return success on 200 response.
+	 */
+	public function test_dispatch_returns_success_on_200(): void {
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertTrue( $result['success'] );
+	}
+
+	/**
+	 * @testdox Should return failure on WP_Error response.
+	 */
+	public function test_dispatch_returns_failure_on_wp_error(): void {
+		$this->mock_response = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertFalse( $result['success'] );
+	}
+
+	/**
+	 * @testdox Should return failure on non-200 response.
+	 */
+	public function test_dispatch_returns_failure_on_non_200(): void {
+		$this->mock_response = $this->make_response( 500 );
+
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertFalse( $result['success'] );
+	}
+
+	/**
+	 * @testdox Should extract Retry-After header from response.
+	 */
+	public function test_dispatch_extracts_retry_after_header(): void {
+		$this->mock_response = $this->make_response( 429, array( 'retry-after' => '60' ) );
+
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 60, $result['retry_after'] );
+	}
+
+	/**
+	 * @testdox Should return null retry_after when header is missing.
+	 */
+	public function test_dispatch_returns_null_retry_after_when_missing(): void {
+		$this->mock_response = $this->make_response( 503 );
+
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertNull( $result['retry_after'] );
+	}
+
+	/**
+	 * @testdox Should return failure when Jetpack site ID is unavailable.
+	 */
+	public function test_dispatch_returns_failure_when_no_site_id(): void {
+		remove_filter( 'pre_option_jetpack_options', array( $this, 'filter_jetpack_options' ) );
+		add_filter( 'pre_option_jetpack_options', array( $this, 'filter_jetpack_options_empty' ) );
+
+		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		remove_filter( 'pre_option_jetpack_options', array( $this, 'filter_jetpack_options_empty' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertNull( $result['retry_after'] );
+		$this->assertNull( $this->captured_url, 'No HTTP request should be made' );
+	}
+
+	/**
+	 * @testdox Should return failure when notification payload is null.
+	 */
+	public function test_dispatch_returns_failure_when_payload_is_null(): void {
+		$notification = $this->create_notification( null );
+		$result       = $this->sut->dispatch( $notification, $this->create_tokens() );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertNull( $this->captured_url, 'No HTTP request should be made' );
+	}
+
+	/**
+	 * @testdox Should include notification payload and formatted tokens in the request body.
+	 */
+	public function test_dispatch_includes_payload_and_tokens_in_request_body(): void {
+		$notification = $this->create_notification( array( 'title' => 'New Order' ) );
+
+		$tokens = array(
+			new PushToken(
+				array(
+					'user_id'       => 1,
+					'token'         => 'abc123',
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+					'platform'      => PushToken::PLATFORM_APPLE,
+					'device_locale' => 'en_US',
+					'device_uuid'   => 'uuid-1',
+				)
+			),
+			new PushToken(
+				array(
+					'user_id'       => 2,
+					'token'         => 'def456',
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_ANDROID,
+					'platform'      => PushToken::PLATFORM_ANDROID,
+					'device_locale' => 'fr_FR',
+					'device_uuid'   => 'uuid-2',
+				)
+			),
+		);
+
+		$this->sut->dispatch( $notification, $tokens );
+
+		$body = json_decode( $this->captured_request['body'], true );
+
+		$this->assertSame( array( 'title' => 'New Order' ), $body['payload'] );
+		$this->assertCount( 2, $body['tokens'] );
+
+		$this->assertSame(
+			array(
+				'user_id'       => 1,
+				'token'         => 'abc123',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+				'device_locale' => 'en_US',
+			),
+			$body['tokens'][0]
+		);
+
+		$this->assertSame(
+			array(
+				'user_id'       => 2,
+				'token'         => 'def456',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_ANDROID,
+				'device_locale' => 'fr_FR',
+			),
+			$body['tokens'][1]
+		);
+	}
+
+	/**
+	 * @testdox Should include the send endpoint in the request URL.
+	 */
+	public function test_dispatch_fires_request_to_send_endpoint(): void {
+		$this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
+
+		$this->assertStringContainsString(
+			WpcomNotificationDispatcher::SEND_ENDPOINT,
+			$this->captured_url
+		);
+	}
+
+	/**
+	 * Returns fake Jetpack options without a site ID.
+	 *
+	 * @return array
+	 */
+	public function filter_jetpack_options_empty(): array {
+		return array();
+	}
+
+	/**
+	 * Creates a mock HTTP response array.
+	 *
+	 * @param int   $status_code HTTP status code.
+	 * @param array $headers     Response headers.
+	 * @return array
+	 */
+	private function make_response( int $status_code, array $headers = array() ): array {
+		return array(
+			'response' => array(
+				'code'    => $status_code,
+				'message' => 'Mock',
+			),
+			'body'     => '',
+			'headers'  => $headers,
+		);
+	}
+
+	/**
+	 * Creates a concrete Notification instance for testing.
+	 *
+	 * @param array|null $payload The payload to return from to_payload().
+	 * @return Notification
+	 */
+	private function create_notification( ?array $payload = array( 'test' => true ) ): Notification {
+		return new class( $payload ) extends Notification {
+			/** @var array|null */
+			private ?array $test_payload;
+
+			/**
+			 * @param array|null $payload The payload to return.
+			 */
+			public function __construct( ?array $payload ) {
+				parent::__construct( 'store_order', 1 );
+				$this->test_payload = $payload;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function to_payload(): ?array {
+				return $this->test_payload;
+			}
+		};
+	}
+
+	/**
+	 * Creates a default set of push tokens for tests that don't need specific token data.
+	 *
+	 * @return PushToken[]
+	 */
+	private function create_tokens(): array {
+		return array(
+			new PushToken(
+				array(
+					'user_id'       => 1,
+					'token'         => 'test-token',
+					'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+					'platform'      => PushToken::PLATFORM_APPLE,
+					'device_locale' => 'en_US',
+					'device_uuid'   => 'test-uuid',
+				)
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
@@ -123,38 +123,20 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should return failure on non-200 response.
+	 * @testdox Should return failure with correct retry_after for non-200 responses.
+	 * @dataProvider non_200_responses_provider
+	 *
+	 * @param int      $status_code    The HTTP status code.
+	 * @param int|null $expected_retry The expected retry_after value.
+	 * @param array    $headers        The response headers.
 	 */
-	public function test_dispatch_returns_failure_on_non_200(): void {
-		$this->mock_response = $this->make_response( 500 );
+	public function test_dispatch_handles_non_200_responses( int $status_code, ?int $expected_retry, array $headers ): void {
+		$this->mock_response = $this->make_response( $status_code, $headers );
 
 		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
 
 		$this->assertFalse( $result['success'] );
-	}
-
-	/**
-	 * @testdox Should extract Retry-After header from response.
-	 */
-	public function test_dispatch_extracts_retry_after_header(): void {
-		$this->mock_response = $this->make_response( 429, array( 'retry-after' => '60' ) );
-
-		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
-
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 60, $result['retry_after'] );
-	}
-
-	/**
-	 * @testdox Should return null retry_after when header is missing.
-	 */
-	public function test_dispatch_returns_null_retry_after_when_missing(): void {
-		$this->mock_response = $this->make_response( 503 );
-
-		$result = $this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
-
-		$this->assertFalse( $result['success'] );
-		$this->assertNull( $result['retry_after'] );
+		$this->assertSame( $expected_retry, $result['retry_after'] );
 	}
 
 	/**
@@ -185,9 +167,9 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include notification payload fields at the top level of the request body.
+	 * @testdox Should fire request to the send endpoint with payload and formatted tokens in the body.
 	 */
-	public function test_dispatch_includes_payload_fields_at_top_level(): void {
+	public function test_dispatch_sends_request_with_payload_and_tokens(): void {
 		$notification = $this->create_notification(
 			array(
 				'type'        => 'store_order',
@@ -196,20 +178,6 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->sut->dispatch( $notification, $this->create_tokens() );
-
-		$body = json_decode( $this->captured_request['body'], true );
-
-		$this->assertArrayNotHasKey( 'payload', $body );
-		$this->assertSame( 'store_order', $body['type'] );
-		$this->assertSame( array( 'format' => 'New Order' ), $body['title'] );
-		$this->assertSame( 1, $body['resource_id'] );
-	}
-
-	/**
-	 * @testdox Should include formatted tokens alongside payload fields in the request body.
-	 */
-	public function test_dispatch_includes_tokens_in_request_body(): void {
 		$tokens = array(
 			new PushToken(
 				array(
@@ -233,12 +201,21 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->sut->dispatch( $this->create_notification(), $tokens );
+		$this->sut->dispatch( $notification, $tokens );
+
+		$this->assertStringContainsString(
+			WpcomNotificationDispatcher::SEND_ENDPOINT,
+			$this->captured_url
+		);
 
 		$body = json_decode( $this->captured_request['body'], true );
 
-		$this->assertCount( 2, $body['tokens'] );
+		$this->assertArrayNotHasKey( 'payload', $body );
+		$this->assertSame( 'store_order', $body['type'] );
+		$this->assertSame( array( 'format' => 'New Order' ), $body['title'] );
+		$this->assertSame( 1, $body['resource_id'] );
 
+		$this->assertCount( 2, $body['tokens'] );
 		$this->assertSame(
 			array(
 				'user_id'       => 1,
@@ -248,7 +225,6 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 			),
 			$body['tokens'][0]
 		);
-
 		$this->assertSame(
 			array(
 				'user_id'       => 2,
@@ -261,24 +237,25 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include the send endpoint in the request URL.
-	 */
-	public function test_dispatch_fires_request_to_send_endpoint(): void {
-		$this->sut->dispatch( $this->create_notification(), $this->create_tokens() );
-
-		$this->assertStringContainsString(
-			WpcomNotificationDispatcher::SEND_ENDPOINT,
-			$this->captured_url
-		);
-	}
-
-	/**
 	 * Returns fake Jetpack options without a site ID.
 	 *
 	 * @return array
 	 */
 	public function filter_jetpack_options_empty(): array {
 		return array();
+	}
+
+	/**
+	 * Data provider for non-200 response scenarios.
+	 *
+	 * @return array<string, array{int, int|null, array}>
+	 */
+	public function non_200_responses_provider(): array {
+		return array(
+			'500 without retry-after' => array( 500, null, array() ),
+			'429 with retry-after'    => array( 429, 60, array( 'retry-after' => '60' ) ),
+			'503 without retry-after' => array( 503, null, array() ),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Dispatchers/WpcomNotificationDispatcherTest.php
@@ -185,11 +185,31 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should include notification payload and formatted tokens in the request body.
+	 * @testdox Should include notification payload fields at the top level of the request body.
 	 */
-	public function test_dispatch_includes_payload_and_tokens_in_request_body(): void {
-		$notification = $this->create_notification( array( 'title' => 'New Order' ) );
+	public function test_dispatch_includes_payload_fields_at_top_level(): void {
+		$notification = $this->create_notification(
+			array(
+				'type'        => 'store_order',
+				'title'       => array( 'format' => 'New Order' ),
+				'resource_id' => 1,
+			)
+		);
 
+		$this->sut->dispatch( $notification, $this->create_tokens() );
+
+		$body = json_decode( $this->captured_request['body'], true );
+
+		$this->assertArrayNotHasKey( 'payload', $body );
+		$this->assertSame( 'store_order', $body['type'] );
+		$this->assertSame( array( 'format' => 'New Order' ), $body['title'] );
+		$this->assertSame( 1, $body['resource_id'] );
+	}
+
+	/**
+	 * @testdox Should include formatted tokens alongside payload fields in the request body.
+	 */
+	public function test_dispatch_includes_tokens_in_request_body(): void {
 		$tokens = array(
 			new PushToken(
 				array(
@@ -213,11 +233,10 @@ class WpcomNotificationDispatcherTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->sut->dispatch( $notification, $tokens );
+		$this->sut->dispatch( $this->create_notification(), $tokens );
 
 		$body = json_decode( $this->captured_request['body'], true );
 
-		$this->assertSame( array( 'title' => 'New Order' ), $body['payload'] );
 		$this->assertCount( 2, $body['tokens'] );
 
 		$this->assertSame(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewOrderNotificationTest.php
@@ -22,7 +22,7 @@ class NewOrderNotificationTest extends WC_Unit_Test_Case {
 		$payload = $notification->to_payload();
 
 		$this->assertArrayHasKey( 'type', $payload );
-		$this->assertArrayHasKey( 'blog_id', $payload );
+		$this->assertArrayHasKey( 'timestamp', $payload );
 		$this->assertArrayHasKey( 'resource_id', $payload );
 		$this->assertArrayHasKey( 'title', $payload );
 		$this->assertArrayHasKey( 'format', $payload['title'] );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Notifications/NewReviewNotificationTest.php
@@ -23,7 +23,7 @@ class NewReviewNotificationTest extends WC_Unit_Test_Case {
 		$payload      = $notification->to_payload();
 
 		$this->assertArrayHasKey( 'type', $payload );
-		$this->assertArrayHasKey( 'blog_id', $payload );
+		$this->assertArrayHasKey( 'timestamp', $payload );
 		$this->assertArrayHasKey( 'resource_id', $payload );
 		$this->assertArrayHasKey( 'title', $payload );
 		$this->assertArrayHasKey( 'format', $payload['title'] );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/PendingNotificationStoreTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
 
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use WC_Unit_Test_Case;
@@ -26,7 +27,10 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		$dispatcher  = $this->createMock( InternalNotificationDispatcher::class );
 		$this->store = new PendingNotificationStore();
+
+		$this->store->init( $dispatcher );
 		$this->store->register();
 	}
 
@@ -92,7 +96,9 @@ class PendingNotificationStoreTest extends WC_Unit_Test_Case {
 	 * @testdox Should not add notifications when store has not been registered.
 	 */
 	public function test_add_does_nothing_when_not_registered(): void {
-		$store = new PendingNotificationStore();
+		$dispatcher = $this->createMock( InternalNotificationDispatcher::class );
+		$store      = new PendingNotificationStore();
+		$store->init( $dispatcher );
 
 		$store->add( $this->create_notification( 'store_order', 42 ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
 
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use WC_Order;

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewOrderNotificationTriggerTest.php
@@ -33,7 +33,10 @@ class NewOrderNotificationTriggerTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		$dispatcher  = $this->createMock( InternalNotificationDispatcher::class );
 		$this->store = new PendingNotificationStore();
+
+		$this->store->init( $dispatcher );
 		$this->store->register();
 
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Triggers/NewReviewNotificationTriggerTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Triggers;
 
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\InternalNotificationDispatcher;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
 use WC_Helper_Product;
@@ -40,7 +41,10 @@ class NewReviewNotificationTriggerTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		$dispatcher  = $this->createMock( InternalNotificationDispatcher::class );
 		$this->store = new PendingNotificationStore();
+
+		$this->store->init( $dispatcher );
 		$this->store->register();
 
 		wc_get_container()->replace( PendingNotificationStore::class, $this->store );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-1799
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change adds the dispatcher classes that will call the internal loopback endpoint, and the WPCOM send endpoint.

**Key requirements:**
* Add `InternalNotificationDispatcher` which will call the `PushNotificationRestController` endpoint in the shutdown hook of the request
    * Essentially functions as a means to kick off an async process to handle the sending, ensuring the user isn't waiting for the notifications to be sent before the request is complete
    * `PushNotificationRestController` will follow in future PR
    * The `ActionScheduler` backup functionality will also follow if a future PR (this will ensure notification is sent if shutdown hook fails to run properly)
* Add `WpcomNotificationDispatcher` which will call the WPCOM endpoint to actually send the notification

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
These new files are not yet used so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack installed and connected
- You have at least 2 test users with `shop_manager` or `administrator` roles
- You have a tool to make HTTP requests (e.g. Postman, curl, or browser REST client)
- You are authenticated as one of your test users when making requests

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

#### 1. Create token

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Request body:
```
{
  "token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  // or "APA91bG4_bGjn7tuU70RAy8EeusXytfv6QYlAbmQG9q-4isZYsm6CLQul2s2lyVK7BPPb6YlxHpml-A4OtBSS9g8O1X0FNeL8nuuz2PsJhM3mvVwXyLnsbfvEVlH_jG6culdaTSTJV0izz-QD-9PbGi6YRTK0vmFiA"
  "platform": "apple", // or "android"
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce", // or "com.woocommerce.android",
  "device_locale": "en_US"
}
```

**Expected result:**
* Status: 201 Created
* Response contains an id field with the created token ID
* Note this ID for later scenarios

#### 2. Update token

Endpoint: `POST /wp-json/wc-push-notifications/push-tokens`

Use the same device_uuid from scenario 1 but with a different token value:

Request body:
```
{
  "token": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
  "platform": "apple",
  "device_uuid": "ABCDEF-123ABC-DEF123-ABCDEF-1234",
  "origin": "com.automattic.woocommerce",
  "device_locale": "en_US"
}
```

**Expected result:**
- Status: 201 Created
- Response contains an id field with the updated token ID

#### 3. Delete tokens

Endpoint: `DELETE /wp-json/wc-push-notifications/push-tokens/{id}`

Use the token ID from scenario 1

**Expected result:**
- Status: 204 No Content
- No response body

Try to delete the same token ID again

**Expected result:**
- Status: 404 Not Found
- Error message: "Push token could not be found."

#### 4. Other

- Ensure your WooCommerce install functions as expected, e.g.:
  - Add a product to cart
  - View WooCommerce settings in WP Admin
  - View WooCommerce orders in WP Admin
- Make an authenticated request to the API to ensure this works as expected, e.g.:
  - https://YOUR_URL/wp-json/wc-admin/features
  - https://YOUR_URL/wp-json/wc/v3/settings
  - https://YOUR_URL/wp-json/wc/v3/customers


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
