### PR TITLE
fix: place new gateways above offline PMs in payment settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6189-gateway-ordering
+++ b/plugins/woocommerce/changelog/fix-wooplug-6189-gateway-ordering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Place newly installed payment gateways above offline payment methods instead of at the bottom of the list.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -136,9 +136,22 @@ class Payments {
 
 		foreach ( $payment_gateways as $payment_gateway ) {
 			// Determine the gateway's order value.
-			// If we don't have an order for it, add it to the end.
+			// If we don't have an order for it, place it above offline PMs if the offline group
+			// is still at the bottom (default ordering). Otherwise, add to the end.
 			if ( ! isset( $providers_order_map[ $payment_gateway->id ] ) ) {
-				$providers_order_map = Utils::order_map_add_at_order( $providers_order_map, $payment_gateway->id, count( $payment_providers ) );
+				if ( $this->providers->is_offline_group_last( $providers_order_map ) ) {
+					$providers_order_map = Utils::order_map_add_at_order(
+						$providers_order_map,
+						$payment_gateway->id,
+						$providers_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ]
+					);
+				} else {
+					$providers_order_map = Utils::order_map_add_at_order(
+						$providers_order_map,
+						$payment_gateway->id,
+						count( $payment_providers )
+					);
+				}
 			}
 
 			$payment_providers[] = $this->providers->get_payment_gateway_details(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -139,19 +139,7 @@ class Payments {
 			// If we don't have an order for it, place it above offline PMs if the offline group
 			// is still at the bottom (default ordering). Otherwise, add to the end.
 			if ( ! isset( $providers_order_map[ $payment_gateway->id ] ) ) {
-				if ( $this->providers->is_offline_group_last( $providers_order_map ) ) {
-					$providers_order_map = Utils::order_map_add_at_order(
-						$providers_order_map,
-						$payment_gateway->id,
-						$providers_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ]
-					);
-				} else {
-					$providers_order_map = Utils::order_map_add_at_order(
-						$providers_order_map,
-						$payment_gateway->id,
-						empty( $providers_order_map ) ? 0 : max( $providers_order_map ) + 1
-					);
-				}
+				$providers_order_map = $this->providers->order_map_add_gateway( $providers_order_map, $payment_gateway->id );
 			}
 
 			$payment_providers[] = $this->providers->get_payment_gateway_details(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -149,7 +149,7 @@ class Payments {
 					$providers_order_map = Utils::order_map_add_at_order(
 						$providers_order_map,
 						$payment_gateway->id,
-						count( $payment_providers )
+						empty( $providers_order_map ) ? 0 : max( $providers_order_map ) + 1
 					);
 				}
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -561,6 +561,41 @@ class PaymentsProviders {
 	}
 
 	/**
+	 * Check if the offline payment methods group is the last non-offline entry in an order map.
+	 *
+	 * This is used to detect whether the merchant has customized the provider ordering.
+	 * If the offline group is still at the bottom (its default position), new gateways
+	 * should be inserted above it. If the merchant has moved it, we respect their layout
+	 * and append new gateways at the end.
+	 *
+	 * @param array $order_map The payment providers order map.
+	 *
+	 * @return bool True if the offline group is the last non-offline entry, false otherwise.
+	 */
+	public function is_offline_group_last( array $order_map ): bool {
+		if ( ! isset( $order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ] ) ) {
+			return false;
+		}
+
+		$offline_group_order = $order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ];
+
+		// Check if any non-offline entry has an order higher than the offline group.
+		foreach ( $order_map as $id => $order ) {
+			if ( self::OFFLINE_METHODS_ORDERING_GROUP === $id ) {
+				continue;
+			}
+			if ( $this->is_offline_payment_method( $id ) ) {
+				continue;
+			}
+			if ( $order > $offline_group_order ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Check if a payment gateway is a shell payment gateway.
 	 *
 	 * A shell payment gateway is generally one that has no method title or description.
@@ -1057,8 +1092,17 @@ class PaymentsProviders {
 				}
 			}
 
-			// Add the missing payment gateway at the end.
-			$order_map[ $id ] = empty( $order_map ) ? 0 : max( $order_map ) + 1;
+			// If the offline PMs group is the last non-offline entry, place above it.
+			// Otherwise (custom ordering or no offline group), place at the end.
+			if ( $this->is_offline_group_last( $order_map ) ) {
+				$order_map = Utils::order_map_add_at_order(
+					$order_map,
+					$id,
+					$order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ]
+				);
+			} else {
+				$order_map[ $id ] = empty( $order_map ) ? 0 : max( $order_map ) + 1;
+			}
 		}
 
 		$handled_suggestion_ids = array_unique( $handled_suggestion_ids );

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -1101,7 +1101,7 @@ class PaymentsProviders {
 					$order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ]
 				);
 			} else {
-				$order_map[ $id ] = empty( $order_map ) ? 0 : max( $order_map ) + 1;
+				$order_map = Utils::order_map_add_at_order( $order_map, $id, empty( $order_map ) ? 0 : max( $order_map ) + 1 );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -579,12 +579,15 @@ class PaymentsProviders {
 
 		$offline_group_order = $order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ];
 
-		// Check if any non-offline entry has an order higher than the offline group.
+		// Check if any non-offline, non-suggestion entry has an order higher than the offline group.
 		foreach ( $order_map as $id => $order ) {
 			if ( self::OFFLINE_METHODS_ORDERING_GROUP === $id ) {
 				continue;
 			}
 			if ( $this->is_offline_payment_method( $id ) ) {
+				continue;
+			}
+			if ( $this->is_suggestion_order_map_id( $id ) ) {
 				continue;
 			}
 			if ( $order > $offline_group_order ) {
@@ -593,6 +596,32 @@ class PaymentsProviders {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Add a new gateway to an order map with offline-awareness.
+	 *
+	 * If the offline payment methods group is the last non-offline, non-suggestion entry,
+	 * the gateway is placed above it. Otherwise, it is appended at the end.
+	 *
+	 * This is the single source of truth for new gateway placement logic,
+	 * used by both the display path (Payments) and the persistence path (enhance_order_map).
+	 *
+	 * @param array  $order_map The payment providers order map.
+	 * @param string $id        The gateway ID to add.
+	 *
+	 * @return array The updated order map.
+	 */
+	public function order_map_add_gateway( array $order_map, string $id ): array {
+		if ( $this->is_offline_group_last( $order_map ) ) {
+			return Utils::order_map_add_at_order(
+				$order_map,
+				$id,
+				$order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ]
+			);
+		}
+
+		return Utils::order_map_add_at_order( $order_map, $id, empty( $order_map ) ? 0 : max( $order_map ) + 1 );
 	}
 
 	/**
@@ -1094,15 +1123,7 @@ class PaymentsProviders {
 
 			// If the offline PMs group is the last non-offline entry, place above it.
 			// Otherwise (custom ordering or no offline group), place at the end.
-			if ( $this->is_offline_group_last( $order_map ) ) {
-				$order_map = Utils::order_map_add_at_order(
-					$order_map,
-					$id,
-					$order_map[ self::OFFLINE_METHODS_ORDERING_GROUP ]
-				);
-			} else {
-				$order_map = Utils::order_map_add_at_order( $order_map, $id, empty( $order_map ) ? 0 : max( $order_map ) + 1 );
-			}
+			$order_map = $this->order_map_add_gateway( $order_map, $id );
 		}
 
 		$handled_suggestion_ids = array_unique( $handled_suggestion_ids );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -5976,12 +5976,12 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 			),
 			'offline group is last'                 => array(
 				array(
-					'gateway1' => 0,
-					'gateway2' => 1,
+					'gateway1'            => 0,
+					'gateway2'            => 1,
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 2,
-					'bacs'     => 3,
-					'cheque'   => 4,
-					'cod'      => 5,
+					WC_Gateway_BACS::ID   => 3,
+					WC_Gateway_Cheque::ID => 4,
+					WC_Gateway_COD::ID    => 5,
 				),
 				true,
 			),
@@ -5995,30 +5995,30 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 			),
 			'gateway after offline group'           => array(
 				array(
-					'gateway1' => 0,
+					'gateway1'            => 0,
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
-					'bacs'     => 2,
-					'cheque'   => 3,
-					'cod'      => 4,
-					'gateway2' => 5,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
+					'gateway2'            => 5,
 				),
 				false,
 			),
 			'offline group at start'                => array(
 				array(
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
-					'bacs'     => 1,
-					'cheque'   => 2,
-					'cod'      => 3,
-					'gateway1' => 4,
+					WC_Gateway_BACS::ID   => 1,
+					WC_Gateway_Cheque::ID => 2,
+					WC_Gateway_COD::ID    => 3,
+					'gateway1'            => 4,
 				),
 				false,
 			),
 			'only offline group and offline PMs'    => array(
 				array(
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
-					'bacs'   => 1,
-					'cheque' => 2,
+					WC_Gateway_BACS::ID   => 1,
+					WC_Gateway_Cheque::ID => 2,
 				),
 				true,
 			),
@@ -6036,13 +6036,11 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 	 *
 	 * @param array    $gateway_ids     The gateway IDs to register.
 	 * @param array    $start_order_map The starting order map.
-	 * @param string   $new_gateway_id  The new gateway ID (present in gateway_ids but missing from start_order_map).
 	 * @param string[] $expected_order  The expected order of IDs after enhancement.
 	 */
 	public function test_enhance_order_map_new_gateway_placement(
 		array $gateway_ids,
 		array $start_order_map,
-		string $new_gateway_id,
 		array $expected_order
 	) {
 		// Mock payment gateways — all gateways including the new one are registered.
@@ -6085,41 +6083,38 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				array( 'gateway1', 'stripe', 'bacs', 'cheque', 'cod' ),
 				// start_order_map: existing map WITHOUT the new gateway.
 				array(
-					'gateway1' => 0,
+					'gateway1'            => 0,
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
-					'bacs'     => 2,
-					'cheque'   => 3,
-					'cod'      => 4,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
 				),
-				// new_gateway_id.
-				'stripe',
 				// expected_order: stripe should be above offline group.
-				array( 'gateway1', 'stripe', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod' ),
+				array( 'gateway1', 'stripe', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, WC_Gateway_BACS::ID, WC_Gateway_Cheque::ID, WC_Gateway_COD::ID ),
 			),
 			'new gateway placed at end (custom ordering — offline group not last)' => array(
 				array( 'gateway1', 'stripe', 'bacs', 'cheque', 'cod' ),
 				array(
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
-					'bacs'     => 1,
-					'cheque'   => 2,
-					'cod'      => 3,
-					'gateway1' => 4,
+					WC_Gateway_BACS::ID   => 1,
+					WC_Gateway_Cheque::ID => 2,
+					WC_Gateway_COD::ID    => 3,
+					'gateway1'            => 4,
 				),
-				'stripe',
 				// expected_order: stripe at the end since offline group is not last.
-				array( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod', 'gateway1', 'stripe' ),
+				array( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, WC_Gateway_BACS::ID, WC_Gateway_Cheque::ID, WC_Gateway_COD::ID, 'gateway1', 'stripe' ),
 			),
 			'multiple new gateways placed above offline group'            => array(
 				array( 'gateway1', 'stripe', 'paypal', 'bacs', 'cheque', 'cod' ),
 				array(
-					'gateway1' => 0,
+					'gateway1'            => 0,
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
-					'bacs'     => 2,
-					'cheque'   => 3,
-					'cod'      => 4,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
 				),
-				'stripe', // We only check stripe here, paypal is also new.
-				array( 'gateway1', 'stripe', 'paypal', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod' ),
+				// expected_order: both stripe and paypal should be above offline group.
+				array( 'gateway1', 'stripe', 'paypal', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, WC_Gateway_BACS::ID, WC_Gateway_Cheque::ID, WC_Gateway_COD::ID ),
 			),
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -6028,6 +6028,17 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				),
 				true,
 			),
+			'suggestion after offline group'        => array(
+				array(
+					'gateway1'            => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
+					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'suggestion1' => 5,
+				),
+				true,
+			),
 		);
 	}
 
@@ -6115,6 +6126,14 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				),
 				// expected_order: both stripe and paypal should be above offline group.
 				array( 'gateway1', 'stripe', 'paypal', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, WC_Gateway_BACS::ID, WC_Gateway_Cheque::ID, WC_Gateway_COD::ID ),
+			),
+			'new gateway placed at end (no offline group in map)'          => array(
+				array( 'gateway1', 'stripe' ),
+				array(
+					'gateway1' => 0,
+				),
+				// expected_order: stripe at the end since there is no offline group.
+				array( 'gateway1', 'stripe' ),
 			),
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -3062,15 +3062,16 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				array(
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
 				),
+				// New gateways are placed above the offline group (default ordering).
 				array(
-					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
-					WC_Gateway_BACS::ID,
-					WC_Gateway_Cheque::ID,
-					WC_Gateway_COD::ID,
 					'gateway1',
 					'gateway2',
 					'gateway3_0',
 					'gateway3_1',
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
+					WC_Gateway_BACS::ID,
+					WC_Gateway_Cheque::ID,
+					WC_Gateway_COD::ID,
 				),
 				$gateways + $offline_payment_methods_gateways,
 				array(),
@@ -3080,17 +3081,18 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				array(
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
 				),
+				// New gateways (and their suggestions) are placed above the offline group (default ordering).
 				array(
-					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
-					WC_Gateway_BACS::ID,
-					WC_Gateway_Cheque::ID,
-					WC_Gateway_COD::ID,
 					'_wc_pes_suggestion1',
 					'gateway1',
 					'gateway2',
 					'_wc_pes_suggestion3',
 					'gateway3_0',
 					'gateway3_1',
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
+					WC_Gateway_BACS::ID,
+					WC_Gateway_Cheque::ID,
+					WC_Gateway_COD::ID,
 				),
 				$gateways + $offline_payment_methods_gateways,
 				$suggestions,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -5943,4 +5943,182 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 
 		$this->sut->reset_memo();
 	}
+
+	/**
+	 * @dataProvider data_provider_is_offline_group_last
+	 *
+	 * @param array $order_map The order map to test.
+	 * @param bool  $expected  Whether the offline group should be considered last.
+	 */
+	public function test_is_offline_group_last( array $order_map, bool $expected ) {
+		$sut = $this->sut;
+
+		$this->assertSame( $expected, $sut->is_offline_group_last( $order_map ) );
+	}
+
+	/**
+	 * Data provider for test_is_offline_group_last.
+	 */
+	public function data_provider_is_offline_group_last(): array {
+		return array(
+			'empty order map'                       => array(
+				array(),
+				false,
+			),
+			'no offline group in map'               => array(
+				array(
+					'gateway1' => 0,
+					'gateway2' => 1,
+				),
+				false,
+			),
+			'offline group is last'                 => array(
+				array(
+					'gateway1' => 0,
+					'gateway2' => 1,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 2,
+					'bacs'     => 3,
+					'cheque'   => 4,
+					'cod'      => 5,
+				),
+				true,
+			),
+			'offline group is last, no offline PMs' => array(
+				array(
+					'gateway1' => 0,
+					'gateway2' => 1,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 2,
+				),
+				true,
+			),
+			'gateway after offline group'           => array(
+				array(
+					'gateway1' => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					'bacs'     => 2,
+					'cheque'   => 3,
+					'cod'      => 4,
+					'gateway2' => 5,
+				),
+				false,
+			),
+			'offline group at start'                => array(
+				array(
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
+					'bacs'     => 1,
+					'cheque'   => 2,
+					'cod'      => 3,
+					'gateway1' => 4,
+				),
+				false,
+			),
+			'only offline group and offline PMs'    => array(
+				array(
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
+					'bacs'   => 1,
+					'cheque' => 2,
+				),
+				true,
+			),
+			'only offline group'                    => array(
+				array(
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
+				),
+				true,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_provider_enhance_order_map_new_gateway_placement
+	 *
+	 * @param array    $gateway_ids     The gateway IDs to register.
+	 * @param array    $start_order_map The starting order map.
+	 * @param string   $new_gateway_id  The new gateway ID (present in gateway_ids but missing from start_order_map).
+	 * @param string[] $expected_order  The expected order of IDs after enhancement.
+	 */
+	public function test_enhance_order_map_new_gateway_placement(
+		array $gateway_ids,
+		array $start_order_map,
+		string $new_gateway_id,
+		array $expected_order
+	) {
+		// Mock payment gateways — all gateways including the new one are registered.
+		$this->mock_payment_gateways(
+			array_combine(
+				$gateway_ids,
+				array_map(
+					function () {
+						return array( 'enabled' => true );
+					},
+					$gateway_ids
+				)
+			)
+		);
+		// No suggestions for any gateway.
+		$this->mock_extension_suggestions
+			->expects( $this->any() )
+			->method( 'get_by_plugin_slug' )
+			->willReturn( null );
+
+		$sut = $this->sut;
+
+		$result = $sut->enhance_order_map( $start_order_map );
+
+		// Extract the order — keys sorted by value.
+		$actual_order = array_keys( $result );
+		// Filter to only the IDs we care about for assertion clarity.
+		$actual_order = array_values( array_intersect( $actual_order, $expected_order ) );
+
+		$this->assertSame( $expected_order, $actual_order );
+	}
+
+	/**
+	 * Data provider for test_enhance_order_map_new_gateway_placement.
+	 */
+	public function data_provider_enhance_order_map_new_gateway_placement(): array {
+		return array(
+			'new gateway placed above offline group (default ordering)'    => array(
+				// gateway_ids: all registered gateways.
+				array( 'gateway1', 'stripe', 'bacs', 'cheque', 'cod' ),
+				// start_order_map: existing map WITHOUT the new gateway.
+				array(
+					'gateway1' => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					'bacs'     => 2,
+					'cheque'   => 3,
+					'cod'      => 4,
+				),
+				// new_gateway_id.
+				'stripe',
+				// expected_order: stripe should be above offline group.
+				array( 'gateway1', 'stripe', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod' ),
+			),
+			'new gateway placed at end (custom ordering — offline group not last)' => array(
+				array( 'gateway1', 'stripe', 'bacs', 'cheque', 'cod' ),
+				array(
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
+					'bacs'     => 1,
+					'cheque'   => 2,
+					'cod'      => 3,
+					'gateway1' => 4,
+				),
+				'stripe',
+				// expected_order: stripe at the end since offline group is not last.
+				array( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod', 'gateway1', 'stripe' ),
+			),
+			'multiple new gateways placed above offline group'            => array(
+				array( 'gateway1', 'stripe', 'paypal', 'bacs', 'cheque', 'cod' ),
+				array(
+					'gateway1' => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					'bacs'     => 2,
+					'cheque'   => 3,
+					'cod'      => 4,
+				),
+				'stripe', // We only check stripe here, paypal is also new.
+				array( 'gateway1', 'stripe', 'paypal', PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, 'bacs', 'cheque', 'cod' ),
+			),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -651,15 +651,10 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
 
-		// Assert: stripe should be between gateway1 and the offline group.
-		$ids               = array_keys( $captured_order_map );
-		$stripe_pos        = array_search( 'stripe', $ids, true );
-		$offline_group_pos = array_search( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, $ids, true );
-		$gateway1_pos      = array_search( 'gateway1', $ids, true );
-
-		$this->assertNotFalse( $stripe_pos, 'stripe should be in the order map' );
-		$this->assertGreaterThan( $gateway1_pos, $stripe_pos, 'stripe should be after gateway1' );
-		$this->assertLessThan( $offline_group_pos, $stripe_pos, 'stripe should be before the offline group' );
+		// Assert: stripe should be between gateway1 and the offline group (compare order values).
+		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
+		$this->assertGreaterThan( $captured_order_map['gateway1'], $captured_order_map['stripe'], 'stripe should be after gateway1' );
+		$this->assertLessThan( $captured_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ], $captured_order_map['stripe'], 'stripe should be before the offline group' );
 	}
 
 	/**
@@ -717,12 +712,13 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
 
-		// Assert: stripe should be at the end (after gateway1).
-		$ids          = array_keys( $captured_order_map );
-		$stripe_pos   = array_search( 'stripe', $ids, true );
-		$gateway1_pos = array_search( 'gateway1', $ids, true );
-
-		$this->assertNotFalse( $stripe_pos, 'stripe should be in the order map' );
-		$this->assertGreaterThan( $gateway1_pos, $stripe_pos, 'stripe should be after gateway1 (at the end)' );
+		// Assert: stripe should NOT be placed at the offline group's position (above-offline logic not triggered).
+		// In the custom ordering fallback, stripe is placed at count($payment_providers) — the old behavior.
+		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
+		$this->assertGreaterThan(
+			$captured_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ],
+			$captured_order_map['stripe'],
+			'stripe should not be placed before the offline group'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -719,12 +719,17 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $data );
 
 		// Assert: stripe should NOT be placed at the offline group's position (above-offline logic not triggered).
-		// In the custom ordering fallback, stripe is placed at count($payment_providers) — the old behavior.
+		// In the custom ordering fallback, stripe is placed at the end — after all existing gateways.
 		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
 		$this->assertGreaterThan(
 			$captured_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ],
 			$captured_order_map['stripe'],
 			'stripe should not be placed before the offline group'
+		);
+		$this->assertGreaterThan(
+			$captured_order_map['gateway1'],
+			$captured_order_map['stripe'],
+			'stripe should be after all non-offline gateways'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -630,17 +630,11 @@ class PaymentsTest extends WC_Unit_Test_Case {
 				)
 			);
 
-		// Pass through the order map so we can verify the loop's placement.
-		$captured_order_map = null;
+		// Pass through the order map unchanged.
 		$this->mock_providers
 			->expects( $this->any() )
 			->method( 'enhance_order_map' )
-			->willReturnCallback(
-				function ( $order_map ) use ( &$captured_order_map ) {
-					$captured_order_map = $order_map;
-					return $order_map;
-				}
-			);
+			->willReturnArgument( 0 );
 
 		$this->mock_providers
 			->expects( $this->any() )
@@ -651,13 +645,16 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
 
-		// Verify providers were returned.
-		$this->assertNotEmpty( $data );
+		// Assert: stripe should appear between gateway1 and the offline group in the final sorted output.
+		$provider_ids        = array_column( $data, 'id' );
+		$stripe_index        = array_search( 'stripe', $provider_ids, true );
+		$gateway1_index      = array_search( 'gateway1', $provider_ids, true );
+		$offline_group_index = array_search( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, $provider_ids, true );
 
-		// Assert: stripe should be between gateway1 and the offline group (compare order values).
-		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
-		$this->assertGreaterThan( $captured_order_map['gateway1'], $captured_order_map['stripe'], 'stripe should be after gateway1' );
-		$this->assertLessThan( $captured_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ], $captured_order_map['stripe'], 'stripe should be before the offline group' );
+		$this->assertNotFalse( $stripe_index, 'stripe should be in the providers list' );
+		$this->assertNotFalse( $offline_group_index, 'offline group should be in the providers list' );
+		$this->assertGreaterThan( $gateway1_index, $stripe_index, 'stripe should be after gateway1' );
+		$this->assertLessThan( $offline_group_index, $stripe_index, 'stripe should be before the offline group' );
 	}
 
 	/**
@@ -694,17 +691,11 @@ class PaymentsTest extends WC_Unit_Test_Case {
 				)
 			);
 
-		// Pass through the order map.
-		$captured_order_map = null;
+		// Pass through the order map unchanged.
 		$this->mock_providers
 			->expects( $this->any() )
 			->method( 'enhance_order_map' )
-			->willReturnCallback(
-				function ( $order_map ) use ( &$captured_order_map ) {
-					$captured_order_map = $order_map;
-					return $order_map;
-				}
-			);
+			->willReturnArgument( 0 );
 
 		$this->mock_providers
 			->expects( $this->any() )
@@ -715,21 +706,14 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
 
-		// Verify providers were returned.
-		$this->assertNotEmpty( $data );
+		// Assert: stripe should be at the end — after all existing gateways (custom ordering fallback).
+		$provider_ids   = array_column( $data, 'id' );
+		$stripe_index   = array_search( 'stripe', $provider_ids, true );
+		$gateway1_index = array_search( 'gateway1', $provider_ids, true );
 
-		// Assert: stripe should NOT be placed at the offline group's position (above-offline logic not triggered).
-		// In the custom ordering fallback, stripe is placed at the end — after all existing gateways.
-		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
-		$this->assertGreaterThan(
-			$captured_order_map[ PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP ],
-			$captured_order_map['stripe'],
-			'stripe should not be placed before the offline group'
-		);
-		$this->assertGreaterThan(
-			$captured_order_map['gateway1'],
-			$captured_order_map['stripe'],
-			'stripe should be after all non-offline gateways'
-		);
+		$this->assertNotFalse( $stripe_index, 'stripe should be in the providers list' );
+		$this->assertGreaterThan( $gateway1_index, $stripe_index, 'stripe should be after gateway1' );
+		// Stripe should be the last non-offline-PM provider.
+		$this->assertSame( count( $provider_ids ) - 1, $stripe_index, 'stripe should be the last provider' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -651,6 +651,9 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
 
+		// Verify providers were returned.
+		$this->assertNotEmpty( $data );
+
 		// Assert: stripe should be between gateway1 and the offline group (compare order values).
 		$this->assertArrayHasKey( 'stripe', $captured_order_map, 'stripe should be in the order map' );
 		$this->assertGreaterThan( $captured_order_map['gateway1'], $captured_order_map['stripe'], 'stripe should be after gateway1' );
@@ -711,6 +714,9 @@ class PaymentsTest extends WC_Unit_Test_Case {
 
 		// Act.
 		$data = $this->sut->get_payment_providers( $location );
+
+		// Verify providers were returned.
+		$this->assertNotEmpty( $data );
 
 		// Assert: stripe should NOT be placed at the offline group's position (above-offline logic not triggered).
 		// In the custom ordering fallback, stripe is placed at count($payment_providers) — the old behavior.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -595,4 +595,134 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertTrue( $result );
 	}
+
+	/**
+	 * Test that new gateways are placed above offline PMs when offline group is last.
+	 */
+	public function test_get_payment_providers_new_gateway_above_offline_pms() {
+		// Arrange.
+		$location = 'US';
+
+		$gateways = array(
+			new FakePaymentGateway( 'gateway1', array( 'plugin_slug' => 'plugin1' ) ),
+			new FakePaymentGateway( 'stripe', array( 'plugin_slug' => 'woocommerce-gateway-stripe' ) ),
+			// The offline PMs.
+			new FakePaymentGateway( WC_Gateway_BACS::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+			new FakePaymentGateway( WC_Gateway_Cheque::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+			new FakePaymentGateway( WC_Gateway_COD::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+		);
+		$this->mock_providers
+			->expects( $this->atLeastOnce() )
+			->method( 'get_payment_gateways' )
+			->willReturn( $gateways );
+
+		// Order map has gateway1 and offline group, but NOT 'stripe'.
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'get_order_map' )
+			->willReturn(
+				array(
+					'gateway1'            => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
+				)
+			);
+
+		// Pass through the order map so we can verify the loop's placement.
+		$captured_order_map = null;
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'enhance_order_map' )
+			->willReturnCallback(
+				function ( $order_map ) use ( &$captured_order_map ) {
+					$captured_order_map = $order_map;
+					return $order_map;
+				}
+			);
+
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'get_extension_suggestions' )
+			->with( $location )
+			->willReturn( array() );
+
+		// Act.
+		$data = $this->sut->get_payment_providers( $location );
+
+		// Assert: stripe should be between gateway1 and the offline group.
+		$ids               = array_keys( $captured_order_map );
+		$stripe_pos        = array_search( 'stripe', $ids, true );
+		$offline_group_pos = array_search( PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP, $ids, true );
+		$gateway1_pos      = array_search( 'gateway1', $ids, true );
+
+		$this->assertNotFalse( $stripe_pos, 'stripe should be in the order map' );
+		$this->assertGreaterThan( $gateway1_pos, $stripe_pos, 'stripe should be after gateway1' );
+		$this->assertLessThan( $offline_group_pos, $stripe_pos, 'stripe should be before the offline group' );
+	}
+
+	/**
+	 * Test that new gateways are placed at end when offline group is NOT last (custom ordering).
+	 */
+	public function test_get_payment_providers_new_gateway_at_end_custom_ordering() {
+		// Arrange.
+		$location = 'US';
+
+		$gateways = array(
+			new FakePaymentGateway( 'gateway1', array( 'plugin_slug' => 'plugin1' ) ),
+			new FakePaymentGateway( 'stripe', array( 'plugin_slug' => 'woocommerce-gateway-stripe' ) ),
+			// The offline PMs.
+			new FakePaymentGateway( WC_Gateway_BACS::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+			new FakePaymentGateway( WC_Gateway_Cheque::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+			new FakePaymentGateway( WC_Gateway_COD::ID, array( 'plugin_slug' => 'woocommerce' ) ),
+		);
+		$this->mock_providers
+			->expects( $this->atLeastOnce() )
+			->method( 'get_payment_gateways' )
+			->willReturn( $gateways );
+
+		// Custom ordering: offline group is NOT last (gateway1 is after it).
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'get_order_map' )
+			->willReturn(
+				array(
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 0,
+					WC_Gateway_BACS::ID   => 1,
+					WC_Gateway_Cheque::ID => 2,
+					WC_Gateway_COD::ID    => 3,
+					'gateway1'            => 4,
+				)
+			);
+
+		// Pass through the order map.
+		$captured_order_map = null;
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'enhance_order_map' )
+			->willReturnCallback(
+				function ( $order_map ) use ( &$captured_order_map ) {
+					$captured_order_map = $order_map;
+					return $order_map;
+				}
+			);
+
+		$this->mock_providers
+			->expects( $this->any() )
+			->method( 'get_extension_suggestions' )
+			->with( $location )
+			->willReturn( array() );
+
+		// Act.
+		$data = $this->sut->get_payment_providers( $location );
+
+		// Assert: stripe should be at the end (after gateway1).
+		$ids          = array_keys( $captured_order_map );
+		$stripe_pos   = array_search( 'stripe', $ids, true );
+		$gateway1_pos = array_search( 'gateway1', $ids, true );
+
+		$this->assertNotFalse( $stripe_pos, 'stripe should be in the order map' );
+		$this->assertGreaterThan( $gateway1_pos, $stripe_pos, 'stripe should be after gateway1 (at the end)' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a new payment gateway is installed (e.g., Stripe via the NOX flow), it was being placed at the absolute bottom of the payment providers list — below offline payment methods (BACS, Cheque, COD). This meant the newly installed gateway wouldn't be expanded by default on checkout and would be buried below less commonly used methods.

This PR fixes the placement logic so that newly installed gateways are inserted **above** the offline payment methods group, unless the merchant has customized the provider ordering (detected by checking whether the offline group is still in its default bottom position).

Closes WOOPLUG-6189.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Spin up a new JurassicNinja store with the WC on this PR's branch, WC Beta Tester (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-beta-tester&branches.woocommerce=fix/wooplug-6189-gateway-ordering))
1. Go to the site's dashboard, click on WooCommerce, and skip the profiler by setting the store country to US.
1. Navigate to **WooCommerce > Settings > Payments**
1. Install and activate a new payment gateway plugin (e.g., Stripe) via the NOX onboarding flow.
![image](https://github.com/user-attachments/assets/98033fc4-b1e4-448b-922d-c15594b767a0)
1. Verify the newly installed gateway appears **above** the "Take offline payments" group, not at the very bottom of the list.
![image](https://github.com/user-attachments/assets/eb215fe9-bfc7-40bc-8ef6-2a2fef064f1e)
1. Now manually drag the offline payment methods group above another gateway (to simulate custom ordering).
1. Install another new payment gateway plugin, e.g. Visa Acceptance Solutions.
1. Verify the new gateway is placed at the **bottom** of the list (respecting the merchant's custom ordering).
1. If you drag offline payment gateways to be the last item in the list, then new gateways will be placed above it again.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> **Note:** A changelog entry has already been manually created at `plugins/woocommerce/changelog/fix-wooplug-6189-gateway-ordering`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Place newly installed payment gateways above offline payment methods instead of at the bottom of the list.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>