### PR TITLE
Fix Store Email personalization tag always returning the admin email

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6390-email-editor-email-template-order-fulfilled-block
+++ b/plugins/woocommerce/changelog/wooplug-6390-email-editor-email-template-order-fulfilled-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug with the Store Email personalization tag that caused it to always return the admin email instead of using the `get_from_address` method from the email object context

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -65149,12 +65149,6 @@ parameters:
 			path: src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
 
 		-
-			message: '#^Call to an undefined method object\:\:get_from_address\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsGenerator\:\:generate_email_templates\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
@@ -27,8 +27,9 @@ class StoreTagsProvider extends AbstractTagProvider {
 				'woocommerce/store-email',
 				__( 'Store', 'woocommerce' ),
 				function ( array $context ): string {
-					if ( isset( $context['wc_email'] ) && method_exists( $context['wc_email'], 'get_from_address' ) ) {
-						return $context['wc_email']->get_from_address();
+					$wc_email = $context['wc_email'] ?? null;
+					if ( $wc_email instanceof \WC_Email ) {
+						return $wc_email->get_from_address();
 					}
 					return get_option( 'admin_email' );
 				},

--- a/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/StoreTagsProvider.php
@@ -27,7 +27,7 @@ class StoreTagsProvider extends AbstractTagProvider {
 				'woocommerce/store-email',
 				__( 'Store', 'woocommerce' ),
 				function ( array $context ): string {
-					if ( isset( $context['wc_email'], $context['wc_email']->get_from_address ) ) {
+					if ( isset( $context['wc_email'] ) && method_exists( $context['wc_email'], 'get_from_address' ) ) {
 						return $context['wc_email']->get_from_address();
 					}
 					return get_option( 'admin_email' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the **Store Email** personalization tag in the block email editor so it correctly uses the from address from the current `WC_Email` when `wc_email` is present in context.

**Cause:** The code used `isset( $context['wc_email']->get_from_address )` to decide whether to call `get_from_address()`. However, since `get_from_address` is a **method** on `WC_Email` and there is no such property and the condition was always false. The tag therefore always fell back to `admin_email` even when a valid email object was in context.

Closes https://github.com/woocommerce/woocommerce/issues/63587.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57479.

### Screenshots or screen recordings:

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
2. Open an email in the editor WooCommerce → Settings → **Emails**
3. Update the `"From" address` to be different from your admin email.
4. Open the preview for an email that is expected to use the `[woocommerce/store-email]` personalization tag (e.g. `Order confirmation`) and confirm the correct email address is rendered.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
