### PR TITLE
Bring select inputs in line with text inputs on checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-select-focus-colors
+++ b/plugins/woocommerce/changelog/fix-select-focus-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make select focused state consistent with other input types

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -52,7 +52,8 @@
 			border-color: $input-border-dark;
 			color: $input-text-dark;
 			&:focus {
-				border-color: currentColor;
+				color: $input-text-dark;
+				border: 1.5px solid currentColor;
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In dark mode, when inputs are focused, they get a color of #fff and the border matches it. Select inputs are inconsistent and do not get this, so tabbing through a form results in inconsistencies.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

In both screenshots, the select input is focused.

| Before | After |
| ------ | ----- |
|  <img width="639" height="236" alt="image" src="https://github.com/user-attachments/assets/e14bfeec-62bd-470b-99f1-ff4617e45064" />      |    <img width="630" height="239" alt="image" src="https://github.com/user-attachments/assets/d5d86600-81f2-474f-81a1-20e439905ea8" />   |

For reference, this is a focused text input

<img width="649" height="231" alt="image" src="https://github.com/user-attachments/assets/5341bb07-0045-4a84-85ea-e06f9bce3923" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up the Checkout block to use `Dark mode inputs` 
2. Add an item to your cart and go to the Checkout block and expand the address card.
3. Tab through the address fields and ensure the select inputs look visually consistent with the text inputs, when focused _and_ not focused.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
