### PR TITLE
Prevent Site Editor welcome guide showing in E2E tests

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/test-env-setup.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/test-env-setup.sh
@@ -7,6 +7,19 @@ wp-env run tests-cli -- rm -f blocks_e2e.sql
 wp-env run tests-cli -- bash wp-content/plugins/woocommerce/blocks-bin/playwright/scripts/index.sh
 # Disable the LYS Coming Soon banner.
 wp-env run tests-cli -- wp option update woocommerce_coming_soon 'no'
+# Dismiss the site editor welcome guide for the admin user so it does not
+# block interactions during tests. The preference is stored in user meta and
+# will be included in the database snapshot that is restored between tests.
+wp-env run tests-cli -- wp eval '
+$prefs = get_user_meta( 1, "wp_persisted_preferences", true );
+if ( ! is_array( $prefs ) ) { $prefs = array(); }
+if ( ! isset( $prefs["core/edit-site"] ) ) { $prefs["core/edit-site"] = array(); }
+$prefs["core/edit-site"]["welcomeGuide"] = false;
+$prefs["core/edit-site"]["welcomeGuideStyles"] = false;
+$prefs["core/edit-site"]["welcomeGuidePage"] = false;
+$prefs["core/edit-site"]["welcomeGuideTemplate"] = false;
+update_user_meta( 1, "wp_persisted_preferences", $prefs );
+'
 # Activate the Test Helper APIs utility plugin.
 wp-env run tests-cli -- wp plugin activate woocommerce-test-plugins/test-helper-apis
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Two WP 7.0 changes were causing template customization e2e tests to fail:

1. The site editor welcome guide modal blocks Save button interactions. Since the DB snapshot is restored and localStorage is cleared between tests, the dismissal preference was lost each time. The fix is to persist the welcome guide preferences in user meta during test env setup so they survive DB resets.

This is not important functionality to test, it is a Gutenberg system that is tested there, and not part of Woo's offering.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure CI passes

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a CI change, not user-facing.

</details>
