### PR TITLE
Add e2e tests for PayPal Standard checkout flow

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/paypal/paypal-checkout.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/paypal/paypal-checkout.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import { addAProductToCart, WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { expect, tags } from '../../fixtures/fixtures';
+import { test as paypalTest } from '../../fixtures/paypal-fixtures';
+import { getFakeCustomer, getFakeProduct } from '../../utils/data';
+import {
+	createClassicCheckoutPage,
+	CLASSIC_CHECKOUT_PAGE,
+} from '../../utils/pages';
+import { wpCLI } from '../../utils/cli';
+
+const PAYPAL_TEST_EMAIL = 'paypal-test@example.com';
+
+const checkoutPages = [
+	{ name: 'blocks checkout', slug: 'checkout' },
+	CLASSIC_CHECKOUT_PAGE,
+];
+
+const test = paypalTest.extend( {
+	page: async ( { page, restApi }, use ) => {
+		await createClassicCheckoutPage();
+
+		// Enable the PayPal Standard gateway if it is not already enabled.
+		const paypalGateway = await restApi.get(
+			`${ WC_API_PATH }/payment_gateways/paypal`
+		);
+		const paypalWasEnabled = paypalGateway.enabled;
+
+		if ( ! paypalWasEnabled ) {
+			await restApi.put( `${ WC_API_PATH }/payment_gateways/paypal`, {
+				enabled: true,
+			} );
+		}
+
+		// Ensure a valid PayPal email is configured so the gateway passes
+		// the needs_setup() check used by the Orders v2 path.
+		await wpCLI(
+			`wp option patch update woocommerce_paypal_settings email '${ PAYPAL_TEST_EMAIL }'`
+		);
+
+		await page.context().clearCookies();
+		await use( page );
+
+		// Restore the gateway's enabled state.
+		if ( ! paypalWasEnabled ) {
+			await restApi.put( `${ WC_API_PATH }/payment_gateways/paypal`, {
+				enabled: false,
+			} );
+		}
+	},
+
+	product: async ( { restApi }, use ) => {
+		let product;
+
+		// Use a virtual product to avoid shipping zone requirements.
+		await restApi
+			.post( `${ WC_API_PATH }/products`, {
+				...getFakeProduct( { dec: 0 } ),
+				virtual: true,
+			} )
+			.then( ( response ) => {
+				product = response.data;
+			} );
+
+		await use( product );
+	},
+} );
+
+test.describe(
+	'PayPal Standard checkout flow',
+	{ tag: [ tags.PAYMENTS, tags.PAYPAL ] },
+	() => {
+		// Run all tests in this suite as a guest (no admin session).
+		test.use( { storageState: { cookies: [], origins: [] } } );
+
+		checkoutPages.forEach( ( { name, slug } ) => {
+			test(
+				`PayPal Standard is available as a payment option at ${ name }`,
+				async ( { page, product } ) => {
+					await addAProductToCart( page, product.id );
+					await page.goto( slug );
+
+					await expect(
+						page.getByText( 'PayPal', { exact: true } )
+					).toBeVisible( { timeout: 30000 } );
+				}
+			);
+		} );
+
+		test(
+			'Selecting PayPal at classic checkout changes the order button to "Proceed to PayPal"',
+			async ( { page, product } ) => {
+				await addAProductToCart( page, product.id );
+				await page.goto( CLASSIC_CHECKOUT_PAGE.slug );
+
+				await page
+					.locator( 'label[for="payment_method_paypal"]' )
+					.click();
+
+				await expect(
+					page.getByRole( 'button', { name: 'Proceed to PayPal' } )
+				).toBeVisible( { timeout: 15000 } );
+			}
+		);
+
+		test(
+			'Guest can initiate PayPal payment at classic checkout and is redirected to PayPal',
+			async ( { page, product } ) => {
+				await addAProductToCart( page, product.id );
+				await page.goto( CLASSIC_CHECKOUT_PAGE.slug );
+
+				await test.step( 'Fill in guest billing details', async () => {
+					const customer = getFakeCustomer();
+
+					await page
+						.getByRole( 'textbox', { name: 'First name' } )
+						.fill( customer.billing.first_name );
+					await page
+						.getByRole( 'textbox', { name: 'Last name' } )
+						.fill( customer.billing.last_name );
+					await page
+						.getByRole( 'textbox', { name: 'Street address' } )
+						.fill( customer.billing.address_1 );
+					await page
+						.getByRole( 'textbox', { name: 'Town / City' } )
+						.fill( customer.billing.city );
+					await page
+						.getByRole( 'textbox', { name: 'ZIP Code' } )
+						.fill( customer.billing.postcode );
+					await page
+						.getByRole( 'textbox', { name: 'Phone' } )
+						.fill( customer.billing.phone );
+					await page
+						.getByRole( 'textbox', { name: 'Email address' } )
+						.fill( customer.billing.email );
+				} );
+
+				await page
+					.locator( 'label[for="payment_method_paypal"]' )
+					.click();
+
+				// Capture the checkout AJAX response before the browser navigates
+				// away to PayPal, so we can verify the redirect URL without leaving
+				// the test environment.
+				const checkoutResponsePromise = page.waitForResponse(
+					( response ) =>
+						response.url().includes( '?wc-ajax=checkout' ) &&
+						response.status() === 200,
+					{ timeout: 30000 }
+				);
+
+				// Abort any navigation to PayPal to keep the test contained.
+				await page.route( /paypal\.com/, ( route ) => route.abort() );
+
+				await page
+					.getByRole( 'button', { name: 'Proceed to PayPal' } )
+					.click();
+
+				const checkoutResponse = await checkoutResponsePromise;
+				const checkoutData = await checkoutResponse.json();
+
+				await test.step(
+					'Checkout response contains a PayPal redirect URL',
+					async () => {
+						expect( checkoutData.result ).toBe( 'success' );
+						expect( checkoutData.redirect ).toContain(
+							'paypal.com'
+						);
+						expect( checkoutData.redirect ).toContain(
+							'cmd=_cart'
+						);
+					}
+				);
+			}
+		);
+	}
+);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Expands the PayPal Standard e2e test suite with a new `paypal-checkout.spec.ts` file covering the checkout flow. Previously, the only PayPal e2e tests covered gateway enablement and Jetpack onboarding in the admin settings — there were no tests exercising the customer-facing checkout experience.

The new tests cover:

- **Payment option visibility** — PayPal Standard appears as a selectable payment method on both the classic (shortcode) and blocks checkout pages when the gateway is enabled.
- **Order button text** — Selecting PayPal on the classic checkout changes the submit button label to "Proceed to PayPal" (the gateway's `order_button_text`).
- **Guest checkout initiation** — A guest fills in billing details, selects PayPal, and clicks "Proceed to PayPal". The test intercepts the checkout AJAX response to assert it returns `result: success` and a redirect URL pointing to `paypal.com` with `cmd=_cart`, without actually navigating away from the test environment.

#### Fixture design notes

- Extends `paypal-fixtures` (which sets `_should_load = yes`) with REST API calls to enable the gateway and WP CLI to set a known test email.
- Uses virtual products to avoid needing a shipping zone.
- Runs all tests as a guest by overriding `storageState` to empty.
- Restores the gateway's enabled state after each test.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Ensure the WooCommerce test environment is running (`pnpm wp-env start` from the plugin directory).
2. Run the new spec: `pnpm exec playwright test tests/paypal/paypal-checkout.spec.ts` from `plugins/woocommerce/tests/e2e-pw/`.
3. Confirm all 4 tests pass: two visibility tests (blocks + classic), one button-text test, and one redirect-initiation test.

### Testing that has already taken place:

Code review of the test logic against the `WC_Gateway_Paypal` class to verify:
- The `order_button_text` ("Proceed to PayPal") is set in the constructor and applied by WooCommerce's classic checkout JS.
- In the test environment (no Jetpack connection), `should_use_orders_v2()` returns `false`, so the legacy `WC_Gateway_Paypal_Request` path is used and produces a `paypal.com/cgi-bin/webscr?cmd=_cart&...` redirect URL.
- The PayPal blocks integration (`src/Blocks/Payments/Integrations/PayPal.php`) is registered, confirming the gateway appears on the blocks checkout page.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR only adds new e2e test files. It does not change any production code, so no user-facing changelog entry is needed.

</details>