### PR TITLE
Replace Linear API key with OAuth 2.0 client credentials

### DIFF
--- a/.github/actions/linear-token/action.yml
+++ b/.github/actions/linear-token/action.yml
@@ -29,14 +29,16 @@ runs:
         body=$(echo "$response" | sed '$d')
 
         if [ "$http_code" -ne 200 ]; then
-          echo "::error::Linear OAuth token request failed with HTTP $http_code: $body"
+          echo "::debug::Response body: $body"
+          echo "::error::Linear OAuth token request failed with HTTP $http_code"
           exit 1
         fi
 
         token=$(echo "$body" | jq -r '.access_token // empty')
 
         if [ -z "$token" ]; then
-          echo "::error::Linear OAuth response did not contain an access_token: $body"
+          echo "::debug::Response body: $body"
+          echo "::error::Linear OAuth response did not contain an access_token"
           exit 1
         fi
 

--- a/.github/actions/linear-token/action.yml
+++ b/.github/actions/linear-token/action.yml
@@ -1,0 +1,45 @@
+name: 'Linear: Get OAuth Token'
+description: 'Fetches a short-lived OAuth 2.0 token from Linear using client credentials.'
+inputs:
+  client-id:
+    description: 'Linear OAuth app client ID'
+    required: true
+  client-secret:
+    description: 'Linear OAuth app client secret'
+    required: true
+outputs:
+  token:
+    description: 'Linear OAuth access token'
+    value: ${{ steps.get-token.outputs.token }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch Linear OAuth token
+      id: get-token
+      shell: bash
+      run: |
+        response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/oauth/token \
+          -H "Content-Type: application/x-www-form-urlencoded" \
+          -d "grant_type=client_credentials" \
+          -d "client_id=${{ inputs.client-id }}" \
+          -d "client_secret=${{ inputs.client-secret }}" \
+          -d "scope=read,write")
+
+        http_code=$(echo "$response" | tail -n1)
+        body=$(echo "$response" | sed '$d')
+
+        if [ "$http_code" -ne 200 ]; then
+          echo "::error::Linear OAuth token request failed with HTTP $http_code: $body"
+          exit 1
+        fi
+
+        token=$(echo "$body" | jq -r '.access_token // empty')
+
+        if [ -z "$token" ]; then
+          echo "::error::Linear OAuth response did not contain an access_token: $body"
+          exit 1
+        fi
+
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"
+        echo "Successfully obtained Linear OAuth token"

--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -157,6 +157,22 @@ jobs:
               } );
             }
 
+      - name: 'Checkout action'
+        if: ${{ steps.analyze.outputs.structured_output && fromJSON(steps.analyze.outputs.structured_output).needs_docs }}
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/linear-token
+          sparse-checkout-cone-mode: false
+
+      - name: 'Get Linear OAuth token'
+        if: ${{ steps.analyze.outputs.structured_output && fromJSON(steps.analyze.outputs.structured_output).needs_docs }}
+        id: get-linear-token
+        uses: ./.github/actions/linear-token
+        with:
+          client-id: ${{ secrets.LINEAR_DOCS_CLIENT_ID }}
+          client-secret: ${{ secrets.LINEAR_DOCS_CLIENT_SECRET }}
+
       - name: 'Setup Linear'
         if: ${{ steps.analyze.outputs.structured_output && fromJSON(steps.analyze.outputs.structured_output).needs_docs }}
         run: npm install @linear/sdk@71.0.0
@@ -166,7 +182,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           STRUCTURED_OUTPUT: ${{ steps.analyze.outputs.structured_output }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_OAUTH_TOKEN }}
+          LINEAR_API_TOKEN: ${{ steps.get-linear-token.outputs.token }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_DOCS_TEAM_ID }}
           LINEAR_LABEL_ID: ${{ secrets.LINEAR_DOCS_AUTO_LABEL }}
         with:
@@ -178,7 +194,7 @@ jobs:
 
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: process.env.LINEAR_API_KEY,
+              accessToken: process.env.LINEAR_API_TOKEN,
             } );
 
             const title = `Docs update needed: ${ prTitle }`;

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -241,8 +241,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
+            .github/actions/linear-token
             .linear
           sparse-checkout-cone-mode: false
+
+      - name: Get Linear OAuth token
+        id: get-linear-token
+        uses: ./.github/actions/linear-token
+        with:
+          client-id: ${{ secrets.LINEAR_CLIENT_ID }}
+          client-secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
 
       - name: Install linear-sdk
         run: npm install @linear/sdk@71.0.0
@@ -254,7 +262,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const releaseMainVersion = '${{ needs.check-upcoming-release-events.outputs.version }}';
@@ -286,7 +294,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const organization = await linearClient.organization;
@@ -319,7 +327,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const email = '${{ needs.trigger-upcoming-code-freeze-events.outputs.release-lead-google-login }}';
@@ -349,7 +357,7 @@ jobs:
             const fs = require( 'fs' );
 
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             // Read template file.
@@ -459,7 +467,8 @@ jobs:
       release-date: ${{ matrix.releaseDate }}
       skip-branch-validation: true
     secrets:
-      LINEAR_OAUTH_TOKEN: ${{ secrets.LINEAR_OAUTH_TOKEN }}
+      LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
+      LINEAR_CLIENT_SECRET: ${{ secrets.LINEAR_CLIENT_SECRET }}
       LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
 
   notify-on-failure:

--- a/.github/workflows/release-create-tracking-issue.yml
+++ b/.github/workflows/release-create-tracking-issue.yml
@@ -28,7 +28,9 @@ on:
         type: boolean
         default: false
     secrets:
-      LINEAR_OAUTH_TOKEN:
+      LINEAR_CLIENT_ID:
+        required: true
+      LINEAR_CLIENT_SECRET:
         required: true
       LINEAR_TEAM_ID:
         required: true
@@ -42,6 +44,20 @@ jobs:
     name: Create Release Tracking Issue
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/linear-token
+          sparse-checkout-cone-mode: false
+
+      - name: Get Linear OAuth token
+        id: get-linear-token
+        uses: ./.github/actions/linear-token
+        with:
+          client-id: ${{ secrets.LINEAR_CLIENT_ID }}
+          client-secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
+
       - name: Parse version and determine template
         id: parse-version
         uses: actions/github-script@v7
@@ -112,7 +128,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const mainVersion = '${{ steps.parse-version.outputs.main-version }}';
@@ -161,7 +177,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const labels = await linearClient.issueLabels( {
@@ -184,7 +200,7 @@ jobs:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             const mainVersion = '${{ steps.parse-version.outputs.main-version }}';
@@ -227,7 +243,7 @@ jobs:
             const fs = require( 'fs' );
 
             const linearClient = new LinearClient( {
-              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+              accessToken: '${{ steps.get-linear-token.outputs.token }}'
             } );
 
             // Read template file.

--- a/.github/workflows/test-linear-oauth.yml
+++ b/.github/workflows/test-linear-oauth.yml
@@ -1,0 +1,132 @@
+name: 'Test: Linear OAuth Token'
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: 'Which OAuth app to test'
+        required: true
+        type: choice
+        options:
+          - release
+          - docs
+          - both
+
+jobs:
+  test-release-app:
+    name: Test Release OAuth App
+    if: ${{ inputs.app == 'release' || inputs.app == 'both' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/linear-token
+          sparse-checkout-cone-mode: false
+
+      - name: Get Linear OAuth token
+        id: get-token
+        uses: ./.github/actions/linear-token
+        with:
+          client-id: ${{ secrets.LINEAR_CLIENT_ID }}
+          client-secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
+
+      - name: Setup linear-sdk
+        run: npm install @linear/sdk@71.0.0
+
+      - name: Verify token with read operation
+        uses: actions/github-script@v7
+        env:
+          LINEAR_API_TOKEN: ${{ steps.get-token.outputs.token }}
+          LINEAR_TEST_TEAM_ID: ${{ secrets.LINEAR_TEST_TEAM_ID }}
+        with:
+          script: |
+            const { LinearClient } = require( '@linear/sdk' );
+            const linearClient = new LinearClient( {
+              accessToken: process.env.LINEAR_API_TOKEN,
+            } );
+
+            const team = await linearClient.team( process.env.LINEAR_TEST_TEAM_ID );
+            console.log( `✅ Read OK — team: ${ team.name }` );
+
+      - name: Create and delete test issue
+        uses: actions/github-script@v7
+        env:
+          LINEAR_API_TOKEN: ${{ steps.get-token.outputs.token }}
+          LINEAR_TEST_TEAM_ID: ${{ secrets.LINEAR_TEST_TEAM_ID }}
+        with:
+          script: |
+            const { LinearClient } = require( '@linear/sdk' );
+            const linearClient = new LinearClient( {
+              accessToken: process.env.LINEAR_API_TOKEN,
+            } );
+
+            const issue = await linearClient.createIssue( {
+              teamId: process.env.LINEAR_TEST_TEAM_ID,
+              title: '[Test] OAuth token validation — safe to delete',
+            } );
+            const created = await issue.issue;
+            console.log( `✅ Write OK — created issue: ${ created.identifier }` );
+
+            await linearClient.deleteIssue( created.id );
+            console.log( `✅ Delete OK — cleaned up issue: ${ created.identifier }` );
+
+  test-docs-app:
+    name: Test Docs OAuth App
+    if: ${{ inputs.app == 'docs' || inputs.app == 'both' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/linear-token
+          sparse-checkout-cone-mode: false
+
+      - name: Get Linear OAuth token
+        id: get-token
+        uses: ./.github/actions/linear-token
+        with:
+          client-id: ${{ secrets.LINEAR_DOCS_CLIENT_ID }}
+          client-secret: ${{ secrets.LINEAR_DOCS_CLIENT_SECRET }}
+
+      - name: Setup linear-sdk
+        run: npm install @linear/sdk@71.0.0
+
+      - name: Verify token with read operation
+        uses: actions/github-script@v7
+        env:
+          LINEAR_API_TOKEN: ${{ steps.get-token.outputs.token }}
+          LINEAR_TEST_TEAM_ID: ${{ secrets.LINEAR_TEST_TEAM_ID }}
+        with:
+          script: |
+            const { LinearClient } = require( '@linear/sdk' );
+            const linearClient = new LinearClient( {
+              accessToken: process.env.LINEAR_API_TOKEN,
+            } );
+
+            const team = await linearClient.team( process.env.LINEAR_TEST_TEAM_ID );
+            console.log( `✅ Read OK — team: ${ team.name }` );
+
+      - name: Create and delete test issue
+        uses: actions/github-script@v7
+        env:
+          LINEAR_API_TOKEN: ${{ steps.get-token.outputs.token }}
+          LINEAR_TEST_TEAM_ID: ${{ secrets.LINEAR_TEST_TEAM_ID }}
+        with:
+          script: |
+            const { LinearClient } = require( '@linear/sdk' );
+            const linearClient = new LinearClient( {
+              accessToken: process.env.LINEAR_API_TOKEN,
+            } );
+
+            const issue = await linearClient.createIssue( {
+              teamId: process.env.LINEAR_TEST_TEAM_ID,
+              title: '[Test] OAuth token validation (docs app) — safe to delete',
+            } );
+            const created = await issue.issue;
+            console.log( `✅ Write OK — created issue: ${ created.identifier }` );
+
+            await linearClient.deleteIssue( created.id );
+            console.log( `✅ Delete OK — cleaned up issue: ${ created.identifier }` );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Replaces the long-lived `LINEAR_OAUTH_TOKEN` API key with short-lived OAuth 2.0 client credentials tokens for all workflows that call the Linear API.

**What changed:**
- New composite action `.github/actions/linear-token/action.yml` that fetches a fresh token from Linear's OAuth endpoint (`POST https://api.linear.app/oauth/token`) using the client credentials grant type
- `release-assignment.yml` — uses the new action to get a token, passes client ID/secret to the sub-workflow
- `release-create-tracking-issue.yml` — accepts client ID/secret (from parent workflow or repo secrets), fetches its own token
- `docs-needed-detection.yml` — uses a separate OAuth app (`LINEAR_DOCS_CLIENT_ID`/`LINEAR_DOCS_CLIENT_SECRET`) for the docs team

**Why:**
Linear is deprecating long-lived API keys in favor of OAuth 2.0 refresh or client credentials tokens. Each workflow run now fetches a fresh token instead of using a shared static secret.

**Security improvements:**
- Token is masked with `::add-mask::` to prevent log leakage
- Error messages use `::debug::` for response bodies to avoid leaking sensitive data
- Separate OAuth apps for release vs. docs workflows (token isolation)

**New secrets required before merging:**
| Secret | Used by |
|--------|---------|
| `LINEAR_CLIENT_ID` | release-assignment, release-create-tracking-issue |
| `LINEAR_CLIENT_SECRET` | release-assignment, release-create-tracking-issue |
| `LINEAR_DOCS_CLIENT_ID` | docs-needed-detection |
| `LINEAR_DOCS_CLIENT_SECRET` | docs-needed-detection |

After migration, `LINEAR_OAUTH_TOKEN` can be removed from repository secrets.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Configure the 4 new secrets (`LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET`, `LINEAR_DOCS_CLIENT_ID`, `LINEAR_DOCS_CLIENT_SECRET`) in the repository settings with valid Linear OAuth app credentials.
2. Trigger `release-assignment.yml` via `workflow_dispatch` and verify it successfully creates Linear tracking issues.
3. Trigger `release-create-tracking-issue.yml` via `workflow_dispatch` with a test version and verify it creates a sub-tracking issue.
4. Merge a PR with user-facing changes and verify `docs-needed-detection.yml` creates a Linear issue in the docs team when flagged.
5. Verify no `LINEAR_OAUTH_TOKEN` references remain in any workflow logs.

### Testing that has already taken place:

- YAML validation passed for all modified files
- Code review verified all `LINEAR_OAUTH_TOKEN` and `apiKey` references are removed
- Cross-workflow interface verified: caller secrets match callee `workflow_call` declarations

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI/CD workflow changes only — no user-facing or plugin code changes.

</details>