### PR TITLE
Add to Cart: improve validation of attributes with multi-word names

### DIFF
--- a/plugins/woocommerce/changelog/fix-63635
+++ b/plugins/woocommerce/changelog/fix-63635
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add to Cart: fix validation of attributes with multiple words name
+Add to Cart: fix validation of attributes with multi-word names

--- a/plugins/woocommerce/changelog/fix-63635
+++ b/plugins/woocommerce/changelog/fix-63635
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart: fix validation of attributes with multiple words name

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
@@ -9,13 +9,14 @@ import type {
 
 /**
  * Normalize attribute name by stripping the 'attribute_' or 'attribute_pa_' prefix
- * that WooCommerce adds for variation attributes.
+ * that WooCommerce adds for variation attributes, and replacing hyphens with spaces
+ * so that slugs (e.g., "some-name") match labels (e.g., "some name").
  *
  * @param name The attribute name (e.g., 'attribute_color' or 'attribute_pa_color').
  * @return The normalized name (e.g., 'color').
  */
 export const normalizeAttributeName = ( name: string ): string => {
-	return name.replace( /^attribute_(pa_)?/, '' );
+	return name.replace( /^attribute_(pa_)?/, '' ).replace( /-/g, ' ' );
 };
 
 /**
@@ -56,7 +57,8 @@ export const getVariationAttributeValue = (
 	const normalizedName =
 		normalizeAttributeName( attributeName ).toLowerCase();
 	const attr = variation.attributes.find(
-		( a ) => a.name.toLowerCase() === normalizedName
+		( a ) =>
+			normalizeAttributeName( a.name ).toLowerCase() === normalizedName
 	);
 	return attr?.value;
 };
@@ -82,12 +84,14 @@ export const findMatchingVariation = (
 	const matchedVariation = product.variations.find(
 		( variation: ProductResponseVariationsItem ) => {
 			return variation.attributes.every( ( attr ) => {
-				const attrNameLower = attr.name.toLowerCase();
+				const attrNameNormalized = normalizeAttributeName(
+					attr.name
+				).toLowerCase();
 				const selectedAttr = selectedAttributes.find(
 					( selected ) =>
 						normalizeAttributeName(
 							selected.attribute
-						).toLowerCase() === attrNameLower
+						).toLowerCase() === attrNameNormalized
 				);
 
 				// If variation attribute is null, it accepts "Any" value.

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
@@ -16,7 +16,10 @@ import type {
  * @return The normalized name (e.g., 'color').
  */
 export const normalizeAttributeName = ( name: string ): string => {
-	return name.replace( /^attribute_(pa_)?/, '' ).replace( /-/g, ' ' );
+	return name
+		.replace( /^attribute_(pa_)?/, '' )
+		.replace( /-/g, ' ' )
+		.toLowerCase();
 };
 
 /**
@@ -33,10 +36,7 @@ export const attributeNamesMatch = (
 	name1: string,
 	name2: string
 ): boolean => {
-	return (
-		normalizeAttributeName( name1 ).toLowerCase() ===
-		normalizeAttributeName( name2 ).toLowerCase()
-	);
+	return normalizeAttributeName( name1 ) === normalizeAttributeName( name2 );
 };
 
 /**
@@ -54,11 +54,8 @@ export const getVariationAttributeValue = (
 	variation: ProductResponseVariationsItem,
 	attributeName: string
 ): string | undefined => {
-	const normalizedName =
-		normalizeAttributeName( attributeName ).toLowerCase();
-	const attr = variation.attributes.find(
-		( a ) =>
-			normalizeAttributeName( a.name ).toLowerCase() === normalizedName
+	const attr = variation.attributes.find( ( a ) =>
+		attributeNamesMatch( attributeName, a.name )
 	);
 	return attr?.value;
 };
@@ -84,14 +81,8 @@ export const findMatchingVariation = (
 	const matchedVariation = product.variations.find(
 		( variation: ProductResponseVariationsItem ) => {
 			return variation.attributes.every( ( attr ) => {
-				const attrNameNormalized = normalizeAttributeName(
-					attr.name
-				).toLowerCase();
-				const selectedAttr = selectedAttributes.find(
-					( selected ) =>
-						normalizeAttributeName(
-							selected.attribute
-						).toLowerCase() === attrNameNormalized
+				const selectedAttr = selectedAttributes.find( ( selected ) =>
+					attributeNamesMatch( attr.name, selected.attribute )
 				);
 
 				// If variation attribute is null, it accepts "Any" value.

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
@@ -19,8 +19,20 @@ describe( 'normalizeAttributeName', () => {
 		);
 	} );
 
-	it( 'returns unchanged name without prefix', () => {
-		expect( normalizeAttributeName( 'Color' ) ).toBe( 'Color' );
+	it( 'returns lowercased name without prefix', () => {
+		expect( normalizeAttributeName( 'Color' ) ).toBe( 'color' );
+	} );
+
+	it( 'replaces hyphens with spaces for multi-word slugs', () => {
+		expect( normalizeAttributeName( 'attribute_pa_numeric-size' ) ).toBe(
+			'numeric size'
+		);
+	} );
+
+	it( 'replaces hyphens with spaces without prefix', () => {
+		expect( normalizeAttributeName( 'numeric-size' ) ).toBe(
+			'numeric size'
+		);
 	} );
 } );
 
@@ -38,6 +50,24 @@ describe( 'attributeNamesMatch', () => {
 	it( 'matches when both have prefixes', () => {
 		expect(
 			attributeNamesMatch( 'attribute_pa_color', 'attribute_color' )
+		).toBe( true );
+	} );
+
+	it( 'matches hyphenated slug against spaced label', () => {
+		expect(
+			attributeNamesMatch( 'attribute_pa_numeric-size', 'numeric size' )
+		).toBe( true );
+	} );
+
+	it( 'matches hyphenated slug against capitalized spaced label', () => {
+		expect(
+			attributeNamesMatch( 'attribute_pa_numeric-size', 'Numeric Size' )
+		).toBe( true );
+	} );
+
+	it( 'matches two hyphenated names', () => {
+		expect(
+			attributeNamesMatch( 'attribute_pa_numeric-size', 'numeric-size' )
 		).toBe( true );
 	} );
 
@@ -77,6 +107,45 @@ describe( 'getVariationAttributeValue', () => {
 		expect(
 			getVariationAttributeValue( variation, 'material' )
 		).toBeUndefined();
+	} );
+
+	describe( 'multi-word attribute names', () => {
+		const variationWithSpaces = {
+			id: 456,
+			attributes: [ { name: 'numeric size', value: '42' } ],
+		};
+
+		const variationWithHyphens = {
+			id: 789,
+			attributes: [ { name: 'numeric-size', value: '44' } ],
+		};
+
+		it( 'finds value when slug has hyphens and Store API has spaces', () => {
+			expect(
+				getVariationAttributeValue(
+					variationWithSpaces,
+					'attribute_pa_numeric-size'
+				)
+			).toBe( '42' );
+		} );
+
+		it( 'finds value when both use hyphens', () => {
+			expect(
+				getVariationAttributeValue(
+					variationWithHyphens,
+					'attribute_pa_numeric-size'
+				)
+			).toBe( '44' );
+		} );
+
+		it( 'finds value when both use spaces', () => {
+			expect(
+				getVariationAttributeValue(
+					variationWithSpaces,
+					'numeric size'
+				)
+			).toBe( '42' );
+		} );
 	} );
 } );
 
@@ -147,6 +216,56 @@ describe( 'findMatchingVariation', () => {
 		expect(
 			findMatchingVariation( product, selectedAttributes )
 		).toBeNull();
+	} );
+
+	describe( 'multi-word attribute names', () => {
+		const productWithMultiWord = {
+			id: 3,
+			type: 'variable',
+			variations: [
+				{
+					id: 301,
+					attributes: [
+						{ name: 'Color', value: 'Blue' },
+						{ name: 'numeric size', value: '42' },
+					],
+				},
+				{
+					id: 302,
+					attributes: [
+						{ name: 'Color', value: 'Red' },
+						{ name: 'numeric size', value: '44' },
+					],
+				},
+			],
+		};
+
+		it( 'matches when selected attributes use hyphenated slugs', () => {
+			const result = findMatchingVariation( productWithMultiWord, [
+				{ attribute: 'attribute_pa_color', value: 'Blue' },
+				{ attribute: 'attribute_pa_numeric-size', value: '42' },
+			] );
+			expect( result?.id ).toBe( 301 );
+		} );
+
+		it( 'matches when Store API uses hyphens instead of spaces', () => {
+			const productWithHyphens = {
+				id: 4,
+				type: 'variable',
+				variations: [
+					{
+						id: 401,
+						attributes: [
+							{ name: 'numeric-size', value: '42' },
+						],
+					},
+				],
+			};
+			const result = findMatchingVariation( productWithHyphens, [
+				{ attribute: 'attribute_pa_numeric-size', value: '42' },
+			] );
+			expect( result?.id ).toBe( 401 );
+		} );
 	} );
 
 	describe( 'Any attribute handling', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
@@ -255,9 +255,7 @@ describe( 'findMatchingVariation', () => {
 				variations: [
 					{
 						id: 401,
-						attributes: [
-							{ name: 'numeric-size', value: '42' },
-						],
+						attributes: [ { name: 'numeric-size', value: '42' } ],
 					},
 				],
 			};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -359,7 +359,8 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					getProductAttributesAndOptions( product );
 				Object.entries( productAttributesAndOptions ).forEach(
 					( [ attribute, options ] ) => {
-						const attributeLower = attribute.toLowerCase();
+						const attributeLower =
+							normalizeAttributeName( attribute ).toLowerCase();
 						if (
 							normalizedIncluded.length !== 0 &&
 							! normalizedIncluded.includes( attributeLower )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -349,10 +349,10 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				// Normalize included/excluded attributes to lowercase for comparison
 				// with Store API labels (e.g., "Color" vs "attribute_pa_color" → "color").
 				const normalizedIncluded = includedAttributes.map( ( attr ) =>
-					normalizeAttributeName( attr ).toLowerCase()
+					normalizeAttributeName( attr )
 				);
 				const normalizedExcluded = excludedAttributes.map( ( attr ) =>
-					normalizeAttributeName( attr ).toLowerCase()
+					normalizeAttributeName( attr )
 				);
 
 				const productAttributesAndOptions: Record< string, string[] > =
@@ -360,7 +360,7 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				Object.entries( productAttributesAndOptions ).forEach(
 					( [ attribute, options ] ) => {
 						const attributeLower =
-							normalizeAttributeName( attribute ).toLowerCase();
+							normalizeAttributeName( attribute );
 						if (
 							normalizedIncluded.length !== 0 &&
 							! normalizedIncluded.includes( attributeLower )
@@ -387,9 +387,8 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 							const contextName =
 								includedAttributes.find(
 									( attr ) =>
-										normalizeAttributeName(
-											attr
-										).toLowerCase() === attributeLower
+										normalizeAttributeName( attr ) ===
+										attributeLower
 								) || attribute;
 							actions.setAttribute( contextName, validOption );
 						}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes attribute options being incorrectly disabled in the Add to Cart with Options block for variable products whose attribute slugs contain hyphens.

Root cause: The PHP context passes attribute names as slugs (e.g., attribute_pa_some-name), which normalizes to some-name. The Store API returns attribute labels with spaces (e.g., some name). The strict comparison "some-name" === "some name" failed, causing `getVariationAttributeValue` to return `undefined `and all options for that attribute to appear disabled.

Fix: Updated `normalizeAttributeName()` in `attribute-matching.ts` to also replace hyphens with spaces, and ensured all comparison points in the file use the normalized form consistently.

Closes https://github.com/woocommerce/woocommerce/issues/63635

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/issues/62880

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="446" height="419" alt="image" src="https://github.com/user-attachments/assets/6bc961b2-9bec-4cbc-bce3-0b8936f90788" /> <img width="409" height="429" alt="image" src="https://github.com/user-attachments/assets/92639b5b-1712-4212-add5-956911139d64" />   |   <img width="518" height="435" alt="image" src="https://github.com/user-attachments/assets/a210aee9-35bd-42a8-b788-7dc3b9c04218" /> <img width="458" height="414" alt="image" src="https://github.com/user-attachments/assets/c0a7e4e9-6cfd-4ca8-8895-033c9c2caaab" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Make sure you have variation product with attribute that's name has multiple words
  - important: slug should differ from name, e.g. name: "Numeric Size", slug: `numeric-size`
2. Make sure you use Add to Cart with Options in your Single Product template
3. Go to product frontend
4. **Expected:** Attributes should be available to choose
5. Confirm they're disabled on `trunk`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
