### PR TITLE
Fix checkout cart [shortcode] Shipment label is not correct

### DIFF
--- a/plugins/woocommerce/changelog/issues-63336-shipping-package-name
+++ b/plugins/woocommerce/changelog/issues-63336-shipping-package-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show shipping package title as "Shipment" instead of "Shipment 1"

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -674,7 +674,7 @@ This hook allows to disable the compatibility layer for the blockified.
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| 1 | \Automattic\WooCommerce\Blocks\Templates\boolean. |  |
+| 1 | \Automattic\WooCommerce\Blocks\Templates\boolean. | |
 
 ### Source
 
@@ -941,7 +941,7 @@ Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\
 Filters the shipping package name.
 
 ```php
-apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_name, string $package_id, array $package )
+apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_name, string $package_id, array $package, int $total_packages )
 ```
 
 
@@ -954,6 +954,7 @@ apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_nam
 | $shipping_package_name | string | Shipping package name. |
 | $package_id | string | Shipping package ID. |
 | $package | array | Shipping package from WooCommerce. |
+| $total_packages | int | Total number of shipping packages. |
 
 ### Returns
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1723,6 +1723,20 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string
 	 */
 	private function get_shipping_package_name( $package, $index, $total_packages ) {
+
+		$shipping_package_name = _x( 'Shipment', 'shipping packages', 'woocommerce' );
+
+		/**
+		 * If there are multiple packages, use the index to show the package number.
+		 */
+		if ( 1 !== $total_packages ) {
+			$shipping_package_name = sprintf(
+				/* translators: %d: shipping package number. */
+				_x( 'Shipment %d', 'shipping packages', 'woocommerce' ),
+				$index
+			);
+		}
+
 		/**
 		 * Filters the shipping package name.
 		 *
@@ -1730,19 +1744,15 @@ class WC_Cart extends WC_Legacy_Cart {
 		 * @param string $shipping_package_name Shipping package name.
 		 * @param string $package_id Shipping package ID.
 		 * @param array $package Shipping package from WooCommerce.
+		 * @param int $total_packages Total number of shipping packages.
 		 * @return string Shipping package name.
 		 */
 		return apply_filters(
 			'woocommerce_shipping_package_name',
-
-				sprintf(
-					/* translators: %d: shipping package number */
-					_x( 'Shipment %d', 'shipping packages', 'woocommerce' ),
-					$index
-				),
-
+			$shipping_package_name,
 			$package['package_id'],
-			$package
+			$package,
+			$total_packages
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1707,7 +1707,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		$index = 1;
 		foreach ( $shipping_packages as $key => $package ) {
 			$shipping_packages[ $key ]['package_id']   = $package['package_id'] ?? $key;
-			$shipping_packages[ $key ]['package_name'] = $this->get_shipping_package_name( $shipping_packages[ $key ], $index );
+			$shipping_packages[ $key ]['package_name'] = $this->get_shipping_package_name( $shipping_packages[ $key ], $index, count( $shipping_packages ) );
 			++$index;
 		}
 
@@ -1719,9 +1719,10 @@ class WC_Cart extends WC_Legacy_Cart {
 	 *
 	 * @param array $package Shipping package data.
 	 * @param int   $index Package number.
+	 * @param int   $total_packages Total number of packages.
 	 * @return string
 	 */
-	private function get_shipping_package_name( $package, $index ) {
+	private function get_shipping_package_name( $package, $index, $total_packages ) {
 		/**
 		 * Filters the shipping package name.
 		 *
@@ -1733,11 +1734,13 @@ class WC_Cart extends WC_Legacy_Cart {
 		 */
 		return apply_filters(
 			'woocommerce_shipping_package_name',
-			sprintf(
-				/* translators: %d: shipping package number */
-				_x( 'Shipment %d', 'shipping packages', 'woocommerce' ),
-				$index
-			),
+
+				sprintf(
+					/* translators: %d: shipping package number */
+					_x( 'Shipment %d', 'shipping packages', 'woocommerce' ),
+					$index
+				),
+
 			$package['package_id'],
 			$package
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -190,11 +190,11 @@ class CartControllerTests extends TestCase {
 
 		$packages = $class->get_shipping_packages( false );
 
-		$this->assertNotEmpty( $packages, 'Should have at least one shipping package.' );
+		$this->assertCount( 1, $packages, 'Should have one shipping package.' );
 		$this->assertArrayHasKey( 'package_id', $packages[0], 'Package should have package_id.' );
 		$this->assertArrayHasKey( 'package_name', $packages[0], 'Package should have package_name.' );
 		$this->assertEquals( 0, $packages[0]['package_id'], 'First package should have package_id of 0 (array key).' );
-		$this->assertStringContainsString( 'Shipment 1', $packages[0]['package_name'], 'First package should have package_name containing "Shipment 1".' );
+		$this->assertSame( 'Shipment', $packages[0]['package_name'], 'Single package should have package_name of "Shipment".' );
 	}
 
 	/**


### PR DESCRIPTION
### This PR is a follow up to https://github.com/woocommerce/woocommerce/pull/63346, please follow up the instructions on #63346 for testing

Show shipping package title as "Shipment" instead of "Shipment 1" if there is only 1 package.

### Changes proposed in this Pull Request:

Send the count of the total number of packages to the `get_shipping_package_name()` method so that the package can be conditionally named "Shipment" if there is only 1 package in total.... or "Shipment 1", "Shipment 2", etc if there are multiple packages.

Closes #63336.

(For Bug Fixes) 
Potentially introduced in https://github.com/woocommerce/woocommerce/commit/daae10db1a9dcb58470ba0ff33b1927b5f21a9d8#diff-cdc9f1829f52d7b83e3542948622d924ef5cf6a3e0b4580e6ebd1c9643bc49b4L261 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before:
<img width="519" height="439" alt="image" src="https://github.com/user-attachments/assets/d35aa453-8a29-49cb-9976-73188349c486" />

After:
<img width="549" height="479" alt="image" src="https://github.com/user-attachments/assets/1f92e3fb-3031-42fb-8578-1f601395d2cb" />

more than 1 package will still show the same... "Shipment 1, Shipment 2, etc"

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Put a single product that requires shipping in the cart
2. Visit the cart shortcode
3. See the shipping area reads "Shipment"

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* The way shipping packages are named and displayed in your cart has been improved. Packages now appear as "Shipment" instead of "Shipment 1" when you review your order, check available shipping options, and proceed through checkout. This change delivers a cleaner and more consistent presentation of your shipping information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
