### PR TITLE
 test: add preferred provider gateway placement tests for enhance_order_map

### DIFF
--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -6137,4 +6137,152 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * @dataProvider data_provider_enhance_order_map_new_gateway_with_suggestion
+	 *
+	 * @param array  $gateway_ids     The gateway IDs to register.
+	 * @param array  $gateway_slugs   Map of gateway ID to plugin slug.
+	 * @param array  $suggestions     The suggestions list.
+	 * @param array  $start_order_map The starting order map.
+	 * @param string[] $expected_order  The expected order of IDs after enhancement.
+	 */
+	public function test_enhance_order_map_new_gateway_with_suggestion(
+		array $gateway_ids,
+		array $gateway_slugs,
+		array $suggestions,
+		array $start_order_map,
+		array $expected_order
+	) {
+		// Mock payment gateways with their plugin slugs.
+		$gateway_details = array();
+		foreach ( $gateway_ids as $id ) {
+			$gateway_details[ $id ] = array(
+				'enabled'     => true,
+				'plugin_slug' => $gateway_slugs[ $id ] ?? $id,
+			);
+		}
+		$this->mock_payment_gateways( $gateway_details );
+
+		// Mock getting suggestions by plugin slug.
+		$this->mock_extension_suggestions
+			->expects( $this->any() )
+			->method( 'get_by_plugin_slug' )
+			->willReturnCallback(
+				function ( $plugin_slug ) use ( $suggestions ) {
+					foreach ( $suggestions as $suggestion ) {
+						if ( $suggestion['plugin']['slug'] === $plugin_slug ) {
+							return $suggestion;
+						}
+					}
+					return null;
+				}
+			);
+		// Mock getting suggestions by id.
+		$this->mock_extension_suggestions
+			->expects( $this->any() )
+			->method( 'get_by_id' )
+			->willReturnCallback(
+				function ( $id ) use ( $suggestions ) {
+					foreach ( $suggestions as $suggestion ) {
+						if ( $suggestion['id'] === $id ) {
+							return $suggestion;
+						}
+					}
+					return null;
+				}
+			);
+
+		$sut = $this->sut;
+
+		$result = $sut->enhance_order_map( $start_order_map );
+
+		// Extract the order — keys sorted by value.
+		$actual_order = array_keys( $result );
+		// Filter to only the IDs we care about for assertion clarity.
+		$actual_order = array_values( array_intersect( $actual_order, $expected_order ) );
+
+		$this->assertSame( $expected_order, $actual_order );
+	}
+
+	/**
+	 * Data provider for test_enhance_order_map_new_gateway_with_suggestion.
+	 */
+	public function data_provider_enhance_order_map_new_gateway_with_suggestion(): array {
+		$preferred_paypal = array(
+			'id'        => 'paypal',
+			'_type'     => ExtensionSuggestions::TYPE_PSP,
+			'_priority' => 0,
+			'plugin'    => array( 'slug' => 'woocommerce-paypal-payments' ),
+		);
+
+		return array(
+			'preferred provider before offline PMs — the gateway takes its placeholder' => array(
+				// gateway_ids.
+				array( 'gateway1', 'ppcp-gateway', 'bacs', 'cheque', 'cod' ),
+				// gateway_slugs.
+				array(
+					'gateway1'     => 'plugin1',
+					'ppcp-gateway' => 'woocommerce-paypal-payments',
+					'bacs'         => 'woocommerce',
+					'cheque'       => 'woocommerce',
+					'cod'          => 'woocommerce',
+				),
+				// suggestions.
+				array( $preferred_paypal ),
+				// start_order_map: preferred provider is before offline PMs, gateway not yet present.
+				array(
+					'gateway1'            => 0,
+					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'paypal' => 1,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 2,
+					WC_Gateway_BACS::ID   => 3,
+					WC_Gateway_Cheque::ID => 4,
+					WC_Gateway_COD::ID    => 5,
+				),
+				// expected_order: PayPal gateway takes the preferred provider's placeholder place, before offline PMs.
+				array(
+					'gateway1',
+					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'paypal',
+					'ppcp-gateway',
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
+					WC_Gateway_BACS::ID,
+					WC_Gateway_Cheque::ID,
+					WC_Gateway_COD::ID,
+				),
+			),
+			'preferred provider after offline PMs — the gateway takes its placeholder' => array(
+				// gateway_ids.
+				array( 'gateway1', 'ppcp-gateway', 'bacs', 'cheque', 'cod' ),
+				// gateway_slugs.
+				array(
+					'gateway1'     => 'plugin1',
+					'ppcp-gateway' => 'woocommerce-paypal-payments',
+					'bacs'         => 'woocommerce',
+					'cheque'       => 'woocommerce',
+					'cod'          => 'woocommerce',
+				),
+				// suggestions.
+				array( $preferred_paypal ),
+				// start_order_map: preferred provider is after offline PMs (custom ordering).
+				array(
+					'gateway1'            => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
+					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'paypal' => 5,
+				),
+				// expected_order: PayPal gateway takes the preferred provider's placeholder place, after offline PMs.
+				array(
+					'gateway1',
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
+					WC_Gateway_BACS::ID,
+					WC_Gateway_Cheque::ID,
+					WC_Gateway_COD::ID,
+					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'paypal',
+					'ppcp-gateway',
+				),
+			),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -6178,21 +6178,6 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 					return null;
 				}
 			);
-		// Mock getting suggestions by id.
-		$this->mock_extension_suggestions
-			->expects( $this->any() )
-			->method( 'get_by_id' )
-			->willReturnCallback(
-				function ( $id ) use ( $suggestions ) {
-					foreach ( $suggestions as $suggestion ) {
-						if ( $suggestion['id'] === $id ) {
-							return $suggestion;
-						}
-					}
-					return null;
-				}
-			);
-
 		$sut = $this->sut;
 
 		$result = $sut->enhance_order_map( $start_order_map );
@@ -6243,6 +6228,37 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 				array(
 					'gateway1',
 					PaymentsProviders::SUGGESTION_ORDERING_PREFIX . 'paypal',
+					'ppcp-gateway',
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
+					WC_Gateway_BACS::ID,
+					WC_Gateway_Cheque::ID,
+					WC_Gateway_COD::ID,
+				),
+			),
+			'suggestion exists but placeholder absent — gateway placed via default logic' => array(
+				// gateway_ids.
+				array( 'gateway1', 'ppcp-gateway', 'bacs', 'cheque', 'cod' ),
+				// gateway_slugs.
+				array(
+					'gateway1'     => 'plugin1',
+					'ppcp-gateway' => 'woocommerce-paypal-payments',
+					'bacs'         => 'woocommerce',
+					'cheque'       => 'woocommerce',
+					'cod'          => 'woocommerce',
+				),
+				// suggestions.
+				array( $preferred_paypal ),
+				// start_order_map: NO placeholder for the suggestion — gateway falls through to default placement.
+				array(
+					'gateway1'            => 0,
+					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP => 1,
+					WC_Gateway_BACS::ID   => 2,
+					WC_Gateway_Cheque::ID => 3,
+					WC_Gateway_COD::ID    => 4,
+				),
+				// expected_order: PayPal gateway placed above offline group (default behavior), not at a placeholder.
+				array(
+					'gateway1',
 					'ppcp-gateway',
 					PaymentsProviders::OFFLINE_METHODS_ORDERING_GROUP,
 					WC_Gateway_BACS::ID,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -6141,11 +6141,11 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 	/**
 	 * @dataProvider data_provider_enhance_order_map_new_gateway_with_suggestion
 	 *
-	 * @param array      $gateway_ids     The gateway IDs to register.
-	 * @param array      $gateway_slugs   Map of gateway ID to plugin slug.
-	 * @param array      $suggestions     The suggestions list.
-	 * @param array      $start_order_map The starting order map.
-	 * @param string[]   $expected_order  The expected order of IDs after enhancement.
+	 * @param array    $gateway_ids     The gateway IDs to register.
+	 * @param array    $gateway_slugs   Map of gateway ID to plugin slug.
+	 * @param array    $suggestions     The suggestions list.
+	 * @param array    $start_order_map The starting order map.
+	 * @param string[] $expected_order  The expected order of IDs after enhancement.
 	 */
 	public function test_enhance_order_map_new_gateway_with_suggestion(
 		array $gateway_ids,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -6141,11 +6141,11 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 	/**
 	 * @dataProvider data_provider_enhance_order_map_new_gateway_with_suggestion
 	 *
-	 * @param array  $gateway_ids     The gateway IDs to register.
-	 * @param array  $gateway_slugs   Map of gateway ID to plugin slug.
-	 * @param array  $suggestions     The suggestions list.
-	 * @param array  $start_order_map The starting order map.
-	 * @param string[] $expected_order  The expected order of IDs after enhancement.
+	 * @param array      $gateway_ids     The gateway IDs to register.
+	 * @param array      $gateway_slugs   Map of gateway ID to plugin slug.
+	 * @param array      $suggestions     The suggestions list.
+	 * @param array      $start_order_map The starting order map.
+	 * @param string[]   $expected_order  The expected order of IDs after enhancement.
 	 */
 	public function test_enhance_order_map_new_gateway_with_suggestion(
 		array $gateway_ids,


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds missing test coverage for `enhance_order_map` in `PaymentsProviders` when a preferred payment provider (`_wc_pes_*` entry) is already in the order map and its matching gateway gets installed.

The existing `test_enhance_order_map_new_gateway_placement` tests only covered the no-suggestion path (where `get_by_plugin_slug` returns `null`). This PR adds a new test method with two data provider cases:

1. **Preferred provider before offline PMs** — verifies the newly installed gateway takes the provider's placeholder place, remaining above the offline group.
2. **Preferred provider after offline PMs** — verifies the gateway takes the provider's placeholder place even when positioned after the offline group (custom ordering).

This is a follow-up to #63604.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the new tests: `pnpm test:php:env -- --filter "test_enhance_order_map_new_gateway_with_suggestion"`
2. Verify both test cases pass (preferred provider before and after offline PMs).
3. Run the full `PaymentsProvidersTest` suite to ensure no regressions: `pnpm test:php:env -- --filter PaymentsProvidersTest`

### Testing that has already taken place:

- Both new tests pass locally (`2 tests, 2 assertions`).
- Existing `test_enhance_order_map_new_gateway_placement` tests still pass (`4 tests, 4 assertions`).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Test-only change — no production code modified.

</details>