### PR TITLE
Update Store API product docs for draft and password-protected products

### DIFF
--- a/docs/apis/store-api/resources-endpoints/products.md
+++ b/docs/apis/store-api/resources-endpoints/products.md
@@ -2,6 +2,20 @@
 
 The store products API provides public product data so it can be rendered on the client side.
 
+## Product Visibility
+
+### Draft and non-published products
+
+Only published products are accessible via the Store API. Requesting a draft, pending, or other non-published product by ID or slug returns a `404` error. Non-published products are also excluded from the collection endpoint.
+
+### Password-protected products
+
+Password-protected products are visible in the API, but their `description` and `short_description` fields are redacted (returned as empty strings) until the correct password has been submitted. The response includes an `is_password_protected` boolean field so clients can detect this state and prompt the user.
+
+Password verification uses WordPress's native `wp-postpass_*` cookie, set when a user submits the password form on the frontend. The Store API does not accept passwords directly.
+
+Other product data (price, images, categories, etc.) remains accessible regardless of password status.
+
 ## List Products
 
 ```http
@@ -119,6 +133,7 @@ curl "https://example-store.com/wp-json/wc/store/v1/products"
 		"has_options": false,
 		"is_purchasable": true,
 		"is_in_stock": true,
+		"is_password_protected": false,
 		"low_stock_remaining": null,
 		"add_to_cart": {
 			"text": "Add to cart",
@@ -187,6 +202,7 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/34"
 	"has_options": false,
 	"is_purchasable": true,
 	"is_in_stock": true,
+	"is_password_protected": false,
 	"low_stock_remaining": null,
 	"add_to_cart": {
 		"text": "Add to cart",
@@ -254,6 +270,7 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/wordpress-pennant"
 	"has_options": false,
 	"is_purchasable": true,
 	"is_in_stock": true,
+	"is_password_protected": false,
 	"low_stock_remaining": null,
 	"add_to_cart": {
 		"text": "Add to cart",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Updates the Store API product endpoint documentation to reflect the changes introduced in #63466:

- Adds a new **Product Visibility** section documenting that draft/non-published products return 404 on single product routes
- Documents password-protected product behavior: description redaction, the `wp-postpass_*` cookie mechanism, and what data remains accessible
- Adds the new `is_password_protected` boolean field to all three example JSON responses (list, by-ID, by-slug)

### Screenshots or screen recordings:

N/A — documentation-only change.

### How to test the changes in this Pull Request:

1. Review the rendered markdown in this PR's "Files changed" tab
2. Verify the new "Product Visibility" section accurately describes the behavior from #63466
3. Verify `is_password_protected` appears in all three example JSON responses

### Testing that has already taken place:

Markdown linting passes cleanly (`markdownlint` with project config).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation-only change — no code or user-facing behavior modified.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)