### PR TITLE
Performance: Prime product caches and add targetHints in REST API v4 orders

### DIFF
--- a/plugins/woocommerce/changelog/rest-api-v4-orders-cache-priming
+++ b/plugins/woocommerce/changelog/rest-api-v4-orders-cache-priming
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Prime product caches and add targetHints to REST API v4 orders endpoint to reduce N+1 queries during serialization.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Controller.php
@@ -202,7 +202,8 @@ class Controller extends AbstractController {
 	protected function prepare_links( $item, WP_REST_Request $request, WP_REST_Response $response ): array {
 		$links = array(
 			'self'            => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $item->get_id() ) ),
+				'href'        => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $item->get_id() ) ),
+				'targetHints' => array( 'allow' => current_user_can( 'edit_shop_orders' ) ? array( 'GET', 'PUT', 'POST', 'PATCH', 'DELETE' ) : array( 'GET' ) ),
 			),
 			'collection'      => array(
 				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
@@ -305,6 +306,21 @@ class Controller extends AbstractController {
 		);
 		$results    = $this->collection_query->get_query_results( $query_args, $request );
 		$items      = array();
+
+		// Prime product caches to avoid N+1 queries during serialization.
+		$product_ids = array();
+		foreach ( $results['results'] as $order ) {
+			foreach ( $order->get_items( 'line_item' ) as $item ) {
+				if ( $item instanceof \WC_Order_Item_Product ) {
+					$product_ids[] = $item->get_product_id();
+					$product_ids[] = $item->get_variation_id();
+				}
+			}
+		}
+		$product_ids = array_unique( array_filter( $product_ids ) );
+		if ( ! empty( $product_ids ) ) {
+			_prime_post_caches( $product_ids, true, true );
+		}
 
 		foreach ( $results['results'] as $result ) {
 			$items[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $result, $request ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Extracted from https://github.com/woocommerce/woocommerce/pull/63440 for smaller review scope. This PR contains the REST API v4 Orders controller changes only:

1. **`targetHints` on self links** — Adds `allow` hints to the `self` link in order responses so clients can determine permitted HTTP methods (GET/PUT/POST/PATCH/DELETE vs GET-only) without making an OPTIONS preflight request.

2. **Prime product caches in `get_items()`** — Before serializing orders in a collection response, collects all product and variation IDs from line items and primes their post caches in a single batch call to `_prime_post_caches()`. This eliminates N+1 queries when resolving product data during order serialization.

### How to test the changes in this Pull Request:

1. Create several orders with product line items.
2. Make a `GET` request to `/wp-json/wc/v4/orders` as an admin user.
3. Verify the response includes `targetHints` in the `_links.self` object with `allow: ["GET", "PUT", "POST", "PATCH", "DELETE"]`.
4. Make the same request as a user without `edit_shop_orders` capability.
5. Verify `targetHints` shows `allow: ["GET"]` only.
6. Enable query logging (e.g. Query Monitor) and confirm product data is fetched in a single batch query rather than per-order.

### Testing that has already taken place:

Code review and manual inspection. Changes are extracted directly from the tested PR #63440.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry was created manually.