### PR TITLE
Fix stored XSS on order notes in REST API v4

### DIFF
--- a/plugins/woocommerce/changelog/fix-xss-order-notes-v4
+++ b/plugins/woocommerce/changelog/fix-xss-order-notes-v4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent stored XSS on order notes added via REST API v4

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Controller.php
@@ -287,7 +287,7 @@ class Controller extends AbstractController {
 		}
 
 		$order   = $this->get_order_by_id( (int) $request['order_id'] );
-		$note_id = $order ? $order->add_order_note( $request['note'], $request['is_customer_note'], true ) : null;
+		$note_id = $order ? $order->add_order_note( wp_kses_post( $request['note'] ), $request['is_customer_note'], true ) : null;
 
 		if ( ! $note_id ) {
 			return $this->get_route_error_by_code( self::CANNOT_CREATE );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Schema/OrderNoteSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Schema/OrderNoteSchema.php
@@ -70,11 +70,10 @@ class OrderNoteSchema extends AbstractSchema {
 				'readonly'    => true,
 			),
 			'note'             => array(
-				'description'       => __( 'Order note content.', 'woocommerce' ),
-				'type'              => 'string',
-				'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
-				'required'          => true,
-				'sanitize_callback' => 'wp_kses_post',
+				'description' => __( 'Order note content.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
+				'required'    => true,
 			),
 			'title'            => array(
 				'description' => __( 'The title of the order note group.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Schema/OrderNoteSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/OrderNotes/Schema/OrderNoteSchema.php
@@ -70,10 +70,11 @@ class OrderNoteSchema extends AbstractSchema {
 				'readonly'    => true,
 			),
 			'note'             => array(
-				'description' => __( 'Order note content.', 'woocommerce' ),
-				'type'        => 'string',
-				'context'     => self::VIEW_EDIT_EMBED_CONTEXT,
-				'required'    => true,
+				'description'       => __( 'Order note content.', 'woocommerce' ),
+				'type'              => 'string',
+				'context'           => self::VIEW_EDIT_EMBED_CONTEXT,
+				'required'          => true,
+				'sanitize_callback' => 'wp_kses_post',
 			),
 			'title'            => array(
 				'description' => __( 'The title of the order note group.', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OrderNotes/class-wc-rest-order-notes-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/OrderNotes/class-wc-rest-order-notes-v4-controller-tests.php
@@ -388,6 +388,29 @@ class WC_REST_Order_Notes_V4_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that order note content is sanitized to prevent XSS.
+	 */
+	public function test_create_item_sanitizes_note_content() {
+		$order = OrderHelper::create_order( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v4/order-notes' );
+		$request->set_body_params(
+			array(
+				'order_id' => $order->get_id(),
+				'note'     => '<script>alert("xss")</script>Safe content<b>bold</b>',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertStringNotContainsString( '<script>', $data['note'] );
+		$this->assertStringContainsString( 'Safe content', $data['note'] );
+		$this->assertStringContainsString( '<b>bold</b>', $data['note'] );
+	}
+
+	/**
 	 * Test deleting order note without permission.
 	 */
 	public function test_delete_item_without_permission() {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Extends the stored XSS fix from #63616 (which covers REST API v1/v2/v3) to the v4 REST API.

Adds `wp_kses_post()` sanitization to the note content in the v4 `OrderNotes\Controller::create_item()` method before passing it to `add_order_note()`. This strips dangerous tags like `<script>` while preserving safe HTML.

Note: Unlike the v1 fix which uses `sanitize_callback` in route args via `array_merge`, the v4 fix sanitizes directly in `create_item()`. This is because v4's schema-driven architecture doesn't use `array_merge` to override endpoint args, and WordPress core's `rest_get_endpoint_args_for_schema()` hardcodes `sanitize_callback` to `rest_sanitize_request_arg` — ignoring any `sanitize_callback` set in the schema. Sanitizing at the point of use is cleaner for v4 and provides defense in depth.

Also adds a unit test verifying the sanitization behavior.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Create an order via the WooCommerce admin.
2. Use the v4 REST API to add an order note containing a `<script>` tag:
   ```
   POST /wp-json/wc/v4/order-notes?order_id=<ORDER_ID>
   { "note": "<script>alert('xss')</script>Safe content<b>bold</b>" }
   ```
3. Verify the response `note` field does not contain `<script>` tags.
4. Verify safe HTML like `<b>bold</b>` is preserved.
5. View the order in the admin and confirm no script injection occurs.

### Testing that has already taken place:

- Unit test `test_create_item_sanitizes_note_content` verifies XSS payloads are stripped and safe HTML is preserved.
- Full v4 OrderNotes test suite passes (17 tests, 55 assertions).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Prevent stored XSS on order notes added via REST API v4

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>