### PR TITLE
Fix floating point precision error in REST API v4 refund amount validation

### DIFF
--- a/plugins/woocommerce/changelog/fix-refund-float-compare
+++ b/plugins/woocommerce/changelog/fix-refund-float-compare
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix floating point precision error in REST API v4 refund amount validation that caused valid refunds to be rejected.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -316,8 +316,8 @@ class Controller extends AbstractController {
 					sprintf(
 						/* translators: %1$s: refund amount, %2$s: calculated total from line items */
 						__( 'Refund amount (%1$s) cannot be less than the total of line items (%2$s).', 'woocommerce' ),
-						wc_format_decimal( $refund_amount, 2 ),
-						wc_format_decimal( $calculated_total, 2 )
+						wc_format_decimal( $refund_amount, wc_get_price_decimals() ),
+						wc_format_decimal( $calculated_total, wc_get_price_decimals() )
 					)
 				);
 			}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -314,8 +314,9 @@ class Controller extends AbstractController {
 				return $this->get_route_error_response(
 					'invalid_refund_amount',
 					sprintf(
-						/* translators: %s: calculated total from line items */
-						__( 'Refund amount cannot be less than the total of line items (%s).', 'woocommerce' ),
+						/* translators: %1$s: refund amount, %2$s: calculated total from line items */
+						__( 'Refund amount (%1$s) cannot be less than the total of line items (%2$s).', 'woocommerce' ),
+						wc_format_decimal( $refund_amount, 2 ),
 						wc_format_decimal( $calculated_total, 2 )
 					)
 				);

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\AbstractController;
 use Automattic\WooCommerce\StoreApi\Utilities\Pagination;
 use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\Schema\RefundSchema;
+use Automattic\WooCommerce\Utilities\NumberUtil;
 use WP_Http;
 use WP_Error;
 use WC_Order_Refund;
@@ -309,7 +310,7 @@ class Controller extends AbstractController {
 
 			// Prevent under-refunding: amount cannot be less than calculated line items total.
 			// Over-refunding is allowed for goodwill/compensation scenarios.
-			if ( ! empty( $request['amount'] ) && $calculated_total > 0 && $refund_amount < $calculated_total ) {
+			if ( ! empty( $request['amount'] ) && $calculated_total > 0 && NumberUtil::round( (float) $refund_amount, wc_get_price_decimals() ) < NumberUtil::round( $calculated_total, wc_get_price_decimals() ) ) {
 				return $this->get_route_error_response(
 					'invalid_refund_amount',
 					sprintf(

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -147,7 +147,7 @@ class DataUtils {
 			}
 		}
 
-		return $amount;
+		return (float) NumberUtil::round( $amount, wc_get_price_decimals() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Refunds/DataUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Refunds/DataUtilsTest.php
@@ -302,6 +302,64 @@ class DataUtilsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that calculate_refund_amount handles floating point precision correctly.
+	 *
+	 * Values like 43.20 + 19.20 can produce 62.400000000000006 in PHP due to IEEE 754
+	 * floating point representation. The method should round the result to avoid false
+	 * positives in under-refund validation.
+	 */
+	public function test_calculate_refund_amount_avoids_floating_point_errors() {
+		$line_items = array(
+			array(
+				'line_item_id' => '62',
+				'quantity'     => 2,
+				'refund_total' => '43.20',
+			),
+			array(
+				'line_item_id' => '63',
+				'quantity'     => 1,
+				'refund_total' => '19.20',
+			),
+		);
+
+		$result = $this->data_utils->calculate_refund_amount( $line_items );
+
+		// Without rounding, 43.20 + 19.20 = 62.400000000000006 in PHP.
+		// The method should return exactly 62.40.
+		$this->assertSame( 62.40, $result );
+	}
+
+	/**
+	 * Test that calculate_refund_amount includes tax totals.
+	 */
+	public function test_calculate_refund_amount_includes_tax() {
+		$line_items = array(
+			array(
+				'line_item_id' => '1',
+				'quantity'     => 1,
+				'refund_total' => '10.00',
+				'refund_tax'   => array(
+					array(
+						'id'           => 1,
+						'refund_total' => '1.50',
+					),
+				),
+			),
+		);
+
+		$result = $this->data_utils->calculate_refund_amount( $line_items );
+
+		$this->assertSame( 11.50, $result );
+	}
+
+	/**
+	 * Test that calculate_refund_amount returns null for empty line items.
+	 */
+	public function test_calculate_refund_amount_returns_null_for_empty() {
+		$this->assertNull( $this->data_utils->calculate_refund_amount( array() ) );
+	}
+
+	/**
 	 * Helper: Create an order with shipping that has tax rate IDs but zero tax amounts.
 	 *
 	 * This simulates the scenario where a tax rate exists but doesn't apply to shipping.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PHP floating point arithmetic can produce precision errors when summing decimal values. For example, `43.20 + 19.20` evaluates to `62.400000000000006` rather than `62.40` due to IEEE 754 representation. This caused the under-refund validation in the REST API v4 refunds controller to falsely reject valid refund amounts — `62.40 < 62.400000000000006` evaluates to `true`, triggering an incorrect error.

**Fix:**
- `DataUtils::calculate_refund_amount()` — Round the accumulated total using `NumberUtil::round()` to the store's configured price decimals before returning.
- `Controller.php` under-refund comparison — Round both sides of the comparison using `NumberUtil::round()` as defense-in-depth.
- Improved the error message to include both the refund amount and the calculated line items total for easier debugging.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Create an order with two line items priced at `$43.20` and `$19.20` (total `$62.40`).
2. Via the REST API v4, create a refund with `"amount": "62.40"` and line items totaling `43.20 + 19.20`:
   ```json
   {
       "order_id": <order_id>,
       "api_refund": false,
       "amount": "62.40",
       "line_items": [
           {"line_item_id": "<id>", "quantity": 2, "refund_total": "43.20"},
           {"line_item_id": "<id>", "quantity": 1, "refund_total": "19.20"}
       ],
       "reason": "",
       "api_restock": false
   }
   ```
3. **Before fix:** The request fails with `"Refund amount cannot be less than the total of line items (62.40)."`.
4. **After fix:** The refund is created successfully.

### Testing that has already taken place:

- PHPUnit tests pass (`DataUtilsTest` — 8 tests, 34 assertions).
- Added 3 new unit tests for `calculate_refund_amount()`:
  - Floating point precision test (the exact failing scenario: `43.20 + 19.20`).
  - Tax inclusion test.
  - Empty input returns null.
- PHP linting clean.
- PHPStan clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry was created manually at `plugins/woocommerce/changelog/fix-refund-float-compare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)