### PR TITLE
[Performance] Add missing indexes to the shipping tables

### DIFF
--- a/plugins/woocommerce/changelog/performance-add-indexes-on-shipping-tables
+++ b/plugins/woocommerce/changelog/performance-add-indexes-on-shipping-tables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Added the missing shipping tables indexes to improve the performance of cart and checkout workflows for complex shipping configurations.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2021,7 +2021,9 @@ CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods (
   method_id varchar(200) NOT NULL,
   method_order bigint(20) unsigned NOT NULL,
   is_enabled tinyint(1) NOT NULL DEFAULT '1',
-  PRIMARY KEY  (instance_id)
+  PRIMARY KEY  (instance_id),
+  KEY zone_id (zone_id),
+  KEY method_id (method_id(20))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_payment_tokens (
   token_id bigint(20) unsigned NOT NULL auto_increment,

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2004,7 +2004,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zones (
   zone_id bigint(20) unsigned NOT NULL auto_increment,
   zone_name varchar(200) NOT NULL,
   zone_order bigint(20) unsigned NOT NULL,
-  PRIMARY KEY  (zone_id)
+  PRIMARY KEY  (zone_id),
+  KEY zone_order_id (zone_order, zone_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations (
   location_id bigint(20) unsigned NOT NULL auto_increment,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6418, #63694

This optimization targets cart and checkout workflows, where complex shipping configurations can slow related SQL queries due to missing table indexes. This PR introduces new indexes based on the identified queries.

```sql
EXPLAIN SELECT method_id, method_order, instance_id, is_enabled FROM wp_woocommerce_shipping_zone_methods WHERE zone_id = 1;

# 1,SIMPLE,wp_woocommerce_shipping_zone_methods,ALL,,,,,1,Using where
# -> ( ALL -> ref !, reduced CPU usage as we are looking up the index now )
# 1,SIMPLE,wp_woocommerce_shipping_zone_methods,ref,zone_id,zone_id,8,const,1,""


EXPLAIN SELECT COUNT(*) FROM wp_woocommerce_shipping_zone_methods WHERE is_enabled=1 AND method_id IN ('flat_rate')

# 1,SIMPLE,wp_woocommerce_shipping_zone_methods,ALL,,,,,1,Using where
# -> ( ALL -> ref !, reduced CPU usage as we are looking up the index now )
# 1,SIMPLE,wp_woocommerce_shipping_zone_methods,ref,method_id,method_id,82,const,1,Using where

EXPLAIN SELECT zones.zone_id FROM wp_woocommerce_shipping_zones as zones
    LEFT OUTER JOIN wp_woocommerce_shipping_zone_locations as locations ON zones.zone_id = locations.zone_id AND location_type != 'postcode'
WHERE
    ( ( location_type = 'country' AND location_code = 'US' )
        OR ( location_type = 'state' AND location_code = 'US:CA' )
        OR ( location_type = 'continent' AND location_code = 'NA' )
        OR ( location_type IS NULL ) )

ORDER BY zone_order ASC, zones.zone_id ASC LIMIT 1;

# 1,SIMPLE,zones,ALL,,,,,500,Using filesort
# 1,SIMPLE,locations,ref,"zone_id,location_type_code",zone_id,8,wordpress.zones.zone_id,1,Using where
# -> ( eliminates filesort operations on larger zone tables; the optimizer may ignore the index when the table size is small )
# 1,SIMPLE,zones,index,,zone_order_id,16,,1,Using index
# 1,SIMPLE,locations,ref,"zone_id,location_type_code",zone_id,8,wordpress.zones.zone_id,1,Using where
```


### How to test the changes in this Pull Request:

- The testing site does not need to meet any special requirements.
- Update the options table by modifying or deleting the following entries: `woocommerce_version`, `woocommerce_db_version`.
- Access the admin area to run db-delta and update the database schema.
- Confirm that the new indices have been added.