### PR TITLE
Fix: Make zone locations optional in V4 Shipping Zones API

### DIFF
--- a/plugins/woocommerce/changelog/63685-fix-woo13-190-i-cant-add-a-zone-for-everywhere
+++ b/plugins/woocommerce/changelog/63685-fix-woo13-190-i-cant-add-a-zone-for-everywhere
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make zone locations optional in the V4 Shipping Zones REST API schema so that "Everywhere" zones can be created without providing a locations array.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/ShippingZoneSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/ShippingZoneSchema.php
@@ -53,7 +53,7 @@ class ShippingZoneSchema extends AbstractSchema {
 				'default'     => 0,
 			),
 			'locations' => array(
-				'description' => __( 'Array of locations for this zone. Can be empty array but must be explicitly provided.', 'woocommerce' ),
+				'description' => __( 'Array of locations for this zone. Omit or pass an empty array for an "Everywhere" zone.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'required'    => false,

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/ShippingZoneSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/ShippingZones/ShippingZoneSchema.php
@@ -56,7 +56,7 @@ class ShippingZoneSchema extends AbstractSchema {
 				'description' => __( 'Array of locations for this zone. Can be empty array but must be explicitly provided.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
-				'required'    => true,
+				'required'    => false,
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/ShippingZones/class-wc-rest-shipping-zones-v4-controller-tests.php
@@ -888,7 +888,7 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
-	 * @testdox Should create zone without required locations.
+	 * @testdox Should create zone without locations (e.g. "Everywhere" zone).
 	 */
 	public function test_create_item_missing_locations() {
 		$request = new WP_REST_Request( 'POST', '/wc/v4/shipping-zones' );
@@ -901,9 +901,9 @@ class WC_REST_Shipping_Zones_V4_Controller_Tests extends WC_REST_Unit_Test_Case 
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 400, $response->get_status() );
-		$this->assertArrayHasKey( 'code', $data );
-		$this->assertEquals( 'rest_missing_callback_param', $data['code'] );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 'Test Zone', $data['name'] );
+		$this->assertEmpty( $data['locations'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

When creating a shipping zone for "Everywhere" (i.e., a zone with no specific locations), the V4 REST API returns a validation error because the `locations` field is marked as `required` in the item schema. Since an "Everywhere" zone intentionally has no locations, the API should allow omitting the `locations` field entirely.

This PR changes the `locations` property from `required: true` to `required: false` in the `ShippingZoneSchema` item schema, allowing zones to be created without explicitly providing a locations array.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Send a `POST` request to the V4 Shipping Zones endpoint (`/wc/v4/shipping/zones`) with only a `name` field (e.g., `{ "name": "Everywhere" }`) and no `locations` field.
2. Verify the zone is created successfully without a validation error.
3. Send a `POST` request with `name` and an empty `locations` array (e.g., `{ "name": "Everywhere", "locations": [] }`).
4. Verify this also succeeds.
5. Send a `POST` request with `name` and a populated `locations` array (e.g., `{ "name": "US Zone", "locations": [{ "code": "US", "type": "country" }] }`).
6. Verify the zone is created with the correct locations.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Make zone locations optional in the V4 Shipping Zones REST API schema so that "Everywhere" zones can be created without providing a locations array.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
