### PR TITLE
Add to Cart with Options: avoid attributes name and slugs normalisation and fallback to slug vs slug comparison

### DIFF
--- a/plugins/woocommerce/changelog/fix-attributes-normalisation
+++ b/plugins/woocommerce/changelog/fix-attributes-normalisation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart with Options: avoid attributes name and slugs normalisation and fallback to slug vs slug comparison

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/attribute-matching.ts
@@ -8,71 +8,48 @@ import type {
 } from '@woocommerce/types';
 
 /**
- * Normalize attribute name by stripping the 'attribute_' or 'attribute_pa_' prefix
- * that WooCommerce adds for variation attributes, and replacing hyphens with spaces
- * so that slugs (e.g., "some-name") match labels (e.g., "some name").
- *
- * @param name The attribute name (e.g., 'attribute_color' or 'attribute_pa_color').
- * @return The normalized name (e.g., 'color').
+ * A mapping of attribute slugs (e.g., "attribute_pa_color") to their
+ * Store API label names (e.g., "Color"). This is provided by the PHP context
+ * and allows reliable matching without heuristic normalization.
  */
-export const normalizeAttributeName = ( name: string ): string => {
-	return name
-		.replace( /^attribute_(pa_)?/, '' )
-		.replace( /-/g, ' ' )
-		.toLowerCase();
-};
+export type AttributeSlugToLabel = Record< string, string >;
 
 /**
- * Check if two attribute names match, using case-insensitive comparison.
- *
- * This handles the mismatch between Store API labels (e.g., "Color") and
- * PHP context slugs (e.g., "attribute_pa_color").
- *
- * @param name1 First attribute name (may be label or slug format).
- * @param name2 Second attribute name (may be label or slug format).
- * @return True if the names match after normalization.
- */
-export const attributeNamesMatch = (
-	name1: string,
-	name2: string
-): boolean => {
-	return normalizeAttributeName( name1 ) === normalizeAttributeName( name2 );
-};
-
-/**
- * Get the attribute value from a variation's attributes array.
- *
- * The Store API returns the attribute label (e.g., "Color") in the name field,
- * while the PHP context uses the attribute slug (e.g., "attribute_pa_color").
- * We do a case-insensitive comparison to match "color" with "Color".
+ * Get the attribute value from a variation's attributes array, using the
+ * slug-to-label mapping to translate between PHP context slugs and Store API
+ * attribute names.
  *
  * @param variation     The variation in Store API format.
- * @param attributeName The attribute name to find (may include 'attribute_' prefix).
+ * @param attributeSlug The attribute slug (e.g., "attribute_pa_color").
+ * @param slugToLabel   Mapping of attribute slugs to Store API label names.
  * @return The attribute value, or undefined if not found.
  */
 export const getVariationAttributeValue = (
 	variation: ProductResponseVariationsItem,
-	attributeName: string
+	attributeSlug: string,
+	slugToLabel: AttributeSlugToLabel
 ): string | undefined => {
-	const attr = variation.attributes.find( ( a ) =>
-		attributeNamesMatch( attributeName, a.name )
-	);
+	const label = slugToLabel[ attributeSlug ];
+	if ( ! label ) {
+		return undefined;
+	}
+	const attr = variation.attributes.find( ( a ) => a.name === label );
 	return attr?.value;
 };
 
 /**
- * Find the matching variation from a product's variations based on selected attributes.
- *
- * Uses case-insensitive comparison since Store API returns labels (e.g., "Color")
- * while PHP context uses slugs (e.g., "attribute_pa_color" → "color").
+ * Find the matching variation from a product's variations based on selected
+ * attributes, using the slug-to-label mapping for reliable matching.
  *
  * @param product            The product in Store API format.
- * @param selectedAttributes The selected attributes.
+ * @param selectedAttributes The selected attributes (using slug format).
+ * @param slugToLabel        Mapping of attribute slugs to Store API label names.
  * @return The matching variation, or null if no match.
  */
 export const findMatchingVariation = (
 	product: ProductResponseItem,
-	selectedAttributes: SelectedAttributes[]
+	selectedAttributes: SelectedAttributes[],
+	slugToLabel: AttributeSlugToLabel
 ): ProductResponseVariationsItem | null => {
 	if ( ! product.variations?.length || ! selectedAttributes?.length ) {
 		return null;
@@ -81,8 +58,9 @@ export const findMatchingVariation = (
 	const matchedVariation = product.variations.find(
 		( variation: ProductResponseVariationsItem ) => {
 			return variation.attributes.every( ( attr ) => {
-				const selectedAttr = selectedAttributes.find( ( selected ) =>
-					attributeNamesMatch( attr.name, selected.attribute )
+				const selectedAttr = selectedAttributes.find(
+					( selected ) =>
+						slugToLabel[ selected.attribute ] === attr.name
 				);
 
 				// If variation attribute is null, it accepts "Any" value.

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
@@ -6,11 +6,6 @@ import type {
 	SelectedAttributes,
 } from '@woocommerce/stores/woocommerce/cart';
 
-/**
- * Internal dependencies
- */
-import { attributeNamesMatch } from './attribute-matching';
-
 export const doesCartItemMatchAttributes = (
 	cartItem: OptimisticCartItem,
 	selectedAttributes: SelectedAttributes[]
@@ -39,11 +34,8 @@ export const doesCartItemMatchAttributes = (
 		} ) =>
 			selectedAttributes.some( ( item: SelectedAttributes ) => {
 				return (
-					attributeNamesMatch(
-						item.attribute,
-						// It needs to check both because it uses different keys from the same value depending on the context.
-						raw_attribute ?? attribute
-					) && item.value.toLowerCase() === value?.toLowerCase()
+					item.attribute === ( raw_attribute ?? attribute ) &&
+					item.value.toLowerCase() === value?.toLowerCase()
 				);
 			} )
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
@@ -185,12 +185,12 @@ describe( 'findMatchingVariation', () => {
 	} );
 
 	describe( 'multi-attribute product with transliterated slugs', () => {
-		// This is the exact scenario that broke with normalization:
-		// German store with "Größe" (slug: groesse) + "Modell" (slug: modell)
-		// with hyphenated term values like "bmc-kaius-01".
+		// Scenario: transliterated umlaut attribute + hyphenated term slugs.
+		// WordPress sanitize_title converts "Größe" → "groesse" and
+		// "Farbe" → "farbe", but wc_attribute_label returns the original.
 		const germanMapping: AttributeSlugToLabel = {
 			attribute_pa_groesse: 'Größe',
-			attribute_pa_modell: 'Modell',
+			attribute_pa_farbe: 'Farbe',
 		};
 
 		const germanProduct = {
@@ -201,14 +201,14 @@ describe( 'findMatchingVariation', () => {
 					id: 501,
 					attributes: [
 						{ name: 'Größe', value: 'xl' },
-						{ name: 'Modell', value: 'bmc-kaius-01' },
+						{ name: 'Farbe', value: 'dunkel-blau' },
 					],
 				},
 				{
 					id: 502,
 					attributes: [
 						{ name: 'Größe', value: 'm' },
-						{ name: 'Modell', value: 'bmc-urs-urs01' },
+						{ name: 'Farbe', value: 'hell-gruen' },
 					],
 				},
 			],
@@ -219,7 +219,7 @@ describe( 'findMatchingVariation', () => {
 				germanProduct,
 				[
 					{ attribute: 'attribute_pa_groesse', value: 'xl' },
-					{ attribute: 'attribute_pa_modell', value: 'bmc-kaius-01' },
+					{ attribute: 'attribute_pa_farbe', value: 'dunkel-blau' },
 				],
 				germanMapping
 			);
@@ -232,8 +232,8 @@ describe( 'findMatchingVariation', () => {
 				[
 					{ attribute: 'attribute_pa_groesse', value: 'm' },
 					{
-						attribute: 'attribute_pa_modell',
-						value: 'bmc-urs-urs01',
+						attribute: 'attribute_pa_farbe',
+						value: 'hell-gruen',
 					},
 				],
 				germanMapping
@@ -247,8 +247,8 @@ describe( 'findMatchingVariation', () => {
 				[
 					{ attribute: 'attribute_pa_groesse', value: 'xl' },
 					{
-						attribute: 'attribute_pa_modell',
-						value: 'bmc-urs-urs01',
+						attribute: 'attribute_pa_farbe',
+						value: 'hell-gruen',
 					},
 				],
 				germanMapping

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/test/attribute-matching.ts
@@ -2,79 +2,15 @@
  * Internal dependencies
  */
 import {
-	normalizeAttributeName,
-	attributeNamesMatch,
 	getVariationAttributeValue,
 	findMatchingVariation,
 } from '../attribute-matching';
+import type { AttributeSlugToLabel } from '../attribute-matching';
 
-describe( 'normalizeAttributeName', () => {
-	it( 'strips attribute_ prefix', () => {
-		expect( normalizeAttributeName( 'attribute_color' ) ).toBe( 'color' );
-	} );
-
-	it( 'strips attribute_pa_ prefix', () => {
-		expect( normalizeAttributeName( 'attribute_pa_color' ) ).toBe(
-			'color'
-		);
-	} );
-
-	it( 'returns lowercased name without prefix', () => {
-		expect( normalizeAttributeName( 'Color' ) ).toBe( 'color' );
-	} );
-
-	it( 'replaces hyphens with spaces for multi-word slugs', () => {
-		expect( normalizeAttributeName( 'attribute_pa_numeric-size' ) ).toBe(
-			'numeric size'
-		);
-	} );
-
-	it( 'replaces hyphens with spaces without prefix', () => {
-		expect( normalizeAttributeName( 'numeric-size' ) ).toBe(
-			'numeric size'
-		);
-	} );
-} );
-
-describe( 'attributeNamesMatch', () => {
-	it( 'matches case-insensitively', () => {
-		expect( attributeNamesMatch( 'Color', 'color' ) ).toBe( true );
-	} );
-
-	it( 'matches after stripping prefix', () => {
-		expect( attributeNamesMatch( 'attribute_pa_color', 'Color' ) ).toBe(
-			true
-		);
-	} );
-
-	it( 'matches when both have prefixes', () => {
-		expect(
-			attributeNamesMatch( 'attribute_pa_color', 'attribute_color' )
-		).toBe( true );
-	} );
-
-	it( 'matches hyphenated slug against spaced label', () => {
-		expect(
-			attributeNamesMatch( 'attribute_pa_numeric-size', 'numeric size' )
-		).toBe( true );
-	} );
-
-	it( 'matches hyphenated slug against capitalized spaced label', () => {
-		expect(
-			attributeNamesMatch( 'attribute_pa_numeric-size', 'Numeric Size' )
-		).toBe( true );
-	} );
-
-	it( 'matches two hyphenated names', () => {
-		expect(
-			attributeNamesMatch( 'attribute_pa_numeric-size', 'numeric-size' )
-		).toBe( true );
-	} );
-
-	it( 'returns false for different names', () => {
-		expect( attributeNamesMatch( 'color', 'size' ) ).toBe( false );
-	} );
-} );
+const slugToLabel: AttributeSlugToLabel = {
+	attribute_pa_color: 'Color',
+	attribute_pa_size: 'Size',
+};
 
 describe( 'getVariationAttributeValue', () => {
 	const variation = {
@@ -85,67 +21,64 @@ describe( 'getVariationAttributeValue', () => {
 		],
 	};
 
-	it( 'finds attribute value by exact name', () => {
-		expect( getVariationAttributeValue( variation, 'Color' ) ).toBe(
-			'Blue'
-		);
-	} );
-
-	it( 'finds attribute value case-insensitively', () => {
-		expect( getVariationAttributeValue( variation, 'color' ) ).toBe(
-			'Blue'
-		);
-	} );
-
-	it( 'finds attribute value when using prefix', () => {
+	it( 'finds attribute value by slug using mapping', () => {
 		expect(
-			getVariationAttributeValue( variation, 'attribute_pa_color' )
+			getVariationAttributeValue(
+				variation,
+				'attribute_pa_color',
+				slugToLabel
+			)
 		).toBe( 'Blue' );
 	} );
 
-	it( 'returns undefined for non-existent attribute', () => {
+	it( 'returns undefined for unknown slug', () => {
 		expect(
-			getVariationAttributeValue( variation, 'material' )
+			getVariationAttributeValue(
+				variation,
+				'attribute_pa_material',
+				slugToLabel
+			)
 		).toBeUndefined();
 	} );
 
-	describe( 'multi-word attribute names', () => {
-		const variationWithSpaces = {
+	it( 'returns undefined when slug not in mapping', () => {
+		expect(
+			getVariationAttributeValue( variation, 'Color', slugToLabel )
+		).toBeUndefined();
+	} );
+
+	it( 'handles special characters where slug differs from label', () => {
+		const variationWithUmlaut = {
 			id: 456,
-			attributes: [ { name: 'numeric size', value: '42' } ],
+			attributes: [ { name: 'Größe', value: 'xl' } ],
 		};
+		const specialMapping: AttributeSlugToLabel = {
+			attribute_pa_groesse: 'Größe',
+		};
+		expect(
+			getVariationAttributeValue(
+				variationWithUmlaut,
+				'attribute_pa_groesse',
+				specialMapping
+			)
+		).toBe( 'xl' );
+	} );
 
-		const variationWithHyphens = {
+	it( 'handles custom slug that differs from label', () => {
+		const variationWithCustom = {
 			id: 789,
-			attributes: [ { name: 'numeric-size', value: '44' } ],
+			attributes: [ { name: 'Shirt Type', value: 'polo' } ],
 		};
-
-		it( 'finds value when slug has hyphens and Store API has spaces', () => {
-			expect(
-				getVariationAttributeValue(
-					variationWithSpaces,
-					'attribute_pa_numeric-size'
-				)
-			).toBe( '42' );
-		} );
-
-		it( 'finds value when both use hyphens', () => {
-			expect(
-				getVariationAttributeValue(
-					variationWithHyphens,
-					'attribute_pa_numeric-size'
-				)
-			).toBe( '44' );
-		} );
-
-		it( 'finds value when both use spaces', () => {
-			expect(
-				getVariationAttributeValue(
-					variationWithSpaces,
-					'numeric size'
-				)
-			).toBe( '42' );
-		} );
+		const customMapping: AttributeSlugToLabel = {
+			attribute_pa_tshirt_type: 'Shirt Type',
+		};
+		expect(
+			getVariationAttributeValue(
+				variationWithCustom,
+				'attribute_pa_tshirt_type',
+				customMapping
+			)
+		).toBe( 'polo' );
 	} );
 } );
 
@@ -180,89 +113,214 @@ describe( 'findMatchingVariation', () => {
 
 	it( 'returns null when product has no variations', () => {
 		const productNoVariations = { id: 1, type: 'variable', variations: [] };
-		const selectedAttributes = [ { attribute: 'Color', value: 'Blue' } ];
 		expect(
-			findMatchingVariation( productNoVariations, selectedAttributes )
+			findMatchingVariation(
+				productNoVariations,
+				[ { attribute: 'attribute_pa_color', value: 'Blue' } ],
+				slugToLabel
+			)
 		).toBeNull();
 	} );
 
 	it( 'returns null when no attributes are selected', () => {
-		expect( findMatchingVariation( product, [] ) ).toBeNull();
+		expect( findMatchingVariation( product, [], slugToLabel ) ).toBeNull();
 	} );
 
 	it( 'finds exact match with all attributes', () => {
-		const selectedAttributes = [
-			{ attribute: 'Color', value: 'Blue' },
-			{ attribute: 'Size', value: 'Large' },
-		];
-		const result = findMatchingVariation( product, selectedAttributes );
+		const result = findMatchingVariation(
+			product,
+			[
+				{ attribute: 'attribute_pa_color', value: 'Blue' },
+				{ attribute: 'attribute_pa_size', value: 'Large' },
+			],
+			slugToLabel
+		);
 		expect( result?.id ).toBe( 102 );
 	} );
 
-	it( 'matches with attribute prefix in selected attributes', () => {
-		const selectedAttributes = [
-			{ attribute: 'attribute_pa_color', value: 'Blue' },
-			{ attribute: 'attribute_pa_size', value: 'Small' },
-		];
-		const result = findMatchingVariation( product, selectedAttributes );
-		expect( result?.id ).toBe( 101 );
-	} );
-
 	it( 'returns null when no variation matches', () => {
-		const selectedAttributes = [
-			{ attribute: 'Color', value: 'Green' },
-			{ attribute: 'Size', value: 'Small' },
-		];
 		expect(
-			findMatchingVariation( product, selectedAttributes )
+			findMatchingVariation(
+				product,
+				[
+					{ attribute: 'attribute_pa_color', value: 'Green' },
+					{ attribute: 'attribute_pa_size', value: 'Small' },
+				],
+				slugToLabel
+			)
 		).toBeNull();
 	} );
 
-	describe( 'multi-word attribute names', () => {
-		const productWithMultiWord = {
+	describe( 'attributes with special characters in labels', () => {
+		const specialMapping: AttributeSlugToLabel = {
+			attribute_pa_groesse: 'Größe',
+			attribute_pa_cafe_style: 'Café Style',
+		};
+
+		const productWithSpecialChars = {
 			id: 3,
 			type: 'variable',
 			variations: [
 				{
 					id: 301,
 					attributes: [
-						{ name: 'Color', value: 'Blue' },
-						{ name: 'numeric size', value: '42' },
-					],
-				},
-				{
-					id: 302,
-					attributes: [
-						{ name: 'Color', value: 'Red' },
-						{ name: 'numeric size', value: '44' },
+						{ name: 'Größe', value: 'xl' },
+						{ name: 'Café Style', value: 'latte' },
 					],
 				},
 			],
 		};
 
-		it( 'matches when selected attributes use hyphenated slugs', () => {
-			const result = findMatchingVariation( productWithMultiWord, [
-				{ attribute: 'attribute_pa_color', value: 'Blue' },
-				{ attribute: 'attribute_pa_numeric-size', value: '42' },
-			] );
+		it( 'matches by slug-to-label mapping regardless of special characters', () => {
+			const result = findMatchingVariation(
+				productWithSpecialChars,
+				[
+					{ attribute: 'attribute_pa_groesse', value: 'xl' },
+					{ attribute: 'attribute_pa_cafe_style', value: 'latte' },
+				],
+				specialMapping
+			);
 			expect( result?.id ).toBe( 301 );
 		} );
+	} );
 
-		it( 'matches when Store API uses hyphens instead of spaces', () => {
-			const productWithHyphens = {
-				id: 4,
-				type: 'variable',
-				variations: [
+	describe( 'multi-attribute product with transliterated slugs', () => {
+		// This is the exact scenario that broke with normalization:
+		// German store with "Größe" (slug: groesse) + "Modell" (slug: modell)
+		// with hyphenated term values like "bmc-kaius-01".
+		const germanMapping: AttributeSlugToLabel = {
+			attribute_pa_groesse: 'Größe',
+			attribute_pa_modell: 'Modell',
+		};
+
+		const germanProduct = {
+			id: 5,
+			type: 'variable',
+			variations: [
+				{
+					id: 501,
+					attributes: [
+						{ name: 'Größe', value: 'xl' },
+						{ name: 'Modell', value: 'bmc-kaius-01' },
+					],
+				},
+				{
+					id: 502,
+					attributes: [
+						{ name: 'Größe', value: 'm' },
+						{ name: 'Modell', value: 'bmc-urs-urs01' },
+					],
+				},
+			],
+		};
+
+		it( 'matches variation with umlaut attribute and hyphenated term values', () => {
+			const result = findMatchingVariation(
+				germanProduct,
+				[
+					{ attribute: 'attribute_pa_groesse', value: 'xl' },
+					{ attribute: 'attribute_pa_modell', value: 'bmc-kaius-01' },
+				],
+				germanMapping
+			);
+			expect( result?.id ).toBe( 501 );
+		} );
+
+		it( 'matches second variation correctly', () => {
+			const result = findMatchingVariation(
+				germanProduct,
+				[
+					{ attribute: 'attribute_pa_groesse', value: 'm' },
 					{
-						id: 401,
-						attributes: [ { name: 'numeric-size', value: '42' } ],
+						attribute: 'attribute_pa_modell',
+						value: 'bmc-urs-urs01',
 					},
 				],
-			};
-			const result = findMatchingVariation( productWithHyphens, [
-				{ attribute: 'attribute_pa_numeric-size', value: '42' },
-			] );
-			expect( result?.id ).toBe( 401 );
+				germanMapping
+			);
+			expect( result?.id ).toBe( 502 );
+		} );
+
+		it( 'returns null when values do not match any variation', () => {
+			const result = findMatchingVariation(
+				germanProduct,
+				[
+					{ attribute: 'attribute_pa_groesse', value: 'xl' },
+					{
+						attribute: 'attribute_pa_modell',
+						value: 'bmc-urs-urs01',
+					},
+				],
+				germanMapping
+			);
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'attribute with accented characters', () => {
+		const accentMapping: AttributeSlugToLabel = {
+			attribute_pa_cafe_style: 'Café Style',
+		};
+
+		const accentProduct = {
+			id: 6,
+			type: 'variable',
+			variations: [
+				{
+					id: 601,
+					attributes: [ { name: 'Café Style', value: 'latte' } ],
+				},
+				{
+					id: 602,
+					attributes: [ { name: 'Café Style', value: 'espresso' } ],
+				},
+			],
+		};
+
+		it( 'matches when slug was transliterated from accented label', () => {
+			const result = findMatchingVariation(
+				accentProduct,
+				[
+					{
+						attribute: 'attribute_pa_cafe_style',
+						value: 'espresso',
+					},
+				],
+				accentMapping
+			);
+			expect( result?.id ).toBe( 602 );
+		} );
+	} );
+
+	describe( 'attribute with manually customized slug', () => {
+		// Admin can set slug to anything, e.g. label "Shirt Type" slug "tshirt-type"
+		const customSlugMapping: AttributeSlugToLabel = {
+			attribute_pa_tshirt_type: 'Shirt Type',
+		};
+
+		const customSlugProduct = {
+			id: 7,
+			type: 'variable',
+			variations: [
+				{
+					id: 701,
+					attributes: [ { name: 'Shirt Type', value: 'polo' } ],
+				},
+			],
+		};
+
+		it( 'matches when slug does not resemble the label at all', () => {
+			const result = findMatchingVariation(
+				customSlugProduct,
+				[
+					{
+						attribute: 'attribute_pa_tshirt_type',
+						value: 'polo',
+					},
+				],
+				customSlugMapping
+			);
+			expect( result?.id ).toBe( 701 );
 		} );
 	} );
 
@@ -289,33 +347,37 @@ describe( 'findMatchingVariation', () => {
 		};
 
 		it( 'matches variation with "Any" attribute when value is selected', () => {
-			const selectedAttributes = [
-				{ attribute: 'Color', value: 'Red' },
-				{ attribute: 'Size', value: 'Small' },
-			];
 			const result = findMatchingVariation(
 				productWithAny,
-				selectedAttributes
+				[
+					{ attribute: 'attribute_pa_color', value: 'Red' },
+					{ attribute: 'attribute_pa_size', value: 'Small' },
+				],
+				slugToLabel
 			);
 			expect( result?.id ).toBe( 201 );
 		} );
 
 		it( 'does not match "Any" attribute when selected value is null', () => {
-			const selectedAttributes = [
-				{ attribute: 'Color', value: null },
-				{ attribute: 'Size', value: 'Small' },
-			];
 			expect(
-				findMatchingVariation( productWithAny, selectedAttributes )
+				findMatchingVariation(
+					productWithAny,
+					[
+						{ attribute: 'attribute_pa_color', value: null },
+						{ attribute: 'attribute_pa_size', value: 'Small' },
+					],
+					slugToLabel
+				)
 			).toBeNull();
 		} );
 
 		it( 'does not match "Any" attribute when attribute is not selected', () => {
-			const selectedAttributes = [
-				{ attribute: 'Size', value: 'Small' },
-			];
 			expect(
-				findMatchingVariation( productWithAny, selectedAttributes )
+				findMatchingVariation(
+					productWithAny,
+					[ { attribute: 'attribute_pa_size', value: 'Small' } ],
+					slugToLabel
+				)
 			).toBeNull();
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/__tests__/frontend.test.ts
@@ -44,7 +44,8 @@ jest.mock( '@woocommerce/stores/woocommerce/products', () => ( {} ), {
 describe( 'getProductData', () => {
 	let getProductData: (
 		id: number,
-		selectedAttributes: Array< { attribute: string; value: string } >
+		selectedAttributes: Array< { attribute: string; value: string } >,
+		slugToLabel?: Record< string, string >
 	) => NormalizedProductData | null;
 
 	beforeEach( () => {
@@ -195,9 +196,11 @@ describe( 'getProductData', () => {
 				},
 			};
 
-			const result = getProductData( 1, [
-				{ attribute: 'Color', value: 'red' },
-			] );
+			const result = getProductData(
+				1,
+				[ { attribute: 'attribute_pa_color', value: 'red' } ],
+				{ attribute_pa_color: 'Color' }
+			);
 
 			expect( result ).toEqual( {
 				id: 10,
@@ -228,9 +231,11 @@ describe( 'getProductData', () => {
 			};
 			mockProductsState.productVariations = {};
 
-			const result = getProductData( 1, [
-				{ attribute: 'Color', value: 'red' },
-			] );
+			const result = getProductData(
+				1,
+				[ { attribute: 'attribute_pa_color', value: 'red' } ],
+				{ attribute_pa_color: 'Color' }
+			);
 
 			expect( result ).toBeNull();
 		} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -21,6 +21,7 @@ import type { ProductsStore } from '@woocommerce/stores/woocommerce/products';
  * Internal dependencies
  */
 import { findMatchingVariation } from '../../base/utils/variations/attribute-matching';
+import type { AttributeSlugToLabel } from '../../base/utils/variations/attribute-matching';
 import type { GroupedProductAddToCartWithOptionsStore } from './grouped-product-selector/frontend';
 import type { Context as QuantitySelectorContext } from './quantity-selector/frontend';
 import type { VariableProductAddToCartWithOptionsStore } from './variation-selector/frontend';
@@ -28,6 +29,7 @@ import type { NormalizedProductData, NormalizedVariationData } from './types';
 
 export type Context = {
 	selectedAttributes: SelectedAttributes[];
+	attributeSlugToLabel: AttributeSlugToLabel;
 	quantity: Record< number, number >;
 	validationErrors: AddToCartError[];
 	tempQuantity: number;
@@ -75,7 +77,8 @@ const { state: productsState } = store< ProductsStore >(
 
 export const getProductData = (
 	id: number,
-	selectedAttributes: SelectedAttributes[]
+	selectedAttributes: SelectedAttributes[],
+	slugToLabel: AttributeSlugToLabel = {}
 ): NormalizedProductData | NormalizedVariationData | null => {
 	const productFromStore = productsState.products[ id ];
 
@@ -93,7 +96,8 @@ export const getProductData = (
 	) {
 		const matchedVariation = findMatchingVariation(
 			productFromStore,
-			selectedAttributes
+			selectedAttributes,
+			slugToLabel
 		);
 
 		if ( matchedVariation ) {
@@ -130,6 +134,7 @@ export type AddToCartWithOptionsStore = {
 		allowsAddingToCart: boolean;
 		quantity: Record< number, number >;
 		selectedAttributes: SelectedAttributes[];
+		attributeSlugToLabel: Record< string, string >;
 		productData: NormalizedProductData | NormalizedVariationData | null;
 	};
 	actions: {
@@ -182,12 +187,18 @@ const { actions, state } = store<
 				const context = getContext< Context >();
 				return context.selectedAttributes || [];
 			},
+			get attributeSlugToLabel(): Record< string, string > {
+				const context = getContext< Context >();
+				return context.attributeSlugToLabel || {};
+			},
 			get productData() {
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 
 				return getProductData(
 					productDataState.productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 			},
 		},
@@ -199,12 +210,14 @@ const { actions, state } = store<
 					return;
 				}
 
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 
 				// If selected quantity is invalid, add an error.
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				if (
@@ -344,14 +357,19 @@ const { actions, state } = store<
 				// woocommerce store is public.
 				yield import( '@woocommerce/stores/woocommerce/cart' );
 
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 
 				const id =
 					productDataState.variationId || productDataState.productId;
 
 				const productType = productDataState.variationId
 					? 'variation'
-					: getProductData( id, selectedAttributes )?.type;
+					: getProductData(
+							id,
+							selectedAttributes,
+							attributeSlugToLabel
+					  )?.type;
 
 				if ( ! productType ) {
 					return;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -128,7 +128,8 @@ store< QuantitySelectorStore >(
 
 				const currentValue = Number( inputElement.value ) || 0;
 
-				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } =
+					addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,
@@ -158,7 +159,8 @@ store< QuantitySelectorStore >(
 				}
 
 				const currentValue = Number( inputElement.value ) || 0;
-				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } =
+					addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,
@@ -191,7 +193,8 @@ store< QuantitySelectorStore >(
 			handleQuantityBlur: () => {
 				const { allowZero, productId, inputElement } =
 					getContext< Context >();
-				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } =
+					addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -63,14 +63,15 @@ store< QuantitySelectorStore >(
 				// Note: in grouped products, `productData` will be the parent product.
 				// We handle grouped products decrease differently because we
 				// allow setting the quantity to 0.
-				const { quantity, selectedAttributes } =
+				const { quantity, selectedAttributes, attributeSlugToLabel } =
 					addToCartWithOptionsStore.state;
 
 				const { allowZero, productId } = getContext< Context >();
 
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				if ( ! productObject ) {
@@ -87,14 +88,15 @@ store< QuantitySelectorStore >(
 				);
 			},
 			get allowsIncrease() {
-				const { quantity, selectedAttributes } =
+				const { quantity, selectedAttributes, attributeSlugToLabel } =
 					addToCartWithOptionsStore.state;
 
 				const { productId } = getContext< Context >();
 
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				if ( ! productObject ) {
@@ -126,11 +128,12 @@ store< QuantitySelectorStore >(
 
 				const currentValue = Number( inputElement.value ) || 0;
 
-				const { selectedAttributes } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				let newValue = currentValue + 1;
@@ -155,11 +158,12 @@ store< QuantitySelectorStore >(
 				}
 
 				const currentValue = Number( inputElement.value ) || 0;
-				const { selectedAttributes } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				let newValue = currentValue - 1;
@@ -187,11 +191,12 @@ store< QuantitySelectorStore >(
 			handleQuantityBlur: () => {
 				const { allowZero, productId, inputElement } =
 					getContext< Context >();
-				const { selectedAttributes } = addToCartWithOptionsStore.state;
+				const { selectedAttributes, attributeSlugToLabel } = addToCartWithOptionsStore.state;
 
 				const productObject = getProductData(
 					productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				if ( ! productObject ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -23,11 +23,10 @@ import type {
 	Context as AddToCartWithOptionsStoreContext,
 } from '../frontend';
 import {
-	normalizeAttributeName,
-	attributeNamesMatch,
 	getVariationAttributeValue,
 	findMatchingVariation,
 } from '../../../base/utils/variations/attribute-matching';
+import type { AttributeSlugToLabel } from '../../../base/utils/variations/attribute-matching';
 import setStyles from './set-styles';
 
 type Option = {
@@ -42,6 +41,7 @@ type Context = AddToCartWithOptionsStoreContext & {
 	option: Option;
 	options: Option[];
 	autoselect: boolean;
+	attributeSlugToLabel: AttributeSlugToLabel;
 };
 
 // Set selected pill styles for proper contrast.
@@ -75,10 +75,12 @@ const isAttributeValueValid = ( {
 	attributeName,
 	attributeValue,
 	selectedAttributes,
+	slugToLabel,
 }: {
 	attributeName: string;
 	attributeValue: string;
 	selectedAttributes: SelectedAttributes[];
+	slugToLabel: AttributeSlugToLabel;
 } ) => {
 	if (
 		! attributeName ||
@@ -94,8 +96,7 @@ const isAttributeValueValid = ( {
 	// valid, that's why we subtract one from the total number of attributes to
 	// match.
 	const isCurrentAttributeSelected = selectedAttributes.some(
-		( selectedAttribute ) =>
-			attributeNamesMatch( selectedAttribute.attribute, attributeName )
+		( selectedAttribute ) => selectedAttribute.attribute === attributeName
 	);
 	const attributesToMatch = isCurrentAttributeSelected
 		? selectedAttributes.length - 1
@@ -112,7 +113,8 @@ const isAttributeValueValid = ( {
 	return product.variations.some( ( variation ) => {
 		const variationAttrValue = getVariationAttributeValue(
 			variation,
-			attributeName
+			attributeName,
+			slugToLabel
 		);
 
 		// Skip variations that don't match the current attribute value.
@@ -129,7 +131,8 @@ const isAttributeValueValid = ( {
 				const availableVariationAttributeValue =
 					getVariationAttributeValue(
 						variation,
-						selectedAttribute.attribute
+						selectedAttribute.attribute,
+						slugToLabel
 					);
 				// If the current available variation matches the selected
 				// value, count it.
@@ -144,10 +147,7 @@ const isAttributeValueValid = ( {
 				// selection.
 				if ( availableVariationAttributeValue === null ) {
 					if (
-						! attributeNamesMatch(
-							selectedAttribute.attribute,
-							attributeName
-						) ||
+						selectedAttribute.attribute !== attributeName ||
 						attributeValue === selectedAttribute.value
 					) {
 						return true;
@@ -162,31 +162,44 @@ const isAttributeValueValid = ( {
 };
 
 /**
- * Return the product attributes and options from Store API format.
+ * Return the product attributes and options from Store API format, keyed by
+ * attribute slug using the label-to-slug reverse mapping.
  *
- * @param product The product in Store API format.
- * @return Record of attribute names to their available option values.
+ * @param product      The product in Store API format.
+ * @param slugToLabel  Mapping of attribute slugs to Store API label names.
+ * @return Record of attribute slugs to their available option values.
  */
 const getProductAttributesAndOptions = (
-	product: ProductResponseItem | null
+	product: ProductResponseItem | null,
+	slugToLabel: AttributeSlugToLabel
 ): Record< string, string[] > => {
 	if ( ! product?.variations?.length ) {
 		return {};
 	}
 
+	// Build a reverse mapping: Store API label → slug.
+	const labelToSlug: Record< string, string > = Object.fromEntries(
+		Object.entries( slugToLabel ).map( ( [ slug, label ] ) => [
+			label,
+			slug,
+		] )
+	);
+
 	const productAttributesAndOptions = {} as Record< string, string[] >;
 	product.variations.forEach( ( variation ) => {
 		variation.attributes.forEach( ( attr ) => {
-			if ( ! Array.isArray( productAttributesAndOptions[ attr.name ] ) ) {
-				productAttributesAndOptions[ attr.name ] = [];
+			const slug = labelToSlug[ attr.name ];
+			if ( ! slug ) {
+				return;
+			}
+			if ( ! Array.isArray( productAttributesAndOptions[ slug ] ) ) {
+				productAttributesAndOptions[ slug ] = [];
 			}
 			if (
 				attr.value &&
-				! productAttributesAndOptions[ attr.name ].includes(
-					attr.value
-				)
+				! productAttributesAndOptions[ slug ].includes( attr.value )
 			) {
-				productAttributesAndOptions[ attr.name ].push( attr.value );
+				productAttributesAndOptions[ slug ].push( attr.value );
 			}
 		} );
 	} );
@@ -238,14 +251,18 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 
 				return selectedAttributes.some( ( attrObject ) => {
 					return (
-						attributeNamesMatch( attrObject.attribute, name ) &&
+						attrObject.attribute === name &&
 						attrObject.value === option.value
 					);
 				} );
 			},
 			get isOptionDisabled() {
-				const { name, option, selectedAttributes } =
-					getContext< Context >();
+				const {
+					name,
+					option,
+					selectedAttributes,
+					attributeSlugToLabel,
+				} = getContext< Context >();
 
 				if ( option.value === '' ) {
 					return false;
@@ -255,6 +272,7 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes,
+					slugToLabel: attributeSlugToLabel,
 				} );
 			},
 		},
@@ -263,10 +281,7 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				const { selectedAttributes } = getContext< Context >();
 				const index = selectedAttributes.findIndex(
 					( selectedAttribute ) =>
-						attributeNamesMatch(
-							selectedAttribute.attribute,
-							attribute
-						)
+						selectedAttribute.attribute === attribute
 				);
 
 				if ( value === '' ) {
@@ -292,10 +307,7 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				const { selectedAttributes } = getContext< Context >();
 				const index = selectedAttributes.findIndex(
 					( selectedAttribute ) =>
-						attributeNamesMatch(
-							selectedAttribute.attribute,
-							attribute
-						)
+						selectedAttribute.attribute === attribute
 				);
 				if ( index >= 0 ) {
 					selectedAttributes.splice( index, 1 );
@@ -333,7 +345,7 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 				includedAttributes?: Array< string >;
 				excludedAttributes?: Array< string >;
 			} = {} ) {
-				const { autoselect, selectedAttributes } =
+				const { autoselect, selectedAttributes, attributeSlugToLabel } =
 					getContext< Context >();
 
 				if ( ! autoselect ) {
@@ -346,51 +358,38 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return;
 				}
 
-				// Normalize included/excluded attributes to lowercase for comparison
-				// with Store API labels (e.g., "Color" vs "attribute_pa_color" → "color").
-				const normalizedIncluded = includedAttributes.map( ( attr ) =>
-					normalizeAttributeName( attr )
-				);
-				const normalizedExcluded = excludedAttributes.map( ( attr ) =>
-					normalizeAttributeName( attr )
-				);
-
 				const productAttributesAndOptions: Record< string, string[] > =
-					getProductAttributesAndOptions( product );
+					getProductAttributesAndOptions(
+						product,
+						attributeSlugToLabel
+					);
 				Object.entries( productAttributesAndOptions ).forEach(
-					( [ attribute, options ] ) => {
-						const attributeLower =
-							normalizeAttributeName( attribute );
+					( [ attributeSlug, options ] ) => {
 						if (
-							normalizedIncluded.length !== 0 &&
-							! normalizedIncluded.includes( attributeLower )
+							includedAttributes.length !== 0 &&
+							! includedAttributes.includes( attributeSlug )
 						) {
 							return;
 						}
 						if (
-							normalizedExcluded.length !== 0 &&
-							normalizedExcluded.includes( attributeLower )
+							excludedAttributes.length !== 0 &&
+							excludedAttributes.includes( attributeSlug )
 						) {
 							return;
 						}
 						const validOptions = options.filter( ( option ) =>
 							isAttributeValueValid( {
-								attributeName: attribute,
+								attributeName: attributeSlug,
 								attributeValue: option,
 								selectedAttributes,
+								slugToLabel: attributeSlugToLabel,
 							} )
 						);
 						if ( validOptions.length === 1 ) {
-							const validOption = validOptions[ 0 ];
-							// Use the context's attribute name format for consistency.
-							// Find the matching context name by comparing normalized versions.
-							const contextName =
-								includedAttributes.find(
-									( attr ) =>
-										normalizeAttributeName( attr ) ===
-										attributeLower
-								) || attribute;
-							actions.setAttribute( contextName, validOption );
+							actions.setAttribute(
+								attributeSlug,
+								validOptions[ 0 ]
+							);
 						}
 					}
 				);
@@ -415,10 +414,12 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return;
 				}
 
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 				const matchedVariation = findMatchingVariation(
 					product,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				const { actions: productDataActions } =
@@ -441,10 +442,12 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return;
 				}
 
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 				const matchedVariation = findMatchingVariation(
 					product,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				const { errorMessages } = getConfig();
@@ -493,11 +496,13 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return;
 				}
 
-				const { selectedAttributes } = getContext< Context >();
+				const { selectedAttributes, attributeSlugToLabel } =
+					getContext< Context >();
 
 				const productObject = getProductData(
 					productDataState.productId,
-					selectedAttributes
+					selectedAttributes,
+					attributeSlugToLabel
 				);
 
 				if ( productObject ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -283,8 +283,8 @@ class AddToCartWithOptions extends AbstractBlock {
 					if ( ! $attribute->get_variation() ) {
 						continue;
 					}
-					$slug  = wc_variation_attribute_name( $attribute->get_name() );
-					$label = wc_attribute_label( $attribute->get_name(), $product );
+					$slug                   = wc_variation_attribute_name( $attribute->get_name() );
+					$label                  = wc_attribute_label( $attribute->get_name(), $product );
 					$slug_to_label[ $slug ] = $label;
 				}
 				$context['attributeSlugToLabel'] = $slug_to_label;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -275,6 +275,20 @@ class AddToCartWithOptions extends AbstractBlock {
 			if ( $product->is_type( ProductType::VARIABLE ) ) {
 				$context['selectedAttributes'] = array();
 
+				// Build a mapping of attribute slugs to Store API labels so the
+				// frontend can reliably match PHP context slugs against Store API
+				// attribute names without heuristic normalization.
+				$slug_to_label = array();
+				foreach ( $product->get_attributes() as $attribute ) {
+					if ( ! $attribute->get_variation() ) {
+						continue;
+					}
+					$slug  = wc_variation_attribute_name( $attribute->get_name() );
+					$label = wc_attribute_label( $attribute->get_name(), $product );
+					$slug_to_label[ $slug ] = $label;
+				}
+				$context['attributeSlugToLabel'] = $slug_to_label;
+
 				// Load all variations into the shared store with full REST API data.
 				$variations = wc_interactivity_api_load_variations(
 					'I acknowledge that using experimental APIs means my theme or plugin will inevitably break in the next version of WooCommerce',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes variation attribute options being disabled in the Add to Cart with Options block when attribute labels contain non-ASCII characters (umlauts, accents) or when attribute slugs were manually customized to differ from labels.

- Root cause: PR https://github.com/woocommerce/woocommerce/pull/62880 switched variation data from `wp_interactivity_config` (slug↔slug matching) to the Store API (slug↔label matching). A heuristic normalisation layer was added to bridge the mismatch, but it breaks whenever `sanitize_title` transliterates characters during slug generation (e.g. "Größe" → slug `groesse`, but label normalises to `größe`).
- Fix: Pass an explicit `slugToLabel` mapping from PHP context (built from `wc_variation_attribute_name` + `wc_attribute_label`) and use direct lookups in JS instead of heuristic normalisation.
- Removes `normalizeAttributeName` and `attributeNamesMatch` entirely.

> [!NOTE]  
> The ideal long-term fix is to add a `slug` field to the Store API variation attributes response (prototyped in https://github.com/woocommerce/woocommerce/pull/63696. However, that changes the Store API schema which is not appropriate for a patch release.

Closes #63635

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/62880

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

0. Create attribute that:
- have custom slug not matching the label at all
- have name with non-ascii characters, e.g. "Größe" or "Café Style" - leave slug untouched so the default is used.
1. Make sure you have variation product with these attributes
2. Make sure you use Add to Cart with Options in your Single Product template
3. Go to product frontend
4. **Expected:** Attributes should be available to choose
5. Confirm they're disabled on `trunk`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
