### PR TITLE
Fix "X in cart" button text not updating for some variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-quantity
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-quantity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart: Fix button label not updating for some variation products

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -298,8 +298,14 @@ const { state, actions } = store< Store >(
 						return key === cartItem.key;
 					}
 					if ( cartItem.type === 'variation' ) {
+						// A variation ID is unique — if it matches, the item
+						// is found without needing attribute comparison.
+						if ( id === cartItem.id ) {
+							return true;
+						}
+						// Fallback for callers that pass the parent product
+						// ID instead of the variation ID.
 						if (
-							id !== cartItem.id ||
 							! cartItem.variation ||
 							! variation ||
 							cartItem.variation.length !== variation.length


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

After adding a variation to cart via the Add to Cart with Options block, the button text stays "Add to cart" instead of showing "1 in cart" for variations whose term values contain multiple words.

Root cause: `findItemInCart` matched the variation by ID correctly, but then called `doesCartItemMatchAttributes` which compared the selected attribute value (a term slug like `dicta-aut`) against the cart response value (a term name like `Dicta aut`). The Store API cart endpoint converts term slugs to display names in `ProductItemTrait::format_variation_data()` but provides no `raw_value` equivalent, so the comparison always failed for multi-word terms.

Fix: When `findItemInCart` finds a cart item whose variation ID matches the requested ID, return it immediately. A variation ID is a unique identifier and attribute comparison is redundant when we already have an ID match. The attribute-based fallback is preserved for callers that only have the parent product ID.

Example flow:

When you click "Add to cart" with variation Placeat et: "aperiam" + Numeric Size: "dicta-aut" selected:

1. The variation gets added to the cart via the Store API
2. The cart response comes back. For each variation attribute, `ProductItemTrait::format_variation_data()` runs:

```
  $term = get_term_by( 'slug', 'dicta-aut', $taxonomy );
  $value = $term->name;  // "Dicta aut"
```

3. So the cart item's variation array looks like:

```
  [
    { "raw_attribute": "attribute_error-placeat-et", "attribute": "Placeat et", "value": "aperiam" },
    { "raw_attribute": "attribute_pa_numeric-size", "attribute": "Numeric Size", "value": "Dicta aut" }
  ]
```

4. Now the button needs to show "1 in cart". The `state.quantity` getter runs:

```
  const item = wooState.findItemInCart({
      id: state.productId,  // resolves to variation ID e.g. 4697
      variation: formContext?.selectedAttributes
      // selectedAttributes = [
      //   { attribute: "attribute_error-placeat-et", value: "aperiam" },
      //   { attribute: "attribute_pa_numeric-size", value: "dicta-aut" }  ← slug!
      // ]
  });
```

6. Inside `findItemInCart`, it finds the cart item with cartItem.id === 4697 — ID matches. But then it calls `doesCartItemMatchAttributes`:

```
  // For each cart variation attribute:
  item.attribute === (raw_attribute ?? attribute)
  // "attribute_pa_numeric-size" === "attribute_pa_numeric-size" ✓ name matches via raw_attribute

  item.value.toLowerCase() === value?.toLowerCase()
  // "dicta-aut" === "dicta aut"  ✗ FAILS! slug vs term name
```

9. `doesCartItemMatchAttributes` returns false → `findItemInCart `returns `undefined` → quantity is 0 → button shows "Add to cart" instead of "1 in cart"

Alternatively we could "normalise" attribute values too but as we know from other issue normalisation is not efficient since we try to compare name vs slugs (apples ve oranges).

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     https://github.com/user-attachments/assets/8833abb4-2a12-44a4-ae9b-a32fed1a5f03   |  https://github.com/user-attachments/assets/2f1e01bb-41e3-46f9-9331-9231f4cd0387     |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a variable product with a taxonomy attribute that has multi-word term values (e.g. attribute "Size" with terms "Dicta aut", "Magni aspernatur")
2. Use the Add to Cart with Options (Beta) block in the Single Product template
3. Select a variation using a multi-word term value
6. Click "Add to cart"
7. **Expected:** button shows "X in cart" instead of going back to "Add to Cart"
9. Swap to different attribute and come back
11. **Expected:** Button gets updated on fly

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
