### PR TITLE
Harden cache priming SQL and add CPT-path test coverage

### DIFF
--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -640,11 +640,13 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		update_meta_cache( 'order_item', $order_item_ids );
 
 		// Prime WC_Data meta cache (includes meta_id required by read_meta_data).
-		$order_item_ids_sql    = esc_sql( $order_item_ids );
-		$order_item_ids_string = implode( ',', $order_item_ids_sql );
-		$raw_meta_data_array   = $wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT order_item_id as object_id, meta_id, meta_key, meta_value FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN ({$order_item_ids_string}) ORDER BY meta_id"
+		$id_placeholders     = implode( ', ', array_fill( 0, count( $order_item_ids ), '%d' ) );
+		$raw_meta_data_array = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $id_placeholders is generated above.
+				"SELECT order_item_id as object_id, meta_id, meta_key, meta_value FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN ({$id_placeholders}) ORDER BY meta_id",
+				...$order_item_ids
+			)
 		);
 
 		if ( ! empty( $raw_meta_data_array ) ) {
@@ -949,13 +951,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * to use a different table (e.g. the HPOS orders table).
 	 *
 	 * @since 10.7.0
-	 * @param string $sanitized_ids Comma-separated list of order IDs (already sanitized via absint).
+	 * @param array $order_ids List of order IDs.
 	 * @return string Prepared SQL JOIN fragment.
 	 */
-	protected function get_refund_orders_batch_join_clause( string $sanitized_ids ): string {
+	protected function get_refund_orders_batch_join_clause( array $order_ids ): string {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $sanitized_ids is sanitized via absint by caller.
-		return $wpdb->prepare( "%i AS refunds ON ( refunds.post_type = %s AND refunds.post_parent IN ( $sanitized_ids ) )", $wpdb->posts, 'shop_order_refund' );
+		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
+		return $wpdb->prepare( "%i AS refunds ON ( refunds.post_type = %s AND refunds.post_parent IN ( $id_list ) )", $wpdb->posts, 'shop_order_refund' );
 	}
 
 	/**
@@ -976,18 +979,20 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * (e.g. HPOS stores it directly in the orders table rather than postmeta).
 	 *
 	 * @since 10.7.0
-	 * @param string $sanitized_ids Comma-separated list of order IDs (already sanitized via absint).
+	 * @param array $order_ids List of order IDs.
 	 * @return array<int, float> Map of order_id => refund total.
 	 */
-	protected function get_batch_refund_totals( string $sanitized_ids ): array {
+	protected function get_batch_refund_totals( array $order_ids ): array {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $sanitized_ids is sanitized via absint by caller.
+		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
 		$refund_totals = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT posts.post_parent AS order_id, SUM( postmeta.meta_value ) AS total
 				FROM %i AS postmeta
-				INNER JOIN %i AS posts ON ( posts.post_type = 'shop_order_refund' AND posts.post_parent IN ( $sanitized_ids ) )
+				INNER JOIN %i AS posts ON ( posts.post_type = 'shop_order_refund' AND posts.post_parent IN ( $id_list ) )
 				WHERE postmeta.meta_key = '_refund_amount'
 				AND postmeta.post_id = posts.ID
 				GROUP BY posts.post_parent",
@@ -1112,16 +1117,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			return;
 		}
 
-		$sanitized_ids = implode( ', ', array_map( 'absint', $non_cached_ids ) );
-
 		// Batch query: total refunded per order.
-		$totals_by_order = $this->get_batch_refund_totals( $sanitized_ids );
+		$totals_by_order = $this->get_batch_refund_totals( $non_cached_ids );
 		foreach ( $non_cached_ids as $order_id ) {
 			wp_cache_set( $total_keys[ $order_id ], $totals_by_order[ $order_id ] ?? 0.0, 'orders' );
 		}
 
 		// Batch query: total tax refunded per order.
-		$refund_join = $this->get_refund_orders_batch_join_clause( $sanitized_ids );
+		$refund_join = $this->get_refund_orders_batch_join_clause( $non_cached_ids );
 		$parent_col  = $this->get_refund_parent_column();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $refund_join is already prepared, $parent_col is hardcoded.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3159,13 +3159,14 @@ FROM $order_meta_table
 	 * Overrides the CPT version to use the HPOS orders table.
 	 *
 	 * @since 10.7.0
-	 * @param string $sanitized_ids Comma-separated list of order IDs (already sanitized via absint).
+	 * @param array $order_ids List of order IDs.
 	 * @return string Prepared SQL JOIN fragment.
 	 */
-	protected function get_refund_orders_batch_join_clause( string $sanitized_ids ): string {
+	protected function get_refund_orders_batch_join_clause( array $order_ids ): string {
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $sanitized_ids is sanitized via absint by caller.
-		return $wpdb->prepare( "%i AS refunds ON ( refunds.type = %s AND refunds.parent_order_id IN ( $sanitized_ids ) )", self::get_orders_table_name(), 'shop_order_refund' );
+		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
+		return $wpdb->prepare( "%i AS refunds ON ( refunds.type = %s AND refunds.parent_order_id IN ( $id_list ) )", self::get_orders_table_name(), 'shop_order_refund' );
 	}
 
 	/**
@@ -3185,18 +3186,20 @@ FROM $order_meta_table
 	 * rather than joining postmeta.
 	 *
 	 * @since 10.7.0
-	 * @param string $sanitized_ids Comma-separated list of order IDs (already sanitized via absint).
+	 * @param array $order_ids List of order IDs.
 	 * @return array<int, float> Map of order_id => refund total.
 	 */
-	protected function get_batch_refund_totals( string $sanitized_ids ): array {
+	protected function get_batch_refund_totals( array $order_ids ): array {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $sanitized_ids is sanitized via absint by caller.
+		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
 		$refund_totals = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT parent_order_id AS order_id, SUM( total_amount ) AS total
 				FROM %i
-				WHERE type = 'shop_order_refund' AND parent_order_id IN ( $sanitized_ids )
+				WHERE type = 'shop_order_refund' AND parent_order_id IN ( $id_list )
 				GROUP BY parent_order_id",
 				self::get_orders_table_name()
 			)

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1257,4 +1257,112 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$expected_final_cogs = $expected_order_cogs + $expected_refund_cogs;
 		$this->assertEquals( $expected_final_cogs, $order->get_cogs_total_value(), 'Order COGS should be reduced by refund amount' );
 	}
+
+	/**
+	 * @testdox CPT cache priming populates refund total and tax caches with correct values.
+	 */
+	public function test_prime_caches_for_orders_primes_refund_totals(): void {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate'          => '20',
+				'tax_rate_name'     => 'tax',
+				'tax_rate_order'    => '1',
+				'tax_rate_shipping' => '1',
+			)
+		);
+
+		$rate = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', array(), 'flat_rate' );
+		$item = new WC_Order_Item_Shipping();
+		$item->set_props(
+			array(
+				'method_title' => $rate->label,
+				'method_id'    => $rate->id,
+				'total'        => wc_format_decimal( $rate->cost ),
+				'taxes'        => $rate->taxes,
+			)
+		);
+
+		$order = WC_Helper_Order::create_order();
+		$order->add_item( $item );
+		$order->calculate_totals();
+		$order->save();
+
+		$product_item_id  = current( $order->get_items() )->get_id();
+		$shipping_item_id = current( $order->get_items( 'shipping' ) )->get_id();
+
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$product_item_id  => array(
+						'id'           => $product_item_id,
+						'qty'          => 1,
+						'refund_total' => 10,
+						'refund_tax'   => array( 1 => 2 ),
+					),
+					$shipping_item_id => array(
+						'id'           => $shipping_item_id,
+						'qty'          => 1,
+						'refund_total' => 10,
+						'refund_tax'   => array( 1 => 3 ),
+					),
+				),
+			)
+		);
+
+		wp_cache_flush();
+		WC_Cache_Helper::invalidate_cache_group( 'orders' );
+
+		$data_store = WC_Data_Store::load( 'order' );
+		$data_store->prime_caches_for_orders(
+			array( $order->get_id() ),
+			array(
+				'fields'    => 'all',
+				'post_type' => 'shop_order',
+			)
+		);
+
+		$cache_prefix = WC_Cache_Helper::get_cache_prefix( 'orders' );
+		$order_id     = $order->get_id();
+
+		$cached_total_refunded = wp_cache_get( $cache_prefix . 'total_refunded' . $order_id, 'orders' );
+		$cached_tax_refunded   = wp_cache_get( $cache_prefix . 'total_tax_refunded' . $order_id, 'orders' );
+
+		$this->assertNotFalse( $cached_total_refunded, 'Total refunded should be cached after priming' );
+		$this->assertNotFalse( $cached_tax_refunded, 'Total tax refunded should be cached after priming' );
+		$this->assertIsFloat( $cached_total_refunded, 'Cached total refunded should be a float' );
+		$this->assertEquals( 5.0, $cached_tax_refunded, 'Cached tax refunded should equal sum of product tax (2) + shipping tax (3)' );
+	}
+
+	/**
+	 * @testdox CPT cache priming populates order item meta caches so item access does not trigger additional queries.
+	 */
+	public function test_prime_caches_for_orders_primes_item_meta(): void {
+		$order = WC_Helper_Order::create_order();
+
+		wp_cache_flush();
+		WC_Cache_Helper::invalidate_cache_group( 'orders' );
+
+		$data_store = WC_Data_Store::load( 'order' );
+		$data_store->prime_caches_for_orders(
+			array( $order->get_id() ),
+			array(
+				'fields'    => 'all',
+				'post_type' => 'shop_order',
+			)
+		);
+
+		$reloaded_order = wc_get_order( $order->get_id() );
+		$items          = $reloaded_order->get_items();
+
+		$this->assertNotEmpty( $items, 'Order should have line items' );
+
+		foreach ( $items as $item ) {
+			$this->assertGreaterThan( 0, $item->get_product_id(), 'Item should have a product ID from cached meta' );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up hardening for #63440. These are small improvements that shouldn't block the parent PR from landing — they can be merged into the feature branch before or after it lands.

**1. Replace `esc_sql()` with `$wpdb->prepare()` for order item meta query**

The order item ID query in `prime_order_item_caches_for_orders` used `esc_sql()` + string interpolation. This switches to `$wpdb->prepare()` with `%d` placeholders and splatted args, consistent with the prepared statement style used everywhere else in the PR.

**2. Eliminate the `string $sanitized_ids` "trust the caller" pattern**

`get_refund_orders_batch_join_clause()` and `get_batch_refund_totals()` accepted a pre-sanitized comma-separated string and trusted the caller to have run `absint`. Now they accept `array $order_ids` and do their own `absint` sanitization internally. This is safer for future maintainers and removes all `// sanitized by caller` phpcs ignore comments.

Updated in both `Abstract_WC_Order_Data_Store_CPT` and `OrdersTableDataStore`.

**3. Add CPT data store test coverage**

The existing test class only covers the HPOS path. Since the refactoring in #63440 touches shared code in the abstract base class, this adds CPT-path tests to `WC_Order_Data_Store_CPT_Test`:
- `test_prime_caches_for_orders_primes_refund_totals` — verifies refund total and tax caches
- `test_prime_caches_for_orders_primes_item_meta` — verifies order item meta priming

### How to test the changes in this Pull Request:

1. Existing unit tests should continue to pass (both HPOS and CPT paths)
2. The two new CPT tests should pass: `pnpm test:php:env -- --filter WC_Order_Data_Store_CPT_Test::test_prime_caches_for_orders`

### Testing that has already taken place:

Code review of the diff. Local tooling (phpcs/phpstan) not available in this environment.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Internal hardening only — no user-facing changes. Parent PR #63440 already has a changelog entry.

</details>