### PR TITLE
Add support for 'woocommerce_get_country_locale_default' to blocks checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-60542
+++ b/plugins/woocommerce/changelog/fix-60542
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure default locale fields are honored in blocks checkout.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/stock-indicator/test/block.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/stock-indicator/test/block.test.tsx
@@ -118,6 +118,7 @@ jest.mock( '@woocommerce/block-settings', () => ( {
 		country: 'US',
 		locale: 'en_US',
 	},
+	DEFAULT_LOCALE: {},
 	blocksConfig: {
 		defaultAvatar: 'test-avatar-url',
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { COUNTRY_LOCALE } from '@woocommerce/block-settings';
+import { COUNTRY_LOCALE, DEFAULT_LOCALE } from '@woocommerce/block-settings';
 import {
 	CountryAddressFields,
 	Field,
@@ -86,6 +86,21 @@ const countryAddressFields: CountryAddressFields = Object.entries(
 }, {} );
 
 /**
+ * Default locale fields from the 'woocommerce_get_country_locale_default' filter.
+ * Used as fallback when no country is selected.
+ */
+const defaultLocaleFields: Record< string, Partial< Field > > = Object.entries(
+	DEFAULT_LOCALE
+).reduce(
+	( fields, [ localeFieldKey, localeField ] ) => {
+		fields[ localeFieldKey ] =
+			getSupportedCoreLocaleProps( localeField );
+		return fields;
+	},
+	{} as Record< string, Partial< Field > >
+);
+
+/**
  * Combines address fields, including fields from the locale, and sorts them by index.
  */
 const prepareFormFields = (
@@ -99,7 +114,7 @@ const prepareFormFields = (
 	const localeConfigs =
 		addressCountry && countryAddressFields[ addressCountry ] !== undefined
 			? countryAddressFields[ addressCountry ]
-			: {};
+			: defaultLocaleFields;
 
 	return fieldKeys
 		.map( ( field ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -90,7 +90,7 @@ const countryAddressFields: CountryAddressFields = Object.entries(
  * Used as fallback when no country is selected.
  */
 const defaultLocaleFields: Record< string, Partial< Field > > = Object.entries(
-	DEFAULT_LOCALE || {}
+	DEFAULT_LOCALE
 ).reduce( ( fields, [ localeFieldKey, localeField ] ) => {
 	fields[ localeFieldKey ] = getSupportedCoreLocaleProps( localeField );
 	return fields;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -91,14 +91,10 @@ const countryAddressFields: CountryAddressFields = Object.entries(
  */
 const defaultLocaleFields: Record< string, Partial< Field > > = Object.entries(
 	DEFAULT_LOCALE
-).reduce(
-	( fields, [ localeFieldKey, localeField ] ) => {
-		fields[ localeFieldKey ] =
-			getSupportedCoreLocaleProps( localeField );
-		return fields;
-	},
-	{} as Record< string, Partial< Field > >
-);
+).reduce( ( fields, [ localeFieldKey, localeField ] ) => {
+	fields[ localeFieldKey ] = getSupportedCoreLocaleProps( localeField );
+	return fields;
+}, {} as Record< string, Partial< Field > > );
 
 /**
  * Combines address fields, including fields from the locale, and sorts them by index.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -90,7 +90,7 @@ const countryAddressFields: CountryAddressFields = Object.entries(
  * Used as fallback when no country is selected.
  */
 const defaultLocaleFields: Record< string, Partial< Field > > = Object.entries(
-	DEFAULT_LOCALE
+	DEFAULT_LOCALE || {}
 ).reduce( ( fields, [ localeFieldKey, localeField ] ) => {
 	fields[ localeFieldKey ] = getSupportedCoreLocaleProps( localeField );
 	return fields;

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -7,6 +7,7 @@ import type {
 	OrderForm,
 	AddressForm,
 	ContactForm,
+	FieldLocaleOverrides,
 } from '@woocommerce/settings';
 
 export type WordCountType =
@@ -115,6 +116,10 @@ export const COUNTRY_LOCALE = Object.fromEntries(
 		return [ countryCode, countryData[ countryCode ].locale || {} ];
 	} )
 );
+
+export const DEFAULT_LOCALE = getSetting<
+	Record< string, FieldLocaleOverrides >
+>( 'defaultLocale', {} );
 
 const defaultFieldsLocations: FieldsLocations = {
 	address: [

--- a/plugins/woocommerce/client/blocks/tests/js/config/global-mocks.js
+++ b/plugins/woocommerce/client/blocks/tests/js/config/global-mocks.js
@@ -124,6 +124,7 @@ global.wcSettings = {
 			format: '{name}\n{company}\n{address_1}\n{address_2}\n{postcode} {city}\n{state}\n{country}',
 		},
 	},
+	defaultLocale: {},
 	storePages: {
 		myaccount: {
 			id: 0,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -234,6 +234,7 @@ class Cart extends AbstractBlock {
 		parent::enqueue_data( $attributes );
 
 		$this->asset_data_registry->add( 'countryData', CartCheckoutUtils::get_country_data() );
+		$this->asset_data_registry->add( 'defaultLocale', CartCheckoutUtils::get_default_country_locale() );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ) );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', 'incl' === get_option( 'woocommerce_tax_display_cart' ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -428,6 +428,7 @@ class Checkout extends AbstractBlock {
 		}
 		$this->asset_data_registry->add( 'addressAutocompleteProviders', $providers_payload );
 		$this->asset_data_registry->add( 'countryData', $country_data );
+		$this->asset_data_registry->add( 'defaultLocale', CartCheckoutUtils::get_default_country_locale() );
 		$this->asset_data_registry->add( 'defaultAddressFormat', $address_formats['default'] );
 		$this->asset_data_registry->add(
 			'checkoutAllowsGuest',

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -2,6 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\Utils;
 
 use Automattic\Block_Scanner;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 /**
  * Class containing utility methods for dealing with the Cart and Checkout blocks.
@@ -324,6 +326,47 @@ class CartCheckoutUtils {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Gets the default country locale data, transformed for frontend use.
+	 * 
+	 * @since 10.7.0
+	 *
+	 * @return array
+	 */
+	public static function get_default_country_locale() {
+		$base = WC()->countries->get_default_address_fields();
+
+		// Temporarily unhook CheckoutFields::update_default_locale_with_fields.
+		$checkout_fields = wc_get_container()->get( CheckoutFields::class );
+		$callback        = array( $checkout_fields, 'update_default_locale_with_fields' );
+		$had_filter      = has_filter( 'woocommerce_get_country_locale_default', $callback );
+		if ( false !== $had_filter ) {
+			remove_filter( 'woocommerce_get_country_locale_default', $callback, $had_filter );
+		}
+
+		$filtered = apply_filters( 'woocommerce_get_country_locale_default', $base );
+
+		if ( false !== $had_filter ) {
+			add_filter( 'woocommerce_get_country_locale_default', $callback, $had_filter );
+		}
+
+		// Only include properties changed by the filter, to avoid overwriting blocks-specific field config (e.g., field index).
+		// Array properties like 'validate' may diff partially, but are filtered out by getSupportedCoreLocaleProps later on.
+		$diff = ArrayUtil::deep_assoc_array_diff( $filtered, $base );
+
+		foreach ( $diff as $field => $field_data ) {
+			if ( isset( $field_data['priority'] ) ) {
+				$diff[ $field ]['index'] = $field_data['priority'];
+				unset( $diff[ $field ]['priority'] );
+			}
+			if ( isset( $field_data['class'] ) ) {
+				unset( $diff[ $field ]['class'] );
+			}
+		}
+
+		return $diff;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -330,7 +330,7 @@ class CartCheckoutUtils {
 
 	/**
 	 * Gets the default country locale data, transformed for frontend use.
-	 * 
+	 *
 	 * @since 10.7.0
 	 *
 	 * @return array
@@ -346,6 +346,14 @@ class CartCheckoutUtils {
 			remove_filter( 'woocommerce_get_country_locale_default', $callback, $had_filter );
 		}
 
+		/**
+		 * Filter the default country locale settings.
+		 *
+		 * @since 3.0.0
+		 * @see WC_Countries::get_country_locale()
+		 *
+		 * @param array $base Default address fields.
+		 */
 		$filtered = apply_filters( 'woocommerce_get_country_locale_default', $base );
 
 		if ( false !== $had_filter ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -148,7 +148,7 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 		add_filter(
 			'woocommerce_get_country_locale_default',
 			function ( $defaults ) {
-				$defaults['last_name']['hidden']   = true;
+				$defaults['last_name']['hidden']    = true;
 				$defaults['last_name']['required']  = false;
 				$defaults['first_name']['label']    = 'Full name';
 				$defaults['first_name']['priority'] = 5;

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -136,6 +136,69 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox get_default_country_locale returns only the diff from the woocommerce_get_country_locale_default filter.
+	 */
+	public function test_get_default_country_locale_returns_filter_diff(): void {
+		// Without filter customizations, the result should be empty.
+		$locale = CartCheckoutUtils::get_default_country_locale();
+		$this->assertIsArray( $locale );
+		$this->assertEmpty( $locale );
+
+		// With filter customizations, only changed properties should be returned.
+		add_filter(
+			'woocommerce_get_country_locale_default',
+			function ( $defaults ) {
+				$defaults['last_name']['hidden']   = true;
+				$defaults['last_name']['required']  = false;
+				$defaults['first_name']['label']    = 'Full name';
+				$defaults['first_name']['priority'] = 5;
+				return $defaults;
+			}
+		);
+
+		$locale = CartCheckoutUtils::get_default_country_locale();
+
+		$this->assertArrayHasKey( 'last_name', $locale );
+		$this->assertTrue( $locale['last_name']['hidden'] );
+		$this->assertFalse( $locale['last_name']['required'] );
+
+		$this->assertArrayHasKey( 'first_name', $locale );
+		$this->assertSame( 'Full name', $locale['first_name']['label'] );
+		$this->assertSame( 5, $locale['first_name']['index'] );
+		$this->assertArrayNotHasKey( 'priority', $locale['first_name'] );
+
+		$this->assertArrayNotHasKey( 'address_1', $locale );
+		$this->assertArrayNotHasKey( 'city', $locale );
+
+		remove_all_filters( 'woocommerce_get_country_locale_default' );
+	}
+
+	/**
+	 * @testdox get_default_country_locale includes custom fields added via the filter.
+	 */
+	public function test_get_default_country_locale_includes_custom_fields(): void {
+		add_filter(
+			'woocommerce_get_country_locale_default',
+			function ( $defaults ) {
+				$defaults['myplugin/custom-field'] = array(
+					'label'    => 'Custom Field',
+					'priority' => 15,
+				);
+				return $defaults;
+			}
+		);
+
+		$locale = CartCheckoutUtils::get_default_country_locale();
+
+		$this->assertArrayHasKey( 'myplugin/custom-field', $locale );
+		$this->assertSame( 'Custom Field', $locale['myplugin/custom-field']['label'] );
+		$this->assertSame( 15, $locale['myplugin/custom-field']['index'] );
+		$this->assertArrayNotHasKey( 'priority', $locale['myplugin/custom-field'] );
+
+		remove_all_filters( 'woocommerce_get_country_locale_default' );
+	}
+
+	/**
 	 * Data provider for has_block_variation test cases
 	 *
 	 * @return array


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Despite the Blocks checkout rendering checkout fields even when no country has been selected, filter `woocommerce_get_country_locale_default` wasn't applied at any point, so we were essentially using the "hardcoded" defaults. Once a country selection was made the fields were changed to the country specific ones (which are indeed filtered).

This PR ensures that when no country is selected we honor the definitions set by the filter `woocommerce_get_country_locale_default`. In some sense, no country is a country that has no locale overrides defined, so it makes sense to honor the return value from this filter.

Closes #60542.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the following snippet as a `.php` file in `wp-content/mu-plugins/` or similar:
   ```php
   <?php
   // Register a custom checkout field.
   add_action( 'woocommerce_init', function() {
       woocommerce_register_additional_checkout_field(
           array(
               'id'       => 'my-plugin/tax-id',
               'label'    => 'Tax ID',
               'location' => 'address',
               'required' => false,
               'type'     => 'text',
           )
       );
   } );
   
   // Hide "Last name", rename "First name" to "Full name", and reorder postcode.
   add_filter(
       'woocommerce_get_country_locale_default',
       function( $fields ) {
           $fields['first_name']['label']   = 'Full name';
           $fields['last_name']['hidden']   = true;
           $fields['last_name']['required'] = false;
           $fields['postcode']['priority']  = 15;
   
           return $fields;
       }
   );
   
   // Also apply the same overrides to all countries.
   add_filter(
       'woocommerce_get_country_locale',
       function( $locales ) {
           foreach ( $locales as $country => $locale ) {
               if ( 'default' === $country ) {
                   continue;
               }
   
               $locales[ $country ]['first_name'] = array( 'label' => 'Full name' );
               $locales[ $country ]['last_name']  = array( 'hidden' => true, 'required' => false );
               $locales[ $country ]['postcode']   = array( 'priority' => 15 );
           }
           return $locales;
       }
   );
   ```
1. Open an incognito window (to ensure no default country is already in the session).
1. Add any item to your cart.
1. Go to the checkout page.
1. Confirm that field first name is actually "Full Name", last name doesn't appear, postcode is located near the top fields and our custom field ("Tax ID") is correctly rendered.
   <img width="531" height="412" alt="Screenshot 2026-03-16 at 19 40 43" src="https://github.com/user-attachments/assets/802202ff-3902-4bb3-8dd1-0c9494df1af5" />
1. Optionally, compare with `trunk` where changes to the fields are ignored:
   <img width="524" height="473" alt="Screenshot 2026-03-16 at 19 41 43" src="https://github.com/user-attachments/assets/0a29efb3-2ddb-4aa9-afda-9545bcc501cc" />
1. Choose a country and confirm the field customizations persist.
1. Remove your PHP snippet.
1. Reload and confirm that the fields are back to the default configuration.
<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.