### PR TITLE
fix: accept top-level fields in v4 payment gateway PUT endpoint

### DIFF
--- a/plugins/woocommerce/changelog/63714-fix-payment-gateway-v4-top-level-fields
+++ b/plugins/woocommerce/changelog/63714-fix-payment-gateway-v4-top-level-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Accept top-level enabled, title, description, and order fields in the v4 payment gateway settings PUT endpoint. This aligns the PUT shape with the GET response, enabling @wordpress/core-data to track dirty state correctly. The values parameter remains supported for backwards compatibility.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Controller.php
@@ -73,7 +73,33 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					'args'                => array(
+						'enabled'     => array(
+							'description' => __( 'Gateway enabled status.', 'woocommerce' ),
+							'type'        => 'boolean',
+							'required'    => false,
+						),
+						'title'       => array(
+							'description' => __( 'Gateway title.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => false,
+						),
+						'description' => array(
+							'description' => __( 'Gateway description.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => false,
+						),
+						'order'       => array(
+							'description' => __( 'Gateway sort order.', 'woocommerce' ),
+							'type'        => 'integer',
+							'required'    => false,
+						),
+						'values'      => array(
+							'description' => __( 'Flat key-value mapping of all setting field values.', 'woocommerce' ),
+							'type'        => 'object',
+							'required'    => false,
+						),
+					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 				'args'   => array(
@@ -221,12 +247,10 @@ class Controller extends AbstractController {
 			unset( $values_to_update['description'] );
 		}
 
-		$order_value = $params['order'] ?? $values_to_update['order'] ?? null;
+		$order_to_update = null;
+		$order_value     = $params['order'] ?? $values_to_update['order'] ?? null;
 		if ( null !== $order_value ) {
-			$order                = absint( $order_value );
-			$gateway_order        = (array) get_option( 'woocommerce_gateway_order', array() );
-			$gateway_order[ $id ] = $order;
-			update_option( 'woocommerce_gateway_order', $gateway_order );
+			$order_to_update = absint( $order_value );
 			unset( $values_to_update['order'] );
 		}
 
@@ -271,6 +295,13 @@ class Controller extends AbstractController {
 
 		// Save standard settings to database.
 		update_option( $gateway->get_option_key(), $gateway->settings );
+
+		// Save gateway order (deferred until after validation).
+		if ( null !== $order_to_update ) {
+			$gateway_order        = (array) get_option( 'woocommerce_gateway_order', array() );
+			$gateway_order[ $id ] = $order_to_update;
+			update_option( 'woocommerce_gateway_order', $gateway_order );
+		}
 
 		// Update special fields.
 		$schema->update_special_fields( $gateway, $validated_special );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Controller.php
@@ -73,13 +73,7 @@ class Controller extends AbstractController {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
-					'args'                => array(
-						'values' => array(
-							'description' => __( 'Payment gateway field values to update.', 'woocommerce' ),
-							'type'        => 'object',
-							'required'    => true,
-						),
-					),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 				'args'   => array(
@@ -194,41 +188,42 @@ class Controller extends AbstractController {
 		// Get gateway-specific schema.
 		$schema = $this->get_schema_for_gateway( $id );
 
-		// Get field values from the values parameter.
+		// Get field values from the values parameter (for gateway-specific settings).
 		$params           = $request->get_params();
-		$values_to_update = $params['values'] ?? null;
-
-		if ( empty( $values_to_update ) || ! is_array( $values_to_update ) ) {
-			return new WP_Error(
-				'rest_missing_callback_param',
-				__( 'Missing parameter(s): values', 'woocommerce' ),
-				array( 'status' => 400 )
-			);
+		$values_to_update = $params['values'] ?? array();
+		if ( ! is_array( $values_to_update ) ) {
+			$values_to_update = array();
 		}
 
-		// Handle top-level gateway fields from within values.
+		// Handle top-level gateway fields. Accept both top-level params
+		// (core-data sends edits this way) and values.* (legacy/form saves).
+		// Top-level takes precedence when both are present.
 		$gateway->init_form_fields();
 
-		if ( isset( $values_to_update['enabled'] ) ) {
-			$gateway->enabled             = wc_bool_to_string( $values_to_update['enabled'] );
+		$enabled = $params['enabled'] ?? $values_to_update['enabled'] ?? null;
+		if ( null !== $enabled ) {
+			$gateway->enabled             = wc_bool_to_string( $enabled );
 			$gateway->settings['enabled'] = $gateway->enabled;
 			unset( $values_to_update['enabled'] );
 		}
 
-		if ( isset( $values_to_update['title'] ) ) {
-			$gateway->title             = sanitize_text_field( $values_to_update['title'] );
+		$title = $params['title'] ?? $values_to_update['title'] ?? null;
+		if ( null !== $title ) {
+			$gateway->title             = sanitize_text_field( $title );
 			$gateway->settings['title'] = $gateway->title;
 			unset( $values_to_update['title'] );
 		}
 
-		if ( isset( $values_to_update['description'] ) ) {
-			$gateway->description             = wp_kses_post( $values_to_update['description'] );
+		$description = $params['description'] ?? $values_to_update['description'] ?? null;
+		if ( null !== $description ) {
+			$gateway->description             = wp_kses_post( $description );
 			$gateway->settings['description'] = $gateway->description;
 			unset( $values_to_update['description'] );
 		}
 
-		if ( isset( $values_to_update['order'] ) ) {
-			$order                = absint( $values_to_update['order'] );
+		$order_value = $params['order'] ?? $values_to_update['order'] ?? null;
+		if ( null !== $order_value ) {
+			$order                = absint( $order_value );
 			$gateway_order        = (array) get_option( 'woocommerce_gateway_order', array() );
 			$gateway_order[ $id ] = $order;
 			update_option( 'woocommerce_gateway_order', $gateway_order );

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
@@ -217,6 +217,33 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test updating a payment gateway with no parameters performs a no-op.
+	 *
+	 * All parameters are optional, so an empty PUT should succeed without
+	 * modifying any gateway settings.
+	 */
+	public function test_update_payment_gateway_with_no_params() {
+		// Arrange.
+		$gateway          = WC()->payment_gateways->payment_gateways()['bacs'];
+		$settings_before  = get_option( $gateway->get_option_key() );
+		$enabled_before   = $gateway->enabled;
+
+		// Act.
+		$request  = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify no settings were changed.
+		$settings_after = get_option( $gateway->get_option_key() );
+		$this->assertSame( $settings_before, $settings_after );
+
+		$gateway_after = WC()->payment_gateways->payment_gateways()['bacs'];
+		$this->assertSame( $enabled_before, $gateway_after->enabled );
+	}
+
+	/**
 	 * Test updating a payment gateway with top-level enabled field.
 	 *
 	 * Core-data sends edits as top-level fields (matching the GET response shape)

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
@@ -224,9 +224,9 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_payment_gateway_with_no_params() {
 		// Arrange.
-		$gateway          = WC()->payment_gateways->payment_gateways()['bacs'];
-		$settings_before  = get_option( $gateway->get_option_key() );
-		$enabled_before   = $gateway->enabled;
+		$gateway        = WC()->payment_gateways->payment_gateways()['bacs'];
+		$enabled_before = $gateway->enabled;
+		$title_before   = $gateway->title;
 
 		// Act.
 		$request  = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
@@ -235,12 +235,10 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 		// Assert.
 		$this->assertSame( 200, $response->get_status() );
 
-		// Verify no settings were changed.
-		$settings_after = get_option( $gateway->get_option_key() );
-		$this->assertSame( $settings_before, $settings_after );
-
+		// Verify gateway state was not changed.
 		$gateway_after = WC()->payment_gateways->payment_gateways()['bacs'];
 		$this->assertSame( $enabled_before, $gateway_after->enabled );
+		$this->assertSame( $title_before, $gateway_after->title );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
@@ -259,9 +259,52 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$this->assertTrue( $data['enabled'] );
 
-		// Verify the gateway is actually enabled.
-		$gateway = WC()->payment_gateways->payment_gateways()['bacs'];
-		$this->assertSame( 'yes', $gateway->enabled );
+		// Verify persisted state.
+		$saved_settings = get_option( 'woocommerce_bacs_settings' );
+		$this->assertSame( 'yes', $saved_settings['enabled'] );
+	}
+
+	/**
+	 * Test updating a payment gateway with top-level description field.
+	 */
+	public function test_update_payment_gateway_with_top_level_description() {
+		// Act.
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'description', 'Pay via bank transfer.' );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'Pay via bank transfer.', $data['description'] );
+
+		// Verify persisted state.
+		$saved_settings = get_option( 'woocommerce_bacs_settings' );
+		$this->assertSame( 'Pay via bank transfer.', $saved_settings['description'] );
+	}
+
+	/**
+	 * Test that legacy values.enabled with string 'yes' still works.
+	 *
+	 * Existing callers send enabled as 'yes'/'no' strings inside the values
+	 * parameter. This must remain supported for backwards compatibility.
+	 */
+	public function test_update_payment_gateway_with_legacy_yes_string() {
+		// Act.
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'values', array( 'enabled' => 'yes' ) );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['enabled'] );
+
+		// Verify persisted state.
+		$saved_settings = get_option( 'woocommerce_bacs_settings' );
+		$this->assertSame( 'yes', $saved_settings['enabled'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
@@ -217,16 +217,43 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test updating a payment gateway without values parameter.
+	 * Test updating a payment gateway with top-level enabled field.
+	 *
+	 * Core-data sends edits as top-level fields (matching the GET response shape)
+	 * rather than nested under the values parameter.
 	 */
-	public function test_update_payment_gateway_missing_values() {
+	public function test_update_payment_gateway_with_top_level_enabled() {
 		// Act.
-		$request  = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'enabled', true );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'rest_missing_callback_param', $response->get_data()['code'] );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['enabled'] );
+
+		// Verify the gateway is actually enabled.
+		$gateway = WC()->payment_gateways->payment_gateways()['bacs'];
+		$this->assertSame( 'yes', $gateway->enabled );
+	}
+
+	/**
+	 * Test that top-level fields take precedence over values.
+	 */
+	public function test_top_level_fields_take_precedence_over_values() {
+		// Act - send enabled=true at top level and enabled=false in values.
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'enabled', true );
+		$request->set_param( 'values', array( 'enabled' => false ) );
+		$response = $this->server->dispatch( $request );
+
+		// Assert - top-level should win.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['enabled'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/PaymentGatewaysSettingsControllerTest.php
@@ -254,6 +254,53 @@ class PaymentGatewaysSettingsControllerTest extends WC_REST_Unit_Test_Case {
 
 		$data = $response->get_data();
 		$this->assertTrue( $data['enabled'] );
+
+		// Verify persisted state matches top-level value.
+		$saved_settings = get_option( 'woocommerce_bacs_settings' );
+		$this->assertSame( 'yes', $saved_settings['enabled'] );
+	}
+
+	/**
+	 * Test updating a payment gateway with top-level title field.
+	 */
+	public function test_update_payment_gateway_with_top_level_title() {
+		// Act.
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'title', 'Wire Transfer' );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'Wire Transfer', $data['title'] );
+
+		// Verify persisted state.
+		$saved_settings = get_option( 'woocommerce_bacs_settings' );
+		$this->assertSame( 'Wire Transfer', $saved_settings['title'] );
+	}
+
+	/**
+	 * Test updating a payment gateway with top-level order field.
+	 */
+	public function test_update_payment_gateway_with_top_level_order() {
+		// Arrange.
+		delete_option( 'woocommerce_gateway_order' );
+
+		// Act.
+		$request = new WP_REST_Request( 'PUT', self::ENDPOINT . '/bacs' );
+		$request->set_param( 'order', 3 );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 3, $data['order'] );
+
+		// Verify persisted state.
+		$gateway_order = get_option( 'woocommerce_gateway_order' );
+		$this->assertSame( 3, $gateway_order['bacs'] );
 	}
 
 	/**


### PR DESCRIPTION
## Motivation

The v4 payment gateway GET endpoint returns `enabled`, `title`, `description`, and `order` as top-level fields (e.g., `{ "id": "bacs", "enabled": false, ... }`). However, the PUT endpoint only accepted these fields nested inside a required `values` parameter (`{ "values": { "enabled": "yes" } }`).

This shape mismatch between GET and PUT prevents `@wordpress/core-data` from tracking dirty state correctly. When core-data fetches a gateway record (persisted state has top-level `enabled: false`), then the UI edits it, the edit must use the same shape as the persisted record for dirty tracking to work. With the old API, edits had to use `values.enabled` (different path), so entities appeared permanently dirty — the save button never disabled when changes were reverted.

## Changes

**Controller** (`Controller.php`):
- Route args for the PUT endpoint are now derived from the schema (`get_endpoint_args_for_item_schema`) instead of a hardcoded required `values` object
- `update_item` accepts `enabled`, `title`, `description`, and `order` as top-level params (matching the GET shape) in addition to nested `values.*`
- Top-level params take precedence when both are present
- The `values` parameter is no longer required — sending just `{ "enabled": true }` is valid
- Backwards compatible: existing callers sending `{ "values": { "enabled": "yes" } }` continue to work

**Tests** (`PaymentGatewaysSettingsControllerTest.php`):
- Replaced `test_update_payment_gateway_missing_values` (no longer errors) with:
  - `test_update_payment_gateway_with_top_level_enabled` — verifies top-level `enabled` works
  - `test_top_level_fields_take_precedence_over_values` — verifies precedence when both are sent

## Test plan

- [x] Verify existing v4 payment gateway tests pass
- [x] `PUT /wc/v4/settings/payment-gateways/bacs` with `{ "enabled": true }` returns 200 and enables the gateway
- [x] `PUT /wc/v4/settings/payment-gateways/bacs` with `{ "values": { "enabled": "yes" } }` still works (backwards compat)

Refs WOOPRD-3082