### PR TITLE
fix: query real order data for CustomerHistory metabox

### DIFF
--- a/plugins/woocommerce/changelog/63715-fix-customer-history-real-time-data
+++ b/plugins/woocommerce/changelog/63715-fix-customer-history-real-time-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix CustomerHistory metabox to query real-time order data instead of analytics tables, ensuring accurate customer order count and spend data regardless of analytics sync status.
+Fix CustomerHistory metabox to query real-time order data (HPOS) instead of analytics tables, ensuring accurate customer order count and spend data regardless of analytics sync status.

--- a/plugins/woocommerce/changelog/63715-fix-customer-history-real-time-data
+++ b/plugins/woocommerce/changelog/63715-fix-customer-history-real-time-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CustomerHistory metabox to query real-time order data instead of analytics tables, ensuring accurate customer order count and spend data regardless of analytics sync status.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -37,16 +37,20 @@ class CustomerHistory {
 	 *
 	 * @param WC_Order $order The order object.
 	 *
-	 * @return array Order count, total spend, and average order value.
+	 * @return array{orders_count: int, total_spend: float, avg_order_value: float} Order count, total spend, and average order value.
 	 */
 	private function get_customer_history( WC_Order $order ): array {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$customer_id   = $order->get_customer_id();
 			$billing_email = $order->get_billing_email();
-			$result = $this->query_hpos( $customer_id, $billing_email );
+			$result        = $this->query_hpos( $customer_id, $billing_email );
 		} elseif ( method_exists( $order, 'get_report_customer_id' ) ) {
 			$result = $this->query_cpt( $order->get_report_customer_id() );
 		} else {
+			wc_get_logger()->warning(
+				'CustomerHistory: Order object does not have get_report_customer_id method.',
+				array( 'source' => 'customer-history' )
+			);
 			$result = (object) array(
 				'orders_count' => 0,
 				'total_spend'  => 0,
@@ -74,11 +78,18 @@ class CustomerHistory {
 	private function query_hpos( int $customer_id, string $billing_email ): object {
 		global $wpdb;
 
+		$default = (object) array(
+			'orders_count' => 0,
+			'total_spend'  => 0,
+		);
+
 		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
 		$orders_table          = OrdersTableDataStore::get_orders_table_name();
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = null;
+
 		if ( $customer_id > 0 ) {
+					// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$sql = $wpdb->prepare(
 				"SELECT COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
@@ -101,6 +112,18 @@ class CustomerHistory {
 				$orders_table,
 				$customer_id
 			);
+
+			if ( null !== $sql ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
+				$row = $wpdb->get_row( $sql );
+
+				if ( $wpdb->last_error ) {
+					wc_get_logger()->error(
+						sprintf( 'CustomerHistory: Failed to query HPOS order stats for customer_id=%d. DB error: %s', $customer_id, $wpdb->last_error ),
+						array( 'source' => 'customer-history' )
+					);
+				}
+			}
 		} elseif ( '' !== $billing_email ) {
 			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
 			$sql             = $wpdb->prepare(
@@ -129,32 +152,27 @@ class CustomerHistory {
 				$addresses_table,
 				$billing_email
 			);
-		} else {
-			return (object) array(
-				'orders_count' => 0,
-				'total_spend'  => 0,
-			);
+
+			if ( null !== $sql ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
+				$row = $wpdb->get_row( $sql );
+
+				if ( $wpdb->last_error ) {
+					wc_get_logger()->error(
+						sprintf( 'CustomerHistory: Failed to query HPOS order stats for email=%s. DB error: %s', $billing_email, $wpdb->last_error ),
+						array( 'source' => 'customer-history' )
+					);
+				}
+			}
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-		$row = $wpdb->get_row( $sql );
-
-		if ( $wpdb->last_error ) {
-			wc_get_logger()->error(
-				sprintf( 'CustomerHistory: Failed to query HPOS order stats. DB error: %s', $wpdb->last_error ),
-				array( 'source' => 'customer-history' )
-			);
-		}
-
-		return $row ?? (object) array(
-			'orders_count' => 0,
-			'total_spend'  => 0,
-		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $row ?? $default;
 	}
 
 	/**
-	 * Query customer order stats from analytics-backed CPT data.
+	 * Query customer order stats via the Analytics Customers report (legacy fallback when HPOS is not active).
 	 *
 	 * @param int $customer_report_id The reports customer ID.
 	 *
@@ -181,9 +199,11 @@ class CustomerHistory {
 	/**
 	 * Get the SQL fragment for excluded order statuses.
 	 *
-	 * @return string SQL IN clause contents, e.g. ( 'wc-pending', 'wc-failed', ... ).
+	 * @return string SQL IN clause, e.g. ( 'auto-draft','trash','wc-pending','wc-failed',... ). Always includes auto-draft and trash without wc- prefix.
 	 */
 	private function get_excluded_statuses_sql(): string {
+		global $wpdb;
+
 		$excluded_statuses = get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
 		if ( ! is_array( $excluded_statuses ) ) {
 			$excluded_statuses = array( 'pending', 'failed', 'cancelled' );
@@ -191,13 +211,13 @@ class CustomerHistory {
 		$excluded_statuses = array_merge( array( 'auto-draft', 'trash' ), $excluded_statuses );
 
 		/**
-		 * Filter the list of excluded order statuses for analytics reports.
+		 * Filter the list of excluded order statuses for customer history and analytics reports.
 		 *
 		 * @since 4.0.0
 		 * @param array $excluded_statuses Order statuses to exclude.
 		 */
 		$excluded_statuses = apply_filters( 'woocommerce_analytics_excluded_order_statuses', $excluded_statuses );
-		if ( ! is_array( $excluded_statuses ) ) {
+		if ( ! is_array( $excluded_statuses ) || empty( $excluded_statuses ) ) {
 			$excluded_statuses = array( 'auto-draft', 'trash', 'pending', 'failed', 'cancelled' );
 		}
 
@@ -209,6 +229,9 @@ class CustomerHistory {
 			$excluded_statuses
 		);
 
-		return "( '" . implode( "','", array_map( 'esc_sql', $prefixed ) ) . "' )";
+		$placeholders = implode( ',', array_fill( 0, count( $prefixed ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is a safe string of %s tokens.
+		return $wpdb->prepare( "( $placeholders )", $prefixed );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -90,20 +90,23 @@ class CustomerHistory {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $customer_id > 0 ) {
+			$status_filter    = $excluded_statuses_sql ? "AND status NOT IN $excluded_statuses_sql" : '';
+			$co_status_filter = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
+
 			$sql = $wpdb->prepare(
 				"SELECT COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
 					SELECT id, total_amount
 					FROM %i
-					WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql
+					WHERE customer_id = %d AND type = 'shop_order' $status_filter
 				) AS filtered
 				LEFT JOIN (
 					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
 					FROM %i AS rp
 					INNER JOIN %i AS co ON rp.parent_order_id = co.id
 					WHERE rp.type = 'shop_order_refund'
-						AND co.customer_id = %d AND co.type = 'shop_order' AND co.status NOT IN $excluded_statuses_sql
+						AND co.customer_id = %d AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
 				$orders_table,
@@ -113,15 +116,18 @@ class CustomerHistory {
 				$customer_id
 			);
 		} elseif ( '' !== $billing_email ) {
-			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
-			$sql             = $wpdb->prepare(
+			$addresses_table  = OrdersTableDataStore::get_addresses_table_name();
+			$o_status_filter  = $excluded_statuses_sql ? "AND o.status NOT IN $excluded_statuses_sql" : '';
+			$co_status_filter = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
+
+			$sql = $wpdb->prepare(
 				"SELECT COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
 					SELECT o.id, o.total_amount
 					FROM %i AS o
 					INNER JOIN %i AS a ON o.id = a.order_id AND a.address_type = 'billing'
-					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' AND o.status NOT IN $excluded_statuses_sql
+					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' $o_status_filter
 				) AS filtered
 				LEFT JOIN (
 					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
@@ -129,7 +135,7 @@ class CustomerHistory {
 					INNER JOIN %i AS co ON rp.parent_order_id = co.id
 					INNER JOIN %i AS ca ON co.id = ca.order_id AND ca.address_type = 'billing'
 					WHERE rp.type = 'shop_order_refund'
-						AND co.customer_id = 0 AND ca.email = %s AND co.type = 'shop_order' AND co.status NOT IN $excluded_statuses_sql
+						AND co.customer_id = 0 AND ca.email = %s AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
 				$orders_table,
@@ -188,7 +194,7 @@ class CustomerHistory {
 	/**
 	 * Get the SQL fragment for excluded order statuses.
 	 *
-	 * @return string SQL IN clause, e.g. ( 'auto-draft','trash','wc-pending','wc-failed',... ), or ( '' ) if no statuses are excluded.
+	 * @return string SQL IN clause, e.g. ( 'auto-draft','trash','wc-pending','wc-failed',... ), or empty string if no statuses are excluded.
 	 */
 	private function get_excluded_statuses_sql(): string {
 		global $wpdb;
@@ -211,7 +217,7 @@ class CustomerHistory {
 		}
 
 		if ( empty( $excluded_statuses ) ) {
-			return "( '' )";
+			return '';
 		}
 
 		$prefixed = array_map(

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -103,7 +103,16 @@ class CustomerHistory {
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-		return $wpdb->get_row( $sql ) ?? (object) array(
+		$row = $wpdb->get_row( $sql );
+
+		if ( $wpdb->last_error ) {
+			wc_get_logger()->error(
+				sprintf( 'CustomerHistory: Failed to query HPOS order stats. DB error: %s', $wpdb->last_error ),
+				array( 'source' => 'customer-history' )
+			);
+		}
+
+		return $row ?? (object) array(
 			'orders_count' => 0,
 			'total_spend'  => 0,
 		);
@@ -132,10 +141,10 @@ class CustomerHistory {
 				FROM {$wpdb->posts} AS p
 				INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
 				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
-				WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %d
+				WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %s
 				AND meta_total.meta_key = '_order_total'
 				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
-				$customer_id
+				(string) $customer_id
 			);
 		} elseif ( '' !== $billing_email ) {
 			$sql = $wpdb->prepare(
@@ -158,7 +167,16 @@ class CustomerHistory {
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-		return $wpdb->get_row( $sql ) ?? (object) array(
+		$row = $wpdb->get_row( $sql );
+
+		if ( $wpdb->last_error ) {
+			wc_get_logger()->error(
+				sprintf( 'CustomerHistory: Failed to query CPT order stats. DB error: %s', $wpdb->last_error ),
+				array( 'source' => 'customer-history' )
+			);
+		}
+
+		return $row ?? (object) array(
 			'orders_count' => 0,
 			'total_spend'  => 0,
 		);
@@ -178,6 +196,14 @@ class CustomerHistory {
 			$excluded_statuses = array( 'pending', 'failed', 'cancelled' );
 		}
 		$excluded_statuses = array_merge( array( 'auto-draft', 'trash' ), $excluded_statuses );
+
+		/**
+		 * Filter the list of excluded order statuses for analytics reports.
+		 *
+		 * @since 4.0.0
+		 * @param array $excluded_statuses Order statuses to exclude.
+		 */
+		$excluded_statuses = apply_filters( 'woocommerce_analytics_excluded_order_statuses', $excluded_statuses );
 
 		$prefixed = array_map(
 			function ( $status ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -152,7 +152,7 @@ class CustomerHistory {
 
 		if ( $wpdb->last_error ) {
 			wc_get_logger()->error(
-				sprintf( 'CustomerHistory: Failed to query HPOS order stats for customer_id=%d, email=%s. DB error: %s', $customer_id, $billing_email, $wpdb->last_error ),
+				sprintf( 'CustomerHistory: Failed to query HPOS order stats for customer_id=%d. DB error: %s', $customer_id, $wpdb->last_error ),
 				array( 'source' => 'customer-history' )
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -2,7 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes;
 
-use Automattic\WooCommerce\Admin\API\Reports\Customers\Query as CustomersQuery;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 
 /**
@@ -20,47 +21,164 @@ class CustomerHistory {
 	 * @return void
 	 */
 	public function output( WC_Order $order ): void {
-		// No history when adding a new order.
 		if ( 'auto-draft' === $order->get_status() ) {
 			return;
 		}
 
-		$customer_history = null;
+		$customer_id   = $order->get_customer_id();
+		$billing_email = $order->get_billing_email();
 
-		if ( method_exists( $order, 'get_report_customer_id' ) ) {
-			$customer_history = $this->get_customer_history( $order->get_report_customer_id() );
-		}
-
-		if ( ! $customer_history ) {
-			$customer_history = array(
-				'orders_count'    => 0,
-				'total_spend'     => 0,
-				'avg_order_value' => 0,
-			);
-		}
+		$customer_history = $this->get_customer_history_from_orders( $customer_id, $billing_email );
 
 		wc_get_template( 'order/customer-history.php', $customer_history );
 	}
 
 	/**
-	 * Get the order history for the customer (data matches Customers report).
+	 * Get the order history for the customer by querying actual order data.
 	 *
-	 * @param int $customer_report_id The reports customer ID (not necessarily User ID).
+	 * @since 10.7.0
 	 *
-	 * @return array|null Order count, total spend, and average spend per order.
+	 * @param int    $customer_id   The customer user ID (0 for guests).
+	 * @param string $billing_email The billing email address (used for guest lookup).
+	 *
+	 * @return array Order count, total spend, and average order value.
 	 */
-	private function get_customer_history( $customer_report_id ): ?array {
+	private function get_customer_history_from_orders( int $customer_id, string $billing_email ): array {
+		$result = OrderUtil::custom_orders_table_usage_is_enabled()
+			? $this->query_hpos( $customer_id, $billing_email )
+			: $this->query_cpt( $customer_id, $billing_email );
 
-		$args = array(
-			'customers'    => array( $customer_report_id ),
-			// If unset, these params have default values that affect the results.
-			'order_after'  => null,
-			'order_before' => null,
+		$orders_count = (int) ( $result->orders_count ?? 0 );
+		$total_spend  = (float) ( $result->total_spend ?? 0 );
+
+		return array(
+			'orders_count'    => $orders_count,
+			'total_spend'     => $total_spend,
+			'avg_order_value' => $orders_count > 0 ? $total_spend / $orders_count : 0,
 		);
-
-		$customers_query = new CustomersQuery( $args );
-		$customer_data   = $customers_query->get_data();
-		return $customer_data->data[0] ?? null;
 	}
 
+	/**
+	 * Query customer order stats from HPOS tables.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @param int    $customer_id   The customer user ID.
+	 * @param string $billing_email The billing email address.
+	 *
+	 * @return object Object with orders_count and total_spend properties.
+	 */
+	private function query_hpos( int $customer_id, string $billing_email ): object {
+		global $wpdb;
+
+		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
+		$orders_table          = OrdersTableDataStore::get_orders_table_name();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		if ( $customer_id > 0 ) {
+			$sql = $wpdb->prepare(
+				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( total_amount ), 0 ) AS total_spend
+				FROM %i
+				WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql",
+				$orders_table,
+				$customer_id
+			);
+		} elseif ( '' !== $billing_email ) {
+			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
+			$sql             = $wpdb->prepare(
+				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( o.total_amount ), 0 ) AS total_spend
+				FROM %i AS o
+				INNER JOIN %i AS a ON o.id = a.order_id AND a.address_type = 'billing'
+				WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' AND o.status NOT IN $excluded_statuses_sql",
+				$orders_table,
+				$addresses_table,
+				$billing_email
+			);
+		} else {
+			return (object) array(
+				'orders_count' => 0,
+				'total_spend'  => 0,
+			);
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $wpdb->get_row( $sql ) ?? (object) array(
+			'orders_count' => 0,
+			'total_spend'  => 0,
+		);
+	}
+
+	/**
+	 * Query customer order stats from CPT tables.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @param int    $customer_id   The customer user ID.
+	 * @param string $billing_email The billing email address.
+	 *
+	 * @return object Object with orders_count and total_spend properties.
+	 */
+	private function query_cpt( int $customer_id, string $billing_email ): object {
+		global $wpdb;
+
+		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		if ( $customer_id > 0 ) {
+			$sql = $wpdb->prepare(
+				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( meta_total.meta_value ), 0 ) AS total_spend
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
+				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
+				WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %d
+				AND meta_total.meta_key = '_order_total'
+				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
+				$customer_id
+			);
+		} elseif ( '' !== $billing_email ) {
+			$sql = $wpdb->prepare(
+				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( meta_total.meta_value ), 0 ) AS total_spend
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS meta_email ON p.ID = meta_email.post_id
+				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
+				WHERE meta_email.meta_key = '_billing_email' AND meta_email.meta_value = %s
+				AND meta_total.meta_key = '_order_total'
+				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
+				$billing_email
+			);
+		} else {
+			return (object) array(
+				'orders_count' => 0,
+				'total_spend'  => 0,
+			);
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $wpdb->get_row( $sql ) ?? (object) array(
+			'orders_count' => 0,
+			'total_spend'  => 0,
+		);
+	}
+
+	/**
+	 * Get the SQL fragment for excluded order statuses.
+	 *
+	 * @since 10.7.0
+	 *
+	 * @return string SQL IN clause contents, e.g. ( 'wc-pending', 'wc-failed', ... ).
+	 */
+	private function get_excluded_statuses_sql(): string {
+		$excluded_statuses = get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
+		$excluded_statuses = array_merge( array( 'auto-draft', 'trash' ), $excluded_statuses );
+
+		$prefixed = array_map(
+			function ( $status ) {
+				$status = sanitize_title( $status );
+				return 'auto-draft' === $status || 'trash' === $status ? $status : 'wc-' . $status;
+			},
+			$excluded_statuses
+		);
+
+		return "( '" . implode( "','", array_map( 'esc_sql', $prefixed ) ) . "' )";
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\Query as CustomersQuery;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
@@ -26,26 +27,23 @@ class CustomerHistory {
 			return;
 		}
 
-		$customer_id   = $order->get_customer_id();
-		$billing_email = $order->get_billing_email();
-
-		$customer_history = $this->get_customer_history_from_orders( $customer_id, $billing_email );
+		$customer_history = $this->get_customer_history( $order );
 
 		wc_get_template( 'order/customer-history.php', $customer_history );
 	}
 
 	/**
-	 * Get the order history for the customer by querying actual order data.
-	 *
-	 * @param int    $customer_id   The customer user ID (0 for guests).
-	 * @param string $billing_email The billing email address (used for guest lookup).
+	 * Get the order history for the customer.
 	 *
 	 * @return array Order count, total spend, and average order value.
 	 */
-	private function get_customer_history_from_orders( int $customer_id, string $billing_email ): array {
+	private function get_customer_history( WC_Order $order ): array {
+		$customer_id   = $order->get_customer_id();
+		$billing_email = $order->get_billing_email();
+
 		$result = OrderUtil::custom_orders_table_usage_is_enabled()
 			? $this->query_hpos( $customer_id, $billing_email )
-			: $this->query_cpt( $customer_id, $billing_email );
+			: $this->query_cpt( $order->get_report_customer_id() );
 
 		$orders_count = (int) ( $result->orders_count ?? 0 );
 		$total_spend  = (float) ( $result->total_spend ?? 0 );
@@ -151,103 +149,28 @@ class CustomerHistory {
 	}
 
 	/**
-	 * Query customer order stats from CPT tables.
+	 * Query customer order stats from analytics-backed CPT data.
 	 *
-	 * @param int    $customer_id   The customer user ID.
-	 * @param string $billing_email The billing email address.
+	 * @param int $customer_report_id The reports customer ID.
 	 *
 	 * @return object Object with orders_count and total_spend properties.
 	 */
-	private function query_cpt( int $customer_id, string $billing_email ): object {
-		global $wpdb;
-
-		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( $customer_id > 0 ) {
-			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count,
-					COALESCE( SUM( filtered.order_total ), 0 ) - COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
-				FROM (
-					SELECT p.ID, meta_total.meta_value AS order_total
-					FROM {$wpdb->posts} AS p
-					INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
-					INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
-					WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %s
-					AND meta_total.meta_key = '_order_total'
-					AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql
-				) AS filtered
-				LEFT JOIN (
-					SELECT rp.post_parent, SUM( rm.meta_value ) AS refund_total
-					FROM {$wpdb->posts} AS rp
-					INNER JOIN {$wpdb->postmeta} AS rm ON rp.ID = rm.post_id AND rm.meta_key = '_refund_amount'
-					WHERE rp.post_type = 'shop_order_refund'
-						AND rp.post_parent IN (
-							SELECT p2.ID FROM {$wpdb->posts} AS p2
-							INNER JOIN {$wpdb->postmeta} AS mc2 ON p2.ID = mc2.post_id
-							WHERE mc2.meta_key = '_customer_user' AND mc2.meta_value = %s
-							AND p2.post_type = 'shop_order' AND p2.post_status NOT IN $excluded_statuses_sql
-						)
-					GROUP BY rp.post_parent
-				) AS r ON filtered.ID = r.post_parent",
-				(string) $customer_id,
-				(string) $customer_id
-			);
-		} elseif ( '' !== $billing_email ) {
-			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count,
-					COALESCE( SUM( filtered.order_total ), 0 ) - COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
-				FROM (
-					SELECT p.ID, meta_total.meta_value AS order_total
-					FROM {$wpdb->posts} AS p
-					INNER JOIN {$wpdb->postmeta} AS meta_email ON p.ID = meta_email.post_id
-					INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
-					INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
-					WHERE meta_email.meta_key = '_billing_email' AND meta_email.meta_value = %s
-					AND meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = '0'
-					AND meta_total.meta_key = '_order_total'
-					AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql
-				) AS filtered
-				LEFT JOIN (
-					SELECT rp.post_parent, SUM( rm.meta_value ) AS refund_total
-					FROM {$wpdb->posts} AS rp
-					INNER JOIN {$wpdb->postmeta} AS rm ON rp.ID = rm.post_id AND rm.meta_key = '_refund_amount'
-					WHERE rp.post_type = 'shop_order_refund'
-						AND rp.post_parent IN (
-							SELECT p2.ID FROM {$wpdb->posts} AS p2
-							INNER JOIN {$wpdb->postmeta} AS me2 ON p2.ID = me2.post_id
-							INNER JOIN {$wpdb->postmeta} AS mc2 ON p2.ID = mc2.post_id
-							WHERE me2.meta_key = '_billing_email' AND me2.meta_value = %s
-							AND mc2.meta_key = '_customer_user' AND mc2.meta_value = '0'
-							AND p2.post_type = 'shop_order' AND p2.post_status NOT IN $excluded_statuses_sql
-						)
-					GROUP BY rp.post_parent
-				) AS r ON filtered.ID = r.post_parent",
-				$billing_email,
-				$billing_email
-			);
-		} else {
-			return (object) array(
-				'orders_count' => 0,
-				'total_spend'  => 0,
-			);
-		}
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-		$row = $wpdb->get_row( $sql );
-
-		if ( $wpdb->last_error ) {
-			wc_get_logger()->error(
-				sprintf( 'CustomerHistory: Failed to query CPT order stats. DB error: %s', $wpdb->last_error ),
-				array( 'source' => 'customer-history' )
-			);
-		}
-
-		return $row ?? (object) array(
-			'orders_count' => 0,
-			'total_spend'  => 0,
+	private function query_cpt( int $customer_report_id ): object {
+		$args = array(
+			'customers'    => array( $customer_report_id ),
+			// If unset, these params have default values that affect the results.
+			'order_after'  => null,
+			'order_before' => null,
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$customers_query = new CustomersQuery( $args );
+		$customer_data   = $customers_query->get_data();
+		$customer_row    = $customer_data->data[0] ?? null;
+
+		return (object) array(
+			'orders_count' => $customer_row['orders_count'] ?? 0,
+			'total_spend'  => $customer_row['total_spend'] ?? 0,
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -196,6 +196,9 @@ class CustomerHistory {
 		 * @param array $excluded_statuses Order statuses to exclude.
 		 */
 		$excluded_statuses = apply_filters( 'woocommerce_analytics_excluded_order_statuses', $excluded_statuses );
+		if ( ! is_array( $excluded_statuses ) ) {
+			$excluded_statuses = array( 'auto-draft', 'trash', 'pending', 'failed', 'cancelled' );
+		}
 
 		$prefixed = array_map(
 			function ( $status ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -37,8 +37,6 @@ class CustomerHistory {
 	/**
 	 * Get the order history for the customer by querying actual order data.
 	 *
-	 * @since 10.7.0
-	 *
 	 * @param int    $customer_id   The customer user ID (0 for guests).
 	 * @param string $billing_email The billing email address (used for guest lookup).
 	 *
@@ -61,8 +59,6 @@ class CustomerHistory {
 
 	/**
 	 * Query customer order stats from HPOS tables.
-	 *
-	 * @since 10.7.0
 	 *
 	 * @param int    $customer_id   The customer user ID.
 	 * @param string $billing_email The billing email address.
@@ -121,8 +117,6 @@ class CustomerHistory {
 
 	/**
 	 * Query customer order stats from CPT tables.
-	 *
-	 * @since 10.7.0
 	 *
 	 * @param int    $customer_id   The customer user ID.
 	 * @param string $billing_email The billing email address.
@@ -185,8 +179,6 @@ class CustomerHistory {
 
 	/**
 	 * Get the SQL fragment for excluded order statuses.
-	 *
-	 * @since 10.7.0
 	 *
 	 * @return string SQL IN clause contents, e.g. ( 'wc-pending', 'wc-failed', ... ).
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -101,12 +101,13 @@ class CustomerHistory {
 				'total_spend'  => 0,
 			);
 		}
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
 		return $wpdb->get_row( $sql ) ?? (object) array(
 			'orders_count' => 0,
 			'total_spend'  => 0,
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -153,12 +154,13 @@ class CustomerHistory {
 				'total_spend'  => 0,
 			);
 		}
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
 		return $wpdb->get_row( $sql ) ?? (object) array(
 			'orders_count' => 0,
 			'total_spend'  => 0,
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -86,10 +86,10 @@ class CustomerHistory {
 		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
 		$orders_table          = OrdersTableDataStore::get_orders_table_name();
 
-		$row = null;
+		$sql = null;
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $customer_id > 0 ) {
-					// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$sql = $wpdb->prepare(
 				"SELECT COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
@@ -112,18 +112,6 @@ class CustomerHistory {
 				$orders_table,
 				$customer_id
 			);
-
-			if ( null !== $sql ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-				$row = $wpdb->get_row( $sql );
-
-				if ( $wpdb->last_error ) {
-					wc_get_logger()->error(
-						sprintf( 'CustomerHistory: Failed to query HPOS order stats for customer_id=%d. DB error: %s', $customer_id, $wpdb->last_error ),
-						array( 'source' => 'customer-history' )
-					);
-				}
-			}
 		} elseif ( '' !== $billing_email ) {
 			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
 			$sql             = $wpdb->prepare(
@@ -152,21 +140,22 @@ class CustomerHistory {
 				$addresses_table,
 				$billing_email
 			);
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-			if ( null !== $sql ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
-				$row = $wpdb->get_row( $sql );
-
-				if ( $wpdb->last_error ) {
-					wc_get_logger()->error(
-						sprintf( 'CustomerHistory: Failed to query HPOS order stats for email=%s. DB error: %s', $billing_email, $wpdb->last_error ),
-						array( 'source' => 'customer-history' )
-					);
-				}
-			}
+		if ( null === $sql ) {
+			return $default;
 		}
 
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
+		$row = $wpdb->get_row( $sql );
+
+		if ( $wpdb->last_error ) {
+			wc_get_logger()->error(
+				sprintf( 'CustomerHistory: Failed to query HPOS order stats for customer_id=%d, email=%s. DB error: %s', $customer_id, $billing_email, $wpdb->last_error ),
+				array( 'source' => 'customer-history' )
+			);
+		}
 
 		return $row ?? $default;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -188,7 +188,7 @@ class CustomerHistory {
 	/**
 	 * Get the SQL fragment for excluded order statuses.
 	 *
-	 * @return string SQL IN clause, e.g. ( 'auto-draft','trash','wc-pending','wc-failed',... ). Always includes auto-draft and trash without wc- prefix.
+	 * @return string SQL IN clause, e.g. ( 'auto-draft','trash','wc-pending','wc-failed',... ), or ( '' ) if no statuses are excluded.
 	 */
 	private function get_excluded_statuses_sql(): string {
 		global $wpdb;
@@ -206,8 +206,12 @@ class CustomerHistory {
 		 * @param array $excluded_statuses Order statuses to exclude.
 		 */
 		$excluded_statuses = apply_filters( 'woocommerce_analytics_excluded_order_statuses', $excluded_statuses );
-		if ( ! is_array( $excluded_statuses ) || empty( $excluded_statuses ) ) {
+		if ( ! is_array( $excluded_statuses ) ) {
 			$excluded_statuses = array( 'auto-draft', 'trash', 'pending', 'failed', 'cancelled' );
+		}
+
+		if ( empty( $excluded_statuses ) ) {
+			return "( '' )";
 		}
 
 		$prefixed = array_map(

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -74,19 +74,54 @@ class CustomerHistory {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $customer_id > 0 ) {
 			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( total_amount ), 0 ) AS total_spend
-				FROM %i
-				WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql",
+				"SELECT COUNT(*) AS orders_count,
+					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
+				FROM (
+					SELECT id, total_amount
+					FROM %i
+					WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql
+				) AS filtered
+				LEFT JOIN (
+					SELECT parent_order_id, SUM( total_amount ) AS refund_total
+					FROM %i
+					WHERE type = 'shop_order_refund'
+						AND parent_order_id IN (
+							SELECT id FROM %i WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql
+						)
+					GROUP BY parent_order_id
+				) AS r ON filtered.id = r.parent_order_id",
+				$orders_table,
+				$customer_id,
+				$orders_table,
 				$orders_table,
 				$customer_id
 			);
 		} elseif ( '' !== $billing_email ) {
 			$addresses_table = OrdersTableDataStore::get_addresses_table_name();
 			$sql             = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( o.total_amount ), 0 ) AS total_spend
-				FROM %i AS o
-				INNER JOIN %i AS a ON o.id = a.order_id AND a.address_type = 'billing'
-				WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' AND o.status NOT IN $excluded_statuses_sql",
+				"SELECT COUNT(*) AS orders_count,
+					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
+				FROM (
+					SELECT o.id, o.total_amount
+					FROM %i AS o
+					INNER JOIN %i AS a ON o.id = a.order_id AND a.address_type = 'billing'
+					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' AND o.status NOT IN $excluded_statuses_sql
+				) AS filtered
+				LEFT JOIN (
+					SELECT parent_order_id, SUM( total_amount ) AS refund_total
+					FROM %i
+					WHERE type = 'shop_order_refund'
+						AND parent_order_id IN (
+							SELECT o2.id FROM %i AS o2
+							INNER JOIN %i AS a2 ON o2.id = a2.order_id AND a2.address_type = 'billing'
+							WHERE o2.customer_id = 0 AND a2.email = %s AND o2.type = 'shop_order' AND o2.status NOT IN $excluded_statuses_sql
+						)
+					GROUP BY parent_order_id
+				) AS r ON filtered.id = r.parent_order_id",
+				$orders_table,
+				$addresses_table,
+				$billing_email,
+				$orders_table,
 				$orders_table,
 				$addresses_table,
 				$billing_email
@@ -131,26 +166,64 @@ class CustomerHistory {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( $customer_id > 0 ) {
 			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( meta_total.meta_value ), 0 ) AS total_spend
-				FROM {$wpdb->posts} AS p
-				INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
-				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
-				WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %s
-				AND meta_total.meta_key = '_order_total'
-				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
+				"SELECT COUNT(*) AS orders_count,
+					COALESCE( SUM( filtered.order_total ), 0 ) - COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
+				FROM (
+					SELECT p.ID, meta_total.meta_value AS order_total
+					FROM {$wpdb->posts} AS p
+					INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
+					INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
+					WHERE meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = %s
+					AND meta_total.meta_key = '_order_total'
+					AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql
+				) AS filtered
+				LEFT JOIN (
+					SELECT rp.post_parent, SUM( rm.meta_value ) AS refund_total
+					FROM {$wpdb->posts} AS rp
+					INNER JOIN {$wpdb->postmeta} AS rm ON rp.ID = rm.post_id AND rm.meta_key = '_refund_amount'
+					WHERE rp.post_type = 'shop_order_refund'
+						AND rp.post_parent IN (
+							SELECT p2.ID FROM {$wpdb->posts} AS p2
+							INNER JOIN {$wpdb->postmeta} AS mc2 ON p2.ID = mc2.post_id
+							WHERE mc2.meta_key = '_customer_user' AND mc2.meta_value = %s
+							AND p2.post_type = 'shop_order' AND p2.post_status NOT IN $excluded_statuses_sql
+						)
+					GROUP BY rp.post_parent
+				) AS r ON filtered.ID = r.post_parent",
+				(string) $customer_id,
 				(string) $customer_id
 			);
 		} elseif ( '' !== $billing_email ) {
 			$sql = $wpdb->prepare(
-				"SELECT COUNT(*) AS orders_count, COALESCE( SUM( meta_total.meta_value ), 0 ) AS total_spend
-				FROM {$wpdb->posts} AS p
-				INNER JOIN {$wpdb->postmeta} AS meta_email ON p.ID = meta_email.post_id
-				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
-				INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
-				WHERE meta_email.meta_key = '_billing_email' AND meta_email.meta_value = %s
-				AND meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = '0'
-				AND meta_total.meta_key = '_order_total'
-				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
+				"SELECT COUNT(*) AS orders_count,
+					COALESCE( SUM( filtered.order_total ), 0 ) - COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
+				FROM (
+					SELECT p.ID, meta_total.meta_value AS order_total
+					FROM {$wpdb->posts} AS p
+					INNER JOIN {$wpdb->postmeta} AS meta_email ON p.ID = meta_email.post_id
+					INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
+					INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
+					WHERE meta_email.meta_key = '_billing_email' AND meta_email.meta_value = %s
+					AND meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = '0'
+					AND meta_total.meta_key = '_order_total'
+					AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql
+				) AS filtered
+				LEFT JOIN (
+					SELECT rp.post_parent, SUM( rm.meta_value ) AS refund_total
+					FROM {$wpdb->posts} AS rp
+					INNER JOIN {$wpdb->postmeta} AS rm ON rp.ID = rm.post_id AND rm.meta_key = '_refund_amount'
+					WHERE rp.post_type = 'shop_order_refund'
+						AND rp.post_parent IN (
+							SELECT p2.ID FROM {$wpdb->posts} AS p2
+							INNER JOIN {$wpdb->postmeta} AS me2 ON p2.ID = me2.post_id
+							INNER JOIN {$wpdb->postmeta} AS mc2 ON p2.ID = mc2.post_id
+							WHERE me2.meta_key = '_billing_email' AND me2.meta_value = %s
+							AND mc2.meta_key = '_customer_user' AND mc2.meta_value = '0'
+							AND p2.post_type = 'shop_order' AND p2.post_status NOT IN $excluded_statuses_sql
+						)
+					GROUP BY rp.post_parent
+				) AS r ON filtered.ID = r.post_parent",
+				$billing_email,
 				$billing_email
 			);
 		} else {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -143,7 +143,9 @@ class CustomerHistory {
 				FROM {$wpdb->posts} AS p
 				INNER JOIN {$wpdb->postmeta} AS meta_email ON p.ID = meta_email.post_id
 				INNER JOIN {$wpdb->postmeta} AS meta_total ON p.ID = meta_total.post_id
+				INNER JOIN {$wpdb->postmeta} AS meta_customer ON p.ID = meta_customer.post_id
 				WHERE meta_email.meta_key = '_billing_email' AND meta_email.meta_value = %s
+				AND meta_customer.meta_key = '_customer_user' AND meta_customer.meta_value = '0'
 				AND meta_total.meta_key = '_order_total'
 				AND p.post_type = 'shop_order' AND p.post_status NOT IN $excluded_statuses_sql",
 				$billing_email
@@ -172,6 +174,9 @@ class CustomerHistory {
 	 */
 	private function get_excluded_statuses_sql(): string {
 		$excluded_statuses = get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
+		if ( ! is_array( $excluded_statuses ) ) {
+			$excluded_statuses = array( 'pending', 'failed', 'cancelled' );
+		}
 		$excluded_statuses = array_merge( array( 'auto-draft', 'trash' ), $excluded_statuses );
 
 		$prefixed = array_map(

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -21,6 +21,7 @@ class CustomerHistory {
 	 * @return void
 	 */
 	public function output( WC_Order $order ): void {
+		// No history when adding a new order.
 		if ( 'auto-draft' === $order->get_status() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -35,15 +35,23 @@ class CustomerHistory {
 	/**
 	 * Get the order history for the customer.
 	 *
+	 * @param WC_Order $order The order object.
+	 *
 	 * @return array Order count, total spend, and average order value.
 	 */
 	private function get_customer_history( WC_Order $order ): array {
-		$customer_id   = $order->get_customer_id();
-		$billing_email = $order->get_billing_email();
-
-		$result = OrderUtil::custom_orders_table_usage_is_enabled()
-			? $this->query_hpos( $customer_id, $billing_email )
-			: $this->query_cpt( $order->get_report_customer_id() );
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$customer_id   = $order->get_customer_id();
+			$billing_email = $order->get_billing_email();
+			$result = $this->query_hpos( $customer_id, $billing_email );
+		} elseif ( method_exists( $order, 'get_report_customer_id' ) ) {
+			$result = $this->query_cpt( $order->get_report_customer_id() );
+		} else {
+			$result = (object) array(
+				'orders_count' => 0,
+				'total_spend'  => 0,
+			);
+		}
 
 		$orders_count = (int) ( $result->orders_count ?? 0 );
 		$total_spend  = (float) ( $result->total_spend ?? 0 );
@@ -80,13 +88,12 @@ class CustomerHistory {
 					WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql
 				) AS filtered
 				LEFT JOIN (
-					SELECT parent_order_id, SUM( total_amount ) AS refund_total
-					FROM %i
-					WHERE type = 'shop_order_refund'
-						AND parent_order_id IN (
-							SELECT id FROM %i WHERE customer_id = %d AND type = 'shop_order' AND status NOT IN $excluded_statuses_sql
-						)
-					GROUP BY parent_order_id
+					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
+					FROM %i AS rp
+					INNER JOIN %i AS co ON rp.parent_order_id = co.id
+					WHERE rp.type = 'shop_order_refund'
+						AND co.customer_id = %d AND co.type = 'shop_order' AND co.status NOT IN $excluded_statuses_sql
+					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
 				$orders_table,
 				$customer_id,
@@ -106,15 +113,13 @@ class CustomerHistory {
 					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' AND o.status NOT IN $excluded_statuses_sql
 				) AS filtered
 				LEFT JOIN (
-					SELECT parent_order_id, SUM( total_amount ) AS refund_total
-					FROM %i
-					WHERE type = 'shop_order_refund'
-						AND parent_order_id IN (
-							SELECT o2.id FROM %i AS o2
-							INNER JOIN %i AS a2 ON o2.id = a2.order_id AND a2.address_type = 'billing'
-							WHERE o2.customer_id = 0 AND a2.email = %s AND o2.type = 'shop_order' AND o2.status NOT IN $excluded_statuses_sql
-						)
-					GROUP BY parent_order_id
+					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
+					FROM %i AS rp
+					INNER JOIN %i AS co ON rp.parent_order_id = co.id
+					INNER JOIN %i AS ca ON co.id = ca.order_id AND ca.address_type = 'billing'
+					WHERE rp.type = 'shop_order_refund'
+						AND co.customer_id = 0 AND ca.email = %s AND co.type = 'shop_order' AND co.status NOT IN $excluded_statuses_sql
+					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
 				$orders_table,
 				$addresses_table,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -48,6 +48,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the customer' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*300/', $output, 'Should show total spend of 300' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150/', $output, 'Should show average order value of 150' );
 	}
 
 	/**
@@ -73,10 +75,12 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the guest customer' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100/', $output, 'Should show total spend of 100' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*50/', $output, 'Should show average order value of 50' );
 	}
 
 	/**
-	 * @testdox Should not count orders with excluded statuses like cancelled and failed.
+	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed.
 	 */
 	public function test_excluded_statuses_not_counted(): void {
 		$customer_id = $this->factory->user->create();
@@ -95,6 +99,11 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$order_failed->set_status( 'failed' );
 		$order_failed->set_total( 30 );
 		$order_failed->save();
+
+		$order_pending = WC_Helper_Order::create_order( $customer_id );
+		$order_pending->set_status( 'pending' );
+		$order_pending->set_total( 20 );
+		$order_pending->save();
 
 		ob_start();
 		$this->sut->output( $order_good );
@@ -117,6 +126,23 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertEmpty( $output, 'Should produce no output for auto-draft orders' );
+	}
+
+	/**
+	 * @testdox Should show zero data for guest order with no billing email.
+	 */
+	public function test_guest_with_no_email_shows_zero(): void {
+		$order = WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( '' );
+		$order->set_status( 'completed' );
+		$order->set_total( 50 );
+		$order->save();
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders for guest with no email' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Orders\MetaBoxes;
 
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use WC_Helper_Order;
 use WC_Unit_Test_Case;
 
@@ -11,6 +12,7 @@ use WC_Unit_Test_Case;
  * Tests for the CustomerHistory class.
  */
 class CustomerHistoryTest extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
 
 	/**
 	 * The System Under Test.
@@ -24,13 +26,38 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+		$this->setup_cot();
 		$this->sut = new CustomerHistory();
 	}
 
 	/**
-	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders.
+	 * Tear down test fixtures.
 	 */
-	public function test_registered_customer_with_multiple_orders(): void {
+	public function tearDown(): void {
+		$this->clean_up_cot_setup();
+		parent::tearDown();
+	}
+
+	/**
+	 * Data provider for storage modes.
+	 *
+	 * @return array<string, array<bool>>
+	 */
+	public function provider_storage_modes(): array {
+		return array(
+			'HPOS' => array( true ),
+			'CPT'  => array( false ),
+		);
+	}
+
+	/**
+	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders ($0: storage mode).
+	 * @dataProvider provider_storage_modes
+	 */
+	public function test_registered_customer_with_multiple_orders( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
 		$customer_id = $this->factory->user->create();
 
 		$order1 = WC_Helper_Order::create_order( $customer_id );
@@ -53,9 +80,12 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fetch data correctly for a guest customer matched by billing email.
+	 * @testdox Should fetch data correctly for a guest customer matched by billing email ($0: storage mode).
+	 * @dataProvider provider_storage_modes
 	 */
-	public function test_guest_customer_by_email(): void {
+	public function test_guest_customer_by_email( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
 		$email = 'guest-test@example.com';
 
 		$order1 = WC_Helper_Order::create_order( 0 );
@@ -80,9 +110,12 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed.
+	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed ($0: storage mode).
+	 * @dataProvider provider_storage_modes
 	 */
-	public function test_excluded_statuses_not_counted(): void {
+	public function test_excluded_statuses_not_counted( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
 		$customer_id = $this->factory->user->create();
 
 		$order_good = WC_Helper_Order::create_order( $customer_id );
@@ -129,9 +162,12 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should show zero data for guest order with no billing email.
+	 * @testdox Should show zero data for guest order with no billing email ($0: storage mode).
+	 * @dataProvider provider_storage_modes
 	 */
-	public function test_guest_with_no_email_shows_zero(): void {
+	public function test_guest_with_no_email_shows_zero( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
 		$order = WC_Helper_Order::create_order( 0 );
 		$order->set_billing_email( '' );
 		$order->set_status( 'completed' );
@@ -146,9 +182,12 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should show zero data when no matching orders exist for the customer.
+	 * @testdox Should show zero data when no matching orders exist for the customer ($0: storage mode).
+	 * @dataProvider provider_storage_modes
 	 */
-	public function test_no_matching_orders_shows_zero(): void {
+	public function test_no_matching_orders_shows_zero( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
 		$customer_id = $this->factory->user->create();
 
 		$order = WC_Helper_Order::create_order( $customer_id );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -35,6 +35,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
+		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		$this->clean_up_cot_setup();
 		parent::tearDown();
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -1,0 +1,139 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Orders\MetaBoxes;
+
+use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
+use WC_Helper_Order;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the CustomerHistory class.
+ */
+class CustomerHistoryTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CustomerHistory
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new CustomerHistory();
+	}
+
+	/**
+	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders.
+	 */
+	public function test_registered_customer_with_multiple_orders(): void {
+		$customer_id = $this->factory->user->create();
+
+		$order1 = WC_Helper_Order::create_order( $customer_id );
+		$order1->set_status( 'completed' );
+		$order1->set_total( 100 );
+		$order1->save();
+
+		$order2 = WC_Helper_Order::create_order( $customer_id );
+		$order2->set_status( 'completed' );
+		$order2->set_total( 200 );
+		$order2->save();
+
+		ob_start();
+		$this->sut->output( $order1 );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '2', $output, 'Should show 2 orders for the customer' );
+	}
+
+	/**
+	 * @testdox Should fetch data correctly for a guest customer matched by billing email.
+	 */
+	public function test_guest_customer_by_email(): void {
+		$email = 'guest-test@example.com';
+
+		$order1 = WC_Helper_Order::create_order( 0 );
+		$order1->set_billing_email( $email );
+		$order1->set_status( 'completed' );
+		$order1->set_total( 75 );
+		$order1->save();
+
+		$order2 = WC_Helper_Order::create_order( 0 );
+		$order2->set_billing_email( $email );
+		$order2->set_status( 'processing' );
+		$order2->set_total( 25 );
+		$order2->save();
+
+		ob_start();
+		$this->sut->output( $order1 );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '2', $output, 'Should show 2 orders for the guest customer' );
+	}
+
+	/**
+	 * @testdox Should not count orders with excluded statuses like cancelled and failed.
+	 */
+	public function test_excluded_statuses_not_counted(): void {
+		$customer_id = $this->factory->user->create();
+
+		$order_good = WC_Helper_Order::create_order( $customer_id );
+		$order_good->set_status( 'completed' );
+		$order_good->set_total( 100 );
+		$order_good->save();
+
+		$order_cancelled = WC_Helper_Order::create_order( $customer_id );
+		$order_cancelled->set_status( 'cancelled' );
+		$order_cancelled->set_total( 50 );
+		$order_cancelled->save();
+
+		$order_failed = WC_Helper_Order::create_order( $customer_id );
+		$order_failed->set_status( 'failed' );
+		$order_failed->set_total( 30 );
+		$order_failed->save();
+
+		ob_start();
+		$this->sut->output( $order_good );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'order-attribution-total-orders', $output );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should only count the completed order' );
+	}
+
+	/**
+	 * @testdox Should return early without output for auto-draft orders.
+	 */
+	public function test_auto_draft_returns_early(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'auto-draft' );
+		$order->save();
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should produce no output for auto-draft orders' );
+	}
+
+	/**
+	 * @testdox Should show zero data when no matching orders exist for the customer.
+	 */
+	public function test_no_matching_orders_shows_zero(): void {
+		$customer_id = $this->factory->user->create();
+
+		$order = WC_Helper_Order::create_order( $customer_id );
+		$order->set_status( 'cancelled' );
+		$order->set_total( 100 );
+		$order->save();
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '0', $output, 'Should show 0 orders when all are excluded' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Orders\MetaBoxes;
 
+use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use WC_Helper_Order;
@@ -364,10 +365,16 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox CPT fallback should render the metabox with zero data when analytics data is unavailable.
+	 * @testdox CPT fallback should render correct customer history from analytics tables.
 	 */
-	public function test_cpt_fallback_renders_with_zero_data(): void {
+	public function test_cpt_fallback_renders_with_analytics_data(): void {
 		$this->toggle_cot_feature_and_usage( false );
+
+		\WC_Helper_Reports::reset_stats_dbs();
+
+		// Register the Override\Order class so wc_get_order() returns an instance
+		// with get_report_customer_id(), which the CPT path requires.
+		\Automattic\WooCommerce\Admin\Overrides\Order::add_filters();
 
 		$customer_id = $this->factory->user->create();
 
@@ -376,11 +383,19 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+
+		// Re-fetch with Override class so output() takes the CPT path.
+		$override_order = wc_get_order( $order->get_id() );
+
 		ob_start();
-		$this->sut->output( $order );
+		$this->sut->output( $override_order );
 		$output = ob_get_clean();
 
+		remove_filter( 'woocommerce_order_class', array( \Automattic\WooCommerce\Admin\Overrides\Order::class, 'order_class_name' ) );
+
 		$this->assertStringContainsString( 'order-attribution-total-orders', $output, 'Should render the metabox template' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders when analytics data is not available' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should show 1 order from analytics data' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should show total spend of 100' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -63,8 +63,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the customer' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*300/', $output, 'Should show total spend of 300' );
-		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150/', $output, 'Should show average order value of 150' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*300\.00/', $output, 'Should show total spend of 300' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150\.00/', $output, 'Should show average order value of 150' );
 	}
 
 	/**
@@ -92,8 +92,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the guest customer' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100/', $output, 'Should show total spend of 100' );
-		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*50/', $output, 'Should show average order value of 50' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should show total spend of 100' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*50\.00/', $output, 'Should show average order value of 50' );
 	}
 
 	/**
@@ -130,6 +130,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'order-attribution-total-orders', $output );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should only count the completed order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should only sum spend from the completed order' );
 	}
 
 	/**
@@ -212,8 +213,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should still count 1 order after partial refund' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*150/', $output, 'Should show net spend of 150 after 50 refund' );
-		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150/', $output, 'Should show average of 150 after partial refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*150\.00/', $output, 'Should show net spend of 150 after 50 refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150\.00/', $output, 'Should show average of 150 after partial refund' );
 	}
 
 	/**
@@ -247,8 +248,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should still count 2 orders after full refund' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*200/', $output, 'Should show net spend of 200 after full refund of first order' );
-		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*100/', $output, 'Should show average of 100 (200 net / 2 orders)' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*200\.00/', $output, 'Should show net spend of 200 after full refund of first order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*100\.00/', $output, 'Should show average of 100 (200 net / 2 orders)' );
 	}
 
 	/**
@@ -278,7 +279,88 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should still count 1 order after guest refund' );
-		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*70/', $output, 'Should show net spend of 70 after 30 refund on guest order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*70\.00/', $output, 'Should show net spend of 70 after 30 refund on guest order' );
+	}
+
+	/**
+	 * @testdox Should only count orders for the specific registered customer, not other customers (HPOS).
+	 */
+	public function test_registered_customer_isolation(): void {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$customer_a = $this->factory->user->create();
+		$customer_b = $this->factory->user->create();
+
+		$order_a = WC_Helper_Order::create_order( $customer_a );
+		$order_a->set_status( 'completed' );
+		$order_a->set_total( 100 );
+		$order_a->save();
+
+		$order_b1 = WC_Helper_Order::create_order( $customer_b );
+		$order_b1->set_status( 'completed' );
+		$order_b1->set_total( 200 );
+		$order_b1->save();
+
+		$order_b2 = WC_Helper_Order::create_order( $customer_b );
+		$order_b2->set_status( 'completed' );
+		$order_b2->set_total( 300 );
+		$order_b2->save();
+
+		ob_start();
+		$this->sut->output( $order_a );
+		$output_a = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output_a, 'Customer A should see only their 1 order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output_a, 'Customer A should see total spend of 100' );
+
+		ob_start();
+		$this->sut->output( $order_b1 );
+		$output_b = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output_b, 'Customer B should see their 2 orders' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*500\.00/', $output_b, 'Customer B should see total spend of 500' );
+	}
+
+	/**
+	 * @testdox Should only count orders for the specific guest email, not other guest emails (HPOS).
+	 */
+	public function test_guest_customer_email_isolation(): void {
+		$this->toggle_cot_feature_and_usage( true );
+
+		$email_a = 'guest-a@example.com';
+		$email_b = 'guest-b@example.com';
+
+		$order_a = WC_Helper_Order::create_order( 0 );
+		$order_a->set_billing_email( $email_a );
+		$order_a->set_status( 'completed' );
+		$order_a->set_total( 50 );
+		$order_a->save();
+
+		$order_b1 = WC_Helper_Order::create_order( 0 );
+		$order_b1->set_billing_email( $email_b );
+		$order_b1->set_status( 'completed' );
+		$order_b1->set_total( 75 );
+		$order_b1->save();
+
+		$order_b2 = WC_Helper_Order::create_order( 0 );
+		$order_b2->set_billing_email( $email_b );
+		$order_b2->set_status( 'completed' );
+		$order_b2->set_total( 125 );
+		$order_b2->save();
+
+		ob_start();
+		$this->sut->output( $order_a );
+		$output_a = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output_a, 'Guest A should see only their 1 order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*50\.00/', $output_a, 'Guest A should see total spend of 50' );
+
+		ob_start();
+		$this->sut->output( $order_b1 );
+		$output_b = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output_b, 'Guest B should see their 2 orders' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*200\.00/', $output_b, 'Guest B should see total spend of 200' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -47,7 +47,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$this->sut->output( $order1 );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '2', $output, 'Should show 2 orders for the customer' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the customer' );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$this->sut->output( $order1 );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '2', $output, 'Should show 2 orders for the guest customer' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should show 2 orders for the guest customer' );
 	}
 
 	/**
@@ -134,6 +134,6 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$this->sut->output( $order );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '0', $output, 'Should show 0 orders when all are excluded' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders when all are excluded' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -54,6 +54,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders ($0: storage mode).
 	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
 	 */
 	public function test_registered_customer_with_multiple_orders( bool $hpos_enabled ): void {
 		$this->toggle_cot_feature_and_usage( $hpos_enabled );
@@ -82,6 +84,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should fetch data correctly for a guest customer matched by billing email ($0: storage mode).
 	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
 	 */
 	public function test_guest_customer_by_email( bool $hpos_enabled ): void {
 		$this->toggle_cot_feature_and_usage( $hpos_enabled );
@@ -112,6 +116,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed ($0: storage mode).
 	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
 	 */
 	public function test_excluded_statuses_not_counted( bool $hpos_enabled ): void {
 		$this->toggle_cot_feature_and_usage( $hpos_enabled );
@@ -164,6 +170,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should show zero data for guest order with no billing email ($0: storage mode).
 	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
 	 */
 	public function test_guest_with_no_email_shows_zero( bool $hpos_enabled ): void {
 		$this->toggle_cot_feature_and_usage( $hpos_enabled );
@@ -184,6 +192,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Should show zero data when no matching orders exist for the customer ($0: storage mode).
 	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
 	 */
 	public function test_no_matching_orders_shows_zero( bool $hpos_enabled ): void {
 		$this->toggle_cot_feature_and_usage( $hpos_enabled );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -35,8 +35,8 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
-		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		$this->clean_up_cot_setup();
+		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		parent::tearDown();
 	}
 
@@ -211,5 +211,109 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders when all are excluded' );
+	}
+
+	/**
+	 * @testdox Should deduct partial refund from total spend ($0: storage mode).
+	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 */
+	public function test_partial_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
+		$customer_id = $this->factory->user->create();
+
+		$order = WC_Helper_Order::create_order( $customer_id );
+		$order->set_status( 'completed' );
+		$order->set_total( 200 );
+		$order->save();
+
+		wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 50,
+				'reason'   => 'Partial refund test',
+			)
+		);
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should still count 1 order after partial refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*150/', $output, 'Should show net spend of 150 after 50 refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*150/', $output, 'Should show average of 150 after partial refund' );
+	}
+
+	/**
+	 * @testdox Should deduct full refund from total spend ($0: storage mode).
+	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 */
+	public function test_full_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
+		$customer_id = $this->factory->user->create();
+
+		$order1 = WC_Helper_Order::create_order( $customer_id );
+		$order1->set_status( 'completed' );
+		$order1->set_total( 100 );
+		$order1->save();
+
+		$order2 = WC_Helper_Order::create_order( $customer_id );
+		$order2->set_status( 'completed' );
+		$order2->set_total( 200 );
+		$order2->save();
+
+		wc_create_refund(
+			array(
+				'order_id' => $order1->get_id(),
+				'amount'   => 100,
+				'reason'   => 'Full refund test',
+			)
+		);
+
+		ob_start();
+		$this->sut->output( $order1 );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should still count 2 orders after full refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*200/', $output, 'Should show net spend of 200 after full refund of first order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*100/', $output, 'Should show average of 100 (200 net / 2 orders)' );
+	}
+
+	/**
+	 * @testdox Should deduct refund from guest order total spend ($0: storage mode).
+	 * @dataProvider provider_storage_modes
+	 *
+	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 */
+	public function test_guest_order_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
+		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+
+		$email = 'guest-refund@example.com';
+
+		$order = WC_Helper_Order::create_order( 0 );
+		$order->set_billing_email( $email );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 30,
+				'reason'   => 'Guest partial refund test',
+			)
+		);
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should still count 1 order after guest refund' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*70/', $output, 'Should show net spend of 70 after 30 refund on guest order' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -41,25 +41,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Data provider for storage modes.
-	 *
-	 * @return array<string, array<bool>>
+	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders (HPOS).
 	 */
-	public function provider_storage_modes(): array {
-		return array(
-			'HPOS' => array( true ),
-			'CPT'  => array( false ),
-		);
-	}
-
-	/**
-	 * @testdox Should return correct count, total, and average for a registered customer with multiple orders ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
-	 */
-	public function test_registered_customer_with_multiple_orders( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_registered_customer_with_multiple_orders(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$customer_id = $this->factory->user->create();
 
@@ -83,13 +68,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fetch data correctly for a guest customer matched by billing email ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should fetch data correctly for a guest customer matched by billing email (HPOS).
 	 */
-	public function test_guest_customer_by_email( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_guest_customer_by_email(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$email = 'guest-test@example.com';
 
@@ -115,13 +97,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should not count orders with excluded statuses like pending, cancelled, and failed (HPOS).
 	 */
-	public function test_excluded_statuses_not_counted( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_excluded_statuses_not_counted(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$customer_id = $this->factory->user->create();
 
@@ -169,13 +148,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should show zero data for guest order with no billing email ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should show zero data for guest order with no billing email (HPOS).
 	 */
-	public function test_guest_with_no_email_shows_zero( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_guest_with_no_email_shows_zero(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$order = WC_Helper_Order::create_order( 0 );
 		$order->set_billing_email( '' );
@@ -191,13 +167,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should show zero data when no matching orders exist for the customer ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should show zero data when no matching orders exist for the customer (HPOS).
 	 */
-	public function test_no_matching_orders_shows_zero( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_no_matching_orders_shows_zero(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$customer_id = $this->factory->user->create();
 
@@ -214,13 +187,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should deduct partial refund from total spend ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should deduct partial refund from total spend (HPOS).
 	 */
-	public function test_partial_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_partial_refund_deducted_from_total_spend(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$customer_id = $this->factory->user->create();
 
@@ -247,13 +217,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should deduct full refund from total spend ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should deduct full refund from total spend (HPOS).
 	 */
-	public function test_full_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_full_refund_deducted_from_total_spend(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$customer_id = $this->factory->user->create();
 
@@ -285,13 +252,10 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should deduct refund from guest order total spend ($0: storage mode).
-	 * @dataProvider provider_storage_modes
-	 *
-	 * @param bool $hpos_enabled Whether HPOS is enabled.
+	 * @testdox Should deduct refund from guest order total spend (HPOS).
 	 */
-	public function test_guest_order_refund_deducted_from_total_spend( bool $hpos_enabled ): void {
-		$this->toggle_cot_feature_and_usage( $hpos_enabled );
+	public function test_guest_order_refund_deducted_from_total_spend(): void {
+		$this->toggle_cot_feature_and_usage( true );
 
 		$email = 'guest-refund@example.com';
 
@@ -315,5 +279,26 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should still count 1 order after guest refund' );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*70/', $output, 'Should show net spend of 70 after 30 refund on guest order' );
+	}
+
+	/**
+	 * @testdox CPT fallback should render the metabox with zero data when analytics data is unavailable.
+	 */
+	public function test_cpt_fallback_renders_with_zero_data(): void {
+		$this->toggle_cot_feature_and_usage( false );
+
+		$customer_id = $this->factory->user->create();
+
+		$order = WC_Helper_Order::create_order( $customer_id );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		ob_start();
+		$this->sut->output( $order );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'order-attribution-total-orders', $output, 'Should render the metabox template' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders when analytics data is not available' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The CustomerHistory metabox on the order edit page queries the `wc_order_stats` analytics table via `CustomersQuery` to show customer order count, total spend, and average order value. When analytics regeneration is delayed or in scheduled mode, this data can become stale — store operators can't reliably tell whether a customer is new or returning.

This PR replaces the analytics-based query with direct SQL against HPOS tables for real-time data. The CPT (legacy) path retains the existing `CustomersQuery` approach to avoid introducing `wp_postmeta`-heavy queries on large legacy stores.

**Key changes:**
- **HPOS path**: Direct SQL against `wc_orders` table (+ `wc_order_addresses` JOIN for guest email matching), providing real-time customer history data
- **HPOS refund handling**: Uses `INNER JOIN` between refund rows and customer orders (instead of `IN (SELECT ...)` subquery) to keep refund aggregation scoped to the customer's orders without duplicating the filter clause
- **CPT path**: Retains existing `CustomersQuery` analytics-based approach with `method_exists` guard for `get_report_customer_id()` to prevent fatal errors with base `WC_Order` instances
- Exclude statuses matching `woocommerce_excluded_report_order_statuses` setting (defaults: pending, failed, cancelled, plus auto-draft and trash)
- Support both registered users (by `customer_id`) and guests (by `billing_email`)
- Unit tests: HPOS-only for data accuracy (registered users, guests, excluded statuses, refunds), plus CPT fallback test

Closes WOOPLUG-6399.

### How to test the changes in this Pull Request:

#### Testing with HPOS enabled (default):

1. Ensure HPOS is enabled: WooCommerce > Settings > Advanced > Features > Order data storage >  High-performance order storage (recommended)
2. Navigate to an existing order edit page (WooCommerce > Orders > click an order)
3. Verify the "Customer History" metabox shows correct **Total orders**, **Total revenue**, and **Average order value**
4. Create a new order for the same customer and set the status to "Completed" with a known total
5. Go back to any of the customer's orders — verify the count is incremented and the total updated immediately (no analytics sync needed)
6. Create an order with status "Cancelled" or "Failed" — verify it is **not** counted in the metabox
7. Test with a guest order (no registered user) — verify the metabox shows data matched by billing email
8. Create a refund on an order — verify the total spend is reduced by the refund amount

#### Testing with CPT (legacy post storage):

1. Disable HPOS: WooCommerce > Settings > Advanced > Features > Order data storage
2. Repeat steps 2–7 above (note: data depends on analytics sync, so may not be immediately up-to-date)
3. Verify the same correct behavior with legacy post-based orders


https://github.com/user-attachments/assets/0e8ae87c-b9db-419b-80c3-6135773715c1

https://github.com/user-attachments/assets/4eb57aa4-c46a-4d04-a3ee-d91609541966


### Testing that has already taken place:

- PHPUnit tests: 10/10 passing (`CustomerHistoryTest`) — HPOS data accuracy + CPT fallback
- PHPStan: no errors
- PHPCS lint: clean
- Manual testing on chi.jurassic.tube with HPOS enabled


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type


<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix CustomerHistory metabox to query real-time order data (HPOS) instead of analytics tables, ensuring accurate customer order count and spend data regardless of analytics sync status.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>