### PR TITLE
[dev] Performance: introduce new skill for using option cache priming (reviews and code generation)

### DIFF
--- a/.ai/skills/woocommerce-performance/SKILL.md
+++ b/.ai/skills/woocommerce-performance/SKILL.md
@@ -11,4 +11,4 @@ Use when writing or reviewing code that loads collections of post-based objects 
 
 ## Options Cache Priming — [options-cache-priming.md](options-cache-priming.md)
 
-Use when writing or reviewing code that reads multiple options in a loop or method. Covers `wp_prime_option_caches()` usage patterns for static key lists, derivable key patterns, and dynamically extracted key sets.
+Use when writing or reviewing code that reads multiple non-autoloaded options in a loop or method. Covers `wp_prime_option_caches()` usage patterns for static key lists, derivable key patterns, and dynamically extracted key sets (excluding autoloaded options, which are already in cache).

--- a/.ai/skills/woocommerce-performance/SKILL.md
+++ b/.ai/skills/woocommerce-performance/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: woocommerce-performance
-description: Identify missing _prime_post_caches calls in WooCommerce PHP code. Use when writing or reviewing code that loads collections of post-based objects (products, orders) or renders product lists with images.
+description: Identify missing cache priming calls in WooCommerce PHP code. Use when writing or reviewing code that loads collections of post-based objects (products, orders), renders product lists with images, or reads multiple options in a loop or method.
 ---
 
 # WooCommerce Performance
 
-## Cache Priming — [cache-priming.md](cache-priming.md)
+## Post Cache Priming — [cache-priming.md](cache-priming.md)
 
 Use when writing or reviewing code that loads collections of post-based objects (products, orders) or renders product lists with images. Covers `_prime_post_caches()` usage patterns — both as a generation guide (apply these patterns when writing new code) and a review guide (flag missing priming in existing code).
+
+## Options Cache Priming — [options-cache-priming.md](options-cache-priming.md)
+
+Use when writing or reviewing code that reads multiple options in a loop or method. Covers `wp_prime_option_caches()` usage patterns for static key lists, derivable key patterns, and dynamically extracted key sets.

--- a/.ai/skills/woocommerce-performance/options-cache-priming.md
+++ b/.ai/skills/woocommerce-performance/options-cache-priming.md
@@ -110,7 +110,9 @@ High `get_option()` concentration alone is **not** a signal. These are common fa
 
 ### Real targets — the `*_settings` per-entity pattern
 
-The only options that are genuinely non-autoloaded in WooCommerce core are **per-entity settings** stored under the key `woocommerce_{id}_settings`. These are written directly with `update_option()` by each entity class, not through the settings API, so they carry no `autoload` flag and default to WordPress's own default (`'yes'` in WP 6.0+, but historically `'no'` for options written without explicit autoload — in practice WooCommerce writes these without the third argument, so they use the WP default which prior to WP 6.0 was `false`).
+Per-entity settings stored under `woocommerce_{id}_settings` are generally non-autoloaded when written directly via `update_option()` — as email classes (`includes/class-wc-emails.php` → `init()`) and shipping methods (`includes/class-wc-shipping.php` → `get_shipping_method_class_names()`) do. These are the real priming targets.
+
+**Exception:** payment gateway settings are saved through `WC_Settings_API::process_admin_options()` with explicit `autoload='yes'`, making them autoloaded and therefore excluded from priming (see `includes/class-wc-payment-gateways.php` → `init()`).
 
 Known non-autoloaded per-entity patterns:
 
@@ -118,13 +120,12 @@ Known non-autoloaded per-entity patterns:
 | --- | --- | --- |
 | Email classes | `woocommerce_{email_id}_settings` | `woocommerce_new_order_settings` |
 | Shipping methods | `woocommerce_{method_id}_settings` | `woocommerce_flat_rate_settings` |
-| Payment gateways | `woocommerce_{gateway_id}_settings` | `woocommerce_bacs_settings` |
 
 ### Coverage status (as of audited codebase)
 
 | Location | Pattern | Status |
 | --- | --- | --- |
-| `includes/class-wc-emails.php` — `init_emails()` | array_map over email class list | ✅ covered |
+| `includes/class-wc-emails.php` — `init()` | array_map over email class list | ✅ covered |
 | `includes/class-wc-shipping.php` — `get_shipping_method_class_names()` | array_map over method ID list | ✅ covered |
 | `includes/class-wc-payment-gateways.php` — `init()` | gateway settings autoloaded (`WC_Settings_API` saves with `autoload='yes'`) — no priming needed | ✅ verified, skipped |
 

--- a/.ai/skills/woocommerce-performance/options-cache-priming.md
+++ b/.ai/skills/woocommerce-performance/options-cache-priming.md
@@ -115,7 +115,7 @@ The only options that are genuinely non-autoloaded in WooCommerce core are **per
 Known non-autoloaded per-entity patterns:
 
 | Entity type | Option key pattern | Example |
-|---|---|---|
+| --- | --- | --- |
 | Email classes | `woocommerce_{email_id}_settings` | `woocommerce_new_order_settings` |
 | Shipping methods | `woocommerce_{method_id}_settings` | `woocommerce_flat_rate_settings` |
 | Payment gateways | `woocommerce_{gateway_id}_settings` | `woocommerce_bacs_settings` |
@@ -123,7 +123,7 @@ Known non-autoloaded per-entity patterns:
 ### Coverage status (as of audited codebase)
 
 | Location | Pattern | Status |
-|---|---|---|
+| --- | --- | --- |
 | `includes/class-wc-emails.php` — `init_emails()` | array_map over email class list | ✅ covered |
 | `includes/class-wc-shipping.php` — `get_shipping_method_class_names()` | array_map over method ID list | ✅ covered |
 | `includes/class-wc-payment-gateways.php` — `init()` | gateway settings autoloaded (`WC_Settings_API` saves with `autoload='yes'`) — no priming needed | ✅ verified, skipped |

--- a/.ai/skills/woocommerce-performance/options-cache-priming.md
+++ b/.ai/skills/woocommerce-performance/options-cache-priming.md
@@ -83,7 +83,14 @@ Guard with `! empty()` when the list is dynamically built and may be empty. When
 
 Always use the comment `// Prime caches to reduce future queries.` directly above the call. When the call is guarded by `! empty()`, the comment sits inside the `if` block — not before it.
 
-Including autoloaded options in the prime call is harmless (they are already in the cache), but the real benefit is for non-autoloaded options such as per-email and per-shipping-method settings.
+The benefit of `wp_prime_option_caches` operates along two complementary dimensions — not binary logic:
+
+- **Existence**: options not yet written to the database are absent from `wp_load_alloptions()` even when flagged autoloaded. Each `get_option()` call for a missing key issues an individual SQL query. Priming batches those misses into one query upfront.
+- **Autoload state**: non-autoloaded options are never loaded at bootstrap regardless of whether they exist. Priming is the primary mechanism to avoid per-request queries for them.
+
+An autoloaded option that has already been saved gains nothing from priming (already in cache). The same option before it is first saved benefits from the existence check. Both dimensions apply independently — consider both when deciding whether to prime.
+
+For multisite contexts, use `wp_prime_network_option_caches( $network_id, $keys )` (available since WP 6.4) for network-scoped options.
 
 ---
 
@@ -108,33 +115,22 @@ High `get_option()` concentration alone is **not** a signal. These are common fa
 - **Feature flags and toggles** — `woocommerce_enable_ajax_add_to_cart`, `woocommerce_enable_checkout_login_reminder`, `woocommerce_tax_display_cart`, etc. All autoloaded.
 - **General store settings** — currency, weight unit, address fields, etc. All autoloaded.
 
-### Real targets — the `*_settings` per-entity pattern
+### The `*_settings` per-entity pattern
 
-Per-entity settings stored under `woocommerce_{id}_settings` are generally non-autoloaded when written directly via `update_option()` — as email classes (`includes/class-wc-emails.php` → `init()`) and shipping methods (`includes/class-wc-shipping.php` → `get_shipping_method_class_names()`) do. These are the real priming targets.
+All three entity types extend `WC_Settings_API`, which saves settings with `autoload='yes'`. Once saved, these options are already in cache. However, on a fresh install or before settings are first saved, they are absent from `wp_load_alloptions()` — each `get_option()` issues an individual query. Priming is justified here specifically for the existence dimension (batching those misses), particularly when looping over a large number of entities such as email classes.
 
-**Exception:** payment gateway settings are saved through `WC_Settings_API::process_admin_options()` with explicit `autoload='yes'`, making them autoloaded and therefore excluded from priming (see `includes/class-wc-payment-gateways.php` → `init()`).
-
-Known non-autoloaded per-entity patterns:
-
-| Entity type | Option key pattern | Example |
-| --- | --- | --- |
-| Email classes | `woocommerce_{email_id}_settings` | `woocommerce_new_order_settings` |
-| Shipping methods | `woocommerce_{method_id}_settings` | `woocommerce_flat_rate_settings` |
-
-### Coverage status (as of audited codebase)
+The four built-in payment gateways are a negligible count and are skipped.
 
 | Location | Pattern | Status |
 | --- | --- | --- |
-| `includes/class-wc-emails.php` — `init()` | array_map over email class list | ✅ covered |
-| `includes/class-wc-shipping.php` — `get_shipping_method_class_names()` | array_map over method ID list | ✅ covered |
-| `includes/class-wc-payment-gateways.php` — `init()` | gateway settings autoloaded (`WC_Settings_API` saves with `autoload='yes'`) — no priming needed | ✅ verified, skipped |
-
-Third-party gateways added via `apply_filters('woocommerce_payment_gateways', ...)` are also autoloaded by the same mechanism.
+| `includes/class-wc-emails.php` — `init()` | array_map over email class list | ✅ covered — batches miss queries on fresh/unconfigured installs |
+| `includes/class-wc-shipping.php` — `get_shipping_method_class_names()` | array_map over method ID list | ✅ covered — same rationale |
+| `includes/class-wc-payment-gateways.php` — `init()` | 4 built-in gateways — negligible count | ✅ verified, skipped |
 
 ### Workflow for gap analysis
 
 When asked to find missing `wp_prime_option_caches` opportunities:
 
 1. Search for multi-`get_option()` methods.
-2. Check whether the options are registered through the WooCommerce settings API (autoloaded → skip).
-3. Only flag methods reading two or more `woocommerce_{id}_settings`-style keys from a loop or known list without existing priming.
+2. Consider both dimensions: autoload state (non-autoloaded options benefit on every request) and existence (options not yet saved benefit on first use regardless of autoload flag).
+3. Flag loops or sequences reading multiple options where either dimension applies and no priming is present.

--- a/.ai/skills/woocommerce-performance/options-cache-priming.md
+++ b/.ai/skills/woocommerce-performance/options-cache-priming.md
@@ -1,0 +1,139 @@
+# Options Cache Priming
+
+Covers correct usage of `wp_prime_option_caches()` to reduce SQL query counts when reading multiple options in a method or loop.
+
+## Patterns
+
+### 1. Missing options priming before reading a known set of keys
+
+**Apply when:** A method reads multiple known `get_option()` keys in sequence.
+
+**Correct pattern:**
+
+```php
+// Prime caches to reduce future queries.
+wp_prime_option_caches(
+    array(
+        'woocommerce_enable_checkout_login_reminder',
+        'woocommerce_tax_display_cart',
+        // ...
+    )
+);
+$login_reminder = get_option( 'woocommerce_enable_checkout_login_reminder' );
+$tax_display    = get_option( 'woocommerce_tax_display_cart' );
+```
+
+No `! empty()` guard is needed for statically declared, always-non-empty arrays. Place the comment directly above the call.
+
+**Common locations to check:**
+
+- `register_routes()` methods that read options immediately after registration
+- Block type `render()` or `get_data()` methods that read several settings
+- Any method that reads more than one non-autoloaded option in sequence
+
+---
+
+### 2. Missing options priming before a loop with a derivable key pattern
+
+**Apply when:** A loop iterates a collection and each iteration calls `get_option()` using a key derived from the item — for example `woocommerce_{class}_settings`.
+
+**Correct pattern:**
+
+```php
+// Prime caches to reduce future queries.
+wp_prime_option_caches(
+    array_map( fn( string $class ) => sprintf( 'woocommerce_%s_settings', $class ), $classes )
+);
+foreach ( $classes as $class ) {
+    $settings = get_option( sprintf( 'woocommerce_%s_settings', $class ) );
+}
+```
+
+**Common locations to check:**
+
+- Email class initialization: key pattern `woocommerce_{email_class_suffix}_settings`
+- Shipping method loops: key pattern `woocommerce_{method}_settings`
+
+---
+
+### 3. Missing options priming when keys are extracted from a settings structure
+
+**Apply when:** A settings array carries an `option_key` field; the array is iterated and each item's option is read via `get_option()`.
+
+**Correct pattern:**
+
+```php
+$prefetch = array_column( $settings, 'option_key' ); // or equivalent extraction
+if ( ! empty( $prefetch ) ) {
+    // Prime caches to reduce future queries.
+    wp_prime_option_caches( $prefetch );
+}
+foreach ( $settings as $setting ) {
+    $value = get_option( $setting['option_key'] );
+}
+```
+
+Guard with `! empty()` when the list is dynamically built and may be empty. When guarded, the comment sits inside the `if` block directly above the call — consistent with `_prime_post_caches` placement rules.
+
+---
+
+## Notes
+
+`wp_prime_option_caches()` is a stable public WordPress function (no underscore prefix), available since WP 6.4. WooCommerce's minimum supported WordPress version guarantees its presence — no `is_callable()` guard is needed.
+
+Always use the comment `// Prime caches to reduce future queries.` directly above the call. When the call is guarded by `! empty()`, the comment sits inside the `if` block — not before it.
+
+Including autoloaded options in the prime call is harmless (they are already in the cache), but the real benefit is for non-autoloaded options such as per-email and per-shipping-method settings.
+
+---
+
+## Autoload Architecture (WooCommerce-specific)
+
+**WooCommerce settings API autoloads by default.** Any option registered and saved through `WC_Admin_Settings::save_fields()` is stored with `autoload = 'yes'` unless the field definition explicitly sets `'autoload' => false`. The relevant code is in `includes/admin/class-wc-admin-settings.php`:
+
+```php
+// Line ~1035
+$autoload_options[ $option_name ] = isset( $option['autoload'] ) ? (bool) $option['autoload'] : true;
+// Line ~1047
+update_option( $name, $value, $autoload_options[ $name ] ? 'yes' : 'no' );
+```
+
+WordPress loads all autoloaded options into the object cache at bootstrap via `wp_load_alloptions()`. This means that **any `get_option()` call reading a WooCommerce settings-API-registered option is already served from cache** — adding `wp_prime_option_caches` there is a no-op.
+
+### False-positive patterns — do NOT add priming
+
+High `get_option()` concentration alone is **not** a signal. These are common false positives:
+
+- **Endpoint options** — `woocommerce_checkout_pay_endpoint`, `woocommerce_myaccount_*_endpoint`, etc. All autoloaded via settings API.
+- **Feature flags and toggles** — `woocommerce_enable_ajax_add_to_cart`, `woocommerce_enable_checkout_login_reminder`, `woocommerce_tax_display_cart`, etc. All autoloaded.
+- **General store settings** — currency, weight unit, address fields, etc. All autoloaded.
+
+### Real targets — the `*_settings` per-entity pattern
+
+The only options that are genuinely non-autoloaded in WooCommerce core are **per-entity settings** stored under the key `woocommerce_{id}_settings`. These are written directly with `update_option()` by each entity class, not through the settings API, so they carry no `autoload` flag and default to WordPress's own default (`'yes'` in WP 6.0+, but historically `'no'` for options written without explicit autoload — in practice WooCommerce writes these without the third argument, so they use the WP default which prior to WP 6.0 was `false`).
+
+Known non-autoloaded per-entity patterns:
+
+| Entity type | Option key pattern | Example |
+|---|---|---|
+| Email classes | `woocommerce_{email_id}_settings` | `woocommerce_new_order_settings` |
+| Shipping methods | `woocommerce_{method_id}_settings` | `woocommerce_flat_rate_settings` |
+| Payment gateways | `woocommerce_{gateway_id}_settings` | `woocommerce_bacs_settings` |
+
+### Coverage status (as of audited codebase)
+
+| Location | Pattern | Status |
+|---|---|---|
+| `includes/class-wc-emails.php` — `init_emails()` | array_map over email class list | ✅ covered |
+| `includes/class-wc-shipping.php` — `get_shipping_method_class_names()` | array_map over method ID list | ✅ covered |
+| `includes/class-wc-payment-gateways.php` — `init()` | gateway settings autoloaded (`WC_Settings_API` saves with `autoload='yes'`) — no priming needed | ✅ verified, skipped |
+
+Third-party gateways added via `apply_filters('woocommerce_payment_gateways', ...)` are also autoloaded by the same mechanism.
+
+### Workflow for gap analysis
+
+When asked to find missing `wp_prime_option_caches` opportunities:
+
+1. Search for multi-`get_option()` methods.
+2. Check whether the options are registered through the WooCommerce settings API (autoloaded → skip).
+3. Only flag methods reading two or more `woocommerce_{id}_settings`-style keys from a loop or known list without existing priming.

--- a/plugins/woocommerce/changelog/performance-extract-options-cache-priming-prs-into-skill
+++ b/plugins/woocommerce/changelog/performance-extract-options-cache-priming-prs-into-skill
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Introduce a new performance skill focused on effectively using option caching priming APIs.
+Introduce a new performance skill focused on effectively using option cache priming APIs.

--- a/plugins/woocommerce/changelog/performance-extract-options-cache-priming-prs-into-skill
+++ b/plugins/woocommerce/changelog/performance-extract-options-cache-priming-prs-into-skill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Introduce a new performance skill focused on effectively using option caching priming APIs.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -308,7 +308,7 @@ class WC_Emails {
 			$emails['WC_Email_Customer_Fulfillment_Deleted'] = __DIR__ . '/emails/class-wc-email-customer-fulfillment-deleted.php';
 		}
 
-		// Preload the options which will be used when emails are getting initialized in the loop below (reduces the number of SQL-queries).
+		// Prime caches to reduce future queries.
 		wp_prime_option_caches(
 			array_map(
 				fn( string $class_name ) => sprintf( 'woocommerce_%s_settings', strtolower( str_replace( 'WC_Email_', '', $class_name ) ) ),

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -91,6 +91,8 @@ class WC_Payment_Gateways {
 		// Filter.
 		$load_gateways = apply_filters( 'woocommerce_payment_gateways', $load_gateways );
 
+		// No wp_prime_option_caches needed: gateway settings are autoloaded (WC_Settings_API saves with autoload='yes').
+
 		// Get sort order option.
 		$ordering  = (array) get_option( 'woocommerce_gateway_order' );
 		$order_end = 999;

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -139,7 +139,7 @@ class WC_Shipping {
 		// For backwards compatibility with 2.5.x we load any ENABLED legacy shipping methods here.
 		$maybe_load_legacy_methods = array( 'flat_rate', 'free_shipping', 'international_delivery', 'local_delivery', 'local_pickup' );
 
-		// Prime the settings options: reduces the number of executed SQLs.
+		// Prime caches to reduce future queries.
 		wp_prime_option_caches( array_map( fn( string $method ) => sprintf( 'woocommerce_%s_settings', $method ), $maybe_load_legacy_methods ) );
 
 		foreach ( $maybe_load_legacy_methods as $method ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-customers-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-customers-v1-controller.php
@@ -42,7 +42,7 @@ class WC_REST_Customers_V1_Controller extends WC_REST_Controller {
 	 * Register the routes for customers.
 	 */
 	public function register_routes() {
-		// Preload the options which will be used in this method (reduces the number of SQL-queries).
+		// Prime caches to reduce future queries.
 		wp_prime_option_caches(
 			array(
 				'woocommerce_registration_generate_username',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -228,6 +228,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 			}
 		}
 		if ( array() !== $prefetch ) {
+			// Prime caches to reduce future queries.
 			wp_prime_option_caches( $prefetch );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -443,7 +443,7 @@ class Checkout extends AbstractBlock {
 				FILTER_VALIDATE_BOOLEAN
 			)
 		);
-		// Optimization note: reduce the number of SQLs required to fetch the options in the lines below.
+		// Prime caches to reduce future queries.
 		wp_prime_option_caches(
 			array(
 				'woocommerce_enable_checkout_login_reminder',

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -154,6 +154,7 @@ class Settings {
 		//phpcs:ignore
 		$preload_options = apply_filters( 'woocommerce_admin_preload_options', array() );
 		if ( ! empty( $preload_options ) ) {
+			// Prime caches to reduce future queries.
 			wp_prime_option_caches( $preload_options );
 			foreach ( $preload_options as $option ) {
 				$settings['preloadOptions'][ $option ] = get_option( $option );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Building on my work from Q1 2026, I created a new skill for using option cache priming in our codebase through my recent PRs. In this PR, I am adding the skill to the repository and using AI-assisted cleanup to standardize existing option cache priming usages.

On the PHP side, this normalises comment text to `// Prime caches to reduce future queries`.

### How to test the changes in this Pull Request:

- Code review only.

> Please note that `.ai/skills/woocommerce-performance/options-cache-priming.md` is intended for AIs, and verified in this PR where Claude uses it for verifying gaps.
