### PR TITLE
[dev] Performance: introduce new skill for reducing store reads (reviews and code generation)

### DIFF
--- a/.ai/skills/woocommerce-performance/SKILL.md
+++ b/.ai/skills/woocommerce-performance/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: woocommerce-performance
-description: Identify missing _prime_post_caches calls in WooCommerce PHP code. Use when writing or reviewing code that loads collections of post-based objects (products, orders) or renders product lists with images.
+description: Identify missing cache priming calls in WooCommerce PHP code. Use when writing or reviewing code that loads collections of post-based objects (products, orders), renders product lists with images, or reads multiple options in a loop or method.
 ---
 
 # WooCommerce Performance
 
-## Cache Priming — [cache-priming.md](cache-priming.md)
+## Post Cache Priming — [cache-priming.md](cache-priming.md)
 
 Use when writing or reviewing code that loads collections of post-based objects (products, orders) or renders product lists with images. Covers `_prime_post_caches()` usage patterns — both as a generation guide (apply these patterns when writing new code) and a review guide (flag missing priming in existing code).
+
+## Reducing Excessive Store Reads — [store-reads-reduction.md](store-reads-reduction.md)
+
+Use when writing or reviewing code that calls lazy-loading data store accessors (e.g. `get_items()`, `get_coupon_codes()`) more than once for the same result within a method or template block. Covers identification criteria and the extract-to-local-variable fix.

--- a/.ai/skills/woocommerce-performance/store-reads-reduction.md
+++ b/.ai/skills/woocommerce-performance/store-reads-reduction.md
@@ -7,6 +7,7 @@ Covers identifying and eliminating redundant data store reads caused by calling 
 `WC_Order` accessors such as `get_items()`, `get_coupon_codes()`, `get_shipping_methods()`, and `get_fees()` use in-memory caching (`isset( $this->items[$group] )` in `abstract-wc-order.php`) — the SQL query is only issued once per request. However, the associated filter (e.g. `woocommerce_order_get_items`) is applied on **every call**, outside the cache guard.
 
 Extracting the result into a local variable:
+
 1. Prevents filters from firing multiple times — important for correctness if a filter has side effects.
 2. Eliminates repeated method call overhead (type coercion, group resolution, array merge).
 3. Makes the intent explicit and the code easier to read.

--- a/.ai/skills/woocommerce-performance/store-reads-reduction.md
+++ b/.ai/skills/woocommerce-performance/store-reads-reduction.md
@@ -23,6 +23,11 @@ if ( ! empty( $order->get_items() ) ) {
     return;
 }
 foreach ( $order->get_items() as $item ) { ... }
+
+// Accessor re-invoked inside the loop body:
+foreach ( $order->get_items() as $item ) {
+    if ( count( $order->get_items() ) === 1 ) { ... } // store read on every iteration
+}
 ```
 
 **Correct pattern — extract once, reuse:**
@@ -52,4 +57,6 @@ An accessor qualifies for extraction when **all** of the following hold:
 | `get_fees()` | `WC_Order` | Delegates to `get_items( 'fee' )` |
 | `get_taxes()` | `WC_Order` | Delegates to `get_items( 'tax' )` |
 | `get_downloadable_items()` | `WC_Order` | Queries downloadable items from order items |
+| `get_attributes()` | `WC_Product` | Loads product attributes from data store; fires `woocommerce_product_get_attributes` |
+| `get_downloads()` | `WC_Product` | Loads downloadable files from data store |
 

--- a/.ai/skills/woocommerce-performance/store-reads-reduction.md
+++ b/.ai/skills/woocommerce-performance/store-reads-reduction.md
@@ -4,7 +4,12 @@ Covers identifying and eliminating redundant data store reads caused by calling 
 
 ## Why it matters
 
-WooCommerce data accessors such as `get_items()`, `get_coupon_codes()`, `get_shipping_methods()`, and `get_fees()` are backed by a data store. On first call they issue a SQL query and populate an internal cache; subsequent calls within the same request may re-invoke the accessor, fire associated hooks a second time, or bypass the cache depending on implementation. Extracting the result into a local variable eliminates the redundant store invocation and guarantees hooks fire exactly once.
+`WC_Order` accessors such as `get_items()`, `get_coupon_codes()`, `get_shipping_methods()`, and `get_fees()` use in-memory caching (`isset( $this->items[$group] )` in `abstract-wc-order.php`) — the SQL query is only issued once per request. However, the associated filter (e.g. `woocommerce_order_get_items`) is applied on **every call**, outside the cache guard.
+
+Extracting the result into a local variable:
+1. Prevents filters from firing multiple times — important for correctness if a filter has side effects.
+2. Eliminates repeated method call overhead (type coercion, group resolution, array merge).
+3. Makes the intent explicit and the code easier to read.
 
 ## Pattern — accessor called more than once for the same result
 

--- a/.ai/skills/woocommerce-performance/store-reads-reduction.md
+++ b/.ai/skills/woocommerce-performance/store-reads-reduction.md
@@ -1,0 +1,55 @@
+# Reducing Excessive Store Reads
+
+Covers identifying and eliminating redundant data store reads caused by calling lazy-loading accessors more than once for the same data within a single execution path.
+
+## Why it matters
+
+WooCommerce data accessors such as `get_items()`, `get_coupon_codes()`, `get_shipping_methods()`, and `get_fees()` are backed by a data store. On first call they issue a SQL query and populate an internal cache; subsequent calls within the same request may re-invoke the accessor, fire associated hooks a second time, or bypass the cache depending on implementation. Extracting the result into a local variable eliminates the redundant store invocation and guarantees hooks fire exactly once.
+
+## Pattern — accessor called more than once for the same result
+
+**Identify when:** The same lazy-loading accessor (with identical arguments) appears two or more times in the same method or template block — typically once for a guard check and once for the loop.
+
+**Common forms:**
+
+```php
+// Guard + loop — two store reads:
+if ( count( $order->get_items() ) > 0 ) {
+    foreach ( $order->get_items() as $item_id => $item ) { ... }
+}
+
+// empty() guard + loop:
+if ( ! empty( $order->get_items() ) ) {
+    return;
+}
+foreach ( $order->get_items() as $item ) { ... }
+```
+
+**Correct pattern — extract once, reuse:**
+
+```php
+$items = $order->get_items();
+if ( count( $items ) > 0 ) {
+    foreach ( $items as $item_id => $item ) { ... }
+}
+```
+
+## Identification criteria
+
+An accessor qualifies for extraction when **all** of the following hold:
+
+1. It is called with **identical arguments** in both call sites.
+2. Both call sites are in the **same method or template block** (not across separate hook callbacks).
+3. The accessor is a **lazy-loading data store method** — i.e., it queries the database or fires hooks on invocation. Pure computed accessors (`get_id()`, `get_total()`) are lower priority; extract them only when called inside a loop.
+
+## Known lazy-loading accessors in WooCommerce
+
+| Accessor | Object | Notes |
+| --- | --- | --- |
+| `get_items( $type )` | `WC_Order` | Loads order line items by type; fires `woocommerce_order_get_items` |
+| `get_coupon_codes()` | `WC_Order` | Delegates to `get_items( 'coupon' )` |
+| `get_shipping_methods()` | `WC_Order` | Delegates to `get_items( 'shipping' )` |
+| `get_fees()` | `WC_Order` | Delegates to `get_items( 'fee' )` |
+| `get_taxes()` | `WC_Order` | Delegates to `get_items( 'tax' )` |
+| `get_downloadable_items()` | `WC_Order` | Queries downloadable items from order items |
+

--- a/plugins/woocommerce/changelog/performance-extract-reduce-store-reads-prs-into-skill
+++ b/plugins/woocommerce/changelog/performance-extract-reduce-store-reads-prs-into-skill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Introduce a new performance skill focused on reducing store reads.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -599,10 +599,11 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	protected function get_attribute_taxonomy_name( $slug, $product ) {
 		// Format slug so it matches attributes of the product.
-		$slug       = wc_attribute_taxonomy_slug( $slug );
-		$attributes = array_combine(
-			array_map( 'wc_sanitize_taxonomy_name', array_keys( $product->get_attributes() ) ),
-			array_values( $product->get_attributes() )
+		$slug               = wc_attribute_taxonomy_slug( $slug );
+		$product_attributes = $product->get_attributes();
+		$attributes         = array_combine(
+			array_map( 'wc_sanitize_taxonomy_name', array_keys( $product_attributes ) ),
+			array_values( $product_attributes )
 		);
 
 		$attribute = false;

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -127,9 +127,10 @@ class WC_Shortcode_Checkout {
 
 				// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
 				if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
-					$quantities = array();
+					$quantities  = array();
+					$order_items = $order->get_items();
 
-					foreach ( $order->get_items() as $item_key => $item ) {
+					foreach ( $order_items as $item_key => $item ) {
 						if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
 							$product = $item->get_product();
 
@@ -143,7 +144,7 @@ class WC_Shortcode_Checkout {
 
 					// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
 					if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
-						foreach ( $order->get_items() as $item_key => $item ) {
+						foreach ( $order_items as $item_key => $item ) {
 							if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
 								$product = $item->get_product();
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1040,8 +1040,9 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		return;
 	}
 
-	if ( count( $order->get_coupon_codes() ) > 0 ) {
-		foreach ( $order->get_coupon_codes() as $code ) {
+	$coupon_codes = $order->get_coupon_codes();
+	if ( count( $coupon_codes ) > 0 ) {
+		foreach ( $coupon_codes as $code ) {
 			if ( StringUtil::is_null_or_whitespace( $code ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -30,8 +30,9 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 			</tr>
 		</thead>
 		<tbody>
-			<?php if ( count( $order->get_items() ) > 0 ) : ?>
-				<?php foreach ( $order->get_items() as $item_id => $item ) : ?>
+			<?php $order_items = $order->get_items(); ?>
+			<?php if ( count( $order_items ) > 0 ) : ?>
+				<?php foreach ( $order_items as $item_id => $item ) : ?>
 					<?php
 					if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 						continue;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Building on my work from Q1 2026, I created a new skill for identifying unnecessary store reads in our codebase through my recent PRs. In this PR, I am adding the skill to the repository and using AI-assisted cleanup to fix the identified gaps.

### How to test the changes in this Pull Request:

- Code review only.

> Please note that `.ai/skills/woocommerce-performance/store-reads-reduction.md` is intended for AIs, and verified in this PR where Claude uses it for verifying gaps.
