### PR TITLE
Cast return values to float for order calculations

### DIFF
--- a/plugins/woocommerce/changelog/63725-patch-1
+++ b/plugins/woocommerce/changelog/63725-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Ensure consistent float return type for order amount methods

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -475,7 +475,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_cart_tax( $context = 'view' ) {
-		return $this->get_prop( 'cart_tax', $context );
+		return (float)$this->get_prop( 'cart_tax', $context );
 	}
 
 	/**
@@ -485,7 +485,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_total( $context = 'view' ) {
-		return $this->get_prop( 'total', $context );
+		return (float)$this->get_prop( 'total', $context );
 	}
 
 	/**
@@ -495,7 +495,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_total_tax( $context = 'view' ) {
-		return $this->get_prop( 'total_tax', $context );
+		return (float)$this->get_prop( 'total_tax', $context );
 	}
 
 	/*
@@ -516,7 +516,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		} else {
 			$total_discount = (float) $this->get_discount_total() + (float) $this->get_discount_tax();
 		}
-		return apply_filters( 'woocommerce_order_get_total_discount', NumberUtil::round( $total_discount, WC_ROUNDING_PRECISION ), $this );
+		return (float)apply_filters( 'woocommerce_order_get_total_discount', NumberUtil::round( $total_discount, WC_ROUNDING_PRECISION ), $this );
 	}
 
 	/**
@@ -528,7 +528,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function get_subtotal() {
 		$subtotal = NumberUtil::round( $this->get_cart_subtotal_for_order(), wc_get_price_decimals() );
-		return apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
+		return (float)apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
 	}
 
 	/**
@@ -2076,7 +2076,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$subtotal = $round ? NumberUtil::round( $subtotal, wc_get_price_decimals() ) : $subtotal;
 		}
 
-		return apply_filters( 'woocommerce_order_amount_item_subtotal', $subtotal, $this, $item, $inc_tax, $round );
+		return (float)apply_filters( 'woocommerce_order_amount_item_subtotal', $subtotal, $this, $item, $inc_tax, $round );
 	}
 
 	/**
@@ -2100,7 +2100,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$subtotal = $round ? NumberUtil::round( $subtotal, wc_get_price_decimals() ) : $subtotal;
 		}
 
-		return apply_filters( 'woocommerce_order_amount_line_subtotal', $subtotal, $this, $item, $inc_tax, $round );
+		return (float)apply_filters( 'woocommerce_order_amount_line_subtotal', $subtotal, $this, $item, $inc_tax, $round );
 	}
 
 	/**
@@ -2124,7 +2124,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$total = $round ? NumberUtil::round( $total, wc_get_price_decimals() ) : $total;
 		}
 
-		return apply_filters( 'woocommerce_order_amount_item_total', $total, $this, $item, $inc_tax, $round );
+		return (float)apply_filters( 'woocommerce_order_amount_item_total', $total, $this, $item, $inc_tax, $round );
 	}
 
 	/**
@@ -2146,7 +2146,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$total = $round ? NumberUtil::round( $total, wc_get_price_decimals() ) : $total;
 		}
 
-		return apply_filters( 'woocommerce_order_amount_line_total', $total, $this, $item, $inc_tax, $round );
+		return (float)apply_filters( 'woocommerce_order_amount_line_total', $total, $this, $item, $inc_tax, $round );
 	}
 
 	/**
@@ -2164,7 +2164,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$tax = $round ? wc_round_tax_total( $tax ) : $tax;
 		}
 
-		return apply_filters( 'woocommerce_order_amount_item_tax', $tax, $item, $round, $this );
+		return (float)apply_filters( 'woocommerce_order_amount_item_tax', $tax, $item, $round, $this );
 	}
 
 	/**
@@ -2174,7 +2174,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_line_tax( $item ) {
-		return apply_filters( 'woocommerce_order_amount_line_tax', is_callable( array( $item, 'get_total_tax' ) ) ? wc_round_tax_total( $item->get_total_tax() ) : 0, $item, $this );
+		return (float)apply_filters( 'woocommerce_order_amount_line_tax', is_callable( array( $item, 'get_total_tax' ) ) ? wc_round_tax_total( $item->get_total_tax() ) : 0, $item, $this );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Ensure consistent return type (float) for order amount methods in abstract-wc-order.php

This PR adds explicit type casting to float for various order amount methods to ensure consistent return types throughout the class. Previously, some methods would return values that could be strings or integers depending on the context, while others already cast to float. This change standardizes all amount-related getters to return float values.

The following methods have been updated to return float:
- `get_cart_tax()`
- `get_total()`
- `get_total_tax()`
- `get_total_discount()`
- `get_subtotal()`
- `get_item_subtotal()`
- `get_line_subtotal()`
- `get_item_total()`
- `get_line_total()`
- `get_item_tax()`
- `get_line_tax()`

Closes # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A - This is a code consistency change with no UI impact.

### How to test the changes in this Pull Request:

1. Create or view an existing order with various items, taxes, and discounts applied
2. Verify that all order amount calculations display correctly in the admin order details page
3. Check order totals on the frontend (checkout, order confirmation, my account pages)
4. Use a debugging tool or add temporary logs to confirm that methods like `$order->get_total()`, `$order->get_total_tax()`, etc. return float values
5. Test with different tax settings (inclusive/exclusive) and discount types
6. Verify that no PHP notices or warnings are generated related to type mismatches

### Testing that has already taken place:

- Tested with a standard WooCommerce installation
- Verified all modified methods return float values
- Checked that filter hooks maintain backward compatibility (values are cast after filters are applied)
- Confirmed no breaking changes to existing code that relies on these methods

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure consistent float return type for order amount methods

</details>