### PR TITLE
Add new thumbnail srcset and sizes properties to ImageAttachmentSchema

### DIFF
--- a/plugins/woocommerce/changelog/63731-fix-image-srcsets
+++ b/plugins/woocommerce/changelog/63731-fix-image-srcsets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add smaller image options for product images in srcset to reduce bandwidth/load time on cart/checkout pages

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -232,12 +232,16 @@ const CartLineItemRow: React.ForwardRefExoticComponent<
 						<ProductImage
 							image={ firstImage }
 							fallbackAlt={ name }
+							width={ 80 }
+							height={ 80 }
 						/>
 					) : (
 						<a href={ permalink } tabIndex={ -1 }>
 							<ProductImage
 								image={ firstImage }
 								fallbackAlt={ name }
+								width={ 80 }
+								height={ 80 }
 							/>
 						</a>
 					) }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-image/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-image/index.tsx
@@ -5,7 +5,12 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/settings';
 
 interface ProductImageProps {
-	image: { alt?: string; thumbnail?: string };
+	image: {
+		alt?: string;
+		thumbnail?: string;
+		thumbnail_srcset?: string;
+		thumbnail_sizes?: string;
+	};
 	fallbackAlt: string;
 	width?: number;
 	height?: number;
@@ -25,20 +30,34 @@ const ProductImage = ( {
 }: ProductImageProps ): JSX.Element => {
 	const rawAlt = image.alt || fallbackAlt;
 
+	// Use display width for sizes so the browser picks an appropriately
+	// sized source from the thumbnail srcset.
+	const sizesAttr = image.thumbnail_srcset
+		? width
+			? `${ width }px`
+			: '100px'
+		: undefined;
+
 	const imageProps = image.thumbnail
 		? {
 				src: image.thumbnail,
 				alt: rawAlt ? decodeEntities( rawAlt ) : 'Product Image',
+				srcSet: image.thumbnail_srcset || undefined,
+				sizes: sizesAttr,
 		  }
 		: {
 				src: PLACEHOLDER_IMG_SRC,
 				alt: '',
+				srcSet: undefined,
+				sizes: undefined,
 		  };
 
 	return (
 		<img
 			src={ imageProps.src }
 			alt={ imageProps.alt }
+			srcSet={ imageProps.srcSet }
+			sizes={ imageProps.sizes }
 			width={ width }
 			height={ height }
 		/>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-image/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-image/index.tsx
@@ -32,11 +32,10 @@ const ProductImage = ( {
 
 	// Use display width for sizes so the browser picks an appropriately
 	// sized source from the thumbnail srcset.
-	const sizesAttr = image.thumbnail_srcset
-		? width
-			? `${ width }px`
-			: '100px'
-		: undefined;
+	let sizesAttr;
+	if ( image.thumbnail_srcset ) {
+		sizesAttr = width ? `${ width }px` : '100px';
+	}
 
 	const imageProps = image.thumbnail
 		? {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -594,6 +594,18 @@ const { state: cartItemState } = store(
 				);
 			},
 
+			get itemSrcset(): string {
+				return (
+					cartItemState.cartItem.images[ 0 ]?.thumbnail_srcset || ''
+				);
+			},
+
+			get itemSizes(): string {
+				return cartItemState.cartItem.images[ 0 ]?.thumbnail_srcset
+					? '64px'
+					: '';
+			},
+
 			get priceWithoutDiscount(): string {
 				const { raw_prices: rawPrices } = cartItemState.cartItem.prices;
 				const priceWithoutDiscount = scalePrice( {

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart-response.ts
@@ -86,6 +86,8 @@ export interface CartResponseImageItem {
 	thumbnail: string;
 	srcset: string;
 	sizes: string;
+	thumbnail_srcset: string;
+	thumbnail_sizes: string;
 	name: string;
 	alt: string;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.js
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.js
@@ -17,8 +17,10 @@
  * @property {number} id        Image id.
  * @property {string} src       Full size image URL.
  * @property {string} thumbnail Thumbnail URL.
- * @property {string} srcset    Thumbnail srcset for responsive image.
- * @property {string} sizes     Thumbnail sizes for responsive images.
+ * @property {string} srcset           Full size image srcset for responsive images.
+ * @property {string} sizes            Full size image sizes for responsive images.
+ * @property {string} thumbnail_srcset Thumbnail srcset for responsive images.
+ * @property {string} thumbnail_sizes  Thumbnail sizes for responsive images.
  * @property {string} name      Image name.
  * @property {string} alt       Image alternative text.
  */

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
@@ -93,6 +93,8 @@ export interface CartImageItem {
 	thumbnail: string;
 	srcset: string;
 	sizes: string;
+	thumbnail_srcset: string;
+	thumbnail_sizes: string;
 	name: string;
 	alt: string;
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -119,8 +119,10 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 							<td data-wp-context='{ "isImageHidden": false }' class="wc-block-cart-item__image" aria-hidden="true">
 								<img
 									data-wp-bind--hidden="!state.isProductHiddenFromCatalog"
-									data-wp-bind--src="state.itemThumbnail" 
+									data-wp-bind--src="state.itemThumbnail"
 									data-wp-bind--alt="state.cartItemName"
+									data-wp-bind--srcset="state.itemSrcset"
+									data-wp-bind--sizes="state.itemSizes"
 									data-wp-on--error="actions.hideImage"
 								>
 								<a data-wp-bind--hidden="state.isProductHiddenFromCatalog" data-wp-bind--href="state.cartItem.permalink" tabindex="-1">
@@ -128,6 +130,8 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										data-wp-bind--hidden="context.isImageHidden"
 										data-wp-bind--src="state.itemThumbnail"
 										data-wp-bind--alt="state.cartItemName"
+										data-wp-bind--srcset="state.itemSrcset"
+										data-wp-bind--sizes="state.itemSizes"
 										data-wp-on--error="actions.hideImage"
 									>	
 								</a>

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -89,8 +89,8 @@ class ImageAttachmentSchema extends AbstractSchema {
 			'id'        => (int) $attachment_id,
 			'src'       => current( $attachment ),
 			'thumbnail' => current( $thumbnail ),
-			'srcset'    => (string) wp_get_attachment_image_srcset( $attachment_id, 'full' ),
-			'sizes'     => (string) wp_get_attachment_image_sizes( $attachment_id, 'full' ),
+			'srcset'    => (string) wp_get_attachment_image_srcset( $attachment_id, 'woocommerce_thumbnail' ),
+			'sizes'     => (string) wp_get_attachment_image_sizes( $attachment_id, 'woocommerce_thumbnail' ),
 			'name'      => get_the_title( $attachment_id ),
 			'alt'       => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
 		];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -43,12 +43,22 @@ class ImageAttachmentSchema extends AbstractSchema {
 				'format'      => 'uri',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'srcset'    => [
+			'srcset'           => [
+				'description' => __( 'Full size image srcset for responsive images.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit', 'embed' ],
+			],
+			'sizes'            => [
+				'description' => __( 'Full size image sizes for responsive images.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit', 'embed' ],
+			],
+			'thumbnail_srcset' => [
 				'description' => __( 'Thumbnail srcset for responsive images.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'sizes'     => [
+			'thumbnail_sizes'  => [
 				'description' => __( 'Thumbnail sizes for responsive images.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit', 'embed' ],
@@ -86,13 +96,15 @@ class ImageAttachmentSchema extends AbstractSchema {
 		$thumbnail = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
 
 		return (object) [
-			'id'        => (int) $attachment_id,
-			'src'       => current( $attachment ),
-			'thumbnail' => current( $thumbnail ),
-			'srcset'    => (string) wp_get_attachment_image_srcset( $attachment_id, 'woocommerce_thumbnail' ),
-			'sizes'     => (string) wp_get_attachment_image_sizes( $attachment_id, 'woocommerce_thumbnail' ),
-			'name'      => get_the_title( $attachment_id ),
-			'alt'       => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'id'               => (int) $attachment_id,
+			'src'              => current( $attachment ),
+			'thumbnail'        => current( $thumbnail ),
+			'srcset'           => (string) wp_get_attachment_image_srcset( $attachment_id, 'full' ),
+			'sizes'            => (string) wp_get_attachment_image_sizes( $attachment_id, 'full' ),
+			'thumbnail_srcset' => (string) wp_get_attachment_image_srcset( $attachment_id, 'woocommerce_thumbnail' ),
+			'thumbnail_sizes'  => (string) wp_get_attachment_image_sizes( $attachment_id, 'woocommerce_thumbnail' ),
+			'name'             => get_the_title( $attachment_id ),
+			'alt'              => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
 		];
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -26,18 +26,18 @@ class ImageAttachmentSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'        => [
+			'id'               => [
 				'description' => __( 'Image ID.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'src'       => [
+			'src'              => [
 				'description' => __( 'Full size image URL.', 'woocommerce' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'thumbnail' => [
+			'thumbnail'        => [
 				'description' => __( 'Thumbnail URL.', 'woocommerce' ),
 				'type'        => 'string',
 				'format'      => 'uri',
@@ -63,12 +63,12 @@ class ImageAttachmentSchema extends AbstractSchema {
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'name'      => [
+			'name'             => [
 				'description' => __( 'Image name.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit', 'embed' ],
 			],
-			'alt'       => [
+			'alt'              => [
 				'description' => __( 'Image alternative text.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit', 'embed' ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Adds new `thumbnail_sizes` and `thumbnail_srcset` properties to `ImageAttachmentSchema` to enable correctly sized images when used in thumbnail contexts.
  - The existing `sizes` and `srcset` properties in this schema are consumed for both thumbnail (cart, mini-cart, and checkout) and full-size (product pages) occurrences, but because they're generated using full as the size, this doesn't always result in the correct `srcset`/`sizes` when consumed in square-cropped thumbnail contexts.
  - `wp_get_attachment_image_srcset` only includes candidates that match the aspect ratio of the reference size, so when the reference is 'full' (e.g. 1456x816), the square crops like 150x150 and 300x300 are excluded from the `srcset`. The browser then has no smaller square candidate to pick from, and falls back to the 300x300 thumbnail src even when displaying at 48-80px.
- Updates Cart/Mini-Cart/Checkout blocks to pull images from these thumbnail properties, and also sets widths on the `ProductImage` used in these contexts, so the browser knows which item from `srcset` it should pick.

Closes WOOPRD-2704

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add an item with images to your cart, open the Mini-Cart block, and inspect the thumbnail. Ensure the image in use is appropriately sized, e.g. a 64x64 image should be using 150x150 if on retina and 100x100 if not.
2. Repeat for the Cart and Checkout blocks, ensuring both times appropriately sized images are in use.
3. Add an item without images, and ensure the placeholder image loads correctly in each context.
4. Test in different screen sizes (mobile, tablet, desktop) and ensure the images display well in each context.
5. Test in Product Collection block and also ensure the image displays correctly in the single product page.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add smaller image options for product images in srcset to reduce bandwidth/load time on cart/checkout pages
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
