### PR TITLE
Fix: variable products not working as expected when name is different than slug

### DIFF
--- a/plugins/woocommerce/changelog/63736-fix-find-matching-variations-by-name
+++ b/plugins/woocommerce/changelog/63736-fix-find-matching-variations-by-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix variable products not working when name is different than the slug

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -278,9 +278,17 @@ async function sendCartRequest(
 
 	return cartQueue.submit( options );
 }
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
 // Todo: export this store once the store is public.
 const { state, actions } = store< Store >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
+store< Store >(
 	'woocommerce',
 	{
 		state: {
@@ -796,7 +804,7 @@ const { state, actions } = store< Store >(
 			},
 		},
 	},
-	{ lock: true }
+	{ lock: universalLock }
 );
 
 // Trigger initial cart refresh.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -283,12 +283,8 @@ const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
 // Todo: export this store once the store is public.
-const { state, actions } = store< Store >(
-	'woocommerce',
-	{},
-	{ lock: universalLock }
-);
-store< Store >(
+const { state } = store< Store >( 'woocommerce', {}, { lock: universalLock } );
+const { actions } = store< Store >(
 	'woocommerce',
 	{
 		state: {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/product-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/product-data.ts
@@ -23,7 +23,8 @@ const productDataStore = store< {
 	actions: {
 		setVariationId: ( variationId: number | null ) => void;
 	};
-} >(
+} >( 'woocommerce/product-data', {}, { lock: universalLock } );
+store(
 	'woocommerce/product-data',
 	{
 		state: {

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
@@ -1,15 +1,28 @@
 /**
  * External dependencies
  */
+import { store } from '@wordpress/interactivity';
 import type {
 	OptimisticCartItem,
 	SelectedAttributes,
 } from '@woocommerce/stores/woocommerce/cart';
+import '@woocommerce/stores/woocommerce/products';
+import type { ProductsStore } from '@woocommerce/stores/woocommerce/products';
 
 /**
  * Internal dependencies
  */
 import { attributeNamesMatch } from './attribute-matching';
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const { state: productsState } = store< ProductsStore >(
+	'woocommerce/products',
+	{},
+	{ lock: universalLock }
+);
 
 export const doesCartItemMatchAttributes = (
 	cartItem: OptimisticCartItem,
@@ -26,25 +39,24 @@ export const doesCartItemMatchAttributes = (
 		return false;
 	}
 
-	return cartItem.variation.every(
-		( {
-			attribute,
-			// eslint-disable-next-line
-			raw_attribute,
-			value,
-		}: {
-			attribute: string;
-			raw_attribute: string;
-			value: string;
-		} ) =>
-			selectedAttributes.some( ( item: SelectedAttributes ) => {
-				return (
-					attributeNamesMatch(
-						item.attribute,
-						// It needs to check both because it uses different keys from the same value depending on the context.
-						raw_attribute ?? attribute
-					) && item.value.toLowerCase() === value?.toLowerCase()
-				);
-			} )
+	const parentProductId =
+		productsState.productVariations[ cartItem.id ]?.parent;
+	const productAttributes =
+		productsState.products[ parentProductId ]?.attributes ?? [];
+
+	return cartItem.variation.every( ( { attribute, value: termName } ) =>
+		selectedAttributes.some( ( selectedAttr: SelectedAttributes ) => {
+			// Find the term matching the cart item's value label.
+			const terms = productAttributes.find(
+				( attr ) => attribute === attr.name
+			)?.terms;
+			const termSlug = terms?.find(
+				( term ) => term.name === termName
+			)?.slug;
+			return (
+				attributeNamesMatch( selectedAttr.attribute, attribute ) &&
+				selectedAttr.value.toLowerCase() === termSlug?.toLowerCase()
+			);
+		} )
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
@@ -47,8 +47,8 @@ export const doesCartItemMatchAttributes = (
 	return cartItem.variation.every( ( { attribute, value: termName } ) =>
 		selectedAttributes.some( ( selectedAttr: SelectedAttributes ) => {
 			// Find the term matching the cart item's value label.
-			const terms = productAttributes.find(
-				( attr ) => attribute === attr.name
+			const terms = productAttributes.find( ( attr ) =>
+				attributeNamesMatch( attribute, attr.name )
 			)?.terms;
 			const termSlug =
 				terms?.find( ( term ) => term.name === termName )?.slug ||

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/variations/does-cart-item-match-attributes.ts
@@ -50,9 +50,9 @@ export const doesCartItemMatchAttributes = (
 			const terms = productAttributes.find(
 				( attr ) => attribute === attr.name
 			)?.terms;
-			const termSlug = terms?.find(
-				( term ) => term.name === termName
-			)?.slug;
+			const termSlug =
+				terms?.find( ( term ) => term.name === termName )?.slug ||
+				termName; // Fallback to termName if no matching term is found.
 			return (
 				attributeNamesMatch( selectedAttr.attribute, attribute ) &&
 				selectedAttr.value.toLowerCase() === termSlug?.toLowerCase()

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -145,7 +145,8 @@ const { actions, state } = store<
 	AddToCartWithOptionsStore &
 		Partial< GroupedProductAddToCartWithOptionsStore > &
 		Partial< VariableProductAddToCartWithOptionsStore >
->(
+>( 'woocommerce/add-to-cart-with-options', {}, { lock: universalLock } );
+store(
 	'woocommerce/add-to-cart-with-options',
 	{
 		state: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -141,12 +141,12 @@ export type AddToCartWithOptionsStore = {
 	};
 };
 
-const { actions, state } = store<
+const { state } = store<
 	AddToCartWithOptionsStore &
 		Partial< GroupedProductAddToCartWithOptionsStore > &
 		Partial< VariableProductAddToCartWithOptionsStore >
 >( 'woocommerce/add-to-cart-with-options', {}, { lock: universalLock } );
-store(
+const { actions } = store(
 	'woocommerce/add-to-cart-with-options',
 	{
 		state: {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -376,71 +376,71 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
-	// test( 'allows adding variable products with custom attribute slugs', async ( {
-	// 	page,
-	// 	pageObject,
-	// 	editor,
-	// } ) => {
-	// 	// Create a global attribute where the slug intentionally differs from the name.
-	// 	const attrOutput = await wpCLI(
-	// 		`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
-	// 	);
-	// 	const attrId = attrOutput.stdout.match(
-	// 		/product_attribute\s+(\d+)/
-	// 	)?.[ 1 ];
+	test( 'allows adding variable products with custom attribute slugs', async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		// Create a global attribute where the slug intentionally differs from the name.
+		const attrOutput = await wpCLI(
+			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+		);
+		const attrId = attrOutput.stdout.match(
+			/product_attribute\s+(\d+)/
+		)?.[ 1 ];
 
-	// 	// Create terms with custom slugs that also differ from the names.
-	// 	await wpCLI(
-	// 		`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
-	// 	);
-	// 	await wpCLI(
-	// 		`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
-	// 	);
+		// Create terms with custom slugs that also differ from the names.
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+		);
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+		);
 
-	// 	// Create a variable product using the global attribute.
-	// 	const prodOutput = await wpCLI(
-	// 		`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
-	// 			[
-	// 				{
-	// 					id: Number( attrId ),
-	// 					visible: true,
-	// 					variation: true,
-	// 					options: [ 'Petit', 'Grand' ],
-	// 				},
-	// 			]
-	// 		) }'`
-	// 	);
-	// 	const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
+		// Create a variable product using the global attribute.
+		const prodOutput = await wpCLI(
+			`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
+				[
+					{
+						id: Number( attrId ),
+						visible: true,
+						variation: true,
+						options: [ 'Petit', 'Grand' ],
+					},
+				]
+			) }'`
+		);
+		const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
 
-	// 	// Create a single "Any" variation (empty attributes = matches all terms).
-	// 	await wpCLI(
-	// 		`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
-	// 	);
+		// Create a single "Any" variation (empty attributes = matches all terms).
+		await wpCLI(
+			`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
+		);
 
-	// 	await pageObject.updateSingleProductTemplate();
+		await pageObject.updateSingleProductTemplate();
 
-	// 	await editor.saveSiteEditorEntities( {
-	// 		isOnlyCurrentEntityDirty: true,
-	// 	} );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
-	// 	await page.goto( '/product/custom-slug-variable/' );
+		await page.goto( '/product/custom-slug-variable/' );
 
-	// 	// Verify the pills show term names (not slugs).
-	// 	const petitOption = page.locator( 'label:has-text("Petit")' );
-	// 	const grandOption = page.locator( 'label:has-text("Grand")' );
-	// 	const addToCartButton = page.getByRole( 'button', {
-	// 		name: 'Add to cart',
-	// 		exact: true,
-	// 	} );
+		// Verify the pills show term names (not slugs).
+		const petitOption = page.locator( 'label:has-text("Petit")' );
+		const grandOption = page.locator( 'label:has-text("Grand")' );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+			exact: true,
+		} );
 
-	// 	await expect( petitOption ).not.toBeDisabled();
-	// 	await expect( grandOption ).not.toBeDisabled();
+		await expect( petitOption ).not.toBeDisabled();
+		await expect( grandOption ).not.toBeDisabled();
 
-	// 	await petitOption.click();
-	// 	await expect( addToCartButton ).not.toBeDisabled();
-	// 	await addToCartButton.click();
-	// 	await expect( page.getByText( '1 in cart' ) ).toBeVisible();
-	// } );
+		await petitOption.click();
+		await expect( addToCartButton ).not.toBeDisabled();
+		await addToCartButton.click();
+		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+	} );
 
 	test( 'allows adding grouped products to cart', async ( {
 		page,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -380,7 +380,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 		page,
 		pageObject,
 		editor,
+		wpCoreVersion,
 	} ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			wpCoreVersion < 6.9,
+			'This test requires WordPress 6.9 or later'
+		);
 		// Create a global attribute where the slug intentionally differs from the name.
 		const attrOutput = await wpCLI(
 			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -376,28 +376,15 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
-	test.describe( 'custom attribute slugs', () => {
+	test( 'allows adding variable products with custom attribute slugs', async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
 		let attrId: string | undefined;
 		let productId: string | undefined;
 
-		test.afterAll( async () => {
-			if ( productId ) {
-				await wpCLI(
-					`wc product delete "${ productId }" --force=true --user=1`
-				);
-			}
-			if ( attrId ) {
-				await wpCLI(
-					`wc product_attribute delete ${ attrId } --user=1`
-				);
-			}
-		} );
-
-		test( 'allows adding variable products with custom attribute slugs', async ( {
-			page,
-			pageObject,
-			editor,
-		} ) => {
+		try {
 			// Create a global attribute where the slug intentionally differs from the name.
 			const attrOutput = await wpCLI(
 				`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
@@ -427,9 +414,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 					]
 				) }'`
 			);
-			productId = prodOutput.stdout.match(
-				/product\s+(\d+)/
-			)?.[ 1 ];
+			productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
 
 			// Create a single "Any" variation (empty attributes = matches all terms).
 			await wpCLI(
@@ -459,7 +444,18 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( addToCartButton ).not.toBeDisabled();
 			await addToCartButton.click();
 			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
-		} );
+		} finally {
+			if ( productId ) {
+				await wpCLI(
+					`wc product delete "${ productId }" --force=true --user=1`
+				);
+			}
+			if ( attrId ) {
+				await wpCLI(
+					`wc product_attribute delete ${ attrId } --user=1`
+				);
+			}
+		}
 	} );
 
 	test( 'allows adding grouped products to cart', async ( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -376,70 +376,90 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
-	test( 'allows adding variable products with custom attribute slugs', async ( {
-		page,
-		pageObject,
-		editor,
-	} ) => {
-		// Create a global attribute where the slug intentionally differs from the name.
-		const attrOutput = await wpCLI(
-			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
-		);
-		const attrId = attrOutput.stdout.match(
-			/product_attribute\s+(\d+)/
-		)?.[ 1 ];
+	test.describe( 'custom attribute slugs', () => {
+		let attrId: string | undefined;
+		let productId: string | undefined;
 
-		// Create terms with custom slugs that also differ from the names.
-		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
-		);
-		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
-		);
-
-		// Create a variable product using the global attribute.
-		const prodOutput = await wpCLI(
-			`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
-				[
-					{
-						id: Number( attrId ),
-						visible: true,
-						variation: true,
-						options: [ 'Petit', 'Grand' ],
-					},
-				]
-			) }'`
-		);
-		const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
-
-		// Create a single "Any" variation (empty attributes = matches all terms).
-		await wpCLI(
-			`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
-		);
-
-		await pageObject.updateSingleProductTemplate();
-
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
+		test.afterAll( async () => {
+			if ( productId ) {
+				await wpCLI(
+					`wc product delete "${ productId }" --force=true --user=1`
+				);
+			}
+			if ( attrId ) {
+				await wpCLI(
+					`wc product_attribute delete ${ attrId } --user=1`
+				);
+			}
 		} );
 
-		await page.goto( '/product/custom-slug-variable/' );
+		test( 'allows adding variable products with custom attribute slugs', async ( {
+			page,
+			pageObject,
+			editor,
+		} ) => {
+			// Create a global attribute where the slug intentionally differs from the name.
+			const attrOutput = await wpCLI(
+				`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+			);
+			attrId = attrOutput.stdout.match(
+				/product_attribute\s+(\d+)/
+			)?.[ 1 ];
 
-		// Verify the pills show term names (not slugs).
-		const petitOption = page.locator( 'label:has-text("Petit")' );
-		const grandOption = page.locator( 'label:has-text("Grand")' );
-		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart',
-			exact: true,
+			// Create terms with custom slugs that also differ from the names.
+			await wpCLI(
+				`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+			);
+			await wpCLI(
+				`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+			);
+
+			// Create a variable product using the global attribute.
+			const prodOutput = await wpCLI(
+				`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
+					[
+						{
+							id: Number( attrId ),
+							visible: true,
+							variation: true,
+							options: [ 'Petit', 'Grand' ],
+						},
+					]
+				) }'`
+			);
+			productId = prodOutput.stdout.match(
+				/product\s+(\d+)/
+			)?.[ 1 ];
+
+			// Create a single "Any" variation (empty attributes = matches all terms).
+			await wpCLI(
+				`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
+			);
+
+			await pageObject.updateSingleProductTemplate();
+
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+
+			await page.goto( '/product/custom-slug-variable/' );
+
+			// Verify the pills show term names (not slugs).
+			const petitOption = page.locator( 'label:has-text("Petit")' );
+			const grandOption = page.locator( 'label:has-text("Grand")' );
+			const addToCartButton = page.getByRole( 'button', {
+				name: 'Add to cart',
+				exact: true,
+			} );
+
+			await expect( petitOption ).not.toBeDisabled();
+			await expect( grandOption ).not.toBeDisabled();
+
+			await petitOption.click();
+			await expect( addToCartButton ).not.toBeDisabled();
+			await addToCartButton.click();
+			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 		} );
-
-		await expect( petitOption ).not.toBeDisabled();
-		await expect( grandOption ).not.toBeDisabled();
-
-		await petitOption.click();
-		await expect( addToCartButton ).not.toBeDisabled();
-		await addToCartButton.click();
-		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
 	test( 'allows adding grouped products to cart', async ( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -410,9 +410,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 				]
 			) }'`
 		);
-		const productId = prodOutput.stdout.match(
-			/product\s+(\d+)/
-		)?.[ 1 ];
+		const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
 
 		// Create a single "Any" variation (empty attributes = matches all terms).
 		await wpCLI(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -376,6 +376,72 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
+	test( 'allows adding variable products with custom attribute slugs', async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		// Create a global attribute where the slug intentionally differs from the name.
+		const attrOutput = await wpCLI(
+			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+		);
+		const attrId = attrOutput.stdout.match(
+			/product_attribute\s+(\d+)/
+		)?.[ 1 ];
+
+		// Create terms with custom slugs that also differ from the names.
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+		);
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+		);
+
+		// Create a variable product using the global attribute.
+		const prodOutput = await wpCLI(
+			`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
+				[
+					{
+						id: Number( attrId ),
+						visible: true,
+						variation: true,
+						options: [ 'Petit', 'Grand' ],
+					},
+				]
+			) }'`
+		);
+		const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
+
+		// Create a single "Any" variation (empty attributes = matches all terms).
+		await wpCLI(
+			`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
+		);
+
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/custom-slug-variable/' );
+
+		// Verify the pills show term names (not slugs).
+		const petitOption = page.locator( 'label:has-text("Petit")' );
+		const grandOption = page.locator( 'label:has-text("Grand")' );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+			exact: true,
+		} );
+
+		await expect( petitOption ).not.toBeDisabled();
+		await expect( grandOption ).not.toBeDisabled();
+
+		await petitOption.click();
+		await expect( addToCartButton ).not.toBeDisabled();
+		await addToCartButton.click();
+		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+	} );
+
 	test( 'allows adding grouped products to cart', async ( {
 		page,
 		pageObject,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -383,7 +383,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 	} ) => {
 		// Create a global attribute where the slug intentionally differs from the name.
 		const attrOutput = await wpCLI(
-			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+			`wc product_attribute create --name="Taille" --slug="custom-waist" --user=1`
 		);
 		const attrId = attrOutput.stdout.match(
 			/product_attribute\s+(\d+)/
@@ -391,10 +391,10 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		// Create terms with custom slugs that also differ from the names.
 		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="s-m" --user=1`
 		);
 		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="m-l" --user=1`
 		);
 
 		// Create a variable product using the global attribute.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -376,71 +376,71 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
-	test( 'allows adding variable products with custom attribute slugs', async ( {
-		page,
-		pageObject,
-		editor,
-	} ) => {
-		// Create a global attribute where the slug intentionally differs from the name.
-		const attrOutput = await wpCLI(
-			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
-		);
-		const attrId = attrOutput.stdout.match(
-			/product_attribute\s+(\d+)/
-		)?.[ 1 ];
+	// test( 'allows adding variable products with custom attribute slugs', async ( {
+	// 	page,
+	// 	pageObject,
+	// 	editor,
+	// } ) => {
+	// 	// Create a global attribute where the slug intentionally differs from the name.
+	// 	const attrOutput = await wpCLI(
+	// 		`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+	// 	);
+	// 	const attrId = attrOutput.stdout.match(
+	// 		/product_attribute\s+(\d+)/
+	// 	)?.[ 1 ];
 
-		// Create terms with custom slugs that also differ from the names.
-		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
-		);
-		await wpCLI(
-			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
-		);
+	// 	// Create terms with custom slugs that also differ from the names.
+	// 	await wpCLI(
+	// 		`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+	// 	);
+	// 	await wpCLI(
+	// 		`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+	// 	);
 
-		// Create a variable product using the global attribute.
-		const prodOutput = await wpCLI(
-			`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
-				[
-					{
-						id: Number( attrId ),
-						visible: true,
-						variation: true,
-						options: [ 'Petit', 'Grand' ],
-					},
-				]
-			) }'`
-		);
-		const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
+	// 	// Create a variable product using the global attribute.
+	// 	const prodOutput = await wpCLI(
+	// 		`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
+	// 			[
+	// 				{
+	// 					id: Number( attrId ),
+	// 					visible: true,
+	// 					variation: true,
+	// 					options: [ 'Petit', 'Grand' ],
+	// 				},
+	// 			]
+	// 		) }'`
+	// 	);
+	// 	const productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
 
-		// Create a single "Any" variation (empty attributes = matches all terms).
-		await wpCLI(
-			`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
-		);
+	// 	// Create a single "Any" variation (empty attributes = matches all terms).
+	// 	await wpCLI(
+	// 		`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
+	// 	);
 
-		await pageObject.updateSingleProductTemplate();
+	// 	await pageObject.updateSingleProductTemplate();
 
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+	// 	await editor.saveSiteEditorEntities( {
+	// 		isOnlyCurrentEntityDirty: true,
+	// 	} );
 
-		await page.goto( '/product/custom-slug-variable/' );
+	// 	await page.goto( '/product/custom-slug-variable/' );
 
-		// Verify the pills show term names (not slugs).
-		const petitOption = page.locator( 'label:has-text("Petit")' );
-		const grandOption = page.locator( 'label:has-text("Grand")' );
-		const addToCartButton = page.getByRole( 'button', {
-			name: 'Add to cart',
-			exact: true,
-		} );
+	// 	// Verify the pills show term names (not slugs).
+	// 	const petitOption = page.locator( 'label:has-text("Petit")' );
+	// 	const grandOption = page.locator( 'label:has-text("Grand")' );
+	// 	const addToCartButton = page.getByRole( 'button', {
+	// 		name: 'Add to cart',
+	// 		exact: true,
+	// 	} );
 
-		await expect( petitOption ).not.toBeDisabled();
-		await expect( grandOption ).not.toBeDisabled();
+	// 	await expect( petitOption ).not.toBeDisabled();
+	// 	await expect( grandOption ).not.toBeDisabled();
 
-		await petitOption.click();
-		await expect( addToCartButton ).not.toBeDisabled();
-		await addToCartButton.click();
-		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
-	} );
+	// 	await petitOption.click();
+	// 	await expect( addToCartButton ).not.toBeDisabled();
+	// 	await addToCartButton.click();
+	// 	await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+	// } );
 
 	test( 'allows adding grouped products to cart', async ( {
 		page,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -380,13 +380,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		page,
 		pageObject,
 		editor,
-		wpCoreVersion,
 	} ) => {
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			wpCoreVersion < 6.9,
-			'This test requires WordPress 6.9 or later'
-		);
 		// Create a global attribute where the slug intentionally differs from the name.
 		const attrOutput = await wpCLI(
 			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -381,81 +381,67 @@ test.describe( 'Add to Cart + Options Block', () => {
 		pageObject,
 		editor,
 	} ) => {
-		let attrId: string | undefined;
-		let productId: string | undefined;
+		// Create a global attribute where the slug intentionally differs from the name.
+		const attrOutput = await wpCLI(
+			`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
+		);
+		const attrId = attrOutput.stdout.match(
+			/product_attribute\s+(\d+)/
+		)?.[ 1 ];
 
-		try {
-			// Create a global attribute where the slug intentionally differs from the name.
-			const attrOutput = await wpCLI(
-				`wc product_attribute create --name="Taille" --slug="custom-taille" --user=1`
-			);
-			attrId = attrOutput.stdout.match(
-				/product_attribute\s+(\d+)/
-			)?.[ 1 ];
+		// Create terms with custom slugs that also differ from the names.
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
+		);
+		await wpCLI(
+			`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
+		);
 
-			// Create terms with custom slugs that also differ from the names.
-			await wpCLI(
-				`wc product_attribute_term create ${ attrId } --name="Petit" --slug="custom-petit" --user=1`
-			);
-			await wpCLI(
-				`wc product_attribute_term create ${ attrId } --name="Grand" --slug="custom-grand" --user=1`
-			);
+		// Create a variable product using the global attribute.
+		const prodOutput = await wpCLI(
+			`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
+				[
+					{
+						id: Number( attrId ),
+						visible: true,
+						variation: true,
+						options: [ 'Petit', 'Grand' ],
+					},
+				]
+			) }'`
+		);
+		const productId = prodOutput.stdout.match(
+			/product\s+(\d+)/
+		)?.[ 1 ];
 
-			// Create a variable product using the global attribute.
-			const prodOutput = await wpCLI(
-				`wc product create --user=1 --slug="custom-slug-variable" --name="Custom Slug Variable" --type="variable" --attributes='${ JSON.stringify(
-					[
-						{
-							id: Number( attrId ),
-							visible: true,
-							variation: true,
-							options: [ 'Petit', 'Grand' ],
-						},
-					]
-				) }'`
-			);
-			productId = prodOutput.stdout.match( /product\s+(\d+)/ )?.[ 1 ];
+		// Create a single "Any" variation (empty attributes = matches all terms).
+		await wpCLI(
+			`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
+		);
 
-			// Create a single "Any" variation (empty attributes = matches all terms).
-			await wpCLI(
-				`wc product_variation create "${ productId }" --user=1 --regular_price="19.99" --attributes='[]'`
-			);
+		await pageObject.updateSingleProductTemplate();
 
-			await pageObject.updateSingleProductTemplate();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
+		await page.goto( '/product/custom-slug-variable/' );
 
-			await page.goto( '/product/custom-slug-variable/' );
+		// Verify the pills show term names (not slugs).
+		const petitOption = page.locator( 'label:has-text("Petit")' );
+		const grandOption = page.locator( 'label:has-text("Grand")' );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+			exact: true,
+		} );
 
-			// Verify the pills show term names (not slugs).
-			const petitOption = page.locator( 'label:has-text("Petit")' );
-			const grandOption = page.locator( 'label:has-text("Grand")' );
-			const addToCartButton = page.getByRole( 'button', {
-				name: 'Add to cart',
-				exact: true,
-			} );
+		await expect( petitOption ).not.toBeDisabled();
+		await expect( grandOption ).not.toBeDisabled();
 
-			await expect( petitOption ).not.toBeDisabled();
-			await expect( grandOption ).not.toBeDisabled();
-
-			await petitOption.click();
-			await expect( addToCartButton ).not.toBeDisabled();
-			await addToCartButton.click();
-			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
-		} finally {
-			if ( productId ) {
-				await wpCLI(
-					`wc product delete "${ productId }" --force=true --user=1`
-				);
-			}
-			if ( attrId ) {
-				await wpCLI(
-					`wc product_attribute delete ${ attrId } --user=1`
-				);
-			}
-		}
+		await petitOption.click();
+		await expect( addToCartButton ).not.toBeDisabled();
+		await addToCartButton.click();
+		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 	} );
 
 	test( 'allows adding grouped products to cart', async ( {

--- a/plugins/woocommerce/client/blocks/tests/js/jest.config.json
+++ b/plugins/woocommerce/client/blocks/tests/js/jest.config.json
@@ -42,6 +42,7 @@
 		"@woocommerce/utils": "assets/js/utils",
 		"@woocommerce/test-utils/msw": "tests/js/config/msw-setup.js",
 		"@woocommerce/entities": "assets/js/entities",
+		"@woocommerce/stores/(.*)$": "assets/js/base/stores/$1",
 		"^react$": "<rootDir>/node_modules/react",
 		"^react-dom$": "<rootDir>/node_modules/react-dom",
 		"^(.+)/build-module/(.*)$": "$1/build/$2"

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -5899,6 +5899,12 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-order-fee.php
 
 		-
+			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: includes/admin/meta-boxes/views/html-order-fee.php
+
+		-
 			message: '#^Variable \$order might not be defined\.$#'
 			identifier: variable.undefined
 			count: 7
@@ -5906,12 +5912,6 @@ parameters:
 
 		-
 			message: '#^Variable \$order_taxes might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/admin/meta-boxes/views/html-order-fee.php
-
-		-
-			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-fee.php
@@ -6085,13 +6085,13 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-order-refund.php
 
 		-
-			message: '#^Variable \$order_taxes might not be defined\.$#'
+			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-refund.php
 
 		-
-			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
+			message: '#^Variable \$order_taxes might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-refund.php
@@ -51726,7 +51726,7 @@ parameters:
 		-
 			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
 			identifier: class.notFound
-			count: 10
+			count: 12
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -5899,12 +5899,6 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-order-fee.php
 
 		-
-			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/admin/meta-boxes/views/html-order-fee.php
-
-		-
 			message: '#^Variable \$order might not be defined\.$#'
 			identifier: variable.undefined
 			count: 7
@@ -5912,6 +5906,12 @@ parameters:
 
 		-
 			message: '#^Variable \$order_taxes might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: includes/admin/meta-boxes/views/html-order-fee.php
+
+		-
+			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-fee.php
@@ -6085,13 +6085,13 @@ parameters:
 			path: includes/admin/meta-boxes/views/html-order-refund.php
 
 		-
-			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
+			message: '#^Variable \$order_taxes might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-refund.php
 
 		-
-			message: '#^Variable \$order_taxes might not be defined\.$#'
+			message: '#^Variable \$cogs_is_enabled might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: includes/admin/meta-boxes/views/html-order-refund.php
@@ -51726,7 +51726,7 @@ parameters:
 		-
 			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
 			identifier: class.notFound
-			count: 12
+			count: 10
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
 
 		-

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -51724,30 +51724,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php
 
 		-
-			message: '#^Access to property \$context on an unknown class Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 10
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
-
-		-
-			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\VariationSelectorAttributeOptions\:\:render\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
-
-		-
-			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\VariationSelectorAttributeOptions\:\:render_dropdown\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
-
-		-
-			message: '#^Parameter \$block of method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\VariationSelectorAttributeOptions\:\:render_pills\(\) has invalid type Automattic\\WooCommerce\\Blocks\\BlockTypes\\AddToCartWithOptions\\WP_Block\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\AllProducts\:\:enqueue_data\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -190,7 +190,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'id'              => $attribute_id,
 					'aria-labelledby' => $attribute_id . '_label',
 					'data-wp-context' => array(
-						'name'          => $attribute_slug,
+						'name'          => wc_attribute_label( $block->context['woocommerce/attributeName'] ),
 						'options'       => $attribute_terms,
 						'selectedValue' => $this->get_default_selected_attribute( $attribute_slug, $attribute_terms ),
 						'focused'       => '',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -133,7 +133,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	/**
 	 * Render the attribute options as pills.
 	 *
-	 * @param array     attributes Block attributes.
+	 * @param array     $attributes Block attributes.
 	 * @param string    $content Block content.
 	 * @param \WP_Block $block Block instance.
 	 * @return string The pills.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -264,7 +264,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 					'class'              => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__dropdown',
 					'id'                 => $attribute_id,
 					'data-wp-context'    => array(
-						'name'          => $attribute_slug,
+						'name'          => wc_attribute_label( $block->context['woocommerce/attributeName'] ),
 						'options'       => $attribute_terms,
 						'selectedValue' => $selected_attribute,
 						'autoselect'    => $autoselect,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -25,9 +25,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Block content.
+	 * @param \WP_Block $block Block instance.
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
@@ -133,9 +133,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	/**
 	 * Render the attribute options as pills.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array     attributes Block attributes.
+	 * @param string    $content Block content.
+	 * @param \WP_Block $block Block instance.
 	 * @return string The pills.
 	 */
 	protected function render_pills( $attributes, $content, $block ) {
@@ -206,9 +206,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	/**
 	 * Render the attribute options as a dropdown.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Block content.
+	 * @param \WP_Block $block Block instance.
 	 * @return string The dropdown.
 	 */
 	protected function render_dropdown( $attributes, $content, $block ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the Add to Cart with Options when the transformation from an attribute name to a slug is different from the current attribute slug. This can happen when it includes special characters or when the slug is defined manually.

I'm fixing it by comparing name vs name instead of transformed name vs slug because the slug is not available in all parts of the Store API, but we should improve that part and rely on the slug in the future, as explained in the [follow-ups](https://github.com/woocommerce/woocommerce/pull/63736#issuecomment-4080563777).

In the case of attribute terms, I'm using the slug, but I need to access the `products` store to do the transformation, which is not ideal and should be changed in the future as well.

Closes #63635 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="322" height="458" alt="Screenshot 2026-03-18 at 10 11 17" src="https://github.com/user-attachments/assets/b6f8f819-aefe-4112-8c83-4945179e157c" /> |  <img width="325" height="458" alt="Screenshot 2026-03-18 at 10 11 33" src="https://github.com/user-attachments/assets/58596c61-142e-4578-89d2-371e9e07c1c1" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to Product Attributes and create a Product Attribute with a custom slug. Add custom slugs to the values as well.
2. Create a Variable Product using that Product Attribute.
3. Add a local attribute with a special symbol like `ó` to the Product.
4. Go to the frontend and check you can select all the attributes.
5. Add products to the cart and check that the number is updated properly.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fix variable products not working when name is different than the slug

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
