### PR TITLE
Add woocommerce_draft_order_batch_size filter to DraftOrders cleanup

### DIFF
--- a/plugins/woocommerce/changelog/add-draft-orders-batch-size-filter
+++ b/plugins/woocommerce/changelog/add-draft-orders-batch-size-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_draft_order_batch_size filter to make draft order cleanup batch size configurable

--- a/plugins/woocommerce/changelog/add-draft-orders-batch-size-filter
+++ b/plugins/woocommerce/changelog/add-draft-orders-batch-size-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add woocommerce_draft_order_batch_size filter to make draft order cleanup batch size configurable
+Add woocommerce_delete_expired_draft_orders_batch_size filter to make draft order cleanup batch size configurable

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -181,7 +181,7 @@ class DraftOrders {
 		/**
 		 * Filters the number of draft orders deleted per batch during cleanup.
 		 *
-		 * @since 9.9.0
+		 * @since 10.7.0
 		 * @param int $batch_size Number of draft orders to delete per batch. Default 20.
 		 */
 		$batch_size = max( 1, (int) apply_filters( 'woocommerce_draft_order_batch_size', 20 ) );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -246,7 +246,7 @@ class DraftOrders {
 		$suffix = ' This is an indicator that something is filtering WooCommerce or WordPress queries and modifying the query parameters.';
 
 		// if count is greater than our expected batch size, then that's a problem.
-		if ( count( $order_results ) > 20 ) {
+		if ( count( $order_results ) > $expected_batch_size ) {
 			throw new Exception( 'There are an unexpected number of results returned from the query.' . $suffix );
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -181,6 +181,9 @@ class DraftOrders {
 		/**
 		 * Filters the number of draft orders deleted per batch during cleanup.
 		 *
+		 * Increasing this value can help improve deletion throughput for high-volume or busy stores
+		 * when the cleanup task cannot keep up with the draft orders backlog.
+		 *
 		 * @since 10.7.0
 		 * @param int $batch_size Number of draft orders to delete per batch. Default 20.
 		 */

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -169,15 +169,22 @@ class DraftOrders {
 	}
 
 	/**
-	 * Delete draft orders older than a day in batches of 20.
+	 * Delete draft orders older than a day in configurable batches (default: 20).
 	 *
-	 * Ran on a daily cron schedule.
+	 * Ran on a daily cron schedule. Batch size is filterable via
+	 * `woocommerce_draft_order_batch_size`.
 	 *
 	 * @internal
 	 */
 	public function delete_expired_draft_orders() {
-		$count      = 0;
-		$batch_size = 20;
+		$count = 0;
+		/**
+		 * Filters the number of draft orders deleted per batch during cleanup.
+		 *
+		 * @since 9.9.0
+		 * @param int $batch_size Number of draft orders to delete per batch. Default 20.
+		 */
+		$batch_size = max( 1, (int) apply_filters( 'woocommerce_draft_order_batch_size', 20 ) );
 		$this->ensure_draft_status_registered();
 		$orders = wc_get_orders(
 			[

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -172,7 +172,7 @@ class DraftOrders {
 	 * Delete draft orders older than a day in configurable batches (default: 20).
 	 *
 	 * Ran on a daily cron schedule. Batch size is filterable via
-	 * `woocommerce_draft_order_batch_size`.
+	 * `woocommerce_delete_expired_draft_orders_batch_size`.
 	 *
 	 * @internal
 	 */
@@ -184,7 +184,7 @@ class DraftOrders {
 		 * @since 10.7.0
 		 * @param int $batch_size Number of draft orders to delete per batch. Default 20.
 		 */
-		$batch_size = max( 1, (int) apply_filters( 'woocommerce_draft_order_batch_size', 20 ) );
+		$batch_size = max( 1, (int) apply_filters( 'woocommerce_delete_expired_draft_orders_batch_size', 20 ) );
 		$this->ensure_draft_status_registered();
 		$orders = wc_get_orders(
 			[

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -123,6 +123,27 @@ class DeleteDraftOrders extends TestCase {
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-on-hold'" ) );
 	}
 
+	public function test_custom_batch_size_filter_allows_larger_results() {
+		add_filter( 'woocommerce_draft_order_batch_size', function() { return 50; } );
+
+		$sample_results = function( $results, $args ) {
+			if ( isset( $args[ 'status' ] ) && DraftOrders::DB_STATUS === $args[ 'status' ] ) {
+				$orders = array_fill( 0, 50, new WC_Order() );
+				foreach ( $orders as $order ) {
+					$order->set_status( DraftOrders::STATUS );
+				}
+				return $orders;
+			}
+			return $results;
+		};
+		$this->mock_results_for_wc_query( $sample_results );
+		$this->draft_orders_instance->delete_expired_draft_orders();
+		$this->assertNull( $this->caught_exception, 'No exception should be thrown when batch size filter allows more results.' );
+		$this->unset_mock_results_for_wc_query( $sample_results );
+
+		remove_all_filters( 'woocommerce_draft_order_batch_size' );
+	}
+
 	public function test_greater_than_batch_results_error() {
 		$sample_results = function( $results, $args ) {
 			if ( isset( $args[ 'status' ] ) && DraftOrders::DB_STATUS === $args[ 'status' ] ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -128,7 +128,7 @@ class DeleteDraftOrders extends TestCase {
 	 */
 	public function test_custom_batch_size_filter_allows_larger_results() {
 		add_filter(
-			'woocommerce_draft_order_batch_size',
+			'woocommerce_delete_expired_draft_orders_batch_size',
 			function () {
 				return 50;
 			}
@@ -149,7 +149,7 @@ class DeleteDraftOrders extends TestCase {
 		$this->assertNull( $this->caught_exception, 'No exception should be thrown when batch size filter allows more results.' );
 		$this->unset_mock_results_for_wc_query( $sample_results );
 
-		remove_all_filters( 'woocommerce_draft_order_batch_size' );
+		remove_all_filters( 'woocommerce_delete_expired_draft_orders_batch_size' );
 	}
 
 	public function test_greater_than_batch_results_error() {

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -123,11 +123,19 @@ class DeleteDraftOrders extends TestCase {
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-on-hold'" ) );
 	}
 
+	/**
+	 * Test that a custom batch size filter allows more than the default 20 results without error.
+	 */
 	public function test_custom_batch_size_filter_allows_larger_results() {
-		add_filter( 'woocommerce_draft_order_batch_size', function() { return 50; } );
+		add_filter(
+			'woocommerce_draft_order_batch_size',
+			function () {
+				return 50;
+			}
+		);
 
-		$sample_results = function( $results, $args ) {
-			if ( isset( $args[ 'status' ] ) && DraftOrders::DB_STATUS === $args[ 'status' ] ) {
+		$sample_results = function ( $results, $args ) {
+			if ( isset( $args['status'] ) && DraftOrders::DB_STATUS === $args['status'] ) {
 				$orders = array_fill( 0, 50, new WC_Order() );
 				foreach ( $orders as $order ) {
 					$order->set_status( DraftOrders::STATUS );

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -136,9 +136,11 @@ class DeleteDraftOrders extends TestCase {
 
 		$sample_results = function ( $results, $args ) {
 			if ( isset( $args['status'] ) && DraftOrders::DB_STATUS === $args['status'] ) {
-				$orders = array_fill( 0, 50, new WC_Order() );
-				foreach ( $orders as $order ) {
+				$orders = array();
+				for ( $i = 0; $i < 50; $i++ ) {
+					$order = new WC_Order();
 					$order->set_status( DraftOrders::STATUS );
+					$orders[] = $order;
 				}
 				return $orders;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Makes the batch size in `delete_expired_draft_orders()` filterable via `woocommerce_draft_order_batch_size` (default: `20`), allowing high-traffic sites to tune cleanup throughput without patching core.

**Why:** Sites with large draft order backlogs are constrained by the hardcoded batch size of 20. A filter lets operators increase throughput (e.g. to 100) without modifying WooCommerce core files.

**Usage:**
```php
add_filter( 'woocommerce_draft_order_batch_size', fn() => 100 );
```

Closes WCCOM-2363.

### How to test the changes in this Pull Request:

Connect to the site via WP-CLI and run the following.

1. Confirm the filter default is unchanged:
```bash
wp eval 'echo apply_filters("woocommerce_draft_order_batch_size", 20);'
# Should return: 20
```

2. Add a filter (e.g. in a mu-plugin) and confirm it is respected:
```php
add_filter( 'woocommerce_draft_order_batch_size', fn() => 100 );
```
```bash
wp eval 'echo apply_filters("woocommerce_draft_order_batch_size", 20);'
# Should return: 100
```

3. Trigger cleanup manually and confirm it runs without errors:
```bash
wp eval 'do_action("woocommerce_cleanup_draft_orders");'
```

4. Confirm no unexpected Action Scheduler fan-out (should be exactly 1 pending instance):
```bash
wp eval 'global $wpdb; $rows = $wpdb->get_results("SELECT status, COUNT(*) as cnt FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = \"woocommerce_cleanup_draft_orders\" GROUP BY status"); foreach($rows as $r) echo $r->status . ": " . $r->cnt . "\n";'
```

5. Confirm pending actions are not stacked at the same scheduled time:
```bash
wp eval 'global $wpdb; $rows = $wpdb->get_results("SELECT action_id, scheduled_date_gmt FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = \"woocommerce_cleanup_draft_orders\" AND status = \"pending\" ORDER BY scheduled_date_gmt ASC"); foreach($rows as $r) echo $r->action_id . " | " . $r->scheduled_date_gmt . "\n";'
```

### Testing that has already taken place:

Validated on a staging environment with a backlog of draft orders. Confirmed:
- Filter correctly overrides the default batch size
- `do_action("woocommerce_cleanup_draft_orders")` completes without errors
- Only 1 pending Action Scheduler instance remains after cleanup

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Add `woocommerce_draft_order_batch_size` filter to make draft order cleanup batch size configurable.

</details>
