### PR TITLE
Fix insufficient color contrast for status marks on System Status page

### DIFF
--- a/plugins/woocommerce/changelog/63746-fix-6389-system-status-a11y-contrast
+++ b/plugins/woocommerce/changelog/63746-fix-6389-system-status-a11y-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix insufficient color contrast for status indicators on the System Status page to meet WCAG 2.2 AA requirements.

--- a/plugins/woocommerce/client/legacy/css/_mixins.scss
+++ b/plugins/woocommerce/client/legacy/css/_mixins.scss
@@ -297,7 +297,7 @@
 	}
 
 	mark.no {
-		color: #999;
+		color: var(--wc-subtext);
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -3,7 +3,7 @@
  */
 
 $woocommerce:   	#720eec !default;
-$green:         	#7ad03a !default;
+$green:         	#008a20 !default;
 $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `.yes` (`#7ad03a`) and `.no` (`#999999`) status indicators on the WooCommerce System Status table fail WCAG 2.2 AA contrast requirements against white and alternating row backgrounds.

This PR updates:
- `$green` from `#7ad03a` (1.92:1 contrast on white) to `#008a20` (~4.6:1 on white) — meets WCAG AA for both text (4.5:1) and non-text contrast (3:1)
- `mark.no` from hardcoded `#999999` (2.84:1) to `var(--wc-subtext)` (`#767676`, 4.54:1) — reuses an existing CSS variable instead of a hardcoded value

The `--wc-green` variable is also used for form validation border colors and a Twenty Twenty theme border — both benefit from the improved contrast.

Closes https://github.com/woocommerce/woocommerce/issues/63586.

### Screenshots or screen recordings:

#### System Status page

| Before | After |
| ------ | ----- |
| <img width="2148" height="1496" alt="CleanShot 2026-03-18 at 14 26 19@2x" src="https://github.com/user-attachments/assets/244f6de5-415d-4699-8908-6add04205997" /> | <img width="2152" height="1498" alt="CleanShot 2026-03-18 at 14 35 02@2x" src="https://github.com/user-attachments/assets/27332bda-226a-480f-9dd5-ea24e1e7e9a1" /> |

#### Shortcode Checkout (validated field border)

| Before | After |
| ------ | ----- |
| <img width="1006" height="372" alt="CleanShot 2026-03-18 at 14 25 52@2x" src="https://github.com/user-attachments/assets/9e1907bd-7fd2-4ff3-a308-d006e3c04b71" /> | <img width="998" height="368" alt="CleanShot 2026-03-18 at 14 35 20@2x" src="https://github.com/user-attachments/assets/39dc7021-08ad-4435-b771-173bdb92ffcd" /> |

### How to test the changes in this Pull Request:

1. Navigate to **WooCommerce → Status** in the WordPress admin.
2. Inspect a `.yes` (green tick/text) and `.no` (grey cross/text) value in the status table.
3. Using DevTools or a contrast checker, verify the green (`#008a20`) meets 4.5:1 against white (`#fff`) and alternating row backgrounds (`#fcfcfc`).
4. Verify the grey (`#767676`) meets 4.5:1 against the same backgrounds.
5. Add a product to the cart and visit a page with the `[woocommerce_checkout]` shortcode.
6. Fill in a required field and tab away — verify the validated field border is now a darker green.

### Testing that has already taken place:

- Verified contrast ratios using DevTools color picker on a local wp-env site (PHP 8.1, WP 6.9, WooCommerce trunk).
- Checked System Status page `.yes` and `.no` marks render correctly with new colors.
- Checked shortcode checkout form validation border color.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix insufficient color contrast for status indicators on the System Status page to meet WCAG 2.2 AA requirements.

</details>