### PR TITLE
Add woocommerce_pre_refresh_order_count_cache filter

### DIFF
--- a/plugins/woocommerce/changelog/63747-add-woocommerce-pre-refresh-order-count-cache-filter
+++ b/plugins/woocommerce/changelog/63747-add-woocommerce-pre-refresh-order-count-cache-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `woocommerce_pre_refresh_order_count_cache` filter to allow short-circuiting the scheduled background order count cache refresh.

--- a/plugins/woocommerce/changelog/add-woocommerce-pre-refresh-order-count-cache-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce-pre-refresh-order-count-cache-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add woocommerce_pre_refresh_order_count_cache filter to allow short-circuiting background cache refresh

--- a/plugins/woocommerce/changelog/add-woocommerce-pre-refresh-order-count-cache-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce-pre-refresh-order-count-cache-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_pre_refresh_order_count_cache filter to allow short-circuiting background cache refresh

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -70,7 +70,9 @@ class OrderCountCacheService {
 		 * Return true to skip the flush + COUNT(*) query entirely. The caller is
 		 * responsible for ensuring counts remain accurate when skipping.
 		 *
+		 * @hook woocommerce_pre_refresh_order_count_cache
 		 * @since 10.7.0
+		 * @return bool Whether to skip the refresh.
 		 * @param bool            $skip       Whether to skip the refresh. Default false.
 		 * @param string          $order_type The order type being refreshed (e.g. 'shop_order').
 		 * @param OrderCountCache $cache      The cache instance.

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -64,6 +64,21 @@ class OrderCountCacheService {
 	 * @return void
 	 */
 	public function refresh_cache( $order_type ) {
+		/**
+		 * Allows short-circuiting the scheduled order count cache refresh.
+		 *
+		 * Return true to skip the flush + COUNT(*) query entirely. The caller is
+		 * responsible for ensuring counts remain accurate when skipping.
+		 *
+		 * @since 10.7.0
+		 * @param bool            $skip       Whether to skip the refresh. Default false.
+		 * @param string          $order_type The order type being refreshed (e.g. 'shop_order').
+		 * @param OrderCountCache $cache      The cache instance.
+		 */
+		if ( apply_filters( 'woocommerce_pre_refresh_order_count_cache', false, $order_type, $this->order_count_cache ) ) {
+			return;
+		}
+
 		$this->order_count_cache->flush( $order_type );
 		OrderUtil::get_count_for_type( $order_type );
 	}

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -146,6 +146,42 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that refresh cache is skipped when the pre-refresh filter returns true.
+	 */
+	public function test_refresh_cache_skipped_when_filter_returns_true() {
+		// Arrange - set a stale value so we can detect whether a refresh occurred.
+		$count         = OrderUtil::get_count_for_type( 'shop_order' );
+		$pending_count = $count[ OrderInternalStatus::PENDING ];
+		$this->order_cache->set( 'shop_order', OrderInternalStatus::PENDING, $pending_count + 10 );
+
+		$received_order_type = null;
+		$received_cache      = null;
+
+		add_filter(
+			'woocommerce_pre_refresh_order_count_cache',
+			function ( $skip, $order_type, $cache ) use ( &$received_order_type, &$received_cache ) {
+				unset( $skip ); // Avoid parameter not used PHPCS errors.
+				$received_order_type = $order_type;
+				$received_cache      = $cache;
+				return true;
+			},
+			10,
+			3
+		);
+
+		// Act.
+		$order_count_cache_service = wc_get_container()->get( OrderCountCacheService::class );
+		$order_count_cache_service->refresh_cache( 'shop_order' );
+
+		// Assert - the stale value must still be present (no flush or re-count happened).
+		$this->assertSame( $pending_count + 10, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
+		$this->assertSame( 'shop_order', $received_order_type );
+		$this->assertInstanceOf( OrderCountCache::class, $received_cache );
+
+		remove_all_filters( 'woocommerce_pre_refresh_order_count_cache' );
+	}
+
+	/**
 	 * Test that refresh cache works.
 	 */
 	public function test_refresh_cache() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a `woocommerce_pre_refresh_order_count_cache` filter to `OrderCountCacheService::refresh_cache()` that allows short-circuiting the scheduled background cache refresh (the flush + `COUNT(*)` query) for a given order type.

On large stores with 100K+ orders, `OrderUtil::get_count_for_type()` runs a `COUNT(*) GROUP BY status` query that takes 50-500ms per order type (longer without HPOS). The background action fires every 12 hours per order type, but if the cache is already warm from incremental updates (new order, status change, trash, delete), flushing and re-counting from scratch is unnecessary work.

The filter is a no-op by default (`false`) so existing behaviour is fully preserved unless a consumer explicitly hooks in. Example usage on WCCOM:

```php
add_filter(
	'woocommerce_pre_refresh_order_count_cache',
	function ( bool $skip, string $order_type, \Automattic\WooCommerce\Caches\OrderCountCache $cache ): bool {
		return $skip || ( null !== $cache->get( $order_type ) );
	},
	10,
	3
);
```

Closes WCCOM-2328.

### How to test the changes in this Pull Request:

1. Hook into the filter returning `true` unconditionally and trigger `woocommerce_refresh_order_count_cache` via Action Scheduler or directly. Confirm `refresh_cache()` returns early - cache is not flushed and no count query runs.
2. Remove the hook (default `false`) and repeat. Confirm the existing flush + `COUNT(*)` behaviour is unchanged.
3. Run existing `OrderCountCacheService` tests and confirm no regressions.

### Testing that has already taken place:

This filter was first shipped as a local patch on WooCommerce.com (a large store with millions of orders) on 2026-02-26 and has been running in production for ~3 weeks.

From Action Scheduler execution logs:

**Before the filter:**
- Execution time per `woocommerce_refresh_order_count_cache` action: ~9-10 seconds per order type (full `COUNT(*)` on a large orders table)

**After the filter (with a hook that skips when cache is warm):**
- Execution time: sub-second for nearly all runs - the filter returns early, no flush or count query runs
- Action Scheduler queue delay for this hook dropped from 23+ minutes to under 60 seconds

Environment: WooCommerce.com, HPOS enabled, millions of orders, multiple order types (`shop_order`, `shop_subscription`, etc.).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Add `woocommerce_pre_refresh_order_count_cache` filter to allow short-circuiting the scheduled background order count cache refresh.

</details>
