### PR TITLE
Prevent margins on empty Store Notices

### DIFF
--- a/plugins/woocommerce/changelog/fix-dont-render-empty-store-notices
+++ b/plugins/woocommerce/changelog/fix-dont-render-empty-store-notices
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Store Notices: Avoid rendering empty Store Notices container
+Store Notices: Remove margins from empty Store Notices container

--- a/plugins/woocommerce/changelog/fix-dont-render-empty-store-notices
+++ b/plugins/woocommerce/changelog/fix-dont-render-empty-store-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Store Notices: Avoid rendering empty Store Notices container

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/store-notices/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/store-notices/index.tsx
@@ -10,6 +10,7 @@ import { totals } from '@woocommerce/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import './style.scss';
 
 registerBlockType( metadata, {
 	icon: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/store-notices/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/store-notices/style.scss
@@ -1,0 +1,4 @@
+.wc-block-store-notices:has(> .woocommerce-notices-wrapper:only-child:empty) {
+	margin-block-start: 0;
+	margin-block-end: 0;
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -41,7 +41,7 @@ class StoreNotices extends AbstractBlock {
 		woocommerce_output_all_notices();
 		$notices = ob_get_clean();
 
-		if ( ! $notices || '' === trim( wp_strip_all_tags( $notices ) ) ) {
+		if ( ! $notices ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -41,7 +41,7 @@ class StoreNotices extends AbstractBlock {
 		woocommerce_output_all_notices();
 		$notices = ob_get_clean();
 
-		if ( ! $notices || '<div class="woocommerce-notices-wrapper"></div>' === $notices ) {
+		if ( ! $notices || '' === trim( wp_strip_all_tags( $notices ) ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -41,7 +41,7 @@ class StoreNotices extends AbstractBlock {
 		woocommerce_output_all_notices();
 		$notices = ob_get_clean();
 
-		if ( ! $notices ) {
+		if ( ! $notices || '<div class="woocommerce-notices-wrapper"></div>' === $notices ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

**Problem:** `woocommerce_output_all_notices()` always outputs a `<div class="woocommerce-notices-wrapper"></div>` wrapper, even when there are no notices. The Store Notices block renders this inside its own wrapper, which carries margins and breaks layouts.
**Solution:** Adds a CSS rule using :has() to collapse margins when the block only contains the empty wrapper div. 

We should preserve the wrapper in the DOM for themes/plugins that injects notices into it.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

In this particular case margins collapse so they don't impact the overall layout but it may in other cases and as you can see, margin is simply there

| Before | After |
| ------ | ----- |
|   <img width="1202" height="624" alt="image" src="https://github.com/user-attachments/assets/9bbf81c5-5cc0-49c5-9e5f-210fa4bb5861" /> | <img width="1209" height="609" alt="image" src="https://github.com/user-attachments/assets/e3a8f34a-6d4c-463a-972f-4f6fe755a31a" />

Margin is there if notice has content:

<img width="1208" height="199" alt="image" src="https://github.com/user-attachments/assets/74bf685b-c340-4327-9408-d20fb6044b07" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

0. Make sure your Single Product templates includes:
- Store Notices
- Classic Add to Cart with Options (new one has dedicated iAPI notices that are not a target of this fix)
2. Go to product page                                                                        
3. Make sure there are no active WooCommerce notices
4. Inspect the page
5. **Expected:** This element renders _without_ `margin-block-start/end`

```
<div data-block-name="woocommerce/store-notices" class="wc-block-store-notices woocommerce alignwide wp-block-woocommerce-store-notices"><div class="woocommerce-notices-wrapper"></div></div>
```                                                          
        
6. In the meantime change the status of one product to out of stock and without refreshing the page, try adding it to cart to trigger the notice
8. **Expected** Notice is displayed correctly and renders _with_ margin            

<img width="1429" height="723" alt="image" src="https://github.com/user-attachments/assets/6ea00283-9aab-413e-98a1-ac7de59f1a33" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
