### PR TITLE
Fix insufficient color contrast for Select2 placeholder text

### DIFF
--- a/plugins/woocommerce/changelog/63751-fix-6409-select2-placeholder-a11y-contrast
+++ b/plugins/woocommerce/changelog/63751-fix-6409-select2-placeholder-a11y-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix insufficient color contrast for Select2 placeholder text to meet WCAG 2.2 AA requirements.

--- a/plugins/woocommerce/client/legacy/css/forms.scss
+++ b/plugins/woocommerce/client/legacy/css/forms.scss
@@ -179,7 +179,7 @@
 			}
 
 			.select2-selection__placeholder {
-				color: #999;
+				color: var(--wc-subtext);
 			}
 
 			.select2-selection__arrow {

--- a/plugins/woocommerce/client/legacy/css/forms.scss
+++ b/plugins/woocommerce/client/legacy/css/forms.scss
@@ -179,7 +179,7 @@
 			}
 
 			.select2-selection__placeholder {
-				color: var(--wc-subtext);
+				color: var(--wc-form-color-text, #444);
 			}
 
 			.select2-selection__arrow {

--- a/plugins/woocommerce/client/legacy/css/select2.scss
+++ b/plugins/woocommerce/client/legacy/css/select2.scss
@@ -194,7 +194,7 @@
 .select2-container--default
 	.select2-selection--single
 	.select2-selection__placeholder {
-	color: #999;
+	color: var(--wc-subtext);
 }
 
 .select2-container--default
@@ -289,7 +289,7 @@
 .select2-container--default
 	.select2-selection--multiple
 	.select2-selection__placeholder {
-	color: #999;
+	color: var(--wc-subtext);
 	margin-top: 5px;
 	float: left;
 }
@@ -530,7 +530,7 @@
 .select2-container--classic
 	.select2-selection--single
 	.select2-selection__placeholder {
-	color: #999;
+	color: var(--wc-subtext);
 }
 
 .select2-container--classic

--- a/plugins/woocommerce/client/legacy/css/select2.scss
+++ b/plugins/woocommerce/client/legacy/css/select2.scss
@@ -194,7 +194,7 @@
 .select2-container--default
 	.select2-selection--single
 	.select2-selection__placeholder {
-	color: var(--wc-subtext);
+	color: #444;
 }
 
 .select2-container--default
@@ -289,7 +289,7 @@
 .select2-container--default
 	.select2-selection--multiple
 	.select2-selection__placeholder {
-	color: var(--wc-subtext);
+	color: #444;
 	margin-top: 5px;
 	float: left;
 }
@@ -530,7 +530,7 @@
 .select2-container--classic
 	.select2-selection--single
 	.select2-selection__placeholder {
-	color: var(--wc-subtext);
+	color: #444;
 }
 
 .select2-container--classic


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Select2 dropdown placeholder text (`.select2-selection__placeholder`) uses a hardcoded color of `#999999` on a white background, resulting in a contrast ratio of 2.84:1. This fails the WCAG 2.2 AA minimum of 4.5:1 (SC 1.4.3).

This PR replaces the hardcoded `#999` with the existing `--wc-subtext` CSS variable (`#767676`, 4.54:1 contrast ratio), which passes WCAG AA and is consistent with how WooCommerce handles muted/secondary text elsewhere.

Four occurrences updated across `select2.scss` (default single, default multiple, classic single) and `forms.scss` (frontend form placeholder).

Before:

<img width="626" height="90" alt="CleanShot 2026-03-18 at 17 58 01@2x" src="https://github.com/user-attachments/assets/e38d7e01-63da-4294-9883-6b9e2b50147c" />

<img width="730" height="164" alt="CleanShot 2026-03-18 at 17 57 55@2x" src="https://github.com/user-attachments/assets/ae07da26-bdce-447b-ba41-907a4e7d6ab5" />

After:

<img width="626" height="100" alt="CleanShot 2026-03-18 at 17 51 47@2x" src="https://github.com/user-attachments/assets/a66ed3e9-dc4e-4f20-95e6-ee03c723d669" />

<img width="744" height="212" alt="CleanShot 2026-03-18 at 17 52 18@2x" src="https://github.com/user-attachments/assets/deb571ae-584e-4340-bd87-b35eb9e2d723" />

Closes https://github.com/woocommerce/woocommerce/issues/63675.

### How to test the changes in this Pull Request:

1. Log in to the WordPress Admin dashboard.
2. Navigate to **WooCommerce > Orders** and observe the "Filter by registered customer" Select2 placeholder text.
3. Navigate to **WooCommerce > Status > Tools** and scroll to "Regenerate the product attributes lookup table" to observe the "Search for a product..." Select2 placeholder.
4. Open DevTools, inspect the placeholder text, and confirm the color is now `#767676` (from the `--wc-subtext` variable) instead of `#999999`.
5. Verify the contrast ratio is at least 4.5:1 against the white background using the DevTools color swatch or [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/?fcolor=767676&bcolor=FFFFFF).
6. Check that the placeholder text is still visually distinct from entered/selected text.
7. Test on a product edit screen with Select2 attribute/category dropdowns to confirm placeholder styling is consistent.

### Testing that has already taken place:

Visual inspection of the CSS diff to confirm all `#999` placeholder color instances are replaced with the `--wc-subtext` variable.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix insufficient color contrast for Select2 placeholder text to meet WCAG 2.2 AA requirements.

</details>