### PR TITLE
Performance: lazy-load _used_by meta in WC_Coupon to fix memory exhaustion on high-usage coupons

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6370-wc_coupon-construct-and-_used_by-meta
+++ b/plugins/woocommerce/changelog/wooplug-6370-wc_coupon-construct-and-_used_by-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Lazy-load _used_by post meta in WC_Coupon to avoid loading all usage records into memory on construction.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -50,7 +50,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		'minimum_amount'              => '',
 		'maximum_amount'              => '',
 		'email_restrictions'          => array(),
-		'used_by'                     => array(),
+		'used_by'                     => null,
 		'virtual'                     => false,
 	);
 
@@ -152,6 +152,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_data() {
+		// Ensure used_by is populated before the raw data array is returned, since
+		// parent::get_data() reads $this->data directly and bypasses get_used_by().
+		$this->get_used_by();
 		$data = parent::get_data();
 		if ( '' === $data['minimum_amount'] ) {
 			$data['minimum_amount'] = '0';
@@ -455,11 +458,22 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Get records of all users who have used the current coupon.
 	 *
+	 * The list is loaded lazily on first access rather than during object construction,
+	 * because a coupon with hundreds of thousands of usages would otherwise allocate an
+	 * enormous PHP array on every WC_Coupon instantiation — even for code paths such as
+	 * order-status changes or cart validation that never need this data.
+	 *
 	 * @since  3.0.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
 	 * @return array
 	 */
 	public function get_used_by( $context = 'view' ) {
+		if ( is_null( $this->data['used_by'] ) ) {
+			// Bypass set_prop() so the lazy fetch does not mark the object as dirty.
+			$this->data['used_by'] = $this->get_id()
+				? array_filter( (array) get_post_meta( $this->get_id(), '_used_by', false ) )
+				: array();
+		}
 		return $this->get_prop( 'used_by', $context );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -154,7 +154,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function get_data() {
 		// Ensure used_by is populated before the raw data array is returned, since
 		// parent::get_data() reads $this->data directly and bypasses get_used_by().
-		$this->get_used_by();
+		$this->get_used_by( 'edit' );
 		$data = parent::get_data();
 		if ( '' === $data['minimum_amount'] ) {
 			$data['minimum_amount'] = '0';

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -144,7 +144,6 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 				'minimum_amount'              => get_post_meta( $coupon_id, 'minimum_amount', true ),
 				'maximum_amount'              => get_post_meta( $coupon_id, 'maximum_amount', true ),
 				'email_restrictions'          => array_filter( (array) get_post_meta( $coupon_id, 'customer_email', true ) ),
-				'used_by'                     => array_filter( (array) get_post_meta( $coupon_id, '_used_by' ) ),
 			)
 		);
 		$coupon->read_meta_data();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes a severe memory exhaustion issue on stores where a single coupon has been used a very large number of times (e.g. 323K usages).

**Root cause:** `WC_Coupon_Data_Store_CPT::read()` called `get_post_meta($id, '_used_by')` (no `$single` arg, so it returns all rows as a PHP array) unconditionally during every `WC_Coupon` construction. On a coupon with 323K usages that's 323K rows loaded into memory — even for code paths like order status changes, cart validation, and admin edits that never touch the `used_by` list. This caused PHP to exhaust its memory limit and crash the request.

**Fix:** Defer the `_used_by` fetch until `get_used_by()` is actually called (lazy-load), following the same `null`-as-sentinel pattern already used by `WC_Data::$meta_data`.

- `$data['used_by']` default changed from `array()` to `null` (sentinel meaning "not yet fetched")
- `get_used_by()` populates `$this->data['used_by']` directly on first access, bypassing `set_prop()` so the lazy fetch does not mark the object dirty
- `get_data()` triggers the lazy load before returning the raw `$this->data` array, so REST API responses (`used_by` field) continue to work correctly
- Removed `'used_by' => get_post_meta(...)` from the `set_props()` call in `WC_Coupon_Data_Store_CPT::read()`

Closes #WOOPLUG-6370.

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Install WooCommerce on a site with a database that has a coupon with a very large number of `_used_by` postmeta rows (or simulate by inserting many rows: `INSERT INTO wp_postmeta (post_id, meta_key, meta_value) SELECT <coupon_id>, '_used_by', CONCAT('user', seq) FROM ...`).
2. Trigger an order status change (e.g. pending → processing) for an order that uses that coupon.
3. **Before this fix:** PHP memory exhaustion / fatal error.
4. **After this fix:** Request completes successfully; no extra memory allocated for `_used_by` during construction.
5. Verify the REST API still returns the `used_by` array correctly: `GET /wp-json/wc/v3/coupons/<id>` should include the full `used_by` list.
6. Verify that applying and removing a coupon in the cart still works end-to-end.

### Testing that has already taken place:

- PHPUnit test suite for `WC_Coupon` (11 tests, 22 assertions — all pass)
- PHPUnit test suite for `WC_Tests_Coupon_Data_Store` (11 tests, 33 assertions — all pass)
- PHP linting via `phpcs-changed` — no errors or warnings

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry has been created manually and pushed in the branch.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Performance - Address performance issues

#### Message

Lazy-load _used_by post meta in WC_Coupon to avoid loading all usage records into memory on construction.

</details>