### PR TITLE
Ensure cart/checkout blocks preview correctly in all post block editors

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5024-cart-block-data-missing-in-custom-editors
+++ b/plugins/woocommerce/changelog/wooplug-5024-cart-block-data-missing-in-custom-editors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Cart and Checkout block editor detection for post-new.php and other custom editor contexts.

--- a/plugins/woocommerce/client/blocks/assets/js/data/utils/is-editor.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/utils/is-editor.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getPath } from '@wordpress/url';
+import { select } from '@wordpress/data';
 
 /**
  * Returns true if the current page is in the editor.
@@ -10,6 +11,7 @@ export const isEditor = (): boolean => {
 	return (
 		getPath( window.location.href )?.includes( 'site-editor.php' ) ||
 		getPath( window.location.href )?.includes( 'post.php' ) ||
+		!! select( 'core/editor' ) ||
 		false
 	);
 };

--- a/plugins/woocommerce/client/blocks/tests/js/config/global-mocks.js
+++ b/plugins/woocommerce/client/blocks/tests/js/config/global-mocks.js
@@ -368,3 +368,12 @@ if ( ! window.DOMRect ) {
 jest.mock( 'client-zip', () => ( {
 	downloadZip: jest.fn(),
 } ) );
+
+/**
+ * Mock isEditor to return false by default in tests, since the core/editor
+ * store may be registered in the test environment without an actual editor
+ * context. Individual tests can override this mock if needed.
+ */
+jest.mock( '../../../assets/js/data/utils/is-editor', () => ( {
+	isEditor: jest.fn().mockReturnValue( false ),
+} ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR ensures that the `isEditor()` utility function used in blocks to determine whether the current page is an editor context also considers the presence of the `core/editor` data store, making the detection a bit more URL agnostic.

This, in particular, makes preview data available in `post-new.php`, which wasn't supported.

Closes WOOPLUG-5024.

> [!IMPORTANT]
> Beyond **Posts > New** I couldn't find any other location where we would normally render the cart/checkout block in "editor context". I wonder if we should simply add `post-new.php` to the checks instead of relying on `core/editor`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Ensure your cart session doesn't have any products.
1. Go to **Posts > Add New** and insert a **Cart** block or **Checkout** block.
1. Confirm both render preview data.
   <img width="419" height="283" alt="Screenshot 2026-03-19 at 19 43 07" src="https://github.com/user-attachments/assets/161c2e8d-f5eb-4a06-8a2c-97876ca21214" />
1. Open the **Cart** page in the admin for editing. Confirm the cart block shows preview data.
1. Open the **Checkout** page in the admin for editing. Confirm the checkout block shows preview data.
1. Go to **Appearance > Editor** and navigate to the **Cart** page. Confirm the cart block shows preview data.
1. Go to **Appearance > Editor** and navigate to the **Checkout** page. Confirm the checkout block shows preview data.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.