### PR TITLE
Allow product image URLs with non-ASCII characters in cart/checkout blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-59043
+++ b/plugins/woocommerce/changelog/fix-59043
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Cart/Checkout blocks not displaying product images with non-ASCII filenames.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -122,13 +122,13 @@ class CartItemSchema extends ItemSchema {
 			}
 
 			// Check if thumbnail is a valid url.
-			if ( empty( $image->thumbnail ) || ! filter_var( $image->thumbnail, FILTER_VALIDATE_URL ) ) {
+			if ( empty( $image->thumbnail ) || ! wp_parse_url( $image->thumbnail, PHP_URL_HOST ) ) {
 				$logger->warning( sprintf( 'After passing through woocommerce_cart_item_images filter, image with id %s did not have a valid thumbnail property.', $image->id ) );
 				continue;
 			}
 
 			// Check if src is a valid url.
-			if ( empty( $image->src ) || ! filter_var( $image->src, FILTER_VALIDATE_URL ) ) {
+			if ( empty( $image->src ) || ! wp_parse_url( $image->src, PHP_URL_HOST ) ) {
 				$logger->warning( sprintf( 'After passing through woocommerce_cart_item_images filter, image with id %s did not have a valid src property.', $image->id ) );
 				continue;
 			}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Cart and Checkout blocks don't display product images whose filenames contain non-ASCII characters because URL validation for those images is currently implemented via `filter_var()` which rejects URLs with unicode.

This PR replaces it with `wp_parse_url()` for a more permissive validation.

Despite the [suggestion on the original issue to use `wp_http_validate_url()`](https://github.com/woocommerce/woocommerce/issues/59043#issuecomment-3004713197) I decided to go with `wp_parse_url()` because the former has some IP and port restrictions, which I don't think are necessary for validating image URLs for display, but happy to reconsider if necessary.

Closes #59043.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Rename (if necessary) an image locally so it has non-ASCII characters. Example: `호랑이.jpg`.
1. Either create a new product in **Products** (admin) or edit an existing one, and upload the image from the previous step as **Featured image**.
1. Upload any other image (with ASCII filename) to teh **Product gallery**.
1. Go to the frontend and add this product to the cart.
1. Go to the cart page.
1. The image you chose as featured image should be shown.
1. Click **Proceed to Checkout** and confirm the image is also shown here.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.