### PR TITLE
[WOOPLUG-6354] Fix fulfillment email subject plural form for multiple items

### DIFF
--- a/plugins/woocommerce/changelog/63765-wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
+++ b/plugins/woocommerce/changelog/63765-wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fulfillment created email subject and heading to use correct plural form when shipment contains multiple items.

--- a/plugins/woocommerce/changelog/wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
+++ b/plugins/woocommerce/changelog/wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix fulfillment created email subject and heading to use correct plural form when shipment contains multiple items.

--- a/plugins/woocommerce/changelog/wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
+++ b/plugins/woocommerce/changelog/wooplug-6354-order-fulfillments-email-subject-line-doesnt-use-correct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fulfillment created email subject and heading to use correct plural form when shipment contains multiple items.

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -87,12 +87,26 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 		}
 
 		/**
+		 * Get the number of items in the fulfillment.
+		 *
+		 * @since 10.7.0
+		 * @return int
+		 */
+		private function get_fulfillment_item_count() {
+			return $this->fulfillment ? count( $this->fulfillment->get_items() ) : 1;
+		}
+
+		/**
 		 * Get email subject.
 		 *
 		 * @since  3.1.0
+		 * @since  10.7.0 Added plural form for multi-item fulfillments.
 		 * @return string
 		 */
 		public function get_default_subject() {
+			if ( $this->get_fulfillment_item_count() > 1 ) {
+				return __( 'Items from {site_title} order {order_number} have been fulfilled!', 'woocommerce' );
+			}
 			return __( 'An item from {site_title} order {order_number} has been fulfilled!', 'woocommerce' );
 		}
 
@@ -100,9 +114,13 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 		 * Get email heading.
 		 *
 		 * @since  3.1.0
+		 * @since  10.7.0 Added plural form for multi-item fulfillments.
 		 * @return string
 		 */
 		public function get_default_heading() {
+			if ( $this->get_fulfillment_item_count() > 1 ) {
+				return __( 'Your items are on the way!', 'woocommerce' );
+			}
 			return __( 'Your item is on the way!', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -87,13 +87,22 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 		}
 
 		/**
-		 * Get the number of items in the fulfillment.
+		 * Get the total quantity of items in the fulfillment.
 		 *
-		 * @since 10.7.0
 		 * @return int
 		 */
 		private function get_fulfillment_item_count() {
-			return $this->fulfillment ? count( $this->fulfillment->get_items() ) : 1;
+			if ( ! $this->fulfillment ) {
+				return 1;
+			}
+
+			return array_reduce(
+				$this->fulfillment->get_items(),
+				function ( int $carry, array $item ) {
+					return $carry + (int) $item['qty'];
+				},
+				0
+			);
 		}
 
 		/**

--- a/plugins/woocommerce/templates/emails/email-fulfillment-details.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.0
+ * @version 10.7.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -39,7 +39,7 @@ if ( null === $fulfillment->get_date_deleted() ) {
 	echo wp_kses_post(
 		sprintf(
 			/* translators: %s: Link to My Account > Orders page. */
-			__( 'You can access to more details of your order by visiting <a href="%s" target="_blank">My Account > Orders</a> and select the order you wish to see the latest status of the delivery.', 'woocommerce' ),
+			__( 'You can access more details of your order by visiting <a href="%s" target="_blank">My Account > Orders</a>, and selecting the order you wish to see the latest status for.', 'woocommerce' ),
 			site_url( 'my-account/orders/' )
 		)
 	);

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-fulfillment-created-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-fulfillment-created-test.php
@@ -134,6 +134,55 @@ class WC_Email_Customer_Fulfillment_Created_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Default subject uses plural form when one item has multiple quantity.
+	 */
+	public function test_default_subject_plural_for_single_item_multiple_qty(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 3,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$subject = $this->sut->get_default_subject();
+
+		$this->assertStringContainsString( 'Items', $subject, 'Subject should use plural form when single item has qty > 1' );
+		$this->assertStringNotContainsString( 'An item', $subject, 'Subject should not contain singular form when single item has qty > 1' );
+	}
+
+	/**
+	 * @testdox Default heading uses plural form when one item has multiple quantity.
+	 */
+	public function test_default_heading_plural_for_single_item_multiple_qty(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 2,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$heading = $this->sut->get_default_heading();
+
+		$this->assertStringContainsString( 'Your items are on the way!', $heading, 'Heading should use plural form when single item has qty > 1' );
+	}
+
+	/**
 	 * @testdox Default subject uses singular form when no fulfillment is set.
 	 */
 	public function test_default_subject_singular_when_no_fulfillment(): void {

--- a/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-fulfillment-created-test.php
+++ b/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-fulfillment-created-test.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\Admin\Features\Fulfillments\Fulfillment;
+
+/**
+ * WC_Email_Customer_Fulfillment_Created test.
+ *
+ * @covers WC_Email_Customer_Fulfillment_Created
+ */
+class WC_Email_Customer_Fulfillment_Created_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Email_Customer_Fulfillment_Created
+	 */
+	private $sut;
+
+	/**
+	 * Load up the email classes since they aren't loaded by default.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email.php';
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email-customer-fulfillment-created.php';
+	}
+
+	/**
+	 * @testdox Default subject uses singular form when fulfillment has one item.
+	 */
+	public function test_default_subject_singular_for_one_item(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 1,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$subject = $this->sut->get_default_subject();
+
+		$this->assertStringContainsString( 'An item', $subject, 'Subject should use singular form for single item fulfillment' );
+	}
+
+	/**
+	 * @testdox Default subject uses plural form when fulfillment has multiple items.
+	 */
+	public function test_default_subject_plural_for_multiple_items(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 1,
+				),
+				array(
+					'item_id' => 2,
+					'qty'     => 1,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$subject = $this->sut->get_default_subject();
+
+		$this->assertStringContainsString( 'Items', $subject, 'Subject should use plural form for multi-item fulfillment' );
+		$this->assertStringNotContainsString( 'An item', $subject, 'Subject should not contain singular form for multi-item fulfillment' );
+	}
+
+	/**
+	 * @testdox Default heading uses singular form when fulfillment has one item.
+	 */
+	public function test_default_heading_singular_for_one_item(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 1,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$heading = $this->sut->get_default_heading();
+
+		$this->assertStringContainsString( 'Your item is on the way!', $heading, 'Heading should use singular form for single item fulfillment' );
+	}
+
+	/**
+	 * @testdox Default heading uses plural form when fulfillment has multiple items.
+	 */
+	public function test_default_heading_plural_for_multiple_items(): void {
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 1,
+				),
+				array(
+					'item_id' => 2,
+					'qty'     => 1,
+				),
+			)
+		);
+
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+		$this->sut->trigger( $order->get_id(), $fulfillment, $order );
+
+		$heading = $this->sut->get_default_heading();
+
+		$this->assertStringContainsString( 'Your items are on the way!', $heading, 'Heading should use plural form for multi-item fulfillment' );
+	}
+
+	/**
+	 * @testdox Default subject uses singular form when no fulfillment is set.
+	 */
+	public function test_default_subject_singular_when_no_fulfillment(): void {
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+
+		$subject = $this->sut->get_default_subject();
+
+		$this->assertStringContainsString( 'An item', $subject, 'Subject should default to singular form when no fulfillment is set' );
+	}
+
+	/**
+	 * @testdox Default heading uses singular form when no fulfillment is set.
+	 */
+	public function test_default_heading_singular_when_no_fulfillment(): void {
+		$this->sut = new WC_Email_Customer_Fulfillment_Created();
+
+		$heading = $this->sut->get_default_heading();
+
+		$this->assertStringContainsString( 'Your item is on the way!', $heading, 'Heading should default to singular form when no fulfillment is set' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

When a fulfillment notification email is sent for a shipment containing multiple items, the email subject line incorrectly reads "An item from {site_title} order {order_number} has been fulfilled!" and the heading reads "Your item is on the way!" regardless of the item count.

This PR updates the `WC_Email_Customer_Fulfillment_Created` class to dynamically choose between singular and plural forms based on the number of items in the fulfillment:

- **1 item (singular):** "An item from {site_title} order {order_number} has been fulfilled!" / "Your item is on the way!"
- **2+ items (plural):** "Items from {site_title} order {order_number} have been fulfilled!" / "Your items are on the way!"

Closes https://github.com/woocommerce/woocommerce/issues/63468.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order with multiple line items (e.g. 2 or more different products).
2. Create a fulfillment for that order containing 2+ items.
3. Mark the fulfillment as Fulfilled with customer notification enabled.
4. Check the email subject line: it should now say "Items from {site_title} order {order_number} have been fulfilled!" and the heading should say "Your items are on the way!"
5. Repeat with a fulfillment containing only 1 item: the subject should say "An item from..." and heading "Your item is on the way!"

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- 6 unit tests covering singular, plural, and no-fulfillment-set cases for both subject and heading. All pass.
- PHPStan analysis passes with no errors.
- PHP linting passes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix fulfillment created email subject and heading to use correct plural form when shipment contains multiple items.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>