### PR TITLE
Add description for COD enable_for_methods field in v4 settings API

### DIFF
--- a/plugins/woocommerce/changelog/63767-update-cod-enable-for-methods-description
+++ b/plugins/woocommerce/changelog/63767-update-cod-enable-for-methods-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add description for COD enable_for_methods field in v4 settings API.

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Schema/CodGatewaySettingsSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Settings/PaymentGateways/Schema/CodGatewaySettingsSchema.php
@@ -71,7 +71,7 @@ class CodGatewaySettingsSchema extends AbstractPaymentGatewaySettingsSchema {
 			'enable_for_methods' => array(
 				'label'   => __( 'Available for shipping methods', 'woocommerce' ),
 				'type'    => 'multiselect',
-				'desc'    => '',
+				'desc'    => __( 'Choose which shipping methods support Cash on delivery.', 'woocommerce' ),
 				'options' => $this->load_shipping_method_options(),
 			),
 			'enable_for_virtual' => array(


### PR DESCRIPTION
## Motivation

The `enable_for_methods` field in the COD (Cash on Delivery) payment gateway's v4 settings API schema was returning an empty description string. All other fields in the COD schema have descriptive help text that explains their purpose.

This was identified while building the CIAB admin's COD settings page, where the description is displayed below the shipping methods selector.

## Changes

Add a description to the `enable_for_methods` field in `CodGatewaySettingsSchema.php`:

> "Choose which shipping methods support Cash on delivery."

This aligns with the design specifications and is consistent with how other fields in the schema provide contextual help text.

## Testing

1. Make a GET request to `/wc/v4/settings/payment-gateways/cod`
2. Find the `enable_for_methods` field in the `settings` group
3. Verify `desc` is now `"Choose which shipping methods support Cash on delivery."` instead of an empty string

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add description for COD enable_for_methods field in v4 settings API.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>