### PR TITLE
Disable Real-time Collaboration in the email editor

### DIFF
--- a/packages/js/email-editor/changelog/stomail-7892-turn-off-real-time-collaboration-in-email-editor
+++ b/packages/js/email-editor/changelog/stomail-7892-turn-off-real-time-collaboration-in-email-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable Real-time Collaboration in the email editor

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -110,6 +110,11 @@ function disableCollab() {
 	) {
 		return;
 	}
+
+	if ( window._wpCollaborationEnabled ) {
+		window._wpCollaborationEnabled = false;
+	}
+
 	addFilter(
 		'sync.providers',
 		'woocommerce/email-editor/disable-collab',

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -9,7 +9,7 @@ import {
 	useState,
 	useMemo,
 } from '@wordpress/element';
-import { addFilter, applyFilters } from '@wordpress/hooks';
+import { addFilter, applyFilters, hasFilter } from '@wordpress/hooks';
 import { store as editorStore } from '@wordpress/editor';
 import { useMergeRefs } from '@wordpress/compose';
 import '@wordpress/format-library'; // Enables text formatting capabilities
@@ -105,6 +105,11 @@ function Editor( {
  * yet fully support it, so we temporarily opt out by clearing sync providers.
  */
 function disableCollab() {
+	if (
+		hasFilter( 'sync.providers', 'woocommerce/email-editor/disable-collab' )
+	) {
+		return;
+	}
 	addFilter(
 		'sync.providers',
 		'woocommerce/email-editor/disable-collab',

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -9,7 +9,7 @@ import {
 	useState,
 	useMemo,
 } from '@wordpress/element';
-import { applyFilters } from '@wordpress/hooks';
+import { addFilter, applyFilters } from '@wordpress/hooks';
 import { store as editorStore } from '@wordpress/editor';
 import { useMergeRefs } from '@wordpress/compose';
 import '@wordpress/format-library'; // Enables text formatting capabilities
@@ -100,7 +100,21 @@ function Editor( {
 	);
 }
 
+/**
+ * WordPress 7.0 introduces Real-time Collaboration. The email editor does not
+ * yet fully support it, so we temporarily opt out by clearing sync providers.
+ */
+function disableCollab() {
+	addFilter(
+		'sync.providers',
+		'woocommerce/email-editor/disable-collab',
+		() => [],
+		1000
+	);
+}
+
 function onInit() {
+	disableCollab();
 	initEventCollector();
 	initStoreTracking();
 	initDomTracking();

--- a/packages/js/email-editor/src/global.d.ts
+++ b/packages/js/email-editor/src/global.d.ts
@@ -1,4 +1,5 @@
 interface Window {
+	_wpCollaborationEnabled?: boolean;
 	WooCommerceEmailEditor: {
 		current_wp_user_email: string;
 		user_theme_post_id: number;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WordPress 7.0 introduces Real-time Collaboration. The email editor does not yet fully support it, so this PR temporarily opts out by clearing sync providers via the `sync.providers` filter.

The filter is registered in `onInit()` — before any React components mount — to ensure it takes effect before the editor reads the provider list.

Related to [STOMAIL-7892: Turn off real-time collaboration in email editor](https://linear.app/a8c/issue/STOMAIL-7892/turn-off-real-time-collaboration-in-email-editor).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1254" height="830" alt="DTicwOJiQfm9Fm1X" src="https://github.com/user-attachments/assets/d75776ae-ece1-4c4b-b084-8463e151361a" /> | <img width="1254" height="830" alt="RFCelBBFrqcUWSTV" src="https://github.com/user-attachments/assets/b5b727b1-3654-45b0-90c6-38190d43591b" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Update your test environment to WordPress version that has the Real-time collaboration feature available, i.e `> 7.0-beta3`.
2. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
`woocommerce/email-content`, or refresh your instance so that the emails are created with the correct block name.
3. Open an email in the editor WooCommerce → Settings → **Emails**
4. Open a secondary tab with the email editor for the same email.
5. Confirm the real time collaboration is not being used.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
