### PR TITLE
Add cache priming to AJAX downloadable search, scheduled sales, and recent reviews widget

### DIFF
--- a/plugins/woocommerce/changelog/63773-add-cache-priming-misc
+++ b/plugins/woocommerce/changelog/63773-add-cache-priming-misc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Add missing `_prime_post_caches()` calls in AJAX downloadable product search, scheduled sales processing, and Recent Reviews widget to batch-load post data and reduce individual database queries.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1867,6 +1867,7 @@ class WC_AJAX {
 		$data_store = WC_Data_Store::load( 'product' );
 		$ids        = $data_store->search_products( $term, 'downloadable', true, false, $limit );
 
+		_prime_post_caches( $ids );
 		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );
 		$products        = array();
 

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -796,6 +796,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to start.
 	$product_ids = $data_store->get_starting_sales();
 	if ( $product_ids ) {
+		_prime_post_caches( $product_ids );
 		$must_refresh_transient = true;
 		do_action( 'wc_before_products_starting_sales', $product_ids );
 
@@ -817,6 +818,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to end.
 	$product_ids = $data_store->get_ending_sales();
 	if ( $product_ids ) {
+		_prime_post_caches( $product_ids );
 		$must_refresh_transient = true;
 		do_action( 'wc_before_products_ending_sales', $product_ids );
 

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
@@ -59,11 +59,11 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 		$number   = ! empty( $instance['number'] ) ? absint( $instance['number'] ) : $this->settings['number']['std'];
 		$comments = get_comments(
 			array(
-				'number'                  => $number,
-				'status'                  => 'approve',
-				'post_status'             => 'publish',
-				'post_type'               => 'product',
-				'parent'                  => 0,
+				'number'                    => $number,
+				'status'                    => 'approve',
+				'post_status'               => 'publish',
+				'post_type'                 => 'product',
+				'parent'                    => 0,
 				'update_comment_post_cache' => true,
 			)
 		); // WPCS: override ok.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-recent-reviews.php
@@ -59,11 +59,12 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 		$number   = ! empty( $instance['number'] ) ? absint( $instance['number'] ) : $this->settings['number']['std'];
 		$comments = get_comments(
 			array(
-				'number'      => $number,
-				'status'      => 'approve',
-				'post_status' => 'publish',
-				'post_type'   => 'product',
-				'parent'      => 0,
+				'number'                  => $number,
+				'status'                  => 'approve',
+				'post_status'             => 'publish',
+				'post_type'               => 'product',
+				'parent'                  => 0,
+				'update_comment_post_cache' => true,
 			)
 		); // WPCS: override ok.
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds `_prime_post_caches()` calls and the `update_comment_post_cache` parameter to batch-load post data before loops that individually load products via `wc_get_product()` in three files:

- **`class-wc-ajax.php`** — AJAX downloadable product search loads each product individually when granting download permissions on an order. Priming batch-loads all matched products in a single query.
- **`wc-product-functions.php`** — `wc_scheduled_sales()` processes products whose sales are starting or ending. Priming batch-loads all affected products before the processing loop.
- **`class-wc-widget-recent-reviews.php`** — The Recent Reviews widget loads each reviewed product individually. Passing `update_comment_post_cache => true` to `get_comments()` batch-loads all associated product posts.

Part of https://github.com/woocommerce/woocommerce/issues/63719

### How to test the changes in this Pull Request:

#### 1. AJAX downloadable product search (`class-wc-ajax.php`)

1. Create 20 downloadable products (or use existing ones):
   ```bash
   for i in $(seq 1 20); do wp wc product create --name="Downloadable Product $i" --type=simple --regular_price="9.99" --downloadable=true --virtual=true --user=1; done
   ```
2. Add a temporary debug line in `class-wc-ajax.php` at line 1878, right before `wp_send_json( $products );` in `json_search_downloadable_products_and_variations()`:
   ```php
   global $wpdb;
   error_log( 'Downloadable search query count: ' . $wpdb->num_queries );
   ```
3. Go to **WooCommerce > Orders**, edit an order, open the **Downloadable product permissions** section, and search for a product.
4. Check `debug.log` for the query count.
5. Remove the `_prime_post_caches()` call from the function, repeat the search, and compare.
6. **Expected:** ~48% reduction in queries (measured: 119 → 62 with 20 downloadable products).

#### 2. Scheduled sales (`wc-product-functions.php`)

We'll use a mu-plugin to test:

1. Create the file `wp-content/mu-plugins/test-scheduled-sales.php`:
   ```php
   <?php
   // Usage: /wp-admin/?test-sales=starting  or  /wp-admin/?test-sales=ending
   add_action( 'admin_init', function() {
       $mode = sanitize_text_field( $_GET['test-sales'] ?? '' );
       if ( ! in_array( $mode, array( 'starting', 'ending' ), true ) ) {
           return;
       }

       global $wpdb;

       $product_ids = $wpdb->get_col(
           "SELECT ID FROM {$wpdb->posts}
           WHERE post_type = 'product' AND post_status = 'publish'
           LIMIT 10"
       );

       if ( empty( $product_ids ) ) {
           wp_die( 'No products found.' );
       }

       $now = time() - 60;

       foreach ( $product_ids as $id ) {
           update_post_meta( $id, '_regular_price', '9.99' );
           update_post_meta( $id, '_sale_price', '4.99' );
           if ( 'starting' === $mode ) {
               update_post_meta( $id, '_price', '9.99' );
               update_post_meta( $id, '_sale_price_dates_from', (string) $now );
               update_post_meta( $id, '_sale_price_dates_to', '' );
           } else {
               update_post_meta( $id, '_price', '4.99' );
               update_post_meta( $id, '_sale_price_dates_from', '' );
               update_post_meta( $id, '_sale_price_dates_to', (string) $now );
           }
       }

       wp_cache_flush();

       $q_before = $wpdb->num_queries;
       wc_scheduled_sales();
       $q_after  = $wpdb->num_queries;

       wp_die( "wc_scheduled_sales() {$mode} queries: " . ( $q_after - $q_before ) . ' for ' . count( $product_ids ) . ' products' );
   });
   ```
2. **Starting sales:** Visit `/wp-admin/?test-sales=starting` and note the query count. Remove `_prime_post_caches( $product_ids );` at line 799 in `wc-product-functions.php`, reload, and compare.
3. **Expected (starting sales):** ~27 fewer queries with 10 products (measured: 626 → 599).
4. **Ending sales:** Visit `/wp-admin/?test-sales=ending` and note the query count. Remove `_prime_post_caches( $product_ids );` at line 821 in `wc-product-functions.php`, reload, and compare.
5. **Expected (ending sales):** ~13 fewer queries with 10 products (measured: 644 → 631).
6. Delete the mu-plugin after testing.

#### 3. Recent Reviews widget (`class-wc-widget-recent-reviews.php`)

1. Ensure you have product reviews (add reviews on several different products).
2. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) and [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) plugins.
3. Activate a classic theme (e.g., Storefront). Go to **Appearance > Widgets** and add the **Recent Product Reviews** widget to a sidebar.
4. Visit a frontend page where the widget is displayed.
5. Open **Query Monitor** and note the total query count.
6. Remove the `'update_comment_post_cache' => true,` line from `class-wc-widget-recent-reviews.php`, reload the page, and compare.
7. **Expected:** ~1 fewer query per review displayed (measured: 97 → 92 with 7 reviews).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Performance - Address performance issues

#### Message
Add missing `_prime_post_caches()` calls in AJAX downloadable product search, scheduled sales processing, and Recent Reviews widget to batch-load post data and reduce individual database queries.

</details>