### PR TITLE
Fix styling issues with WordPress 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-7.0-issues
+++ b/plugins/woocommerce/changelog/fix-7.0-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix styling issues with WP 7.0

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8304,6 +8304,10 @@ table.bar_chart {
 		.select2-selection--multiple {
 			min-height: 40px;
 			height: 38px;
+
+			.select2-selection__rendered li {
+				margin-top: 0;
+			}
 		}
 
 		.select2-search--inline .select2-search__field {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8360,6 +8360,17 @@ table.bar_chart {
 			padding-right: 0;
 		}
 	}
+
+	// Publish box: WP 7.0 flex-row breaks layout when #duplicate-action is present.
+	// Revert to block + float to stack copy/trash links on the left, button on the right.
+	#major-publishing-actions {
+		display: block;
+		overflow: hidden;
+
+		#delete-action {
+			float: left;
+		}
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8379,6 +8379,11 @@ table.bar_chart {
 		padding-top: 8px;
 	}
 
+	// Help tips: vertically center with taller WP 7.0 inputs.
+	.woocommerce_options_panel .form-field .woocommerce-help-tip {
+		margin-top: 12px;
+	}
+
 	// Search box select: match WP 7.0 compact search-box sizing (32px).
 	.search-box select {
 		min-height: 32px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8415,6 +8415,10 @@ table.bar_chart {
 			border-radius: 2px;
 		}
 	}
+
+	#variable_product_options .form-row select {
+		height: 50px;
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8402,6 +8402,10 @@ table.bar_chart {
 			width: 55%;
 		}
 
+		input[type="number"] {
+			padding-right: 0;
+		}
+
 		.dimensions_field .wrap {
 			width: 55%;
 			border-radius: 2px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8371,6 +8371,20 @@ table.bar_chart {
 			float: left;
 		}
 	}
+
+	// Product data panel labels: vertically center with taller WP 7.0 inputs.
+	.woocommerce_options_panel p.form-field label,
+	.woocommerce_options_panel fieldset.form-field label,
+	.woocommerce_options_panel fieldset.form-field legend {
+		padding-top: 8px;
+	}
+
+	// Search box select: match WP 7.0 compact search-box sizing (32px).
+	.search-box select {
+		min-height: 32px;
+		line-height: 2.14285714; /* 30px for 32px height */
+		padding: 0 24px 0 8px;
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8282,6 +8282,60 @@ table.bar_chart {
 }
 
 /**
+ * WP 7.0+ compatibility.
+ * WP 7.0 increased default form element sizing from 30px to 40px min-height.
+ */
+.wc-wp-version-gte-70 {
+	// Select2 single: match WP 7.0 native select height (40px).
+	.select2-container {
+		.select2-selection--single {
+			height: 40px;
+			border-radius: 2px;
+
+			.select2-selection__rendered {
+				line-height: 38px;
+			}
+
+			.select2-selection__arrow {
+				height: 38px;
+			}
+		}
+
+		.select2-selection--multiple {
+			min-height: 40px;
+		}
+
+		.select2-search--inline .select2-search__field {
+			min-height: 38px;
+		}
+	}
+}
+
+// Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
+// Match Select2 to 32px here (not the global 40px).
+// These page classes are on the body alongside wc-wp-version-gte-70, so use compound selectors.
+.wc-wp-version-gte-70.woocommerce_page_wc-customer-stock-notifications .tablenav,
+.wc-wp-version-gte-70.woocommerce_page_wc-orders .tablenav,
+.wc-wp-version-gte-70.post-type-product .tablenav,
+.wc-wp-version-gte-70.post-type-shop_order .tablenav {
+	.select2-container {
+		margin-top: 0;
+	}
+
+	.select2-container .select2-selection--single {
+		height: 32px;
+
+		.select2-selection__rendered {
+			line-height: 30px;
+		}
+
+		.select2-selection__arrow {
+			height: 30px;
+		}
+	}
+}
+
+/**
   * Select2 colors for built-in admin color themes.
   */
 .wp-admin {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8303,6 +8303,7 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 40px;
+			height: 38px;
 		}
 
 		.select2-search--inline .select2-search__field {
@@ -8389,6 +8390,22 @@ table.bar_chart {
 		min-height: 32px;
 		line-height: 2.14285714; /* 30px for 32px height */
 		padding: 0 24px 0 8px;
+	}
+
+	// Short inputs are wider to compensate for WP 7.0 increased padding.
+	.woocommerce_options_panel {
+		.short,
+		input[type="text"].short,
+		input[type="number"].short,
+		input[type="email"].short,
+		input[type="password"].short {
+			width: 55%;
+		}
+
+		.dimensions_field .wrap {
+			width: 55%;
+			border-radius: 2px;
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8421,6 +8421,11 @@ table.bar_chart {
 	#variable_product_options .form-row select {
 		height: 50px;
 	}
+
+	// Variable product low stock row: clear preceding floats to prevent vertical stretching.
+	#variable_product_options .form-row[class*="variable_low_stock_amount"] {
+		clear: both;
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8289,8 +8289,8 @@ table.bar_chart {
 	// Select2 single: match WP 7.0 native select height (40px).
 	.select2-container {
 		.select2-selection--single {
-			height: 40px;
-			border-radius: 2px;
+			height: 40px; // Match WP 7.0 native select height.
+			border-radius: 2px; // Match WP 7.0 native select border-radius.
 
 			.select2-selection__rendered {
 				line-height: 38px;
@@ -8306,7 +8306,7 @@ table.bar_chart {
 			height: 38px;
 
 			.select2-selection__rendered li {
-				margin-top: 0;
+				margin-top: 0; // Prevent extra spacing inside multi-select.
 			}
 		}
 
@@ -8354,6 +8354,7 @@ table.bar_chart {
 		}
 	}
 
+	// Order actions button margin causes overflow with WP 7.0 sizing.
 	#poststuff #woocommerce-order-actions .inside button {
 		margin: 0;
 	}
@@ -8407,15 +8408,16 @@ table.bar_chart {
 		}
 
 		input[type="number"] {
-			padding-right: 0;
+			padding-right: 0; // Keep stepper controls flush right.
 		}
 
 		.dimensions_field .wrap {
-			width: 55%;
-			border-radius: 2px;
+			width: 55%; // Wider to compensate for increased padding.
+			border-radius: 2px; // Match WP 7.0 input border-radius.
 		}
 	}
 
+	// Variable product selects need more height to accommodate WP 7.0 padding.
 	#variable_product_options .form-row select {
 		height: 50px;
 	}
@@ -8429,11 +8431,11 @@ table.bar_chart {
 .wc-wp-version-gte-70.post-type-product .tablenav,
 .wc-wp-version-gte-70.post-type-shop_order .tablenav {
 	.select2-container {
-		margin-top: 0;
+		margin-top: 0; // Align with other tablenav elements.
 	}
 
 	.select2-container .select2-selection--single {
-		height: 32px;
+		height: 32px; // WP 7.0 tablenav uses compact 32px, not 40px.
 
 		.select2-selection__rendered {
 			line-height: 30px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8336,6 +8336,30 @@ table.bar_chart {
 	.wc-action-button-group .wc-action-button {
 		min-height: 0 !important;
 	}
+
+	// Order actions: select + button overflow container due to WP 7.0 select margins.
+	.order_actions #actions select {
+		width: calc(100% - 32px);
+	}
+
+	// Order actions reload button: icon line-height must match WP 7.0 button height.
+	.button.wc-reload {
+		&::after {
+			line-height: 40px;
+		}
+	}
+
+	#poststuff #woocommerce-order-actions .inside button {
+		margin: 0;
+	}
+
+	// Order date hour/minute inputs: WP 7.0 padding pushes stepper controls inward.
+	#order_data .order_data_column .form-field-wide {
+		input.hour,
+		input.minute {
+			padding-right: 0;
+		}
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8309,6 +8309,33 @@ table.bar_chart {
 			min-height: 38px;
 		}
 	}
+
+	// Table action icon buttons: prevent WP 7.0 min-height from stretching them.
+	.widefat {
+		.column-wc_actions {
+			a.button {
+				min-height: 0 !important;
+				line-height: 1 !important;
+
+				&::after {
+					line-height: 1.85;
+					margin-top: 0;
+				}
+			}
+		}
+	}
+
+	// Order preview action buttons.
+	.wc-order-preview footer {
+		.button.button-large {
+			min-height: 0;
+		}
+	}
+
+	// Action button groups.
+	.wc-action-button-group .wc-action-button {
+		min-height: 0 !important;
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -409,27 +409,27 @@ class WC_Admin {
 	 * @return string
 	 */
 	public function include_admin_body_class( $classes ) {
-		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55', 'wc-wp-version-gte-70' ), explode( ' ', $classes ), true ) ) {
+		$raw_version = get_bloginfo( 'version' );
+
+		if ( ! $raw_version ) {
 			return $classes;
 		}
 
-		$raw_version   = get_bloginfo( 'version' );
 		$version_parts = explode( '-', $raw_version );
 		$version       = count( $version_parts ) > 1 ? $version_parts[0] : $raw_version;
+		$class_list    = explode( ' ', $classes );
 
-		// Add WP 5.3+ compatibility class.
-		if ( $raw_version && version_compare( $version, '5.3', '>=' ) ) {
-			$classes .= ' wc-wp-version-gte-53';
-		}
+		// WP version compatibility classes.
+		$version_classes = array(
+			'5.3' => 'wc-wp-version-gte-53',
+			'5.5' => 'wc-wp-version-gte-55',
+			'7.0' => 'wc-wp-version-gte-70',
+		);
 
-		// Add WP 5.5+ compatibility class.
-		if ( $raw_version && version_compare( $version, '5.5', '>=' ) ) {
-			$classes .= ' wc-wp-version-gte-55';
-		}
-
-		// Add WP 7.0+ compatibility class.
-		if ( $raw_version && version_compare( $version, '7.0', '>=' ) ) {
-			$classes .= ' wc-wp-version-gte-70';
+		foreach ( $version_classes as $min_version => $class_name ) {
+			if ( ! in_array( $class_name, $class_list, true ) && version_compare( $version, $min_version, '>=' ) ) {
+				$classes .= ' ' . $class_name;
+			}
 		}
 
 		return $classes;

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -409,7 +409,7 @@ class WC_Admin {
 	 * @return string
 	 */
 	public function include_admin_body_class( $classes ) {
-		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55' ), explode( ' ', $classes ), true ) ) {
+		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55', 'wc-wp-version-gte-70' ), explode( ' ', $classes ), true ) ) {
 			return $classes;
 		}
 
@@ -425,6 +425,11 @@ class WC_Admin {
 		// Add WP 5.5+ compatibility class.
 		if ( $raw_version && version_compare( $version, '5.5', '>=' ) ) {
 			$classes .= ' wc-wp-version-gte-55';
+		}
+
+		// Add WP 7.0+ compatibility class.
+		if ( $raw_version && version_compare( $version, '7.0', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-70';
 		}
 
 		return $classes;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Updates various CSS rules to prevent the admin dashboard displaying incorrectly in WordPress 7.0
- The changes are conditionally applied if WP >= 7.0
- Inline comments explain each rule change.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-6412
Closes WOOPLUG-6442

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

#### Order list

| Before | After | 6.9 |
| ------ | ----- | ----- |
| <img width="1551" height="478" alt="image" src="https://github.com/user-attachments/assets/53393ceb-7e2b-460c-ae4c-ef5ab7dd0f2d" /> |  <img width="1535" height="484" alt="image" src="https://github.com/user-attachments/assets/65cabd99-632a-42a6-ae06-3031c68fe41b" />     |   <img width="1535" height="380" alt="image" src="https://github.com/user-attachments/assets/c1d4dbcc-e207-4792-92f2-f97cbb2c425b" /> |


#### Individual Order

| Before | After | 6.9 |
| ------ | ----- | ----- |
|     <img width="1534" height="517" alt="image" src="https://github.com/user-attachments/assets/4bdb5ad9-8ea8-444e-b00d-91fefa2d7649" />   |  <img width="1518" height="577" alt="image" src="https://github.com/user-attachments/assets/01e68c60-f672-465b-a51e-750e088aa369" />  |   <img width="3136" height="1342" alt="image" src="https://github.com/user-attachments/assets/840154da-6530-4e28-a76b-d4370c498689" />  |


#### Individual order refund

| Before | After | 6.9 |
| ------ | ----- | ----- |
|    <img width="1217" height="561" alt="image" src="https://github.com/user-attachments/assets/05ca902a-2d22-4504-af46-2ef265b938b7" />   |      <img width="2438" height="1106" alt="image" src="https://github.com/user-attachments/assets/6900439f-71be-4e97-a92e-4a6d4a0aaa3c" /> |  <img width="1216" height="501" alt="image" src="https://github.com/user-attachments/assets/39724001-ca58-43c7-825b-5e56d3106452" />  |

#### Individual Product publish metabox

| Before | After | 6.9 |
| ------ | ----- | ----- |
|   <img width="298" height="369" alt="image" src="https://github.com/user-attachments/assets/6d434b9c-aafd-431b-a410-cf59121ecde5" />    |   <img width="286" height="356" alt="image" src="https://github.com/user-attachments/assets/7aa1649c-9e8f-42b4-9ef9-4c0f32f00c12" />    |   <img width="300" height="344" alt="image" src="https://github.com/user-attachments/assets/771926f1-1583-407b-aaee-7a0cd5861bc5" />  |

#### Individual product details

| Before | After | 6.9 |
| ------ | ----- | ----- |
|   <img width="1224" height="376" alt="image" src="https://github.com/user-attachments/assets/7399b576-2a3a-422a-aba9-39b18c8d02a7" />   |     <img width="1222" height="383" alt="image" src="https://github.com/user-attachments/assets/1a0bb7c1-7531-4f43-9c3c-99e3dea19c32" />  |   <img width="1229" height="424" alt="image" src="https://github.com/user-attachments/assets/0c76c52c-5e7b-4a53-a1c5-9d36e53d33f8" />  |

| Before | After | 6.9 |
| ------ | ----- | ----- |
|    <img width="1227" height="449" alt="image" src="https://github.com/user-attachments/assets/bfa470ba-ba7a-4243-9192-a13c9b6f02ab" />   |  <img width="918" height="426" alt="image" src="https://github.com/user-attachments/assets/62cb29bd-158b-48d2-9c71-59f6e5fbf041" />     |   <img width="1231" height="371" alt="image" src="https://github.com/user-attachments/assets/da8f081e-50af-419d-9f9c-66929696656d" />  |

| Before | After | 6.9 |
| ------ | ----- | ----- |
|  <img width="964" height="787" alt="image" src="https://github.com/user-attachments/assets/f83a8443-4cae-42cd-b1ab-6eb2b4a08951" />  |    <img width="962" height="805" alt="image" src="https://github.com/user-attachments/assets/9cbf0005-01f7-4b52-805c-07b0b054f537" />     |   <img width="1924" height="1460" alt="image" src="https://github.com/user-attachments/assets/bb665e76-0baa-447b-9ef3-c2b162b8b30c" />  |

#### Coupons

| Before | After | 6.9 |
| ------ | ----- | ----- |
|    <img width="1248" height="332" alt="image" src="https://github.com/user-attachments/assets/1cf5f39a-d12c-4dd1-9209-b304b6bf10bd" />   |    <img width="1248" height="334" alt="image" src="https://github.com/user-attachments/assets/cada40f6-a9f5-4604-b936-fe76c9395645" />   |  <img width="1236" height="347" alt="image" src="https://github.com/user-attachments/assets/14e639fe-8133-4a75-aca1-9c3f0b3f137c" />   |

#### Settings

| Before | After | 6.9 |
| ------ | ----- | ----- |
|   <img width="694" height="728" alt="image" src="https://github.com/user-attachments/assets/347fd1b4-8d1c-44d0-9c45-aa6e77c2a7b4" />  |   <img width="685" height="781" alt="image" src="https://github.com/user-attachments/assets/209a215e-96d2-487a-8749-a7a394366313" />   |   <img width="692" height="689" alt="image" src="https://github.com/user-attachments/assets/013ec316-c8d2-46bf-b86f-d5d385b50fd5" />  |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set your store up to use WordPress 7.0 (beta5)
2. Visit each of the sections screenshotted above, and ensure they display correctly, no poorly sized controls, nothing out of alignment etc.
3. Look for visual inconsistencies across any admin surface, compared to when viewed WordPress 6.9
4. Downgrade to WordPress 6.9
5. Ensure the styling of these admin surfaces looks the same as it did before these changes
6. Click around the admin and ensure nothing looks out of place, general smoke testing of your team's areas of responsibility would be good.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
