### PR TITLE
Fix file paths in actions documentation

### DIFF
--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
@@ -1,4 +1,3 @@
-<!-- DO NOT UPDATE THIS DOC DIRECTLY -->
 
 <!-- Use `npm run build:docs` to automatically build hook documentation -->
 
@@ -55,7 +54,7 @@ do_action( 'deprecated_function_run' )
 ### Source
 
 
-- [Domain/Bootstrap.php](../../../../../woocommerce/src/Blocks/Domain/Bootstrap.php)
+- [Domain/Bootstrap.php](../../../../../../../woocommerce/src/Blocks/Domain/Bootstrap.php)
 
 ---
 
@@ -89,7 +88,7 @@ This hook fires when an item is added to the cart. This is triggered from the St
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -114,8 +113,8 @@ Called after rendering the main content for a product.
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -136,7 +135,7 @@ do_action( 'woocommerce_after_shop_loop' )
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -161,7 +160,7 @@ do_action( 'woocommerce_applied_coupon', string $coupon_code )
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -183,7 +182,7 @@ do_action( 'woocommerce_archive_description' )
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -210,8 +209,8 @@ Called before rendering the main content for a product.
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -234,7 +233,7 @@ do_action( 'woocommerce_before_shop_loop' )
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -250,8 +249,8 @@ do_action( 'woocommerce_blocks_cart_enqueue_data' )
 ### Source
 
 
-- [BlockTypes/MiniCart.php](../../../../../woocommerce/src/Blocks/BlockTypes/MiniCart.php)
-- [BlockTypes/Cart.php](../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
+- [BlockTypes/MiniCart.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/MiniCart.php)
+- [BlockTypes/Cart.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
 
 ---
 
@@ -267,7 +266,7 @@ do_action( 'woocommerce_blocks_checkout_enqueue_data' )
 ### Source
 
 
-- [BlockTypes/Checkout.php](../../../../../woocommerce/src/Blocks/BlockTypes/Checkout.php)
+- [BlockTypes/Checkout.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/Checkout.php)
 
 ---
 
@@ -283,7 +282,7 @@ do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' )
 ### Source
 
 
-- [BlockTypes/Cart.php](../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
+- [BlockTypes/Cart.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
 
 ---
 
@@ -299,7 +298,7 @@ do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' )
 ### Source
 
 
-- [BlockTypes/Cart.php](../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
+- [BlockTypes/Cart.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/Cart.php)
 
 ---
 
@@ -315,7 +314,7 @@ do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' )
 ### Source
 
 
-- [BlockTypes/Checkout.php](../../../../../woocommerce/src/BLocks/BlockTypes/Checkout.php)
+- [BlockTypes/Checkout.php](../../../../../../../woocommerce/src/BLocks/BlockTypes/Checkout.php)
 
 ---
 
@@ -331,7 +330,7 @@ do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' )
 ### Source
 
 
-- [BlockTypes/Checkout.php](../../../../../woocommerce/src/Blocks/BlockTypes/Checkout.php)
+- [BlockTypes/Checkout.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/Checkout.php)
 
 ---
 
@@ -351,7 +350,7 @@ This hook is intended to be used as a safe event hook for when the plugin has be
 ### Source
 
 
-- [Domain/Bootstrap.php](../../../../../woocommerce/src/Blocks/Domain/Bootstrap.php)
+- [Domain/Bootstrap.php](../../../../../../../woocommerce/src/Blocks/Domain/Bootstrap.php)
 
 ---
 
@@ -377,7 +376,7 @@ Runs before integrations are initialized allowing new integration to be register
 ### Source
 
 
-- [Integrations/IntegrationRegistry.php](../../../../../woocommerce/src/Blocks/Integrations/IntegrationRegistry.php)
+- [Integrations/IntegrationRegistry.php](../../../../../../../woocommerce/src/Blocks/Integrations/IntegrationRegistry.php)
 
 ---
 
@@ -403,7 +402,7 @@ Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. T
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -434,7 +433,8 @@ This hook fires after customer accounts are created and passes the customer data
 ### Source
 
 
-- [StoreApi/Routes/V1/Checkout.php](../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -455,7 +455,7 @@ do_action( 'woocommerce_no_products_found' )
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -486,7 +486,7 @@ This hook fires before customer accounts are created and passes the form data (u
 ### Source
 
 
-- [StoreApi/Routes/V1/Checkout.php](../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -502,7 +502,7 @@ do_action( 'woocommerce_shop_loop' )
 ### Source
 
 
-- [BlockTypes/ClassicTemplate.php](../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
+- [BlockTypes/ClassicTemplate.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php)
 
 ---
 
@@ -547,7 +547,7 @@ add_action( 'woocommerce_store_api_cart_errors', 'my_function_callback', 10 );
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -575,7 +575,7 @@ This allows extensions to perform addition actions after a shipping method has b
 ### Source
 
 
-- [StoreApi/Routes/V1/CartSelectShippingRate.php](../../../../../woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php)
+- [StoreApi/Routes/V1/CartSelectShippingRate.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/CartSelectShippingRate.php)
 
 ---
 
@@ -598,7 +598,7 @@ do_action( 'woocommerce_store_api_cart_update_customer_from_request', \WC_Custom
 ### Source
 
 
-- [StoreApi/Routes/V1/CartUpdateCustomer.php](../../../../../woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php)
+- [StoreApi/Routes/V1/CartUpdateCustomer.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php)
 
 ---
 
@@ -622,7 +622,7 @@ do_action( 'woocommerce_store_api_cart_update_order_from_request', \WC_Order $dr
 ### Source
 
 
-- [StoreApi/Routes/V1/AbstractCartRoute.php](../../../../../woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php)
+- [StoreApi/Routes/V1/AbstractCartRoute.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php)
 
 ---
 
@@ -671,8 +671,8 @@ add_action( 'woocommerce_blocks_checkout_order_processed', 'my_function_callback
 ### Source
 
 
-- [StoreApi/Routes/V1/CheckoutOrder.php](../../../../../woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php)
-- [StoreApi/Routes/V1/Checkout.php](../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/CheckoutOrder.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -695,8 +695,8 @@ do_action( 'woocommerce_store_api_checkout_update_customer_from_request', \WC_Cu
 ### Source
 
 
-- [StoreApi/Routes/V1/CheckoutOrder.php](../../../../../woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php)
-- [StoreApi/Routes/V1/Checkout.php](../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/CheckoutOrder.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/CheckoutOrder.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -730,7 +730,7 @@ This hook gives extensions the chance to add or update metadata on the $order. T
 ### Source
 
 
-- [StoreApi/Routes/V1/Checkout.php](../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
+- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -752,7 +752,7 @@ do_action( 'woocommerce_store_api_rate_limit_exceeded', string $ip_address, stri
 ### Source
 
 
-- [StoreApi/Authentication.php](../../../../../woocommerce/src/StoreApi/Authentication.php)
+- [StoreApi/Authentication.php](../../../../../../../woocommerce/src/StoreApi/Authentication.php)
 
 ---
 
@@ -779,7 +779,7 @@ Fire action to validate add to cart. Functions hooking into this should throw an
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -802,7 +802,7 @@ do_action( 'woocommerce_store_api_validate_cart_item', \WC_Product $product, arr
 ### Source
 
 
-- [StoreApi/Utilities/CartController.php](../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
+- [StoreApi/Utilities/CartController.php](../../../../../../../woocommerce/src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -818,7 +818,7 @@ do_action( 'woocommerce_{$product->get_type()}_add_to_cart' )
 ### Source
 
 
-- [BlockTypes/AddToCartForm.php](../../../../../woocommerce/src/Blocks/BlockTypes/AddToCartForm.php)
+- [BlockTypes/AddToCartForm.php](../../../../../../../woocommerce/src/Blocks/BlockTypes/AddToCartForm.php)
 
 ---
 
@@ -834,7 +834,7 @@ do_action( '{$hook}' )
 ### Source
 
 
-- [Templates/AbstractTemplateCompatibility.php](../../../../../woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php)
+- [Templates/AbstractTemplateCompatibility.php](../../../../../../../woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php)
 
 ---
 <!-- FEEDBACK -->

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/actions.md
@@ -434,7 +434,6 @@ This hook fires after customer accounts are created and passes the customer data
 
 
 - [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
-- [StoreApi/Routes/V1/Checkout.php](../../../../../../../woocommerce/src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 


### PR DESCRIPTION
Updated file paths in hook documentation to reflect newer directory structure.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Update file path links to reflect deeper nested location of actions.md documentation file

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

### Testing that has already taken place:

- Manually modified `href` attribute on two target elements (one targeting a file in StoreApi and one in Blocks) using browser dev tools to exactly match the URL listed in the Markdown file

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

The bug has apparently gone a while without an issue being raised, so I doubt it even needs a mention in release notes.

</details>
