### PR TITLE
Avoid duplicate processor entries in BatchProcessingController::enqueue_processor()

### DIFF
--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -97,7 +97,7 @@ class BatchProcessingController {
 	 */
 	public function enqueue_processor( string $processor_class_name ): void {
 		$pending_updates = $this->get_enqueued_processors();
-		if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {
+		if ( ! in_array( $processor_class_name, $pending_updates, true ) ) {
 			$pending_updates[] = $processor_class_name;
 			$this->set_enqueued_processors( $pending_updates );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -51,6 +51,21 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The same processor is not enqueued more than once.
+	 */
+	public function test_enqueue_processor_does_not_duplicate_entries() {
+		$processor_class_name = get_class( $this->test_process );
+
+		$this->sut->enqueue_processor( $processor_class_name );
+		$this->sut->enqueue_processor( $processor_class_name );
+
+		$this->assertEquals(
+			array( $processor_class_name ),
+			get_option( BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME )
+		);
+	}
+
+	/**
 	 * @testdox 'remove_processor' dequeues and unschedules a processor, but the watchdog is kept alive if more processors are still enqueued.
 	 */
 	public function test_remove_processor_when_others_are_still_enqueued() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This change prevents duplicate processor class names from being appended to the `wc_pending_batch_processes` option.

`BatchProcessingController::enqueue_processor()` currently checks `array_keys( $pending_updates )`, which compares the processor class name against numeric array indexes instead of the stored processor values. As a result, the same processor can be enqueued repeatedly.

This patch switches the duplicate check to the actual option values and adds a regression test that enqueues the same processor twice and verifies that the option still contains only one entry.

Closes #63786.

### Screenshots or screen recordings:

Not applicable.

### How to test the changes in this Pull Request:

1. Run the `BatchProcessingControllerTests` test class and confirm the new duplicate-enqueue regression test passes.
2. In a WooCommerce test environment, obtain `BatchProcessingController` from the container.
3. Call `enqueue_processor( DataSynchronizer::class )` more than once.
4. Read the `wc_pending_batch_processes` option.
5. Confirm `Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\DataSynchronizer` appears only once.

### Testing that has already taken place:

- Reproduced on a production store and a staging clone running WooCommerce `10.6.1`, WordPress `6.9.4`, and PHP `8.3.27`.
- Confirmed the duplicated option state was generating disproportionate `wc_run_batch_process` background load.
- Added a regression test covering the duplicate-enqueue case.
- Ran `php -l` on the changed source file and the changed test file.
- Attempted to run `./vendor/bin/phpunit -c phpunit.xml --filter BatchProcessingControllerTests`, but the local environment here does not have the WordPress test bootstrap available (`wordpress-tests-lib/includes/functions.php` missing), so I could not complete the PHPUnit run in this machine-local clone.
- No UI changes are involved, so screenshots are not applicable for this PR.
- Environment notes for the reproduction and analysis:
  - Store type: established production WooCommerce store plus a staging clone
  - Relevant stack: HPOS-related batch processing, Action Scheduler, WordPress `6.9.4`, WooCommerce `10.6.1`, PHP `8.3.27`
  - Analysis performed: direct option inspection, repeated enqueue reproduction, operational queue analysis, and comparison against WooCommerce batch-processing code paths

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is a small internal bug fix with no user-facing behavior change beyond preventing duplicated batch processor queue state.

</details>
