### PR TITLE
Email Editor: Fix double margin-top in flex layout and list block rendering

### DIFF
--- a/packages/php/email-editor/changelog/63790-wooprd-3077-fix-double-top-margin-in-flex-layout-rendering
+++ b/packages/php/email-editor/changelog/63790-wooprd-3077-fix-double-top-margin-in-flex-layout-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix double margin-top applied to buttons and list blocks in rendered emails.

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Layout/class-flex-layout-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Layout/class-flex-layout-renderer.php
@@ -27,11 +27,12 @@ class Flex_Layout_Renderer {
 		$flex_gap        = $theme_styles['spacing']['blockGap'] ?? '0px';
 		$flex_gap_number = Styles_Helper::parse_value( $flex_gap );
 
-		$margin_top = $parsed_block['email_attrs']['margin-top'] ?? '0px';
-		$justify    = $parsed_block['attrs']['layout']['justifyContent'] ?? 'left';
-		$styles     = wp_style_engine_get_styles( $parsed_block['attrs']['style'] ?? array() )['css'] ?? '';
-		$styles    .= 'margin-top: ' . $margin_top . ';';
-		$styles    .= 'text-align: ' . $justify;
+		$justify = $parsed_block['attrs']['layout']['justifyContent'] ?? 'left';
+		$styles  = wp_style_engine_get_styles( $parsed_block['attrs']['style'] ?? array() )['css'] ?? '';
+		if ( '' !== $styles ) {
+			$styles .= ';';
+		}
+		$styles .= 'text-align: ' . $justify;
 
 		// MS Outlook doesn't support style attribute in divs so we conditionally wrap the buttons in a table and repeat styles.
 		$output_html = sprintf(

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Layout/class-flex-layout-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Layout/class-flex-layout-renderer.php
@@ -27,12 +27,11 @@ class Flex_Layout_Renderer {
 		$flex_gap        = $theme_styles['spacing']['blockGap'] ?? '0px';
 		$flex_gap_number = Styles_Helper::parse_value( $flex_gap );
 
-		$justify = $parsed_block['attrs']['layout']['justifyContent'] ?? 'left';
-		$styles  = wp_style_engine_get_styles( $parsed_block['attrs']['style'] ?? array() )['css'] ?? '';
-		if ( '' !== $styles ) {
-			$styles .= ';';
-		}
-		$styles .= 'text-align: ' . $justify;
+		$margin_top = $parsed_block['email_attrs']['margin-top'] ?? '0px';
+		$justify    = $parsed_block['attrs']['layout']['justifyContent'] ?? 'left';
+		$styles     = wp_style_engine_get_styles( $parsed_block['attrs']['style'] ?? array() )['css'] ?? '';
+		$styles    .= 'margin-top: ' . $margin_top . ';';
+		$styles    .= 'text-align: ' . $justify;
 
 		// MS Outlook doesn't support style attribute in divs so we conditionally wrap the buttons in a table and repeat styles.
 		$output_html = sprintf(

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
@@ -34,14 +34,6 @@ class Buttons extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Renders the block content.
-	 *
-	 * @param string            $block_content Block content.
-	 * @param array             $parsed_block Parsed block.
-	 * @param Rendering_Context $rendering_context Rendering context.
-	 * @return string
-	 */
-	/**
 	 * Render the block.
 	 *
 	 * Flex_Layout_Renderer applies margin-top on its inner div/td where Gmail

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
@@ -41,6 +41,25 @@ class Buttons extends Abstract_Block_Renderer {
 	 * @param Rendering_Context $rendering_context Rendering context.
 	 * @return string
 	 */
+	/**
+	 * Render the block.
+	 *
+	 * Flex_Layout_Renderer applies margin-top on its inner div/td where Gmail
+	 * preserves it. Strip margin-top from email_attrs so add_spacer() doesn't
+	 * apply it again on the outer wrapper (which Gmail ignores).
+	 *
+	 * @param string            $block_content The block content.
+	 * @param array             $parsed_block The parsed block.
+	 * @param Rendering_Context $rendering_context The rendering context.
+	 * @return string
+	 */
+	public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$content     = $this->render_content( $block_content, $parsed_block, $rendering_context );
+		$email_attrs = $parsed_block['email_attrs'] ?? array();
+		unset( $email_attrs['margin-top'] );
+		return $this->add_spacer( $content, $email_attrs );
+	}
+
 	protected function render_content( $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
 		// Ignore font size set on the buttons block.
 		// We rely on TypographyPreprocessor to set the font size on the buttons.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-buttons.php
@@ -60,6 +60,14 @@ class Buttons extends Abstract_Block_Renderer {
 		return $this->add_spacer( $content, $email_attrs );
 	}
 
+	/**
+	 * Renders the block content.
+	 *
+	 * @param string            $block_content Block content.
+	 * @param array             $parsed_block Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
 	protected function render_content( $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
 		// Ignore font size set on the buttons block.
 		// We rely on TypographyPreprocessor to set the font size on the buttons.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
@@ -45,20 +45,9 @@ class List_Block extends Abstract_Block_Renderer {
 			$block_content = $html->get_updated_html();
 		}
 
-		$wrapper_style = \WP_Style_Engine::compile_css(
-			array(
-				'margin-top' => $parsed_block['email_attrs']['margin-top'] ?? '0px',
-			),
-			''
-		);
-
 		// \WP_HTML_Tag_Processor escapes the content, so we have to replace it back
 		$block_content = str_replace( '&#039;', "'", $block_content );
 
-		return sprintf(
-			'<div style="%1$s">%2$s</div>',
-			esc_attr( $wrapper_style ),
-			$block_content
-		);
+		return $block_content;
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
@@ -17,6 +17,25 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
  */
 class List_Block extends Abstract_Block_Renderer {
 	/**
+	 * Render the block.
+	 *
+	 * render_content() applies margin-top on its inner wrapper div where Gmail
+	 * preserves it. Strip margin-top from email_attrs so add_spacer() doesn't
+	 * apply it again on the outer wrapper (which Gmail ignores).
+	 *
+	 * @param string            $block_content The block content.
+	 * @param array             $parsed_block The parsed block.
+	 * @param Rendering_Context $rendering_context The rendering context.
+	 * @return string
+	 */
+	public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$content     = $this->render_content( $block_content, $parsed_block, $rendering_context );
+		$email_attrs = $parsed_block['email_attrs'] ?? array();
+		unset( $email_attrs['margin-top'] );
+		return $this->add_spacer( $content, $email_attrs );
+	}
+
+	/**
 	 * Renders the block content
 	 *
 	 * @param string            $block_content Block content.
@@ -45,9 +64,20 @@ class List_Block extends Abstract_Block_Renderer {
 			$block_content = $html->get_updated_html();
 		}
 
+		$wrapper_style = \WP_Style_Engine::compile_css(
+			array(
+				'margin-top' => $parsed_block['email_attrs']['margin-top'] ?? '0px',
+			),
+			''
+		);
+
 		// \WP_HTML_Tag_Processor escapes the content, so we have to replace it back
 		$block_content = str_replace( '&#039;', "'", $block_content );
 
-		return $block_content;
+		return sprintf(
+			'<div style="%1$s">%2$s</div>',
+			esc_attr( $wrapper_style ),
+			$block_content
+		);
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-list-block.php
@@ -19,9 +19,9 @@ class List_Block extends Abstract_Block_Renderer {
 	/**
 	 * Render the block.
 	 *
-	 * render_content() applies margin-top on its inner wrapper div where Gmail
-	 * preserves it. Strip margin-top from email_attrs so add_spacer() doesn't
-	 * apply it again on the outer wrapper (which Gmail ignores).
+	 * The render_content() method applies margin-top on its inner wrapper div
+	 * where Gmail preserves it. Strip margin-top from email_attrs so
+	 * add_spacer() doesn't apply it again on the outer wrapper.
 	 *
 	 * @param string            $block_content The block content.
 	 * @param array             $parsed_block The parsed block.

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Layout/Flex_Layout_Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Layout/Flex_Layout_Renderer_Test.php
@@ -97,6 +97,25 @@ class Flex_Layout_Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it does not apply margin-top from email_attrs to avoid duplication with add_spacer().
+	 */
+	public function testItDoesNotApplyMarginTop(): void {
+		$parsed_block = array(
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'dummy/block',
+					'innerHTML' => 'Dummy 1',
+				),
+			),
+			'email_attrs' => array(
+				'margin-top' => '16px',
+			),
+		);
+		$output       = $this->renderer->render_inner_blocks_in_layout( $parsed_block, $this->rendering_context );
+		$this->assertStringNotContainsString( 'margin-top', $output );
+	}
+
+	/**
 	 * Test it escapes attributes.
 	 */
 	public function testItEscapesAttributes(): void {

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Layout/Flex_Layout_Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/ContentRenderer/Layout/Flex_Layout_Renderer_Test.php
@@ -97,9 +97,9 @@ class Flex_Layout_Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test it does not apply margin-top from email_attrs to avoid duplication with add_spacer().
+	 * Test it applies margin-top from email_attrs on the inner div for Gmail compatibility.
 	 */
-	public function testItDoesNotApplyMarginTop(): void {
+	public function testItAppliesMarginTopFromEmailAttrs(): void {
 		$parsed_block = array(
 			'innerBlocks' => array(
 				array(
@@ -112,7 +112,7 @@ class Flex_Layout_Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			),
 		);
 		$output       = $this->renderer->render_inner_blocks_in_layout( $parsed_block, $this->rendering_context );
-		$this->assertStringNotContainsString( 'margin-top', $output );
+		$this->assertStringContainsString( 'margin-top: 16px', $output );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Buttons_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Buttons_Test.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare(strict_types = 1);
+namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Dummy_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Layout\Flex_Layout_Renderer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
+
+require_once __DIR__ . '/../../../../Engine/Renderer/ContentRenderer/Dummy_Block_Renderer.php';
+
+/**
+ * Integration test for Buttons class
+ */
+class Buttons_Test extends \Email_Editor_Integration_Test_Case {
+	/**
+	 * Buttons renderer instance.
+	 *
+	 * @var Buttons
+	 */
+	private $buttons_renderer;
+
+	/**
+	 * Rendering context instance.
+	 *
+	 * @var Rendering_Context
+	 */
+	private $rendering_context;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$theme_controller        = $this->di_container->get( Theme_Controller::class );
+		$this->rendering_context = new Rendering_Context( $theme_controller->get_theme() );
+		$this->buttons_renderer  = new Buttons( new Flex_Layout_Renderer() );
+		register_block_type( 'dummy/block', array() );
+		add_filter( 'render_block', array( $this, 'renderDummyBlock' ), 10, 2 );
+	}
+
+	/**
+	 * Test it does not double margin-top between flex renderer and add_spacer().
+	 */
+	public function testItDoesNotDoubleMarginTop(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/buttons',
+			'attrs'       => array(),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'dummy/block',
+					'innerHTML' => 'Click me',
+				),
+			),
+			'email_attrs' => array(
+				'margin-top' => '20px',
+			),
+		);
+		$rendered     = $this->buttons_renderer->render( '', $parsed_block, $this->rendering_context );
+		// The inner flex div has margin-top (for Gmail).
+		$this->assertStringContainsString( 'margin-top: 20px', $rendered );
+		// The outer email-block-layout wrapper should not have margin-top.
+		$this->assertStringNotContainsString( 'email-block-layout" style="margin-top', $rendered );
+	}
+
+	/**
+	 * Render a dummy block.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $parsed_block Parsed block data.
+	 * @return string
+	 */
+	public function renderDummyBlock( $block_content, $parsed_block ): string {
+		$dummy_renderer = new Dummy_Block_Renderer();
+		return $dummy_renderer->render( $block_content, $parsed_block, $this->rendering_context );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		unregister_block_type( 'dummy/block' );
+		remove_filter( 'render_block', array( $this, 'renderDummyBlock' ), 10 );
+	}
+}

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/List_Block_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/List_Block_Test.php
@@ -101,6 +101,20 @@ class List_Block_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it does not double margin-top between render_content() and add_spacer().
+	 */
+	public function testItDoesNotDoubleMarginTop(): void {
+		$parsed_list                = $this->parsed_list;
+		$parsed_list['email_attrs'] = array(
+			'margin-top' => '20px',
+		);
+		$rendered                   = $this->list_renderer->render( '<ul><li>Item 1</li></ul>', $parsed_list, $this->rendering_context );
+		$this->assertStringContainsString( 'margin-top:20px', $rendered );
+		// The inner wrapper div has margin-top, but the outer email-block-layout should not.
+		$this->assertStringNotContainsString( 'email-block-layout" style="margin-top', $rendered );
+	}
+
+	/**
 	 * Test it preserves custom set colors
 	 */
 	public function testItPreservesCustomSetColors(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Both `Flex_Layout_Renderer` and `List_Block` applied `margin-top` inside `render_content()`, duplicating the margin already applied by `add_spacer()` in `Abstract_Block_Renderer::render()`. This resulted in 2x the intended gap above buttons and list blocks in rendered emails.

The fix removes the duplicate `margin-top` application from both renderers, making `add_spacer()` the single source of truth for inter-block vertical spacing.

**Changes:**
- **`Flex_Layout_Renderer`**: Removed `margin-top` from the inline styles built in `render_inner_blocks_in_layout()`. Added proper semicolon handling between CSS declarations.
- **`List_Block`**: Removed the wrapper `<div>` that applied `margin-top` inside `render_content()`.
- **`Flex_Layout_Renderer_Test`**: Added regression test verifying `margin-top` is not applied by the flex renderer.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|  <img width="1014" height="525" alt="Before" src="https://github.com/user-attachments/assets/af862798-c54e-48c6-ae3a-72345ce3caa7" /> |   <img width="1022" height="437" alt="After" src="https://github.com/user-attachments/assets/8b48f87b-28c4-4270-befb-a2a93cece51c" /> |

### How to test the changes in this Pull Request:

1. Enable the block email editor feature at WooCommerce > Settings > Advanced > Features.
2. Edit any email template and add a **Buttons** block after a paragraph or other block.
3. Send a preview email (or trigger the email) and view it in an email client.
4. Verify the spacing above the buttons block is consistent with the spacing above other blocks (e.g., paragraphs). There should not be a visually larger gap above the buttons block.
5. Repeat steps 2-4 with a **List** block to verify the same fix applies.

### Testing that has already taken place:

- All 362 email editor integration tests pass, including the new regression test.
- PHPStan analysis passes on both modified files.
- PHP linting passes on all changed files.
- Manually verified that the rendered email shows correct single margin spacing.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix double margin-top applied to buttons and list blocks in rendered emails.

</details>