### PR TITLE
Add installed_path fallback in plugin activate step

### DIFF
--- a/plugins/woocommerce/changelog/63796-fix-WCCOM-2367-wccom-auto-install-errors
+++ b/plugins/woocommerce/changelog/63796-fix-WCCOM-2367-wccom-auto-install-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adds a fallback path to the plugin file during plugin activation step. Prevents `unknown_filename` error when trying to activate a plugin during the auto-installation flow.

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-activate-product.php
@@ -75,6 +75,13 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 			$filename = is_array( $plugins ) && ! empty( $plugins ) ? key( $plugins ) : '';
 		}
 
+		// Fallback: use installed_path from the move_product step.
+		if ( empty( $filename ) && ! empty( $this->state->get_installed_path() ) ) {
+			$filename = \WC_WCCOM_Site_Installer::get_wporg_plugin_main_file(
+				basename( $this->state->get_installed_path() )
+			);
+		}
+
 		if ( empty( $filename ) ) {
 			throw new Installer_Error( Installer_Error_Codes::UNKNOWN_FILENAME );
 		}
@@ -118,6 +125,11 @@ class WC_WCCOM_Site_Installation_Step_Activate_Product implements WC_WCCOM_Site_
 			);
 
 			$theme_slug = is_array( $themes ) && ! empty( $themes ) ? dirname( key( $themes ) ) : '';
+		}
+
+		// Fallback: use installed_path from the move_product step.
+		if ( empty( $theme_slug ) && ! empty( $this->state->get_installed_path() ) ) {
+			$theme_slug = basename( $this->state->get_installed_path() );
 		}
 
 		if ( empty( $theme_slug ) ) {

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-move-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-move-product.php
@@ -6,6 +6,9 @@
  * @since   7.7.0
  */
 
+use WC_REST_WCCOM_Site_Installer_Error_Codes as Installer_Error_Codes;
+use WC_REST_WCCOM_Site_Installer_Error as Installer_Error;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -30,6 +33,8 @@ class WC_WCCOM_Site_Installation_Step_Move_Product implements WC_WCCOM_Site_Inst
 
 	/**
 	 * Run the step installation process.
+	 *
+	 * @throws WC_REST_WCCOM_Site_Installer_Error If installation failed.
 	 */
 	public function run() {
 		$upgrader = WC_WCCOM_Site_Installer::get_wp_upgrader();
@@ -64,11 +69,12 @@ class WC_WCCOM_Site_Installation_Step_Move_Product implements WC_WCCOM_Site_Inst
 			return $this->state;
 		}
 
-		if ( ! is_wp_error( $result ) ) {
-			$this->maybe_connect_theme();
+		if ( is_wp_error( $result ) ) {
+			throw new Installer_Error( Installer_Error_Codes::INSTALLATION_FAILED, $result->get_error_message() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Error code constant is not user-facing output.
 		}
 
 		$this->state->set_installed_path( $result['destination'] );
+		$this->maybe_connect_theme();
 
 		return $this->state;
 	}

--- a/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-move-product.php
+++ b/plugins/woocommerce/includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-move-product.php
@@ -70,7 +70,7 @@ class WC_WCCOM_Site_Installation_Step_Move_Product implements WC_WCCOM_Site_Inst
 		}
 
 		if ( is_wp_error( $result ) ) {
-			throw new Installer_Error( Installer_Error_Codes::INSTALLATION_FAILED, $result->get_error_message() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Error code constant is not user-facing output.
+			throw new Installer_Error( Installer_Error_Codes::INSTALLATION_FAILED, esc_html( $result->get_error_message() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Installer_Error_Codes constant is a static string, not unescaped output.
 		}
 
 		$this->state->set_installed_path( $result['destination'] );

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -37222,12 +37222,6 @@ parameters:
 			path: includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-get-product-info.php
 
 		-
-			message: '#^Cannot access offset ''destination'' on array\|WP_Error\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: includes/wccom-site/installation/installation-steps/class-wc-wccom-site-installation-step-move-product.php
-
-		-
 			message: '#^Method WC_WCCOM_Site_Installation_Step_Move_Product\:\:run\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
This addresses the cause of `unknown_filename` errors during the plugin auto-install flow's activation step. This error happens when a plugin is hosted on WooCommerce.com, but doesn't have the `Woo` header set.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- Add fallback in activate_plugin() using installed_path from move_product step
- Add equivalent fallback in activate_theme()
- Fix WP_Error access bug in move_product step where $result['destination'] was accessed on error

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WCCOM-2367

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Make sure your local WooCommerce.com account owns a product that's not hosted on WordPress.org, and that's missing the `Woo:` header in the main plugin.php file. I used https://woocommerce.test/products/storefront-product-hero/ to test.
2. Check out this branch
3. Follow the steps in p6JqRr-cDo-p2 to connect your local site to your local woocommerce.test (make sure to include the step in the comments to force http URLs on the WCCOM-dev side.)
4. In your Core site mu-plugin, include this hack:
```
add_filter( 'woo_com_base_url', function ( $base ) {
	return 'https://woocommerce.test/';
} );
```
5. Modify the `MARKETPLACE_HOST` value in `plugins/woocommerce/client/admin/client/marketplace/components/constants.ts` to point to woocommerce.test.
6. `pnpm run build`, and connect to your local WCCOM. Install Woo Update Manager if needed.
7. Go to in-app My Subscriptions, and try installing the product from step 1.
8. Ensure the installation succeeds, and that the plugin shows as activated and connected back on your site (on `trunk` you'll see a plugin installed but not activated error on WCCOM, with that state reflected on your site.
9. Test around this issue.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Adds a fallback path to the plugin file during plugin activation step. Prevents `unknown_filename` error when trying to activate a plugin during the auto-installation flow.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>