### PR TITLE
Restore LOWER() in coupon SQL lookups for case-sensitive collations

### DIFF
--- a/plugins/woocommerce/changelog/63800-fix-WOO6-55-case-sensitive-coupon-lookups
+++ b/plugins/woocommerce/changelog/63800-fix-WOO6-55-case-sensitive-coupon-lookups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore case-insensitive coupon lookups on databases with case-sensitive collations.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -130,7 +130,7 @@ if ( wc_tax_enabled() ) {
 						$coupon_info = json_decode( $coupon_info, true );
 						$post_id     = $coupon_info[0]; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					} else {
-						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 					}
 					$class = $order->is_editable() ? 'code editable' : 'code';
 					?>

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -789,7 +789,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		global $wpdb;
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
+				"SELECT ID FROM $wpdb->posts WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
 				wc_sanitize_coupon_code( $code )
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Commit `1c4581fba7b4` removed `LOWER()` from two coupon SQL queries as a performance optimization, relying on the database collation being case-insensitive. On databases with case-sensitive collations (e.g. `utf8mb4_bin`), this causes coupon lookups to fail when input casing doesn't match the stored `post_title`, while the cache (keyed on lowercase) may return inconsistent results.

This PR restores `LOWER()` on both sides of the comparison in two locations:
1. `get_ids_by_code()` in `class-wc-coupon-data-store-cpt.php` — the core coupon lookup used by `wc_get_coupon_id_by_code()`
2. The admin order items template in `html-order-items.php` — coupon display when viewing order details

The `wc_strtolower()` cache invalidation improvements from the same commit are intentionally kept.

Bug introduced in PR `1c4581fba7b4`.

### How to test the changes in this Pull Request:

1. Configure MySQL/MariaDB with a case-sensitive collation (e.g. `utf8mb4_bin`) on the `wp_posts` table.
2. Create a coupon with code `SAVE10`.
3. Apply the coupon at checkout using `save10` (lowercase) — it should be found and applied successfully.
4. View an order that used a coupon in WP Admin → the coupon link should resolve correctly regardless of stored case.

### Testing that has already taken place:

- Verified existing unit test `test_wc_get_coupon_id_by_code_case_insensitive` still passes.
- Code review confirmed the change is an exact revert of the SQL portion of `1c4581fba7b4`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Restore case-insensitive coupon lookups on databases with case-sensitive collations.

</details>
