### PR TITLE
Restore function_exists guard in PTKPatternsStore

### DIFF
--- a/plugins/woocommerce/changelog/63805-fix-ptk-patterns-action-scheduler-guard-WOO6-58
+++ b/plugins/woocommerce/changelog/63805-fix-ptk-patterns-action-scheduler-guard-WOO6-58
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore function_exists guard in PTKPatternsStore to prevent fatal errors when an older Action Scheduler version is loaded by another plugin.

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -113,6 +113,10 @@ class PTKPatternsStore {
 	 * @return void
 	 */
 	private function schedule_action_if_not_pending( $action ) {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+
 		if ( as_has_scheduled_action( $action, array(), 'woocommerce' ) ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `schedule_action_if_not_pending` method in `PTKPatternsStore` calls `as_has_scheduled_action()` and `as_schedule_recurring_action()` without a `function_exists()` guard. If a plugin bundles an older version of Action Scheduler that doesn't define these functions and loads before WooCommerce's bundled version, this causes a fatal error.

The `flush_cached_patterns()` method in the same file already correctly guards its `as_unschedule_all_actions()` call with `function_exists()`. This PR adds the same guard to `schedule_action_if_not_pending` for consistency and safety.

Fixes WOO6-58.

Bug introduced in PR #61749 (commit 66d7b67f9d7e).

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Install a plugin that bundles an older version of Action Scheduler (one that does not define `as_has_scheduled_action()`), and ensure it loads before WooCommerce's bundled version.
2. Activate WooCommerce and navigate to the admin dashboard.
3. Verify that no fatal error occurs related to `as_has_scheduled_action` being undefined.
4. Deactivate or remove the older Action Scheduler plugin, and verify that WooCommerce pattern scheduling continues to work as expected.

### Testing that has already taken place:

Code review confirming the fix matches the existing guard pattern used in `flush_cached_patterns()` within the same file.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Restore function_exists guard in PTKPatternsStore to prevent fatal errors when an older Action Scheduler version is loaded by another plugin.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>