### PR TITLE
Fix scheduled import preference lost after option rename

### DIFF
--- a/plugins/woocommerce/changelog/63808-fix-scheduled-import-migration-WOO6-53
+++ b/plugins/woocommerce/changelog/63808-fix-scheduled-import-migration-WOO6-53
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix scheduled import preference lost after analytics option rename in 10.5.0.

--- a/plugins/woocommerce/changelog/63808-fix-scheduled-import-migration-WOO6-53
+++ b/plugins/woocommerce/changelog/63808-fix-scheduled-import-migration-WOO6-53
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix scheduled import preference lost after analytics option rename in 10.5.0.

--- a/plugins/woocommerce/changelog/fix-scheduled-import-migration-WOO6-53
+++ b/plugins/woocommerce/changelog/fix-scheduled-import-migration-WOO6-53
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix scheduled import preference lost after analytics option rename in 10.5.0.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -324,6 +324,7 @@ class WC_Install {
 		),
 		'10.7.0' => array(
 			'wc_update_1070_disable_hpos_sync_on_read',
+			'wc_update_1070_migrate_analytics_import_option',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -324,7 +324,9 @@ class WC_Install {
 		),
 		'10.7.0' => array(
 			'wc_update_1070_disable_hpos_sync_on_read',
-			'wc_update_1070_migrate_analytics_import_option',
+		),
+		'10.8.0' => array(
+			'wc_update_1080_migrate_analytics_import_option',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3427,11 +3427,11 @@ function wc_update_1070_disable_hpos_sync_on_read(): void {
  * migration was added. Stores that had opted into scheduled imports (legacy
  * value 'no') silently reverted to immediate imports on upgrade.
  *
- * @since 10.7.0
+ * @since 10.8.0
  *
  * @return void
  */
-function wc_update_1070_migrate_analytics_import_option(): void {
+function wc_update_1080_migrate_analytics_import_option(): void {
 	$legacy_option = 'woocommerce_analytics_immediate_import';
 	$new_option    = 'woocommerce_analytics_scheduled_import';
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3418,3 +3418,44 @@ function wc_update_1070_disable_hpos_sync_on_read(): void {
 
 	WC_Admin_Notices::add_notice( 'hpos_sync_on_read_disabled' );
 }
+
+/**
+ * Migrate the legacy analytics immediate import option to the renamed scheduled import option.
+ *
+ * In 10.5.0, `woocommerce_analytics_immediate_import` was renamed to
+ * `woocommerce_analytics_scheduled_import` with inverted semantics, but no
+ * migration was added. Stores that had opted into scheduled imports (legacy
+ * value 'no') silently reverted to immediate imports on upgrade.
+ *
+ * @since 10.7.0
+ *
+ * @return void
+ */
+function wc_update_1070_migrate_analytics_import_option(): void {
+	$legacy_option = 'woocommerce_analytics_immediate_import';
+	$new_option    = 'woocommerce_analytics_scheduled_import';
+
+	$legacy_value = get_option( $legacy_option, false );
+
+	// Nothing to migrate if the legacy option was never set.
+	if ( false === $legacy_value ) {
+		return;
+	}
+
+	// If the new option already exists, just clean up the legacy option.
+	if ( false !== get_option( $new_option, false ) ) {
+		delete_option( $legacy_option );
+		return;
+	}
+
+	// Invert the semantics: legacy 'yes' (immediate) = new 'no' (not scheduled),
+	// legacy 'no' (not immediate) = new 'yes' (scheduled).
+	$new_value = 'no' === $legacy_value ? 'yes' : 'no';
+
+	// Only delete the legacy option if the new option was written successfully.
+	// On failure, the runtime fallback in is_scheduled_import_enabled() can
+	// still read the legacy option to preserve the store's preference.
+	if ( add_option( $new_option, $new_value ) ) {
+		delete_option( $legacy_option );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -796,6 +796,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 			return 'no' === $legacy_value;
 		}
 
-		return 'yes' === self::SCHEDULED_IMPORT_OPTION_DEFAULT_VALUE;
+		// Neither option exists — use the default (not scheduled).
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -61,6 +61,16 @@ class OrdersScheduler extends ImportScheduler {
 	const SCHEDULED_IMPORT_OPTION = 'woocommerce_analytics_scheduled_import';
 
 	/**
+	 * Legacy option name before the rename in 10.5.0.
+	 *
+	 * Used as a fallback during upgrades before the migration routine runs.
+	 * The old option stored inverted semantics: 'yes' = immediate, 'no' = scheduled.
+	 *
+	 * @var string
+	 */
+	const LEGACY_IMMEDIATE_IMPORT_OPTION = 'woocommerce_analytics_immediate_import';
+
+	/**
 	 * Default value for the scheduled import option.
 	 *
 	 * @var string
@@ -772,6 +782,20 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 			return false;
 		}
 
-		return 'yes' === get_option( self::SCHEDULED_IMPORT_OPTION, self::SCHEDULED_IMPORT_OPTION_DEFAULT_VALUE );
+		$value = get_option( self::SCHEDULED_IMPORT_OPTION, false );
+
+		if ( false !== $value ) {
+			return 'yes' === $value;
+		}
+
+		// Fall back to the legacy option (pre-10.5.0) which used inverted semantics:
+		// 'yes' meant immediate import (= not scheduled), 'no' meant scheduled.
+		$legacy_value = get_option( self::LEGACY_IMMEDIATE_IMPORT_OPTION, false );
+
+		if ( false !== $legacy_value ) {
+			return 'no' === $legacy_value;
+		}
+
+		return 'yes' === self::SCHEDULED_IMPORT_OPTION_DEFAULT_VALUE;
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -272,4 +272,55 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		// Verify the actions were removed.
 		$this->assertFalse( as_has_scheduled_action( 'fetch_patterns' ), 'fetch_patterns action should be removed after update' );
 	}
+
+	/**
+	 * @testdox Migration converts legacy 'no' (not immediate) to new 'yes' (scheduled).
+	 */
+	public function test_migrate_analytics_import_option_legacy_no_becomes_yes(): void {
+		delete_option( 'woocommerce_analytics_scheduled_import' );
+		update_option( 'woocommerce_analytics_immediate_import', 'no' );
+
+		wc_update_1070_migrate_analytics_import_option();
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
+		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );
+	}
+
+	/**
+	 * @testdox Migration converts legacy 'yes' (immediate) to new 'no' (not scheduled).
+	 */
+	public function test_migrate_analytics_import_option_legacy_yes_becomes_no(): void {
+		delete_option( 'woocommerce_analytics_scheduled_import' );
+		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
+
+		wc_update_1070_migrate_analytics_import_option();
+
+		$this->assertSame( 'no', get_option( 'woocommerce_analytics_scheduled_import' ) );
+		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );
+	}
+
+	/**
+	 * @testdox Migration does nothing when legacy option is absent.
+	 */
+	public function test_migrate_analytics_import_option_no_legacy_option(): void {
+		delete_option( 'woocommerce_analytics_immediate_import' );
+		delete_option( 'woocommerce_analytics_scheduled_import' );
+
+		wc_update_1070_migrate_analytics_import_option();
+
+		$this->assertFalse( get_option( 'woocommerce_analytics_scheduled_import' ) );
+	}
+
+	/**
+	 * @testdox Migration preserves existing new option and deletes legacy.
+	 */
+	public function test_migrate_analytics_import_option_new_option_already_exists(): void {
+		update_option( 'woocommerce_analytics_scheduled_import', 'yes' );
+		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
+
+		wc_update_1070_migrate_analytics_import_option();
+
+		$this->assertSame( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
+		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -280,7 +280,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_analytics_scheduled_import' );
 		update_option( 'woocommerce_analytics_immediate_import', 'no' );
 
-		wc_update_1070_migrate_analytics_import_option();
+		wc_update_1080_migrate_analytics_import_option();
 
 		$this->assertSame( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
 		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );
@@ -293,7 +293,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_analytics_scheduled_import' );
 		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
 
-		wc_update_1070_migrate_analytics_import_option();
+		wc_update_1080_migrate_analytics_import_option();
 
 		$this->assertSame( 'no', get_option( 'woocommerce_analytics_scheduled_import' ) );
 		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );
@@ -306,7 +306,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_analytics_immediate_import' );
 		delete_option( 'woocommerce_analytics_scheduled_import' );
 
-		wc_update_1070_migrate_analytics_import_option();
+		wc_update_1080_migrate_analytics_import_option();
 
 		$this->assertFalse( get_option( 'woocommerce_analytics_scheduled_import' ) );
 	}
@@ -318,7 +318,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		update_option( 'woocommerce_analytics_scheduled_import', 'yes' );
 		update_option( 'woocommerce_analytics_immediate_import', 'yes' );
 
-		wc_update_1070_migrate_analytics_import_option();
+		wc_update_1080_migrate_analytics_import_option();
 
 		$this->assertSame( 'yes', get_option( 'woocommerce_analytics_scheduled_import' ) );
 		$this->assertFalse( get_option( 'woocommerce_analytics_immediate_import' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Schedulers/OrdersSchedulerTest.php
@@ -35,6 +35,7 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 		delete_option( OrdersScheduler::LAST_PROCESSED_ORDER_DATE_OPTION );
 		delete_option( OrdersScheduler::LAST_PROCESSED_ORDER_ID_OPTION );
 		delete_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION );
+		delete_option( OrdersScheduler::LEGACY_IMMEDIATE_IMPORT_OPTION );
 
 		// Clean up any scheduled actions.
 		$this->clear_scheduled_batch_processor();
@@ -385,6 +386,61 @@ class OrdersSchedulerTest extends WC_Unit_Test_Case {
 		$result = OrdersStatsDataStore::sync_order( $order->get_id() );
 
 		$this->assertSame( -1, $result );
+	}
+
+	/**
+	 * @testdox is_scheduled_import_enabled falls back to legacy option when new option is absent.
+	 */
+	public function test_is_scheduled_import_enabled_falls_back_to_legacy_option(): void {
+		// Simulate a pre-10.5.0 store that opted into scheduled imports (legacy 'no' = not immediate = scheduled).
+		delete_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION );
+		update_option( OrdersScheduler::LEGACY_IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		$reflection = new \ReflectionClass( OrdersScheduler::class );
+		$method     = $reflection->getMethod( 'is_scheduled_import_enabled' );
+		$method->setAccessible( true );
+
+		$this->assertTrue(
+			$method->invoke( null ),
+			'Legacy option "no" (not immediate) should be interpreted as scheduled import enabled'
+		);
+	}
+
+	/**
+	 * @testdox is_scheduled_import_enabled falls back to legacy option 'yes' correctly.
+	 */
+	public function test_is_scheduled_import_enabled_falls_back_to_legacy_option_yes(): void {
+		// Simulate a pre-10.5.0 store with default immediate import (legacy 'yes' = immediate = not scheduled).
+		delete_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION );
+		update_option( OrdersScheduler::LEGACY_IMMEDIATE_IMPORT_OPTION, 'yes' );
+
+		$reflection = new \ReflectionClass( OrdersScheduler::class );
+		$method     = $reflection->getMethod( 'is_scheduled_import_enabled' );
+		$method->setAccessible( true );
+
+		$this->assertFalse(
+			$method->invoke( null ),
+			'Legacy option "yes" (immediate) should be interpreted as scheduled import disabled'
+		);
+	}
+
+	/**
+	 * @testdox is_scheduled_import_enabled prefers new option over legacy option when they conflict.
+	 */
+	public function test_is_scheduled_import_enabled_prefers_new_option(): void {
+		// New option says "not scheduled", legacy says "scheduled" (inverted 'no' = scheduled).
+		// If the new option takes precedence, result should be false.
+		update_option( OrdersScheduler::SCHEDULED_IMPORT_OPTION, 'no' );
+		update_option( OrdersScheduler::LEGACY_IMMEDIATE_IMPORT_OPTION, 'no' );
+
+		$reflection = new \ReflectionClass( OrdersScheduler::class );
+		$method     = $reflection->getMethod( 'is_scheduled_import_enabled' );
+		$method->setAccessible( true );
+
+		$this->assertFalse(
+			$method->invoke( null ),
+			'New option "no" should take precedence over legacy option "no" (which would mean scheduled)'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

In 10.5.0 (commit 185d9c177c23, PR #62303), the `woocommerce_analytics_immediate_import` option was renamed to `woocommerce_analytics_scheduled_import` with inverted semantics (`yes` = immediate became `no` = not scheduled), but no migration was added.

Stores that had deliberately opted into scheduled imports (setting the legacy option to `no`) silently reverted to immediate imports on upgrade, because the new code reads `woocommerce_analytics_scheduled_import` which doesn't exist, gets the default `no`, and treats that as "not scheduled" — the opposite of what the store had configured. This is particularly problematic for high-volume stores that use scheduled imports to avoid per-order processing overhead.

This PR adds:

1. **Runtime fallback** in `OrdersScheduler::is_scheduled_import_enabled()` — when the new option is absent, falls back to reading the legacy option with correct semantic inversion. This covers the window between plugin update and migration execution.
2. **Migration routine** (`wc_update_1070_migrate_analytics_import_option`) — converts the legacy option value to the new format and cleans up. Guards against write failures by only deleting the legacy option after a successful `add_option()`, so the runtime fallback remains functional if the migration hits a database error.

Bug introduced in PR #62303.

Fixes WOO6-53

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. On a WooCommerce 10.4.x install (before the rename), enable the `analytics-scheduled-import` feature and set `woocommerce_analytics_immediate_import` to `no` in `wp_options` (this means "use scheduled imports").
2. Upgrade to this branch.
3. Verify that `woocommerce_analytics_scheduled_import` is now `yes` and `woocommerce_analytics_immediate_import` has been deleted.
4. Verify that the scheduled import behavior is preserved (the recurring batch processor action should be scheduled).
5. Test a fresh install to confirm the default behavior (immediate imports) is unchanged.

### Testing that has already taken place:

- PHPStan analysis: no errors
- PHPCS linting: all files pass
- PHP syntax validation: all files pass
- Unit tests written covering:
  - Runtime fallback: legacy `no` maps to scheduled enabled, legacy `yes` maps to disabled, new option takes precedence over legacy
  - Migration: legacy `no` becomes `yes`, legacy `yes` becomes `no`, absent legacy is a no-op, existing new option is preserved while legacy is cleaned up

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Changelog entry was created manually and is included in the PR as `plugins/woocommerce/changelog/fix-scheduled-import-migration-WOO6-53`.

</details>