### PR TITLE
Fix analytics tables showing extra padding on WordPress 7.0

### DIFF
--- a/packages/js/components/changelog/fix-analytics-tables-extra-padding-wp70
+++ b/packages/js/components/changelog/fix-analytics-tables-extra-padding-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix extra padding on analytics Card and CardBody components on WordPress 7.0 by setting size to "none".

--- a/packages/js/components/src/abbreviated-card/index.js
+++ b/packages/js/components/src/abbreviated-card/index.js
@@ -21,7 +21,7 @@ const AbbreviatedCard = ( {
 } ) => {
 	return (
 		<Card className={ clsx( 'woocommerce-abbreviated-card', className ) }>
-			<CardBody size={ null }>
+			<CardBody size="none">
 				<Link href={ href } onClick={ onClick } type={ type }>
 					<div className="woocommerce-abbreviated-card__icon">
 						<Icon icon={ icon } />

--- a/packages/js/components/src/advanced-filters/index.js
+++ b/packages/js/components/src/advanced-filters/index.js
@@ -294,7 +294,7 @@ class AdvancedFilters extends Component {
 					</Text>
 				</CardHeader>
 				{ !! activeFilters.length && (
-					<CardBody size={ null }>
+					<CardBody size="none">
 						<ul
 							className="woocommerce-filters-advanced__list"
 							ref={ this.filterListRef }

--- a/packages/js/components/src/table/index.tsx
+++ b/packages/js/components/src/table/index.tsx
@@ -182,7 +182,7 @@ const TableCard: React.VFC< TableCardProps > = ( {
 			</CardHeader>
 			{ /* Ignoring the error to make it backward compatible for now. */ }
 			{ /* @ts-expect-error: size must be one of none, small, medium, largel, xSmall, extraSmall. */ }
-			<CardBody size={ 'none' }>
+			<CardBody size="none">
 				{ tablePreface && (
 					<div className="woocommerce-table__preface">
 						{ tablePreface }

--- a/packages/js/components/src/table/index.tsx
+++ b/packages/js/components/src/table/index.tsx
@@ -181,8 +181,8 @@ const TableCard: React.VFC< TableCardProps > = ( {
 				) }
 			</CardHeader>
 			{ /* Ignoring the error to make it backward compatible for now. */ }
-			{ /* @ts-expect-error: size must be one of small, medium, largel, xSmall, extraSmall. */ }
-			<CardBody size={ null }>
+			{ /* @ts-expect-error: size must be one of none, small, medium, largel, xSmall, extraSmall. */ }
+			<CardBody size={ 'none' }>
 				{ tablePreface && (
 					<div className="woocommerce-table__preface">
 						{ tablePreface }

--- a/packages/js/components/src/table/stories/table-placeholder.story.tsx
+++ b/packages/js/components/src/table/stories/table-placeholder.story.tsx
@@ -12,8 +12,7 @@ import { headers } from './index';
 
 export const Basic = () => {
 	return (
-		/* @ts-expect-error: size must be one of small, medium, largel, xSmall, extraSmall. */
-		<Card size={ null }>
+		<Card size="none">
 			<TablePlaceholder caption="Revenue last week" headers={ headers } />
 		</Card>
 	);

--- a/packages/js/components/src/table/stories/table.story.tsx
+++ b/packages/js/components/src/table/stories/table.story.tsx
@@ -11,7 +11,7 @@ import { createElement } from '@wordpress/element';
 import { rows, headers } from './index';
 
 export const Basic = () => (
-	<Card size={ null }>
+	<Card size="none">
 		<Table
 			caption="Revenue last week"
 			rows={ rows }
@@ -23,8 +23,7 @@ export const Basic = () => (
 
 export const NoDataCustomMessage = () => {
 	return (
-		/* @ts-expect-error: size must be one of small, medium, largel, xSmall, extraSmall. */
-		<Card size={ null }>
+		<Card size="none">
 			<Table
 				caption="Revenue last week"
 				rows={ [] }

--- a/plugins/woocommerce/changelog/fix-analytics-tables-extra-padding-wp70
+++ b/plugins/woocommerce/changelog/fix-analytics-tables-extra-padding-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix extra padding on analytics tables, dashboard charts, leaderboards, and store alerts on WordPress 7.0 by setting Card/CardBody size to "none".

--- a/plugins/woocommerce/client/admin/client/analytics/components/leaderboard/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/leaderboard/index.js
@@ -105,7 +105,7 @@ export class Leaderboard extends Component {
 							{ title }
 						</Text>
 					</CardHeader>
-					<CardBody size={ null }>
+					<CardBody size="none">
 						<EmptyTable>
 							{ __(
 								'No data recorded for the selected time period.',

--- a/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/block.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/block.js
@@ -59,7 +59,7 @@ class ChartBlock extends Component {
 							{ selectedChart.label }
 						</Text>
 					</CardHeader>
-					<CardBody size={ null }>
+					<CardBody size="none">
 						<a
 							className="screen-reader-text"
 							href={ getAdminLink(

--- a/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
@@ -300,7 +300,7 @@ export const StoreAlerts = () => {
 	};
 
 	return (
-		<Card className={ className } size={ null }>
+		<Card className={ className } size="none">
 			<CardHeader
 				className="woocommerce-store-alerts__header"
 				isBorderless

--- a/plugins/woocommerce/client/admin/client/layout/store-alerts/placeholder.js
+++ b/plugins/woocommerce/client/admin/client/layout/store-alerts/placeholder.js
@@ -17,7 +17,7 @@ class StoreAlertsPlaceholder extends Component {
 					className
 				) }
 				aria-hidden
-				size={ null }
+				size="none"
 			>
 				<CardHeader isBorderless>
 					<span className="is-placeholder" />


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes extra padding appearing on analytics tables and related card components when running on WordPress 7.0.

WordPress 7.0 (Gutenberg [#72511](https://github.com/WordPress/gutenberg/pull/72511)) added a `none` size value to the `Card` component. Previously, we were passing `size={ null }` to suppress default padding, which worked as an undocumented side-effect. With WordPress 7.0 this no longer works as expected and results in extra padding being applied.

This PR updates all affected `Card` and `CardBody` usages to use the new explicit `size="none"` value, and removes the `@ts-expect-error` comments that were needed when `null` was the only workaround.

Closes [WOOA7S-1158](https://linear.app/a8c/issue/WOOA7S-1158).

### Screenshots or screen recordings:

| before | after |
| --- | ---- |
| <img width="1305" height="296" alt="Screenshot 2026-03-23 at 20 09 04" src="https://github.com/user-attachments/assets/27a84f5f-e4c1-4256-bfbf-5d6522d72ac8" /> | <img width="1347" height="299" alt="Screenshot 2026-03-23 at 20 09 42" src="https://github.com/user-attachments/assets/8a8ac6fc-8842-4e3c-803b-5ec579be6c68" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**Setup:** Ensure you are running WordPress 7.0 or later ( you can use the WordPress beta tester for this ), please also test against 6.9 to make sure it still works fine there.

**Analytics Tables (TableCard)**
1. Go to **WooCommerce → Analytics → Revenue** (or any analytics report: Orders, Products, Categories, Coupons, etc.).
2. Verify the data table renders without unexpected top/bottom padding inside the card body — the table content should sit flush against the card borders with no extra whitespace.

**Advanced Filters**
1. Go to **WooCommerce → Analytics → Orders**.
2. Click **Add filter** and add one or more filters (e.g. filter by order status).
3. Verify the active filter chips inside the card body display without extra padding.

**Leaderboards (Dashboard)**
1. Go to **WooCommerce → Analytics → Overview** (dashboard).
2. Scroll down to the leaderboard section (e.g. Top Products, Top Coupons).
3. Verify the leaderboard cards render without unexpected padding around their content.
4. If there is no data for the selected period, verify the "No data recorded for the selected time period." empty state also has no extra padding.

**Dashboard Charts**
1. Go to **WooCommerce → Analytics → Overview**.
2. Verify the chart cards (Revenue, Orders, etc.) render without extra padding around the chart area.

**Abbreviated Cards**
1. Go to **WooCommerce → Analytics → Overview**.
2. Verify the small summary cards (e.g. total sales, orders) at the top of the page render without extra padding.

**Store Alerts**
1. Use WP-CLI to create an unactioned admin note of type `error` or `update`:
```bash
wp eval "
  \$note = new \Automattic\WooCommerce\Admin\Notes\Note();
  \$note->set_name( 'test-store-alert' );
  \$note->set_title( 'Test Store Alert' );
  \$note->set_content( 'This is a test store alert.' );
  \$note->set_type( \Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_ERROR );
  \$note->set_status( \Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_UNACTIONED );
  \$note->set_source( 'woocommerce' );
  \$note->set_content_data( (object) array() );
  \$note->save();
  echo 'Note created with ID: ' . \$note->get_id();
  "
```
2. Go to **WooCommerce → Home**.
3. Verify the store alert card at the top of the page renders without unexpected extra padding around the alert content.

### Testing that has already taken place:

Code change reviewed and verified against the Gutenberg PR #72511 which added `none` as an explicit supported `size` value for `Card`/`CardBody`. The `@ts-expect-error` suppression comments were also removed since `"none"` is now a valid type.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix analytics tables and dashboard cards showing extra padding on WordPress 7.0 by setting Card/CardBody size to "none".

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>