### PR TITLE
[WOOPRD-3134] Fix pagination select field oversized on WP 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPRD-3134-pagination-select-oversized
+++ b/plugins/woocommerce/changelog/fix-WOOPRD-3134-pagination-select-oversized
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix oversized pagination select field on orders and products list pages for WordPress 7.0.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8282,6 +8282,22 @@ table.bar_chart {
 }
 
 /**
+ * WP 7.0+ compatibility.
+ * WP 7.0 increased default form element min-height from 30px to 40px.
+ * Native <select> elements in the tablenav pagination area need to be
+ * constrained to the compact 32px sizing used by the tablenav.
+ */
+.wc-wp-version-gte-70.woocommerce_page_wc-orders .tablenav,
+.wc-wp-version-gte-70.post-type-product .tablenav,
+.wc-wp-version-gte-70.post-type-shop_order .tablenav {
+	select {
+		min-height: 32px;
+		height: 32px;
+		line-height: 2;
+	}
+}
+
+/**
   * Select2 colors for built-in admin color themes.
   */
 .wp-admin {

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -409,7 +409,7 @@ class WC_Admin {
 	 * @return string
 	 */
 	public function include_admin_body_class( $classes ) {
-		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55' ), explode( ' ', $classes ), true ) ) {
+		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55', 'wc-wp-version-gte-70' ), explode( ' ', $classes ), true ) ) {
 			return $classes;
 		}
 
@@ -425,6 +425,11 @@ class WC_Admin {
 		// Add WP 5.5+ compatibility class.
 		if ( $raw_version && version_compare( $version, '5.5', '>=' ) ) {
 			$classes .= ' wc-wp-version-gte-55';
+		}
+
+		// Add WP 7.0+ compatibility class.
+		if ( $raw_version && version_compare( $version, '7.0', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-70';
 		}
 
 		return $classes;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This PR is part of the **WordPress 7.0 Visual Compatibility** effort (parent: WOOPRD-3133).

WordPress 7.0 increased the default form element `min-height` from 30px to 40px. The `.tablenav` area uses compact 32px sizing, but native `<select>` elements in the pagination area were not constrained to match, causing them to appear oversized on the orders list, products list, and legacy shop_order pages.

This fix:
- Adds a `.wc-wp-version-gte-70` body class for WP 7.0+ detection (same pattern as PR #63779)
- Adds CSS rules scoped under `.wc-wp-version-gte-70` to constrain native `<select>` elements in `.tablenav` to 32px height

The CSS is scoped to:
- `.woocommerce_page_wc-orders` (HPOS orders list)
- `.post-type-product` (products list)
- `.post-type-shop_order` (legacy orders list)

This complements PR #63779 which fixes Select2 elements in the same area but does not address native `<select>` elements.

Closes WOOPRD-3134

### How to test the changes in this Pull Request:

1. Set up a store running WordPress 7.0 (beta5 or later)
2. Navigate to WooCommerce → Orders (`wp-admin/admin.php?page=wc-orders`)
3. Observe the "items per page" pagination select at the bottom of the table
4. **Expected**: The select height should be 32px, matching the adjacent tablenav elements
5. Also check the Products list page for the same fix
6. Downgrade to WordPress 6.9 and verify the pagination select still looks correct (CSS is scoped to WP 7.0+ only via `.wc-wp-version-gte-70`)

### Testing that has already taken place:

- Verified SCSS compiles correctly and produces expected CSS output
- PHPStan analysis passes with no errors on modified PHP file
- CSS rules confirmed in compiled output: `.wc-wp-version-gte-70.woocommerce_page_wc-orders .tablenav select` with `min-height:32px;height:32px;line-height:2`

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog was created manually via `pnpm --filter=@woocommerce/plugin-woocommerce changelog add`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix oversized pagination select field on orders and products list pages for WordPress 7.0.

</details>