### PR TITLE
[WOOPRD-3153] Fix stock status dropdown text vertically misaligned on WP 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-stock-status-dropdown-alignment-wp70
+++ b/plugins/woocommerce/changelog/fix-stock-status-dropdown-alignment-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix stock status dropdown text vertical alignment on WP 7.0 by setting consistent height and line-height for native selects in the product data panel.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8281,6 +8281,13 @@ table.bar_chart {
 	}
 }
 
+.wc-wp-version-gte-70 {
+	.woocommerce_options_panel select {
+		height: 40px;
+		line-height: 2;
+	}
+}
+
 /**
   * Select2 colors for built-in admin color themes.
   */

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -409,7 +409,7 @@ class WC_Admin {
 	 * @return string
 	 */
 	public function include_admin_body_class( $classes ) {
-		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55' ), explode( ' ', $classes ), true ) ) {
+		if ( in_array( array( 'wc-wp-version-gte-53', 'wc-wp-version-gte-55', 'wc-wp-version-gte-70' ), explode( ' ', $classes ), true ) ) {
 			return $classes;
 		}
 
@@ -425,6 +425,11 @@ class WC_Admin {
 		// Add WP 5.5+ compatibility class.
 		if ( $raw_version && version_compare( $version, '5.5', '>=' ) ) {
 			$classes .= ' wc-wp-version-gte-55';
+		}
+
+		// Add WP 7.0+ compatibility class.
+		if ( $raw_version && version_compare( $version, '7.0', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-70';
 		}
 
 		return $classes;

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-inventory-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-inventory-stock-status.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test as baseTest, expect, tags } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+const test = baseTest.extend( {
+	storageState: ADMIN_STATE_PATH,
+	product: async ( { restApi }, use ) => {
+		let product;
+
+		await restApi
+			.post( `${ WC_API_PATH }/products`, {
+				name: `Stock status test product ${ Date.now() }`,
+				type: 'simple',
+				regular_price: '10.00',
+			} )
+			.then( ( response ) => {
+				product = response.data;
+			} );
+
+		await use( product );
+
+		await restApi.delete( `${ WC_API_PATH }/products/${ product.id }`, {
+			force: true,
+		} );
+	},
+} );
+
+test(
+	'stock status dropdown has consistent height with other selects on WP 7.0+',
+	{ tag: [ tags.GUTENBERG ] },
+	async ( { page, product } ) => {
+		await test.step(
+			'navigate to the product Inventory tab',
+			async () => {
+				await page.goto(
+					`wp-admin/post.php?post=${ product.id }&action=edit`
+				);
+
+				await page
+					.getByRole( 'link' )
+					.filter( { hasText: 'Inventory' } )
+					.click();
+			}
+		);
+
+		await test.step(
+			'verify stock status select height and alignment',
+			async () => {
+				const stockStatusSelect = page.locator(
+					'select#_stock_status'
+				);
+				await expect( stockStatusSelect ).toBeVisible();
+
+				// On WP 7.0+ with the wc-wp-version-gte-70 body class,
+				// the select should have height: 40px and line-height: 2
+				// to match the WP 7.0 native form element sizing.
+				const hasWp70Class = await page.evaluate( () =>
+					document.body.classList.contains(
+						'wc-wp-version-gte-70'
+					)
+				);
+
+				if ( hasWp70Class ) {
+					await expect( stockStatusSelect ).toHaveCSS(
+						'height',
+						'40px'
+					);
+				}
+
+				// Regardless of WP version, verify the select is visible
+				// and has a reasonable height (not collapsed or oversized).
+				const height = await stockStatusSelect.evaluate(
+					( el ) => el.getBoundingClientRect().height
+				);
+				expect( height ).toBeGreaterThanOrEqual( 28 );
+				expect( height ).toBeLessThanOrEqual( 44 );
+			}
+		);
+	}
+);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The stock status dropdown on the Inventory tab of the classic product editor has a medium-sized height (between the old 30px and new 40px) on WordPress 7.0, and the text within it is not vertically centred. This happens because WP 7.0's form element changes create mixed height inheritance for native `<select>` elements.

This PR:
1. Adds a `wc-wp-version-gte-70` body class for WordPress 7.0+ (following the existing pattern for WP 5.3+ and 5.5+)
2. Adds scoped CSS rules under `.wc-wp-version-gte-70` to set consistent `height: 40px` and `line-height: 2` for native selects in `.woocommerce_options_panel`

This fix complements PR #63779 which addresses Select2 heights and label alignment but does not target native `<select>` text alignment.

Closes WOOPRD-3153

**Parent issue:** WOOPRD-3148 (Product Editor Classic — WP 7.0 Visual Regressions)

### How to test the changes in this Pull Request:

1. Set up a WordPress 7.0 (beta/RC) environment with WooCommerce
2. Navigate to WooCommerce → Products → Edit any simple product (classic editor)
3. Click the "Inventory" tab in the Product Data panel
4. Observe the "Stock status" dropdown — text should be vertically centred within the 40px height
5. Check other native selects in the product data panels (e.g. tax status, shipping class) — they should also have consistent height and centred text
6. Verify on WP 6.9 that there is no visual regression (the `.wc-wp-version-gte-70` class is not added, so the CSS does not apply)

### Testing that has already taken place:

- PHPCS linting: passes (0 errors)
- PHPStan static analysis: passes (0 errors)
- SCSS compilation: passes
- Playwright E2E test added to verify stock status select height and alignment

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually in `plugins/woocommerce/changelog/fix-stock-status-dropdown-alignment-wp70`.

</details>