### PR TITLE
Fix product collection block live preview for unsaved relationship changes

### DIFF
--- a/plugins/woocommerce/changelog/63822-fix-product-collection-live-preview
+++ b/plugins/woocommerce/changelog/63822-fix-product-collection-live-preview
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix product collection block (upsells/cross-sells) editor preview to reflect unsaved relationship changes instead of stale DB data.
+Fix product collection block (upsells/cross-sells) editor preview to reflect unsaved relationship changes.

--- a/plugins/woocommerce/changelog/63822-fix-product-collection-live-preview
+++ b/plugins/woocommerce/changelog/63822-fix-product-collection-live-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product collection block (upsells/cross-sells) editor preview to reflect unsaved relationship changes instead of stale DB data.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -257,6 +257,9 @@ const ProductTemplateEdit = (
 		queryContextIncludes: queryContextIncludesWithDefaults,
 	} );
 
+	const productReference = ( restQueryArgs as Record< string, unknown > )
+		.productReference as number | undefined;
+
 	const { products, isInSingleProductBlock, blocks } = useSelect(
 		( select ) => {
 			const { getEntityRecords, getEditedEntityRecord, getTaxonomies } =
@@ -343,6 +346,38 @@ const ProductTemplateEdit = (
 				query.orderby = orderProperties.orderby;
 				query.order = orderProperties.order;
 			}
+			// Read edited product entity to get unsaved relationship data
+			// for live preview of upsells/cross-sells collections.
+			let editedProductRelationships:
+				| Record< string, number[] >
+				| undefined;
+			if ( productReference ) {
+				const editedProduct = getEditedEntityRecord(
+					'postType',
+					'product',
+					productReference
+				) as Record< string, unknown > | undefined;
+				if ( editedProduct ) {
+					const upsellIds = editedProduct.upsell_ids as
+						| number[]
+						| undefined;
+					const crossSellIds = editedProduct.cross_sell_ids as
+						| number[]
+						| undefined;
+					if ( upsellIds || crossSellIds ) {
+						editedProductRelationships = {};
+						if ( upsellIds ) {
+							editedProductRelationships.upsell_ids =
+								upsellIds;
+						}
+						if ( crossSellIds ) {
+							editedProductRelationships.cross_sell_ids =
+								crossSellIds;
+						}
+					}
+				}
+			}
+
 			return {
 				products: getEntityRecords( 'postType', postType, {
 					...query,
@@ -350,6 +385,11 @@ const ProductTemplateEdit = (
 					productCollectionLocation: location,
 					productCollectionQueryContext,
 					previewState: __privateProductCollectionPreviewState,
+					...( editedProductRelationships && {
+						editedProductRelationships: JSON.stringify(
+							editedProductRelationships
+						),
+					} ),
 					/**
 					 * Use value of "Out of stock visibility" setting to determine
 					 * which stock statuses to include if inherit query
@@ -384,6 +424,7 @@ const ProductTemplateEdit = (
 			productCollectionQueryContext,
 			loopShopPerPage,
 			__privateProductCollectionPreviewState,
+			productReference,
 		]
 	);
 	const blockContexts = useMemo(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -358,9 +358,8 @@ const ProductTemplateEdit = (
 			}
 			// Read edited product entity to get unsaved relationship data
 			// for live preview of upsells/cross-sells collections.
-			let editedProductRelationships:
-				| Record< string, number[] >
-				| undefined;
+			let editedUpsellIds: number[] | undefined;
+			let editedCrossSellIds: number[] | undefined;
 			if ( productIdForRelationships ) {
 				const editedProduct = getEditedEntityRecord(
 					'postType',
@@ -368,23 +367,12 @@ const ProductTemplateEdit = (
 					productIdForRelationships
 				) as Record< string, unknown > | undefined;
 				if ( editedProduct ) {
-					const upsellIds = editedProduct.upsell_ids as
+					editedUpsellIds = editedProduct.upsell_ids as
 						| number[]
 						| undefined;
-					const crossSellIds = editedProduct.cross_sell_ids as
+					editedCrossSellIds = editedProduct.cross_sell_ids as
 						| number[]
 						| undefined;
-					if ( upsellIds || crossSellIds ) {
-						editedProductRelationships = {};
-						if ( upsellIds ) {
-							editedProductRelationships.upsell_ids =
-								upsellIds;
-						}
-						if ( crossSellIds ) {
-							editedProductRelationships.cross_sell_ids =
-								crossSellIds;
-						}
-					}
 				}
 			}
 
@@ -395,10 +383,11 @@ const ProductTemplateEdit = (
 					productCollectionLocation: location,
 					productCollectionQueryContext,
 					previewState: __privateProductCollectionPreviewState,
-					...( editedProductRelationships && {
-						editedProductRelationships: JSON.stringify(
-							editedProductRelationships
-						),
+					...( editedUpsellIds && {
+						editedUpsellIds,
+					} ),
+					...( editedCrossSellIds && {
+						editedCrossSellIds,
 					} ),
 					/**
 					 * Use value of "Out of stock visibility" setting to determine

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -257,8 +257,18 @@ const ProductTemplateEdit = (
 		queryContextIncludes: queryContextIncludesWithDefaults,
 	} );
 
-	const productReference = ( restQueryArgs as Record< string, unknown > )
-		.productReference as number | undefined;
+	// Determine the product ID for reading edited entity data.
+	// productReference is set explicitly; otherwise fall back to location context
+	// (e.g., inside single-product block where postId provides the product ID).
+	const productReferenceFromQuery = ( restQueryArgs as Record<
+		string,
+		unknown
+	> ).productReference as number | undefined;
+	const productIdForRelationships =
+		productReferenceFromQuery ||
+		( location?.type === 'product'
+			? ( location.sourceData as { productId?: number } )?.productId
+			: undefined );
 
 	const { products, isInSingleProductBlock, blocks } = useSelect(
 		( select ) => {
@@ -351,11 +361,11 @@ const ProductTemplateEdit = (
 			let editedProductRelationships:
 				| Record< string, number[] >
 				| undefined;
-			if ( productReference ) {
+			if ( productIdForRelationships ) {
 				const editedProduct = getEditedEntityRecord(
 					'postType',
 					'product',
-					productReference
+					productIdForRelationships
 				) as Record< string, unknown > | undefined;
 				if ( editedProduct ) {
 					const upsellIds = editedProduct.upsell_ids as
@@ -424,7 +434,7 @@ const ProductTemplateEdit = (
 			productCollectionQueryContext,
 			loopShopPerPage,
 			__privateProductCollectionPreviewState,
-			productReference,
+			productIdForRelationships,
 		]
 	);
 	const blockContexts = useMemo(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -260,10 +260,9 @@ const ProductTemplateEdit = (
 	// Determine the product ID for reading edited entity data.
 	// productReference is set explicitly; otherwise fall back to location context
 	// (e.g., inside single-product block where postId provides the product ID).
-	const productReferenceFromQuery = ( restQueryArgs as Record<
-		string,
-		unknown
-	> ).productReference as number | undefined;
+	const productReferenceFromQuery = (
+		restQueryArgs as Record< string, unknown >
+	 ).productReference as number | undefined;
 	const productIdForRelationships =
 		productReferenceFromQuery ||
 		( location?.type === 'product'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -190,6 +190,17 @@ class HandlerRegistry {
 		$this->register_collection_handlers(
 			'woocommerce/product-collection/upsells',
 			function ( $collection_args ) {
+				// Use client-provided resolved IDs when available (live preview of unsaved changes).
+				if ( ! empty( $collection_args['resolvedProductIds'] ) ) {
+					$resolved_ids      = array_map( 'absint', $collection_args['resolvedProductIds'] );
+					$product_reference = $collection_args['upsellsProductReferences'] ?? array();
+					$upsells           = array_diff( array_unique( $resolved_ids ), $product_reference );
+
+					return array(
+						'post__in' => empty( $upsells ) ? array( -1 ) : array_values( $upsells ),
+					);
+				}
+
 				$product_reference = $collection_args['upsellsProductReferences'] ?? null;
 				// No products should be shown if no upsells product reference is set.
 				if ( empty( $product_reference ) ) {
@@ -258,6 +269,16 @@ class HandlerRegistry {
 				}
 
 				$collection_args['upsellsProductReferences'] = array( $product_reference );
+
+				// Use client-provided relationship IDs for live preview of unsaved changes.
+				$edited_relationships = $request->get_param( 'editedProductRelationships' );
+				if ( ! empty( $edited_relationships ) ) {
+					$relationships = json_decode( $edited_relationships, true );
+					if ( is_array( $relationships ) && isset( $relationships['upsell_ids'] ) && is_array( $relationships['upsell_ids'] ) ) {
+						$collection_args['resolvedProductIds'] = array_map( 'absint', $relationships['upsell_ids'] );
+					}
+				}
+
 				return $collection_args;
 			}
 		);
@@ -265,6 +286,17 @@ class HandlerRegistry {
 		$this->register_collection_handlers(
 			'woocommerce/product-collection/cross-sells',
 			function ( $collection_args ) {
+				// Use client-provided resolved IDs when available (live preview of unsaved changes).
+				if ( ! empty( $collection_args['resolvedProductIds'] ) ) {
+					$resolved_ids      = array_map( 'absint', $collection_args['resolvedProductIds'] );
+					$product_reference = $collection_args['crossSellsProductReferences'] ?? array();
+					$cross_sells       = array_diff( array_unique( $resolved_ids ), $product_reference );
+
+					return array(
+						'post__in' => empty( $cross_sells ) ? array( -1 ) : array_values( $cross_sells ),
+					);
+				}
+
 				$product_reference = $collection_args['crossSellsProductReferences'] ?? null;
 				// No products should be shown if no cross-sells product reference is set.
 				if ( empty( $product_reference ) ) {
@@ -340,6 +372,16 @@ class HandlerRegistry {
 				}
 
 				$collection_args['crossSellsProductReferences'] = array( $product_reference );
+
+				// Use client-provided relationship IDs for live preview of unsaved changes.
+				$edited_relationships = $request->get_param( 'editedProductRelationships' );
+				if ( ! empty( $edited_relationships ) ) {
+					$relationships = json_decode( $edited_relationships, true );
+					if ( is_array( $relationships ) && isset( $relationships['cross_sell_ids'] ) && is_array( $relationships['cross_sell_ids'] ) ) {
+						$collection_args['resolvedProductIds'] = array_map( 'absint', $relationships['cross_sell_ids'] );
+					}
+				}
+
 				return $collection_args;
 			}
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -270,13 +270,10 @@ class HandlerRegistry {
 
 				$collection_args['upsellsProductReferences'] = array( $product_reference );
 
-				// Use client-provided relationship IDs for live preview of unsaved changes.
-				$edited_relationships = $request->get_param( 'editedProductRelationships' );
-				if ( ! empty( $edited_relationships ) ) {
-					$relationships = json_decode( $edited_relationships, true );
-					if ( is_array( $relationships ) && isset( $relationships['upsell_ids'] ) && is_array( $relationships['upsell_ids'] ) ) {
-						$collection_args['resolvedProductIds'] = array_map( 'absint', $relationships['upsell_ids'] );
-					}
+				// Use client-provided upsell IDs for live preview of unsaved changes.
+				$edited_upsell_ids = $request->get_param( 'editedUpsellIds' );
+				if ( is_array( $edited_upsell_ids ) ) {
+					$collection_args['resolvedProductIds'] = array_map( 'absint', $edited_upsell_ids );
 				}
 
 				return $collection_args;
@@ -373,13 +370,10 @@ class HandlerRegistry {
 
 				$collection_args['crossSellsProductReferences'] = array( $product_reference );
 
-				// Use client-provided relationship IDs for live preview of unsaved changes.
-				$edited_relationships = $request->get_param( 'editedProductRelationships' );
-				if ( ! empty( $edited_relationships ) ) {
-					$relationships = json_decode( $edited_relationships, true );
-					if ( is_array( $relationships ) && isset( $relationships['cross_sell_ids'] ) && is_array( $relationships['cross_sell_ids'] ) ) {
-						$collection_args['resolvedProductIds'] = array_map( 'absint', $relationships['cross_sell_ids'] );
-					}
+				// Use client-provided cross-sell IDs for live preview of unsaved changes.
+				$edited_cross_sell_ids = $request->get_param( 'editedCrossSellIds' );
+				if ( is_array( $edited_cross_sell_ids ) ) {
+					$collection_args['resolvedProductIds'] = array_map( 'absint', $edited_cross_sell_ids );
 				}
 
 				return $collection_args;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -191,7 +191,7 @@ class HandlerRegistry {
 			'woocommerce/product-collection/upsells',
 			function ( $collection_args ) {
 				// Use client-provided resolved IDs when available (live preview of unsaved changes).
-				if ( ! empty( $collection_args['resolvedProductIds'] ) ) {
+				if ( isset( $collection_args['resolvedProductIds'] ) ) {
 					$resolved_ids      = array_map( 'absint', $collection_args['resolvedProductIds'] );
 					$product_reference = $collection_args['upsellsProductReferences'] ?? array();
 					$upsells           = array_diff( array_unique( $resolved_ids ), $product_reference );
@@ -287,7 +287,7 @@ class HandlerRegistry {
 			'woocommerce/product-collection/cross-sells',
 			function ( $collection_args ) {
 				// Use client-provided resolved IDs when available (live preview of unsaved changes).
-				if ( ! empty( $collection_args['resolvedProductIds'] ) ) {
+				if ( isset( $collection_args['resolvedProductIds'] ) ) {
 					$resolved_ids      = array_map( 'absint', $collection_args['resolvedProductIds'] );
 					$product_reference = $collection_args['crossSellsProductReferences'] ?? array();
 					$cross_sells       = array_diff( array_unique( $resolved_ids ), $product_reference );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -271,6 +271,123 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the upsells handler uses client-provided IDs for live preview.
+	 */
+	public function test_collection_upsells_with_edited_relationships() {
+		$client_upsell_ids = array( 10, 20, 30 );
+
+		// Create a product with different upsell IDs saved in DB.
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_upsell_ids( array( 99, 100 ) );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'upsell_ids' => $client_upsell_ids ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Should use client-provided IDs, not DB-saved ones.
+		$this->assertEqualsCanonicalizing( $client_upsell_ids, $result['post__in'] );
+	}
+
+	/**
+	 * Tests that the upsells handler falls back to DB when no client-provided IDs.
+	 */
+	public function test_collection_upsells_falls_back_without_edited_relationships() {
+		$db_upsell_ids = array( 2, 3, 4 );
+		$test_product  = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_upsell_ids( $db_upsell_ids );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+		// No editedProductRelationships param set.
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		$this->assertEqualsCanonicalizing( $db_upsell_ids, $result['post__in'] );
+	}
+
+	/**
+	 * Tests that the cross-sells handler uses client-provided IDs for live preview.
+	 */
+	public function test_collection_cross_sells_with_edited_relationships() {
+		$client_cross_sell_ids = array( 10, 20, 30 );
+
+		// Create a product with different cross-sell IDs saved in DB.
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_cross_sell_ids( array( 99, 100 ) );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/cross-sells',
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'cross_sell_ids' => $client_cross_sell_ids ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Should use client-provided IDs, not DB-saved ones.
+		$this->assertEqualsCanonicalizing( $client_cross_sell_ids, $result['post__in'] );
+	}
+
+	/**
+	 * Tests that the upsells handler excludes the product reference from resolved IDs.
+	 */
+	public function test_collection_upsells_edited_relationships_excludes_self() {
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->save();
+
+		$product_id = $test_product->get_id();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $product_id )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+		// Include the product itself in the upsell IDs — should be excluded.
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'upsell_ids' => array( $product_id, 10, 20 ) ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		$this->assertEqualsCanonicalizing( array( 10, 20 ), $result['post__in'] );
+		$this->assertNotContains( $product_id, $result['post__in'] );
+	}
+
+	/**
 	 * Tests that the hand-picked collection handler works with empty product selection.
 	 */
 	public function test_collection_hand_picked_empty() {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -290,10 +290,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/upsells',
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'upsell_ids' => $client_upsell_ids ) )
-		);
+		$request->set_param( 'editedUpsellIds', $client_upsell_ids );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -319,7 +316,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/upsells',
 			)
 		);
-		// No editedProductRelationships param set.
+		// No editedUpsellIds param set.
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -346,10 +343,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/cross-sells',
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'cross_sell_ids' => $client_cross_sell_ids ) )
-		);
+		$request->set_param( 'editedCrossSellIds', $client_cross_sell_ids );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -399,10 +393,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/cross-sells',
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'cross_sell_ids' => array( $product_id, 10, 20 ) ) )
-		);
+		$request->set_param( 'editedCrossSellIds', array( $product_id, 10, 20 ) );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -427,10 +418,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/upsells',
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'upsell_ids' => array() ) )
-		);
+		$request->set_param( 'editedUpsellIds', array() );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -455,10 +443,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				'collection' => 'woocommerce/product-collection/cross-sells',
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'cross_sell_ids' => array() ) )
-		);
+		$request->set_param( 'editedCrossSellIds', array() );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -485,10 +470,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 			)
 		);
 		// Include the product itself in the upsell IDs — should be excluded.
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'upsell_ids' => array( $product_id, 10, 20 ) ) )
-		);
+		$request->set_param( 'editedUpsellIds', array( $product_id, 10, 20 ) );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -524,10 +506,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				),
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'upsell_ids' => $client_upsell_ids ) )
-		);
+		$request->set_param( 'editedUpsellIds', $client_upsell_ids );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
@@ -562,10 +541,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 				),
 			)
 		);
-		$request->set_param(
-			'editedProductRelationships',
-			wp_json_encode( array( 'cross_sell_ids' => $client_cross_sell_ids ) )
-		);
+		$request->set_param( 'editedCrossSellIds', $client_cross_sell_ids );
 
 		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -497,6 +497,83 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests upsells with edited relationships via location context (no productReference).
+	 * This is the flow used inside the single-product block editor.
+	 */
+	public function test_collection_upsells_edited_relationships_via_location() {
+		$client_upsell_ids = array( 10, 20, 30 );
+
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_upsell_ids( array( 99, 100 ) );
+		$test_product->save();
+
+		// No productReference param — product ID comes from location context.
+		$request = Utils::build_request();
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+		$request->set_param(
+			'productCollectionLocation',
+			array(
+				'type'       => 'product',
+				'sourceData' => array(
+					'productId' => $test_product->get_id(),
+				),
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'upsell_ids' => $client_upsell_ids ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Should use client-provided IDs even without explicit productReference.
+		$this->assertEqualsCanonicalizing( $client_upsell_ids, $result['post__in'] );
+	}
+
+	/**
+	 * Tests cross-sells with edited relationships via location context (no productReference).
+	 */
+	public function test_collection_cross_sells_edited_relationships_via_location() {
+		$client_cross_sell_ids = array( 10, 20, 30 );
+
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_cross_sell_ids( array( 99, 100 ) );
+		$test_product->save();
+
+		// No productReference param — product ID comes from location context.
+		$request = Utils::build_request();
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/cross-sells',
+			)
+		);
+		$request->set_param(
+			'productCollectionLocation',
+			array(
+				'type'       => 'product',
+				'sourceData' => array(
+					'productId' => $test_product->get_id(),
+				),
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'cross_sell_ids' => $client_cross_sell_ids ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Should use client-provided IDs even without explicit productReference.
+		$this->assertEqualsCanonicalizing( $client_cross_sell_ids, $result['post__in'] );
+	}
+
+	/**
 	 * Tests that the hand-picked collection handler works with empty product selection.
 	 */
 	public function test_collection_hand_picked_empty() {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -358,6 +358,115 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the cross-sells handler falls back to DB when no client-provided IDs.
+	 */
+	public function test_collection_cross_sells_falls_back_without_edited_relationships() {
+		$db_cross_sell_ids = array( 2, 3, 4 );
+		$test_product      = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_cross_sell_ids( $db_cross_sell_ids );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/cross-sells',
+			)
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		$this->assertEqualsCanonicalizing( $db_cross_sell_ids, $result['post__in'] );
+	}
+
+	/**
+	 * Tests that the cross-sells handler excludes the product reference from resolved IDs.
+	 */
+	public function test_collection_cross_sells_edited_relationships_excludes_self() {
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->save();
+
+		$product_id = $test_product->get_id();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $product_id )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/cross-sells',
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'cross_sell_ids' => array( $product_id, 10, 20 ) ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		$this->assertEqualsCanonicalizing( array( 10, 20 ), $result['post__in'] );
+		$this->assertNotContains( $product_id, $result['post__in'] );
+	}
+
+	/**
+	 * Tests that empty edited upsell_ids results in no products (not DB fallback).
+	 */
+	public function test_collection_upsells_edited_empty_array_shows_nothing() {
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_upsell_ids( array( 2, 3, 4 ) );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'upsell_ids' => array() ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Empty array means user cleared all upsells — should show nothing, not DB data.
+		$this->assertSame( array( -1 ), $result['post__in'] );
+	}
+
+	/**
+	 * Tests that empty edited cross_sell_ids results in no products (not DB fallback).
+	 */
+	public function test_collection_cross_sells_edited_empty_array_shows_nothing() {
+		$test_product = WC_Helper_Product::create_simple_product( false );
+		$test_product->set_cross_sell_ids( array( 2, 3, 4 ) );
+		$test_product->save();
+
+		$request = Utils::build_request(
+			array( 'productReference' => $test_product->get_id() )
+		);
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/cross-sells',
+			)
+		);
+		$request->set_param(
+			'editedProductRelationships',
+			wp_json_encode( array( 'cross_sell_ids' => array() ) )
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		// Empty array means user cleared all cross-sells — should show nothing, not DB data.
+		$this->assertSame( array( -1 ), $result['post__in'] );
+	}
+
+	/**
 	 * Tests that the upsells handler excludes the product reference from resolved IDs.
 	 */
 	public function test_collection_upsells_edited_relationships_excludes_self() {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Product collection blocks (upsells, cross-sells) in the editor preview show saved DB state, not unsaved edits. The server calls `wc_get_product()->get_upsell_ids()` which reads from DB.

Fix: pass edited relationship IDs from client core-data store to server via REST params (`editedUpsellIds`, `editedCrossSellIds`). Server uses them directly when present, falls back to DB when absent.

### How to test the changes in this Pull Request:

1. Create products A, B, C.
2. Edit product A, add B+C as upsells — preview updates immediately without saving.
3. Remove C — preview updates. Clear all — preview shows nothing.
4. Save, verify frontend matches. Repeat for cross-sells.

### Testing that has already taken place:

10 new PHPUnit tests. PHP lint clean.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix product collection block (upsells/cross-sells) editor preview to reflect unsaved relationship changes.

</details>