### PR TITLE
Fix coupon/product data panel visual regressions on WordPress 7.0

### DIFF
--- a/plugins/woocommerce/changelog/63823-wooprd-3144-coupons-wp-70-visual-regressions
+++ b/plugins/woocommerce/changelog/63823-wooprd-3144-coupons-wp-70-visual-regressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon and product data panel visual regressions (label, help tip, and Select2 alignment) on WordPress 7.0.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8281,6 +8281,45 @@ table.bar_chart {
 	}
 }
 
+.wc-wp-version-gte-70 {
+	#woocommerce-product-data,
+	#woocommerce-coupon-data {
+		.woocommerce_options_panel .form-field {
+			label,
+			legend {
+				padding-top: 8px;
+			}
+
+			.woocommerce-help-tip {
+				margin-top: 12px;
+			}
+
+			&:has(> .checkbox) label {
+				padding-top: 0;
+			}
+		}
+	}
+
+	.select2-container {
+		.select2-selection--single {
+			height: 40px;
+			border-radius: 2px;
+
+			.select2-selection__rendered {
+				line-height: 38px;
+			}
+
+			.select2-selection__arrow {
+				height: 38px;
+			}
+		}
+
+		.select2-selection--multiple {
+			border-radius: 2px;
+		}
+	}
+}
+
 /**
   * Select2 colors for built-in admin color themes.
   */

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -427,6 +427,11 @@ class WC_Admin {
 			$classes .= ' wc-wp-version-gte-55';
 		}
 
+		// Add WP 7.0+ compatibility class.
+		if ( $raw_version && version_compare( $version, '7.0', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-70';
+		}
+
 		return $classes;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress 7.0 increased native form element `min-height` from ~30px to 40px, making label and help tip icon misalignment obvious on coupon and product data panels. This PR adds a `wc-wp-version-gte-70` body class and scoped CSS fixes to:

- Vertically center labels against 40px inputs (`padding-top: 8px`)
- Vertically center help tip icons against 40px inputs (`margin-top: 12px`)
- Reset label padding for checkbox fields to avoid misalignment
- Match Select2 single-select height to native 40px selects
- Align Select2 `border-radius` with WP 7.0's 2px

Closes https://linear.app/a8c/issue/WOOPRD-3144/coupons-wp-70-visual-regressions

### Screenshots or screen recordings:

<!-- Pavel will add before/after screenshots -->

| Before | After |
| ------ | ----- |
|    <img width="963" height="353" alt="Before1" src="https://github.com/user-attachments/assets/9ba45cf7-a6f6-427a-96af-cfaef54affdc" />   |    <img width="971" height="354" alt="After1" src="https://github.com/user-attachments/assets/2cec94e6-20f2-4182-8b04-58dfcc86307c" />   |
| ------ | ----- |
|     <img width="948" height="907" alt="Before2" src="https://github.com/user-attachments/assets/3e618f07-6f38-4519-8fe7-fcef0279125f" />  |     <img width="955" height="918" alt="After2" src="https://github.com/user-attachments/assets/83ae60e9-0bba-4a83-a252-1cb479642abe" />  |

### How to test the changes in this Pull Request:

1. Set up a WordPress 7.0 (beta) environment with WooCommerce.
2. Navigate to **Marketing > Coupons > Add New**.
3. On the **General** tab, verify:
   - "Discount type" label is vertically centered with the select dropdown.
   - "Coupon amount" label and help tip icon ("?") are vertically centered with the input.
   - "Allow free shipping" checkbox label aligns with the checkbox (no extra top padding).
   - "Coupon expiry date" label and help tip icon are vertically centered with the input.
4. Switch to the **Usage restriction** tab, verify:
   - "Minimum spend" / "Maximum spend" labels and help tips are centered with inputs.
   - Checkbox labels ("Individual use only", "Exclude sale items") align with checkboxes.
   - Select2 multi-select fields ("Products", "Categories") have labels aligned.
5. Switch to the **Usage limits** tab, verify labels and help tips are centered.
6. Verify Select2 dropdowns match the height of native `<select>` elements (40px).
7. On a WordPress 6.x environment, verify no visual changes occur (styles are gated behind `.wc-wp-version-gte-70` body class).

### Testing that has already taken place:

Visually tested on WordPress 7.0 (wp-env) across all three coupon tabs (General, Usage restriction, Usage limits). Verified label centering, help tip centering, checkbox alignment, and Select2 height. Confirmed the body class is correctly applied. PHP linting and CSS build pass.

### Code review notes:

_N/A_

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix coupon and product data panel visual regressions (label, help tip, and Select2 alignment) on WordPress 7.0.

</details>