### PR TITLE
Shorten email editor reset action label for consistency with site templates

### DIFF
--- a/plugins/woocommerce/changelog/update-email-post-reset-content-action-label
+++ b/plugins/woocommerce/changelog/update-email-post-reset-content-action-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Shorten the email editor reset action label from "Reset content to default" to "Reset" for consistency with site template resets and to reduce i18n overhead.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
@@ -169,7 +169,7 @@ const getResetNotificationEmailContentAction = () => {
 							disabled={ isBusy }
 							__next40pxDefaultSize
 						>
-							{ __( 'Reset to default', 'woocommerce' ) }
+							{ __( 'Reset', 'woocommerce' ) }
 						</Button>
 					</HStack>
 				</VStack>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/reset-notification-email-content.tsx
@@ -42,7 +42,7 @@ const getResetNotificationEmailContentAction = () => {
 	 */
 	const resetNotificationEmailContent = {
 		id: 'reset-notification-email-content',
-		label: __( 'Reset content to default', 'woocommerce' ),
+		label: __( 'Reset', 'woocommerce' ),
 		supportsBulk: false,
 		icon: backup,
 		isEligible( item: PostWithPermissions ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The email editor's "Reset content to default" action label is inconsistent with how WordPress site template resets label the same action — simply "Reset". This PR shortens the label to "Reset" to align with the existing pattern and reduce unnecessary i18n strings.

Context: pfRkvP-1SP-p2#comment-514

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="286" height="271" alt="Screenshot 2026-03-24 at 12 49 01 PM" src="https://github.com/user-attachments/assets/d2f89827-4ad4-4518-8bf2-62b9289fedc7" /> |  <img width="280" height="275" alt="Screenshot 2026-03-24 at 12 48 50 PM" src="https://github.com/user-attachments/assets/05228c29-f4cc-40cf-b214-b006f04b5956" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block email editor feature (ensure the `woocommerce_feature_email_editor_enabled` option is set to `yes`).
2. Navigate to **WooCommerce > Settings > Emails** and open an email content in the block editor.
3. Open the actions menu (⋮) for an email post in the editor.
4. Verify the reset action label reads **"Reset"** instead of "Reset content to default".
5. Click "Reset" and confirm the confirmation modal and the reset flow still work correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

Manual verification that the label renders correctly and the reset action continues to function as expected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
