### PR TITLE
Emails: Migrate deferred email sending to Action Scheduler

### DIFF
--- a/plugins/woocommerce/changelog/63832-wooplug-1935-the-wp_background_process-class-do-we-still-need-it
+++ b/plugins/woocommerce/changelog/63832-wooplug-1935-the-wp_background_process-class-do-we-still-need-it
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Migrate deferred transactional email sending to Action Scheduler

--- a/plugins/woocommerce/changelog/wooplug-1935-the-wp_background_process-class-do-we-still-need-it
+++ b/plugins/woocommerce/changelog/wooplug-1935-the-wp_background_process-class-do-we-still-need-it
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Migrate deferred transactional email sending from WC_Background_Emailer to Action Scheduler.

--- a/plugins/woocommerce/changelog/wooplug-1935-the-wp_background_process-class-do-we-still-need-it
+++ b/plugins/woocommerce/changelog/wooplug-1935-the-wp_background_process-class-do-we-still-need-it
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Migrate deferred transactional email sending from WC_Background_Emailer to Action Scheduler.

--- a/plugins/woocommerce/includes/class-wc-background-emailer.php
+++ b/plugins/woocommerce/includes/class-wc-background-emailer.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Background_Process', false ) ) {
 /**
  * WC_Background_Emailer Class.
  *
- * @deprecated 10.8.0 Use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue instead.
+ * @deprecated 10.8.0 Deferred emails now use Action Scheduler. No stable public replacement exists.
  */
 class WC_Background_Emailer extends WC_Background_Process {
 

--- a/plugins/woocommerce/includes/class-wc-background-emailer.php
+++ b/plugins/woocommerce/includes/class-wc-background-emailer.php
@@ -16,6 +16,8 @@ if ( ! class_exists( 'WC_Background_Process', false ) ) {
 
 /**
  * WC_Background_Emailer Class.
+ *
+ * @deprecated 10.8.0 Use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue instead.
  */
 class WC_Background_Emailer extends WC_Background_Process {
 

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -155,7 +155,7 @@ class WC_Emails {
 	 */
 	public static function queue_transactional_email( ...$args ) {
 		if ( self::$deferred_queue instanceof DeferredEmailQueue ) {
-			self::$deferred_queue->push( current_filter(), func_get_args() );
+			self::$deferred_queue->push( current_filter(), $args );
 		} else {
 			self::send_transactional_email( ...$args );
 		}

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -11,6 +11,7 @@
 declare( strict_types = 1 );
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 use Automattic\WooCommerce\Enums\ProductType;
@@ -39,11 +40,12 @@ class WC_Emails {
 	protected static $instance = null;
 
 	/**
-	 * Background emailer class.
+	 * Deferred email queue instance.
 	 *
-	 * @var WC_Background_Emailer
+	 * @since 10.8.0
+	 * @var DeferredEmailQueue|null
 	 */
-	protected static $background_emailer = null;
+	protected static $deferred_queue = null;
 
 	/**
 	 * Main WC_Emails Instance.
@@ -123,14 +125,16 @@ class WC_Emails {
 			)
 		);
 
+		$defer_default = FeaturesUtil::feature_is_enabled( 'deferred_transactional_emails' );
+
 		/**
 		 * Filter whether to defer transactional emails.
 		 *
 		 * @since 3.0.0
 		 * @param bool $defer Whether to defer transactional emails.
 		 */
-		if ( apply_filters( 'woocommerce_defer_transactional_emails', false ) ) {
-			self::$background_emailer = new WC_Background_Emailer();
+		if ( apply_filters( 'woocommerce_defer_transactional_emails', $defer_default ) ) {
+			self::$deferred_queue = wc_get_container()->get( DeferredEmailQueue::class );
 
 			foreach ( $email_actions as $action ) {
 				add_action( $action, array( __CLASS__, 'queue_transactional_email' ), 10, 10 );
@@ -150,13 +154,8 @@ class WC_Emails {
 	 * @return void
 	 */
 	public static function queue_transactional_email( ...$args ) {
-		if ( is_a( self::$background_emailer, 'WC_Background_Emailer' ) ) {
-			self::$background_emailer->push_to_queue(
-				array(
-					'filter' => current_filter(),
-					'args'   => func_get_args(),
-				)
-			);
+		if ( self::$deferred_queue instanceof DeferredEmailQueue ) {
+			self::$deferred_queue->push( current_filter(), func_get_args() );
 		} else {
 			self::send_transactional_email( ...$args );
 		}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -29,6 +29,7 @@ use Automattic\WooCommerce\Internal\Settings\OptionSanitizer;
 use Automattic\WooCommerce\Internal\Utilities\LegacyRestApiStub;
 use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
 use Automattic\WooCommerce\Internal\Admin\EmailImprovements\EmailImprovements;
+use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue;
 use Automattic\WooCommerce\Internal\Admin\Marketplace;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\{LoggingUtil, TimeUtil};
@@ -368,6 +369,7 @@ final class WooCommerce {
 		$container->get( ComingSoonRequestHandler::class );
 		$container->get( OrderCountCacheService::class );
 		$container->get( EmailImprovements::class );
+		$container->get( DeferredEmailQueue::class );
 		$container->get( AddressProviderController::class );
 		$container->get( AbilitiesRegistry::class );
 		$container->get( MCPAdapterProvider::class );

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -44,7 +44,7 @@ final class DeferredEmailQueue {
 	 *
 	 * @internal
 	 */
-	final public function init(): void {
+	public function init(): void {
 		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_emails' ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Email;
+
+/**
+ * Handles deferred transactional email sending via Action Scheduler.
+ *
+ * Collects email callbacks during a request and dispatches them as a single
+ * batched Action Scheduler action on shutdown, replacing the legacy
+ * WC_Background_Emailer approach.
+ *
+ * @since 10.8.0
+ */
+final class DeferredEmailQueue {
+
+	/**
+	 * Action Scheduler hook for processing queued emails.
+	 */
+	private const AS_HOOK = 'woocommerce_send_queued_transactional_emails';
+
+	/**
+	 * Action Scheduler group for email actions.
+	 */
+	private const AS_GROUP = 'woocommerce-emails';
+
+	/**
+	 * Queue of email callbacks collected during the current request.
+	 *
+	 * @var array<int, array{filter: string, args: array}>
+	 */
+	private array $queue = array();
+
+	/**
+	 * Whether the shutdown hook has been registered.
+	 *
+	 * @var bool
+	 */
+	private bool $shutdown_registered = false;
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @internal
+	 */
+	final public function init(): void {
+		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_emails' ) );
+	}
+
+	/**
+	 * Add an email callback to the queue.
+	 *
+	 * @param string $filter The action hook name that triggered the email.
+	 * @param array  $args   The arguments passed to the action hook.
+	 */
+	public function push( string $filter, array $args ): void {
+		$this->queue[] = array(
+			'filter' => $filter,
+			'args'   => $args,
+		);
+
+		if ( ! $this->shutdown_registered ) {
+			add_action( 'shutdown', array( $this, 'dispatch' ), 100 );
+			$this->shutdown_registered = true;
+		}
+	}
+
+	/**
+	 * Dispatch queued emails via Action Scheduler on shutdown.
+	 *
+	 * @internal
+	 */
+	public function dispatch(): void {
+		if ( empty( $this->queue ) ) {
+			return;
+		}
+
+		\WC()->queue()->add( self::AS_HOOK, array( $this->queue ), self::AS_GROUP );
+		$this->queue = array();
+	}
+
+	/**
+	 * Process a batch of queued transactional emails from Action Scheduler.
+	 *
+	 * @internal
+	 *
+	 * @param mixed $queue The batch of email callbacks to process.
+	 */
+	public function send_queued_transactional_emails( $queue ): void {
+		if ( ! is_array( $queue ) ) {
+			return;
+		}
+
+		foreach ( $queue as $callback ) {
+			if ( ! is_array( $callback ) || ! isset( $callback['filter'], $callback['args'] ) || ! is_string( $callback['filter'] ) || ! is_array( $callback['args'] ) ) {
+				continue;
+			}
+			\WC_Emails::send_queued_transactional_email( $callback['filter'], $callback['args'] );
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -50,6 +50,8 @@ final class DeferredEmailQueue {
 	 * @internal
 	 */
 	final public function init(): void { // phpcs:ignore Generic.CodeAnalysis.UnnecessaryFinalModifier.Found
+		// Registered unconditionally so previously-scheduled AS jobs can still
+		// be processed even if the feature is later disabled.
 		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_emails' ) );
 	}
 
@@ -94,7 +96,8 @@ final class DeferredEmailQueue {
 			\WC()->queue()->add( self::AS_HOOK, array( $chunk ), self::AS_GROUP );
 		}
 
-		$this->queue = array();
+		$this->queue              = array();
+		$this->shutdown_registered = false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -7,8 +7,8 @@ namespace Automattic\WooCommerce\Internal\Email;
 /**
  * Handles deferred transactional email sending via Action Scheduler.
  *
- * Collects email callbacks during a request and dispatches them as a single
- * batched Action Scheduler action on shutdown, replacing the legacy
+ * Collects email callbacks during a request and dispatches each one as an
+ * individual Action Scheduler action on shutdown, replacing the legacy
  * WC_Background_Emailer approach.
  *
  * @since 10.8.0
@@ -16,19 +16,14 @@ namespace Automattic\WooCommerce\Internal\Email;
 final class DeferredEmailQueue {
 
 	/**
-	 * Action Scheduler hook for processing queued emails.
+	 * Action Scheduler hook for processing a queued email.
 	 */
-	private const AS_HOOK = 'woocommerce_send_queued_transactional_emails';
+	private const AS_HOOK = 'woocommerce_send_queued_transactional_email';
 
 	/**
 	 * Action Scheduler group for email actions.
 	 */
 	private const AS_GROUP = 'woocommerce-emails';
-
-	/**
-	 * Default number of emails per Action Scheduler job.
-	 */
-	private const DEFAULT_CHUNK_SIZE = 10;
 
 	/**
 	 * Queue of email callbacks collected during the current request.
@@ -52,7 +47,7 @@ final class DeferredEmailQueue {
 	final public function init(): void { // phpcs:ignore Generic.CodeAnalysis.UnnecessaryFinalModifier.Found
 		// Registered unconditionally so previously-scheduled AS jobs can still
 		// be processed even if the feature is later disabled.
-		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_emails' ) );
+		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_email' ), 10, 2 );
 	}
 
 	/**
@@ -76,6 +71,9 @@ final class DeferredEmailQueue {
 	/**
 	 * Dispatch queued emails via Action Scheduler on shutdown.
 	 *
+	 * Each email is scheduled as an individual AS action for atomic
+	 * processing and per-email failure isolation.
+	 *
 	 * @internal
 	 */
 	public function dispatch(): void {
@@ -83,17 +81,8 @@ final class DeferredEmailQueue {
 			return;
 		}
 
-		/**
-		 * Filter the number of emails per Action Scheduler job.
-		 *
-		 * @since 10.8.0
-		 * @param int $chunk_size Number of emails per batch. Default 10.
-		 */
-		$chunk_size = max( 1, (int) apply_filters( 'woocommerce_deferred_email_chunk_size', self::DEFAULT_CHUNK_SIZE ) );
-		$chunks     = array_chunk( $this->queue, $chunk_size );
-
-		foreach ( $chunks as $chunk ) {
-			\WC()->queue()->add( self::AS_HOOK, array( $chunk ), self::AS_GROUP );
+		foreach ( $this->queue as $item ) {
+			\WC()->queue()->add( self::AS_HOOK, array( $item['filter'], $item['args'] ), self::AS_GROUP );
 		}
 
 		$this->queue               = array();
@@ -101,29 +90,18 @@ final class DeferredEmailQueue {
 	}
 
 	/**
-	 * Process a batch of queued transactional emails from Action Scheduler.
+	 * Process a single queued transactional email from Action Scheduler.
 	 *
 	 * @internal
 	 *
-	 * @param mixed $queue The batch of email callbacks to process.
+	 * @param mixed $filter The action hook name.
+	 * @param mixed $args   The arguments for the email callback.
 	 */
-	public function send_queued_transactional_emails( $queue ): void {
-		if ( ! is_array( $queue ) ) {
+	public function send_queued_transactional_email( $filter, $args ): void {
+		if ( ! is_string( $filter ) || ! is_array( $args ) ) {
 			return;
 		}
 
-		foreach ( $queue as $callback ) {
-			if ( ! is_array( $callback ) || ! isset( $callback['filter'], $callback['args'] ) || ! is_string( $callback['filter'] ) || ! is_array( $callback['args'] ) ) {
-				continue;
-			}
-			try {
-				\WC_Emails::send_queued_transactional_email( $callback['filter'], $callback['args'] );
-			} catch ( \Throwable $e ) {
-				wc_get_logger()->error(
-					sprintf( 'Deferred email failed for %s: %s', $callback['filter'], $e->getMessage() ),
-					array( 'source' => 'deferred-emails' )
-				);
-			}
-		}
+		\WC_Emails::send_queued_transactional_email( $filter, $args );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -96,7 +96,7 @@ final class DeferredEmailQueue {
 			\WC()->queue()->add( self::AS_HOOK, array( $chunk ), self::AS_GROUP );
 		}
 
-		$this->queue              = array();
+		$this->queue               = array();
 		$this->shutdown_registered = false;
 	}
 

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -44,7 +44,7 @@ final class DeferredEmailQueue {
 	 *
 	 * @internal
 	 */
-	public function init(): void {
+	final public function init(): void { // phpcs:ignore Generic.CodeAnalysis.UnnecessaryFinalModifier.Found
 		add_action( self::AS_HOOK, array( $this, 'send_queued_transactional_emails' ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -96,7 +96,14 @@ final class DeferredEmailQueue {
 			if ( ! is_array( $callback ) || ! isset( $callback['filter'], $callback['args'] ) || ! is_string( $callback['filter'] ) || ! is_array( $callback['args'] ) ) {
 				continue;
 			}
-			\WC_Emails::send_queued_transactional_email( $callback['filter'], $callback['args'] );
+			try {
+				\WC_Emails::send_queued_transactional_email( $callback['filter'], $callback['args'] );
+			} catch ( \Throwable $e ) {
+				wc_get_logger()->error(
+					sprintf( 'Deferred email failed for %s: %s', $callback['filter'], $e->getMessage() ),
+					array( 'source' => 'deferred-emails' )
+				);
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
+++ b/plugins/woocommerce/src/Internal/Email/DeferredEmailQueue.php
@@ -26,6 +26,11 @@ final class DeferredEmailQueue {
 	private const AS_GROUP = 'woocommerce-emails';
 
 	/**
+	 * Default number of emails per Action Scheduler job.
+	 */
+	private const DEFAULT_CHUNK_SIZE = 10;
+
+	/**
 	 * Queue of email callbacks collected during the current request.
 	 *
 	 * @var array<int, array{filter: string, args: array}>
@@ -76,7 +81,19 @@ final class DeferredEmailQueue {
 			return;
 		}
 
-		\WC()->queue()->add( self::AS_HOOK, array( $this->queue ), self::AS_GROUP );
+		/**
+		 * Filter the number of emails per Action Scheduler job.
+		 *
+		 * @since 10.8.0
+		 * @param int $chunk_size Number of emails per batch. Default 10.
+		 */
+		$chunk_size = max( 1, (int) apply_filters( 'woocommerce_deferred_email_chunk_size', self::DEFAULT_CHUNK_SIZE ) );
+		$chunks     = array_chunk( $this->queue, $chunk_size );
+
+		foreach ( $chunks as $chunk ) {
+			\WC()->queue()->add( self::AS_HOOK, array( $chunk ), self::AS_GROUP );
+		}
+
 		$this->queue = array();
 	}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -429,6 +429,17 @@ class FeaturesController {
 					},
 				),
 			),
+			'deferred_transactional_emails'      => array(
+				'name'                         => __( 'Deferred emails', 'woocommerce' ),
+				'description'                  => __(
+					'Send transactional emails asynchronously via Action Scheduler instead of during the current request.',
+					'woocommerce'
+				),
+				'skip_compatibility_checks'    => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+				'enabled_by_default'           => false,
+				'is_experimental'              => false,
+			),
 			'email_improvements'                 => array(
 				'name'                         => __( 'Email improvements', 'woocommerce' ),
 				'description'                  => __(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -435,7 +435,6 @@ class FeaturesController {
 					'Send transactional emails asynchronously via Action Scheduler instead of during the current request.',
 					'woocommerce'
 				),
-				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 				'enabled_by_default'           => false,
 				'is_experimental'              => false,

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -191,6 +191,43 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A throwing callback does not prevent subsequent emails from being sent.
+	 */
+	public function test_send_queued_transactional_emails_continues_after_exception(): void {
+		$sent = array();
+
+		add_filter(
+			'woocommerce_allow_send_queued_transactional_email',
+			function ( $allow, $filter ) use ( &$sent ) {
+				unset( $allow );
+				if ( 'woocommerce_order_status_completed' === $filter ) {
+					throw new \RuntimeException( 'Simulated failure' );
+				}
+				$sent[] = $filter;
+				return false;
+			},
+			10,
+			2
+		);
+
+		$batch = array(
+			array(
+				'filter' => 'woocommerce_order_status_completed',
+				'args'   => array( 1 ),
+			),
+			array(
+				'filter' => 'woocommerce_new_customer_note',
+				'args'   => array( 2 ),
+			),
+		);
+
+		$this->sut->send_queued_transactional_emails( $batch );
+
+		$this->assertCount( 1, $sent, 'Second callback should still be processed after first throws' );
+		$this->assertSame( 'woocommerce_new_customer_note', $sent[0] );
+	}
+
+	/**
 	 * @testdox Processing handles non-array input gracefully without errors.
 	 */
 	public function test_send_queued_transactional_emails_handles_non_array(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -39,16 +39,15 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_all_filters( 'woocommerce_queue_class' );
 		remove_all_filters( 'woocommerce_allow_send_queued_transactional_email' );
-		remove_all_filters( 'woocommerce_deferred_email_chunk_size' );
-		remove_all_actions( 'woocommerce_send_queued_transactional_emails' );
+		remove_all_actions( 'woocommerce_send_queued_transactional_email' );
 		$this->reset_queue_singleton();
 		parent::tearDown();
 	}
 
 	/**
-	 * @testdox Push collects email callbacks and dispatch schedules a single AS action for the batch.
+	 * @testdox Push and dispatch schedules one AS action per email.
 	 */
-	public function test_push_and_dispatch_schedules_batch(): void {
+	public function test_push_and_dispatch_schedules_per_email(): void {
 		$this->sut->push( 'woocommerce_order_status_completed', array( 123 ) );
 		$this->sut->push( 'woocommerce_new_customer_note', array( 456, 'note' ) );
 
@@ -56,9 +55,9 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 
 		$queue = $this->get_test_queue();
 
-		$this->assertCount( 1, $queue->actions, 'Should schedule exactly one AS action for the batch' );
-		$this->assertSame( 'woocommerce_send_queued_transactional_emails', $queue->actions[0]['hook'] );
-		$this->assertCount( 2, $queue->actions[0]['args'][0], 'Batch should contain two email callbacks' );
+		$this->assertCount( 2, $queue->actions, 'Should schedule one AS action per email' );
+		$this->assertSame( 'woocommerce_send_queued_transactional_email', $queue->actions[0]['hook'] );
+		$this->assertSame( 'woocommerce_send_queued_transactional_email', $queue->actions[1]['hook'] );
 	}
 
 	/**
@@ -92,15 +91,15 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		$this->sut->push( 'woocommerce_order_status_pending_to_processing', array( 42, 'extra' ) );
 		$this->sut->dispatch();
 
-		$queue = $this->get_test_queue();
-		$batch = $queue->actions[0]['args'][0];
+		$queue  = $this->get_test_queue();
+		$action = $queue->actions[0];
 
-		$this->assertSame( 'woocommerce_order_status_pending_to_processing', $batch[0]['filter'] );
-		$this->assertSame( array( 42, 'extra' ), $batch[0]['args'] );
+		$this->assertSame( 'woocommerce_order_status_pending_to_processing', $action['args'][0] );
+		$this->assertSame( array( 42, 'extra' ), $action['args'][1] );
 	}
 
 	/**
-	 * @testdox Dispatch assigns the woocommerce-emails group to the scheduled action.
+	 * @testdox Dispatch assigns the woocommerce-emails group to scheduled actions.
 	 */
 	public function test_dispatch_uses_correct_group(): void {
 		$this->sut->push( 'woocommerce_order_status_completed', array( 1 ) );
@@ -112,33 +111,9 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Dispatch splits the queue into chunks when it exceeds the chunk size.
+	 * @testdox Processing calls WC_Emails::send_queued_transactional_email with the correct filter and args.
 	 */
-	public function test_dispatch_chunks_large_queue(): void {
-		add_filter(
-			'woocommerce_deferred_email_chunk_size',
-			function () {
-				return 2;
-			}
-		);
-
-		$this->sut->push( 'woocommerce_order_status_completed', array( 1 ) );
-		$this->sut->push( 'woocommerce_new_customer_note', array( 2 ) );
-		$this->sut->push( 'woocommerce_created_customer', array( 3 ) );
-
-		$this->sut->dispatch();
-
-		$queue = $this->get_test_queue();
-
-		$this->assertCount( 2, $queue->actions, 'Should schedule two AS actions for 3 emails with chunk size 2' );
-		$this->assertCount( 2, $queue->actions[0]['args'][0], 'First chunk should have 2 emails' );
-		$this->assertCount( 1, $queue->actions[1]['args'][0], 'Second chunk should have 1 email' );
-	}
-
-	/**
-	 * @testdox Processing a batch calls send_queued_transactional_email for each valid callback.
-	 */
-	public function test_send_queued_transactional_emails_processes_valid_callbacks(): void {
+	public function test_send_queued_transactional_email_processes_callback(): void {
 		$sent = array();
 
 		add_filter(
@@ -155,30 +130,17 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 			3
 		);
 
-		$batch = array(
-			array(
-				'filter' => 'woocommerce_order_status_completed',
-				'args'   => array( 100 ),
-			),
-			array(
-				'filter' => 'woocommerce_new_customer_note',
-				'args'   => array( 200 ),
-			),
-		);
+		$this->sut->send_queued_transactional_email( 'woocommerce_order_status_completed', array( 100 ) );
 
-		$this->sut->send_queued_transactional_emails( $batch );
-
-		$this->assertCount( 2, $sent, 'Should process both email callbacks' );
+		$this->assertCount( 1, $sent, 'Should process the email callback' );
 		$this->assertSame( 'woocommerce_order_status_completed', $sent[0]['filter'] );
 		$this->assertSame( array( 100 ), $sent[0]['args'] );
-		$this->assertSame( 'woocommerce_new_customer_note', $sent[1]['filter'] );
-		$this->assertSame( array( 200 ), $sent[1]['args'] );
 	}
 
 	/**
-	 * @testdox Processing skips malformed callbacks in the batch.
+	 * @testdox Processing skips invalid input types gracefully.
 	 */
-	public function test_send_queued_transactional_emails_skips_malformed(): void {
+	public function test_send_queued_transactional_email_skips_invalid_input(): void {
 		$sent = array();
 
 		add_filter(
@@ -192,75 +154,25 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 			2
 		);
 
-		$batch = array(
-			'not-an-array',
-			array( 'missing_filter_key' => true ),
-			array(
-				'filter' => 123,
-				'args'   => array(),
-			),
-			array(
-				'filter' => 'valid_hook',
-				'args'   => 'not-array',
-			),
-			array(
-				'filter' => 'woocommerce_order_status_completed',
-				'args'   => array( 1 ),
-			),
-		);
+		$this->sut->send_queued_transactional_email( 123, array() );
+		$this->sut->send_queued_transactional_email( 'valid_hook', 'not-array' );
 
-		$this->sut->send_queued_transactional_emails( $batch );
-
-		$this->assertCount( 1, $sent, 'Should only process the one valid callback' );
-		$this->assertSame( 'woocommerce_order_status_completed', $sent[0] );
+		$this->assertEmpty( $sent, 'Should not process callbacks with invalid types' );
 	}
 
 	/**
-	 * @testdox A throwing callback does not prevent subsequent emails from being sent.
+	 * @testdox Push can be called again after dispatch to queue new emails.
 	 */
-	public function test_send_queued_transactional_emails_continues_after_exception(): void {
-		$sent = array();
+	public function test_push_after_dispatch_queues_new_emails(): void {
+		$this->sut->push( 'woocommerce_order_status_completed', array( 1 ) );
+		$this->sut->dispatch();
 
-		add_filter(
-			'woocommerce_allow_send_queued_transactional_email',
-			function ( $allow, $filter ) use ( &$sent ) {
-				unset( $allow );
-				if ( 'woocommerce_order_status_completed' === $filter ) {
-					throw new \RuntimeException( 'Simulated failure' );
-				}
-				$sent[] = $filter;
-				return false;
-			},
-			10,
-			2
-		);
+		$this->sut->push( 'woocommerce_new_customer_note', array( 2 ) );
+		$this->sut->dispatch();
 
-		$batch = array(
-			array(
-				'filter' => 'woocommerce_order_status_completed',
-				'args'   => array( 1 ),
-			),
-			array(
-				'filter' => 'woocommerce_new_customer_note',
-				'args'   => array( 2 ),
-			),
-		);
+		$queue = $this->get_test_queue();
 
-		$this->sut->send_queued_transactional_emails( $batch );
-
-		$this->assertCount( 1, $sent, 'Second callback should still be processed after first throws' );
-		$this->assertSame( 'woocommerce_new_customer_note', $sent[0] );
-	}
-
-	/**
-	 * @testdox Processing handles non-array input gracefully without errors.
-	 */
-	public function test_send_queued_transactional_emails_handles_non_array(): void {
-		$this->sut->send_queued_transactional_emails( 'not-an-array' );
-		$this->sut->send_queued_transactional_emails( null );
-		$this->sut->send_queued_transactional_emails( 42 );
-
-		$this->assertTrue( true, 'Should not throw for non-array input' );
+		$this->assertCount( 2, $queue->actions, 'Should schedule actions from both dispatch cycles' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -39,6 +39,7 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_all_filters( 'woocommerce_queue_class' );
 		remove_all_filters( 'woocommerce_allow_send_queued_transactional_email' );
+		remove_all_filters( 'woocommerce_deferred_email_chunk_size' );
 		remove_all_actions( 'woocommerce_send_queued_transactional_emails' );
 		$this->reset_queue_singleton();
 		parent::tearDown();
@@ -108,6 +109,30 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		$queue = $this->get_test_queue();
 
 		$this->assertSame( 'woocommerce-emails', $queue->actions[0]['group'] );
+	}
+
+	/**
+	 * @testdox Dispatch splits the queue into chunks when it exceeds the chunk size.
+	 */
+	public function test_dispatch_chunks_large_queue(): void {
+		add_filter(
+			'woocommerce_deferred_email_chunk_size',
+			function () {
+				return 2;
+			}
+		);
+
+		$this->sut->push( 'woocommerce_order_status_completed', array( 1 ) );
+		$this->sut->push( 'woocommerce_new_customer_note', array( 2 ) );
+		$this->sut->push( 'woocommerce_created_customer', array( 3 ) );
+
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+
+		$this->assertCount( 2, $queue->actions, 'Should schedule two AS actions for 3 emails with chunk size 2' );
+		$this->assertCount( 2, $queue->actions[0]['args'][0], 'First chunk should have 2 emails' );
+		$this->assertCount( 1, $queue->actions[1]['args'][0], 'Second chunk should have 1 email' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -1,0 +1,224 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Email;
+
+use Automattic\WooCommerce\Internal\Email\DeferredEmailQueue;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the DeferredEmailQueue class.
+ */
+class DeferredEmailQueueTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var DeferredEmailQueue
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new DeferredEmailQueue();
+		$this->reset_queue_singleton();
+		add_filter(
+			'woocommerce_queue_class',
+			function () {
+				return \WC_Admin_Test_Action_Queue::class;
+			}
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_queue_class' );
+		remove_all_filters( 'woocommerce_allow_send_queued_transactional_email' );
+		remove_all_actions( 'woocommerce_send_queued_transactional_emails' );
+		$this->reset_queue_singleton();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Push collects email callbacks and dispatch schedules a single AS action for the batch.
+	 */
+	public function test_push_and_dispatch_schedules_batch(): void {
+		$this->sut->push( 'woocommerce_order_status_completed', array( 123 ) );
+		$this->sut->push( 'woocommerce_new_customer_note', array( 456, 'note' ) );
+
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+
+		$this->assertCount( 1, $queue->actions, 'Should schedule exactly one AS action for the batch' );
+		$this->assertSame( 'woocommerce_send_queued_transactional_emails', $queue->actions[0]['hook'] );
+		$this->assertCount( 2, $queue->actions[0]['args'][0], 'Batch should contain two email callbacks' );
+	}
+
+	/**
+	 * @testdox Dispatch does nothing when the queue is empty.
+	 */
+	public function test_dispatch_noop_when_empty(): void {
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+
+		$this->assertEmpty( $queue->actions, 'Should not schedule any AS action when queue is empty' );
+	}
+
+	/**
+	 * @testdox Dispatch clears the queue after scheduling so a second dispatch is a no-op.
+	 */
+	public function test_dispatch_clears_queue(): void {
+		$this->sut->push( 'woocommerce_order_status_completed', array( 123 ) );
+		$this->sut->dispatch();
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+
+		$this->assertCount( 1, $queue->actions, 'Second dispatch should not schedule another action' );
+	}
+
+	/**
+	 * @testdox Dispatch preserves the filter name and args for each queued email.
+	 */
+	public function test_dispatch_preserves_callback_data(): void {
+		$this->sut->push( 'woocommerce_order_status_pending_to_processing', array( 42, 'extra' ) );
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+		$batch = $queue->actions[0]['args'][0];
+
+		$this->assertSame( 'woocommerce_order_status_pending_to_processing', $batch[0]['filter'] );
+		$this->assertSame( array( 42, 'extra' ), $batch[0]['args'] );
+	}
+
+	/**
+	 * @testdox Dispatch assigns the woocommerce-emails group to the scheduled action.
+	 */
+	public function test_dispatch_uses_correct_group(): void {
+		$this->sut->push( 'woocommerce_order_status_completed', array( 1 ) );
+		$this->sut->dispatch();
+
+		$queue = $this->get_test_queue();
+
+		$this->assertSame( 'woocommerce-emails', $queue->actions[0]['group'] );
+	}
+
+	/**
+	 * @testdox Processing a batch calls send_queued_transactional_email for each valid callback.
+	 */
+	public function test_send_queued_transactional_emails_processes_valid_callbacks(): void {
+		$sent = array();
+
+		add_filter(
+			'woocommerce_allow_send_queued_transactional_email',
+			function ( $allow, $filter, $args ) use ( &$sent ) {
+				unset( $allow );
+				$sent[] = array(
+					'filter' => $filter,
+					'args'   => $args,
+				);
+				return false;
+			},
+			10,
+			3
+		);
+
+		$batch = array(
+			array(
+				'filter' => 'woocommerce_order_status_completed',
+				'args'   => array( 100 ),
+			),
+			array(
+				'filter' => 'woocommerce_new_customer_note',
+				'args'   => array( 200 ),
+			),
+		);
+
+		$this->sut->send_queued_transactional_emails( $batch );
+
+		$this->assertCount( 2, $sent, 'Should process both email callbacks' );
+		$this->assertSame( 'woocommerce_order_status_completed', $sent[0]['filter'] );
+		$this->assertSame( array( 100 ), $sent[0]['args'] );
+		$this->assertSame( 'woocommerce_new_customer_note', $sent[1]['filter'] );
+		$this->assertSame( array( 200 ), $sent[1]['args'] );
+	}
+
+	/**
+	 * @testdox Processing skips malformed callbacks in the batch.
+	 */
+	public function test_send_queued_transactional_emails_skips_malformed(): void {
+		$sent = array();
+
+		add_filter(
+			'woocommerce_allow_send_queued_transactional_email',
+			function ( $allow, $filter ) use ( &$sent ) {
+				unset( $allow );
+				$sent[] = $filter;
+				return false;
+			},
+			10,
+			2
+		);
+
+		$batch = array(
+			'not-an-array',
+			array( 'missing_filter_key' => true ),
+			array(
+				'filter' => 123,
+				'args'   => array(),
+			),
+			array(
+				'filter' => 'valid_hook',
+				'args'   => 'not-array',
+			),
+			array(
+				'filter' => 'woocommerce_order_status_completed',
+				'args'   => array( 1 ),
+			),
+		);
+
+		$this->sut->send_queued_transactional_emails( $batch );
+
+		$this->assertCount( 1, $sent, 'Should only process the one valid callback' );
+		$this->assertSame( 'woocommerce_order_status_completed', $sent[0] );
+	}
+
+	/**
+	 * @testdox Processing handles non-array input gracefully without errors.
+	 */
+	public function test_send_queued_transactional_emails_handles_non_array(): void {
+		$this->sut->send_queued_transactional_emails( 'not-an-array' );
+		$this->sut->send_queued_transactional_emails( null );
+		$this->sut->send_queued_transactional_emails( 42 );
+
+		$this->assertTrue( true, 'Should not throw for non-array input' );
+	}
+
+	/**
+	 * Reset the WC_Queue singleton so the test queue filter takes effect.
+	 */
+	private function reset_queue_singleton(): void {
+		$reflection = new \ReflectionClass( \WC_Queue::class );
+		$instance   = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+	}
+
+	/**
+	 * Get the test action queue instance.
+	 *
+	 * @return \WC_Admin_Test_Action_Queue
+	 */
+	private function get_test_queue(): \WC_Admin_Test_Action_Queue {
+		$queue = \WC_Queue::instance();
+		$this->assertInstanceOf( \WC_Admin_Test_Action_Queue::class, $queue );
+		return $queue;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Replaces the legacy `WC_Background_Emailer` (built on the forked `WP_Background_Process` library) with a new `DeferredEmailQueue` class that dispatches deferred transactional emails via Action Scheduler.

Closes https://github.com/woocommerce/woocommerce/issues/44246.

- Each email is scheduled as an **individual AS action** for atomic processing and per-email failure isolation — AS built-in retry handles failures automatically
- New internal class `DeferredEmailQueue` in `src/Internal/Email/` handles queueing, dispatch, and processing
- The `woocommerce_defer_transactional_emails` filter continues to work as before
- Adds a feature toggle under **Settings > Advanced > Features** ("Deferred emails") so it can be enabled for testing without code changes
- `WC_Background_Emailer` is marked `@deprecated` but left in place

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > Advanced > Features** and enable **Deferred emails**
2. Place an order as a customer (or change an order status in the admin)
3. Confirm the order confirmation email is received
4. Go to **Tools > Scheduled Actions** and search for `woocommerce_send_queued_transactional_email` — confirm individual email actions ran with a "Complete" status
5. Disable the feature toggle and repeat steps 2-3 — emails should still send synchronously as before

### Testing that has already taken place:

- Unit tests added for `DeferredEmailQueue` covering: per-email action scheduling, empty queue no-op, queue clearing after dispatch, callback data preservation, AS group assignment, valid callback processing, invalid input handling, and push-after-dispatch

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Migrate deferred transactional email sending to Action Scheduler

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>