### PR TITLE
Fix interval selector shifting downward on WP 7.0

### DIFF
--- a/packages/js/components/changelog/fix-wooa7s-1161-interval-selector-shift
+++ b/packages/js/components/changelog/fix-wooa7s-1161-interval-selector-shift
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix interval selector shifting downward on WP 7.0 by restoring margin-bottom.

--- a/packages/js/components/src/chart/index.js
+++ b/packages/js/components/src/chart/index.js
@@ -250,6 +250,7 @@ class Chart extends Component {
 			<div className="woocommerce-chart__interval-select">
 				<SelectControl
 					__next40pxDefaultSize
+					__nextHasNoMarginBottom
 					value={ interval }
 					options={ allowedIntervals.map( ( allowedInterval ) => ( {
 						value: allowedInterval,

--- a/packages/js/components/src/chart/style.scss
+++ b/packages/js/components/src/chart/style.scss
@@ -63,7 +63,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	margin: 0 0 0 auto;
+	margin: 0 0 8px auto;
 	min-height: 50px;
 	padding: 8px $gap 0 $gap;
 

--- a/packages/js/components/src/chart/style.scss
+++ b/packages/js/components/src/chart/style.scss
@@ -63,14 +63,13 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	margin: 0 0 8px auto;
+	margin: 0 0 0 auto;
 	min-height: 50px;
-	padding: 8px $gap 0 $gap;
+	padding: 0 $gap;
 
 	@include breakpoint( '<960px' ) {
 		width: 100%;
 		order: 1;
-		margin-top: -8px;
 		margin-left: 0;
 		padding-left: math.div($gap, 2);
 		border-right: 0;

--- a/packages/js/components/src/section-header/style.scss
+++ b/packages/js/components/src/section-header/style.scss
@@ -46,11 +46,7 @@
 	justify-content: flex-end;
 
 	.components-base-control {
-		padding-top: 0;
-		min-height: 34px;
-
 		.components-base-control__field {
-			margin-bottom: 0;
 			select {
 				background: transparent;
 			}

--- a/plugins/woocommerce/changelog/fix-dashboard-charts-margin-bottom-deprecation
+++ b/plugins/woocommerce/changelog/fix-dashboard-charts-margin-bottom-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add __nextHasNoMarginBottom prop to dashboard-charts interval SelectControl to resolve deprecation warning.

--- a/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/index.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/index.js
@@ -76,6 +76,7 @@ const renderIntervalSelector = ( {
 	return (
 		<SelectControl
 			__next40pxDefaultSize
+			__nextHasNoMarginBottom
 			className="woocommerce-chart__interval-select"
 			value={ chartInterval }
 			options={ allowedIntervals.map( ( allowedInterval ) => ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

In WordPress 7.0, the `SelectControl` component changed its default margin-bottom from `8px` to `0`. This caused the interval selector in the Analytics chart header to shift downward, misaligning it with the other header elements.

This PR:
- Add the `8px` margin-bottom on `.woocommerce-chart__interval-select` to fix the alignment
- Adds `__next40pxDefaultSize` and `__nextHasNoMarginBottom` props to the `SelectControl` to opt into WP 7.0 defaults explicitly

Closes WOOA7S-1161.

### How to test the changes in this Pull Request:

**Setup:** Ensure you are running WordPress 7.0 or later ( you can use the WordPress beta tester for this ), please also test against 6.9 to make sure it still works fine there.

1. Navigate to **Analytics > Overview** (or any analytics page with a chart).
2. Verify the interval selector (by day/week) is properly aligned with the date range picker and comparison controls in the chart header.
3. Confirm no vertical shift or misalignment of the interval dropdown.


| Before | After |
|--------|-------|
| <img width="919" height="615" alt="Screenshot 2026-03-25 at 15 23 54" src="https://github.com/user-attachments/assets/aa97c9ab-ee80-4b4e-a8c9-1cf3d9ddb241" /> | <img width="904" height="577" alt="Screenshot 2026-03-25 at 15 24 37" src="https://github.com/user-attachments/assets/7016233f-4368-46b4-8bea-e233dfd7bc6c" /> |


Order attribution report:

Before:
<img width="1852" height="475" alt="Screenshot 2026-03-25 at 15 25 38" src="https://github.com/user-attachments/assets/acf63226-4db2-4174-951b-374be9300eca" />

After:
<img width="1840" height="466" alt="Screenshot 2026-03-25 at 15 25 15" src="https://github.com/user-attachments/assets/fbc0ec7a-edb8-4276-8303-672349ac2ff2" />


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Changelog entry was created manually for the `@woocommerce/components` package.
</details>