### PR TITLE
Fix date range input height increased on WP 7.0

### DIFF
--- a/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
+++ b/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix date range input height increase on WP 7.0 by setting explicit line-height
+Fix date range input height increase on WP 7.0 by aligning with WordPress input styling

--- a/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
+++ b/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix date range input height increase on WP 7.0 by setting explicit font-size and line-height

--- a/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
+++ b/packages/js/components/changelog/63844-fix-date-range-input-height-wp70
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix date range input height increase on WP 7.0 by setting explicit font-size and line-height
+Fix date range input height increase on WP 7.0 by setting explicit line-height

--- a/packages/js/components/changelog/fix-date-range-input-height-wp70
+++ b/packages/js/components/changelog/fix-date-range-input-height-wp70
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix date range input height increase on WP 7.0 by setting explicit font-size and line-height

--- a/packages/js/components/changelog/fix-date-range-input-height-wp70
+++ b/packages/js/components/changelog/fix-date-range-input-height-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix date range input height increase on WP 7.0 by setting explicit font-size and line-height

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -168,7 +168,7 @@
 	.woocommerce-calendar__input-text {
 		color: $gray-700;
 		border-radius: 3px;
-		padding: 0px 10px 0px 30px;
+		padding: 0 10px 0 30px;
 		width: 100%;
 		@include font-size( 13 );
 		min-height: 40px;

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -4,9 +4,10 @@
  * We have to include the RTL-ignore directives via imports because of the ordering of how
  * @imports are included in the output (see https://github.com/MohammadYounes/rtlcss/issues/113).
  **/
-@import "./calendar/begin-rtl-ignore.css";
-@import "../node_modules/react-dates/lib/css/_datepicker.css";
-@import "./calendar/end-rtl-ignore.css";
+@import './calendar/begin-rtl-ignore.css';
+@import '../node_modules/react-dates/lib/css/_datepicker.css';
+@import './calendar/end-rtl-ignore.css';
+
 
 .woocommerce-calendar {
 	width: 100%;
@@ -169,7 +170,7 @@
 		border-radius: 3px;
 		padding: 10px 10px 10px 30px;
 		width: 100%;
-		@include font-size(13);
+		@include font-size( 13 );
 		line-height: 2;
 
 		&::placeholder {
@@ -180,8 +181,8 @@
 
 .woocommerce-filters-date__content {
 	&.is-mobile
-		.woocommerce-calendar__input-error
-		.components-popover__content {
+	.woocommerce-calendar__input-error
+	.components-popover__content {
 		height: initial;
 	}
 }
@@ -227,7 +228,7 @@
 }
 
 .woocommerce-calendar__date-picker-title {
-	@include font-size(12);
+	@include font-size( 12 );
 	font-weight: 100;
 	text-transform: uppercase;
 	text-align: center;

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -171,7 +171,7 @@
 		padding: 0px 10px 0px 30px;
 		width: 100%;
 		@include font-size( 13 );
-		line-height: 2;
+		min-height: 40px;
 
 		&::placeholder {
 			color: $gray-700;

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -168,7 +168,7 @@
 	.woocommerce-calendar__input-text {
 		color: $gray-700;
 		border-radius: 3px;
-		padding: 10px 10px 10px 30px;
+		padding: 0px 10px 0px 30px;
 		width: 100%;
 		@include font-size( 13 );
 		line-height: 2;

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -4,10 +4,9 @@
  * We have to include the RTL-ignore directives via imports because of the ordering of how
  * @imports are included in the output (see https://github.com/MohammadYounes/rtlcss/issues/113).
  **/
-@import './calendar/begin-rtl-ignore.css';
-@import '../node_modules/react-dates/lib/css/_datepicker.css';
-@import './calendar/end-rtl-ignore.css';
-
+@import "./calendar/begin-rtl-ignore.css";
+@import "../node_modules/react-dates/lib/css/_datepicker.css";
+@import "./calendar/end-rtl-ignore.css";
 
 .woocommerce-calendar {
 	width: 100%;
@@ -170,7 +169,7 @@
 		border-radius: 3px;
 		padding: 10px 10px 10px 30px;
 		width: 100%;
-		font-size: 13px;
+		@include font-size(13);
 		line-height: 2;
 
 		&::placeholder {
@@ -181,8 +180,8 @@
 
 .woocommerce-filters-date__content {
 	&.is-mobile
-	.woocommerce-calendar__input-error
-	.components-popover__content {
+		.woocommerce-calendar__input-error
+		.components-popover__content {
 		height: initial;
 	}
 }
@@ -228,7 +227,7 @@
 }
 
 .woocommerce-calendar__date-picker-title {
-	@include font-size( 12 );
+	@include font-size(12);
 	font-weight: 100;
 	text-transform: uppercase;
 	text-align: center;

--- a/packages/js/components/src/calendar/style.scss
+++ b/packages/js/components/src/calendar/style.scss
@@ -170,7 +170,8 @@
 		border-radius: 3px;
 		padding: 10px 10px 10px 30px;
 		width: 100%;
-		@include font-size( 13 );
+		font-size: 13px;
+		line-height: 2;
 
 		&::placeholder {
 			color: $gray-700;


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress 7.0 changed the default `<input>` element `line-height` from `2` to `2.71429` (part of Gutenberg design system updates). This caused the date range input in the Analytics calendar component to increase in height from ~54px to ~65.6px.

This PR aligns the `.woocommerce-calendar__input-text` styling with WordPress's own input pattern by removing top/bottom padding and adding `min-height: 40px`, rather than overriding `line-height` directly. This approach is more stable across WP versions since it matches how WP core styles its text inputs.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOA7S-1162.


### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="457" height="844" alt="Screenshot 2026-03-25 at 16 13 03" src="https://github.com/user-attachments/assets/7a6b1416-428f-4ad6-84bf-87b7d181afdc" /> | <img width="517" height="847" alt="Screenshot 2026-03-25 at 16 13 15" src="https://github.com/user-attachments/assets/03954c60-4156-44d2-9726-e0ee326e03f9" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a WooCommerce store running WordPress 7.0.
2. Navigate to **Analytics > Revenue** (or any Analytics page with a date range picker).
3. Verify the date range input fields have a consistent height and are not taller than expected.
4. Also verify on WordPress 6.9 that the inputs render at the same size (no regression).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested locally on WP 7.0 and WP 6.9 — confirmed the input height renders correctly in both versions.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>