### PR TITLE
Fix Store API related products filter allowing transient bloat via arbitrary product IDs

### DIFF
--- a/plugins/woocommerce/changelog/63846-woo6-37-codex-review-store-api-related-filter-enables-transient
+++ b/plugins/woocommerce/changelog/63846-woo6-37-codex-review-store-api-related-filter-enables-transient
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Store API products endpoint allowing transient bloat via arbitrary product IDs in the `related` query parameter.

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use WC_Tax;
 
 /**
@@ -20,6 +21,7 @@ class ProductQuery implements QueryClausesGenerator {
 	 *
 	 * @param \WP_REST_Request $request Request data.
 	 * @return array
+	 * @throws RouteException If the related product ID is invalid or the product is not visible.
 	 */
 	public function prepare_objects_query( $request ) {
 		$args = array(
@@ -253,9 +255,19 @@ class ProductQuery implements QueryClausesGenerator {
 
 		// Filter by related products.
 		if ( ! empty( $request['related'] ) ) {
-			$product_id = absint( $request['related'] );
-			$limit      = ! empty( $request['per_page'] ) ? (int) $request['per_page'] : 100;
-			$related    = wc_get_related_products( $product_id, $limit );
+			$product_id      = absint( $request['related'] );
+			$related_product = wc_get_product( $product_id );
+
+			if ( ! $related_product || ! $related_product->is_visible() ) {
+				throw new RouteException(
+					'woocommerce_rest_product_not_found',
+					__( 'The related product ID is invalid or the product is not visible.', 'woocommerce' ), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- REST API JSON response, not HTML.
+					404
+				);
+			}
+
+			$limit   = ! empty( $request['per_page'] ) ? (int) $request['per_page'] : 100;
+			$related = wc_get_related_products( $product_id, $limit );
 
 			if ( ! empty( $related ) ) {
 				$args['post__in'] = ! empty( $args['post__in'] )

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -761,4 +761,19 @@ class Products extends ControllerTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $response->get_data() );
 	}
+
+	/**
+	 * @testdox Related query parameter returns 404 for non-existent product and does not create a transient.
+	 */
+	public function test_related_query_parameter_returns_404_for_nonexistent_product() {
+		$nonexistent_id = 999999999;
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$request->set_param( 'related', $nonexistent_id );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertFalse( get_transient( 'wc_related_' . $nonexistent_id ), 'No transient should be created for a non-existent product.' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Store API products endpoint (`/wc/store/v1/products`) accepts an unauthenticated `related` query parameter. When a non-existent product ID is passed, `wc_get_related_products()` unconditionally writes a transient keyed by that ID to the database, which could cause database bloat.

This PR adds a validation check in `ProductQuery::prepare_objects_query()` that verifies the referenced product exists and is visible before calling `wc_get_related_products()`. If the product is invalid, a `RouteException` with HTTP 404 is thrown, preventing any transient from being created.

Bug introduced in PR #62603.

### How to test the changes in this Pull Request:

1. Send an unauthenticated request with a non-existent product ID: `/wp-json/wc/store/v1/products?related=999999999`.
2. Verify that you receive a 404.
3. Verify no transient was created:
   ```sql
   SELECT option_name FROM wp_options WHERE option_name LIKE '%wc_related_999999999%';
   ```
   **Expected:** Empty result set.
4. Send a request with a valid product ID with related products: `/wp-json/wc/store/v1/products?related={{YOUR_PRODUCT_ID}}`.
5. Verify that you get a 200 and a list of related products.
6. Verify the transient was created.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix Store API products endpoint allowing transient bloat via arbitrary product IDs in the `related` query parameter.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>