### PR TITLE
fix: add __next40pxDefaultSize to SelectControl components

### DIFF
--- a/packages/js/components/changelog/fix-select-control-deprecated-size-warning
+++ b/packages/js/components/changelog/fix-select-control-deprecated-size-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add __next40pxDefaultSize prop to SelectControl components to resolve deprecated size warning on WP 7.0+.

--- a/packages/js/components/src/advanced-filters/attribute-filter.js
+++ b/packages/js/components/src/advanced-filters/attribute-filter.js
@@ -151,6 +151,7 @@ const AttributeFilter = ( props ) => {
 					title: <span className={ className } />,
 					rule: (
 						<Select
+							__next40pxDefaultSize
 							className={ clsx(
 								className,
 								'woocommerce-filters-advanced__rule'
@@ -213,6 +214,7 @@ const AttributeFilter = ( props ) => {
 											=
 										</span>
 										<SelectControl
+											__next40pxDefaultSize
 											className="woocommerce-filters-advanced__input woocommerce-search"
 											placeholder={ __(
 												'Attribute value',

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -231,6 +231,7 @@ class DateFilter extends Component {
 			title: <span className={ className } />,
 			rule: (
 				<SelectControl
+					__next40pxDefaultSize
 					className={ clsx(
 						className,
 						'woocommerce-filters-advanced__rule'

--- a/packages/js/components/src/advanced-filters/index.js
+++ b/packages/js/components/src/advanced-filters/index.js
@@ -147,6 +147,7 @@ class AdvancedFilters extends Component {
 		return createInterpolateElement( config.title, {
 			select: (
 				<SelectControl
+					__next40pxDefaultSize
 					className="woocommerce-filters-advanced__title-select"
 					options={ matches }
 					value={ match }

--- a/packages/js/components/src/advanced-filters/number-filter.js
+++ b/packages/js/components/src/advanced-filters/number-filter.js
@@ -218,6 +218,7 @@ class NumberFilter extends Component {
 			title: <span className={ className } />,
 			rule: (
 				<SelectControl
+					__next40pxDefaultSize
 					className={ clsx(
 						className,
 						'woocommerce-filters-advanced__rule'

--- a/packages/js/components/src/advanced-filters/search-filter.js
+++ b/packages/js/components/src/advanced-filters/search-filter.js
@@ -106,6 +106,7 @@ class SearchFilter extends Component {
 			title: <span className={ className } />,
 			rule: (
 				<SelectControl
+					__next40pxDefaultSize
 					className={ clsx(
 						className,
 						'woocommerce-filters-advanced__rule'

--- a/packages/js/components/src/advanced-filters/select-filter.js
+++ b/packages/js/components/src/advanced-filters/select-filter.js
@@ -74,6 +74,7 @@ class SelectFilter extends Component {
 			title: <span className={ className } />,
 			rule: (
 				<SelectControl
+					__next40pxDefaultSize
 					className={ clsx(
 						className,
 						'woocommerce-filters-advanced__rule'
@@ -91,6 +92,7 @@ class SelectFilter extends Component {
 			),
 			filter: options ? (
 				<SelectControl
+					__next40pxDefaultSize
 					className={ clsx(
 						className,
 						'woocommerce-filters-advanced__input'

--- a/packages/js/components/src/chart/index.js
+++ b/packages/js/components/src/chart/index.js
@@ -249,6 +249,7 @@ class Chart extends Component {
 		return (
 			<div className="woocommerce-chart__interval-select">
 				<SelectControl
+					__next40pxDefaultSize
 					value={ interval }
 					options={ allowedIntervals.map( ( allowedInterval ) => ( {
 						value: allowedInterval,

--- a/packages/js/components/src/pagination/page-size-picker.tsx
+++ b/packages/js/components/src/pagination/page-size-picker.tsx
@@ -45,6 +45,7 @@ export function PageSizePicker( {
 	return (
 		<div className="woocommerce-pagination__per-page-picker">
 			<SelectControl
+				__next40pxDefaultSize
 				label={ label }
 				labelPosition="side"
 				value={ perPage.toString() }

--- a/plugins/woocommerce/changelog/fix-select-control-deprecated-size-warning
+++ b/plugins/woocommerce/changelog/fix-select-control-deprecated-size-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add __next40pxDefaultSize prop to SelectControl components to resolve deprecated size warning on WP 7.0+.

--- a/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/period-selector.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/period-selector.js
@@ -65,6 +65,7 @@ function HistoricalDataPeriodSelector( {
 		<div className="woocommerce-settings-historical-data__columns">
 			<div className="woocommerce-settings-historical-data__column">
 				<SelectControl
+					__next40pxDefaultSize
 					label={ __( 'Import historical data', 'woocommerce' ) }
 					value={ value.label }
 					disabled={ disabled }

--- a/plugins/woocommerce/client/admin/client/analytics/settings/setting.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/setting.js
@@ -83,6 +83,7 @@ class Setting extends Component {
 			case 'select':
 				return (
 					<SelectControl
+						__next40pxDefaultSize
 						options={ options }
 						value={ value }
 						onChange={ ( newValue ) =>

--- a/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/index.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/index.js
@@ -75,6 +75,7 @@ const renderIntervalSelector = ( {
 
 	return (
 		<SelectControl
+			__next40pxDefaultSize
 			className="woocommerce-chart__interval-select"
 			value={ chartInterval }
 			options={ allowedIntervals.map( ( allowedInterval ) => ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Adds the `__next40pxDefaultSize` prop to all `SelectControl` components (from `@wordpress/components` used in Analytics, resolving the deprecation warning:

> 36px default size for wp.components.SelectControl is deprecated since version 6.8 and will be removed in version 7.1.

Affected components:
- **Advanced Filters**: `attribute-filter.js`, `date-filter.js`, `index.js`, `number-filter.js`, `search-filter.js`, `select-filter.js`
- **Chart**: `chart/index.js`
- **Pagination**: `page-size-picker.tsx`
- **Dashboard Charts**: `dashboard-charts/index.js`
- **Analytics Settings**: `setting.js`, `period-selector.js`

WOOA7S-1163

### Screenshots or screen recordings:

#### No `__next40pxDefaultSize` warning in the browser console:

<img width="2560" height="1329" alt="Screenshot 2026-03-25 at 16 31 09" src="https://github.com/user-attachments/assets/0ed24324-5939-47f6-9086-4bb22f87e98d" />

#### The UI still looks good with 40px size select control.

<img width="1591" height="979" alt="Screenshot 2026-03-25 at 16 27 55" src="https://github.com/user-attachments/assets/bc4e4ac7-e539-4a77-8a76-d9f4d270dbdb" />
<img width="1102" height="1027" alt="Screenshot 2026-03-25 at 16 29 25" src="https://github.com/user-attachments/assets/fc621d91-361c-485a-8eba-7859d255811f" />


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Navigate to **WooCommerce > Analytics > Products** (or any analytics page).
2. Open the browser console 
3. Verify there are no deprecation warnings about `36px default size for wp.components.SelectControl`.
4. Verify the SelectControl components (chart interval selector, pagination rows-per-page, advanced filter dropdowns) still function correctly and look good.

### Testing that has already taken place:

- Verified the deprecation warning appears on the analytics/products page before the fix.
- Confirmed the chart interval `SelectControl` is the source of the warning on the products analytics page via browser console inspection.
- Verified all `SelectControl` instances from `@wordpress/components` in the affected files now include the `__next40pxDefaultSize` prop.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add __next40pxDefaultSize prop to SelectControl components to resolve deprecated size warning on WP 7.0+.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>