### PR TITLE
Test PR: BC review action trigger [do not merge or review]

### DIFF
--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -28,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: PR Review with Progress Tracking (inline-only)
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@64c7a0ef71df67b14cb4471f4d9c8565c61042bf # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -113,4 +112,4 @@ jobs:
             6. Submit the review using: gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" -X POST --input bc_review_payload.json
 
           claude_args: >
-            --allowedTools "Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*)"
+            --allowedTools "Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*)"

--- a/.github/workflows/backwards-compatibility-review.yml
+++ b/.github/workflows/backwards-compatibility-review.yml
@@ -112,4 +112,4 @@ jobs:
             6. Submit the review using: gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" -X POST --input bc_review_payload.json
 
           claude_args: >
-            --allowedTools "Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*)"
+            --allowedTools "Write,Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} *),Bash(git show *),Bash(git diff *),Bash(git ls-files *),Bash(git grep *)"

--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -26,7 +26,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >
-            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *)"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
             --json-schema '{"type":"object","properties":{"needs_docs":{"type":"boolean"},"confidence":{"type":"string","enum":["high","medium","low"]},"reason":{"type":"string"}},"required":["needs_docs","confidence","reason"]}'
           prompt: |
             Docs update detection for WooCommerce

--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -26,7 +26,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *)"
             --json-schema '{"type":"object","properties":{"needs_docs":{"type":"boolean"},"confidence":{"type":"string","enum":["high","medium","low"]},"reason":{"type":"string"}},"required":["needs_docs","confidence","reason"]}'
           prompt: |
             Docs update detection for WooCommerce

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -315,7 +315,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $context If the context is view, the value will be formatted for display. This keeps it compatible with pre-3.2 versions.
 	 * @return float|string
 	 */
-	public function get_total( $context = 'view' ) {
+	public function get_total( int $context ) {
 		$total = apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'total' ) );
 		return 'view' === $context ? apply_filters( 'woocommerce_cart_total', wc_price( $total ) ) : $total;
 	}


### PR DESCRIPTION
## Summary
- Adds an incompatible `int` type hint to `WC_Cart::get_total()` to test the backwards compatibility review workflow

## Test plan
- [ ] Verify the BC review GitHub Action triggers and posts a comment flagging the type hint change