### PR TITLE
[Performance] Products: reduce the number of SQLs required to populate cart data in StoreApi

### DIFF
--- a/plugins/woocommerce/changelog/performance-reduce-sqls-number-cart-checkout-pages
+++ b/plugins/woocommerce/changelog/performance-reduce-sqls-number-cart-checkout-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Products: reduced the number of SQL queries required to populate cart data in StoreApi.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
@@ -343,14 +343,30 @@ class CartSchema extends AbstractSchema {
 		// Get visible cross sells products.
 		$cross_sells    = array();
 		$cross_sell_ids = $cart->get_cross_sells();
+		$image_ids      = array();
 		if ( ! empty( $cross_sell_ids ) ) {
 			// Prime caches to reduce future queries.
 			_prime_post_caches( $cross_sell_ids );
 			$cross_sells = array_filter( array_map( 'wc_get_product', $cross_sell_ids ), 'wc_products_array_filter_visible' );
+			/** @var \WC_Product[] $cross_sells */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			// Identify which images need priming.
+			$image_ids[] = array_values( array_filter( array_map( static fn( $product ) => (int) $product->get_image_id(), $cross_sells ) ) );
+		}
+
+		$cart_all_items  = $cart->get_cart();
+		$cart_line_items = array_filter( $cart_all_items, static fn( $item ) => ( $item['data'] ?? null ) instanceof \WC_Product );
+		if ( ! empty( $cart_line_items ) ) {
+			// Identify which images need priming.
+			$image_ids[] = array_values( array_filter( array_map( static fn( $item ) => (int) $item['data']->get_image_id(), $cart_line_items ) ) );
+		}
+
+		if ( ! empty( $image_ids ) ) {
+			// Prime caches to reduce future queries.
+			_prime_post_caches( array_unique( array_merge( ...$image_ids ) ) );
 		}
 
 		return [
-			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
+			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart_all_items ),
 			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
 			'fees'                    => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
 			'totals'                  => (object) $this->prepare_currency_response( $this->get_totals( $cart ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6468, #63853

Implements bulk cache priming for product images during cart data generation in the Store API. This helps maintain a more consistent database load for HVM and BFCM scenarios.

```
Page     | 1 product (SQLs) | 5 products (SQLs) | 10 products (SQLs) |
cart     | 76  -> 74        | 114 -> 94  (-18%) | 167 -> 121 (-28%)  |
checkout | 101 -> 99        | 152 -> 132 (-13%) | 220 -> 174 (-21%) |
```

### How to test the changes in this Pull Request:

- Ensure that Query Monitor or a similar plugin is installed on your test site.
- Add several products to the cart, such as 5 or 10 items.
- Using the trunk branch, check the number of SQL queries on the cart and checkout pages. Refresh the pages several times until the query count stabilizes.
- Switch to this branch and confirm that the number of SQL queries is reduced on the same pages. Refresh the pages several times until the query count stabilizes.