### PR TITLE
Minor UI fixes to orders screens under WP 7.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-minor-wp-7.0-style-issues
+++ b/plugins/woocommerce/changelog/fix-minor-wp-7.0-style-issues
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This is already covered in a previous changelog entry.
+
+

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8343,8 +8343,15 @@ table.bar_chart {
 	}
 
 	// Order actions: select + button overflow container due to WP 7.0 select margins.
-	.order_actions #actions select {
-		width: calc(100% - 32px);
+	.order_actions {
+		#actions select {
+			width: calc(100% - 32px);
+		}
+
+		// Move to trash: make sure it aligns better vertically with 7.0's increased button height.
+		#delete-action {
+			line-height: 35px;
+		}
 	}
 
 	// Order actions reload button: icon line-height must match WP 7.0 button height.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8497,35 +8497,34 @@ table.bar_chart {
 			}
 		}
 	}
-}
 
-// Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
-// Match Select2 to 32px here (not the global 40px).
-// These page classes are on the body alongside wc-wp-version-gte-70, so use compound selectors.
-.wc-wp-version-gte-70.woocommerce_page_wc-customer-stock-notifications .tablenav,
-.wc-wp-version-gte-70.woocommerce_page_wc-orders .tablenav,
-.wc-wp-version-gte-70.post-type-product .tablenav,
-.wc-wp-version-gte-70.post-type-shop_order .tablenav {
-	.select2-container {
-		margin-top: 0; // Align with other tablenav elements.
-	}
-
-	.select2-container .select2-selection--single {
-		height: 32px; // WP 7.0 tablenav uses compact 32px, not 40px.
-
-		.select2-selection__rendered {
-			line-height: 30px;
+	// Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
+	// Match Select2 to 32px here (not the global 40px).
+	&.woocommerce_page_wc-customer-stock-notifications .tablenav,
+	&.woocommerce_page_wc-orders .tablenav,
+	&.post-type-product .tablenav,
+	&.post-type-shop_order .tablenav {
+		.select2-container {
+			margin-top: 0; // Align with other tablenav elements.
 		}
 
-		.select2-selection__arrow {
-			height: 30px;
-		}
-	}
+		.select2-container .select2-selection--single {
+			height: 32px; // WP 7.0 tablenav uses compact 32px, not 40px.
 
-	// Current page in pagination gets smaller than surrounding buttons at 782px breakpoint.
-	@media screen and (max-width: 782px) {
-		#current-page-selector {
-			height: 44px;
+			.select2-selection__rendered {
+				line-height: 30px;
+			}
+
+			.select2-selection__arrow {
+				height: 30px;
+			}
+		}
+
+		// Current page in pagination gets smaller than surrounding buttons at 782px breakpoint.
+		@media screen and (max-width: 782px) {
+			#current-page-selector {
+				height: 44px;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8483,6 +8483,13 @@ table.bar_chart {
 			height: 30px;
 		}
 	}
+
+	// Current page in pagination gets smaller than surrounding buttons at 782px breakpoint.
+	@media screen and (max-width: 782px) {
+		#current-page-selector {
+			height: 44px;
+		}
+	}
 }
 
 /**

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8459,6 +8459,44 @@ table.bar_chart {
 			line-height: 40px;
 		}
 	}
+
+	// Action button rows wrap/stack at ~1200px viewports.
+	@media screen and (max-width: 1200px) {
+		// Order items meta box: reduce button padding to prevent wrapping prematurely.
+		#woocommerce-order-items .wc-order-data-row {
+			.button {
+				padding-left: 8px;
+				padding-right: 8px;
+			}
+		}
+
+		// Refund action buttons: switch to flex layout so long labels wrap gracefully.
+		#woocommerce-order-items .refund-actions {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 4px;
+			align-items: center;
+
+			.button,
+			.cancel-action {
+				float: none;
+			}
+
+			.button {
+				margin: 0;
+				font-size: 12px;
+			}
+
+			.cancel-action {
+				margin-right: auto;
+				order: -1;
+			}
+
+			.clear {
+				display: none;
+			}
+		}
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.
@@ -9502,48 +9540,4 @@ body.woocommerce-settings-payments-section_legacy {
 	}
 }
 
-/**
- * WP 7.0+ responsive fixes for order meta box buttons.
- * WP 7.0 increased default button min-height from 30px to 40px,
- * causing action button rows to wrap/stack at ~1200px viewports.
- */
-.wc-wp-version-gte-70 {
-	@media screen and (max-width: 1200px) {
-		// Order items meta box: reduce button padding to prevent wrapping prematurely.
-		#woocommerce-order-items .wc-order-data-row {
-			.button {
-				padding-left: 8px;
-				padding-right: 8px;
-			}
-		}
 
-		// Refund action buttons: switch to flex layout so long labels wrap gracefully.
-		#woocommerce-order-items .refund-actions {
-			display: flex;
-			flex-wrap: wrap;
-			gap: 4px;
-			align-items: center;
-
-			.button,
-			.cancel-action {
-				float: none;
-			}
-
-			.button {
-				margin: 0;
-				font-size: 12px;
-			}
-
-			.cancel-action {
-				margin-right: auto;
-				order: -1;
-			}
-
-			.clear {
-				display: none;
-			}
-		}
-
-
-	}
-}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8433,6 +8433,32 @@ table.bar_chart {
 	#variable_product_options .form-row[class*="variable_low_stock_amount"] {
 		clear: both;
 	}
+
+	#poststuff #woocommerce-order-notes .inside button {
+		margin: 0 1px 1px;
+	}
+
+	@media screen and (max-width: 850px), screen and (min-width: 931px) {
+		#woocommerce-order-downloads .buttons button {
+			margin: 0;
+		}
+	}
+
+	// 782px breakpoint, when the admin sidebar is hidden.
+	@media screen and (max-width: 782px) {
+		// Make buttons match the now taller selects.
+		#poststuff #woocommerce-order-actions .inside button {
+			height: 42px;
+
+			&::after {
+				line-height: 40px;
+			}
+		}
+
+		#poststuff #woocommerce-order-notes .inside button {
+			line-height: 40px;
+		}
+	}
 }
 
 // Tablenav: WP 7.0 tablenav uses compact 32px sizing for native selects.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR solves a few remaining UI style issues when running WC under WP 7.0, after most were addressed in https://github.com/woocommerce/woocommerce/pull/63779.

Closes WOOPRD-3141, WOOPRD-3215 and WOOPRD-3216.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

|What?| Before | After | WordPress 6.9 |
| -- | ------ | ----- | ------------- |
|Order single view - actions metabox|<img width="310" height="170" alt="Screenshot 2026-03-25 at 17 39 07" src="https://github.com/user-attachments/assets/db1d5515-7766-4da9-bcb4-d365c1822572" />|<img width="297" height="167" alt="Screenshot 2026-03-25 at 16 51 47" src="https://github.com/user-attachments/assets/bcee296e-1662-4c60-a1c4-77e0f23b06b1" />|<img width="308" height="165" alt="Screenshot 2026-03-25 at 16 51 11" src="https://github.com/user-attachments/assets/23f58dd0-aa1d-46ef-a20a-512a2f66d840" />|
|Order single view - notes metabox|<img width="296" height="258" alt="Screenshot 2026-03-25 at 17 39 14" src="https://github.com/user-attachments/assets/053f58a7-fc8b-458e-bebe-ec1657db5718" />|<img width="301" height="216" alt="Screenshot 2026-03-25 at 17 35 31" src="https://github.com/user-attachments/assets/4c1b476d-e529-4886-a196-58fb2a86aec3" />|<img width="302" height="253" alt="Screenshot 2026-03-25 at 17 33 01" src="https://github.com/user-attachments/assets/f43381aa-196e-44c9-be34-24b9ee6dfe0f" />|
|Order single view - permissions metabox|<img width="679" height="121" alt="Screenshot 2026-03-25 at 17 39 18" src="https://github.com/user-attachments/assets/9fc5f5ae-7fc9-44a4-ad61-3d9fe93b36e1" />|<img width="619" height="120" alt="Screenshot 2026-03-25 at 17 35 34" src="https://github.com/user-attachments/assets/3307915f-a64d-4bec-91b4-97397e08ee39" />|<img width="1211" height="120" alt="Screenshot 2026-03-25 at 17 32 54" src="https://github.com/user-attachments/assets/2051a5c3-29b1-428e-9281-ec3bc06977ac" />|
|Orders list (< 782px)|<img width="723" height="142" alt="Screenshot 2026-03-25 at 17 38 59" src="https://github.com/user-attachments/assets/5e7de291-9694-4249-b35f-be97211c28e2" />|<img width="564" height="138" alt="Screenshot 2026-03-25 at 20 57 12" src="https://github.com/user-attachments/assets/70c99dfb-5298-4e4c-b021-a2e8bd2d7612" />|<img width="474" height="120" alt="Screenshot 2026-03-25 at 17 39 39" src="https://github.com/user-attachments/assets/f0ffeba6-5673-4dc5-ac58-609eb272c868" />|



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set up your store to use WordPress 7.0.
2. Visit each section (as described in the screenshots section above) and ensure they display correctly (correct controls sizes, alignment, etc.). Try different screen sizes as well: in particular, the 782px and 960px breakpoints are of interest as WP collapses or hides the nav bar at those. 
4. Downgrade to WordPress 6.9.
5. Ensure the styling of those admin views is the same as before this PR.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.