### PR TITLE
Fix Playground blueprint: deprecated options, broken proxy, and stale instance URL

### DIFF
--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -16,7 +16,7 @@ const generateWordpressPlaygroundBlueprint = ( runId, prNumber ) => {
 		steps: [
 			{
 				step: 'installPlugin',
-				pluginZipFile: {
+				pluginData: {
 					resource: 'url',
 					url: `https://playground.wordpress.net/plugin-proxy.php?org=woocommerce&repo=woocommerce&workflow=Build%20Live%20Branch&artifact=plugins-${ runId }&pr=${ prNumber }`,
 				},
@@ -26,9 +26,9 @@ const generateWordpressPlaygroundBlueprint = ( runId, prNumber ) => {
 			},
 			{
 				step: 'installPlugin',
-				pluginZipFile: {
+				pluginData: {
 					resource: 'url',
-					url: `https://github-proxy.com/https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.1/woocommerce-beta-tester.zip`,
+					url: 'https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-3.0.0/woocommerce-beta-tester.zip',
 				},
 				options: {
 					activate: true,
@@ -80,7 +80,7 @@ async function run( { github, context, core } ) {
 		context.issue.number
 	);
 
-	const url = `https://wordpress-playground.atomicsites.blog/#${ JSON.stringify(
+	const url = `https://playground.wordpress.net/#${ JSON.stringify(
 		defaultSchema
 	) }`;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Playground blueprint links on PRs have been broken due to three issues:

1. **Deprecated `pluginZipFile` option** — the Playground API renamed this to `pluginData`. The old option no longer works.
2. **Dead `github-proxy.com` proxy** — the third-party CORS proxy used to install the WooCommerce Beta Tester plugin is down ([Action Required: github-proxy.com Shutdown](https://make.wordpress.org/playground/2025/12/19/action-required-github-proxy-com-shutdown/)). Replaced with a direct GitHub release URL. Playground's [built-in CORS proxy](https://github.com/WordPress/wordpress-playground/pull/2076) handles the cross-origin fetch automatically when `networking: true` is set.
3. **Stale Playground instance** — the `wordpress-playground.atomicsites.blog` instance runs an older Playground version. Switched to the official `playground.wordpress.net`.

Also updated the beta tester version from 2.3.1 to 3.0.0 (latest release).

### How to test the changes in this Pull Request:

1. Open this [Playground blueprint](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/admin.php?page=wc-admin%22,%22preferredVersions%22:%7B%22php%22:%228.0%22,%22wp%22:%22latest%22%7D,%22phpExtensionBundles%22:%5B%22kitchen-sink%22%5D,%22features%22:%7B%22networking%22:true%7D,%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22url%22,%22url%22:%22https://playground.wordpress.net/plugin-proxy.php?org=woocommerce&repo=woocommerce&workflow=Build%20Live%20Branch&artifact=plugins-23559356186&pr=63738%22%7D,%22options%22:%7B%22activate%22:true%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-3.0.0/woocommerce-beta-tester.zip%22%7D,%22options%22:%7B%22activate%22:true%7D%7D,%7B%22step%22:%22setSiteOptions%22,%22options%22:%7B%22woocommerce_onboarding_profile%22:%7B%22skipped%22:true%7D%7D%7D,%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D%5D,%22plugins%22:%5B%5D%7D) which uses the updated blueprint format.
2. Verify WooCommerce and the Beta Tester plugin both install and activate successfully.
3. Confirm the WooCommerce admin dashboard loads at `/wp-admin/admin.php?page=wc-admin`.
4. Verify the **WC Beta Tester** menu appears in the admin bar.

### Testing that has already taken place:

Manually tested the Playground blueprint URL — both WooCommerce (from Build Live Branch artifact) and the Beta Tester (from GitHub release zip) install and activate successfully in Playground.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
CI/workflow change only — fixes the Playground blueprint generator script. No plugin code is affected.

</details>