### PR TITLE
Fix beta tester crash on activation due to removed rest_api_includes method

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
+++ b/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix crash when generating system status report due to removed rest_api_includes method.

--- a/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
+++ b/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix potential crash when generating system status report due to removed rest_api_includes method.
+Fix crash on activation in WordPress Playground due to removed rest_api_includes method.

--- a/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
+++ b/plugins/woocommerce-beta-tester/changelog/63861-fix-beta-tester-legacy-rest-api-crash
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix crash when generating system status report due to removed rest_api_includes method.
+Fix potential crash when generating system status report due to removed rest_api_includes method.

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-menus.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-menus.php
@@ -169,7 +169,7 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 
 		if ( false === $ssr ) {
 			// When running WC 3.6 or greater it is necessary to manually load the REST API classes.
-			if ( ! did_action( 'rest_api_init' ) ) {
+			if ( ! did_action( 'rest_api_init' ) && is_callable( array( WC()->api, 'rest_api_includes' ) ) ) {
 				WC()->api->rest_api_includes();
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The WooCommerce Beta Tester plugin crashes on activation in WordPress Playground. The `construct_ssr()` method calls `WC()->api->rest_api_includes()`, but since WooCommerce 9.0 `WC()->api` returns a `LegacyRestApiStub` that doesn't have this method. The existing guard (`did_action('rest_api_init')`) normally prevents this code path on standard admin page loads, but in Playground's environment `rest_api_init` never fires because there's no HTTP request to trigger `parse_request`. This causes a fatal error during plugin activation, breaking Playground blueprints that include the beta tester.

This adds an `is_callable` check before invoking the method.

Discovered while working on #63860.

### How to test the changes in this Pull Request:

1. Open this [Playground blueprint](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/admin.php?page=wc-admin%22,%22preferredVersions%22:%7B%22php%22:%228.0%22,%22wp%22:%22latest%22%7D,%22phpExtensionBundles%22:%5B%22kitchen-sink%22%5D,%22features%22:%7B%22networking%22:true%7D,%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22url%22,%22url%22:%22https://playground.wordpress.net/plugin-proxy.php?org=woocommerce%26repo=woocommerce%26workflow=Build%20Live%20Branch%26artifact=plugins-23559356186%26pr=63738%22%7D,%22options%22:%7B%22activate%22:true%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22git:directory%22,%22url%22:%22https://github.com/woocommerce/woocommerce%22,%22path%22:%22plugins/woocommerce-beta-tester%22,%22ref%22:%22trunk%22,%22refType%22:%22branch%22%7D,%22options%22:%7B%22activate%22:true%7D%7D,%7B%22step%22:%22setSiteOptions%22,%22options%22:%7B%22woocommerce_onboarding_profile%22:%7B%22skipped%22:true%7D%7D%7D,%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D%5D,%22plugins%22:%5B%5D%7D) which loads the beta tester from trunk — confirm it crashes with a fatal error at the `installPlugin` step.
2. Update the blueprint to load the beta tester from this branch instead (change `"ref": "trunk"` to `"ref": "fix/beta-tester-legacy-rest-api-crash"`). Confirm the blueprint completes successfully and the WooCommerce admin page loads.

### Testing that has already taken place:

Code review — confirmed that `LegacyRestApiStub` (which replaced `WC_API` in WooCommerce 9.0) does not implement `rest_api_includes()`, and that Playground's activation context skips `rest_api_init`, bypassing the existing guard.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix crash on activation in WordPress Playground due to removed rest_api_includes method.

</details>