### PR TITLE
Fix email editor background color mismatch between layout and template

### DIFF
--- a/packages/php/email-editor/changelog/63862-fix-email-editor-background-color-mismatch
+++ b/packages/php/email-editor/changelog/63862-fix-email-editor-background-color-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix background color mismatch between layout and template group when per-block padding distribution is active in email rendering

--- a/packages/php/email-editor/changelog/fix-email-editor-background-color-mismatch
+++ b/packages/php/email-editor/changelog/fix-email-editor-background-color-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix background color mismatch between layout and template group when per-block padding distribution is active

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-spacing-preprocessor.php
@@ -29,9 +29,10 @@ class Spacing_Preprocessor implements Preprocessor {
 	 * @return array
 	 */
 	public function preprocess( array $parsed_blocks, array $layout, array $styles ): array {
-		$root_padding      = $this->get_root_padding( $styles );
-		$container_padding = $styles['__container_padding'] ?? array();
-		$parsed_blocks     = $this->add_block_gaps( $parsed_blocks, $styles['spacing']['blockGap'] ?? '', null, $root_padding, false, $container_padding );
+		$root_padding               = $this->get_root_padding( $styles );
+		$container_padding          = $styles['__container_padding'] ?? array();
+		$container_background_color = $styles['__container_background_color'] ?? null;
+		$parsed_blocks              = $this->add_block_gaps( $parsed_blocks, $styles['spacing']['blockGap'] ?? '', null, $root_padding, false, $container_padding, $container_background_color );
 		return $parsed_blocks;
 	}
 
@@ -95,15 +96,16 @@ class Spacing_Preprocessor implements Preprocessor {
 	 *   padding ensures inset from the email edge. These blocks also stop delegation.
 	 * - No explicit padding: receive root padding if delegated, or delegate if a container.
 	 *
-	 * @param array      $parsed_blocks Parsed blocks.
-	 * @param string     $gap Gap.
-	 * @param array|null $parent_block Parent block.
-	 * @param array      $root_padding Root horizontal padding with 'left' and 'right' keys.
-	 * @param bool       $apply_root_padding Whether this block should receive root padding (delegated by parent container).
-	 * @param array      $container_padding Container horizontal padding with 'left' and 'right' keys.
+	 * @param array       $parsed_blocks Parsed blocks.
+	 * @param string      $gap Gap.
+	 * @param array|null  $parent_block Parent block.
+	 * @param array       $root_padding Root horizontal padding with 'left' and 'right' keys.
+	 * @param bool        $apply_root_padding Whether this block should receive root padding (delegated by parent container).
+	 * @param array       $container_padding Container horizontal padding with 'left' and 'right' keys.
+	 * @param string|null $container_background_color Background color from the container group.
 	 * @return array
 	 */
-	private function add_block_gaps( array $parsed_blocks, string $gap = '', $parent_block = null, array $root_padding = array(), bool $apply_root_padding = false, array $container_padding = array() ): array {
+	private function add_block_gaps( array $parsed_blocks, string $gap = '', $parent_block = null, array $root_padding = array(), bool $apply_root_padding = false, array $container_padding = array(), ?string $container_background_color = null ): array {
 		foreach ( $parsed_blocks as $key => $block ) {
 			$block_name        = $block['blockName'] ?? '';
 			$parent_block_name = $parent_block['blockName'] ?? '';
@@ -156,6 +158,12 @@ class Spacing_Preprocessor implements Preprocessor {
 			if ( $should_apply && ! $has_zero_padding && 'full' !== $alignment && ! in_array( $block_name, $post_content_block_names, true ) && ! $wraps_post_content && ! empty( $container_padding ) ) {
 				$block['email_attrs']['container-padding-left']  = $container_padding['left'];
 				$block['email_attrs']['container-padding-right'] = $container_padding['right'];
+
+				// Pass the container's background color so the padding wrapper
+				// matches the group's background visually.
+				if ( is_string( $container_background_color ) && '' !== $container_background_color ) {
+					$block['email_attrs']['container-background-color'] = $container_background_color;
+				}
 			}
 
 			// Determine whether children should receive root padding delegation.
@@ -167,6 +175,7 @@ class Spacing_Preprocessor implements Preprocessor {
 			// manage their own layout.
 			$children_apply         = false;
 			$children_container_pad = $container_padding;
+			$children_container_bg  = $container_background_color;
 			if ( $is_root_level && $is_container && ! $has_own_padding ) {
 				$children_apply = true;
 			} elseif ( $apply_root_padding && in_array( $block_name, $post_content_block_names, true ) ) {
@@ -180,6 +189,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				$block_padding = $this->get_block_horizontal_padding( $block );
 				if ( ! empty( $block_padding ) ) {
 					$children_container_pad                              = $block_padding;
+					$children_container_bg                               = $this->get_block_background_color( $block );
 					$block['email_attrs']['suppress-horizontal-padding'] = true;
 				}
 			} elseif ( $is_root_level && $is_container && $has_own_padding && ! $has_zero_padding && $this->contains_post_content( $block ) ) {
@@ -189,6 +199,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				$block_padding  = $this->get_block_horizontal_padding( $block );
 				if ( ! empty( $block_padding ) ) {
 					$children_container_pad                              = $block_padding;
+					$children_container_bg                               = $this->get_block_background_color( $block );
 					$block['email_attrs']['suppress-horizontal-padding'] = true;
 				}
 
@@ -197,7 +208,7 @@ class Spacing_Preprocessor implements Preprocessor {
 				unset( $block['email_attrs']['root-padding-left'], $block['email_attrs']['root-padding-right'] );
 			}
 
-			$block['innerBlocks']  = $this->add_block_gaps( $block['innerBlocks'] ?? array(), $gap, $block, $root_padding, $children_apply, $children_container_pad );
+			$block['innerBlocks']  = $this->add_block_gaps( $block['innerBlocks'] ?? array(), $gap, $block, $root_padding, $children_apply, $children_container_pad, $children_container_bg );
 			$parsed_blocks[ $key ] = $block;
 		}
 
@@ -244,6 +255,24 @@ class Spacing_Preprocessor implements Preprocessor {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Extract a block's background color from its attributes.
+	 *
+	 * Returns the inline background color value. Preset slugs (backgroundColor
+	 * attribute) require the theme variables map for resolution, which is
+	 * handled by Content_Renderer::find_container_background_color() instead.
+	 *
+	 * @param array $block The block to extract background color from.
+	 * @return string|null The inline background color value, or null if not set.
+	 */
+	private function get_block_background_color( array $block ): ?string {
+		$inline_bg = $block['attrs']['style']['color']['background'] ?? null;
+		if ( is_string( $inline_bg ) && '' !== $inline_bg ) {
+			return $inline_bg;
+		}
+		return null;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
@@ -119,6 +119,18 @@ class Content_Renderer {
 	private array $container_padding = array();
 
 	/**
+	 * Background color from the template group wrapping post-content.
+	 *
+	 * When per-block padding distribution is active (suppress-horizontal-padding),
+	 * the group's horizontal padding area no longer shows the group's background.
+	 * This color is passed to user blocks so the email-root-padding wrapper can
+	 * apply it, keeping the visual result consistent.
+	 *
+	 * @var string|null
+	 */
+	private ?string $container_background_color = null;
+
+	/**
 	 * CSS inliner
 	 *
 	 * @var Css_Inliner
@@ -253,19 +265,24 @@ class Content_Renderer {
 				unset( $styles['spacing']['padding']['left'], $styles['spacing']['padding']['right'] );
 			}
 
-			// Pass container padding from the first pass so the
-			// Spacing_Preprocessor can distribute it to user blocks.
+			// Pass container padding and background color from the first pass
+			// so the Spacing_Preprocessor can distribute them to user blocks.
 			if ( ! empty( $this->container_padding ) ) {
 				$styles['__container_padding'] = $this->container_padding;
+			}
+			if ( null !== $this->container_background_color ) {
+				$styles['__container_background_color'] = $this->container_background_color;
 			}
 		}
 
 		$result = $this->process_manager->preprocess( $parsed_blocks, $layout, $styles );
 
-		// After the first pass: find the post-content block's width and container padding.
+		// After the first pass: find the post-content block's width, container padding,
+		// and container background color.
 		if ( null === $this->post_content_width ) {
-			$this->post_content_width = $this->find_post_content_width( $result );
-			$this->container_padding  = $this->find_container_padding( $result );
+			$this->post_content_width         = $this->find_post_content_width( $result );
+			$this->container_padding          = $this->find_container_padding( $result );
+			$this->container_background_color = $this->find_container_background_color( $result );
 		}
 
 		return $result;
@@ -336,6 +353,49 @@ class Content_Renderer {
 			}
 		}
 		return array();
+	}
+
+	/**
+	 * Find the background color from the container with suppress-horizontal-padding.
+	 *
+	 * When a template group distributes its horizontal padding per-block, the
+	 * padding wrappers need the group's background color so the padding area
+	 * matches visually.
+	 *
+	 * @param array $blocks Preprocessed blocks.
+	 * @return string|null The resolved background color or null if not found.
+	 */
+	private function find_container_background_color( array $blocks ): ?string {
+		$variables_map = $this->theme_controller->get_variables_values_map();
+
+		foreach ( $blocks as $block ) {
+			$email_attrs = $block['email_attrs'] ?? array();
+			if ( ! empty( $email_attrs['suppress-horizontal-padding'] ) ) {
+				$attrs = $block['attrs'] ?? array();
+
+				// Check for inline background color first.
+				$inline_bg = $attrs['style']['color']['background'] ?? null;
+				if ( is_string( $inline_bg ) && '' !== $inline_bg ) {
+					return $inline_bg;
+				}
+
+				// Check for preset backgroundColor slug.
+				$bg_slug = $attrs['backgroundColor'] ?? null;
+				if ( is_string( $bg_slug ) && '' !== $bg_slug ) {
+					$css_var_name = '--wp--preset--color--' . $bg_slug;
+					return $variables_map[ $css_var_name ] ?? null;
+				}
+
+				return null;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = $this->find_container_background_color( $block['innerBlocks'] );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -433,6 +493,13 @@ class Content_Renderer {
 			return $content;
 		}
 
+		// When container padding is present, apply the container's background
+		// color so the padding area matches the group's background visually.
+		$container_bg = $email_attrs['container-background-color'] ?? null;
+		if ( is_string( $container_bg ) && '' !== $container_bg ) {
+			$css_attrs['background-color'] = $container_bg;
+		}
+
 		$padding_style = WP_Style_Engine::compile_css( $css_attrs, '' );
 		if ( empty( $padding_style ) ) {
 			return $content;
@@ -525,8 +592,9 @@ class Content_Renderer {
 		remove_filter( 'block_parser_class', array( $this, 'block_parser' ) );
 		remove_filter( 'woocommerce_email_blocks_renderer_parsed_blocks', array( $this, 'preprocess_parsed_blocks' ) );
 
-		$this->post_content_width = null;
-		$this->container_padding  = array();
+		$this->post_content_width         = null;
+		$this->container_padding          = array();
+		$this->container_background_color = null;
 
 		// Restore the original core/post-content render callback.
 		// Note: We always restore it, even if it was null originally.

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Spacing_Preprocessor_Test.php
@@ -912,4 +912,138 @@ class Spacing_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		// Should not have padding-left due to malicious value.
 		$this->assertArrayNotHasKey( 'padding-left', $second_column['email_attrs'] );
 	}
+
+	/**
+	 * Test container background color is distributed alongside container padding (inline color)
+	 */
+	public function testItDistributesContainerBackgroundColorFromRootGroup(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'padding' => array(
+								'left'   => '20px',
+								'right'  => '20px',
+								'top'    => '15px',
+								'bottom' => '15px',
+							),
+						),
+						'color'   => array(
+							'background' => '#333333',
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/post-content',
+						'attrs'       => array(),
+						'innerBlocks' => array(
+							array(
+								'blockName'   => 'core/paragraph',
+								'attrs'       => array(),
+								'innerBlocks' => array(),
+							),
+							array(
+								'blockName'   => 'core/group',
+								'attrs'       => array( 'align' => 'full' ),
+								'innerBlocks' => array(),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$result    = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$paragraph = $result[0]['innerBlocks'][0]['innerBlocks'][0];
+		$alignfull = $result[0]['innerBlocks'][0]['innerBlocks'][1];
+
+		// Normal paragraph gets container background color.
+		$this->assertEquals( '#333333', $paragraph['email_attrs']['container-background-color'] );
+
+		// Alignfull block does NOT get container background color.
+		$this->assertArrayNotHasKey( 'container-background-color', $alignfull['email_attrs'] );
+	}
+
+	/**
+	 * Test container background color is passed from styles (second pass) to user blocks
+	 */
+	public function testItAppliesContainerBackgroundColorFromStyles(): void {
+		$styles                               = $this->styles;
+		$styles['__container_padding']        = array(
+			'left'  => '20px',
+			'right' => '20px',
+		);
+		$styles['__container_background_color'] = '#444444';
+
+		$blocks = array(
+			array(
+				'blockName'   => 'core/paragraph',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+			),
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array( 'align' => 'full' ),
+				'innerBlocks' => array(),
+			),
+		);
+
+		$result    = $this->preprocessor->preprocess( $blocks, $this->layout, $styles );
+		$paragraph = $result[0];
+		$alignfull = $result[1];
+
+		// Normal block gets container background color.
+		$this->assertEquals( '#444444', $paragraph['email_attrs']['container-background-color'] );
+
+		// Alignfull block does NOT get container background color.
+		$this->assertArrayNotHasKey( 'container-background-color', $alignfull['email_attrs'] );
+	}
+
+	/**
+	 * Test no container background color when group has no background set
+	 */
+	public function testItDoesNotSetContainerBackgroundColorWhenGroupHasNoBackground(): void {
+		$blocks = array(
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array(
+					'style' => array(
+						'spacing' => array(
+							'padding' => array(
+								'left'   => '20px',
+								'right'  => '20px',
+								'top'    => '15px',
+								'bottom' => '15px',
+							),
+						),
+					),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/post-content',
+						'attrs'       => array(),
+						'innerBlocks' => array(
+							array(
+								'blockName'   => 'core/paragraph',
+								'attrs'       => array(),
+								'innerBlocks' => array(),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$result    = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$paragraph = $result[0]['innerBlocks'][0]['innerBlocks'][0];
+
+		// Paragraph should still get container padding.
+		$this->assertEquals( '20px', $paragraph['email_attrs']['container-padding-left'] );
+
+		// But no container background color.
+		$this->assertArrayNotHasKey( 'container-background-color', $paragraph['email_attrs'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

PR #63752 introduced per-block container padding distribution for email rendering. Instead of the template group applying its own CSS horizontal padding, padding is now distributed to individual blocks via `email-root-padding` wrapper divs.

When the layout background color (email body/wrapper) differs from the template group's background color, the per-block padding distribution creates a visible color mismatch. The `email-root-padding` div's padding area shows through to the layout/body background color instead of the group's background, creating visible gap stripes between the group edge and block content.

**Fix:** Propagate the container group's background color to the `email-root-padding` wrapper div so the padding area matches the group's background visually. The color flows through the same data path as container padding: extracted during the first preprocessing pass, stored on the renderer, and distributed to user blocks in the second pass.

Closes https://linear.app/a8c/issue/WOOPRD-3166

Bug introduced in PR #63752.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Padding area shows body background (gray) instead of group background (green) | Padding area correctly shows the group's background color |

### How to test the changes in this Pull Request:

1. Open the WooCommerce email editor and select any email template
2. Set the template group's (content area) background color to something distinct (e.g. a dark or colored value)
3. Set a different layout/body background color (e.g. white or gray)
4. Preview or send a test email
5. Verify the padding area between the group edge and block content shows the group's background color, not the body background
6. Add a full-width (alignfull) block — verify it still spans the full width without background color on its padding

### Testing that has already taken place:

- All 209 email editor unit tests pass (including 3 new tests)
- PHPCS: 0 errors, 0 warnings
- PHPStan level 9: 0 errors

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix background color mismatch between layout and template group when per-block padding distribution is active in email rendering

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)