### PR TITLE
Performance: add new index on wc_reserved_stock table.

### DIFF
--- a/plugins/woocommerce/changelog/performance-new-index-for-wc_reserved_stock
+++ b/plugins/woocommerce/changelog/performance-new-index-for-wc_reserved_stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+A new index has been added to the `wc_reserved_stock` table to maintain stock reservation performance during peak sales events.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2124,7 +2124,8 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	`stock_quantity` double NOT NULL DEFAULT 0,
 	`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-	PRIMARY KEY  (`order_id`, `product_id`)
+	PRIMARY KEY  (`order_id`, `product_id`),
+	KEY product_id_expires (product_id, expires)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_rate_limits (
   rate_limit_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,

--- a/plugins/woocommerce/src/Blocks/Installer.php
+++ b/plugins/woocommerce/src/Blocks/Installer.php
@@ -69,7 +69,8 @@ class Installer {
 				`stock_quantity` double NOT NULL DEFAULT 0,
 				`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 				`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-				PRIMARY KEY  (`order_id`, `product_id`)
+				PRIMARY KEY  (`order_id`, `product_id`),
+				KEY product_id_expires (product_id, expires)
 			) $collate;
 			"
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes WOOPLUG-6471, #63865

This update introduces a new index to the `wc_reserved_stock` table to maintain a consistent `orders - stock reservation` join execution plan in HVM and BFCM scenarios. These scenarios are affected by the ratio of draft or pending orders to product stock reservations. The join occurs in a `(query FOR UPDATE)` locking context, where minimizing lock duration is essential.

Additionally, if a store experiences delays in draft order cleanup, the new index will help maintain join query performance until the issue is addressed.

Here are the details of the AI-assisted verification:

```
SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 )
FROM wp_wc_reserved_stock stock_table
LEFT JOIN wp_posts posts ON stock_table.`order_id` = posts.ID
WHERE posts.post_status IN ( 'wc-checkout-draft', 'wc-pending' )
AND stock_table.`expires` > NOW()
AND stock_table.`product_id` = {product_id}
AND stock_table.`order_id` != {exclude_order_id}

# table=posts        type=index   key=type_status_author   rows=610   Extra=Using where; Using index
# table=stock_table  type=eq_ref  key=PRIMARY              rows=1     Extra=Using where
# after adding the index -> same data set, fewer rows scanned, and a smaller index has been used
# table=stock_table  type=range   key=product_id_expires   rows=56    Extra=Using index condition
# table=posts        type=eq_ref  key=PRIMARY              rows=1     Extra=Using where

SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 )
FROM wp_wc_reserved_stock stock_table
LEFT JOIN wp_wc_orders orders ON stock_table.`order_id` = orders.id
WHERE orders.status IN ( 'wc-checkout-draft', 'wc-pending' )
AND stock_table.`expires` > NOW()
AND stock_table.`product_id` = {product_id}
AND stock_table.`order_id` != {exclude_order_id}

table=orders       type=range   key=status               rows=2000  Extra=Using where; Using index
table=stock_table  type=eq_ref  key=PRIMARY              rows=1     Extra=Using where
# after adding the index -> same data set, fewer rows scanned, and a smaller index has been used
table=stock_table  type=range   key=product_id_expires   rows=222   Extra=Using index condition
table=orders       type=eq_ref  key=PRIMARY              rows=1     Extra=Using where
```

### How to test the changes in this Pull Request:

- Remove the `woocommerce_version` and `woocommerce_db_version` entries from the options table.
- Access the admin area.
- Confirm that the new index has been added.
- Perform a test purchase.
