### PR TITLE
Fix: Don't print quantity output symbol if there's no quantity

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-empty-quantity-output
+++ b/plugins/woocommerce/changelog/fix-email-empty-quantity-output
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Prevent empty quantity output markers in order email templates.

--- a/plugins/woocommerce/changelog/fix-email-empty-quantity-output
+++ b/plugins/woocommerce/changelog/fix-email-empty-quantity-output
@@ -1,4 +1,4 @@
 Significance: patch
-Type: update
+Type: fix
 
 Prevent empty quantity output markers in order email templates.

--- a/plugins/woocommerce/templates/emails/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-items.php
@@ -145,7 +145,6 @@ foreach ( $items as $item_id => $item ) :
 		</td>
 		<td class="td font-family text-align-<?php echo esc_attr( $price_text_align ); ?>" style="vertical-align:middle;">
 			<?php
-			echo '&times;';
 			$qty         = $item->qty;
 			$qty_display = esc_html( $qty );
 			/**
@@ -153,7 +152,10 @@ foreach ( $items as $item_id => $item ) :
 			 *
 			 * @since 2.4.0
 			 */
-			echo wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item->item ) );
+			$quantity = wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item->item ) );
+			if ( $quantity !== '' ) {
+				echo '&times; ' . $quantity;
+			}
 			?>
 		</td>
 		<td class="td font-family text-align-<?php echo esc_attr( $price_text_align ); ?>" style="vertical-align:middle;">

--- a/plugins/woocommerce/templates/emails/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.0
+ * @version 10.1.1
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.1
+ * @version 10.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-items.php
@@ -154,7 +154,7 @@ foreach ( $items as $item_id => $item ) :
 			 */
 			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item->item );
 			if ( '' !== $quantity ) {
-				echo '&times; ' . wp_kses_post( $quantity );
+				echo '&times;' . wp_kses_post( $quantity );
 			}
 			?>
 		</td>

--- a/plugins/woocommerce/templates/emails/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/email-fulfillment-items.php
@@ -152,9 +152,9 @@ foreach ( $items as $item_id => $item ) :
 			 *
 			 * @since 2.4.0
 			 */
-			$quantity = wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item->item ) );
-			if ( $quantity !== '' ) {
-				echo '&times; ' . $quantity;
+			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item->item );
+			if ( '' !== $quantity ) {
+				echo '&times; ' . wp_kses_post( $quantity );
 			}
 			?>
 		</td>

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.7.1
+ * @version 10.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.7.0
+ * @version 10.7.1
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -201,10 +201,18 @@ foreach ( $items as $item_id => $item ) :
 			} else {
 				$qty_display = esc_html( $qty );
 			}
-			$quantity = wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item ) );
-			if ( $quantity !== '' ) {
+			/**
+			 * Email Order Item Quantity hook.
+			 *
+			 * @since 2.4.0
+			 * @param string        $qty_display Item quantity.
+			 * @param WC_Order_Item $item        Item object.
+			 * @return string
+			 */
+			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item );
+			if ( '' !== $quantity ) {
 				$quantity_prefix = $email_improvements_enabled ? '&times;' : '';
-				echo $quantity_prefix . $quantity;
+				echo wp_kses_post( $quantity_prefix . $quantity );
 			}
 			?>
 		</td>

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -193,7 +193,6 @@ foreach ( $items as $item_id => $item ) :
 		</td>
 		<td class="td font-family text-align-<?php echo esc_attr( $price_text_align ); ?>" style="vertical-align:middle;">
 			<?php
-			echo $email_improvements_enabled ? '&times;' : '';
 			$qty          = $item->get_quantity();
 			$refunded_qty = $order->get_qty_refunded_for_item( $item_id );
 
@@ -202,7 +201,11 @@ foreach ( $items as $item_id => $item ) :
 			} else {
 				$qty_display = esc_html( $qty );
 			}
-			echo wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item ) );
+			$quantity = wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item ) );
+			if ( $quantity !== '' ) {
+				$quantity_prefix = $email_improvements_enabled ? '&times;' : '';
+				echo $quantity_prefix . $quantity;
+			}
 			?>
 		</td>
 		<td class="td font-family text-align-<?php echo esc_attr( $price_text_align ); ?>" style="vertical-align:middle;">

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -205,8 +205,8 @@ foreach ( $items as $item_id => $item ) :
 			 * Email Order Item Quantity hook.
 			 *
 			 * @since 2.4.0
-			 * @param string        $qty_display Item quantity.
-			 * @param WC_Order_Item $item        Item object.
+			 * @param string                $qty_display Item quantity.
+			 * @param WC_Order_Item_Product $item        Item object.
 			 * @return string
 			 */
 			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $qty_display, $item );

--- a/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates\Emails\Plain
- * @version     10.1.1
+ * @version     10.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
@@ -61,7 +61,7 @@ foreach ( $items as $item_id => $item ) :
 		 * @param WC_Order_Item $item     Item object.
 		 */
 		$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->qty, $item->item );
-		if ( $quantity !== '' ) {
+		if ( '' !== $quantity ) {
 			$product_name .= ' × ' . $quantity;
 		}
 		echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );

--- a/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates\Emails\Plain
- * @version     10.1.0
+ * @version     10.1.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-fulfillment-items.php
@@ -60,7 +60,10 @@ foreach ( $items as $item_id => $item ) :
 		 * @param int           $quantity Item quantity.
 		 * @param WC_Order_Item $item     Item object.
 		 */
-		$product_name .= ' × ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->qty, $item->item );
+		$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->qty, $item->item );
+		if ( $quantity !== '' ) {
+			$product_name .= ' × ' . $quantity;
+		}
 		echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
 		echo ' ';
 		echo esc_html( str_pad( wp_kses( $order->get_formatted_line_subtotal( $item->item ), array() ), 20, ' ', STR_PAD_LEFT ) ) . "\n";

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -86,7 +86,7 @@ foreach ( $items as $item_id => $item ) :
 			 */
 			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
 			if ( '' !== $quantity ) {
-				echo ' X ' . $quantity;
+				echo ' × ' . $quantity;
 			}
 			echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -52,7 +52,10 @@ foreach ( $items as $item_id => $item ) :
 			 * @param int           $quantity Item quantity.
 			 * @param WC_Order_Item $item     Item object.
 			 */
-			$product_name .= ' × ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			if ( $quantity !== '' ) {
+				$product_name .= ' × ' . $quantity;
+			}
 			echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
 			echo ' ';
 			echo esc_html( str_pad( wp_kses( $order->get_formatted_line_subtotal( $item ), array() ), 20, ' ', STR_PAD_LEFT ) ) . "\n";
@@ -81,7 +84,10 @@ foreach ( $items as $item_id => $item ) :
 			 * @param int           $quantity Item quantity.
 			 * @param WC_Order_Item $item     Item object.
 			 */
-			echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			if ( $quantity !== '' ) {
+				echo ' X ' . $quantity;
+			}
 			echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 		}

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates\Emails\Plain
- * @version     9.8.1
+ * @version     10.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates\Emails\Plain
- * @version     9.8.0
+ * @version     9.8.1
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -53,7 +53,7 @@ foreach ( $items as $item_id => $item ) :
 			 * @param WC_Order_Item $item     Item object.
 			 */
 			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
-			if ( $quantity !== '' ) {
+			if ( '' !== $quantity ) {
 				$product_name .= ' × ' . $quantity;
 			}
 			echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
@@ -85,7 +85,7 @@ foreach ( $items as $item_id => $item ) :
 			 * @param WC_Order_Item $item     Item object.
 			 */
 			$quantity = apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
-			if ( $quantity !== '' ) {
+			if ( '' !== $quantity ) {
 				echo ' X ' . $quantity;
 			}
 			echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update quantity symbol in plain text email for `plugins/woocommerce/templates/emails/plain/email-order-items.php` fragment from `X` to `×` to match other templates.
Prevent the quantity prefix from being printed in case `woocommerce_email_order_item_quantity` is an empty string.

For example, let's say we don't want to show quantity 1 for a product.

<details>
<summary>In this case a booked service</summary>

<img width="609" height="449" alt="CleanShot 2026-03-26 at 16 41 41" src="https://github.com/user-attachments/assets/aa25b3ba-7d7b-428a-b487-4c0de2bbfcd2" />

</details>

You can try using:

```php
add_filter( 'woocommerce_email_order_item_quantity', 'hide_booking_item_quantity' );
function hide_booking_item_quantity() {
	return '';
}
```

<details>
<summary>This would hide the number, but not the prefix.</summary>

<img width="616" height="264" alt="CleanShot 2026-03-26 at 16 46 30" src="https://github.com/user-attachments/assets/e8d46e84-6a77-4472-a2df-fc1d149b7a23" />

</details>

After applying the changes from this PR.

<details>
<summary>No more prefix</summary>

<img width="610" height="265" alt="CleanShot 2026-03-26 at 16 47 32" src="https://github.com/user-attachments/assets/f435ee21-dd42-4aeb-8265-28b7cf04cc9b" />

</details>

### How to test the changes in this Pull Request:

### Test that quantity info works as expected

- Apply this patch
- Checkout one product
- Check the email confirmation and make sure the quantity info is there

### Test that quantity info no longer shows (the prefix is gone)

- Apply this patch
- Add some code that hides quantity info. For example this:

```php
add_filter( 'woocommerce_email_order_item_quantity', 'hide_booking_item_quantity' );
function hide_booking_item_quantity() {
	return '';
}
```

- Checkout one product
- Check the email confirmation and make sure the quantity info is not there

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
