### PR TITLE
Fix: Order status text wrapping vertically when Gutenberg plugin is active

### DIFF
--- a/packages/js/components/changelog/fix-order-status-text-wrap-gutenberg
+++ b/packages/js/components/changelog/fix-order-status-text-wrap-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order status text wrapping vertically when Gutenberg plugin is active by adding white-space: nowrap to prevent inherited word-break styles from affecting grid min-content sizing

--- a/packages/js/components/src/order-status/style.scss
+++ b/packages/js/components/src/order-status/style.scss
@@ -3,6 +3,7 @@
 	grid-template-columns: min-content min-content;
 	grid-gap: $gap-smallest * 2;
 	align-items: center;
+	white-space: nowrap;
 }
 
 .woocommerce-order-status__indicator {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes order status text in the Orders activity panel wrapping incorrectly when the Gutenberg plugin is active.

The `woocommerce-order-status` component uses `display: grid` with `grid-template-columns: min-content min-content`. The second column's `min-content` size is computed based on inherited `word-break` rules. When Gutenberg (v32.3.0) added `word-break: break-word` to `.components-button`, and with WP 7.0 global styles, this cascaded down and caused the text column's `min-content` to shrink — resulting in characters rendering letter-by-letter vertically for single-word statuses, and splitting across lines for multi-word statuses like "On hold".

The root cause in Gutenberg (the per-letter wrapping) was reverted in v32.4.0, but multi-word statuses like "On hold" are still split across two lines as seen in the screenshot below.

The fix adds `white-space: nowrap` to `.woocommerce-order-status`, preventing any inherited `word-break` styles from affecting the component's grid column sizing. Order status labels are always short and should never wrap.

Closes https://linear.app/a8c/issue/WOOA7S-1159/order-activity-status-text-wraps-vertically-with-gutenberg-plugin .

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| "On hold" splits across two lines | "On hold" stays on a single line |

### How to test the changes in this Pull Request:

1. Set up a local WooCommerce dev environment with `wp-env`.
2. Install and activate the latest [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
3. Create several orders with mixed statuses, including at least one with status **"On hold"**.
4. Navigate to **WooCommerce > Home** (the homescreen) and open the **Orders** activity panel.
5. Verify that "On hold" and all other order statuses display on a single line next to the status indicator dot.
6. Optionally, test without the Gutenberg plugin active and confirm status labels remain on a single line.

### Testing that has already taken place:

Manually verified on a local `wp-env` environment with WooCommerce trunk and Gutenberg plugin v32.4.0 active. Confirmed "On hold" renders on one line after the fix, and all other statuses ("Processing", "Completed", etc.) are unaffected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry has been manually created in `packages/js/components/changelog/fix-order-status-text-wrap-gutenberg`.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix order status text wrapping vertically or across multiple lines when Gutenberg plugin is active

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

N/A — changelog entry created manually.

</details>