### PR TITLE
[WOOPLUG-6477] fix: fix _load_textdomain_just_in_time warning in FulfillmentsController::register_data_stores

### DIFF
--- a/plugins/woocommerce/changelog/63888-fix-wooplug-6477-fix-_load_textdomain_just_in_time-warning-in
+++ b/plugins/woocommerce/changelog/63888-fix-wooplug-6477-fix-_load_textdomain_just_in_time-warning-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix _load_textdomain_just_in_time warning in FulfillmentsController by checking feature option directly instead of using FeaturesController::feature_is_enabled() before init action.

--- a/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsController.php
+++ b/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsController.php
@@ -48,11 +48,11 @@ class FulfillmentsController {
 			return $data_stores;
 		}
 
-		$container           = wc_get_container();
-		$features_controller = $container->get( FeaturesController::class );
-
-		// If fulfillments feature is not enabled, don't register the data store.
-		if ( ! $features_controller->feature_is_enabled( 'fulfillments' ) ) {
+		// Check the option directly instead of using FeaturesController::feature_is_enabled()
+		// because the woocommerce_data_stores filter can fire before the 'init' action
+		// (e.g. from WC Payments during 'plugins_loaded'), and feature_is_enabled() would
+		// trigger translation loading too early, causing _load_textdomain_just_in_time warnings.
+		if ( 'yes' !== get_option( 'woocommerce_feature_fulfillments_enabled', 'no' ) ) {
 			return $data_stores;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Fixes `_load_textdomain_just_in_time` warning triggered when `FulfillmentsController::register_data_stores()` calls `FeaturesController::feature_is_enabled()` before the `init` action fires.

When plugins like WC Payments call `WC_Data_Store::load()` during `plugins_loaded`, the `woocommerce_data_stores` filter fires, and `feature_is_enabled()` triggers `init_feature_definitions()` which uses `__()` for translations. This causes WordPress to warn about loading textdomains too early.

The fix checks the option directly with `get_option()` instead of going through `FeaturesController::feature_is_enabled()`, matching the established pattern in `OrdersVersionStringInvalidator`, `TaxRateVersionStringInvalidator`, and `ProductVersionStringInvalidator`.

Related issue: [WOOPLUG-6477](https://linear.app/a8c/issue/WOOPLUG-6477/fix-load-textdomain-just-in-time-warning-in)

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Install and activate WooCommerce Payments plugin (or any plugin that calls `WC_Data_Store::load()` during `plugins_loaded`)
2. Enable the fulfillments feature flag
3. Enable `WP_DEBUG` and `WP_DEBUG_LOG`
4. Load any admin page
5. Check `wp-content/debug.log` for `_load_textdomain_just_in_time` warnings related to the woocommerce textdomain
6. Verify no such warning appears after the fix

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix _load_textdomain_just_in_time warning in FulfillmentsController by checking feature option directly instead of using FeaturesController::feature_is_enabled() before init action.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>