### PR TITLE
Prevent unnecessary DELETE queries in order datastore

### DIFF
--- a/plugins/woocommerce/changelog/fix-63680
+++ b/plugins/woocommerce/changelog/fix-63680
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip unnecessary DELETE queries in update_line_items_from_cart when order ID is 0.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -760,6 +760,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function delete_items( $order, $type = null ) {
 		global $wpdb;
 
+		if ( ! $order->get_id() ) {
+			return;
+		}
+
 		if ( ! empty( $type ) ) {
 			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order->get_id(), $type ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $order->get_id(), $type ) );

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -760,16 +760,18 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function delete_items( $order, $type = null ) {
 		global $wpdb;
 
-		if ( ! $order->get_id() ) {
+		$order_id = $order->get_id();
+
+		if ( ! $order_id ) {
 			return;
 		}
 
 		if ( ! empty( $type ) ) {
-			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order->get_id(), $type ) );
-			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $order->get_id(), $type ) );
+			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order_id, $type ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $order_id, $type ) );
 		} else {
-			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order->get_id() ) );
-			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() ) );
+			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order_id ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order_id ) );
 		}
 
 		$this->clear_caches( $order );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a draft order is first created via the Store API, `update_line_items_from_cart()` calls `remove_order_items()` before the order has been saved to the database. This causes up to 10 unnecessary `DELETE ... WHERE order_id = 0` queries to be executed against the database on every new checkout session.

This PR adds an early return in `Abstract_WC_Order_Data_Store_CPT::delete_items()` when the order ID is 0, skipping the DELETE queries altogether. The in-memory item clearing in `WC_Abstract_Order::remove_order_items()` still executes normally for all callers.

Closes #63680.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin.
1. Remove all products from your cart (if any).
1. Add a few products to your cart and navigate to the block-based checkout page.
1. Open Query Monitor and look at the database queries panel.
1. Confirm that no `order_id = 0` DELETE queries appear.
1. Go back to your cart (without completing the purchase) and remove some items or change quantities.
1. Go back to the checkout.
1. Complete the checkout and verify the order is created correctly with all line items, shipping, coupons, fees, and taxes intact.
1. Repeat all of the above on `trunk`, and you will see multiple `DELETE`  queries with `order_id = 0` involving tables `wp_woocommerce_order_items` and `wp_woocommerce_order_itemmeta` when you first visit the checkout page.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.