### PR TITLE
Add QR code direct login for mobile app

### DIFF
--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/MobileAppLoginStepper.tsx
@@ -13,6 +13,7 @@ import { SendMagicLinkButton, SendMagicLinkStates } from './';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { MobileAppInstallationInfo } from '../components/MobileAppInstallationInfo';
 import { MobileAppLoginInfo } from '../components/MobileAppLoginInfo';
+import { QRDirectLoginCode } from '../components/QRDirectLoginCode';
 
 export const MobileAppLoginStepper = ( {
 	step,
@@ -66,38 +67,26 @@ export const MobileAppLoginStepper = ( {
 					content: <></>,
 				},
 			] );
-		} else if ( step === 'second' ) {
+		} else if ( step === ‘second’ ) {
 			if (
 				isJetpackPluginInstalled &&
 				wordpressAccountEmailAddress !== undefined
 			) {
 				setStepsToDisplay( [
 					{
-						key: 'first',
-						label: __( 'App installed', 'woocommerce' ),
-						description: '',
+						key: ‘first’,
+						label: __( ‘App installed’, ‘woocommerce’ ),
+						description: ‘’,
 						content: <></>,
 					},
 					{
-						key: 'second',
-						label: 'Sign into the app',
-						description: sprintf(
-							/* translators: Reflecting to the user that the magic link has been sent to their WordPress account email address */
-							__(
-								'We’ll send a magic link to %s. Open it on your smartphone or tablet to sign into your store instantly.',
-								'woocommerce'
-							),
-							wordpressAccountEmailAddress
+						key: ‘second’,
+						label: __( ‘Sign into the app’, ‘woocommerce’ ),
+						description: __(
+							‘Scan the QR code below with your phone to sign in instantly — no password needed.’,
+							‘woocommerce’
 						),
-						content: (
-							<SendMagicLinkButton
-								isFetching={
-									sendMagicLinkStatus ===
-									SendMagicLinkStates.FETCHING
-								}
-								onClickHandler={ sendMagicLinkHandler }
-							/>
-						),
+						content: <QRDirectLoginCode />,
 					},
 				] );
 			} else {

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/QRDirectLoginCode.tsx
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { QRCodeSVG } from 'qrcode.react';
+import React, { useEffect } from '@wordpress/element';
+import { Button, Spinner } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import interpolateComponents from '@automattic/interpolate-components';
+import { recordEvent } from '@woocommerce/tracks';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { useQRLoginToken, QRLoginTokenStates } from './useQRLoginToken';
+
+export const QRDirectLoginCode = () => {
+	const {
+		state,
+		qrUrl,
+		secondsRemaining,
+		errorMessage,
+		fetchToken,
+		refreshToken,
+	} = useQRLoginToken();
+
+	useEffect( () => {
+		fetchToken();
+		recordEvent( 'mobile_app_qr_direct_login_displayed' );
+	}, [ fetchToken ] );
+
+	const formatTime = ( seconds: number ) => {
+		const mins = Math.floor( seconds / 60 );
+		const secs = seconds % 60;
+		return `${ mins }:${ secs.toString().padStart( 2, '0' ) }`;
+	};
+
+	if ( state === QRLoginTokenStates.LOADING ) {
+		return (
+			<div className="qr-direct-login">
+				<Spinner />
+				<p>
+					{ __(
+						'Generating secure login code…',
+						'woocommerce'
+					) }
+				</p>
+			</div>
+		);
+	}
+
+	if ( state === QRLoginTokenStates.ERROR ) {
+		return (
+			<div className="qr-direct-login">
+				<p className="qr-direct-login__error">
+					{ errorMessage }
+				</p>
+				<Button variant="secondary" onClick={ refreshToken }>
+					{ __( 'Try again', 'woocommerce' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	if ( state === QRLoginTokenStates.EXPIRED ) {
+		return (
+			<div className="qr-direct-login">
+				<p>
+					{ __(
+						'The login code has expired.',
+						'woocommerce'
+					) }
+				</p>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						recordEvent(
+							'mobile_app_qr_direct_login_refreshed'
+						);
+						refreshToken();
+					} }
+				>
+					{ __( 'Generate new code', 'woocommerce' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	if ( state === QRLoginTokenStates.READY && qrUrl ) {
+		return (
+			<div className="qr-direct-login">
+				<QRCodeSVG value={ qrUrl } size={ 140 } />
+				<p className="qr-direct-login__timer">
+					{ sprintf(
+						/* translators: %s: time remaining in M:SS format */
+						__(
+							'Code expires in %s',
+							'woocommerce'
+						),
+						formatTime( secondsRemaining )
+					) }
+				</p>
+				<p className="qr-direct-login__version-note">
+					{ __(
+						'The app version needs to be 15.7 or above to sign in with this link.',
+						'woocommerce'
+					) }
+				</p>
+				<div>
+					{ interpolateComponents( {
+						mixedString: __(
+							'Any troubles signing in? Check out the {{link}}FAQ{{/link}}.',
+							'woocommerce'
+						),
+						components: {
+							link: (
+								<Link
+									href="https://woocommerce.com/document/android-ios-apps-login-help-faq/"
+									target="_blank"
+									type="external"
+									onClick={ () => {
+										recordEvent(
+											'onboarding_app_login_faq_click'
+										);
+									} }
+								/>
+							),
+							strong: <strong />,
+						},
+					} ) }
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+};

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/index.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/index.tsx
@@ -4,3 +4,5 @@ export {
 } from './useJetpackPluginState';
 export { useSendMagicLink, SendMagicLinkStates } from './useSendMagicLink';
 export { SendMagicLinkButton } from './SendMagicLinkButton';
+export { useQRLoginToken, QRLoginTokenStates } from './useQRLoginToken';
+export { QRDirectLoginCode } from './QRDirectLoginCode';

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useQRLoginToken.ts
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
+import apiFetch from '@wordpress/api-fetch';
+
+export const QRLoginTokenStates = {
+	IDLE: 'idle',
+	LOADING: 'loading',
+	READY: 'ready',
+	EXPIRED: 'expired',
+	ERROR: 'error',
+} as const;
+
+export type QRLoginTokenState =
+	( typeof QRLoginTokenStates )[ keyof typeof QRLoginTokenStates ];
+
+type QRLoginTokenResponse = {
+	qr_url: string;
+	expires_at: number;
+	ttl: number;
+};
+
+export const useQRLoginToken = () => {
+	const [ state, setState ] = useState< QRLoginTokenState >(
+		QRLoginTokenStates.IDLE
+	);
+	const [ qrUrl, setQrUrl ] = useState< string | null >( null );
+	const [ secondsRemaining, setSecondsRemaining ] = useState< number >( 0 );
+	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	const timerRef = useRef< ReturnType< typeof setInterval > | null >( null );
+	const expiresAtRef = useRef< number >( 0 );
+
+	const clearTimer = useCallback( () => {
+		if ( timerRef.current ) {
+			clearInterval( timerRef.current );
+			timerRef.current = null;
+		}
+	}, [] );
+
+	const startCountdown = useCallback(
+		( expiresAt: number ) => {
+			clearTimer();
+			expiresAtRef.current = expiresAt;
+
+			const updateRemaining = () => {
+				const remaining = Math.max(
+					0,
+					Math.floor( expiresAtRef.current - Date.now() / 1000 )
+				);
+				setSecondsRemaining( remaining );
+
+				if ( remaining <= 0 ) {
+					clearTimer();
+					setState( QRLoginTokenStates.EXPIRED );
+					setQrUrl( null );
+				}
+			};
+
+			updateRemaining();
+			timerRef.current = setInterval( updateRemaining, 1000 );
+		},
+		[ clearTimer ]
+	);
+
+	const fetchToken = useCallback( async () => {
+		setState( QRLoginTokenStates.LOADING );
+		setErrorMessage( null );
+
+		try {
+			const response = await apiFetch< QRLoginTokenResponse >( {
+				path: `${ WC_ADMIN_NAMESPACE }/mobile-app/qr-login-token`,
+				method: 'POST',
+			} );
+
+			setQrUrl( response.qr_url );
+			setState( QRLoginTokenStates.READY );
+			startCountdown( response.expires_at );
+		} catch ( error: unknown ) {
+			setState( QRLoginTokenStates.ERROR );
+
+			const err = error as { code?: string; message?: string };
+			if ( err.code === 'wpcom_account_required' ) {
+				setErrorMessage(
+					__(
+						'QR login is only available for WordPress.com connected accounts.',
+						'woocommerce'
+					)
+				);
+			} else if ( err.code === 'rate_limit_exceeded' ) {
+				setErrorMessage(
+					__(
+						'Too many requests. Please try again in a few minutes.',
+						'woocommerce'
+					)
+				);
+			} else if ( err.code === 'ssl_required' ) {
+				setErrorMessage(
+					__(
+						'QR login requires an HTTPS connection.',
+						'woocommerce'
+					)
+				);
+			} else {
+				setErrorMessage(
+					err.message ||
+						__(
+							'Failed to generate QR login code. Please try again.',
+							'woocommerce'
+						)
+				);
+			}
+		}
+	}, [ startCountdown ] );
+
+	// Cleanup timer on unmount.
+	useEffect( () => {
+		return () => clearTimer();
+	}, [ clearTimer ] );
+
+	return {
+		state,
+		qrUrl,
+		secondsRemaining,
+		errorMessage,
+		fetchToken,
+		refreshToken: fetchToken,
+	};
+};

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -102,6 +102,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\OnboardingPlugins',
 			'Automattic\WooCommerce\Admin\API\OnboardingProducts',
 			'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
+			'Automattic\WooCommerce\Admin\API\MobileAppQRLogin',
 			'Automattic\WooCommerce\Admin\API\ShippingPartnerSuggestions',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
+++ b/plugins/woocommerce/src/Admin/API/MobileAppQRLogin.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * REST API Mobile App QR Login controller.
+ *
+ * Handles requests to generate and exchange QR login tokens
+ * for direct mobile app authentication via Application Passwords.
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API controller for QR code direct login.
+ *
+ * Provides two endpoints:
+ * 1. Token generation (authenticated) - creates a short-lived token displayed as QR code
+ * 2. Token exchange (unauthenticated) - exchanges the token for an Application Password
+ *
+ * Only available for users with a linked WordPress.com account (wpcom_user_id meta).
+ *
+ * @internal
+ * @extends WC_REST_Data_Controller
+ */
+class MobileAppQRLogin extends \WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'mobile-app';
+
+	/**
+	 * Token TTL in seconds (5 minutes).
+	 */
+	const TOKEN_TTL = 300;
+
+	/**
+	 * Transient prefix for QR login tokens.
+	 */
+	const TOKEN_TRANSIENT_PREFIX = '_wc_qr_login_token_';
+
+	/**
+	 * Rate limit transient prefix.
+	 */
+	const RATE_LIMIT_PREFIX = '_wc_qr_login_rate_';
+
+	/**
+	 * Max tokens per user per 15-minute window.
+	 */
+	const MAX_TOKENS_PER_WINDOW = 5;
+
+	/**
+	 * Max exchange attempts per IP per 15-minute window.
+	 */
+	const MAX_EXCHANGE_ATTEMPTS = 10;
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		// Generate a QR login token (requires authentication).
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/qr-login-token',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'generate_token' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		// Exchange a QR login token for Application Password (no authentication required).
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/qr-login-exchange',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'exchange_token' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'token' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		parent::register_routes();
+	}
+
+	/**
+	 * Check if the current user has a linked WordPress.com account.
+	 *
+	 * @return bool
+	 */
+	private function is_wpcom_authenticated_user() {
+		$wpcom_user_id = get_user_meta( get_current_user_id(), 'wpcom_user_id', true );
+		return ! empty( $wpcom_user_id );
+	}
+
+	/**
+	 * Check if Application Passwords are available.
+	 *
+	 * @return bool
+	 */
+	private function are_application_passwords_available() {
+		return function_exists( 'wp_is_application_passwords_available' )
+			&& wp_is_application_passwords_available();
+	}
+
+	/**
+	 * Check rate limit for token generation.
+	 *
+	 * @param int $user_id The user ID.
+	 * @return bool True if within rate limit.
+	 */
+	private function check_generation_rate_limit( $user_id ) {
+		$key   = self::RATE_LIMIT_PREFIX . 'gen_' . $user_id;
+		$count = (int) get_transient( $key );
+
+		if ( $count >= self::MAX_TOKENS_PER_WINDOW ) {
+			return false;
+		}
+
+		set_transient( $key, $count + 1, 15 * MINUTE_IN_SECONDS );
+		return true;
+	}
+
+	/**
+	 * Check rate limit for token exchange.
+	 *
+	 * @return bool True if within rate limit.
+	 */
+	private function check_exchange_rate_limit() {
+		$ip    = $this->get_client_ip();
+		$key   = self::RATE_LIMIT_PREFIX . 'exc_' . md5( $ip );
+		$count = (int) get_transient( $key );
+
+		if ( $count >= self::MAX_EXCHANGE_ATTEMPTS ) {
+			return false;
+		}
+
+		set_transient( $key, $count + 1, 15 * MINUTE_IN_SECONDS );
+		return true;
+	}
+
+	/**
+	 * Get the client IP address.
+	 *
+	 * @return string
+	 */
+	private function get_client_ip() {
+		$ip = '';
+		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$ips = explode( ',', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) );
+			$ip  = trim( $ips[0] );
+		} elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+			$ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+		}
+		return $ip;
+	}
+
+	/**
+	 * Generate a QR login token.
+	 *
+	 * Creates a short-lived one-time token that can be exchanged for
+	 * an Application Password by the mobile app.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function generate_token( $request ) {
+		// Check HTTPS.
+		if ( ! is_ssl() ) {
+			return new \WP_Error(
+				'ssl_required',
+				__( 'QR login requires an HTTPS connection.', 'woocommerce' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Check Application Passwords are available.
+		if ( ! $this->are_application_passwords_available() ) {
+			return new \WP_Error(
+				'application_passwords_unavailable',
+				__( 'Application Passwords are not available on this site.', 'woocommerce' ),
+				array( 'status' => 501 )
+			);
+		}
+
+		// Check user has linked WPCOM account.
+		if ( ! $this->is_wpcom_authenticated_user() ) {
+			return new \WP_Error(
+				'wpcom_account_required',
+				__( 'QR login is only available for users with a linked WordPress.com account.', 'woocommerce' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Check rate limit.
+		if ( ! $this->check_generation_rate_limit( get_current_user_id() ) ) {
+			return new \WP_Error(
+				'rate_limit_exceeded',
+				__( 'Too many QR login requests. Please try again later.', 'woocommerce' ),
+				array( 'status' => 429 )
+			);
+		}
+
+		// Generate a cryptographically secure token.
+		$token      = wp_generate_password( 64, false );
+		$token_hash = hash( 'sha256', $token );
+		$expires_at = time() + self::TOKEN_TTL;
+
+		// Store token data as a transient.
+		$token_data = array(
+			'user_id'    => get_current_user_id(),
+			'site_url'   => get_site_url(),
+			'expires_at' => $expires_at,
+		);
+
+		set_transient( self::TOKEN_TRANSIENT_PREFIX . $token_hash, $token_data, self::TOKEN_TTL );
+
+		// Build the QR URL (deep link for the mobile app).
+		$site_url = get_site_url();
+		$qr_url   = sprintf(
+			'woocommerce://qr-login?token=%s&siteUrl=%s',
+			rawurlencode( $token ),
+			rawurlencode( $site_url )
+		);
+
+		return rest_ensure_response(
+			array(
+				'qr_url'     => $qr_url,
+				'expires_at' => $expires_at,
+				'ttl'        => self::TOKEN_TTL,
+			)
+		);
+	}
+
+	/**
+	 * Exchange a QR login token for an Application Password.
+	 *
+	 * This endpoint does not require authentication — the token serves
+	 * as the authentication mechanism.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function exchange_token( $request ) {
+		// Check rate limit.
+		if ( ! $this->check_exchange_rate_limit() ) {
+			return new \WP_Error(
+				'rate_limit_exceeded',
+				__( 'Too many exchange attempts. Please try again later.', 'woocommerce' ),
+				array( 'status' => 429 )
+			);
+		}
+
+		$token      = $request->get_param( 'token' );
+		$token_hash = hash( 'sha256', $token );
+		$key        = self::TOKEN_TRANSIENT_PREFIX . $token_hash;
+
+		// Retrieve and immediately delete the token (one-time use).
+		$token_data = get_transient( $key );
+		delete_transient( $key );
+
+		if ( false === $token_data ) {
+			return new \WP_Error(
+				'invalid_token',
+				__( 'Invalid or expired QR login token.', 'woocommerce' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		// Validate token hasn't expired (belt and suspenders with transient TTL).
+		if ( time() > $token_data['expires_at'] ) {
+			return new \WP_Error(
+				'token_expired',
+				__( 'QR login token has expired.', 'woocommerce' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$user_id = $token_data['user_id'];
+		$user    = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return new \WP_Error(
+				'user_not_found',
+				__( 'User associated with this token no longer exists.', 'woocommerce' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Create an Application Password for the mobile app.
+		$app_password_result = \WP_Application_Passwords::create_new_application_password(
+			$user_id,
+			array(
+				'name' => __( 'WooCommerce Mobile App (QR Login)', 'woocommerce' ),
+			)
+		);
+
+		if ( is_wp_error( $app_password_result ) ) {
+			return new \WP_Error(
+				'application_password_failed',
+				$app_password_result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		list( $new_password, $item ) = $app_password_result;
+
+		return rest_ensure_response(
+			array(
+				'success'              => true,
+				'user_login'           => $user->user_login,
+				'user_email'           => $user->user_email,
+				'user_id'              => $user_id,
+				'site_url'             => get_site_url(),
+				'application_password' => $new_password,
+				'uuid'                 => $item['uuid'],
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new QR code login flow that allows WooCommerce mobile app users to sign in by scanning a QR code displayed in wc-admin — **no password entry needed**.

### How it works

1. **Token generation**: When a WPCOM-authenticated admin user opens the mobile app modal, the frontend calls `POST /wc-admin/mobile-app/qr-login-token` to get a short-lived (5-minute) one-time token
2. **QR display**: The token is encoded into a deep link and displayed as a QR code with an expiry countdown
3. **Token exchange**: The mobile app scans the QR, calls `POST /wc-admin/mobile-app/qr-login-exchange` with the token, and receives a WordPress Application Password
4. **Login complete**: The app uses the Application Password for all future authenticated API calls

### Who sees the new flow

- **WPCOM-linked users** (have wpcom_user_id user meta, Jetpack connected): See the direct-login QR code
- **Site-credential users** (no WPCOM link): See the existing pre-filled credentials QR code (unchanged)

### Security

- Tokens stored as WP transients with 5-minute TTL
- One-time use: token deleted on first exchange attempt
- Rate limiting on both generation and exchange endpoints
- HTTPS required
- Uses WordPress core Application Passwords (site-scoped, avoids the 2022 WPCOM privilege escalation concern)

### Background

In 2022, a QR direct login was attempted but blocked because WPCOM magic links grant access to ALL sites on a WPCOM account. Application Passwords are site-scoped, eliminating that vulnerability.

## How to test

### Test the token generation endpoint
\`\`\`bash
curl -X POST "https://your-site.com/wp-json/wc-admin/mobile-app/qr-login-token" \
  -H "X-WP-Nonce: {nonce}" --cookie "{auth_cookies}"
\`\`\`

### Test the token exchange endpoint
\`\`\`bash
curl -X POST "https://your-site.com/wp-json/wc-admin/mobile-app/qr-login-exchange" \
  -H "Content-Type: application/json" -d '{"token": "{token}"}'
\`\`\`

### Test the UI
1. Log into wc-admin as a WPCOM-linked user
2. Navigate to WooCommerce > Home
3. Click "Get the free WooCommerce mobile app" task > "App is installed"
4. Should see QR code with countdown timer (not magic link button)
5. Wait for expiry > should show "Generate new code" button

### Test error cases
- Non-HTTPS: should return ssl_required error
- Non-WPCOM user: should fall back to existing QR
- Rate limiting: 6+ tokens quickly should get rate_limit_exceeded
- Expired/reused token: exchange should fail

## Mobile app changes needed (separate PR)

The mobile app needs to handle the woocommerce://qr-login deep link, exchange the token for an Application Password, and use it for auth.