### PR TITLE
Add hooks for email order details headings

### DIFF
--- a/plugins/woocommerce/changelog/add-email-order-details-hooks
+++ b/plugins/woocommerce/changelog/add-email-order-details-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add woocommerce_email_order_details_heading and woocommerce_email_display_order_number filters to the email order details template.

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -50,29 +50,38 @@ if ( $email_improvements_enabled ) {
  */
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email ); ?>
 
-<h2 class="<?php echo esc_attr( $heading_class ); ?>">
-	<?php
-	if ( $email_improvements_enabled ) {
-		/**
-		 * Filter the heading text shown in the order details section of emails.
-		 *
-		 * @since 10.8.0
-		 * @param string   $heading The heading text.
-		 * @param WC_Order $order   Order object.
-		 * @param WC_Email $email   Email object.
-		 */
-		$order_details_heading = apply_filters( 'woocommerce_email_order_details_heading', __( 'Order summary', 'woocommerce' ), $order, $email );
-		echo wp_kses_post( $order_details_heading );
-	}
+<?php
+$order_details_heading = '';
+if ( $email_improvements_enabled ) {
 	/**
-	 * Filter whether to display the order number in the order details heading of emails.
+	 * Filter the heading text shown in the order details section of emails.
 	 *
 	 * @since 10.8.0
-	 * @param bool     $display Whether to display the order number. Default true.
+	 * @param string   $heading The heading text.
 	 * @param WC_Order $order   Order object.
 	 * @param WC_Email $email   Email object.
 	 */
-	if ( apply_filters( 'woocommerce_email_display_order_number', true, $order, $email ) ) {
+	$order_details_heading = apply_filters( 'woocommerce_email_order_details_heading', __( 'Order summary', 'woocommerce' ), $order, $email );
+}
+
+/**
+ * Filter whether to display the order number in the order details heading of emails.
+ *
+ * @since 10.8.0
+ * @param bool     $display Whether to display the order number. Default true.
+ * @param WC_Order $order   Order object.
+ * @param WC_Email $email   Email object.
+ */
+$display_order_number = apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
+
+if ( $order_details_heading || $display_order_number ) :
+?>
+<h2 class="<?php echo esc_attr( $heading_class ); ?>">
+	<?php
+	if ( $order_details_heading ) {
+		echo wp_kses_post( $order_details_heading );
+	}
+	if ( $display_order_number ) {
 		if ( $sent_to_admin ) {
 			$before = '<a class="link" href="' . esc_url( $order->get_edit_order_url() ) . '"' . ( $block_email_editor_enabled ? ' style="text-decoration: none;"' : '' ) . '>';
 			$after  = '</a>';
@@ -96,6 +105,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 	}
 	?>
 </h2>
+<?php endif; ?>
 
 <div style="margin-bottom: <?php echo $email_improvements_enabled ? '24px' : '40px'; ?>;">
 	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -90,7 +90,12 @@ if ( $order_details_heading || $display_order_number ) :
 				$after  = '';
 			}
 			if ( $email_improvements_enabled ) {
-				echo '<br><span>';
+				// Only output <br> when both a heading and order number are shown; otherwise, avoid leading line break.
+				if ( $order_details_heading ) {
+					echo '<br><span>';
+				} else {
+					echo '<span>';
+				}
 			}
 			/* translators: %s: Order ID. */
 			$order_number_string = __( '[Order #%s]', 'woocommerce' );

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -75,37 +75,39 @@ if ( $email_improvements_enabled ) {
 $display_order_number = apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
 
 if ( $order_details_heading || $display_order_number ) :
-?>
-<h2 class="<?php echo esc_attr( $heading_class ); ?>">
-	<?php
-	if ( $order_details_heading ) {
-		echo wp_kses_post( $order_details_heading );
-	}
-	if ( $display_order_number ) {
-		if ( $sent_to_admin ) {
-			$before = '<a class="link" href="' . esc_url( $order->get_edit_order_url() ) . '"' . ( $block_email_editor_enabled ? ' style="text-decoration: none;"' : '' ) . '>';
-			$after  = '</a>';
-		} else {
-			$before = '';
-			$after  = '';
-		}
-		if ( $email_improvements_enabled ) {
-			echo '<br><span>';
-		}
-		/* translators: %s: Order ID. */
-		$order_number_string = __( '[Order #%s]', 'woocommerce' );
-		if ( $email_improvements_enabled ) {
-			/* translators: %s: Order ID. */
-			$order_number_string = __( 'Order #%s', 'woocommerce' );
-		}
-		echo wp_kses_post( $before . sprintf( $order_number_string . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
-		if ( $email_improvements_enabled ) {
-			echo '</span>';
-		}
-	}
 	?>
-</h2>
-<?php endif; ?>
+	<h2 class="<?php echo esc_attr( $heading_class ); ?>">
+		<?php
+		if ( $order_details_heading ) {
+			echo wp_kses_post( $order_details_heading );
+		}
+		if ( $display_order_number ) {
+			if ( $sent_to_admin ) {
+				$before = '<a class="link" href="' . esc_url( $order->get_edit_order_url() ) . '"' . ( $block_email_editor_enabled ? ' style="text-decoration: none;"' : '' ) . '>';
+				$after  = '</a>';
+			} else {
+				$before = '';
+				$after  = '';
+			}
+			if ( $email_improvements_enabled ) {
+				echo '<br><span>';
+			}
+			/* translators: %s: Order ID. */
+			$order_number_string = __( '[Order #%s]', 'woocommerce' );
+			if ( $email_improvements_enabled ) {
+				/* translators: %s: Order ID. */
+				$order_number_string = __( 'Order #%s', 'woocommerce' );
+			}
+			echo wp_kses_post( $before . sprintf( $order_number_string . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
+			if ( $email_improvements_enabled ) {
+				echo '</span>';
+			}
+		}
+		?>
+	</h2>
+	<?php
+endif;
+?>
 
 <div style="margin-bottom: <?php echo $email_improvements_enabled ? '24px' : '40px'; ?>;">
 	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.7.0
+ * @version 10.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -53,27 +53,46 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 <h2 class="<?php echo esc_attr( $heading_class ); ?>">
 	<?php
 	if ( $email_improvements_enabled ) {
-		echo wp_kses_post( __( 'Order summary', 'woocommerce' ) );
+		/**
+		 * Filter the heading text shown in the order details section of emails.
+		 *
+		 * @since 10.8.0
+		 * @param string   $heading The heading text.
+		 * @param WC_Order $order   Order object.
+		 * @param WC_Email $email   Email object.
+		 */
+		$order_details_heading = apply_filters( 'woocommerce_email_order_details_heading', __( 'Order summary', 'woocommerce' ), $order, $email );
+		echo wp_kses_post( $order_details_heading );
 	}
-	if ( $sent_to_admin ) {
-		$before = '<a class="link" href="' . esc_url( $order->get_edit_order_url() ) . '"' . ( $block_email_editor_enabled ? ' style="text-decoration: none;"' : '' ) . '>';
-		$after  = '</a>';
-	} else {
-		$before = '';
-		$after  = '';
-	}
-	if ( $email_improvements_enabled ) {
-		echo '<br><span>';
-	}
-	/* translators: %s: Order ID. */
-	$order_number_string = __( '[Order #%s]', 'woocommerce' );
-	if ( $email_improvements_enabled ) {
+	/**
+	 * Filter whether to display the order number in the order details heading of emails.
+	 *
+	 * @since 10.8.0
+	 * @param bool     $display Whether to display the order number. Default true.
+	 * @param WC_Order $order   Order object.
+	 * @param WC_Email $email   Email object.
+	 */
+	if ( apply_filters( 'woocommerce_email_display_order_number', true, $order, $email ) ) {
+		if ( $sent_to_admin ) {
+			$before = '<a class="link" href="' . esc_url( $order->get_edit_order_url() ) . '"' . ( $block_email_editor_enabled ? ' style="text-decoration: none;"' : '' ) . '>';
+			$after  = '</a>';
+		} else {
+			$before = '';
+			$after  = '';
+		}
+		if ( $email_improvements_enabled ) {
+			echo '<br><span>';
+		}
 		/* translators: %s: Order ID. */
-		$order_number_string = __( 'Order #%s', 'woocommerce' );
-	}
-	echo wp_kses_post( $before . sprintf( $order_number_string . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
-	if ( $email_improvements_enabled ) {
-		echo '</span>';
+		$order_number_string = __( '[Order #%s]', 'woocommerce' );
+		if ( $email_improvements_enabled ) {
+			/* translators: %s: Order ID. */
+			$order_number_string = __( 'Order #%s', 'woocommerce' );
+		}
+		echo wp_kses_post( $before . sprintf( $order_number_string . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
+		if ( $email_improvements_enabled ) {
+			echo '</span>';
+		}
 	}
 	?>
 </h2>

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -72,7 +72,7 @@ if ( $email_improvements_enabled ) {
  * @param WC_Order $order   Order object.
  * @param WC_Email $email   Email object.
  */
-$display_order_number = apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
+$display_order_number = (bool) apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
 
 if ( $order_details_heading || $display_order_number ) :
 	?>

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
  * @param WC_Order $order   Order object.
  * @param WC_Email $email   Email object.
  */
-if ( apply_filters( 'woocommerce_email_display_order_number', true, $order, $email ) ) {
+if ( (bool) apply_filters( 'woocommerce_email_display_order_number', true, $order, $email ) ) {
 	if ( $email_improvements_enabled ) {
 		/* translators: %1$s: Order ID. %2$s: Order date */
 		echo wp_kses_post( sprintf( esc_html__( 'Order #%1$s (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) . "\n";

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -35,20 +35,17 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
  * @param WC_Order $order   Order object.
  * @param WC_Email $email   Email object.
  */
-$display_order_number = apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
-
-if ( $email_improvements_enabled ) {
-	if ( $display_order_number ) {
+if ( apply_filters( 'woocommerce_email_display_order_number', true, $order, $email ) ) {
+	if ( $email_improvements_enabled ) {
 		/* translators: %1$s: Order ID. %2$s: Order date */
 		echo wp_kses_post( sprintf( esc_html__( 'Order #%1$s (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) . "\n";
 		echo "\n==========\n";
-	}
-} else {
-	if ( $display_order_number ) {
+	} else {
 		/* translators: %1$s: Order ID. %2$s: Order date */
 		echo wp_kses_post( wc_strtoupper( sprintf( esc_html__( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
 	}
 }
+
 echo "\n" . wc_get_email_order_items( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	$order,
 	array(

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.0
+ * @version 10.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -27,13 +27,27 @@ if ( $email_improvements_enabled ) {
 
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
+/**
+ * Filter whether to display the order number in the order details heading of emails.
+ *
+ * @since 10.8.0
+ * @param bool     $display Whether to display the order number. Default true.
+ * @param WC_Order $order   Order object.
+ * @param WC_Email $email   Email object.
+ */
+$display_order_number = apply_filters( 'woocommerce_email_display_order_number', true, $order, $email );
+
 if ( $email_improvements_enabled ) {
-	/* translators: %1$s: Order ID. %2$s: Order date */
-	echo wp_kses_post( sprintf( esc_html__( 'Order #%1$s (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) . "\n";
-	echo "\n==========\n";
+	if ( $display_order_number ) {
+		/* translators: %1$s: Order ID. %2$s: Order date */
+		echo wp_kses_post( sprintf( esc_html__( 'Order #%1$s (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) . "\n";
+		echo "\n==========\n";
+	}
 } else {
-	/* translators: %1$s: Order ID. %2$s: Order date */
-	echo wp_kses_post( wc_strtoupper( sprintf( esc_html__( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
+	if ( $display_order_number ) {
+		/* translators: %1$s: Order ID. %2$s: Order date */
+		echo wp_kses_post( wc_strtoupper( sprintf( esc_html__( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
+	}
 }
 echo "\n" . wc_get_email_order_items( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	$order,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Add two new hooks for `email-order-details` fragment:
- `woocommerce_email_order_details_heading` - allows updating the `Order summary` text;
- `woocommerce_email_display_order_number` - allows hiding the `Order #ORDER_ID` text.

### Screenshots or screen recordings:

Below is what using the filter looks like (notice the `Order summary` on the `Before` screenshot).

| Before | After |
| ------ | ----- |
| <img width="626" height="502" alt="CleanShot 2026-03-27 at 14 06 47" src="https://github.com/user-attachments/assets/07a1cfe2-7bb9-441e-810e-66121afedaf2" /> | <img width="626" height="502" alt="CleanShot 2026-03-27 at 14 06 28" src="https://github.com/user-attachments/assets/1cc85d39-9b41-4fcf-ac56-d5d671ce3d48" /> |

#### Plain text emails

| Before | After |
| ------ | ----- |
| <img width="768" height="288" alt="CleanShot 2026-03-27 at 15 37 37" src="https://github.com/user-attachments/assets/1b429c95-24f7-4dab-9df6-4d16425d7643" /> | <img width="769" height="248" alt="CleanShot 2026-03-27 at 15 36 57" src="https://github.com/user-attachments/assets/6a0a2805-14ac-4b4f-9cd4-aab31193ef81" /> |


### How to test the changes in this Pull Request:

#### Test that the elements show as expected

1. Apply this patch;
2. Checkout a product;
3. Make sure the email shows the original headings (for example, like the `Before` image).

#### Test that the filters work

1. Add this snippet:

```php
add_filter( 'woocommerce_email_order_details_heading', 'order_details_heading' );
function order_details_heading() {
	return __( 'Booking details', 'woocommerce' );
}

add_filter( 'woocommerce_email_display_order_number', 'hide_display_order_number' );
function hide_display_order_number() {
	return false;
}
```

2. Checkout a product;
3. Make sure the email shows `Booking details` and `Order #ORDER_ID` is not showing.

#### Test that H2 isn't showing when filters decide that

1. Add this snippet (remove the old one):

```php
add_filter( 'woocommerce_email_order_details_heading', 'order_details_heading' );
function order_details_heading() {
	return '';
}

add_filter( 'woocommerce_email_display_order_number', 'hide_display_order_number' );
function hide_display_order_number() {
	return false;
}
```

2. Checkout a product;
3. Make sure there's no H2 tag in the email.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
