### PR TITLE
Checkout: Prevent address autocomplete from triggering on browser autofill

### DIFF
--- a/plugins/woocommerce/changelog/63902-wooplug-6341-address-autocomplete-cannot-distinguish-between-a-user
+++ b/plugins/woocommerce/changelog/63902-wooplug-6341-address-autocomplete-cannot-distinguish-between-a-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix address autocomplete dropdown appearing after browser autofill on checkout

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -150,19 +150,6 @@ export const AddressAutocomplete = ( {
 	const autofillDetectedRef = useRef( false );
 	const searchGenerationRef = useRef( 0 );
 
-	// Shared helper: mark that the user is actively typing, with an
-	// auto-reset after TYPING_RESET_MS. Used by both the native input
-	// listener (primary) and the keydown handler (fallback).
-	const markUserTyping = () => {
-		userIsTypingRef.current = true;
-		if ( typingTimeoutRef.current ) {
-			clearTimeout( typingTimeoutRef.current );
-		}
-		typingTimeoutRef.current = setTimeout( () => {
-			userIsTypingRef.current = false;
-		}, TYPING_RESET_MS );
-	};
-
 	// Trigger search when searchValue changes
 	useEffect( () => {
 		if (
@@ -313,8 +300,15 @@ export const AddressAutocomplete = ( {
 				inputType === 'deleteContentForward'
 			) {
 				// These inputTypes indicate direct user interaction (typing,
-				// IME composition, backspace/delete).
-				markUserTyping();
+				// IME composition, backspace/delete). Set the typing flag so
+				// that addressChangeHandler allows the search.
+				userIsTypingRef.current = true;
+				if ( typingTimeoutRef.current ) {
+					clearTimeout( typingTimeoutRef.current );
+				}
+				typingTimeoutRef.current = setTimeout( () => {
+					userIsTypingRef.current = false;
+				}, TYPING_RESET_MS );
 			}
 		};
 
@@ -354,19 +348,6 @@ export const AddressAutocomplete = ( {
 	const handleKeyDown = (
 		event: React.KeyboardEvent< HTMLInputElement >
 	) => {
-		// Fallback keyboard tracking for browsers that don't reliably set
-		// inputType on native input events. The native input listener is the
-		// primary signal; this ensures typing is still detected when inputType
-		// is unavailable.
-		if (
-			event.key.length === 1 ||
-			event.key === 'Backspace' ||
-			event.key === 'Delete' ||
-			event.key === 'Process' // IME composition key
-		) {
-			markUserTyping();
-		}
-
 		if ( suggestions.length === 0 ) {
 			return;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -296,12 +296,18 @@ export const AddressAutocomplete = ( {
 			} else if (
 				inputType === 'insertText' ||
 				inputType === 'insertCompositionText' ||
+				inputType === 'insertFromPaste' ||
+				inputType === 'insertFromDrop' ||
 				inputType === 'deleteContentBackward' ||
-				inputType === 'deleteContentForward'
+				inputType === 'deleteContentForward' ||
+				inputType === 'deleteByCut' ||
+				inputType === 'historyUndo' ||
+				inputType === 'historyRedo'
 			) {
 				// These inputTypes indicate direct user interaction (typing,
-				// IME composition, backspace/delete). Set the typing flag so
-				// that addressChangeHandler allows the search.
+				// IME composition, paste, drag-drop, cut, undo/redo,
+				// backspace/delete). Set the typing flag so that
+				// addressChangeHandler allows the search.
 				userIsTypingRef.current = true;
 				if ( typingTimeoutRef.current ) {
 					clearTimeout( typingTimeoutRef.current );
@@ -331,6 +337,8 @@ export const AddressAutocomplete = ( {
 		// (Chrome/Firefox fire "insertReplacementText" for autofill).
 		if ( autofillDetectedRef.current ) {
 			autofillDetectedRef.current = false;
+			setSearchValue( '' );
+			setSuggestions( [] );
 			return;
 		}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -23,6 +23,24 @@ import './style.scss';
 import { Suggestions } from './suggestions';
 import { useUpdatePreferredAutocompleteProvider } from '../../../hooks/use-update-preferred-autocomplete-provider';
 
+// Maximum gap (ms) between a keydown event and the resulting React onChange.
+// After this window, userIsTypingRef resets to false so that programmatic
+// value changes (e.g. late-arriving autofill) are not mistaken for typing.
+const TYPING_RESET_MS = 200;
+
+/**
+ * Check whether an element is currently in the browser's autofill state.
+ * Safari Contacts applies :-webkit-autofill during/after its fill.
+ * Firefox does not support this selector and throws, so we catch that.
+ */
+function isAutofilled( el: HTMLInputElement ): boolean {
+	try {
+		return el.matches( ':-webkit-autofill' );
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Address Autocomplete component.
  *
@@ -123,6 +141,28 @@ export const AddressAutocomplete = ( {
 	const [ isSettingAddress, setIsSettingAddress ] = useState( false );
 	const suppressSearchTimeoutRef = useRef< NodeJS.Timeout | null >( null );
 
+	// Tracks whether the current value change originated from the user typing
+	// (as opposed to browser autofill). Browser autofill fires onChange but
+	// does NOT fire keydown events, and its native input event has
+	// inputType "insertReplacementText" rather than "insertText".
+	const userIsTypingRef = useRef( false );
+	const typingTimeoutRef = useRef< NodeJS.Timeout | null >( null );
+	const autofillDetectedRef = useRef( false );
+	const searchGenerationRef = useRef( 0 );
+
+	// Shared helper: mark that the user is actively typing, with an
+	// auto-reset after TYPING_RESET_MS. Used by both the native input
+	// listener (primary) and the keydown handler (fallback).
+	const markUserTyping = () => {
+		userIsTypingRef.current = true;
+		if ( typingTimeoutRef.current ) {
+			clearTimeout( typingTimeoutRef.current );
+		}
+		typingTimeoutRef.current = setTimeout( () => {
+			userIsTypingRef.current = false;
+		}, TYPING_RESET_MS );
+	};
+
 	// Trigger search when searchValue changes
 	useEffect( () => {
 		if (
@@ -141,9 +181,23 @@ export const AddressAutocomplete = ( {
 			];
 
 		if ( provider ) {
+			const generation = ++searchGenerationRef.current;
 			provider
 				.search( searchValue, country )
 				.then( ( results ) => {
+					// Discard stale results from a superseded search.
+					if ( generation !== searchGenerationRef.current ) {
+						return;
+					}
+
+					// Discard results if the field entered browser autofill
+					// state while the search was in-flight (Safari Contacts).
+					const el = inputRef.current?.inputRef?.current;
+					if ( el && isAutofilled( el ) ) {
+						setSuggestions( [] );
+						return;
+					}
+
 					if ( results && results.length ) {
 						setSuggestions( results );
 					} else {
@@ -162,6 +216,9 @@ export const AddressAutocomplete = ( {
 		return () => {
 			if ( suppressSearchTimeoutRef.current ) {
 				clearTimeout( suppressSearchTimeoutRef.current );
+			}
+			if ( typingTimeoutRef.current ) {
+				clearTimeout( typingTimeoutRef.current );
 			}
 		};
 	}, [] );
@@ -232,12 +289,61 @@ export const AddressAutocomplete = ( {
 		};
 	}, [ props.autoComplete ] );
 
+	// Detect browser autofill vs user typing via the native input event's
+	// inputType property. Browser autofill produces "insertReplacementText"
+	// while user typing produces "insertText" (or "insertCompositionText"
+	// for CJK/IME input). This listener sets flags that addressChangeHandler
+	// checks before triggering a provider search.
+	useEffect( () => {
+		const inputElement = inputRef.current?.inputRef?.current;
+		if ( ! inputElement ) {
+			return;
+		}
+
+		const handleNativeInput = ( event: Event ) => {
+			const inputEvent = event as InputEvent;
+			const { inputType } = inputEvent;
+
+			if ( inputType === 'insertReplacementText' ) {
+				autofillDetectedRef.current = true;
+			} else if (
+				inputType === 'insertText' ||
+				inputType === 'insertCompositionText' ||
+				inputType === 'deleteContentBackward' ||
+				inputType === 'deleteContentForward'
+			) {
+				// These inputTypes indicate direct user interaction (typing,
+				// IME composition, backspace/delete).
+				markUserTyping();
+			}
+		};
+
+		inputElement.addEventListener( 'input', handleNativeInput );
+		return () => {
+			inputElement.removeEventListener( 'input', handleNativeInput );
+		};
+	}, [] );
+
 	const addressChangeHandler = ( value: string ) => {
 		props.onChange( value );
 
 		// Don't trigger search when we're programmatically setting the address
-		// or when search is temporarily suppressed after address selection
-		if ( ! isSettingAddress && ! suppressSearchTimeoutRef.current ) {
+		// or when search is temporarily suppressed after address selection.
+		if ( isSettingAddress || suppressSearchTimeoutRef.current ) {
+			return;
+		}
+
+		// Suppress search when browser autofill was detected via inputType
+		// (Chrome/Firefox fire "insertReplacementText" for autofill).
+		if ( autofillDetectedRef.current ) {
+			autofillDetectedRef.current = false;
+			return;
+		}
+
+		// Only trigger search when keyboard or IME activity preceded the
+		// change. This is the fallback for browsers that don't support
+		// inputType or :-webkit-autofill.
+		if ( userIsTypingRef.current ) {
 			setSearchValue( value );
 		}
 	};
@@ -248,6 +354,19 @@ export const AddressAutocomplete = ( {
 	const handleKeyDown = (
 		event: React.KeyboardEvent< HTMLInputElement >
 	) => {
+		// Fallback keyboard tracking for browsers that don't reliably set
+		// inputType on native input events. The native input listener is the
+		// primary signal; this ensures typing is still detected when inputType
+		// is unavailable.
+		if (
+			event.key.length === 1 ||
+			event.key === 'Backspace' ||
+			event.key === 'Delete' ||
+			event.key === 'Process' // IME composition key
+		) {
+			markUserTyping();
+		}
+
 		if ( suggestions.length === 0 ) {
 			return;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -292,22 +292,12 @@ export const AddressAutocomplete = ( {
 			const { inputType } = inputEvent;
 
 			if ( inputType === 'insertReplacementText' ) {
+				// Browser autofill (Chrome/Firefox). Flag it so
+				// addressChangeHandler suppresses the search.
 				autofillDetectedRef.current = true;
-			} else if (
-				inputType === 'insertText' ||
-				inputType === 'insertCompositionText' ||
-				inputType === 'insertFromPaste' ||
-				inputType === 'insertFromDrop' ||
-				inputType === 'deleteContentBackward' ||
-				inputType === 'deleteContentForward' ||
-				inputType === 'deleteByCut' ||
-				inputType === 'historyUndo' ||
-				inputType === 'historyRedo'
-			) {
-				// These inputTypes indicate direct user interaction (typing,
-				// IME composition, paste, drag-drop, cut, undo/redo,
-				// backspace/delete). Set the typing flag so that
-				// addressChangeHandler allows the search.
+			} else if ( inputType ) {
+				// Any other known inputType is user-initiated (typing,
+				// paste, drag-drop, IME, undo/redo, etc.).
 				userIsTypingRef.current = true;
 				if ( typingTimeoutRef.current ) {
 					clearTimeout( typingTimeoutRef.current );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
@@ -54,18 +54,16 @@ wpData.useSelect.mockImplementation(
 	} )
 );
 
-wpData.useDispatch.mockImplementation(
-	( store: StoreDescriptor | string ) => {
-		if ( store === cartStore || store === 'wc/store/cart' ) {
-			return {
-				...jest.requireActual( '@wordpress/data' ).useDispatch( store ),
-				setShippingAddress: jest.fn(),
-				setBillingAddress: jest.fn(),
-			};
-		}
-		return jest.requireActual( '@wordpress/data' ).useDispatch( store );
+wpData.useDispatch.mockImplementation( ( store: StoreDescriptor | string ) => {
+	if ( store === cartStore || store === 'wc/store/cart' ) {
+		return {
+			...jest.requireActual( '@wordpress/data' ).useDispatch( store ),
+			setShippingAddress: jest.fn(),
+			setBillingAddress: jest.fn(),
+		};
 	}
-);
+	return jest.requireActual( '@wordpress/data' ).useDispatch( store );
+} );
 
 jest.mock( '@woocommerce/settings', () => ( {
 	...jest.requireActual( '@woocommerce/settings' ),
@@ -165,9 +163,7 @@ describe( 'Browser autofill vs user typing — WOOPLUG-6341', () => {
 
 	it( 'should NOT trigger search when browser autofill fires insertReplacementText', async () => {
 		render( <TestAddressField /> );
-		const input = screen.getByLabelText(
-			'Address 1'
-		) as HTMLInputElement;
+		const input = screen.getByLabelText( 'Address 1' ) as HTMLInputElement;
 
 		// Simulate browser autofill: dispatch a native input event with
 		// inputType "insertReplacementText", which is what Chrome/Firefox
@@ -190,9 +186,7 @@ describe( 'Browser autofill vs user typing — WOOPLUG-6341', () => {
 
 	it( 'should NOT trigger search when value changes without keyboard input (fallback detection)', async () => {
 		render( <TestAddressField /> );
-		const input = screen.getByLabelText(
-			'Address 1'
-		) as HTMLInputElement;
+		const input = screen.getByLabelText( 'Address 1' ) as HTMLInputElement;
 
 		// Simulate a programmatic value change with no inputType and no
 		// preceding keydown — e.g. a password manager or extension that
@@ -215,9 +209,7 @@ describe( 'Browser autofill vs user typing — WOOPLUG-6341', () => {
 
 	it( 'should discard search results when :-webkit-autofill is detected (Safari Contacts)', async () => {
 		render( <TestAddressField /> );
-		const input = screen.getByLabelText(
-			'Address 1'
-		) as HTMLInputElement;
+		const input = screen.getByLabelText( 'Address 1' ) as HTMLInputElement;
 
 		// Safari Contacts fills character-by-character with insertText events
 		// (indistinguishable from typing). A search may fire, but by the time
@@ -247,7 +239,9 @@ describe( 'Browser autofill vs user typing — WOOPLUG-6341', () => {
 		// But because :-webkit-autofill matched when results came back,
 		// no suggestions should be visible.
 		expect(
-			document.querySelector( '.wc-block-components-address-autocomplete-suggestions' )
+			document.querySelector(
+				'.wc-block-components-address-autocomplete-suggestions'
+			)
 		).toBeNull();
 
 		// Restore original matches.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
@@ -1,0 +1,289 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from '@wordpress/element';
+import * as wpData from '@wordpress/data';
+import { cartStore } from '@woocommerce/block-data';
+import type { StoreDescriptor } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { AddressAutocomplete } from '../address-autocomplete';
+import {
+	createMockProvider,
+	installMockProvider,
+	type MockProvider,
+} from './utils/mock-provider';
+
+// --- Mocks (same pattern as integration.tsx) ---
+
+const mockUseCheckoutAddress = jest.fn();
+jest.mock( '@woocommerce/base-context', () => ( {
+	...jest.requireActual( '@woocommerce/base-context' ),
+	useCheckoutAddress: () => mockUseCheckoutAddress(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+wpData.useSelect.mockImplementation(
+	jest.fn().mockImplementation( ( passedMapSelect ) => {
+		const mockedSelect = jest.fn().mockImplementation( ( storeName ) => {
+			if ( storeName === 'wc/store/cart' || storeName === cartStore ) {
+				return {
+					getCartData() {
+						return {
+							shippingAddress: { country: 'DE' },
+							billingAddress: { country: 'DE' },
+						};
+					},
+				};
+			}
+			return jest.requireActual( '@wordpress/data' ).select( storeName );
+		} );
+		return passedMapSelect( mockedSelect, {
+			dispatch: jest.requireActual( '@wordpress/data' ).dispatch,
+		} );
+	} )
+);
+
+wpData.useDispatch.mockImplementation(
+	( store: StoreDescriptor | string ) => {
+		if ( store === cartStore || store === 'wc/store/cart' ) {
+			return {
+				...jest.requireActual( '@wordpress/data' ).useDispatch( store ),
+				setShippingAddress: jest.fn(),
+				setBillingAddress: jest.fn(),
+			};
+		}
+		return jest.requireActual( '@wordpress/data' ).useDispatch( store );
+	}
+);
+
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSettingWithCoercion: jest
+		.fn()
+		.mockImplementation( ( value, fallback, typeguard ) => {
+			if ( value === 'addressAutocompleteProviders' ) {
+				return [
+					{
+						id: 'mock-test-provider',
+						name: 'Mock Test Provider',
+						branding_html: '<div>Mock Provider</div>',
+					},
+				];
+			}
+			return jest
+				.requireActual( '@woocommerce/settings' )
+				.getSettingWithCoercion( value, fallback, typeguard );
+		} ),
+} ) );
+
+// --- Helper ---
+
+const TestAddressField = ( {
+	addressType = 'shipping' as const,
+}: {
+	addressType?: 'shipping' | 'billing';
+} ) => {
+	const [ value, setValue ] = useState( '' );
+	return (
+		<AddressAutocomplete
+			addressType={ addressType }
+			id={ `${ addressType }-address_1` }
+			label="Address 1"
+			onChange={ setValue }
+			value={ value }
+		/>
+	);
+};
+
+/**
+ * Dispatch a native InputEvent with the given inputType on the element.
+ * This simulates what the browser does for autofill (insertReplacementText)
+ * or user typing (insertText).
+ */
+function fireNativeInputEvent(
+	element: HTMLInputElement,
+	value: string,
+	inputType: string
+) {
+	// Set the value on the native element (as the browser would).
+	const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		'value'
+	)?.set;
+	nativeInputValueSetter?.call( element, value );
+
+	// Dispatch the native input event with the specified inputType.
+	const inputEvent = new InputEvent( 'input', {
+		bubbles: true,
+		cancelable: false,
+		inputType,
+		data: value,
+	} );
+	element.dispatchEvent( inputEvent );
+}
+
+// --- Tests ---
+
+describe( 'Browser autofill vs user typing — WOOPLUG-6341', () => {
+	let mockProvider: MockProvider;
+
+	beforeEach( () => {
+		mockUseCheckoutAddress.mockReturnValue( {
+			useShippingAsBilling: false,
+			useBillingAsShipping: false,
+		} );
+		mockProvider = createMockProvider();
+		installMockProvider( mockProvider );
+	} );
+
+	it( 'triggers search when user types into the field', async () => {
+		render( <TestAddressField /> );
+		const input = screen.getByLabelText( 'Address 1' );
+
+		await act( async () => {
+			await userEvent.type( input, '123 Main' );
+		} );
+
+		await waitFor(
+			() => {
+				expect( mockProvider.search ).toHaveBeenCalled();
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'should NOT trigger search when browser autofill fires insertReplacementText', async () => {
+		render( <TestAddressField /> );
+		const input = screen.getByLabelText(
+			'Address 1'
+		) as HTMLInputElement;
+
+		// Simulate browser autofill: dispatch a native input event with
+		// inputType "insertReplacementText", which is what Chrome/Firefox
+		// produce when the browser's saved-address autofill populates a field.
+		await act( async () => {
+			fireNativeInputEvent(
+				input,
+				'742 Evergreen Terrace, Springfield',
+				'insertReplacementText'
+			);
+		} );
+
+		// Give the search effect time to fire.
+		await act( async () => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+		} );
+
+		expect( mockProvider.search ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should NOT trigger search when value changes without keyboard input (fallback detection)', async () => {
+		render( <TestAddressField /> );
+		const input = screen.getByLabelText(
+			'Address 1'
+		) as HTMLInputElement;
+
+		// Simulate a programmatic value change with no inputType and no
+		// preceding keydown — e.g. a password manager or extension that
+		// sets the value via script. The fallback keyboard-gating should
+		// prevent search since userIsTypingRef was never set.
+		await act( async () => {
+			fireNativeInputEvent(
+				input,
+				'742 Evergreen Terrace, Springfield',
+				''
+			);
+		} );
+
+		await act( async () => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+		} );
+
+		expect( mockProvider.search ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should discard search results when :-webkit-autofill is detected (Safari Contacts)', async () => {
+		render( <TestAddressField /> );
+		const input = screen.getByLabelText(
+			'Address 1'
+		) as HTMLInputElement;
+
+		// Safari Contacts fills character-by-character with insertText events
+		// (indistinguishable from typing). A search may fire, but by the time
+		// results resolve the field will have :-webkit-autofill applied.
+		// Mock matches() to simulate this state so results are discarded.
+		const originalMatches = input.matches.bind( input );
+		input.matches = ( selector: string ) => {
+			if ( selector === ':-webkit-autofill' ) {
+				return true;
+			}
+			return originalMatches( selector );
+		};
+
+		// Type enough to trigger a search (simulates Safari Contacts fill).
+		await act( async () => {
+			await userEvent.type( input, '742 Evergreen' );
+		} );
+
+		await waitFor(
+			() => {
+				// The search should have been called (characters looked like typing).
+				expect( mockProvider.search ).toHaveBeenCalled();
+			},
+			{ timeout: 3000 }
+		);
+
+		// But because :-webkit-autofill matched when results came back,
+		// no suggestions should be visible.
+		expect(
+			document.querySelector( '.wc-block-components-address-autocomplete-suggestions' )
+		).toBeNull();
+
+		// Restore original matches.
+		input.matches = originalMatches;
+	} );
+
+	it( 'resumes search normally after autofill if user starts typing again', async () => {
+		render( <TestAddressField /> );
+		const input = screen.getByLabelText( 'Address 1' );
+
+		// First: browser autofill (should NOT trigger search)
+		await act( async () => {
+			fireNativeInputEvent(
+				input as HTMLInputElement,
+				'742 Evergreen Terrace',
+				'insertReplacementText'
+			);
+		} );
+
+		await act( async () => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+		} );
+
+		mockProvider.search.mockClear();
+
+		// Then: user clears and types manually (SHOULD trigger search)
+		await act( async () => {
+			await userEvent.clear( input );
+			await userEvent.type( input, '456 Oak' );
+		} );
+
+		await waitFor(
+			() => {
+				expect( mockProvider.search ).toHaveBeenCalled();
+			},
+			{ timeout: 3000 }
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils/mock-provider.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils/mock-provider.ts
@@ -4,6 +4,10 @@
  * Returns deterministic results and exposes jest spies on all methods
  * so tests can assert on search/select calls.
  */
+
+/**
+ * External dependencies
+ */
 import type { ClientAddressAutocompleteProvider } from '@woocommerce/types';
 
 export const MOCK_PROVIDER_ID = 'mock-test-provider';

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils/mock-provider.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils/mock-provider.ts
@@ -1,0 +1,70 @@
+/**
+ * A mock address autocomplete provider for testing.
+ *
+ * Returns deterministic results and exposes jest spies on all methods
+ * so tests can assert on search/select calls.
+ */
+import type { ClientAddressAutocompleteProvider } from '@woocommerce/types';
+
+export const MOCK_PROVIDER_ID = 'mock-test-provider';
+
+export const MOCK_SEARCH_RESULTS = [
+	{
+		label: '123 Example St, Berlin, Germany',
+		id: 'result-1',
+		matchedSubstrings: [ { length: 3, offset: 0 } ],
+	},
+	{
+		label: '456 Sample Rd, Munich, Germany',
+		id: 'result-2',
+		matchedSubstrings: [ { length: 3, offset: 0 } ],
+	},
+];
+
+export const MOCK_SELECTED_ADDRESS = {
+	address_1: '123 Example St',
+	address_2: '',
+	city: 'Berlin',
+	state: 'BE',
+	postcode: '10115',
+	country: 'DE',
+};
+
+export interface MockProvider extends ClientAddressAutocompleteProvider {
+	search: jest.Mock;
+	select: jest.Mock;
+	canSearch: jest.Mock;
+}
+
+/**
+ * Creates a fresh mock provider with jest spies. Call this in beforeEach
+ * to get isolated spy state per test.
+ */
+export function createMockProvider(): MockProvider {
+	return {
+		id: MOCK_PROVIDER_ID,
+		canSearch: jest.fn().mockReturnValue( true ),
+		search: jest.fn().mockResolvedValue( MOCK_SEARCH_RESULTS ),
+		select: jest.fn().mockResolvedValue( MOCK_SELECTED_ADDRESS ),
+	};
+}
+
+/**
+ * Installs the given mock provider onto window.wc.addressAutocomplete
+ * as the active provider for both billing and shipping.
+ */
+export function installMockProvider( provider: MockProvider ): void {
+	window.wc = {
+		...( window.wc || {} ),
+		addressAutocomplete: {
+			providers: { [ MOCK_PROVIDER_ID ]: provider },
+			activeProvider: {
+				billing: provider,
+				shipping: provider,
+			},
+			registerAddressAutocompleteProvider( p ) {
+				return !! p;
+			},
+		},
+	};
+}

--- a/plugins/woocommerce/client/blocks/tests/js/jest.config.json
+++ b/plugins/woocommerce/client/blocks/tests/js/jest.config.json
@@ -38,6 +38,7 @@
 		"@woocommerce/shared-hocs": "assets/js/shared/hocs",
 		"@woocommerce/blocks-test-utils/(.*)$": "tests/utils/$1",
 		"@woocommerce/blocks-test-utils": "tests/utils",
+		"@woocommerce/sanitize": "<rootDir>/node_modules/@woocommerce/sanitize/src",
 		"@woocommerce/types": "assets/js/types",
 		"@woocommerce/utils": "assets/js/utils",
 		"@woocommerce/test-utils/msw": "tests/js/config/msw-setup.js",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `AddressAutocomplete` component fired provider searches (e.g. Google Places) whenever the `address_1` field value changed — including when the browser's native autofill populated the field. This caused:

- Confusing double-autocomplete UX (Google Places dropdown appeared after browser autofill completed the form)
- Potential data corruption if the user interacted with the unexpected dropdown (state/province overwritten)
- Wasted API calls on checkouts that use browser autofill

Added detection to distinguish browser autofill from user typing via a native `input` event listener:

1. **`InputEvent.inputType` check** — Chrome/Firefox autofill fires `insertReplacementText` rather than `insertText`; this is detected and the search is suppressed. Only user-initiated inputTypes (`insertText`, `insertCompositionText`, `deleteContentBackward`, `deleteContentForward`) set the typing flag that gates search.
2. **`:-webkit-autofill` CSS pseudo-class check** — Safari Contacts fills character-by-character with `insertText` events (indistinguishable from typing at the event level) but applies `:-webkit-autofill` once complete; search results are discarded if this is detected when results arrive.

Also:
- Added a search generation counter to discard stale results from superseded searches
- Fixed a missing `@woocommerce/sanitize` Jest module mapping that prevented all address-autocomplete tests from running
- Added a reusable mock autocomplete provider for testing

Closes [#63423](https://github.com/woocommerce/woocommerce/issues/63423).

### How to test the changes in this Pull Request:

**Prerequisites:**
- Enable a mock address autocomplete provider by following the setup in [#59426](https://github.com/woocommerce/woocommerce/pull/59426)
- Turn on the provider in **WooCommerce > Settings** (or the appropriate settings screen)
- Have browser autofill data saved for an address (or use Safari Contacts)

**Test on Chrome, Firefox, and Safari:**

1. Navigate to the Checkout page
2. Clear the address form fields
3. Click into the Address Line 1 field
4. Use the browser's native autofill to populate the address (select a saved address from the browser dropdown, or use Safari Contacts)
5. **Expected:** The address fields are filled by the browser, and the autocomplete provider dropdown does **not** appear
6. Clear the address form again
7. Manually type an address into Address Line 1 (e.g. "123 Main")
8. **Expected:** The autocomplete provider dropdown **does** appear with suggestions
9. Select a suggestion and confirm the address fields are populated correctly

### Testing that has already taken place:

- Manual testing on Safari (macOS) with Safari Contacts autofill — confirmed `:-webkit-autofill` detection works
- Manual testing on Chrome (macOS) with browser saved addresses — confirmed `insertReplacementText` detection works
- 31 Jest unit tests passing (5 new browser-autofill tests + 26 existing)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix address autocomplete dropdown appearing after browser autofill on checkout

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>