### PR TITLE
Fix PHP 8.5 fatal error in StoreApi AbstractSchema

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-6417-php-8-5-abstract-schema
+++ b/plugins/woocommerce/changelog/fix-wooplug-6417-php-8-5-abstract-schema
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP 8.5 fatal error when unsetting string offsets in StoreApi AbstractSchema.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractSchema.php
@@ -90,6 +90,9 @@ abstract class AbstractSchema {
 	protected function remove_arg_options( $properties ) {
 		return array_map(
 			function( $property ) {
+				if ( ! is_array( $property ) ) {
+					return $property;
+				}
 				if ( isset( $property['properties'] ) ) {
 					$property['properties'] = $this->remove_arg_options( $property['properties'] );
 				} elseif ( isset( $property['items']['properties'] ) ) {

--- a/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/AbstractSchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Schemas/V1/AbstractSchemaTest.php
@@ -1,0 +1,200 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the AbstractSchema class.
+ */
+class AbstractSchemaTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var AbstractSchema
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+		$extend     = new ExtendSchema( $formatters );
+		$controller = new SchemaController( $extend );
+
+		$this->sut = new class( $extend, $controller ) extends AbstractSchema {
+			public function get_properties() {
+				return array();
+			}
+
+			public function expose_remove_arg_options( $properties ) {
+				return $this->remove_arg_options( $properties );
+			}
+		};
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should handle array properties with arg_options correctly.
+	 */
+	public function test_remove_arg_options_with_array_properties(): void {
+		$properties = array(
+			'field1' => array(
+				'type'        => 'string',
+				'arg_options' => array(
+					'default' => 'test',
+				),
+			),
+			'field2' => array(
+				'type'        => 'integer',
+				'arg_options' => array(
+					'default' => 42,
+				),
+			),
+		);
+
+		$result = $this->sut->expose_remove_arg_options( $properties );
+
+		$this->assertArrayHasKey( 'field1', $result );
+		$this->assertArrayHasKey( 'field2', $result );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field1'] );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field2'] );
+		$this->assertSame( 'string', $result['field1']['type'] );
+		$this->assertSame( 'integer', $result['field2']['type'] );
+	}
+
+	/**
+	 * @testdox Should handle non-array properties without errors in PHP 8.5.
+	 */
+	public function test_remove_arg_options_with_non_array_properties(): void {
+		$properties = array(
+			'field1' => 'string',
+			'field2' => array(
+				'type'        => 'integer',
+				'arg_options' => array(
+					'default' => 42,
+				),
+			),
+		);
+
+		$result = $this->sut->expose_remove_arg_options( $properties );
+
+		$this->assertArrayHasKey( 'field1', $result );
+		$this->assertArrayHasKey( 'field2', $result );
+		$this->assertSame( 'string', $result['field1'] );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field2'] );
+		$this->assertSame( 'integer', $result['field2']['type'] );
+	}
+
+	/**
+	 * @testdox Should recursively remove arg_options from nested properties.
+	 */
+	public function test_remove_arg_options_with_nested_properties(): void {
+		$properties = array(
+			'field1' => array(
+				'type'        => 'object',
+				'arg_options' => array(
+					'default' => array(),
+				),
+				'properties'  => array(
+					'nested1' => array(
+						'type'        => 'string',
+						'arg_options' => array(
+							'default' => 'nested',
+						),
+					),
+				),
+			),
+		);
+
+		$result = $this->sut->expose_remove_arg_options( $properties );
+
+		$this->assertArrayHasKey( 'field1', $result );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field1'] );
+		$this->assertArrayHasKey( 'properties', $result['field1'] );
+		$this->assertArrayHasKey( 'nested1', $result['field1']['properties'] );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field1']['properties']['nested1'] );
+		$this->assertSame( 'string', $result['field1']['properties']['nested1']['type'] );
+	}
+
+	/**
+	 * @testdox Should recursively remove arg_options from array item properties.
+	 */
+	public function test_remove_arg_options_with_array_items(): void {
+		$properties = array(
+			'field1' => array(
+				'type'        => 'array',
+				'arg_options' => array(
+					'default' => array(),
+				),
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'item_field' => array(
+							'type'        => 'string',
+							'arg_options' => array(
+								'default' => 'item',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$result = $this->sut->expose_remove_arg_options( $properties );
+
+		$this->assertArrayHasKey( 'field1', $result );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field1'] );
+		$this->assertArrayHasKey( 'items', $result['field1'] );
+		$this->assertArrayHasKey( 'properties', $result['field1']['items'] );
+		$this->assertArrayHasKey( 'item_field', $result['field1']['items']['properties'] );
+		$this->assertArrayNotHasKey( 'arg_options', $result['field1']['items']['properties']['item_field'] );
+		$this->assertSame( 'string', $result['field1']['items']['properties']['item_field']['type'] );
+	}
+
+	/**
+	 * @testdox Should handle mixed array and non-array properties.
+	 */
+	public function test_remove_arg_options_with_mixed_properties(): void {
+		$properties = array(
+			'string_field' => 'string',
+			'array_field'  => array(
+				'type'        => 'object',
+				'arg_options' => array(
+					'default' => array(),
+				),
+			),
+			'another_string' => 'integer',
+		);
+
+		$result = $this->sut->expose_remove_arg_options( $properties );
+
+		$this->assertArrayHasKey( 'string_field', $result );
+		$this->assertArrayHasKey( 'array_field', $result );
+		$this->assertArrayHasKey( 'another_string', $result );
+		$this->assertSame( 'string', $result['string_field'] );
+		$this->assertSame( 'integer', $result['another_string'] );
+		$this->assertArrayNotHasKey( 'arg_options', $result['array_field'] );
+		$this->assertSame( 'object', $result['array_field']['type'] );
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes a PHP 8.5 compatibility issue in `AbstractSchema::remove_arg_options()` that causes a fatal error when attempting to unset array keys on non-array values.

**The Problem:**
In PHP 8.5, attempting to `unset($property['arg_options'])` when `$property` is a string (not an array) throws a fatal error: "Cannot unset string offsets". This error occurs during WP-CLI usage and any StoreApi schema initialization.

**The Solution:**
Add a type check at the beginning of the `array_map` callback to return non-array properties unchanged, preventing the attempted unset operation on strings.

Fixes Linear issue WOOPLUG-6417.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a WordPress environment with PHP 8.5 (or PHP 8.4 which also exhibits this issue)
2. Install WooCommerce from this branch
3. Run any WP-CLI command, for example: `wp plugin get woocommerce --allow-root`
4. Verify no fatal error occurs
5. Run the new unit tests: `pnpm run test:php:env -- --filter AbstractSchemaTest`
6. Verify all tests pass

### Testing that has already taken place:

- Created comprehensive unit tests covering:
  - Array properties with arg_options (normal case)
  - Non-array properties (the bug case)
  - Nested properties
  - Array item properties
  - Mixed array and non-array properties
- Verified the fix matches the solution suggested by the community in the issue comments
- Code review to ensure backward compatibility (non-array properties are now properly handled instead of causing fatal errors)

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix PHP 8.5 fatal error when unsetting string offsets in StoreApi AbstractSchema.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry created manually in `plugins/woocommerce/changelog/fix-wooplug-6417-php-8-5-abstract-schema`

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [WOOPLUG-6417](https://linear.app/a8c/issue/WOOPLUG-6417/php-85-fatal-error-cannot-unset-string-offsets-in)

<div><a href="https://cursor.com/agents/bc-31df0f70-0e5a-4f78-802b-1b5219505457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31df0f70-0e5a-4f78-802b-1b5219505457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

