### PR TITLE
fix: Add preparation checklist and improve messaging on payments onboarding screen

### DIFF
--- a/plugins/woocommerce/changelog/63915-fix-woopmnt-5477-payments-onboarding-checklist
+++ b/plugins/woocommerce/changelog/63915-fix-woopmnt-5477-payments-onboarding-checklist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add preparation checklist and clearer messaging to the payments onboarding screen to help users understand what they need before activating real payments.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
@@ -4,7 +4,8 @@
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice, Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -97,25 +98,60 @@ const TestOrLiveAccountStep = () => {
 										) }
 									</h3>
 									<div>
-										{ interpolateComponents( {
-											mixedString: __(
-												'Provide some additional details about your business to process real transactions. {{link}}Learn more{{/link}}',
-												'woocommerce'
-											),
-											components: {
-												link: (
-													<Link
-														href="https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process"
-														target="_blank"
-														rel="noreferrer"
-														type="external"
-													/>
-												),
-											},
-										} ) }
+										{ __(
+											"To start processing real transactions, you'll need to verify your identity and business details.",
+											'woocommerce'
+										) }
 									</div>
 								</div>
 							</div>
+							<ul
+								className="woocommerce-payments-test-or-live-account-step__checklist"
+								aria-label={ __(
+									'What you will need',
+									'woocommerce'
+								) }
+							>
+								<li>
+									<Icon
+										icon={ check }
+										size={ 20 }
+										aria-hidden="true"
+									/>
+									<span>
+										{ __(
+											"Government-issued ID (passport or driver's license)",
+											'woocommerce'
+										) }
+									</span>
+								</li>
+								<li>
+									<Icon
+										icon={ check }
+										size={ 20 }
+										aria-hidden="true"
+									/>
+									<span>
+										{ __(
+											'Tax ID or employer identification number',
+											'woocommerce'
+										) }
+									</span>
+								</li>
+								<li>
+									<Icon
+										icon={ check }
+										size={ 20 }
+										aria-hidden="true"
+									/>
+									<span>
+										{ __(
+											'Bank account details for deposits',
+											'woocommerce'
+										) }
+									</span>
+								</li>
+							</ul>
 							<Button
 								variant="primary"
 								onClick={ () => {
@@ -216,7 +252,7 @@ const TestOrLiveAccountStep = () => {
 										<div className="woocommerce-woopayments-modal__content__item-flex__description">
 											<h3>
 												{ __(
-													'Test payments first, activate later',
+													'Not ready? Set up your store first',
 													'woocommerce'
 												) }
 											</h3>
@@ -224,7 +260,7 @@ const TestOrLiveAccountStep = () => {
 												<p>
 													{ interpolateComponents( {
 														mixedString: __(
-															"A test account will be created for you to {{link}}test payments on your store{{/link}}. You'll need to activate payments later to process real transactions.",
+															'Use test mode to configure your store and {{link}}try test payments{{/link}} without providing business details. You can activate real payments anytime.',
 															'woocommerce'
 														),
 														components: {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
@@ -49,6 +49,29 @@
 		}
 	}
 
+	&__checklist {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: $gap-smaller;
+
+		li {
+			display: flex;
+			align-items: flex-start;
+			gap: $gap-smaller;
+			font-size: 13px;
+			line-height: 20px;
+			color: $gray-700;
+
+			.components-icon {
+				fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+				flex-shrink: 0;
+			}
+		}
+	}
+
 	&__success-whats-next {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "Start accepting payments" screen doesn't adequately explain what users need before activating real payments, leading to high drop-off when they encounter unexpected requirements (passport, tax ID, bank account). The test mode option also underplays its purpose.

This PR adds a preparation checklist and improves messaging to set clear expectations before users commit to the activation flow.

### How to test the changes in this Pull Request:

1. Apply this diff to ensure you can reach the test-or-live-account step with the test account option visible:
```diff
--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
@@ -39,0 +40 @@
+	const canCreateTestAccount = true; // Force test account option visible
-	const canCreateTestAccount = testAccountStepActions?.finish?.href;
```
2. Navigate to **WooCommerce > Settings > Payments** and trigger the WooPayments onboarding flow (click "Get started" or equivalent)
3. Progress to the "You're almost there" step
4. **Verify the "Activate real payments" section:**
   - Description reads: "To start processing real transactions, you'll need to verify your identity and business details."
   - A checklist appears with three items: government-issued ID, tax ID, and bank account details
   - Each item has a check icon
5. **Verify the test mode section:**
   - Heading reads: "Not ready? Set up your store first"
   - Description reads: "Use test mode to configure your store and try test payments without providing business details. You can activate real payments anytime."
   - "try test payments" is a link to the test accounts documentation
6. **Verify accessibility:** Tab through the checklist — the `<ul>` should have an accessible label "What you will need" and icons should be hidden from screen readers
7. Revert the test diff from step 1

### Testing that has already taken place:

- ESLint passed with no errors
- Visual review of code changes
- Self-review via automated code quality agent (accessibility, architecture, performance, security)

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Enhancement - Improvement to existing functionality

#### Message
Add preparation checklist and clearer messaging to the payments onboarding screen to help users understand what they need before activating real payments.

</details>

<details>
<summary>🤖 AI-generated details</summary>

### Files changed
- `plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx` — Replaced vague description + external "Learn more" link with clear inline copy and a 3-item preparation checklist (government ID, tax ID, bank account). Updated test mode heading and description to better explain its purpose. Added `aria-label` and `aria-hidden` for accessibility.
- `plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss` — Added styles for the `__checklist` list items with flex layout, proper spacing, and themed icon fill color matching the existing codebase pattern.

### Implementation notes
- The checklist uses `@wordpress/icons` `check` icon with `@wordpress/components` `Icon` component, consistent with existing WP component usage in the codebase
- Icons are marked `aria-hidden="true"` since they are decorative; the `<ul>` has `aria-label="What you will need"` for screen reader context
- Icon fill color uses `var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9))` matching the existing pattern in `banner-notice/style.scss`
- The external "Learn more" link to the sign-up documentation was removed since the checklist now inlines the key information; the test accounts documentation link is preserved in the test mode section

</details>