### PR TITLE
Improve payments onboarding screen with clearer messaging and layout

### DIFF
--- a/plugins/woocommerce/changelog/63919-fix-woopmnt-5477-payments-onboarding-messaging
+++ b/plugins/woocommerce/changelog/63919-fix-woopmnt-5477-payments-onboarding-messaging
@@ -1,4 +1,4 @@
-Significance: patch
-Type: enhancement
+Significance: minor
+Type: update
 
-Improve payments onboarding screen with clearer messaging about activation requirements and separate cards for activate vs test payment options.
+Update copy on the activate payments step in NOX

--- a/plugins/woocommerce/changelog/63919-fix-woopmnt-5477-payments-onboarding-messaging
+++ b/plugins/woocommerce/changelog/63919-fix-woopmnt-5477-payments-onboarding-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve payments onboarding screen with clearer messaging about activation requirements and separate cards for activate vs test payment options.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
@@ -50,16 +50,6 @@ const TestOrLiveAccountStep = () => {
 								'woocommerce'
 							) }
 						</h1>
-						<div className="woocommerce-woopayments-modal__content__item">
-							<div className="woocommerce-woopayments-modal__content__item__description">
-								<p>
-									{ __(
-										'Activate payments to accept real orders and process transactions.',
-										'woocommerce'
-									) }
-								</p>
-							</div>
-						</div>
 						{ currentStep?.errors &&
 							currentStep.errors.length > 0 && (
 								<Notice

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
@@ -92,27 +92,15 @@ const TestOrLiveAccountStep = () => {
 								<div className="woocommerce-woopayments-modal__content__item-flex__description">
 									<h3>
 										{ __(
-											'Activate real payments',
+											'Activate payments in two easy steps',
 											'woocommerce'
 										) }
 									</h3>
 									<div>
-										{ interpolateComponents( {
-											mixedString: __(
-												'Provide some additional details about your business to process real transactions. {{link}}Learn more{{/link}}',
-												'woocommerce'
-											),
-											components: {
-												link: (
-													<Link
-														href="https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process"
-														target="_blank"
-														rel="noreferrer"
-														type="external"
-													/>
-												),
-											},
-										} ) }
+										{ __(
+											'Answer a few questions and verify your business details with our payments partner, including owner, address, and bank information.',
+											'woocommerce'
+										) }
 									</div>
 								</div>
 							</div>
@@ -190,70 +178,70 @@ const TestOrLiveAccountStep = () => {
 								isBusy={ isContinueButtonLoading }
 								disabled={ isContinueButtonLoading }
 							>
-								{ __(
-									'Start accepting payments',
-									'woocommerce'
-								) }
+								{ __( 'Activate payments', 'woocommerce' ) }
 							</Button>
+							<Link
+								className="woocommerce-payments-test-or-live-account-step__learn-more"
+								href="https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process"
+								target="_blank"
+								rel="noreferrer"
+								type="external"
+							>
+								{ __( 'Learn more', 'woocommerce' ) }
+							</Link>
+						</div>
 
-							{ canCreateTestAccount && (
-								<>
-									<div className="woocommerce-payments-test-or-live-account-step__success_content_or-divider">
-										<hr />
-										{ __( 'OR', 'woocommerce' ) }
-										<hr />
-									</div>
-
-									<div className="woocommerce-woopayments-modal__content__item-flex">
-										<img
-											src={
-												WC_ASSET_URL +
-												'images/icons/post-list.svg'
-											}
-											alt=""
-											role="presentation"
-										/>
-										<div className="woocommerce-woopayments-modal__content__item-flex__description">
-											<h3>
-												{ __(
-													'Test payments first, activate later',
-													'woocommerce'
-												) }
-											</h3>
-											<div>
-												<p>
-													{ interpolateComponents( {
-														mixedString: __(
-															"A test account will be created for you to {{link}}test payments on your store{{/link}}. You'll need to activate payments later to process real transactions.",
-															'woocommerce'
+						{ canCreateTestAccount && (
+							<div className="woocommerce-payments-test-or-live-account-step__success-whats-next">
+								<div className="woocommerce-woopayments-modal__content__item-flex">
+									<img
+										src={
+											WC_ASSET_URL +
+											'images/icons/post-list.svg'
+										}
+										alt=""
+										role="presentation"
+									/>
+									<div className="woocommerce-woopayments-modal__content__item-flex__description">
+										<h3>
+											{ __(
+												'Test payments first, activate later',
+												'woocommerce'
+											) }
+										</h3>
+										<div>
+											<p>
+												{ interpolateComponents( {
+													mixedString: __(
+														"A test account will be created for you to {{link}}test payments on your store{{/link}}. You'll still need to activate payments later to process real transactions.",
+														'woocommerce'
+													),
+													components: {
+														link: (
+															<Link
+																href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/"
+																target="_blank"
+																rel="noreferrer"
+																type="external"
+															/>
 														),
-														components: {
-															link: (
-																<Link
-																	href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/"
-																	target="_blank"
-																	rel="noreferrer"
-																	type="external"
-																/>
-															),
-														},
-													} ) }
-												</p>
-											</div>
+													},
+												} ) }
+											</p>
 										</div>
 									</div>
-									<Button
-										variant="secondary"
-										disabled={ isContinueButtonLoading }
-										onClick={ () => {
-											navigateToNextStep();
-										} }
-									>
-										{ __( 'Test payments', 'woocommerce' ) }
-									</Button>
-								</>
-							) }
-						</div>
+								</div>
+								<Button
+									variant="secondary"
+									disabled={ isContinueButtonLoading }
+									onClick={ () => {
+										navigateToNextStep();
+									} }
+								>
+									{ __( 'Test payments', 'woocommerce' ) }
+								</Button>
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/index.tsx
@@ -176,6 +176,10 @@ const TestOrLiveAccountStep = () => {
 								target="_blank"
 								rel="noreferrer"
 								type="external"
+								aria-label={ __(
+									'Learn more about the WooPayments sign-up process (opens in a new tab)',
+									'woocommerce'
+								) }
 							>
 								{ __( 'Learn more', 'woocommerce' ) }
 							</Link>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
@@ -33,20 +33,6 @@
 			width: 100%;
 			justify-content: center;
 		}
-
-		&_or-divider {
-			text-align: center;
-			display: flex;
-			width: 100%;
-			align-items: center;
-			color: $gray-700;
-			gap: $gap-small;
-
-			hr {
-				width: 100%;
-				border-top: 1px solid $gray-200;
-			}
-		}
 	}
 
 	&__learn-more {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-or-live-account/style.scss
@@ -10,7 +10,7 @@
 	&__success_content {
 		display: flex;
 		flex-direction: column;
-		gap: $gap-small;
+		gap: $gap-large;
 		align-items: center;
 
 		&_title {
@@ -49,13 +49,25 @@
 		}
 	}
 
+	&__learn-more {
+		align-self: center;
+	}
+
 	&__success-whats-next {
 		display: flex;
 		flex-direction: column;
-		gap: $gap-smaller * 2;
+		gap: $gap;
 		border: 1px solid $gray-200;
 		border-radius: 2px;
-		padding: $gap-large;
+		padding: $gap-large $gap-large ($gap-large + $gap-smaller);
+
+		.woocommerce-woopayments-modal__content__item-flex {
+			gap: $gap-smaller - 2;
+
+			&__description {
+				gap: $gap-small;
+			}
+		}
 
 		.woocommerce-woopayments-modal__content__item h2 {
 			font-size: 15px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This improves the wording of the activate payments page in NOX.

Closes https://linear.app/a8c/issue/WOOPMNT-5477

### How to test the changes in this Pull Request:

1. Navigate to **WooCommerce > Settings > Payments** and trigger the WooPayments onboarding flow
2. Progress to the "You're almost there" step (Activate payments)
3. **Verify that the new design matches the Figma design**

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update copy on the activate payments step in NOX
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
