### PR TITLE
In-App subscriptions: show managed status for host plan and agency orders

### DIFF
--- a/plugins/woocommerce/changelog/63925-update-marketplace-host-plan-orders-label
+++ b/plugins/woocommerce/changelog/63925-update-marketplace-host-plan-orders-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+My Subscriptions: show "Managed by host" or "Managed by agency" in the expiry column for host plan and agency subscriptions.

--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -332,8 +332,6 @@ export function nameAndStatus( subscription: Subscription ): TableRow {
 }
 
 export function expiry( subscription: Subscription ): TableRow {
-	const expiryDate = subscription.expires;
-
 	if (
 		subscription.local.installed === true &&
 		subscription.product_key === ''
@@ -344,8 +342,26 @@ export function expiry( subscription: Subscription ): TableRow {
 		};
 	}
 
+	if ( subscription.is_agency || subscription.included_in_host_plan ) {
+		const isAgency = subscription.is_agency;
+		const text = isAgency
+			? __( 'Managed by agency', 'woocommerce' )
+			: __( 'Managed by host', 'woocommerce' );
+		return {
+			display: (
+				<StatusPopover
+					text={ text }
+					level={ StatusLevel.Info }
+					explanation=""
+				/>
+			),
+			value: 'host_plan',
+		};
+	}
+
 	let expiryDateElement = __( 'Never expires', 'woocommerce' );
 
+	const expiryDate = subscription.expires;
 	if ( expiryDate ) {
 		expiryDateElement = gmdateI18n(
 			'j M, Y',

--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/types.ts
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/types.ts
@@ -31,6 +31,8 @@ export type Subscription = {
 	subscription_installed: boolean;
 	subscription_available: boolean;
 	is_installable: boolean;
+	included_in_host_plan?: boolean;
+	is_agency?: boolean;
 	is_shared: boolean;
 	owner_email: boolean;
 	has_changelog: boolean;


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Improves the expiry column in the My Subscriptions table for subscriptions that are included in a host plan or managed by an agency. Instead of showing an expiry date (which is not meaningful for these subscription types), the column now displays "Managed by host" or "Managed by agency" with an info-level status popover.

Changes:
- Added `included_in_host_plan` and `is_agency` optional boolean fields to the `Subscription` type
- Added early return in the `expiry()` function to show a descriptive status for host plan and agency subscriptions before attempting to render an expiry date
- Moved the `expiryDate` variable declaration closer to where it is used

### How to test the changes in this Pull Request:

1. Navigate to WooCommerce → Extensions → My Subscriptions.
2. If you have a subscription included in a host plan, verify the expiry column shows "Managed by host" with an info popover.
3. If you have an agency-managed subscription, verify the expiry column shows "Managed by agency" with an info popover.
4. Verify that regular subscriptions still display their expiry date or "Never expires" as before.

<img width="1530" height="67" alt="Screenshot 2026-03-30 at 16 29 44" src="https://github.com/user-attachments/assets/3fc310e6-0e44-4f6d-b3c6-f423f6fbb288" />
<img width="1531" height="64" alt="Screenshot 2026-03-30 at 16 30 05" src="https://github.com/user-attachments/assets/2622dfef-3300-4108-83aa-b2896f0f708b" />


### Testing that has already taken place:

Manual testing in local development environment.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Enhancement - Improvement to existing functionality

#### Message
My Subscriptions: show "Managed by host" or "Managed by agency" in the expiry column for host plan and agency subscriptions.

</details>