### PR TITLE
Fix setup wizard TypeError on first site load

### DIFF
--- a/plugins/woocommerce/changelog/63929-fix-setup-wizard-site-title-error
+++ b/plugins/woocommerce/changelog/63929-fix-setup-wizard-site-title-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix setup wizard TypeError on first site load by reading site title from wcSettings instead of core-data entity record.

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -16,7 +16,7 @@ import {
 import { useMachine, useSelector } from '@xstate5/react';
 import { useMemo } from '@wordpress/element';
 import { resolveSelect, dispatch } from '@wordpress/data';
-import { store as coreStore, Settings } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import {
 	updateQueryString,
 	getQuery,
@@ -39,7 +39,7 @@ import {
 } from '@woocommerce/data';
 import { initializeExPlat } from '@woocommerce/explat';
 import { CountryStateOption } from '@woocommerce/onboarding';
-import { getAdminLink } from '@woocommerce/settings';
+import { getAdminLink, getSetting } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -148,12 +148,10 @@ const handleTrackingOption = assign( {
 	} ) => event.output !== 'no',
 } );
 
-const getStoreNameOption = fromPromise( async () =>
-	resolveSelect( coreStore )
-		// @ts-expect-error getEntityRecord is not typed correctly in coreStore
-		.getEntityRecord( 'root', 'site' )
-		.then( ( site ) => ( site as Settings ).title )
-);
+const getStoreNameOption = fromPromise( async () => {
+	const value = getSetting( 'siteTitle', '' );
+	return typeof value === 'string' ? value : '';
+} );
 
 const handleStoreNameOption = assign( {
 	businessInfo: ( {

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -148,9 +148,9 @@ const handleTrackingOption = assign( {
 	} ) => event.output !== 'no',
 } );
 
-const getStoreNameOption = fromPromise( async () => {
+const getStoreNameOption = fromPromise( () => {
 	const value = getSetting( 'siteTitle', '' );
-	return typeof value === 'string' ? value : '';
+	return Promise.resolve( typeof value === 'string' ? value : '' );
 } );
 
 const handleStoreNameOption = assign( {

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -148,6 +148,8 @@ const handleTrackingOption = assign( {
 	} ) => event.output !== 'no',
 } );
 
+// Reading synchronously from wcSettings, but wrapped in fromPromise because
+// xstate's invoke with onDone/onError requires a promise-based actor.
 const getStoreNameOption = fromPromise( () => {
 	const value = getSetting( 'siteTitle', '' );
 	return Promise.resolve( typeof value === 'string' ? value : '' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On a fresh WooCommerce install, the very first load of the setup wizard throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'title')
    at core-profiler.js
```

**Root cause:** `resolveSelect(coreStore).getEntityRecord('root', 'site')` requires a two-step async resolver chain — first an HTTP OPTIONS request to `/wp/v2/settings` to discover the schema, then a GET to fetch the data. On a fresh site's first page load, this resolver chain can silently fail (the `getEntitiesConfig` resolver has a bare `catch {}` block), causing the entity record to resolve as `undefined`. Accessing `.title` on `undefined` throws.

**Fix:** Replace the fragile `getEntityRecord` call with `getSetting('siteTitle')`, which reads from the `wcSettings` global that WooCommerce already inlines in the page HTML. This is synchronous, reliable, and already used elsewhere in the codebase for the same purpose (e.g., `client/header/index.tsx`, `client/task-lists/progress-title/default-progress-title.tsx`).

Closes https://linear.app/a8c/issue/WOOPLUG-5961

### Screenshots or screen recordings:

N/A — no UI changes, this fixes a JS error on first load.

### How to test the changes in this Pull Request:

1. Create a **brand new** WordPress site (e.g., using Studio CLI: `studio site create --name test-site --path /tmp/test-site`)
2. Symlink or install the WooCommerce plugin from this branch
3. Activate WooCommerce
4. Open the browser console (DevTools → Console)
5. Navigate to the setup wizard: `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
6. **Expected:** The setup wizard loads with no `TypeError` in the console
7. Continue through the setup wizard until you get to the screen where it shows site title - this should be pre-populated with your site title.

**Important:** The bug only reproduces on the **very first** page load of a fresh site. Subsequent loads work because the core-data store caches the entity. You need a fresh site each time you test.

### Testing that has already taken place:

- Verified the fix on 2 fresh WordPress sites created via Studio CLI
- Used a mu-plugin error catcher (`window.addEventListener('error', ...)`) injected via `admin_head` to confirm zero `TypeError` errors on first load
- Ran all core-profiler Jest tests — 86/87 pass (1 pre-existing failure on trunk: `joinWithAnd` locale fallback test)

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix setup wizard TypeError on first site load by reading site title from wcSettings instead of core-data entity record.

</details>