### PR TITLE
Skip suggestion matching for offline payment methods

### DIFF
--- a/plugins/woocommerce/changelog/63930-fix-skip-incentive-check-offline-payment-methods
+++ b/plugins/woocommerce/changelog/63930-fix-skip-incentive-check-offline-payment-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Skip unnecessary extension suggestion lookup for offline payment methods in enhance_payment_gateway_details().

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -1298,6 +1298,12 @@ class PaymentsProviders {
 		// We discriminate between offline payment methods and gateways.
 		$gateway_details['_type'] = $this->is_offline_payment_method( $payment_gateway->id ) ? self::TYPE_OFFLINE_PM : self::TYPE_GATEWAY;
 
+		// Offline payment methods don't have extension suggestions or incentives.
+		// Skip the suggestion matching to avoid unnecessary processing.
+		if ( self::TYPE_OFFLINE_PM === $gateway_details['_type'] ) {
+			return $gateway_details;
+		}
+
 		$plugin_slug = $gateway_details['plugin']['slug'];
 		// The payment gateway plugin might use a non-standard directory name.
 		// Try to normalize it to the common slug to avoid false negatives when matching.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -1116,6 +1116,43 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that get_payment_gateway_details skips suggestion matching for offline payment methods.
+	 *
+	 * Offline PMs (BACS, COD, Cheque) don't have extension suggestions or incentives.
+	 * The suggestion lookup should be skipped entirely for them.
+	 */
+	public function test_get_payment_gateway_details_skips_suggestion_matching_for_offline_pms() {
+		// Arrange.
+		$fake_gateway = new FakePaymentGateway(
+			'bacs',
+			array(
+				'enabled'            => true,
+				'title'              => 'Direct bank transfer',
+				'method_title'       => 'Direct bank transfer',
+				'description'        => 'Make your payment directly into our bank account.',
+				'method_description' => 'Take payments in person via BACS.',
+				'plugin_slug'        => 'woocommerce',
+				'plugin_file'        => 'woocommerce/woocommerce.php',
+			),
+		);
+
+		// The suggestion service should never be called for offline PMs.
+		$this->mock_extension_suggestions
+			->expects( $this->never() )
+			->method( 'get_by_plugin_slug' );
+
+		// Act.
+		$gateway_details = $this->sut->get_payment_gateway_details( $fake_gateway, 0, 'US' );
+
+		// Assert that the gateway is correctly identified as an offline PM.
+		$this->assertSame( PaymentsProviders::TYPE_OFFLINE_PM, $gateway_details['_type'] );
+
+		// Assert that no suggestion-derived fields are present.
+		$this->assertArrayNotHasKey( '_suggestion_id', $gateway_details );
+		$this->assertArrayNotHasKey( '_incentive', $gateway_details );
+	}
+
+	/**
 	 * Test getting the plugin slug of a payment gateway instance.
 	 */
 	public function test_get_payment_gateway_plugin_slug() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php
@@ -1124,7 +1124,7 @@ class PaymentsProvidersTest extends WC_Unit_Test_Case {
 	public function test_get_payment_gateway_details_skips_suggestion_matching_for_offline_pms() {
 		// Arrange.
 		$fake_gateway = new FakePaymentGateway(
-			'bacs',
+			WC_Gateway_BACS::ID,
 			array(
 				'enabled'            => true,
 				'title'              => 'Direct bank transfer',


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Offline payment methods (BACS, Cheque, COD) ship with WooCommerce core and can never have extension suggestions or incentives. Yet `enhance_payment_gateway_details()` was calling `get_extension_suggestion_by_plugin_slug()` for every gateway — including offline PMs — doing unnecessary work that always returned `null`.

This adds an early return for offline PMs right after the `_type` assignment, skipping the suggestion lookup entirely. This avoids wasted processing and, in the broader call chain, reduces unnecessary external API calls to the incentives endpoint.

Closes WOOPRD-2473.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Payments** in the admin.
2. Verify that offline payment methods (Direct bank transfer, Check payments, Cash on delivery) still appear correctly in the list.
3. Verify that each offline PM can be enabled/disabled and configured as before.
4. Verify that non-offline gateways (e.g., WooPayments, PayPal) still show their suggestion-derived details (icons, descriptions, incentives) correctly.

### Testing that has already taken place:

- New unit test verifies `get_by_plugin_slug` is never called for offline PMs and that no suggestion-derived fields (`_suggestion_id`, `_incentive`) are present.
- Code review confirmed no downstream code expects offline PMs to have suggestion-derived fields.

<details>

<summary>🤖 AI-generated details</summary>

### Files changed

- `plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php` — Added early return in `enhance_payment_gateway_details()` for offline PMs (after `_type` assignment on line 1299), skipping the `get_extension_suggestion_by_plugin_slug()` call and all subsequent suggestion-derived field population.
- `plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProvidersTest.php` — Added `test_get_payment_gateway_details_skips_suggestion_matching_for_offline_pms()` using a `FakePaymentGateway` with `bacs` id, asserting `$this->never()` on `get_by_plugin_slug` and absence of `_suggestion_id` / `_incentive` keys.

### Implementation notes

The fix is intentionally minimal — a 4-line early return. The `_type` field is still set before the return so downstream code that checks `_type` (e.g., `process_payment_provider_states()`, REST response separation into `offline_payment_methods`) continues to work correctly.

The broader performance issue (the `get_extension_suggestions()` call in `Payments.php:91` that triggers the external API call) is not addressed here — that would require a larger refactor. This fix eliminates the per-gateway wasted work in `enhance_payment_gateway_details()` for offline PMs.

### Architectural context

Call chain that benefits:
```
PaymentsController::store_has_providers_with_incentive()
  └─ Payments::get_payment_providers()
       └─ For each gateway:
            └─ PaymentsProviders::enhance_payment_gateway_details() ← early return here for offline PMs
                 └─ get_extension_suggestion_by_plugin_slug() ← SKIPPED for offline PMs
```

No code depends on offline PMs having suggestion-derived fields:
- `process_payment_provider_states()` filters out non-`TYPE_GATEWAY` providers
- REST response separates offline PMs into their own `offline_payment_methods` array
- `store_has_providers_with_incentive()` would never find an incentive on an offline PM anyway

</details>

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Skip unnecessary extension suggestion lookup for offline payment methods in enhance_payment_gateway_details().

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
