### PR TITLE
Fix Add to Cart button not visible when displaying a Product block with a variation with only one product left

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOO6-48-add-to-cart-variation-one-item
+++ b/plugins/woocommerce/changelog/fix-WOO6-48-add-to-cart-variation-one-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Add to Cart button not visible when displaying a Single Product block with a variation with only one product left

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -47,6 +47,18 @@ class AddToCartWithOptions extends AbstractBlock {
 	}
 
 	/**
+	 * Product type string used to resolve add-to-cart template parts.
+	 * It returns the product type in most cases, except for variations,
+	 * which use the simple product template.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return string Product type slug.
+	 */
+	private function get_product_type_for_add_to_cart_template( \WC_Product $product ): string {
+		return ProductType::VARIATION === $product->get_type() ? ProductType::SIMPLE : $product->get_type();
+	}
+
+	/**
 	 * Enqueue assets specific to this block.
 	 * We enqueue frontend scripts only if the product type has a block template
 	 * part (that's WC core product types and extensions that migrated to block
@@ -65,7 +77,8 @@ class AddToCartWithOptions extends AbstractBlock {
 			$rendered_product = wc_get_product( $product_id );
 
 			if ( $rendered_product instanceof \WC_Product ) {
-				$template_part_path = $this->get_template_part_path( $rendered_product->get_type() );
+				$product_type       = $this->get_product_type_for_add_to_cart_template( $rendered_product );
+				$template_part_path = $this->get_template_part_path( $product_type );
 
 				if ( is_string( $template_part_path ) && '' !== $template_part_path && file_exists( $template_part_path ) ) {
 					wp_enqueue_script_module( 'woocommerce/add-to-cart-with-options' );
@@ -177,8 +190,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			return '';
 		}
 
-		// For variations, we display the simple product form.
-		$product_type = ProductType::VARIATION === $product->get_type() ? ProductType::SIMPLE : $product->get_type();
+		$product_type = $this->get_product_type_for_add_to_cart_template( $product );
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classes            = implode(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOO6-48.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/62681.

When selecting a variation in the _Product_ block, the _Add to Cart + Options_ block was displaying the _Simple Product_ template part. However, we were only enqueuing the frontend scripts when the type was one of simple, grouped or variable.

The issue was not easily reproducible because the _Product Quantity_ block was actually enqueuing the missing scripts. But in the case the variation had only one item left in stock, the _Product Quantity_ block would not be rendered, making the missing scripts not to load, so the _Add to Cart_ block was missing.

Note: the _Product_ block has a few other issues which I'm fixing in https://github.com/woocommerce/woocommerce/pull/63934.

### How to test the changes in this Pull Request:

1. Set a variation to have only one product left in stock (so the Quantity Selector won't show up).
2. Add the Product block to a post or page.
3. Select the variation edited in step 1.
4. Verify the _Add to Cart_ button is visible in the frontend and you can click on it.

Before | After
--- | ---
<img width="853" height="473" alt="imatge" src="https://github.com/user-attachments/assets/df8082b9-00b8-44c1-8de5-3e9f7833b3ec" /> | <img width="853" height="473" alt="imatge" src="https://github.com/user-attachments/assets/142589a6-b7ba-4bf0-a302-3a0a8d3c6149" />