### PR TITLE
Fix Coupon Code block search to include all default statuses

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3258-coupon-created-in-ciab-not-found-in-coupon-block-search
+++ b/plugins/woocommerce/changelog/wooprd-3258-coupon-created-in-ciab-not-found-in-coupon-block-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Coupon Code block search to include coupons in all default statuses (draft, future, pending, private, publish), not just published ones

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coupon-code/edit.tsx
@@ -25,6 +25,14 @@ interface Coupon {
 	code: string;
 }
 
+const DEFAULT_COUPON_STATUSES = [
+	'draft',
+	'future',
+	'pending',
+	'private',
+	'publish',
+] as const;
+
 /**
  * Edit component for the Coupon Code block.
  *
@@ -90,10 +98,16 @@ export default function Edit( props: BlockEditProps ): JSX.Element {
 		setIsLoading( true );
 		abortControllerRef.current = new AbortController();
 
+		const params = new URLSearchParams( {
+			per_page: '20',
+			search,
+		} );
+		DEFAULT_COUPON_STATUSES.forEach( ( status ) => {
+			params.append( 'status[]', status );
+		} );
+
 		apiFetch< Coupon[] >( {
-			path: `/wc/v3/coupons?per_page=20&search=${ encodeURIComponent(
-				search
-			) }`,
+			path: `/wc/v3/coupons?${ params.toString() }`,
 			signal: abortControllerRef.current.signal,
 		} )
 			.then( ( results ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Coupon Code block's search only returned published coupons. This PR adds a status parameter to the coupon search API request, including all default post statuses (draft, future, pending, private, publish), so users can find and select coupons regardless of their publication state.

Related to WOOPRD-3258.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="278" height="394" alt="u83st3bKoaa3V5VU" src="https://github.com/user-attachments/assets/66805e89-8b4a-4306-91cf-5a4b051f85f3" /> | <img width="278" height="394" alt="VafzIpxoADMH0IAt" src="https://github.com/user-attachments/assets/6981eec8-9174-40ee-a408-29e0cb3f4f27" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create several coupons with different statuses: one published, one draft, one scheduled (future), one pending review, and one private.
2. Open the email editor and add a Coupon Code block.
3. In the block's sidebar settings, search for your coupons by name.
4. Verify that coupons in all statuses appear in the search results, not just published ones.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
