### PR TITLE
Fix workflow path filters to correctly re-include workflow files

### DIFF
--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -3,22 +3,23 @@ on:
     push:
         branches:
             - trunk
-        paths-ignore:
-            - 'docs/**'
-            - 'packages/php/**'
-            - 'tools/**'
-            - '**/changelog/**'
-            - '**/changelog.txt'
-            - '**/readme.txt'
-            - '.gitignore'
-            - '.coderabbit.yml'
-            - 'CODEOWNERS'
-            - '**/tests/**'
-            - '**/*.md'
-            - '.husky/**'
-            - '.cursor/**'
-            - '.github/**'
-            - '!.github/workflows/build-live-branch.yml'
+        paths:
+            - '**'
+            - '!docs/**'
+            - '!packages/php/**'
+            - '!tools/**'
+            - '!**/changelog/**'
+            - '!**/changelog.txt'
+            - '!**/readme.txt'
+            - '!.gitignore'
+            - '!.coderabbit.yml'
+            - '!CODEOWNERS'
+            - '!**/tests/**'
+            - '!**/*.md'
+            - '!.husky/**'
+            - '!.cursor/**'
+            - '!.github/**'
+            - '.github/workflows/build-live-branch.yml'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -2,14 +2,15 @@ name: 'Changelog Auto Add'
 on:
     pull_request_target:
         types: [opened, synchronize, reopened, edited]
-        paths-ignore:
-          - 'docs/**'
-          - '**/changelog/**'
-          - '**/changelog.txt'
-          - '.husky/**'
-          - '.cursor/**'
-          - '.github/**'
-          - '!.github/workflows/changelog-auto-add.yml'
+        paths:
+          - '**'
+          - '!docs/**'
+          - '!**/changelog/**'
+          - '!**/changelog.txt'
+          - '!.husky/**'
+          - '!.cursor/**'
+          - '!.github/**'
+          - '.github/workflows/changelog-auto-add.yml'
     workflow_dispatch:
         inputs:
             prNumber:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,18 @@ name: 'CI'
 on:
   pull_request:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '**/changelog/**'
-      - '.cursor/**'
-      - '**/*.md'
-      - '**/changelog.txt'
-      - '.gitignore'
-      - '.coderabbit.yml'
-      - 'CODEOWNERS'
-      - '.github/**'
-      - '!.github/workflows/ci.yml'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!**/changelog/**'
+      - '!.cursor/**'
+      - '!**/*.md'
+      - '!**/changelog.txt'
+      - '!.gitignore'
+      - '!.coderabbit.yml'
+      - '!CODEOWNERS'
+      - '!.github/**'
+      - '.github/workflows/ci.yml'
     branches:
       - 'trunk'
       - 'release/*'

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -6,23 +6,25 @@ on:
             - reopened
             - synchronize
             - ready_for_review
-        paths-ignore:
-            - 'docs/**'
-            - 'packages/php/**'
-            - '!packages/php/blueprint/**'
-            - 'tools/**'
-            - '**/changelog/**'
-            - '**/changelog.txt'
-            - '**/readme.txt'
-            - '.gitignore'
-            - '.coderabbit.yml'
-            - 'CODEOWNERS'
-            - '**/tests/**'
-            - '**/*.md'
-            - '.husky/**'
-            - '.cursor/**'
-            - '.github/**'
-            - '!.github/workflows/pr-build-live-branch.yml'
+        paths:
+            - '**'
+            - '!docs/**'
+            - '!packages/php/**'
+            - 'packages/php/blueprint/**'
+            - '!tools/**'
+            - '!**/changelog/**'
+            - '!**/changelog.txt'
+            - '!**/readme.txt'
+            - '!.gitignore'
+            - '!.coderabbit.yml'
+            - '!CODEOWNERS'
+            - '!**/tests/**'
+            - '!**/*.md'
+            - '!.husky/**'
+            - '!.cursor/**'
+            - '!.github/**'
+            - '.github/workflows/pr-build-live-branch.yml'
+            - '.github/workflows/scripts/generate-playground-blueprint.js'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -91,7 +91,7 @@ The changes in this pull request can be previewed and tested using a [WordPress 
 
 [Test this pull request with WordPress Playground](${ url }).
 
-Note that this URL is valid for 30 days from when this comment was last updated. You can update it by closing/reopening the PR or pushing a new commit.
+Note that this URL is valid for 30 days from when this comment was last updated. You can update it by closing/reopening the PR or pushing a commit that changes plugin code.
 `;
 
 	if ( existingCommentId ) {

--- a/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
+++ b/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: dev
 
 Update Playground preview workflow to refresh comment when blueprint script changes.

--- a/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
+++ b/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Update Playground preview workflow to refresh comment when blueprint script changes.
+Fix workflow path filters to correctly re-run when workflow files change.

--- a/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
+++ b/plugins/woocommerce/changelog/fix-playground-comment-refresh-on-blueprint-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Playground preview workflow to refresh comment when blueprint script changes.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Several workflows (`pr-build-live-branch.yml`, `build-live-branch.yml`, `ci.yml`, `changelog-auto-add.yml`) use `paths-ignore` with `!` negation patterns to re-include their own workflow files. This doesn't work reliably with GitHub Actions — when a push only touches files in the re-include set (e.g. the workflow file itself), the workflow still won't trigger because `paths-ignore` requires at least one non-ignored file to change.

This PR replaces `paths-ignore` with `paths` (include/exclude) in all affected workflows:
- Start with `'**'` to include everything
- Exclude the same paths that were previously ignored (with `!` prefix)
- Re-include specific files (workflow files, blueprint script) as positive entries

Also updates the Playground preview comment text to clarify that only commits changing plugin code will refresh the preview URL.

Fixes https://github.com/woocommerce/woocommerce/issues/63923

### How to test the changes in this Pull Request:

1. Review the diff for each workflow file and confirm the `paths` block has the same exclusions as the old `paths-ignore`, with re-include entries for the workflow's own file.
2. Confirm the comment text change in `generate-playground-blueprint.js` now says "pushing a commit that changes plugin code" instead of "pushing a new commit".
3. To fully validate, after this merges, push a changelog-only commit to a test PR and verify the affected workflows trigger correctly when their own workflow files were also modified on trunk.

### Testing that has already taken place:

Verified the diffs match the intended path filter behavior by reviewing GitHub Actions documentation on `paths` filter semantics with negation patterns. Confirmed no other workflows in the repo use the broken `paths-ignore` + `!` pattern.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually and included in the commits.

</details>