### PR TITLE
Fix Product Summary "Upgrade now" button not working in Site Editor

### DIFF
--- a/plugins/woocommerce/changelog/tangerine-1d1ffd0a
+++ b/plugins/woocommerce/changelog/tangerine-1d1ffd0a
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Product Summary "Upgrade now (just this block)" button not working in the Site Editor.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
@@ -3,16 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-import {
-	store as blockEditorStore,
-	InspectorControls,
-} from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	createBlock,
 	type BlockEditProps,
 	type BlockInstance,
 } from '@wordpress/blocks';
-import { select, dispatch } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import {
 	createInterpolateElement,
 	type ComponentType,
@@ -36,6 +33,9 @@ const isProductSummaryBlockVariation = ( props: BlockInstance ) => {
 };
 
 const UpgradeNotice = ( { clientId }: { clientId: string } ) => {
+	const registry = useRegistry();
+	const { replaceBlock } = useDispatch( 'core/block-editor' );
+
 	const notice = createInterpolateElement(
 		__(
 			"There's <strongText /> with important fixes and brand new features.",
@@ -53,12 +53,10 @@ const UpgradeNotice = ( { clientId }: { clientId: string } ) => {
 	const buttonLabel = __( 'Upgrade now (just this block)', 'woocommerce' );
 
 	const handleClick = () => {
-		const blocks =
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore No types for this exist yet.
-			select( blockEditorStore ).getBlocksByClientId( clientId );
+		const { getBlocksByClientId } = registry.select( 'core/block-editor' );
+		const blocks = getBlocksByClientId( clientId );
 
-		if ( blocks.length ) {
+		if ( blocks?.length && blocks[ 0 ] ) {
 			const currentBlock = blocks[ 0 ];
 			const {
 				excerptLength,
@@ -71,12 +69,7 @@ const UpgradeNotice = ( { clientId }: { clientId: string } ) => {
 				'woocommerce/product-summary',
 				restAttributes
 			);
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore No types for this exist yet.
-			dispatch( blockEditorStore ).replaceBlock(
-				clientId,
-				productSummaryBlock
-			);
+			replaceBlock( clientId, productSummaryBlock );
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The "Upgrade now (just this block)" button on Product Summary block does nothing in Site Editor.

**Cause:** `upgrade.tsx` used bare `select()`/`dispatch()` from `@wordpress/data` (default registry). Site Editor runs block editor in a sub-registry, so these calls hit the wrong store — `getBlocksByClientId` returns `[null]`, `replaceBlock` silently fails.

**Fix:** Use `useRegistry()` + `useDispatch()` hooks to bind to the correct registry context. Added null check on `blocks[0]`. Matches pattern in `filter-wrapper/upgrade.tsx`.

Closes #63785.

### How to test the changes in this Pull Request:

1. Go to Appearance → Editor → Templates → Single Product
2. Select the "Product Summary" block
3. Click "Upgrade now (just this block)" in the Settings panel
4. Verify `core/post-excerpt` is replaced with `woocommerce/product-summary`

https://github.com/user-attachments/assets/d2952b39-055b-4047-8c87-da7a7aff2dc0

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

> Changelog entry committed to branch.