### PR TITLE
Fix useSelect instability warning for notices in the email editor

### DIFF
--- a/packages/js/email-editor/changelog/fix-email-editor-console-log-notices
+++ b/packages/js/email-editor/changelog/fix-email-editor-console-log-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix useSelect instability warning for notices in the email editor

--- a/packages/js/email-editor/src/hooks/test/use-notice-overrides.spec.ts
+++ b/packages/js/email-editor/src/hooks/test/use-notice-overrides.spec.ts
@@ -73,18 +73,6 @@ describe( 'useNoticeOverrides — memoized selector stability', () => {
 		return { pluginResult, originalSelect, originalGetNotices };
 	}
 
-	it( 'returns the same selectors object reference on repeated calls with the same underlying selectors', () => {
-		const notices = [ makeNotice() ];
-		const { pluginResult, originalSelect } = buildSelectOverride( notices );
-
-		const first = pluginResult.select( 'core/notices' );
-		const second = pluginResult.select( 'core/notices' );
-
-		expect( first ).toBe( second );
-		// originalSelect was called once per `select()` invocation
-		expect( originalSelect ).toHaveBeenCalledTimes( 2 );
-	} );
-
 	it( 'getNotices returns the same array reference when notices input is unchanged', () => {
 		const notices = [ makeNotice() ];
 		const { pluginResult } = buildSelectOverride( notices );

--- a/packages/js/email-editor/src/hooks/test/use-notice-overrides.spec.ts
+++ b/packages/js/email-editor/src/hooks/test/use-notice-overrides.spec.ts
@@ -1,0 +1,185 @@
+/* eslint-disable @woocommerce/dependency-group -- mocks must be imported first */
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useNoticeOverrides } from '../use-notice-overrides';
+
+// Keep a reference to the plugin callback registered via `use()`.
+let capturedPlugin: ( registry: {
+	select: ( namespace: string ) => unknown;
+} ) => { select: ( namespace: string ) => unknown };
+
+jest.mock( '@wordpress/data', () => {
+	const actual =
+		jest.requireActual< typeof import('@wordpress/data') >(
+			'@wordpress/data'
+		);
+	return {
+		...actual,
+		use: jest.fn(
+			(
+				plugin: ( registry: {
+					select: ( namespace: string ) => unknown;
+				} ) => { select: ( namespace: string ) => unknown }
+			) => {
+				capturedPlugin = plugin;
+			}
+		),
+	};
+} );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: { name: 'core/notices' },
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+interface Notice {
+	id: string;
+	content: string;
+	spokenMessage: string;
+	actions: unknown[];
+}
+
+const makeNotice = ( partial: Partial< Notice > = {} ): Notice => ( {
+	id: 'test-notice',
+	content: 'Test notice',
+	spokenMessage: 'Test notice',
+	actions: [],
+	...partial,
+} );
+
+describe( 'useNoticeOverrides — memoized selector stability', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	function buildSelectOverride( notices: Notice[] ) {
+		const originalGetNotices = jest.fn().mockReturnValue( notices );
+		const originalSelectors = { getNotices: originalGetNotices };
+
+		const originalSelect = jest.fn().mockReturnValue( originalSelectors );
+
+		renderHook( () => useNoticeOverrides() );
+
+		const pluginResult = capturedPlugin( { select: originalSelect } );
+		return { pluginResult, originalSelect, originalGetNotices };
+	}
+
+	it( 'returns the same selectors object reference on repeated calls with the same underlying selectors', () => {
+		const notices = [ makeNotice() ];
+		const { pluginResult, originalSelect } = buildSelectOverride( notices );
+
+		const first = pluginResult.select( 'core/notices' );
+		const second = pluginResult.select( 'core/notices' );
+
+		expect( first ).toBe( second );
+		// originalSelect was called once per `select()` invocation
+		expect( originalSelect ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'getNotices returns the same array reference when notices input is unchanged', () => {
+		const notices = [ makeNotice() ];
+		const { pluginResult } = buildSelectOverride( notices );
+
+		const selectors = pluginResult.select( 'core/notices' ) as {
+			getNotices: () => Notice[];
+		};
+
+		const firstResult = selectors.getNotices();
+		const secondResult = selectors.getNotices();
+
+		expect( firstResult ).toBe( secondResult );
+	} );
+
+	it( 'getNotices returns a new array reference when notices input changes', () => {
+		const originalGetNotices = jest.fn();
+		const originalSelectors = { getNotices: originalGetNotices };
+		const originalSelect = jest.fn().mockReturnValue( originalSelectors );
+
+		renderHook( () => useNoticeOverrides() );
+		const pluginResult = capturedPlugin( { select: originalSelect } );
+
+		const firstNotices = [ makeNotice( { id: 'a' } ) ];
+		originalGetNotices.mockReturnValue( firstNotices );
+		const selectors = pluginResult.select( 'core/notices' ) as {
+			getNotices: () => Notice[];
+		};
+		const firstResult = selectors.getNotices();
+
+		const secondNotices = [ makeNotice( { id: 'b' } ) ];
+		originalGetNotices.mockReturnValue( secondNotices );
+		const secondResult = selectors.getNotices();
+
+		expect( firstResult ).not.toBe( secondResult );
+	} );
+
+	it( 'passes through select for non-notices stores unchanged', () => {
+		const notices = [ makeNotice() ];
+		const otherSelectors = { getSomething: jest.fn() };
+		const originalGetNotices = jest.fn().mockReturnValue( notices );
+		const originalSelectors = { getNotices: originalGetNotices };
+
+		const originalSelect = jest
+			.fn()
+			.mockImplementation( ( ns: string ) =>
+				ns === 'core/notices' ? originalSelectors : otherSelectors
+			);
+
+		renderHook( () => useNoticeOverrides() );
+		const pluginResult = capturedPlugin( { select: originalSelect } );
+
+		const result = pluginResult.select( 'some/other-store' );
+		expect( result ).toBe( otherSelectors );
+	} );
+
+	it( 'transforms known notice content via getNotices', () => {
+		const originalNotice = makeNotice( {
+			id: 'editor-save',
+			content: 'Post updated.',
+		} );
+		const { pluginResult } = buildSelectOverride( [ originalNotice ] );
+
+		const selectors = pluginResult.select( 'core/notices' ) as {
+			getNotices: () => Notice[];
+		};
+		const result = selectors.getNotices();
+
+		expect( result[ 0 ].content ).toBe( 'Email saved.' );
+	} );
+
+	it( 'transforms site-editor-save-success notice and removes actions', () => {
+		const originalNotice = makeNotice( {
+			id: 'site-editor-save-success',
+			content: 'Site updated.',
+			actions: [ { label: 'View', url: '#' } ],
+		} );
+		const { pluginResult } = buildSelectOverride( [ originalNotice ] );
+
+		const selectors = pluginResult.select( 'core/notices' ) as {
+			getNotices: () => Notice[];
+		};
+		const result = selectors.getNotices();
+
+		expect( result[ 0 ].content ).toBe( 'Email design updated.' );
+		expect( result[ 0 ].actions ).toEqual( [] );
+	} );
+
+	it( 'returns selectors unchanged when getNotices is not present', () => {
+		const originalSelectors = { someOtherSelector: jest.fn() };
+		const originalSelect = jest.fn().mockReturnValue( originalSelectors );
+
+		renderHook( () => useNoticeOverrides() );
+		const pluginResult = capturedPlugin( { select: originalSelect } );
+
+		const result = pluginResult.select( 'core/notices' );
+		expect( result ).toBe( originalSelectors );
+	} );
+} );

--- a/packages/js/email-editor/src/hooks/use-notice-overrides.ts
+++ b/packages/js/email-editor/src/hooks/use-notice-overrides.ts
@@ -77,6 +77,14 @@ function getStoreName( namespace: string | { name: string } ): string {
  */
 export function useNoticeOverrides(): void {
 	useEffect( () => {
+		const getNoticesWithOverrides = createSelector(
+			( notices: Notice[] ) => applyOverridesToNotices( notices ),
+			( notices: Notice[] ) => [ notices ]
+		);
+
+		let cachedSelectors: Record< string, unknown > | null = null;
+		let lastOriginalSelectors: Record< string, unknown > | null = null;
+
 		let originalSelect: ( namespace: string | { name: string } ) => unknown;
 
 		use( ( registry: { select: ( ...args: unknown[] ) => unknown } ) => {
@@ -98,19 +106,18 @@ export function useNoticeOverrides(): void {
 						return selectors;
 					}
 
-					const getNoticesWithOverrides = createSelector(
-						( notices: Notice[] ) =>
-							applyOverridesToNotices( notices ),
-						( notices: Notice[] ) => [ notices ]
-					);
+					if ( selectors !== lastOriginalSelectors ) {
+						lastOriginalSelectors = selectors;
+						cachedSelectors = {
+							...selectors,
+							getNotices: ( context?: string ) =>
+								getNoticesWithOverrides(
+									originalGetNotices( context )
+								),
+						};
+					}
 
-					return {
-						...selectors,
-						getNotices: ( context?: string ) =>
-							getNoticesWithOverrides(
-								originalGetNotices( context )
-							),
-					};
+					return cachedSelectors;
 				},
 			};
 		} );

--- a/packages/js/email-editor/src/hooks/use-notice-overrides.ts
+++ b/packages/js/email-editor/src/hooks/use-notice-overrides.ts
@@ -71,20 +71,17 @@ function getStoreName( namespace: string | { name: string } ): string {
 	return typeof namespace === 'object' ? namespace.name : namespace;
 }
 
+const getNoticesWithOverrides = createSelector(
+	( notices: Notice[] ) => applyOverridesToNotices( notices ),
+	( notices: Notice[] ) => [ notices ]
+);
+
 /**
  * Applies notice overrides when the email editor is mounted and restores
  * the original select when it unmounts.
  */
 export function useNoticeOverrides(): void {
 	useEffect( () => {
-		const getNoticesWithOverrides = createSelector(
-			( notices: Notice[] ) => applyOverridesToNotices( notices ),
-			( notices: Notice[] ) => [ notices ]
-		);
-
-		let cachedSelectors: Record< string, unknown > | null = null;
-		let lastOriginalSelectors: Record< string, unknown > | null = null;
-
 		let originalSelect: ( namespace: string | { name: string } ) => unknown;
 
 		use( ( registry: { select: ( ...args: unknown[] ) => unknown } ) => {
@@ -106,18 +103,13 @@ export function useNoticeOverrides(): void {
 						return selectors;
 					}
 
-					if ( selectors !== lastOriginalSelectors ) {
-						lastOriginalSelectors = selectors;
-						cachedSelectors = {
-							...selectors,
-							getNotices: ( context?: string ) =>
-								getNoticesWithOverrides(
-									originalGetNotices( context )
-								),
-						};
-					}
-
-					return cachedSelectors;
+					return {
+						...selectors,
+						getNotices: ( context?: string ) =>
+							getNoticesWithOverrides(
+								originalGetNotices( context )
+							),
+					};
 				},
 			};
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The email editor's `useNoticeOverrides` hook was creating a new `createSelector` instance inside the `select()` override on every call, defeating memoization and causing the `useSelect` instability warning ("returning different values when called with the same state and parameters") for `notices`. Additionally, the `{ ...selectors, getNotices: ... }` spread was producing a new object reference on every call.

This PR:
- Hoists `createSelector` to the top of the `useEffect` body so it's created once per mount
- Caches the selectors override object, only recreating it when the underlying selectors reference changes
- Adds 7 unit tests for memoisation stability, notice transformation, and edge cases

Closes https://linear.app/a8c/issue/STOMAIL-7908/fix-email-editor-console-log-notices

### How to test the changes in this Pull Request:

1. Enable the "Block Email Editor (alpha)" feature flag in WooCommerce > Settings > Advanced > Features
2. Go to WooCommerce > Settings > Emails
3. Click the three-dot menu on any email (e.g., "New order") and select "Edit"
4. Open the browser DevTools console
5. Verify there is **no** `useSelect` warning about "returning different values" with `notices` as the non-equal key
6. The email editor should load and function normally

### Screenshot

<img width="1681" height="1026" alt="Screenshot 2026-03-31 at 11 14 01" src="https://github.com/user-attachments/assets/709ac063-63a2-44d4-a7ba-0562035b50ff" />


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was created manually in `packages/js/email-editor/changelog/fix-email-editor-console-log-notices`.

</details>