### PR TITLE
Fix 404 requests for category-title and category-description frontend scripts

### DIFF
--- a/plugins/woocommerce/changelog/63945-fix-404-requests
+++ b/plugins/woocommerce/changelog/63945-fix-404-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 404 requests for category-title and category-description block frontend scripts

--- a/plugins/woocommerce/changelog/63945-fix-404-requests
+++ b/plugins/woocommerce/changelog/63945-fix-404-requests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix 404 requests for category-title and category-description block frontend scripts

--- a/plugins/woocommerce/changelog/fix-404-requests
+++ b/plugins/woocommerce/changelog/fix-404-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 404 requests for category-title and category-description block frontend scripts

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
@@ -70,6 +70,16 @@ class CategoryDescription extends AbstractBlock {
 	}
 
 	/**
+	 * Disable the frontend script for this block.
+	 *
+	 * @param string|null $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
 	 * Disable the style handle for this block.
 	 *
 	 * @return null

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
@@ -83,6 +83,16 @@ class CategoryTitle extends AbstractBlock {
 	}
 
 	/**
+	 * Disable the frontend script for this block.
+	 *
+	 * @param string|null $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
 	 * Disable the style handle for this block.
 	 *
 	 * @return null


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `CategoryTitle` and `CategoryDescription` blocks are server-rendered only (no client-side JavaScript). However, they inherit `get_block_type_script()` from `AbstractBlock`, which constructs a path to a `-frontend.js` file that doesn't exist, causing 404 errors in the browser console:

```
GET .../assets/client/blocks/category-title-frontend.js 404 (Not Found)
GET .../assets/client/blocks/category-description-frontend.js 404 (Not Found)
```

This PR overrides `get_block_type_script()` to return `null` in both blocks, matching the established pattern used by other server-only blocks like `PageContentWrapper`, `Breadcrumbs`, `ProductMeta`, etc.

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with product categories that have titles and descriptions.
2. Visit a page that renders the `category-title` or `category-description` blocks
3. Open the browser developer console (Network tab).
4. Verify that there are no 404 requests for `category-title-frontend.js` or `category-description-frontend.js`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix 404 requests for category-title and category-description block frontend scripts

</details>
