### PR TITLE
Add parent category support to Product Categories List block

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/block.json
@@ -43,6 +43,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"parentCategoryId": {
+			"type": "number",
+			"default": 0
+		},
 		"showChildrenOnly": {
 			"type": "boolean",
 			"default": false

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/block.tsx
@@ -7,7 +7,10 @@ import ServerSideRender from '@wordpress/server-side-render';
 import { Icon, listView } from '@wordpress/icons';
 import { isSiteEditorPage, isWidgetEditorPage } from '@woocommerce/utils';
 import { useSelect } from '@wordpress/data';
+import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
+import type { ProductCategoryResponseItem } from '@woocommerce/types';
 import {
+	BaseControl,
 	Disabled,
 	PanelBody,
 	ToggleControl,
@@ -65,6 +68,7 @@ const ProductCategoriesBlock = ( {
 			hasEmpty,
 			isDropdown,
 			isHierarchical,
+			parentCategoryId,
 			showChildrenOnly,
 		} = attributes;
 
@@ -141,6 +145,35 @@ const ProductCategoriesBlock = ( {
 							setAttributes( { hasEmpty: ! hasEmpty } )
 						}
 					/>
+					<BaseControl
+						label={ __( 'Parent category', 'woocommerce' ) }
+						help={ __(
+							'Show the children of a specific category on any page.',
+							'woocommerce'
+						) }
+					>
+						<ProductCategoryControl
+							selected={
+								parentCategoryId ? [ parentCategoryId ] : []
+							}
+							onChange={ (
+								value: ProductCategoryResponseItem[] = []
+							) => {
+								const selectedParentCategoryId = value[ 0 ]
+									? value[ 0 ].id
+									: 0;
+
+								setAttributes( {
+									parentCategoryId: selectedParentCategoryId,
+									showChildrenOnly: selectedParentCategoryId
+										? false
+										: showChildrenOnly,
+								} );
+							} }
+							isCompact
+							isSingle
+						/>
+					</BaseControl>
 					{ ( isSiteEditor || isWidgetEditor ) && (
 						<ToggleControl
 							label={ __(
@@ -148,12 +181,16 @@ const ProductCategoriesBlock = ( {
 								'woocommerce'
 							) }
 							help={ __(
-								'This will affect product category pages',
+								parentCategoryId
+									? 'Clear the selected parent category to use the current product category instead.'
+									: 'This will affect product category pages',
 								'woocommerce'
 							) }
 							checked={ showChildrenOnly }
+							disabled={ parentCategoryId > 0 }
 							onChange={ () =>
 								setAttributes( {
+									parentCategoryId: 0,
 									showChildrenOnly: ! showChildrenOnly,
 								} )
 							}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-categories/types.ts
@@ -5,6 +5,7 @@ export interface ProductCategoriesBlockProps {
 		hasEmpty: boolean;
 		isDropdown: boolean;
 		isHierarchical: boolean;
+		parentCategoryId: number;
 		showChildrenOnly: boolean;
 	};
 	name: string;
@@ -14,6 +15,7 @@ export interface ProductCategoriesBlockProps {
 		hasEmpty?: boolean;
 		isDropdown?: boolean;
 		isHierarchical?: boolean;
+		parentCategoryId?: number;
 		showChildrenOnly?: boolean;
 	} ) => void;
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCategories.php
@@ -27,6 +27,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		'hasEmpty'         => false,
 		'isDropdown'       => false,
 		'isHierarchical'   => true,
+		'parentCategoryId' => 0,
 		'showChildrenOnly' => false,
 	);
 
@@ -46,6 +47,7 @@ class ProductCategories extends AbstractDynamicBlock {
 				'hasEmpty'         => $this->get_schema_boolean( false ),
 				'isDropdown'       => $this->get_schema_boolean( false ),
 				'isHierarchical'   => $this->get_schema_boolean( true ),
+				'parentCategoryId' => $this->get_schema_number( 0 ),
 				'showChildrenOnly' => $this->get_schema_boolean( false ),
 				'textColor'        => $this->get_schema_string(),
 				'fontSize'         => $this->get_schema_string(),
@@ -132,30 +134,21 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return array
 	 */
 	protected function get_categories( $attributes ) {
-		$hierarchical  = wc_string_to_bool( $attributes['isHierarchical'] );
-		$children_only = wc_string_to_bool( $attributes['showChildrenOnly'] ) && is_product_category();
+		$hierarchical      = wc_string_to_bool( $attributes['isHierarchical'] );
+		$children_only     = wc_string_to_bool( $attributes['showChildrenOnly'] ) && is_product_category();
+		$parent_category   = absint( $attributes['parentCategoryId'] ?? 0 );
+		$root_category_id  = $children_only ? get_queried_object_id() : $parent_category;
+		$categories_args   = [
+			'hide_empty'   => ! $attributes['hasEmpty'],
+			'pad_counts'   => true,
+			'hierarchical' => true,
+		];
 
-		if ( $children_only ) {
-			$term_id    = get_queried_object_id();
-			$categories = get_terms(
-				'product_cat',
-				[
-					'hide_empty'   => ! $attributes['hasEmpty'],
-					'pad_counts'   => true,
-					'hierarchical' => true,
-					'child_of'     => $term_id,
-				]
-			);
-		} else {
-			$categories = get_terms(
-				'product_cat',
-				[
-					'hide_empty'   => ! $attributes['hasEmpty'],
-					'pad_counts'   => true,
-					'hierarchical' => true,
-				]
-			);
+		if ( $root_category_id > 0 ) {
+			$categories_args['child_of'] = $root_category_id;
 		}
+
+		$categories = get_terms( 'product_cat', $categories_args );
 
 		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];
@@ -170,17 +163,27 @@ class ProductCategories extends AbstractDynamicBlock {
 				}
 			);
 		}
-		return $hierarchical ? $this->build_category_tree( $categories, $children_only ) : $categories;
+
+		if ( ! $hierarchical && $root_category_id > 0 ) {
+			$categories = wp_list_filter(
+				$categories,
+				array(
+					'parent' => $root_category_id,
+				)
+			);
+		}
+
+		return $hierarchical ? $this->build_category_tree( $categories, $root_category_id ) : $categories;
 	}
 
 	/**
 	 * Build hierarchical tree of categories.
 	 *
 	 * @param array $categories List of terms.
-	 * @param bool  $children_only Is the block rendering only the children of the current category.
+	 * @param int   $root_category_id Root category ID for the rendered tree.
 	 * @return array
 	 */
-	protected function build_category_tree( $categories, $children_only ) {
+	protected function build_category_tree( $categories, $root_category_id = 0 ) {
 		$categories_by_parent = [];
 
 		foreach ( $categories as $category ) {
@@ -190,9 +193,8 @@ class ProductCategories extends AbstractDynamicBlock {
 			$categories_by_parent[ 'cat-' . $category->parent ][] = $category;
 		}
 
-		$parent_id = $children_only ? get_queried_object_id() : 0;
-		$tree      = $categories_by_parent[ 'cat-' . $parent_id ]; // these are top level categories. So all parents.
-		unset( $categories_by_parent[ 'cat-' . $parent_id ] );
+		$tree = $categories_by_parent[ 'cat-' . $root_category_id ] ?? [];
+		unset( $categories_by_parent[ 'cat-' . $root_category_id ] );
 
 		foreach ( $tree as $category ) {
 			if ( ! empty( $categories_by_parent[ 'cat-' . $category->term_id ] ) ) {


### PR DESCRIPTION
This lets merchants scope the Product Categories List block to the children of a selected category on static pages, closing a gap with the legacy shortcode and avoiding unrelated categories in multi-line stores.

Made-with: Cursor

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This PR adds a `Parent category` setting to the `Product Categories List` block.

When set, the block renders only the direct children of the selected product category. 
This makes it possible to use the block on static pages such as separate landing pages for different product lines, while keeping the existing `Only show children of current category` behaviour for archive-context use cases.

Related to #42406.
Related to #42664.

### Screenshots or screen recordings:

Before: Product Categories List shows all top-level categories plus unrelated category trees on a static page.

<img width="2092" height="591" alt="CleanShot 2026-03-31 at 15 37 36" src="https://github.com/user-attachments/assets/68cfd28d-ba76-4d55-9bec-bc64e70957aa" />


After: Product Categories List can be scoped to the children of a selected parent category.

<img width="2090" height="964" alt="CleanShot 2026-03-31 at 15 35 00" src="https://github.com/user-attachments/assets/5ea757ca-9744-4821-8bde-c8268ff22851" />



### How to test the changes in this Pull Request:

1. Create at least one parent product category with child categories, for example:
   - `Clothing`
   - `Accessories` (child of `Clothing`)
   - `Hoodies` (child of `Clothing`)
   - `Tshirts` (child of `Clothing`)
2. Create another unrelated top-level category, for example `Music` or `Decor`.
3. Add a `Product Categories List` block to a regular page.
4. Confirm that by default the block still renders all categories as it did previously.
5. Select the block and open the inspector controls.
6. In the new `Parent category` control, choose the parent category created in step 1, such as `Clothing`.
7. Confirm the block now renders only that category's child terms, for example `Accessories`, `Hoodies`, and `Tshirts`.
8. Confirm unrelated categories such as `Music` or `Decor` are not displayed.
9. Clear the selected parent category and confirm the block returns to the default behavior.
10. If testing in a product category template or archive context, confirm `Only show children of current category` still works when no parent category is selected.

### Testing that has already taken place:

- Verified in a Local WooCommerce development environment using a full WooCommerce monorepo checkout.
- Confirmed the default block behavior is unchanged when no parent category is selected.
- Confirmed that setting a parent category scopes output to that category's children only.
- Confirmed unrelated top-level categories are excluded from the rendered list.
- Confirmed the existing archive-context `Only show children of current category` behavior remains available when no parent category is selected.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Add a parent category selector to the Product Categories List block.

</details>