### PR TITLE
Add unit tests for cart and checkout SlotFill components

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control/test/slotfill.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control/test/slotfill.tsx
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import {
-	useStoreCart,
-	useEditorContext,
-	useShippingData,
-} from '@woocommerce/base-context';
+import { useStoreCart } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -26,9 +22,7 @@ jest.mock( '@woocommerce/base-hooks', () => ( {
 	usePrevious: jest.fn(),
 } ) );
 
-const mockSlotRender = jest.fn( () => (
-	<div data-testid="shipping-slot" />
-) );
+const mockSlotRender = jest.fn( () => <div data-testid="shipping-slot" /> );
 jest.mock( '@woocommerce/blocks-checkout', () => {
 	const MockFill = ( { children }: { children: React.ReactNode } ) => (
 		<>{ children }</>
@@ -62,9 +56,7 @@ describe( 'ShippingRatesControl slot rendering', () => {
 	it( 'renders ExperimentalOrderShippingPackages.Slot with correct props when not loading', () => {
 		render( <ShippingRatesControl { ...defaultProps } /> );
 
-		expect(
-			screen.getByTestId( 'shipping-slot' )
-		).toBeInTheDocument();
+		expect( screen.getByTestId( 'shipping-slot' ) ).toBeInTheDocument();
 
 		expect( mockSlotRender ).toHaveBeenCalledWith(
 			expect.objectContaining( {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control/test/slotfill.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control/test/slotfill.tsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import {
+	useStoreCart,
+	useEditorContext,
+	useShippingData,
+} from '@woocommerce/base-context';
+
+/**
+ * Internal dependencies
+ */
+import ShippingRatesControl from '..';
+
+jest.mock( '@woocommerce/base-context', () => ( {
+	useStoreCart: jest.fn(),
+	useEditorContext: jest.fn( () => ( { isEditor: false } ) ),
+	useShippingData: jest.fn( () => ( {
+		hasSelectedLocalPickup: false,
+		selectedRates: {},
+	} ) ),
+} ) );
+
+jest.mock( '@woocommerce/base-hooks', () => ( {
+	usePrevious: jest.fn(),
+} ) );
+
+const mockSlotRender = jest.fn( () => (
+	<div data-testid="shipping-slot" />
+) );
+jest.mock( '@woocommerce/blocks-checkout', () => {
+	const MockFill = ( { children }: { children: React.ReactNode } ) => (
+		<>{ children }</>
+	);
+	MockFill.Slot = ( props: Record< string, unknown > ) =>
+		mockSlotRender( props );
+	return { ExperimentalOrderShippingPackages: MockFill };
+} );
+
+const defaultProps = {
+	shippingRates: [],
+	isLoadingRates: false,
+	className: 'test-class',
+	collapsible: false,
+	showItems: false,
+	noResultsMessage: <span>No rates</span>,
+	renderOption: jest.fn(),
+	context: 'woocommerce/checkout',
+};
+
+describe( 'ShippingRatesControl slot rendering', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			extensions: { 'ship-ext': true },
+			receiveCart: jest.fn(),
+			cartTotals: {},
+		} );
+	} );
+
+	it( 'renders ExperimentalOrderShippingPackages.Slot with correct props when not loading', () => {
+		render( <ShippingRatesControl { ...defaultProps } /> );
+
+		expect(
+			screen.getByTestId( 'shipping-slot' )
+		).toBeInTheDocument();
+
+		expect( mockSlotRender ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: 'woocommerce/checkout',
+				extensions: { 'ship-ext': true },
+				collapsible: false,
+				showItems: false,
+			} )
+		);
+
+		const slotProps = mockSlotRender.mock.calls[ 0 ][ 0 ];
+		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
+		expect( slotProps ).toHaveProperty( 'components' );
+		expect( slotProps ).toHaveProperty( 'renderOption' );
+		expect( slotProps ).toHaveProperty( 'noResultsMessage' );
+	} );
+
+	it( 'does not render the slot when rates are loading', () => {
+		render(
+			<ShippingRatesControl { ...defaultProps } isLoadingRates={ true } />
+		);
+
+		expect(
+			screen.queryByTestId( 'shipping-slot' )
+		).not.toBeInTheDocument();
+		expect( mockSlotRender ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/test/slotfills.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/test/slotfills.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { OrderMetaSlotFill } from '../slotfills';
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	useStoreCart: jest.fn(),
+} ) );
+
+const mockSlotRender = jest.fn( () => <div data-testid="order-meta-slot" /> );
+jest.mock( '@woocommerce/blocks-checkout', () => {
+	const MockFill = ( { children }: { children: React.ReactNode } ) => (
+		<>{ children }</>
+	);
+	MockFill.Slot = ( props: Record< string, unknown > ) =>
+		mockSlotRender( props );
+	return { ExperimentalOrderMeta: MockFill };
+} );
+
+describe( 'Cart OrderMetaSlotFill', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'always renders ExperimentalOrderMeta.Slot with cart context and correct props', () => {
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			extensions: { 'my-ext': true },
+			receiveCart: jest.fn(),
+			cartTotals: { total: '1000' },
+		} );
+
+		render( <OrderMetaSlotFill /> );
+
+		expect( mockSlotRender ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: 'woocommerce/cart',
+				extensions: { 'my-ext': true },
+				cart: expect.objectContaining( {
+					cartTotals: { total: '1000' },
+				} ),
+			} )
+		);
+
+		// receiveCart should be excluded from cart props.
+		const slotProps = mockSlotRender.mock.calls[ 0 ][ 0 ];
+		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/test/block.tsx
@@ -18,9 +18,7 @@ jest.mock( '@woocommerce/base-context/hooks', () => ( {
 	useOrderSummaryLoadingState: jest.fn( () => ( { isLoading: false } ) ),
 } ) );
 
-const mockSlotRender = jest.fn( () => (
-	<div data-testid="discount-slot" />
-) );
+const mockSlotRender = jest.fn( () => <div data-testid="discount-slot" /> );
 jest.mock( '@woocommerce/blocks-checkout', () => {
 	const MockFill = ( { children }: { children: React.ReactNode } ) => (
 		<>{ children }</>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/test/block.tsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	useStoreCart: jest.fn(),
+	useStoreCartCoupons: jest.fn( () => ( {
+		removeCoupon: jest.fn(),
+		isRemovingCoupon: false,
+	} ) ),
+	useOrderSummaryLoadingState: jest.fn( () => ( { isLoading: false } ) ),
+} ) );
+
+const mockSlotRender = jest.fn( () => (
+	<div data-testid="discount-slot" />
+) );
+jest.mock( '@woocommerce/blocks-checkout', () => {
+	const MockFill = ( { children }: { children: React.ReactNode } ) => (
+		<>{ children }</>
+	);
+	MockFill.Slot = ( props: Record< string, unknown > ) =>
+		mockSlotRender( props );
+	return {
+		ExperimentalDiscountsMeta: MockFill,
+		applyCheckoutFilter: jest.fn(
+			( { defaultValue }: { defaultValue: unknown } ) => defaultValue
+		),
+	};
+} );
+
+const mockCartData = {
+	cartTotals: {
+		currency_code: 'USD',
+		currency_symbol: '$',
+		currency_minor_unit: 2,
+		currency_decimal_separator: '.',
+		currency_thousand_separator: ',',
+		currency_prefix: '$',
+		currency_suffix: '',
+		total_discount: '0',
+		total_discount_tax: '0',
+	},
+	cartCoupons: [],
+	extensions: { some: 'data' },
+	receiveCart: jest.fn(),
+};
+
+describe( 'Checkout Order Summary Discount Block', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useStoreCart as jest.Mock ).mockReturnValue( mockCartData );
+	} );
+
+	it( 'renders the DiscountsMeta slot with checkout context when no coupons', () => {
+		render( <Block /> );
+
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+		expect( mockSlotRender ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: 'woocommerce/checkout',
+				extensions: { some: 'data' },
+			} )
+		);
+
+		const slotProps = mockSlotRender.mock.calls[ 0 ][ 0 ];
+		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
+	} );
+
+	it( 'still renders the DiscountsMeta slot when coupons are present', () => {
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			...mockCartData,
+			cartCoupons: [
+				{
+					code: 'SAVE10',
+					label: 'SAVE10',
+					totals: {
+						total_discount: '1000',
+						total_discount_tax: '0',
+					},
+				},
+			],
+			cartTotals: {
+				...mockCartData.cartTotals,
+				total_discount: '1000',
+			},
+		} );
+
+		render( <Block className="test-class" /> );
+
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/discounts-meta/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/discounts-meta/test/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ExperimentalDiscountsMeta from '..';
+import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+
+const defaultSlotProps = {
+	extensions: {},
+	cart: {},
+	context: 'woocommerce/checkout',
+};
+
+describe( 'ExperimentalDiscountsMeta', () => {
+	it( 'renders fill content inside the slot', () => {
+		renderSlotFill( ExperimentalDiscountsMeta, defaultSlotProps );
+
+		expect( screen.getByTestId( 'fill-content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'wraps the slot in a TotalsWrapper with expected classes', () => {
+		const { container } = renderSlotFill( ExperimentalDiscountsMeta, {
+			...defaultSlotProps,
+			className: 'my-discount-class',
+		} );
+
+		const wrapper = container.querySelector(
+			'.wc-block-components-totals-wrapper.slot-wrapper'
+		);
+		expect( wrapper ).toBeInTheDocument();
+
+		const slot = container.querySelector(
+			'.wc-block-components-discounts-meta'
+		);
+		expect( slot ).toBeInTheDocument();
+		expect( slot ).toHaveClass( 'my-discount-class' );
+	} );
+
+	it( 'passes extensions, cart, and context via fillProps', () => {
+		const extensions = { 'discount-ext': { active: true } };
+		const cart = { coupons: [ { code: 'SAVE10' } ] };
+		const context = 'woocommerce/cart';
+
+		const fillProps = getFillProps( ExperimentalDiscountsMeta, {
+			extensions,
+			cart,
+			context,
+		} );
+
+		expect( fillProps ).toEqual(
+			expect.objectContaining( { extensions, cart, context } )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/discounts-meta/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/discounts-meta/test/index.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/react';
  * Internal dependencies
  */
 import ExperimentalDiscountsMeta from '..';
-import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+import { renderSlotFill, getFillProps } from '../../../slot/test-utils';
 
 const defaultSlotProps = {
 	extensions: {},

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/test/index.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/react';
  * Internal dependencies
  */
 import ExperimentalOrderLocalPickupPackages from '..';
-import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+import { renderSlotFill, getFillProps } from '../../../slot/test-utils';
 
 describe( 'ExperimentalOrderLocalPickupPackages', () => {
 	const defaultSlotProps = {
@@ -37,10 +37,12 @@ describe( 'ExperimentalOrderLocalPickupPackages', () => {
 		const components = { PickupOption: () => null };
 		const renderPickupLocation = jest.fn();
 
-		const fillProps = getFillProps(
-			ExperimentalOrderLocalPickupPackages,
-			{ extensions, cart, components, renderPickupLocation }
-		);
+		const fillProps = getFillProps( ExperimentalOrderLocalPickupPackages, {
+			extensions,
+			cart,
+			components,
+			renderPickupLocation,
+		} );
 
 		expect( fillProps ).toEqual(
 			expect.objectContaining( {

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-local-pickup-packages/test/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ExperimentalOrderLocalPickupPackages from '..';
+import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+
+describe( 'ExperimentalOrderLocalPickupPackages', () => {
+	const defaultSlotProps = {
+		extensions: {},
+		cart: {},
+		components: {},
+		renderPickupLocation: jest.fn(),
+	};
+
+	it( 'renders fill content inside the slot with expected classes', () => {
+		const { container } = renderSlotFill(
+			ExperimentalOrderLocalPickupPackages,
+			defaultSlotProps
+		);
+
+		expect( screen.getByTestId( 'fill-content' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector(
+				'.wc-block-components-local-pickup-rates-control'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'passes all expected fillProps', () => {
+		const extensions = { 'pickup-ext': { locations: [] } };
+		const cart = { items: [ { id: 1 } ] };
+		const components = { PickupOption: () => null };
+		const renderPickupLocation = jest.fn();
+
+		const fillProps = getFillProps(
+			ExperimentalOrderLocalPickupPackages,
+			{ extensions, cart, components, renderPickupLocation }
+		);
+
+		expect( fillProps ).toEqual(
+			expect.objectContaining( {
+				extensions,
+				cart,
+				components,
+				renderPickupLocation,
+			} )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-meta/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-meta/test/index.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/react';
  * Internal dependencies
  */
 import ExperimentalOrderMeta from '..';
-import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+import { renderSlotFill, getFillProps } from '../../../slot/test-utils';
 
 const defaultSlotProps = {
 	extensions: {},

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-meta/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-meta/test/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ExperimentalOrderMeta from '..';
+import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+
+const defaultSlotProps = {
+	extensions: {},
+	cart: {},
+	context: 'woocommerce/checkout',
+};
+
+describe( 'ExperimentalOrderMeta', () => {
+	it( 'renders fill content inside the slot', () => {
+		renderSlotFill( ExperimentalOrderMeta, defaultSlotProps );
+
+		expect( screen.getByTestId( 'fill-content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'wraps the slot in a TotalsWrapper with expected classes', () => {
+		const { container } = renderSlotFill( ExperimentalOrderMeta, {
+			...defaultSlotProps,
+			className: 'custom-class',
+		} );
+
+		const wrapper = container.querySelector(
+			'.wc-block-components-totals-wrapper.slot-wrapper'
+		);
+		expect( wrapper ).toBeInTheDocument();
+
+		const slot = container.querySelector(
+			'.wc-block-components-order-meta'
+		);
+		expect( slot ).toBeInTheDocument();
+		expect( slot ).toHaveClass( 'custom-class' );
+	} );
+
+	it( 'passes extensions, cart, and context via fillProps', () => {
+		const extensions = { 'my-extension': { key: 'value' } };
+		const cart = { items: [], totals: {} };
+		const context = 'woocommerce/cart';
+
+		const fillProps = getFillProps( ExperimentalOrderMeta, {
+			extensions,
+			cart,
+			context,
+		} );
+
+		expect( fillProps ).toEqual(
+			expect.objectContaining( { extensions, cart, context } )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-shipping-packages/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-shipping-packages/test/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ExperimentalOrderShippingPackages from '..';
+import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+
+describe( 'ExperimentalOrderShippingPackages', () => {
+	const defaultSlotProps = {
+		extensions: {},
+		cart: {},
+		components: {},
+		context: 'woocommerce/checkout',
+		noResultsMessage: 'No shipping options.',
+		renderOption: jest.fn(),
+		collapsible: false,
+		showItems: false,
+	};
+
+	it( 'renders fill content inside the slot with expected classes', () => {
+		const { container } = renderSlotFill(
+			ExperimentalOrderShippingPackages,
+			{ ...defaultSlotProps, className: 'custom-shipping' }
+		);
+
+		expect( screen.getByTestId( 'fill-content' ) ).toBeInTheDocument();
+
+		const slot = container.querySelector(
+			'.wc-block-components-shipping-rates-control'
+		);
+		expect( slot ).toBeInTheDocument();
+		expect( slot ).toHaveClass( 'custom-shipping' );
+	} );
+
+	it( 'passes all expected fillProps', () => {
+		const extensions = { 'shipping-ext': { zones: [] } };
+		const cart = { shippingRates: [ { rate: '5.00' } ] };
+		const components = { ShippingRate: () => null };
+		const renderOption = jest.fn();
+
+		const fillProps = getFillProps( ExperimentalOrderShippingPackages, {
+			extensions,
+			cart,
+			components,
+			context: 'woocommerce/cart',
+			noResultsMessage: 'No options available',
+			renderOption,
+			collapsible: true,
+			showItems: true,
+		} );
+
+		expect( fillProps ).toEqual(
+			expect.objectContaining( {
+				extensions,
+				cart,
+				components,
+				context: 'woocommerce/cart',
+				noResultsMessage: 'No options available',
+				renderOption,
+				collapsible: true,
+				collapse: true,
+				showItems: true,
+			} )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/checkout/components/order-shipping-packages/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/components/order-shipping-packages/test/index.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/react';
  * Internal dependencies
  */
 import ExperimentalOrderShippingPackages from '..';
-import { renderSlotFill, getFillProps } from '../../../slot/test/test-utils';
+import { renderSlotFill, getFillProps } from '../../../slot/test-utils';
 
 describe( 'ExperimentalOrderShippingPackages', () => {
 	const defaultSlotProps = {

--- a/plugins/woocommerce/client/blocks/packages/checkout/slot/test-utils.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/slot/test-utils.tsx
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-
-// It is very important to import this directly from the build module to avoid introducing side-effects.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Provider is used as JSX.
-import { Provider as SlotFillProvider } from 'wordpress-components-slotfill/build-module/slot-fill';
+import { Provider as SlotFillProvider } from 'wordpress-components-slotfill/build-module/slot-fill'; // eslint-disable-line @typescript-eslint/no-unused-vars -- Provider is used as JSX.
 
 type SlotFillComponent = {
 	( props: { children: React.ReactNode } ): JSX.Element;

--- a/plugins/woocommerce/client/blocks/packages/checkout/slot/test/test-utils.tsx
+++ b/plugins/woocommerce/client/blocks/packages/checkout/slot/test/test-utils.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+// It is very important to import this directly from the build module to avoid introducing side-effects.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Provider is used as JSX.
+import { Provider as SlotFillProvider } from 'wordpress-components-slotfill/build-module/slot-fill';
+
+type SlotFillComponent = {
+	( props: { children: React.ReactNode } ): JSX.Element;
+	Slot: ( props: Record< string, unknown > ) => JSX.Element;
+};
+
+/**
+ * Renders a SlotFill pair within a SlotFillProvider.
+ *
+ * Places a spy component inside the Fill that captures the fillProps
+ * passed via cloneElement. Returns both the render result and a
+ * jest.fn() that was called with the received fillProps.
+ *
+ * @param Fill      The Fill component (e.g. ExperimentalOrderMeta).
+ * @param slotProps Props passed to Fill.Slot (including fillProps).
+ * @return Object with render result and fillPropsSpy.
+ */
+export const renderSlotFill = (
+	Fill: SlotFillComponent,
+	slotProps: Record< string, unknown > = {}
+) => {
+	const fillPropsSpy = jest.fn();
+
+	// A component that captures all props it receives (merged via cloneElement)
+	// and calls the spy with them for assertion.
+	const FillPropsSpy = ( props: Record< string, unknown > ) => {
+		fillPropsSpy( props );
+		return <div data-testid="fill-content" />;
+	};
+
+	const result = render(
+		<SlotFillProvider>
+			<Fill>
+				<FillPropsSpy />
+			</Fill>
+			<Fill.Slot { ...slotProps } />
+		</SlotFillProvider>
+	);
+
+	return { ...result, fillPropsSpy };
+};
+
+/**
+ * Renders a SlotFill and returns the fillProps received by the fill child.
+ *
+ * Unlike JSON-based approaches, this preserves function references and
+ * other non-serializable values.
+ *
+ * @param Fill      The Fill component.
+ * @param slotProps Props to pass to Fill.Slot.
+ * @return The fillProps object.
+ */
+export const getFillProps = (
+	Fill: SlotFillComponent,
+	slotProps: Record< string, unknown > = {}
+): Record< string, unknown > => {
+	const { fillPropsSpy } = renderSlotFill( Fill, slotProps );
+
+	expect( fillPropsSpy ).toHaveBeenCalled();
+	return fillPropsSpy.mock.calls[ 0 ][ 0 ];
+};

--- a/plugins/woocommerce/client/blocks/tests/js/jest.config.json
+++ b/plugins/woocommerce/client/blocks/tests/js/jest.config.json
@@ -14,6 +14,7 @@
 		"@wordpress/core-data": "<rootDir>/node_modules/@wordpress/core-data",
 		"@wordpress/components": "<rootDir>/node_modules/@wordpress/components",
 		"@woocommerce/data": "<rootDir>/node_modules/@woocommerce/data/build",
+		"@woocommerce/sanitize": "<rootDir>/node_modules/@woocommerce/sanitize/src/index.ts",
 		"@woocommerce/atomic-blocks": "assets/js/atomic/blocks",
 		"@woocommerce/atomic-utils": "assets/js/atomic/utils",
 		"@woocommerce/icons": "assets/js/icons",


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds unit tests for all 4 public cart/checkout SlotFill components and their consumer blocks to ensure fills render correctly, fillProps are forwarded, and slots are always mounted regardless of consumer state.

**SlotFill component tests** (verify the slot/fill mechanism works correctly):
- `ExperimentalOrderMeta` — renders fill content, wraps in TotalsWrapper, forwards extensions/cart/context
- `ExperimentalDiscountsMeta` — same pattern as OrderMeta
- `ExperimentalOrderShippingPackages` — renders fill content, forwards all fillProps including collapsible/showItems/renderOption
- `ExperimentalOrderLocalPickupPackages` — renders fill content, forwards extensions/cart/components/renderPickupLocation

**Consumer block tests** (verify slots are always rendered, preventing regressions like #59227):
- `cart-order-summary-block/slotfills` — OrderMeta slot always renders with cart context, receiveCart excluded
- `checkout-order-summary-discount/block` — DiscountsMeta slot renders both with and without coupons
- `shipping-rates-control` — ShippingPackages slot renders when not loading; documents it's skipped during loading

**Shared test utility** (`packages/checkout/slot/test/test-utils.tsx`):
- `renderSlotFill(Fill, slotProps)` — renders a Fill+Slot pair in SlotFillProvider with a spy component
- `getFillProps(Fill, slotProps)` — returns captured fillProps preserving function references

**Jest config fix**: Added missing `@woocommerce/sanitize` moduleNameMapper entry.

### Screenshots or screen recordings:

N/A — test-only changes.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Run `pnpm install` from the monorepo root
3. Run the new tests from `plugins/woocommerce/client/blocks/`:
   ```
   pnpm test:js -- packages/checkout/components/order-meta/test/index.tsx packages/checkout/components/discounts-meta/test/index.tsx packages/checkout/components/order-shipping-packages/test/index.tsx packages/checkout/components/order-local-pickup-packages/test/index.tsx assets/js/blocks/cart/inner-blocks/cart-order-summary-block/test/slotfills.tsx assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/test/block.tsx assets/js/base/components/cart-checkout/shipping-rates-control/test/slotfill.tsx
   ```
4. All 15 tests across 7 suites should pass

### Testing that has already taken place:

All 15 tests pass locally (7 suites, 15 tests, ~4s).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only changes — no user-facing or developer-facing behavior is modified.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)