### PR TITLE
Add Claude Code hook to block edits to generated/built files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,18 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r \".tool_input.file_path // empty\" | { read -r f; if echo \"$f\" | grep -qE \"/(build|build-module|build-style|build-types|dist)/|[.]asset[.]php$\"; then printf '{\"decision\":\"block\",\"reason\":\"This is a generated/built file. Edit the source instead.\"}'; fi; }"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` hook to `.claude/settings.json` that blocks Claude Code from editing generated/built files
- Matches files in `build/`, `build-module/`, `build-style/`, `build-types/`, `dist/` directories, and `*.asset.php` files
- When triggered, blocks the edit with a message directing to edit the source instead
- Can be temporarily disabled via `/hooks` if a built file genuinely needs editing

## Test plan
- [ ] Start a Claude Code session in the monorepo
- [ ] Ask Claude to edit a file in `plugins/woocommerce/client/blocks/build/` — should be blocked
- [ ] Ask Claude to edit a source file like `plugins/woocommerce/client/blocks/assets/js/blocks/cart/block.tsx` — should proceed normally
- [ ] Verify `/hooks` shows the new hook and can toggle it off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>