### PR TITLE
Use default cursor in Product Gallery large image when it's not clickable

### DIFF
--- a/plugins/woocommerce/changelog/fix-63955-product-gallery-cursor
+++ b/plugins/woocommerce/changelog/fix-63955-product-gallery-cursor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use default cursor in Product Gallery large image when it's not clickable

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -57,6 +57,10 @@ $dialog-padding: 20px;
 
 	}
 
+	&:not(.wc-block-woocommerce-product-gallery-large-image__image--full-screen-on-click) :where(.wc-block-components-product-image > a)  {
+		cursor: default;
+	}
+
 	:where(.wc-block-woocommerce-product-gallery-large-image__image) {
 		display: block;
 		position: relative;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -57,19 +57,14 @@ $dialog-padding: 20px;
 
 	}
 
-	&:not(.wc-block-woocommerce-product-gallery-large-image__image--full-screen-on-click) :where(.wc-block-components-product-image > a)  {
-		cursor: default;
-	}
-
 	:where(.wc-block-woocommerce-product-gallery-large-image__image) {
 		display: block;
 		position: relative;
 		transition: all 0.1s linear;
 		z-index: 1;
 
-		// Keep the order in this way. The hoverZoom class should override the full-screen-on-click class when both are applied.
-		&:where(.wc-block-woocommerce-product-gallery-large-image__image--full-screen-on-click) {
-			cursor: pointer;
+		&:where(:not(.wc-block-woocommerce-product-gallery-large-image__image--full-screen-on-click)) {
+			cursor: default;
 		}
 
 		&:where(.wc-block-woocommerce-product-gallery-large-image__image--hoverZoom) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -145,7 +145,7 @@ class ProductGalleryLargeImage extends AbstractBlock {
 			$p->set_attribute( 'tabindex', '-1' );
 		} else {
 			/**
-			 * If we can't find and <a> tag, we're at then end of the document.
+			 * If we can't find and <a> tag, we're at th end of the document.
 			 * We need to reinitialize the processor instance to search for <img> tag.
 			 */
 			$p = new \WP_HTML_Tag_Processor( $image_html );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -145,7 +145,7 @@ class ProductGalleryLargeImage extends AbstractBlock {
 			$p->set_attribute( 'tabindex', '-1' );
 		} else {
 			/**
-			 * If we can't find and <a> tag, we're at th end of the document.
+			 * If we can't find and <a> tag, we're at the end of the document.
 			 * We need to reinitialize the processor instance to search for <img> tag.
 			 */
 			$p = new \WP_HTML_Tag_Processor( $image_html );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #63955.
Closes WOOPLUG-6497.

This PR makes it so when the Large Image of the Product Gallery is not clickable and can't be zoomed, it displays the default cursor instead of a pointer.

### How to test the changes in this Pull Request:

1. Edit the Single Product template, and update to the blockified Product Gallery block.
2. Disable both attributes: Zoom while hovering and Open pop-up when clicked.
3. Visit a product in the frontend.
4. Verify the image shows a default cursor instead of a pointer.

Before | After
--- | ---
<img width="686" height="866" alt="Captura de pantalla de 2026-03-31 18-09-22" src="https://github.com/user-attachments/assets/865f55ec-f9de-463e-a460-0f0561c5a5e3" /> | <img width="686" height="866" alt="imatge" src="https://github.com/user-attachments/assets/a1f13447-b225-4558-b2aa-f5ca7de7aeb0" />

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.