### PR TITLE
Prevent `is_checkout()` and `is_cart()` from possibly caching invalid values

### DIFF
--- a/plugins/woocommerce/changelog/fix-62538
+++ b/plugins/woocommerce/changelog/fix-62538
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix is_checkout/is_cart cache poisoning causing 404 on checkout endpoints when called before main query is ready

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -27,13 +27,13 @@ class CartCheckoutUtils {
 	 * This is determined by looking at the global $post object and comparing it to the post ID defined in settings,
 	 * or checking the page contents for a block or shortcode.
 	 *
-	 * This function cannot be used accurately before the `pre_get_posts` action has been run.
+	 * This function cannot be used accurately before the `wp` action has been run.
 	 *
 	 * @param string $page_type The page type to check for.
 	 * @return bool|null
 	 */
 	private static function is_page_type( string $page_type ): ?bool {
-		if ( ! did_action( 'pre_get_posts' ) ) {
+		if ( ! did_action( 'wp' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR switches the resolution of `is_page_type()` (which powers `is_checkout()`, `is_cart()`, etc.) to at least the `wp` hook, from the prior `pre_get_posts`.

Note that `wp` is only fired once, unlike `pre_get_posts` which gets called for each `WP_Query`, not just the main one. This could result in the wrong value being cached if any plugin runs a custom query early in the lifecycle, possibly producing 404 errors like described in #62538.

The `wp` action fires once per request, only after `WP::main()` has fully resolved the main query, making it a more reliable indicator that `is_page()` will return the correct result.

Closes #62538.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add the following snippet as a `.php` file in `wp-content/mu-plugins/`:
   ```php
   <?php
   add_action(
	   'init',
	   function() {
		   // Simulate a plugin running a query during init and the global post being modified early (like BuddyPress did in #62538).
		   $query = new WP_Query( 'post_type=post&posts_per_page=1' );
		   $query->have_posts();
		   $GLOBALS['post'] = $query->posts[0];
   
		   // Simulate is_checkout() getting called early.
		   is_checkout();
	   },
	   20
   );
   ```
1. Add a product to the cart and go to checkout.
1. Complete checkout and it should work correctly.
1. Visit `/checkout/order-received/123/` and it shouldn't show a generic confirmation message.
1. Optional: repeat the above on `trunk` and you should see 404 errors after checkout or when visiting the `order-received` endpoint.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.