### PR TITLE
Add block patterns smoke test utility for visual review

### DIFF
--- a/plugins/woocommerce/tests/smoke-test-patterns/README.md
+++ b/plugins/woocommerce/tests/smoke-test-patterns/README.md
@@ -1,0 +1,31 @@
+# WooCommerce Block Patterns Smoke Test
+
+Bulk-insert all WooCommerce block patterns into a test page for visual review.
+
+## Option 1: Browser Console Snippet (Recommended)
+
+1. Open wp-admin and create a new **Page** (or edit an existing one) in the block editor.
+2. Open browser DevTools (`F12` or `Cmd+Shift+J`).
+3. Paste the contents of `console-snippet.js` into the console and press Enter.
+4. All WooCommerce block patterns will be inserted into the page with heading separators.
+5. Preview the page to visually review all patterns at once.
+
+## Option 2: WP-CLI Script
+
+From the WordPress root (or via `wp-env`):
+
+```bash
+# If using wp-env from plugins/woocommerce/:
+pnpm wp-env run cli wp eval-file wp-content/plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
+
+# Or with standalone WP-CLI:
+wp eval-file plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
+```
+
+This creates a draft page titled "WooCommerce Patterns Smoke Test" with all patterns inserted.
+
+## Notes
+
+- These are **dev-only utilities**, not production code.
+- The browser snippet works with any WooCommerce version that registers block patterns.
+- The WP-CLI script creates a draft page (not published).

--- a/plugins/woocommerce/tests/smoke-test-patterns/console-snippet.js
+++ b/plugins/woocommerce/tests/smoke-test-patterns/console-snippet.js
@@ -1,0 +1,71 @@
+/**
+ * WooCommerce Block Patterns Smoke Test — Browser Console Snippet
+ *
+ * Usage: Open a page in the block editor, paste this into the browser console, and run it.
+ * All registered WooCommerce block patterns will be inserted with heading separators.
+ */
+( async () => {
+	const { select, dispatch } = wp.data;
+	const { parse } = wp.blocks;
+
+	// Fetch all block patterns from the store.
+	const allPatterns = select( 'core' ).getBlockPatterns();
+
+	if ( ! allPatterns || allPatterns.length === 0 ) {
+		console.error( 'No block patterns found. Make sure WooCommerce is active.' );
+		return;
+	}
+
+	// Filter to WooCommerce patterns (name starts with "woocommerce-blocks/" or "woocommerce/").
+	// Exclude email-specific patterns (not meant for page content).
+	const wooPatterns = allPatterns.filter(
+		( p ) =>
+			( p.name.startsWith( 'woocommerce-blocks/' ) ||
+				p.name.startsWith( 'woocommerce/' ) ) &&
+			! p.name.includes( 'email' )
+	);
+
+	if ( wooPatterns.length === 0 ) {
+		console.error( 'No WooCommerce block patterns found. Is WooCommerce active?' );
+		return;
+	}
+
+	console.log( `Found ${ wooPatterns.length } WooCommerce patterns. Inserting...` );
+
+	const blocksToInsert = [];
+
+	for ( const pattern of wooPatterns ) {
+		// Add a separator heading with the pattern name.
+		const headingMarkup = `<!-- wp:heading {"level":2,"style":{"color":{"background":"#7f54b3","text":"#ffffff"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"15px","right":"15px"}}}} -->
+<h2 class="wp-block-heading has-text-color has-background" style="color:#ffffff;background-color:#7f54b3;padding-top:10px;padding-right:15px;padding-bottom:10px;padding-left:15px">${ pattern.name }</h2>
+<!-- /wp:heading -->`;
+
+		const headingBlocks = parse( headingMarkup );
+		blocksToInsert.push( ...headingBlocks );
+
+		// Parse and add the pattern content.
+		try {
+			const patternBlocks = parse( pattern.content );
+			blocksToInsert.push( ...patternBlocks );
+		} catch ( e ) {
+			console.warn( `Failed to parse pattern "${ pattern.name }":`, e );
+			const errorMarkup = `<!-- wp:paragraph {"style":{"color":{"text":"#cc0000"}}} -->
+<p class="has-text-color" style="color:#cc0000">⚠ Failed to parse pattern: ${ pattern.name }</p>
+<!-- /wp:paragraph -->`;
+			blocksToInsert.push( ...parse( errorMarkup ) );
+		}
+
+		// Add a spacer between patterns.
+		const spacerMarkup = `<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->`;
+		blocksToInsert.push( ...parse( spacerMarkup ) );
+	}
+
+	// Insert all blocks at the end of the editor.
+	dispatch( 'core/block-editor' ).insertBlocks( blocksToInsert );
+
+	console.log(
+		`✅ Inserted ${ wooPatterns.length } WooCommerce patterns. Preview the page to review.`
+	);
+} )();

--- a/plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
+++ b/plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WooCommerce Block Patterns Smoke Test — WP-CLI Script
+ *
+ * Creates a draft page with all registered WooCommerce block patterns.
+ *
+ * Usage:
+ *   wp eval-file wp-content/plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
+ *
+ * @package WooCommerce\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Ensure block patterns are registered.
+if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
+	WP_CLI::error( 'Block patterns registry not available. Requires WordPress 5.5+.' );
+}
+
+$registry     = WP_Block_Patterns_Registry::get_instance();
+$all_patterns = $registry->get_all_registered();
+
+if ( empty( $all_patterns ) ) {
+	WP_CLI::error( 'No block patterns registered. Make sure WooCommerce is active.' );
+}
+
+// Filter to WooCommerce patterns, excluding email patterns.
+$woo_patterns = array_filter(
+	$all_patterns,
+	function ( $pattern ) {
+		$name = $pattern['name'];
+		return ( str_starts_with( $name, 'woocommerce-blocks/' ) || str_starts_with( $name, 'woocommerce/' ) )
+			&& false === strpos( $name, 'email' );
+	}
+);
+
+if ( empty( $woo_patterns ) ) {
+	WP_CLI::error( 'No WooCommerce block patterns found.' );
+}
+
+WP_CLI::log( sprintf( 'Found %d WooCommerce patterns. Building page...', count( $woo_patterns ) ) );
+
+$content = '';
+
+foreach ( $woo_patterns as $pattern ) {
+	$name = esc_html( $pattern['name'] );
+
+	// Heading separator.
+	$content .= <<<BLOCK
+<!-- wp:heading {"level":2,"style":{"color":{"background":"#7f54b3","text":"#ffffff"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"15px","right":"15px"}}}} -->
+<h2 class="wp-block-heading has-text-color has-background" style="color:#ffffff;background-color:#7f54b3;padding-top:10px;padding-right:15px;padding-bottom:10px;padding-left:15px">{$name}</h2>
+<!-- /wp:heading -->
+
+BLOCK;
+
+	// Pattern content.
+	$content .= $pattern['content'] . "\n\n";
+
+	// Spacer.
+	$content .= <<<BLOCK
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+BLOCK;
+}
+
+$page_id = wp_insert_post(
+	array(
+		'post_title'   => 'WooCommerce Patterns Smoke Test',
+		'post_content' => $content,
+		'post_status'  => 'draft',
+		'post_type'    => 'page',
+	)
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create page: ' . $page_id->get_error_message() );
+}
+
+WP_CLI::success(
+	sprintf(
+		'Created draft page ID %d with %d patterns. Edit: %s',
+		$page_id,
+		count( $woo_patterns ),
+		admin_url( 'post.php?post=' . $page_id . '&action=edit' )
+	)
+);


### PR DESCRIPTION
## Summary
- Adds a browser console snippet (`console-snippet.js`) that bulk-inserts all WooCommerce block patterns into the current page in the block editor, with purple heading separators labeling each pattern.
- Adds a WP-CLI script (`wp-cli-insert-patterns.php`) that creates a draft page containing all WooCommerce patterns for visual QA.
- Includes a README with usage instructions for both approaches.

Files are in `plugins/woocommerce/tests/smoke-test-patterns/` — dev-only utility, no production code changes.

## How to test the changes in this Pull Request
1. Open wp-admin → Pages → Add New in the block editor.
2. Open browser DevTools console.
3. Paste contents of `plugins/woocommerce/tests/smoke-test-patterns/console-snippet.js` and run.
4. Verify all WooCommerce patterns are inserted with labeled separators.
5. Preview the page to visually review patterns.

**WP-CLI alternative:**
```bash
pnpm wp-env run cli wp eval-file wp-content/plugins/woocommerce/tests/smoke-test-patterns/wp-cli-insert-patterns.php
```

## Testing that has already taken place
- Reviewed pattern registration code to ensure correct namespace filtering (`woocommerce-blocks/` and `woocommerce/` prefixes).
- Email patterns excluded from insertion (not page content).

## Changelog entry
Dev utility only — no changelog needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)