### PR TITLE
Add to Cart Button: open external products link in a new tab

### DIFF
--- a/plugins/woocommerce/changelog/2026-04-01-13-16-19-880401
+++ b/plugins/woocommerce/changelog/2026-04-01-13-16-19-880401
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart Button: open external products link in a new tab

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -166,10 +166,13 @@ class ProductButton extends AbstractBlock {
 
 		if ( 'a' === $html_element ) {
 			$attributes = array(
-				'href'   => esc_url( $product->add_to_cart_url() ),
-				'rel'    => 'nofollow',
-				'target' => '_blank',
+				'href' => esc_url( $product->add_to_cart_url() ),
+				'rel'  => 'nofollow',
 			);
+
+			if ( $product->is_type( ProductType::EXTERNAL ) ) {
+				$attributes['target'] = '_blank';
+			}
 		}
 
 		wp_interactivity_config(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -172,6 +172,7 @@ class ProductButton extends AbstractBlock {
 
 			if ( $product->is_type( ProductType::EXTERNAL ) ) {
 				$attributes['target'] = '_blank';
+				$attributes['rel']    = 'nofollow noopener noreferrer';
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -166,8 +166,9 @@ class ProductButton extends AbstractBlock {
 
 		if ( 'a' === $html_element ) {
 			$attributes = array(
-				'href' => esc_url( $product->add_to_cart_url() ),
-				'rel'  => 'nofollow',
+				'href'   => esc_url( $product->add_to_cart_url() ),
+				'rel'    => 'nofollow',
+				'target' => '_blank',
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPRD-2856.

Updates the _Add to Cart Button_ block so links to external products open in a new tab.

### How to test the changes in this Pull Request:

1. Create an external product.
2. Go to the _Shop_ page (or any _Product Collection_-based product grid). Verify clicking on the external product button opens the link in a new tab.
3. Test the same in the _Single Product_ template.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.