### PR TITLE
Cart: Fix stale pending delete state for bundled products

### DIFF
--- a/plugins/woocommerce/changelog/63972-mikejolley-fix-stale-pending-delete
+++ b/plugins/woocommerce/changelog/63972-mikejolley-fix-stale-pending-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cart shipping and totals stuck as loading when removing bundled products

--- a/plugins/woocommerce/changelog/mikejolley-fix-stale-pending-delete
+++ b/plugins/woocommerce/changelog/mikejolley-fix-stale-pending-delete
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix cart shipping and totals stuck as loading when removing bundled products

--- a/plugins/woocommerce/changelog/mikejolley-fix-stale-pending-delete
+++ b/plugins/woocommerce/changelog/mikejolley-fix-stale-pending-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cart shipping and totals stuck as loading when removing bundled products

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -1,11 +1,19 @@
 /**
  * Internal dependencies
  */
-import { changeCartItemQuantity } from '../thunks';
+import { changeCartItemQuantity, receiveCart } from '../thunks';
 import { apiFetchWithHeaders } from '../../shared-controls';
 
 jest.mock( '../../shared-controls', () => ( {
 	apiFetchWithHeaders: jest.fn(),
+} ) );
+
+jest.mock( '../notify-quantity-changes', () => ( {
+	notifyQuantityChanges: jest.fn(),
+} ) );
+
+jest.mock( '../notify-errors', () => ( {
+	updateCartErrorNotices: jest.fn(),
 } ) );
 
 const mockApiFetchWithHeaders = apiFetchWithHeaders as jest.MockedFunction<
@@ -13,7 +21,7 @@ const mockApiFetchWithHeaders = apiFetchWithHeaders as jest.MockedFunction<
 >;
 
 describe( 'changeCartItemQuantity', () => {
-	const createMockDispatchAndSelect = (
+	const createChangeQuantityMocks = (
 		cartItems: Record< string, number >
 	) => {
 		const mockDispatch = {
@@ -39,7 +47,7 @@ describe( 'changeCartItemQuantity', () => {
 	} );
 
 	it( 'should not make API call if quantity is unchanged', async () => {
-		const { dispatch, select } = createMockDispatchAndSelect( {
+		const { dispatch, select } = createChangeQuantityMocks( {
 			'item-1': 5,
 		} );
 
@@ -53,7 +61,7 @@ describe( 'changeCartItemQuantity', () => {
 	} );
 
 	it( 'should make API call when quantity changes', async () => {
-		const { dispatch, select } = createMockDispatchAndSelect( {
+		const { dispatch, select } = createChangeQuantityMocks( {
 			'item-1': 1,
 		} );
 
@@ -225,7 +233,7 @@ describe( 'changeCartItemQuantity', () => {
 	} );
 
 	it( 'should handle API errors', async () => {
-		const { dispatch, select } = createMockDispatchAndSelect( {
+		const { dispatch, select } = createChangeQuantityMocks( {
 			'item-1': 1,
 		} );
 
@@ -245,5 +253,113 @@ describe( 'changeCartItemQuantity', () => {
 			'item-1',
 			false
 		);
+	} );
+} );
+
+describe( 'receiveCart', () => {
+	const createReceiveCartMocks = ( {
+		cartItems,
+		pendingDelete,
+	}: {
+		cartItems: Array< { key: string } >;
+		pendingDelete: string[];
+	} ) => {
+		let cartData = { items: cartItems, errors: [] as never[] };
+
+		const mockDispatch = {
+			setCartData: jest.fn( ( newCart ) => {
+				cartData = newCart;
+			} ),
+			itemIsPendingDelete: jest.fn(),
+			setErrorData: jest.fn(),
+		};
+
+		const mockSelect = {
+			getCartData: jest.fn( () => cartData ),
+			getCartErrors: jest.fn( () => [] ),
+			getItemsPendingDelete: jest.fn( () => pendingDelete ),
+			getItemsPendingQuantityUpdate: jest.fn( () => [] ),
+			getProductsPendingAdd: jest.fn( () => [] ),
+		};
+
+		return { dispatch: mockDispatch, select: mockSelect };
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should clear pending delete for items removed server-side (e.g. bundle children)', () => {
+		// Simulate: parent bundle "bundle-parent" was deleted by the user.
+		// Its children "bundle-child-1" and "bundle-child-2" were marked
+		// as pending delete by the extension but removed server-side
+		// when the parent was deleted.
+		const { dispatch, select } = createReceiveCartMocks( {
+			cartItems: [
+				{ key: 'bundle-parent' },
+				{ key: 'bundle-child-1' },
+				{ key: 'bundle-child-2' },
+				{ key: 'simple-product' },
+			],
+			pendingDelete: [
+				'bundle-parent',
+				'bundle-child-1',
+				'bundle-child-2',
+			],
+		} );
+
+		// The API response after removing the parent no longer contains
+		// the parent or its children — only the simple product remains.
+		receiveCart( {
+			items: [ { key: 'simple-product' } ],
+			errors: [],
+		} as never )( { dispatch, select } as never );
+
+		// All three pending-delete items are gone from the cart,
+		// so their pending status should be cleared.
+		expect( dispatch.itemIsPendingDelete ).toHaveBeenCalledWith(
+			'bundle-parent',
+			false
+		);
+		expect( dispatch.itemIsPendingDelete ).toHaveBeenCalledWith(
+			'bundle-child-1',
+			false
+		);
+		expect( dispatch.itemIsPendingDelete ).toHaveBeenCalledWith(
+			'bundle-child-2',
+			false
+		);
+		expect( dispatch.itemIsPendingDelete ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'should not clear pending delete for items still in the cart', () => {
+		// An item is pending delete but still present in the response
+		// (e.g. the API call hasn't finished processing yet).
+		const { dispatch, select } = createReceiveCartMocks( {
+			cartItems: [ { key: 'item-1' }, { key: 'item-2' } ],
+			pendingDelete: [ 'item-1' ],
+		} );
+
+		receiveCart( {
+			items: [ { key: 'item-1' }, { key: 'item-2' } ],
+			errors: [],
+		} as never )( { dispatch, select } as never );
+
+		// item-1 is still in the cart, so pending delete should NOT be cleared.
+		expect( dispatch.itemIsPendingDelete ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle empty pending delete list', () => {
+		const { dispatch, select } = createReceiveCartMocks( {
+			cartItems: [ { key: 'item-1' } ],
+			pendingDelete: [],
+		} );
+
+		receiveCart( {
+			items: [ { key: 'item-1' } ],
+			errors: [],
+		} as never )( { dispatch, select } as never );
+
+		expect( dispatch.itemIsPendingDelete ).not.toHaveBeenCalled();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -61,13 +61,30 @@ export const receiveCart =
 		// Get the new cart data before showing updates.
 		const newCart = select.getCartData();
 
+		const cartItemsPendingDelete = select.getItemsPendingDelete();
+
 		notifyQuantityChanges( {
 			oldCart,
 			newCart,
 			cartItemsPendingQuantity: select.getItemsPendingQuantityUpdate(),
-			cartItemsPendingDelete: select.getItemsPendingDelete(),
+			cartItemsPendingDelete,
 			productsPendingAdd: select.getProductsPendingAdd(),
 		} );
+
+		// Clear pending delete status for items no longer in the cart.
+		// This handles cases where removing one item causes dependent items
+		// to also be removed server-side (e.g., bundled product children
+		// removed when their parent bundle is deleted).
+		if ( cartItemsPendingDelete.length > 0 ) {
+			const newCartItemKeys = new Set(
+				newCart.items.map( ( item ) => item.key )
+			);
+			cartItemsPendingDelete.forEach( ( key ) => {
+				if ( ! newCartItemKeys.has( key ) ) {
+					dispatch.itemIsPendingDelete( key, false );
+				}
+			} );
+		}
 
 		updateCartErrorNotices( newCart.errors, oldCartErrors );
 		dispatch.setErrorData( null );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a bundled product parent is removed from the block-based cart, the server also removes its child items. However, the cart data store kept those children marked as "pending delete" indefinitely, causing `hasPendingItemsOperations` to remain `true`. This left shipping and cart totals stuck showing skeleton placeholders.

- In `receiveCart`, after processing the API response, clear the pending delete flag for any items no longer present in the cart
- Guard the cleanup with a length check to avoid unnecessary work on every cart update (the common case has no pending deletes)

### How to test the changes in this Pull Request:

**Prerequisites:** WooCommerce Product Bundles extension installed and active.

1. Create a product bundle containing at least one child product
2. Add the bundle and a simple product to the cart
3. Go to the block-based Cart page
4. Remove the bundle parent item
5. Verify that shipping and cart totals update correctly (no stuck skeleton/grey placeholders)
6. Verify the simple product still shows correctly with accurate totals

### Testing that has already taken place:

- Jest unit tests added and passing for `receiveCart` thunk covering:
  - Bundle children cleanup when parent is removed
  - Items still in cart retain their pending delete state
  - Empty pending delete list is a no-op

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix cart shipping and totals stuck as loading when removing bundled products

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>