### PR TITLE
Fix email editor styling regressions in block emails

### DIFF
--- a/packages/php/email-editor/changelog/63974-fix-email-editor-styling-regressions
+++ b/packages/php/email-editor/changelog/63974-fix-email-editor-styling-regressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email editor styling regressions: logo/title font competition, inconsistent bold in order totals, and incorrect content indentation in block emails.

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -33,7 +33,7 @@
         },
         {
           "name": "2",
-          "size": "20px",
+          "size": "24px",
           "slug": "20"
         },
         {
@@ -225,10 +225,10 @@
     "spacing": {
       "blockGap": "16px",
       "padding": {
-        "bottom": "20px",
-        "left": "20px",
-        "right": "20px",
-        "top": "20px"
+        "bottom": "24px",
+        "left": "24px",
+        "right": "24px",
+        "top": "24px"
       }
     },
     "color": {
@@ -245,10 +245,23 @@
       "textDecoration": "none",
       "textTransform": "none"
     },
+    "blocks": {
+      "core/site-title": {
+        "typography": {
+          "fontSize": "11px",
+          "fontWeight": "500",
+          "letterSpacing": "0.55px",
+          "textTransform": "uppercase"
+        },
+        "color": {
+          "text": "#757575"
+        }
+      }
+    },
     "elements": {
       "heading": {
         "typography": {
-          "fontWeight": "400",
+          "fontWeight": "700",
           "fontStyle": "normal",
           "lineHeight": "1.2"
         }

--- a/plugins/woocommerce/changelog/63974-fix-email-editor-styling-regressions
+++ b/plugins/woocommerce/changelog/63974-fix-email-editor-styling-regressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email editor styling regressions: logo/title font competition, inconsistent bold in order totals, and incorrect content indentation in block emails.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -65059,17 +65059,6 @@ parameters:
 			count: 1
 			path: src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
 
-		-
-			message: '#^Method Automattic\\WooCommerce\\Internal\\EmailEditor\\WooContentProcessor\:\:prepare_css\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Internal/EmailEditor/WooContentProcessor.php
-
-		-
-			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/EmailEditor/WooContentProcessor.php
 
 		-
 			message: '#^@param string \$feature_id does not accept actual type of parameter\: int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string\.$#'

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -80,6 +80,6 @@ class WooEmailTemplate {
 			return '<!-- wp:site-logo {"width":130,"isLink":false,"align":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
 		}
 
-		return '<!-- wp:site-title {"level":2,"textAlign":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
+		return '<!-- wp:site-title {"level":2,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WooContentProcessor.php
@@ -49,18 +49,33 @@ class WooContentProcessor {
 
 	/**
 	 * Filter CSS for the email.
-	 * The CSS was from email editor was already inlined.
-	 * The method hookes to woocommerce_email_styles and removes CSS rules that we don't want to apply to the email.
+	 * The CSS from the email editor was already inlined.
+	 * The method hooks to woocommerce_email_styles and removes CSS rules that we don't want to apply to the email.
 	 *
+	 * Typography properties (font-size, font-weight, line-height, letter-spacing) are stripped
+	 * because the email editor theme controls all typography via theme.json. Leaving these in
+	 * the WooCommerce CSS would override the editor's heading sizes and weights.
+	 *
+	 * @since 10.8.0
 	 * @param string $css CSS.
 	 * @return string
 	 */
 	public function prepare_css( string $css ): string {
 		remove_filter( 'woocommerce_email_styles', array( $this, 'prepare_css' ) );
-		// Remove color and font-family declarations from WooCommerce CSS.
-		$css = preg_replace( '/color\s*:\s*[^;]+;/', '', $css );
-		$css = preg_replace( '/font-family\s*:\s*[^;]+;/', '', $css );
-		return $css;
+		// Remove typography declarations from WooCommerce CSS.
+		// The email editor theme.json controls all typography; WC CSS would override it.
+		return (string) preg_replace(
+			array(
+				'/color\s*:\s*[^;]+;/',
+				'/font-family\s*:\s*[^;]+;/',
+				'/font-size\s*:\s*[^;]+;/',
+				'/font-weight\s*:\s*[^;]+;/',
+				'/line-height\s*:\s*[^;]+;/',
+				'/letter-spacing\s*:\s*[^;]+;/',
+			),
+			'',
+			$css
+		);
 	}
 
 	/**
@@ -87,8 +102,72 @@ class WooContentProcessor {
 		if ( empty( $woo_content ) ) {
 			return '';
 		}
-		$css = $this->theme_controller->get_stylesheet_for_rendering();
+		$css  = $this->theme_controller->get_stylesheet_for_rendering();
+		$css .= $this->get_woo_content_styles();
 		return $this->css_inliner->from_html( $woo_content )->inline_css( $css )->render();
+	}
+
+	/**
+	 * Get CSS styles specific to WooCommerce email content.
+	 *
+	 * These styles target WooCommerce-specific HTML classes in the order details,
+	 * totals, and other email content areas. They are needed because the WooCommerce
+	 * email CSS selectors (prefixed with #body_content) do not match in the block
+	 * email editor template structure.
+	 *
+	 * @since 10.8.0
+	 * @return string CSS styles.
+	 */
+	private function get_woo_content_styles(): string {
+		return '
+			.email-order-details td,
+			.email-order-details th {
+				padding: 8px 12px;
+			}
+			.email-order-details td:first-child,
+			.email-order-details th:first-child {
+				padding-left: 0;
+			}
+			.email-order-details td:last-child,
+			.email-order-details th:last-child {
+				padding-right: 0;
+			}
+			.order-item-data td {
+				border: 0;
+				padding: 0;
+				vertical-align: top;
+			}
+			.order-item-data img {
+				border-radius: 4px;
+			}
+			.order-totals th,
+			.order-totals td {
+				font-weight: 400;
+				padding-bottom: 5px;
+				padding-top: 5px;
+			}
+			.order-totals-total th {
+				font-weight: 700;
+			}
+			.order-totals-total td {
+				font-weight: 700;
+				font-size: 20px;
+			}
+			h2.email-order-detail-heading {
+				font-size: 20px;
+				font-weight: 700;
+				line-height: 1.6;
+			}
+			h2.email-order-detail-heading span {
+				font-size: 14px;
+				font-weight: 400;
+				color: #757575;
+			}
+			.email-order-item-meta {
+				font-size: 14px;
+				line-height: 1.4;
+			}
+		';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WooContentProcessorTest.php
@@ -24,6 +24,43 @@ class WooContentProcessorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should strip typography properties from WooCommerce CSS.
+	 */
+	public function test_prepare_css_strips_typography_properties(): void {
+		$css = 'h2 { color: red; font-family: Arial; font-size: 20px; font-weight: bold; line-height: 1.5; letter-spacing: -1px; margin: 0; }';
+
+		$result = $this->woo_content_processor->prepare_css( $css );
+
+		$this->assertStringNotContainsString( 'color', $result, 'Color should be stripped' );
+		$this->assertStringNotContainsString( 'font-family', $result, 'Font-family should be stripped' );
+		$this->assertStringNotContainsString( 'font-size', $result, 'Font-size should be stripped' );
+		$this->assertStringNotContainsString( 'font-weight', $result, 'Font-weight should be stripped' );
+		$this->assertStringNotContainsString( 'line-height', $result, 'Line-height should be stripped' );
+		$this->assertStringNotContainsString( 'letter-spacing', $result, 'Letter-spacing should be stripped' );
+		$this->assertStringContainsString( 'margin', $result, 'Non-typography properties should be preserved' );
+	}
+
+	/**
+	 * @testdox Should return WooCommerce content styles with correct order totals CSS.
+	 */
+	public function test_get_woo_content_styles_contains_order_totals_css(): void {
+		$reflection = new \ReflectionClass( $this->woo_content_processor );
+		$method     = $reflection->getMethod( 'get_woo_content_styles' );
+		$method->setAccessible( true );
+
+		$css = $method->invoke( $this->woo_content_processor );
+
+		$this->assertStringContainsString( '.order-totals th', $css, 'Should target order totals headers' );
+		$this->assertStringContainsString( '.order-totals-total th', $css, 'Should target total row header' );
+		$this->assertStringContainsString( '.order-totals-total td', $css, 'Should target total row value' );
+		$this->assertStringContainsString( 'font-weight: 400', $css, 'Non-total rows should be regular weight' );
+		$this->assertStringContainsString( 'font-weight: 700', $css, 'Total row should be bold' );
+		$this->assertStringContainsString( 'font-size: 20px', $css, 'Total value should be 20px' );
+		$this->assertStringContainsString( '.email-order-item-meta', $css, 'Should target order item metadata' );
+		$this->assertStringContainsString( 'h2.email-order-detail-heading', $css, 'Should target section headings' );
+	}
+
+	/**
 	 * Test that the BlockEmailRenderer can render email and replaces Woo Content.
 	 */
 	public function testItCapturesWooContent(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3275

Fixes three email preview styling regressions in block emails caused by a CSS selector mismatch between the traditional WC email system (`#body_content` scoping) and the block email DOM structure (`.email_layout_wrapper`):

1. **Logo/title font competition**: The email editor `theme.json` set heading `fontWeight` to `400` (Regular), while WC CSS overrode all headings to `20px bold` — making the logo (site-title) and email title visually identical. Fixed by:
   - Setting heading `fontWeight` to `700` in theme.json
   - Adding `core/site-title` block styles (11px, 500 weight, uppercase, #757575)
   - Stripping typography properties from WC CSS in `prepare_css()` to prevent overrides

2. **Totals bold inconsistency**: All order totals rows (Subtotal, Shipping, etc.) appeared bold because the `email-styles.php` rules correcting `<th>` font-weight were scoped to `#body_content`, which doesn't exist in block emails. Fixed by adding targeted CSS via `WooContentProcessor::get_woo_content_styles()` — regular weight (400) for non-total rows, bold (700) for the Total row only.

3. **Incorrect indentation**: Root padding (20px) plus spacing preset "20" (20px) gave 40px total horizontal padding instead of the expected 48px. Fixed by updating both values to 24px in theme.json.

**Additional changes:**
- `WooContentProcessor::prepare_css()` now strips `font-size`, `font-weight`, `line-height`, and `letter-spacing` from WC CSS (previously only stripped `color` and `font-family`)
- New `get_woo_content_styles()` method provides block-email-specific CSS for order totals, section headings ("Order summary" at 20px), order meta (#757575), and item metadata (14px)
- Removed default `textAlign: "center"` from site-title in `WooEmailTemplate` (new installations only)
- Cleaned up stale PHPStan baseline entries
- Added unit tests for `prepare_css()` and `get_woo_content_styles()`

All changes are scoped to block email rendering — traditional (non-block) emails are unaffected.

### How to test the changes in this Pull Request:

1. Enable the **Email Improvements** and **Block Email Editor** features under WooCommerce > Settings > Advanced > Features.
2. Go to WooCommerce > Settings > Emails and open any email template in the block editor.
3. **Logo vs title**: Verify the site-title appears as a subtle label (small, uppercase, gray) and the email title ("Thank you for your order") appears as a dominant bold heading. They should not compete visually.
4. **Totals area**: Preview an order confirmation email. Verify that Subtotal, Discount, Shipping, and Payment method rows are **regular weight (not bold)**, while only the **Total** row is bold with a larger (20px) value.
5. **Indentation**: Verify all content (logo, title, body text, order details, addresses) shares the same left alignment with 48px horizontal padding from the email container edge.
6. **Section headings**: Verify "Order summary" and "Downloads" headings appear at 20px bold.
7. **Order meta**: Verify the order number and date below the heading appear at 14px in gray (#757575).
8. **Traditional emails**: Send a test email with block editor disabled and verify no regression in traditional email styling.

### Testing that has already taken place:

- PHP linting (`lint:php:changes`): clean
- PHPStan analysis on changed files: clean
- Branch-level linting (`lint:changes:branch`): clean
- Code review of CSS selectors against template HTML class names
- Verified `$total['type']` values in `abstract-wc-order.php` match CSS selectors

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix email editor styling regressions: logo/title font competition, inconsistent bold in order totals, and incorrect content indentation in block emails.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)