### PR TITLE
Added Standardized Contributing Doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ This is a quick reference for common commands used during development. For broad
 ## Tooling
 
 - [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) (recommended for Node version management)
-- [Node.js](https://nodejs.org/) ^20.11.1
-- [PNPM](https://pnpm.io/installation) 9.15.0
-- [PHP](https://www.php.net/manual/en/install.php) 7.4+
+- [Node.js](https://nodejs.org/)
+- [PNPM](https://pnpm.io/installation)
+- [PHP](https://www.php.net/manual/en/install.php)
 - [Composer](https://getcomposer.org/doc/00-intro.md)
 - [Docker](https://docs.docker.com/get-docker/) (for running tests and local environments)
 
@@ -19,9 +19,7 @@ A POSIX-compliant OS (Linux, macOS) is assumed. On Windows, use [WSL](https://le
 # Use the pinned Node version from .nvmrc
 nvm install
 # Install JS and PHP dependencies
-pnpm install --frozen-lockfile
-# Build all plugins, packages, and tools
-pnpm build
+pnpm install
 ```
 
 ## Monorepo filtering
@@ -116,9 +114,10 @@ pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:fix -- path/to/file.php
 pnpm --filter='@woocommerce/plugin-woocommerce' lint:lang:js
 ```
 
-PHPStan (from `plugins/woocommerce`):
+PHPStan:
 
 ```sh
+cd plugins/woocommerce
 composer exec -- phpstan analyse path/to/File.php --memory-limit=2G
 ```
 
@@ -133,25 +132,9 @@ Every PR that changes code in a project requires a changelog entry:
 pnpm --filter='@woocommerce/plugin-woocommerce' changelog add
 ```
 
-Replace `@woocommerce/plugin-woocommerce` with the relevant package name if your changes affect a different project. You will be prompted to select:
+Replace `@woocommerce/plugin-woocommerce` with the relevant package name if your changes affect a different project.
 
-- **Significance**: Patch (bug fixes, minor tweaks), Minor (new features, enhancements), or Major (breaking changes)
-- **Type**: Fix, Add, Update, Dev, Tweak, Performance, or Enhancement
-
-Keep the entry message concise — describe the change from a user's perspective (e.g. "Fix shipping tax rate calculation for international orders") rather than implementation details.
-
-## Submitting a pull request
-
-1. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and create a branch (e.g. `fix/12345-description` or `feature/description`).
-2. Make your changes and write appropriate tests.
-3. Run linting and tests locally before pushing.
-4. Create a changelog entry for each affected project.
-5. Push and [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) against `trunk`.
-6. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with testing instructions and changelog details.
-
-For bug fixes, reference the PR that introduced the bug: `Bug introduced in PR #XXXXX.`
-
-See [Git Conventions](https://developer.woocommerce.com/docs/contribution/contributing/woocommerce-git-flow/) for branching and release conventions.
+For the full PR workflow, changelog conventions, and coding guidelines, see [Contributing to WooCommerce](.github/CONTRIBUTING.md) and the [contribution docs](https://developer.woocommerce.com/docs/contribution/contributing/).
 
 ## Repository structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,171 @@
+# Contributing to WooCommerce
+
+This is a quick reference for common commands used during development. For broader contribution guidelines, see the [Contributing to WooCommerce](https://developer.woocommerce.com/docs/contribution/contributing/) docs. For detailed development notes, see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Tooling
+
+- [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) (recommended for Node version management)
+- [Node.js](https://nodejs.org/) ^20.11.1
+- [PNPM](https://pnpm.io/installation) 9.15.0
+- [PHP](https://www.php.net/manual/en/install.php) 7.4+
+- [Composer](https://getcomposer.org/doc/00-intro.md)
+- [Docker](https://docs.docker.com/get-docker/) (for running tests and local environments)
+
+A POSIX-compliant OS (Linux, macOS) is assumed. On Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+
+## Initial install
+
+```sh
+# Use the pinned Node version from .nvmrc
+nvm install
+# Install JS and PHP dependencies
+pnpm install --frozen-lockfile
+# Build all plugins, packages, and tools
+pnpm build
+```
+
+## Monorepo filtering
+
+This is a PNPM workspaces monorepo. Use `--filter` to target individual projects:
+
+```sh
+# Build WooCommerce Core + deps
+pnpm --filter='@woocommerce/plugin-woocommerce' build
+# Lint a specific package
+pnpm --filter='@woocommerce/components' lint
+# Build all JS packages
+pnpm --filter='./packages/js/*' build
+# Build only what changed
+pnpm --filter='[HEAD^1]' build
+```
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for more filtering examples and [tools/README.md](tools/README.md) for monorepo infrastructure details.
+
+## Local WordPress environment
+
+The repository uses [`@wordpress/env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) (`wp-env`) for local development environments.
+
+```sh
+cd plugins/woocommerce
+# Start the environment (creates it if needed, pulls latest config)
+pnpm env:dev
+# Stop the environment
+pnpm env:stop
+# Remove all environment files
+pnpm env:destroy
+```
+
+## Build
+
+```sh
+# Build everything
+pnpm build
+# Build WooCommerce Core
+pnpm --filter='@woocommerce/plugin-woocommerce' build
+# Create woocommerce.zip
+pnpm --filter='@woocommerce/plugin-woocommerce' build:zip
+```
+
+For active development with file watching:
+
+```sh
+# Watch and rebuild on changes
+pnpm --filter='@woocommerce/plugin-woocommerce' watch:build
+```
+
+## Tests
+
+```sh
+# PHP unit tests (requires wp-env)
+cd plugins/woocommerce
+# Start the test environment
+pnpm env:dev
+# Run all PHP unit tests
+pnpm test:unit:env
+# Run a specific test class
+pnpm test:unit:env -- --filter=TestClassName
+# Watch mode
+pnpm test:unit:env:watch
+
+# E2E tests (requires Docker)
+cd plugins/woocommerce
+# Start the E2E environment
+pnpm env:start
+# Run Playwright E2E tests
+pnpm test:e2e
+
+# JavaScript tests
+pnpm --filter='@woocommerce/admin-library' test:js
+pnpm --filter='@woocommerce/block-library' test:js
+```
+
+See the [unit tests README](plugins/woocommerce/tests/README.md), [E2E tests README](plugins/woocommerce/tests/e2e-pw/README.md), and [performance tests README](plugins/woocommerce/tests/performance/README.md) for full details.
+
+## Linting and static analysis
+
+```sh
+# Lint everything
+pnpm lint
+# Lint changed PHP files
+pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:changes
+# Lint PHP changes on branch (vs trunk)
+pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:changes:branch
+# Auto-fix PHP lint issues
+pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:fix -- path/to/file.php
+# Lint JS/TS (ESLint)
+pnpm --filter='@woocommerce/plugin-woocommerce' lint:lang:js
+```
+
+PHPStan (from `plugins/woocommerce`):
+
+```sh
+composer exec -- phpstan analyse path/to/File.php --memory-limit=2G
+```
+
+See the [Coding Standards](https://developer.woocommerce.com/docs/best-practices/coding-standards/) docs and the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/) for conventions.
+
+## Changelog
+
+Every PR that changes code in a project requires a changelog entry:
+
+```sh
+# Interactive prompt for WooCommerce Core
+pnpm --filter='@woocommerce/plugin-woocommerce' changelog add
+```
+
+Replace `@woocommerce/plugin-woocommerce` with the relevant package name if your changes affect a different project. You will be prompted to select:
+
+- **Significance**: Patch (bug fixes, minor tweaks), Minor (new features, enhancements), or Major (breaking changes)
+- **Type**: Fix, Add, Update, Dev, Tweak, Performance, or Enhancement
+
+Keep the entry message concise — describe the change from a user's perspective (e.g. "Fix shipping tax rate calculation for international orders") rather than implementation details.
+
+## Submitting a pull request
+
+1. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and create a branch (e.g. `fix/12345-description` or `feature/description`).
+2. Make your changes and write appropriate tests.
+3. Run linting and tests locally before pushing.
+4. Create a changelog entry for each affected project.
+5. Push and [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) against `trunk`.
+6. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with testing instructions and changelog details.
+
+For bug fixes, reference the PR that introduced the bug: `Bug introduced in PR #XXXXX.`
+
+See [Git Conventions](https://developer.woocommerce.com/docs/contribution/contributing/woocommerce-git-flow/) for branching and release conventions.
+
+## Repository structure
+
+```
+plugins/                   # WordPress plugins
+  woocommerce/             # WooCommerce Core plugin
+    src/                   #   Modern PHP (PSR-4, DI container)
+    includes/              #   Legacy PHP
+    client/admin/          #   Admin React/TypeScript app
+    tests/                 #   PHP unit, E2E, performance tests
+packages/                  # Shared libraries
+  js/                      #   JavaScript/TypeScript packages
+  php/                     #   PHP packages
+tools/                     # Monorepo utilities and scripts
+```
+
+See [plugins/woocommerce/src/README.md](plugins/woocommerce/src/README.md) for modern PHP architecture and [tools/README.md](tools/README.md) for monorepo tooling.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ For peer to peer support, real-time announcements, and office hours, please [joi
 
 ## Contributing to WooCommerce
 
-As an open source project, we rely on community contributions to continue to improve WooCommerce. To contribute, please follow the pre-requisites above and visit our [Contributing to Woo](https://developer.woocommerce.com/docs/contribution/contributing/) doc for more links and contribution guidelines.
+As an open source project, we rely on community contributions to continue to improve WooCommerce. To get started, check out our [Contributing guide](CONTRIBUTING.md) for a quick reference of common development commands, or visit the [Contributing to Woo](https://developer.woocommerce.com/docs/contribution/contributing/) docs for broader contribution guidelines.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ For peer to peer support, real-time announcements, and office hours, please [joi
 
 ## Contributing to WooCommerce
 
-As an open source project, we rely on community contributions to continue to improve WooCommerce. To get started, check out our [Contributing guide](CONTRIBUTING.md) for a quick reference of common development commands, or visit the [Contributing to Woo](https://developer.woocommerce.com/docs/contribution/contributing/) docs for broader contribution guidelines.
+As an open-source project, we rely on community contributions to continue to improve WooCommerce. To get started, check out our [Contributing guide](CONTRIBUTING.md) for a quick reference of common development commands, or visit the [Contributing to Woo](https://developer.woocommerce.com/docs/contribution/contributing/) docs for broader contribution guidelines.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As a sister PR to https://github.com/Automattic/jetpack/pull/47517, this one adds a centralized `CONTRIBUTING.md` document to serve as an entry point into the monorepo developer documentation. It provides a quick reference for common commands as well as links to relevant sources for deeper details.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Read the documentation

<!-- End testing instructions -->

### Testing that has already taken place:

N/A

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation only.

</details>
