### PR TITLE
Add content role to block attributes for WP 7.0 pattern editing

### DIFF
--- a/plugins/woocommerce/changelog/tangerine-934e8d29
+++ b/plugins/woocommerce/changelog/tangerine-934e8d29
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add "role": "content" to editable block attributes (product-sku, product-reviews-pagination-next, product-reviews-pagination-previous) for WordPress 7.0 contentOnly pattern editing compatibility.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
@@ -18,11 +18,13 @@
 		},
 		"prefix": {
 			"type": "string",
-			"default": "SKU:"
+			"default": "SKU:",
+			"role": "content"
 		},
 		"suffix": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "query", "queryId", "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -57,7 +57,9 @@ const Preview = ( {
 		/>
 		<span> { sku }</span>
 		<RichText
-			className="wc-block-components-product-sku__suffix"
+			className={ clsx( 'wc-block-components-product-sku__suffix', {
+				'has-content': !! suffix,
+			} ) }
 			tagName="span"
 			placeholder={ ' ' + __( 'Suffix', 'woocommerce' ) }
 			value={ suffix }

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
@@ -8,7 +8,8 @@
 	&__suffix {
 		display: none;
 
-		.wc-block-components-product-sku.is-selected & {
+		.wc-block-components-product-sku.is-selected &,
+		&.has-content {
 			display: inline;
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "woocommerce",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "postId", "reviews/paginationArrow" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "woocommerce",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "postId", "reviews/paginationArrow" ],


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

[WP 7.0 defaults unsynced patterns to `contentOnly` mode](https://make.wordpress.org/core/2026/03/15/pattern-editing-in-wordpress-7-0/), making blocks without `"role": "content"` on editable attributes hidden/non-selectable.

This PR adds `"role": "content"` to editable attributes in `product-sku`, `product-reviews-pagination-next`, and `product-reviews-pagination-previous`. Expanding support to other blocks is future work.

Also fixes the SKU suffix not showing in the editor preview when the block is not selected — it had `display: none` gated on `.is-selected`, which doesn't apply in contentOnly mode.

### How to test the changes in this Pull Request:

1. Use WordPress 7.0+ (or Gutenberg with contentOnly support)
2. Insert the **Product List with Full Product Description** pattern into a page
3. Verify the Product SKU block is visible in List View and selectable in contentOnly mode
4. Edit the SKU suffix, exit contentOnly mode, and confirm the value stays visible in the preview

### Testing that has already taken place:

Manual testing of SKU prefix/suffix editing in contentOnly pattern.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog created manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)