### PR TITLE
Add functionality to retry failed requests to the wpcom send

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
@@ -115,7 +115,7 @@ class PushNotificationRestController {
 	 * @since 10.7.0
 	 */
 	public function authorize( WP_REST_Request $request ) {
-		$header = $request->get_header( 'authorization' );
+		$header = trim( (string) $request->get_header( 'authorization' ) );
 
 		if ( empty( $header ) ) {
 			return new WP_Error(
@@ -125,7 +125,7 @@ class PushNotificationRestController {
 			);
 		}
 
-		$token = (string) preg_replace( '/^\s*Bearer\s+/i', '', $header );
+		$token = strncasecmp( $header, 'Bearer ', 7 ) === 0 ? substr( $header, 7 ) : $header;
 
 		if ( ! JsonWebToken::validate( $token, wp_salt( 'auth' ) ) ) {
 			return new WP_Error(

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
@@ -75,8 +75,8 @@ class PushNotificationRestController {
 	public function create( WP_REST_Request $request ) {
 		wc_set_time_limit( 30 );
 
-		$body          = json_decode( $request->get_body(), true );
-		$notifications = is_array( $body ) ? ( $body['notifications'] ?? array() ) : array();
+		$body             = json_decode( $request->get_body(), true );
+		$notifications    = is_array( $body ) ? ( $body['notifications'] ?? array() ) : array();
 		$success_response = new WP_REST_Response( array( 'success' => true ), WP_Http::OK );
 
 		if ( empty( $notifications ) || ! is_array( $notifications ) ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushNotificationRestController.php
@@ -75,8 +75,8 @@ class PushNotificationRestController {
 	public function create( WP_REST_Request $request ) {
 		wc_set_time_limit( 30 );
 
-		$body             = json_decode( $request->get_body(), true );
-		$notifications    = is_array( $body ) ? ( $body['notifications'] ?? array() ) : array();
+		$body          = json_decode( $request->get_body(), true );
+		$notifications = is_array( $body ) ? ( $body['notifications'] ?? array() ) : array();
 		$success_response = new WP_REST_Response( array( 'success' => true ), WP_Http::OK );
 
 		if ( empty( $notifications ) || ! is_array( $notifications ) ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushNotificati
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
@@ -88,6 +89,7 @@ class PushNotifications {
 		( new StockNotificationRecoveryHandler() )->register();
 
 		wc_get_container()->get( NotificationProcessor::class )->register();
+		wc_get_container()->get( NotificationRetryHandler::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -36,11 +36,6 @@ class PushNotifications {
 	const FEATURE_NAME = 'push_notifications';
 
 	/**
-	 * ActionScheduler group for all push notification jobs.
-	 */
-	const ACTION_SCHEDULER_GROUP = 'wc-push-notifications';
-
-	/**
 	 * Roles that can receive push notifications.
 	 *
 	 * This will be used to gate functionality access to just these roles.

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -36,6 +36,11 @@ class PushNotifications {
 	const FEATURE_NAME = 'push_notifications';
 
 	/**
+	 * ActionScheduler group for all push notification jobs.
+	 */
+	const ACTION_SCHEDULER_GROUP = 'wc-push-notifications';
+
+	/**
 	 * Roles that can receive push notifications.
 	 *
 	 * This will be used to gate functionality access to just these roles.

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -33,6 +33,11 @@ class PushNotifications {
 	const FEATURE_NAME = 'push_notifications';
 
 	/**
+	 * ActionScheduler group for all push notification jobs.
+	 */
+	const ACTION_SCHEDULER_GROUP = 'wc-push-notifications';
+
+	/**
 	 * Roles that can receive push notifications.
 	 *
 	 * This will be used to gate functionality access to just these roles.

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushNotificati
 use Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\PendingNotificationStore;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewOrderNotificationTrigger;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotificationTrigger;
@@ -82,6 +83,7 @@ class PushNotifications {
 		( new NewReviewNotificationTrigger() )->register();
 
 		wc_get_container()->get( NotificationProcessor::class )->register();
+		wc_get_container()->get( NotificationRetryHandler::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -33,11 +33,6 @@ class PushNotifications {
 	const FEATURE_NAME = 'push_notifications';
 
 	/**
-	 * ActionScheduler group for all push notification jobs.
-	 */
-	const ACTION_SCHEDULER_GROUP = 'wc-push-notifications';
-
-	/**
 	 * Roles that can receive push notifications.
 	 *
 	 * This will be used to gate functionality access to just these roles.

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -170,6 +170,7 @@ class NotificationProcessor {
 		 */
 		if ( empty( $tokens ) ) {
 			$notification->write_meta( self::SENT_META_KEY );
+			$this->cancel_safety_net( $notification );
 			return true;
 		}
 
@@ -245,7 +246,7 @@ class NotificationProcessor {
 	 * @since 10.9.0
 	 */
 	private function cancel_safety_net( Notification $notification ): void {
-		as_unschedule_action(
+		as_unschedule_all_actions(
 			self::SAFETY_NET_HOOK,
 			array(
 				'type'        => $notification->get_type(),
@@ -282,13 +283,22 @@ class NotificationProcessor {
 			) + $extra;
 
 			$notification = Notification::from_array( $data );
+		} catch ( Exception $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Safety net failed: %s', $e->getMessage() ),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
 
+		try {
 			$this->process( $notification, true );
 		} catch ( Exception $e ) {
 			wc_get_logger()->error(
 				sprintf( 'Safety net failed: %s', $e->getMessage() ),
 				array( 'source' => PushNotifications::FEATURE_NAME )
 			);
+			$this->retry_handler->schedule( $notification, null, 0 );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -85,7 +85,7 @@ class NotificationProcessor {
 	 * @param WpcomNotificationDispatcher    $dispatcher          The WPCOM dispatcher.
 	 * @param PushTokensDataStore            $data_store          The push tokens data store.
 	 * @param NotificationPreferencesService $preferences_service The notification preferences service.
-	 * @param NotificationRetryHandler    $retry_handler The retry handler.
+	 * @param NotificationRetryHandler       $retry_handler The retry handler.
 	 *
 	 * @since 10.7.0
 	 */

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -71,6 +71,13 @@ class NotificationProcessor {
 	private NotificationPreferencesService $preferences_service;
 
 	/**
+	 * The retry handler.
+	 *
+	 * @var NotificationRetryHandler
+	 */
+	private NotificationRetryHandler $retry_handler;
+
+	/**
 	 * Initialize dependencies.
 	 *
 	 * @internal
@@ -78,17 +85,20 @@ class NotificationProcessor {
 	 * @param WpcomNotificationDispatcher    $dispatcher          The WPCOM dispatcher.
 	 * @param PushTokensDataStore            $data_store          The push tokens data store.
 	 * @param NotificationPreferencesService $preferences_service The notification preferences service.
+	 * @param NotificationRetryHandler    $retry_handler The retry handler.
 	 *
 	 * @since 10.7.0
 	 */
 	final public function init(
 		WpcomNotificationDispatcher $dispatcher,
 		PushTokensDataStore $data_store,
-		NotificationPreferencesService $preferences_service
+		NotificationPreferencesService $preferences_service,
+		NotificationRetryHandler $retry_handler
 	): void {
 		$this->dispatcher          = $dispatcher;
 		$this->data_store          = $data_store;
 		$this->preferences_service = $preferences_service;
+		$this->retry_handler = $retry_handler;
 	}
 
 	/**
@@ -107,11 +117,12 @@ class NotificationProcessor {
 	 *
 	 * @param Notification $notification The notification to process.
 	 * @param bool         $is_retry     Whether this is a retry or safety net attempt.
+	 * @param int          $attempt      The current attempt number (0 = first attempt).
 	 * @return bool True if successfully sent (or already sent).
 	 *
 	 * @since 10.7.0
 	 */
-	public function process( Notification $notification, bool $is_retry = false ): bool {
+	public function process( Notification $notification, bool $is_retry = false, int $attempt = 0 ): bool {
 		/**
 		 * This notification has already been sent - don't continue.
 		 */
@@ -167,13 +178,12 @@ class NotificationProcessor {
 		if ( ! empty( $result['success'] ) ) {
 			$notification->write_meta( self::SENT_META_KEY );
 			$notification->delete_meta( self::CLAIMED_META_KEY );
+			$this->cancel_safety_net( $notification );
 			return true;
 		}
 
-		/**
-		 * Retry scheduling and safety net deletion will be added here when
-		 * NotificationRetryHandler is added.
-		 */
+		$this->retry_handler->schedule( $notification, $result['retry_after'] ?? null, $attempt );
+		$this->cancel_safety_net( $notification );
 
 		return false;
 	}
@@ -220,6 +230,28 @@ class NotificationProcessor {
 					return $decision_cache[ $user_id ];
 				}
 			)
+		);
+	}
+
+	/**
+	 * Cancels the pending safety net ActionScheduler job for a notification.
+	 *
+	 * Called after the processor handles the notification (whether success or
+	 * failure with retry scheduled) so the safety net doesn't fire redundantly.
+	 *
+	 * @param Notification $notification The notification whose safety net to cancel.
+	 * @return void
+	 *
+	 * @since 10.9.0
+	 */
+	private function cancel_safety_net( Notification $notification ): void {
+		as_unschedule_action(
+			self::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $notification->get_resource_id(),
+			),
+			self::ACTION_SCHEDULER_GROUP
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -98,7 +98,7 @@ class NotificationProcessor {
 		$this->dispatcher          = $dispatcher;
 		$this->data_store          = $data_store;
 		$this->preferences_service = $preferences_service;
-		$this->retry_handler = $retry_handler;
+		$this->retry_handler       = $retry_handler;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -149,6 +149,7 @@ class NotificationProcessor {
 		 */
 		if ( empty( $tokens ) ) {
 			$notification->write_meta( self::SENT_META_KEY );
+			$this->cancel_safety_net( $notification );
 			return true;
 		}
 
@@ -179,7 +180,7 @@ class NotificationProcessor {
 	 * @since 10.8.0
 	 */
 	private function cancel_safety_net( Notification $notification ): void {
-		as_unschedule_action(
+		as_unschedule_all_actions(
 			self::SAFETY_NET_HOOK,
 			array(
 				'type'        => $notification->get_type(),
@@ -211,13 +212,22 @@ class NotificationProcessor {
 					'resource_id' => $resource_id,
 				)
 			);
+		} catch ( Exception $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Safety net failed: %s', $e->getMessage() ),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
 
+		try {
 			$this->process( $notification, true );
 		} catch ( Exception $e ) {
 			wc_get_logger()->error(
 				sprintf( 'Safety net failed: %s', $e->getMessage() ),
 				array( 'source' => PushNotifications::FEATURE_NAME )
 			);
+			$this->retry_handler->schedule( $notification, null, 0 );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -64,21 +64,31 @@ class NotificationProcessor {
 	private PushTokensDataStore $data_store;
 
 	/**
+	 * The retry handler.
+	 *
+	 * @var NotificationRetryHandler
+	 */
+	private NotificationRetryHandler $retry_handler;
+
+	/**
 	 * Initialize dependencies.
 	 *
 	 * @internal
 	 *
-	 * @param WpcomNotificationDispatcher $dispatcher The WPCOM dispatcher.
-	 * @param PushTokensDataStore         $data_store The push tokens data store.
+	 * @param WpcomNotificationDispatcher $dispatcher    The WPCOM dispatcher.
+	 * @param PushTokensDataStore         $data_store    The push tokens data store.
+	 * @param NotificationRetryHandler    $retry_handler The retry handler.
 	 *
 	 * @since 10.7.0
 	 */
 	final public function init(
 		WpcomNotificationDispatcher $dispatcher,
-		PushTokensDataStore $data_store
+		PushTokensDataStore $data_store,
+		NotificationRetryHandler $retry_handler
 	): void {
-		$this->dispatcher = $dispatcher;
-		$this->data_store = $data_store;
+		$this->dispatcher    = $dispatcher;
+		$this->data_store    = $data_store;
+		$this->retry_handler = $retry_handler;
 	}
 
 	/**
@@ -97,11 +107,12 @@ class NotificationProcessor {
 	 *
 	 * @param Notification $notification The notification to process.
 	 * @param bool         $is_retry     Whether this is a retry or safety net attempt.
+	 * @param int          $attempt      The current attempt number (0 = first attempt).
 	 * @return bool True if successfully sent (or already sent).
 	 *
 	 * @since 10.7.0
 	 */
-	public function process( Notification $notification, bool $is_retry = false ): bool {
+	public function process( Notification $notification, bool $is_retry = false, int $attempt = 0 ): bool {
 		/**
 		 * This notification has already been sent - don't continue.
 		 */
@@ -146,15 +157,36 @@ class NotificationProcessor {
 		if ( ! empty( $result['success'] ) ) {
 			$notification->write_meta( self::SENT_META_KEY );
 			$notification->delete_meta( self::CLAIMED_META_KEY );
+			$this->cancel_safety_net( $notification );
 			return true;
 		}
 
-		/**
-		 * Retry scheduling and safety net deletion will be added here when
-		 * NotificationRetryHandler is added.
-		 */
+		$this->retry_handler->schedule( $notification, $result['retry_after'] ?? null, $attempt );
+		$this->cancel_safety_net( $notification );
 
 		return false;
+	}
+
+	/**
+	 * Cancels the pending safety net ActionScheduler job for a notification.
+	 *
+	 * Called after the processor handles the notification (whether success or
+	 * failure with retry scheduled) so the safety net doesn't fire redundantly.
+	 *
+	 * @param Notification $notification The notification whose safety net to cancel.
+	 * @return void
+	 *
+	 * @since 10.8.0
+	 */
+	private function cancel_safety_net( Notification $notification ): void {
+		as_unschedule_action(
+			self::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $notification->get_resource_id(),
+			),
+			self::ACTION_SCHEDULER_GROUP
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -32,6 +32,13 @@ class NotificationRetryHandler {
 	const MAX_RETRIES = 4;
 
 	/**
+	 * Maximum retry delay in seconds (24 hours). If WPCOM requests a
+	 * Retry-After longer than this the notification is dropped — a push
+	 * notification arriving days late would be more confusing than helpful.
+	 */
+	const MAX_RETRY_DELAY = 86400;
+
+	/**
 	 * Backoff delays in seconds, indexed by attempt number (1-based).
 	 *
 	 * Attempt 1: 60s (1 minute)
@@ -73,9 +80,9 @@ class NotificationRetryHandler {
 	 * @since 10.8.0
 	 */
 	public function schedule( Notification $notification, ?int $retry_after, int $current_attempt ): void {
-		$next_attempt = $current_attempt + 1;
+		$next_attempt = max( 0, $current_attempt ) + 1;
 
-		if ( $next_attempt > self::MAX_RETRIES ) {
+		if ( $next_attempt > self::MAX_RETRIES || ! isset( self::BACKOFF_SCHEDULE[ $next_attempt ] ) ) {
 			wc_get_logger()->error(
 				sprintf(
 					'Push notification permanently failed after %d attempts (type=%s, resource_id=%d).',
@@ -89,6 +96,20 @@ class NotificationRetryHandler {
 		}
 
 		$delay = $retry_after ?? self::BACKOFF_SCHEDULE[ $next_attempt ];
+
+		if ( $delay > self::MAX_RETRY_DELAY ) {
+			wc_get_logger()->warning(
+				sprintf(
+					'Push notification dropped: retry delay %ds exceeds maximum %ds (type=%s, resource_id=%d).',
+					$delay,
+					self::MAX_RETRY_DELAY,
+					$notification->get_type(),
+					$notification->get_resource_id()
+				),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
 
 		as_schedule_single_action(
 			time() + $delay,

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -1,0 +1,139 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\PushNotifications\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\Notification;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Exception;
+
+/**
+ * Handles retry scheduling for failed WPCOM push notification sends.
+ *
+ * Uses ActionScheduler to schedule retries with exponential backoff.
+ * After all retry attempts are exhausted, logs a permanent failure.
+ *
+ * @since 10.8.0
+ */
+class NotificationRetryHandler {
+
+	/**
+	 * ActionScheduler hook for retry jobs.
+	 */
+	const RETRY_HOOK = 'wc_push_notification_retry';
+
+	/**
+	 * Maximum number of retries before giving up (5 total attempts including
+	 * the initial send).
+	 */
+	const MAX_RETRIES = 4;
+
+	/**
+	 * Backoff delays in seconds, indexed by attempt number (1-based).
+	 *
+	 * Attempt 1: 60s (1 minute)
+	 * Attempt 2: 300s (5 minutes)
+	 * Attempt 3: 900s (15 minutes)
+	 * Attempt 4: 3600s (60 minutes)
+	 *
+	 * @var array<int, int>
+	 */
+	const BACKOFF_SCHEDULE = array(
+		1 => 60,
+		2 => 300,
+		3 => 900,
+		4 => 3600,
+	);
+
+	/**
+	 * Registers the ActionScheduler hook for retry jobs.
+	 *
+	 * @return void
+	 *
+	 * @since 10.8.0
+	 */
+	public function register(): void {
+		add_action( self::RETRY_HOOK, array( $this, 'handle_retry' ), 10, 3 );
+	}
+
+	/**
+	 * Schedules a retry for a failed notification send.
+	 *
+	 * If the maximum number of retries has been reached, logs a permanent
+	 * failure instead of scheduling another attempt.
+	 *
+	 * @param Notification $notification    The notification that failed.
+	 * @param int|null     $retry_after     Optional Retry-After value from WPCOM (seconds).
+	 * @param int          $current_attempt The attempt number that just failed (0-based).
+	 * @return void
+	 *
+	 * @since 10.8.0
+	 */
+	public function schedule( Notification $notification, ?int $retry_after, int $current_attempt ): void {
+		$next_attempt = $current_attempt + 1;
+
+		if ( $next_attempt > self::MAX_RETRIES ) {
+			wc_get_logger()->error(
+				sprintf(
+					'Push notification permanently failed after %d attempts (type=%s, resource_id=%d).',
+					$next_attempt,
+					$notification->get_type(),
+					$notification->get_resource_id()
+				),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
+
+		$delay = $retry_after ?? self::BACKOFF_SCHEDULE[ $next_attempt ];
+
+		as_schedule_single_action(
+			time() + $delay,
+			self::RETRY_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $notification->get_resource_id(),
+				'attempt'     => $next_attempt,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+	}
+
+	/**
+	 * ActionScheduler callback for retry jobs.
+	 *
+	 * Reconstructs the notification from the stored type and resource ID,
+	 * then delegates to the processor with is_retry=true.
+	 *
+	 * @param string $type        The notification type.
+	 * @param int    $resource_id The resource ID.
+	 * @param int    $attempt     The current retry attempt number (1-based).
+	 * @return void
+	 *
+	 * @since 10.8.0
+	 */
+	public function handle_retry( string $type, int $resource_id, int $attempt ): void {
+		try {
+			$notification = Notification::from_array(
+				array(
+					'type'        => $type,
+					'resource_id' => $resource_id,
+				)
+			);
+
+			wc_get_container()->get( NotificationProcessor::class )->process(
+				$notification,
+				true,
+				$attempt
+			);
+		} catch ( Exception $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Retry failed: %s', $e->getMessage() ),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -123,7 +123,15 @@ class NotificationRetryHandler {
 					'resource_id' => $resource_id,
 				)
 			);
+		} catch ( Exception $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Retry failed: %s', $e->getMessage() ),
+				array( 'source' => PushNotifications::FEATURE_NAME )
+			);
+			return;
+		}
 
+		try {
 			wc_get_container()->get( NotificationProcessor::class )->process(
 				$notification,
 				true,
@@ -134,6 +142,7 @@ class NotificationRetryHandler {
 				sprintf( 'Retry failed: %s', $e->getMessage() ),
 				array( 'source' => PushNotifications::FEATURE_NAME )
 			);
+			$this->schedule( $notification, null, $attempt );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationRetryHandler.php
@@ -98,7 +98,8 @@ class NotificationRetryHandler {
 				'resource_id' => $notification->get_resource_id(),
 				'attempt'     => $next_attempt,
 			),
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+			NotificationProcessor::ACTION_SCHEDULER_GROUP,
+			true
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -139,7 +139,8 @@ class PendingNotificationStore {
 			time() + NotificationProcessor::SAFETY_NET_DELAY,
 			NotificationProcessor::SAFETY_NET_HOOK,
 			$args,
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+			NotificationProcessor::ACTION_SCHEDULER_GROUP,
+			true
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/PendingNotificationStore.php
@@ -133,7 +133,8 @@ class PendingNotificationStore {
 			time() + NotificationProcessor::SAFETY_NET_DELAY,
 			NotificationProcessor::SAFETY_NET_HOOK,
 			$args,
-			NotificationProcessor::ACTION_SCHEDULER_GROUP
+			NotificationProcessor::ACTION_SCHEDULER_GROUP,
+			true
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/helpers/LoggerSpyTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/LoggerSpyTrait.php
@@ -41,6 +41,16 @@ trait LoggerSpyTrait {
 		$this->captured_logs = array();
 		$this->spy_logger    = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
 
+		$capture = function ( $level ) {
+			return function ( $message, $context = array() ) use ( $level ) {
+				$this->captured_logs[] = array(
+					'level'   => $level,
+					'message' => $message,
+					'context' => $context,
+				);
+			};
+		};
+
 		$this->spy_logger->method( 'log' )->willReturnCallback(
 			function ( $level, $message, $context = array() ) {
 				$this->captured_logs[] = array(
@@ -50,6 +60,10 @@ trait LoggerSpyTrait {
 				);
 			}
 		);
+
+		foreach ( array( 'emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug' ) as $level ) {
+			$this->spy_logger->method( $level )->willReturnCallback( $capture( $level ) );
+		}
 
 		add_filter( 'woocommerce_logging_class', array( $this, 'get_spy_logger' ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use WC_Helper_Product;
+use WC_Logger_Interface;
 use WC_Unit_Test_Case;
 
 /**
@@ -548,7 +549,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	 * @testdox Should catch and log exception when safety net receives an unknown type.
 	 */
 	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
-		$mock_logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$mock_logger = $this->createMock( WC_Logger_Interface::class );
 		$mock_logger->expects( $this->once() )
 			->method( 'error' )
 			->with(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Notifications\StockNotific
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use WC_Helper_Product;
 use WC_Logger_Interface;
 use WC_Unit_Test_Case;
@@ -52,6 +53,13 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	private $preferences_service;
 
 	/**
+	 * Mock retry handler.
+	 *
+	 * @var NotificationRetryHandler
+	 */
+	private $retry_handler;
+
+	/**
 	 * A test order ID.
 	 *
 	 * @var int
@@ -67,10 +75,11 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher          = $this->createMock( WpcomNotificationDispatcher::class );
 		$this->data_store          = $this->createMock( PushTokensDataStore::class );
 		$this->preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$this->retry_handler       = $this->createMock( NotificationRetryHandler::class );
 		$this->order_id            = wc_create_order( array( 'status' => 'processing' ) )->get_id();
 
 		$this->sut = new NotificationProcessor();
-		$this->sut->init( $this->dispatcher, $this->data_store, $this->preferences_service );
+		$this->sut->init( $this->dispatcher, $this->data_store, $this->preferences_service, $this->retry_handler );
 
 		// By default every user has every notification type enabled, so existing
 		// tests behave as before. Per-user/per-type filtering is exercised in
@@ -234,7 +243,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $data_store, $this->preferences_service );
+		$sut->init( $this->dispatcher, $data_store, $this->preferences_service, $this->retry_handler );
 
 		$notification = new NewOrderNotification( $this->order_id );
 		$result       = $sut->process( $notification );
@@ -261,7 +270,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		$notification = new NewOrderNotification( $this->order_id );
 		$result       = $sut->process( $notification );
@@ -332,7 +341,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			);
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $data_store, $preferences_service, $this->retry_handler );
 
 		$notification = new NewOrderNotification( $this->order_id );
 		$result       = $sut->process( $notification );
@@ -363,7 +372,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			);
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		// store_order is enabled — should dispatch.
 		$order_notification = new NewOrderNotification( $this->order_id );
@@ -443,7 +452,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			);
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $data_store, $preferences_service, $this->retry_handler );
 
 		$this->assertTrue( $sut->process( new NewOrderNotification( $this->order_id ) ) );
 	}
@@ -491,7 +500,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		$result = $sut->process( $notification );
 
@@ -546,6 +555,143 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should schedule retry via handler on dispatch failure.
+	 */
+	public function test_process_schedules_retry_on_failure(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => 120,
+			)
+		);
+
+		$this->retry_handler->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				$this->isInstanceOf( NewOrderNotification::class ),
+				$this->equalTo( 120 ),
+				$this->equalTo( 0 )
+			);
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification );
+	}
+
+	/**
+	 * @testdox Should pass attempt number through to retry handler on failure.
+	 */
+	public function test_process_passes_attempt_to_retry_handler(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => null,
+			)
+		);
+
+		$this->retry_handler->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( 3 )
+			);
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification, true, 3 );
+	}
+
+	/**
+	 * @testdox Should cancel safety net after successful dispatch.
+	 */
+	public function test_process_cancels_safety_net_on_success(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$notification = new NewOrderNotification( $this->order_id );
+
+		as_schedule_single_action(
+			time() + NotificationProcessor::SAFETY_NET_DELAY,
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->sut->process( $notification );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'Safety net should be cancelled after successful send.' );
+	}
+
+	/**
+	 * @testdox Should cancel safety net after failed dispatch with retry scheduled.
+	 */
+	public function test_process_cancels_safety_net_on_failure(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => null,
+			)
+		);
+
+		$notification = new NewOrderNotification( $this->order_id );
+
+		as_schedule_single_action(
+			time() + NotificationProcessor::SAFETY_NET_DELAY,
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->sut->process( $notification );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'Safety net should be cancelled when retry is scheduled.' );
+	}
+
+	/**
+	 * @testdox Should not schedule retry on successful dispatch.
+	 */
+	public function test_process_does_not_retry_on_success(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$this->retry_handler->expects( $this->never() )->method( 'schedule' );
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification );
+	}
+
+	/**
 	 * @testdox Should catch and log exception when safety net receives an unknown type.
 	 */
 	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
@@ -589,7 +735,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		$notification = new NewOrderNotification( $order->get_id() );
 		$result       = $sut->process( $notification );
@@ -625,7 +771,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		$notification = new NewReviewNotification( $comment_id );
 		$result       = $sut->process( $notification );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -948,7 +948,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $this->data_store, $preferences_service );
+		$sut->init( $this->dispatcher, $this->data_store, $preferences_service, $this->retry_handler );
 
 		$notification = new StockNotification( $product->get_id(), StockNotification::EVENT_LOW_STOCK );
 		$result       = $sut->process( $notification );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -545,6 +545,28 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should catch and log exception when safety net receives an unknown type.
+	 */
+	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
+		$mock_logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				$this->stringContains( 'Safety net failed:' ),
+				$this->equalTo( array( 'source' => PushNotifications::FEATURE_NAME ) )
+			);
+
+		$logger_override = fn () => $mock_logger;
+		add_filter( 'woocommerce_logging_class', $logger_override );
+
+		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$this->sut->handle_safety_net( 'unknown_type', 1 );
+
+		remove_filter( 'woocommerce_logging_class', $logger_override );
+	}
+
+	/**
 	 * @testdox Should skip dispatch when the order total is below the user's min_amount threshold.
 	 */
 	public function test_process_skips_dispatch_when_order_below_min_amount(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -15,14 +15,16 @@ use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 use WC_Helper_Product;
-use WC_Logger_Interface;
 use WC_Unit_Test_Case;
 
 /**
  * Tests for the NotificationProcessor class.
  */
 class NotificationProcessorTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
 
 	/**
 	 * The System Under Test.
@@ -695,22 +697,11 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	 * @testdox Should catch and log exception when safety net receives an unknown type.
 	 */
 	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
-		$mock_logger = $this->createMock( WC_Logger_Interface::class );
-		$mock_logger->expects( $this->once() )
-			->method( 'error' )
-			->with(
-				$this->stringContains( 'Safety net failed:' ),
-				$this->equalTo( array( 'source' => PushNotifications::FEATURE_NAME ) )
-			);
-
-		$logger_override = fn () => $mock_logger;
-		add_filter( 'woocommerce_logging_class', $logger_override );
-
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$this->sut->handle_safety_net( 'unknown_type', 1 );
 
-		remove_filter( 'woocommerce_logging_class', $logger_override );
+		$this->assertLogged( 'error', 'Safety net failed:', array( 'source' => PushNotifications::FEATURE_NAME ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -12,14 +12,16 @@ use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNot
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 use WC_Helper_Product;
-use WC_Logger_Interface;
 use WC_Unit_Test_Case;
 
 /**
  * Tests for the NotificationProcessor class.
  */
 class NotificationProcessorTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
 
 	/**
 	 * The System Under Test.
@@ -413,21 +415,10 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	 * @testdox Should catch and log exception when safety net receives an unknown type.
 	 */
 	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
-		$mock_logger = $this->createMock( WC_Logger_Interface::class );
-		$mock_logger->expects( $this->once() )
-			->method( 'error' )
-			->with(
-				$this->stringContains( 'Safety net failed:' ),
-				$this->equalTo( array( 'source' => PushNotifications::FEATURE_NAME ) )
-			);
-
-		$logger_override = fn () => $mock_logger;
-		add_filter( 'woocommerce_logging_class', $logger_override );
-
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$this->sut->handle_safety_net( 'unknown_type', 1 );
 
-		remove_filter( 'woocommerce_logging_class', $logger_override );
+		$this->assertLogged( 'error', 'Safety net failed:', array( 'source' => PushNotifications::FEATURE_NAME ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNot
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use WC_Helper_Product;
+use WC_Logger_Interface;
 use WC_Unit_Test_Case;
 
 /**
@@ -266,7 +267,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	 * @testdox Should catch and log exception when safety net receives an unknown type.
 	 */
 	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
-		$mock_logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$mock_logger = $this->createMock( WC_Logger_Interface::class );
 		$mock_logger->expects( $this->once() )
 			->method( 'error' )
 			->with(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -261,4 +261,26 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 
 		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
 	}
+
+	/**
+	 * @testdox Should catch and log exception when safety net receives an unknown type.
+	 */
+	public function test_handle_safety_net_logs_error_for_unknown_type(): void {
+		$mock_logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				$this->stringContains( 'Safety net failed:' ),
+				$this->equalTo( array( 'source' => PushNotifications::FEATURE_NAME ) )
+			);
+
+		$logger_override = fn () => $mock_logger;
+		add_filter( 'woocommerce_logging_class', $logger_override );
+
+		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$this->sut->handle_safety_net( 'unknown_type', 1 );
+
+		remove_filter( 'woocommerce_logging_class', $logger_override );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNoti
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewReviewNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use WC_Helper_Product;
 use WC_Logger_Interface;
 use WC_Unit_Test_Case;
@@ -42,6 +43,13 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	private $data_store;
 
 	/**
+	 * Mock retry handler.
+	 *
+	 * @var NotificationRetryHandler
+	 */
+	private $retry_handler;
+
+	/**
 	 * A test order ID.
 	 *
 	 * @var int
@@ -54,12 +62,13 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->dispatcher = $this->createMock( WpcomNotificationDispatcher::class );
-		$this->data_store = $this->createMock( PushTokensDataStore::class );
-		$this->order_id   = wc_create_order( array( 'status' => 'processing' ) )->get_id();
+		$this->dispatcher    = $this->createMock( WpcomNotificationDispatcher::class );
+		$this->data_store    = $this->createMock( PushTokensDataStore::class );
+		$this->retry_handler = $this->createMock( NotificationRetryHandler::class );
+		$this->order_id      = wc_create_order( array( 'status' => 'processing' ) )->get_id();
 
 		$this->sut = new NotificationProcessor();
-		$this->sut->init( $this->dispatcher, $this->data_store );
+		$this->sut->init( $this->dispatcher, $this->data_store, $this->retry_handler );
 
 		$this->data_store->method( 'get_tokens_for_roles' )->willReturn(
 			array(
@@ -204,7 +213,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$this->dispatcher->expects( $this->never() )->method( 'dispatch' );
 
 		$sut = new NotificationProcessor();
-		$sut->init( $this->dispatcher, $data_store );
+		$sut->init( $this->dispatcher, $data_store, $this->retry_handler );
 
 		$notification = new NewOrderNotification( $this->order_id );
 		$result       = $sut->process( $notification );
@@ -261,6 +270,143 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 		$order = wc_get_order( $this->order_id );
 
 		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Should schedule retry via handler on dispatch failure.
+	 */
+	public function test_process_schedules_retry_on_failure(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => 120,
+			)
+		);
+
+		$this->retry_handler->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				$this->isInstanceOf( NewOrderNotification::class ),
+				$this->equalTo( 120 ),
+				$this->equalTo( 0 )
+			);
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification );
+	}
+
+	/**
+	 * @testdox Should pass attempt number through to retry handler on failure.
+	 */
+	public function test_process_passes_attempt_to_retry_handler(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => null,
+			)
+		);
+
+		$this->retry_handler->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( 3 )
+			);
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification, true, 3 );
+	}
+
+	/**
+	 * @testdox Should cancel safety net after successful dispatch.
+	 */
+	public function test_process_cancels_safety_net_on_success(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$notification = new NewOrderNotification( $this->order_id );
+
+		as_schedule_single_action(
+			time() + NotificationProcessor::SAFETY_NET_DELAY,
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->sut->process( $notification );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'Safety net should be cancelled after successful send.' );
+	}
+
+	/**
+	 * @testdox Should cancel safety net after failed dispatch with retry scheduled.
+	 */
+	public function test_process_cancels_safety_net_on_failure(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => null,
+			)
+		);
+
+		$notification = new NewOrderNotification( $this->order_id );
+
+		as_schedule_single_action(
+			time() + NotificationProcessor::SAFETY_NET_DELAY,
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => $notification->get_type(),
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->sut->process( $notification );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationProcessor::SAFETY_NET_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'Safety net should be cancelled when retry is scheduled.' );
+	}
+
+	/**
+	 * @testdox Should not schedule retry on successful dispatch.
+	 */
+	public function test_process_does_not_retry_on_success(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$this->retry_handler->expects( $this->never() )->method( 'schedule' );
+
+		$notification = new NewOrderNotification( $this->order_id );
+		$this->sut->process( $notification );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificat
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationPreferencesService;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
 use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
 use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
@@ -196,9 +197,14 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 	 * @testdox Should delegate to NotificationProcessor with is_retry and attempt on retry callback.
 	 */
 	public function test_handle_retry_delegates_to_processor(): void {
-		$dispatcher    = $this->createMock( WpcomNotificationDispatcher::class );
-		$data_store    = $this->createMock( PushTokensDataStore::class );
-		$retry_handler = $this->createMock( NotificationRetryHandler::class );
+		$dispatcher          = $this->createMock( WpcomNotificationDispatcher::class );
+		$data_store          = $this->createMock( PushTokensDataStore::class );
+		$preferences_service = $this->createMock( NotificationPreferencesService::class );
+		$retry_handler       = $this->createMock( NotificationRetryHandler::class );
+
+		$preferences_service->method( 'get_preferences' )->willReturn(
+			array( 'store_order' => array( 'enabled' => true ) )
+		);
 
 		$dispatcher->expects( $this->once() )->method( 'dispatch' )->willReturn(
 			array(
@@ -223,7 +229,7 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 		);
 
 		$processor = new NotificationProcessor();
-		$processor->init( $dispatcher, $data_store, $retry_handler );
+		$processor->init( $dispatcher, $data_store, $preferences_service, $retry_handler );
 		wc_get_container()->replace( NotificationProcessor::class, $processor );
 
 		$this->sut->handle_retry( 'store_order', $this->order_id, 2 );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -128,6 +128,71 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should clamp a negative current_attempt to zero and schedule attempt 1.
+	 */
+	public function test_schedule_clamps_negative_attempt(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, null, -3 );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => 1,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertNotFalse( $scheduled, 'A retry action should be scheduled for attempt 1.' );
+		$this->assertEqualsWithDelta( time() + 60, $scheduled, 2, 'Retry should use the attempt-1 backoff delay.' );
+	}
+
+	/**
+	 * @testdox Should drop notification and log warning when retry delay exceeds the 24-hour cap.
+	 */
+	public function test_schedule_drops_notification_when_retry_after_exceeds_max(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, NotificationRetryHandler::MAX_RETRY_DELAY + 1, 0 );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => 1,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'No retry should be scheduled when delay exceeds maximum.' );
+		$this->assertLogged( 'warning', 'retry delay', array( 'source' => PushNotifications::FEATURE_NAME ) );
+	}
+
+	/**
+	 * @testdox Should schedule retry when retry delay equals the 24-hour cap exactly.
+	 */
+	public function test_schedule_allows_retry_at_max_delay(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, NotificationRetryHandler::MAX_RETRY_DELAY, 0 );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => 1,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertNotFalse( $scheduled, 'A retry should be scheduled when delay equals the maximum.' );
+	}
+
+	/**
 	 * @testdox Should delegate to NotificationProcessor with is_retry and attempt on retry callback.
 	 */
 	public function test_handle_retry_delegates_to_processor(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Services;
+
+use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore;
+use Automattic\WooCommerce\Internal\PushNotifications\Dispatchers\WpcomNotificationDispatcher;
+use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
+use Automattic\WooCommerce\Internal\PushNotifications\Notifications\NewOrderNotification;
+use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationProcessor;
+use Automattic\WooCommerce\Internal\PushNotifications\Services\NotificationRetryHandler;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the NotificationRetryHandler class.
+ */
+class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var NotificationRetryHandler
+	 */
+	private $sut;
+
+	/**
+	 * A test order ID.
+	 *
+	 * @var int
+	 */
+	private int $order_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut      = new NotificationRetryHandler();
+		$this->order_id = wc_create_order( array( 'status' => 'processing' ) )->get_id();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		as_unschedule_all_actions( NotificationRetryHandler::RETRY_HOOK );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should schedule retry with default backoff delay for attempt $attempt.
+	 * @testWith [0, 1, 60]
+	 *           [1, 2, 300]
+	 *           [2, 3, 900]
+	 *           [3, 4, 3600]
+	 *
+	 * @param int $current_attempt The attempt that just failed.
+	 * @param int $expected_next   The expected next attempt number in the AS args.
+	 * @param int $expected_delay  The expected delay in seconds.
+	 */
+	public function test_schedule_uses_default_backoff( int $current_attempt, int $expected_next, int $expected_delay ): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, null, $current_attempt );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => $expected_next,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertNotFalse( $scheduled, 'A retry action should be scheduled.' );
+		$this->assertEqualsWithDelta( time() + $expected_delay, $scheduled, 2, 'Retry should be scheduled with the correct backoff delay.' );
+	}
+
+	/**
+	 * @testdox Should use Retry-After value when provided instead of default backoff.
+	 */
+	public function test_schedule_respects_retry_after(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, 120, 0 );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => 1,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertNotFalse( $scheduled );
+		$this->assertEqualsWithDelta( time() + 120, $scheduled, 2, 'Retry should use the Retry-After delay.' );
+	}
+
+	/**
+	 * @testdox Should log permanent failure and not schedule when max retries exceeded.
+	 */
+	public function test_schedule_logs_permanent_failure_after_max_retries(): void {
+		$notification = new NewOrderNotification( $this->order_id );
+
+		$this->sut->schedule( $notification, null, NotificationRetryHandler::MAX_RETRIES );
+
+		$scheduled = as_next_scheduled_action(
+			NotificationRetryHandler::RETRY_HOOK,
+			array(
+				'type'        => 'store_order',
+				'resource_id' => $this->order_id,
+				'attempt'     => NotificationRetryHandler::MAX_RETRIES + 1,
+			),
+			NotificationProcessor::ACTION_SCHEDULER_GROUP
+		);
+
+		$this->assertFalse( $scheduled, 'No retry should be scheduled after max retries.' );
+		$this->assertLogged( 'error', 'permanently failed after 5 attempts', array( 'source' => PushNotifications::FEATURE_NAME ) );
+	}
+
+	/**
+	 * @testdox Should delegate to NotificationProcessor with is_retry and attempt on retry callback.
+	 */
+	public function test_handle_retry_delegates_to_processor(): void {
+		$dispatcher    = $this->createMock( WpcomNotificationDispatcher::class );
+		$data_store    = $this->createMock( PushTokensDataStore::class );
+		$retry_handler = $this->createMock( NotificationRetryHandler::class );
+
+		$dispatcher->expects( $this->once() )->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$data_store->method( 'get_tokens_for_roles' )->willReturn(
+			array(
+				new PushToken(
+					array(
+						'user_id'       => 1,
+						'token'         => 'test-token',
+						'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+						'platform'      => PushToken::PLATFORM_APPLE,
+						'device_locale' => 'en_US',
+						'device_uuid'   => 'test-uuid',
+					)
+				),
+			)
+		);
+
+		$processor = new NotificationProcessor();
+		$processor->init( $dispatcher, $data_store, $retry_handler );
+		wc_get_container()->get( NotificationProcessor::class )->init( $dispatcher, $data_store, $retry_handler );
+
+		$this->sut->handle_retry( 'store_order', $this->order_id, 2 );
+
+		$order = wc_get_order( $this->order_id );
+		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+	}
+
+	/**
+	 * @testdox Should catch and log exception when retry receives an unknown type.
+	 */
+	public function test_handle_retry_logs_error_for_unknown_type(): void {
+		$this->sut->handle_retry( 'unknown_type', 1, 1 );
+
+		$this->assertLogged( 'error', 'Retry failed:', array( 'source' => PushNotifications::FEATURE_NAME ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationRetryHandlerTest.php
@@ -224,12 +224,14 @@ class NotificationRetryHandlerTest extends WC_Unit_Test_Case {
 
 		$processor = new NotificationProcessor();
 		$processor->init( $dispatcher, $data_store, $retry_handler );
-		wc_get_container()->get( NotificationProcessor::class )->init( $dispatcher, $data_store, $retry_handler );
+		wc_get_container()->replace( NotificationProcessor::class, $processor );
 
 		$this->sut->handle_retry( 'store_order', $this->order_id, 2 );
 
 		$order = wc_get_order( $this->order_id );
 		$this->assertNotEmpty( $order->get_meta( NotificationProcessor::SENT_META_KEY ) );
+
+		$this->reset_container_replacements();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
**Focus**: WooCommerce-driven Push Notifications
**Team**: Apps Infrastructure
**Relates to**: AINFRA-1800
**Roadmap**: [ROADMAP.md](https://github.com/woocommerce/woocommerce/blob/293189544c9eb8353b4d46027424dbfe28fde461/plugins/woocommerce/src/Internal/PushNotifications/ROADMAP.md) or paaHJt-9vT-p2

Apps Infrastructure are currently working with Kiwi to allow WooCommerce instances to trigger their own push notifications, rather than relying on Jetpack Sync. This change adds the failure handling/retry functionality, which ensures failed requests to WordPress.com are attempted up to 5 times (total - initial attempt + 4 retries).

**Key requirements:**
* Add `NotificationRetryHandler`, which schedules retries for failed attempts, and processed retries
* Wire `NotificationRetryHandler` up to the `NotificationProcessor`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
These new files are not yet used so there is no new functionality to test, however you can run through some regression test steps. My suggested steps are below.

#### Prerequisites

**Before testing, ensure:**
- You have a WooCommerce site with Jetpack Connection package installed and connected (I couldn't find a way to connect without installing the full Jetpack plugin, but I think they're working on that)
- Replace the WooCommerce core files with the files from this PR
- You have at least 1 test user with `shop_manager` or `administrator` roles
- You have enabled the feature (see below)
- You have registered an iOS* token with your WooCommerce site (see below) - the current version of the iOS app supports remote notifications, Android does not
- **IMPORTANT:** If you have Jetpack Sync installed (via the Jetpack plugin), then also disable it or you won't know if Woo or Jetpack Sync is sending the notifications. I had to install Jetpack, connect, and then deactivate it to get to the right state

**Enabling/Disabling the Feature:**
The push notifications feature is controlled by the FeaturesController and requires both the feature flag to be
enabled AND Jetpack to be connected.
```
update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );
```

**Registering a Token:**
You can find your token by finding the most recently active token on [this page](https://mc.a8c.com/mobile/push-notifications/) for WooCommerce iOS, then using this cURL example to send it to your site:
```
curl --location 'https://YOUR_TEST_SITE_HERE/wp-json/wc-push-notifications/push-tokens' \
	--header 'Accept: application/json' \
	--header 'Authorization: YOUR_BASIC_AUTH_TOKEN_HERE' \
	--form 'token="YOUR_TOKEN_HERE"' \
	--form 'platform="apple"' \
	--form 'device_uuid="ABCDEF-123ABC-DEF123-ABCDE81"' \
	--form 'origin="com.automattic.woocommerce"' \
	--form 'metadata[app_version]="1.0"' \
	--form 'device_locale="en_US"'
```

#### Testing steps

1. Add an `mu-plugin` that simulates failures for requests to WPCOM, feel free to play around with the response code:
  ```
  <?php
  add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
      // Match the WPCOM push notification endpoint.
      if ( strpos( $url, 'push-notification' ) === false ) {
          return $preempt;
      }

      // Simulate a 429 with Retry-After header.
      return array(
          'response' => array( 'code' => 429, 'message' => 'Too Many Requests' ),
          'headers'  => array( 'retry-after' => '30' ),
          'body'     => '',
      );
  }, 10, 3 );
```
2. Place an order on your store
3. Observe the retries (methods below)
4. Leave a review on a product on your store
5. Observe the retries (methods below)
6. Optionally retry the above steps but remove the `mu-plugin` mid-way through to mimic a send that fails and then succeeds

**Observing Retries**
You can observe retries via:
  - wp action-scheduler list --hook=wc_push_notification_retry --group=wc-push-notifications to see scheduled retries and their
  timestamps
  - The WooCommerce logs (wc-push-notifications source) for retry attempts and eventual permanent failure
  - The ActionScheduler admin panel at Tools > Scheduled Actions


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an internal library, and is not yet complete.

</details>
