### PR TITLE
Fix fatal error on shop page when Product Filters block references deleted attribute

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filter-deleted-attribute-fatal
+++ b/plugins/woocommerce/changelog/fix-product-filter-deleted-attribute-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error on shop page when a product attribute taxonomy used in Product Filters block is deleted.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53733,17 +53733,6 @@ parameters:
 			count: 1
 			path: src/Blocks/BlockTypes/ProductFilterAttribute.php
 
-		-
-			message: '#^Cannot access property \$name on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/Blocks/BlockTypes/ProductFilterAttribute.php
-
-		-
-			message: '#^Cannot access property \$slug on stdClass\|null\.$#'
-			identifier: property.nonObject
-			count: 5
-			path: src/Blocks/BlockTypes/ProductFilterAttribute.php
 
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductFilterAttribute\:\:delete_default_attribute_id_transient\(\) has no return type specified\.$#'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -152,10 +152,15 @@ final class ProductFilterAttribute extends AbstractBlock {
 		}
 
 		$product_attribute = wc_get_attribute( $block_attributes['attributeId'] );
-		$attribute_counts  = $this->get_attribute_counts( $block, $product_attribute->slug, $block_attributes['queryType'] );
-		$hide_empty        = $block_attributes['hideEmpty'] ?? true;
-		$orderby           = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
-		$order             = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
+
+		if ( ! $product_attribute ) {
+			return '';
+		}
+
+		$attribute_counts = $this->get_attribute_counts( $block, $product_attribute->slug, $block_attributes['queryType'] );
+		$hide_empty       = $block_attributes['hideEmpty'] ?? true;
+		$orderby          = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
+		$order            = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
 
 		$args = array(
 			'taxonomy' => $product_attribute->slug,

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterAttributeTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterAttributeTest.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+/**
+ * Tests for the ProductFilterAttribute block type.
+ */
+class ProductFilterAttributeTest extends \WP_UnitTestCase {
+
+	/**
+	 * Test that rendering returns empty string when the attribute ID references a deleted taxonomy.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/63791
+	 */
+	public function test_render_returns_empty_for_deleted_attribute() {
+		$non_existent_attribute_id = 999999;
+
+		$block_markup = sprintf(
+			'<!-- wp:woocommerce/product-filter-attribute {"attributeId":%d,"queryType":"or","sortOrder":"name-asc"} -->
+			<div class="wp-block-woocommerce-product-filter-attribute"></div>
+			<!-- /wp:woocommerce/product-filter-attribute -->',
+			$non_existent_attribute_id
+		);
+
+		$blocks = parse_blocks( $block_markup );
+		$output = render_block( $blocks[0] );
+
+		$this->assertSame( '', $output );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`wc_get_attribute()` returns `null` for deleted attributes. `ProductFilterAttribute::render()` accesses `->slug` on it without null check → fatal error (HTTP 500) on shop pages.

Fix: early return `''` when attribute doesn't exist.

Kudos @bhavz-10 for the great investigation!

Closes #63791.

### How to test the changes in this Pull Request:

1. Create two product attributes, assign to products
2. Add Product Filters block to Product Catalog template with both attributes
3. Delete one attribute from Products → Attributes
4. Visit shop page → should load without error, deleted filter simply absent

### Testing that has already taken place:

PHPStan + PHPCS clean. Regression test added.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

> Changelog entry created manually.