### PR TITLE
Fix address autocomplete branding logo not rendering in block checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-address-autocomplete-branding-logo
+++ b/plugins/woocommerce/changelog/fix-address-autocomplete-branding-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix address autocomplete branding logo not rendering in block checkout due to sanitizeHTML stripping img tags

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
@@ -118,25 +118,11 @@ export const Suggestions = ( {
 					className="woocommerce-address-autocomplete-branding"
 					dangerouslySetInnerHTML={ {
 						__html: sanitizeHTML( branding, {
-							tags: [
-								'a',
-								'b',
-								'em',
-								'i',
-								'strong',
-								'p',
-								'br',
-								'abbr',
-								'img',
-								'span',
-							],
+							tags: [ 'a', 'img', 'span', 'br' ],
 							attr: [
-								'target',
 								'href',
+								'target',
 								'rel',
-								'name',
-								'download',
-								'title',
 								'src',
 								'alt',
 								'style',

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
@@ -117,7 +117,10 @@ export const Suggestions = ( {
 				<div
 					className="woocommerce-address-autocomplete-branding"
 					dangerouslySetInnerHTML={ {
-						__html: sanitizeHTML( branding ),
+						__html: sanitizeHTML( branding, {
+							tags: [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br', 'abbr', 'img', 'span' ],
+							attr: [ 'target', 'href', 'rel', 'name', 'download', 'title', 'src', 'alt', 'style', 'width', 'height' ],
+						} ),
 					} }
 				/>
 			) : null }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/suggestions.tsx
@@ -118,8 +118,31 @@ export const Suggestions = ( {
 					className="woocommerce-address-autocomplete-branding"
 					dangerouslySetInnerHTML={ {
 						__html: sanitizeHTML( branding, {
-							tags: [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br', 'abbr', 'img', 'span' ],
-							attr: [ 'target', 'href', 'rel', 'name', 'download', 'title', 'src', 'alt', 'style', 'width', 'height' ],
+							tags: [
+								'a',
+								'b',
+								'em',
+								'i',
+								'strong',
+								'p',
+								'br',
+								'abbr',
+								'img',
+								'span',
+							],
+							attr: [
+								'target',
+								'href',
+								'rel',
+								'name',
+								'download',
+								'title',
+								'src',
+								'alt',
+								'style',
+								'width',
+								'height',
+							],
 						} ),
 					} }
 				/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes WOOPRD-3297
The "Powered by Google" branding logo in the address autocomplete dropdown does not render on block checkout. The branding HTML from the address provider contains an `<img>` tag, but `sanitizeHTML()` in `suggestions.tsx` was called with no config, falling back to `DEFAULT_ALLOWED_TAGS` which does not include `img`. DOMPurify strips the `<img>` tag entirely, leaving only "Powered by " text with no logo.

The shortcode checkout does not have this issue because its `address-autocomplete.js` uses DOMPurify directly with a permissive config that explicitly allows `img`, `src`, `alt`, and `style`.

The fix passes a custom sanitization config to `sanitizeHTML()` that includes `img` and `span` in allowed tags, and `src`, `alt`, `style`, `width`, `height` in allowed attributes.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|<img width="833" height="308" alt="image" src="https://github.com/user-attachments/assets/9894801c-3aba-48e6-b3b2-b53363316bab" />|<img width="833" height="312" alt="image" src="https://github.com/user-attachments/assets/fb195686-dde8-4d86-8ea7-b2d6373f66aa" />|

### How to test the changes in this Pull Request:

1. Enable address autocomplete on a store with a registered address provider (WooPayment, CIAB) or use this plugin 
[test-address-provider.zip](https://github.com/user-attachments/files/26436593/test-address-provider.zip).
2. Go to the **block checkout** page.
3. Start typing an address in the shipping or billing address field.
4. Verify that the "Powered by Google" logo (not just text) appears at the bottom of the autocomplete suggestions dropdown.

### Testing that has already taken place:

Manually verified on a Commerce Garden site using block checkout that the `<img>` tag was being stripped by `sanitizeHTML()` with default config. Confirmed the branding HTML arrives intact from the server (verified via `addressAutocompleteProviders` in page source).

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog was added manually.